### PR TITLE
Makes all unit tests look the same

### DIFF
--- a/test/units/modules/network/f5/test_bigip_command.py
+++ b/test/units/modules/network/f5/test_bigip_command.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -45,11 +44,10 @@ except ImportError:
         from ansible.modules.network.f5.bigip_command import ModuleManager
         from ansible.modules.network.f5.bigip_command import ArgumentSpec
     except ImportError:
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("%s requires the python modules for f5/bigip" % __file__)
-
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
 
 
 def set_module_args(args):

--- a/test/units/modules/network/f5/test_bigip_config.py
+++ b/test/units/modules/network/f5/test_bigip_config.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -45,10 +44,10 @@ except ImportError:
         from ansible.modules.network.f5.bigip_config import ModuleManager
         from ansible.modules.network.f5.bigip_config import ArgumentSpec
     except ImportError:
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("%s requires the python modules for f5/bigip" % __file__)
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
+fixture_data = {}
 
 
 def set_module_args(args):

--- a/test/units/modules/network/f5/test_bigip_gtm_pool.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_pool.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -49,9 +48,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_gtm_pool import UntypedManager
         from ansible.modules.network.f5.bigip_gtm_pool import TypedManager
     except ImportError:
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("%s requires the python modules for f5/bigip" % __file__)
-
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -20,15 +20,14 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
 import pytest
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -44,11 +43,14 @@ try:
     from library.bigip_gtm_wide_ip import UntypedManager
     from library.bigip_gtm_wide_ip import TypedManager
 except ImportError:
-    from ansible.modules.network.f5.bigip_gtm_wide_ip import Parameters
-    from ansible.modules.network.f5.bigip_gtm_wide_ip import ModuleManager
-    from ansible.modules.network.f5.bigip_gtm_wide_ip import ArgumentSpec
-    from ansible.modules.network.f5.bigip_gtm_wide_ip import UntypedManager
-    from ansible.modules.network.f5.bigip_gtm_wide_ip import TypedManager
+    try:
+        from ansible.modules.network.f5.bigip_gtm_wide_ip import Parameters
+        from ansible.modules.network.f5.bigip_gtm_wide_ip import ModuleManager
+        from ansible.modules.network.f5.bigip_gtm_wide_ip import ArgumentSpec
+        from ansible.modules.network.f5.bigip_gtm_wide_ip import UntypedManager
+        from ansible.modules.network.f5.bigip_gtm_wide_ip import TypedManager
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_iapp_template.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_template.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.module_utils import basic
@@ -40,9 +39,12 @@ try:
     from library.bigip_iapp_template import ModuleManager
     from library.bigip_iapp_template import ArgumentSpec
 except ImportError:
-    from ansible.modules.network.f5.bigip_iapp_template import Parameters
-    from ansible.modules.network.f5.bigip_iapp_template import ArgumentSpec
-    from ansible.modules.network.f5.bigip_iapp_template import ModuleManager
+    try:
+        from ansible.modules.network.f5.bigip_iapp_template import Parameters
+        from ansible.modules.network.f5.bigip_iapp_template import ArgumentSpec
+        from ansible.modules.network.f5.bigip_iapp_template import ModuleManager
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_irule.py
+++ b/test/units/modules/network/f5/test_bigip_irule.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, mock_open, Mock
@@ -43,11 +42,14 @@ try:
     from library.bigip_irule import GtmManager
     from library.bigip_irule import LtmManager
 except ImportError:
-    from ansible.modules.network.f5.bigip_irule import Parameters
-    from ansible.modules.network.f5.bigip_irule import ModuleManager
-    from ansible.modules.network.f5.bigip_irule import ArgumentSpec
-    from ansible.modules.network.f5.bigip_irule import GtmManager
-    from ansible.modules.network.f5.bigip_irule import LtmManager
+    try:
+        from ansible.modules.network.f5.bigip_irule import Parameters
+        from ansible.modules.network.f5.bigip_irule import ModuleManager
+        from ansible.modules.network.f5.bigip_irule import ArgumentSpec
+        from ansible.modules.network.f5.bigip_irule import GtmManager
+        from ansible.modules.network.f5.bigip_irule import LtmManager
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_pool.py
+++ b/test/units/modules/network/f5/test_bigip_pool.py
@@ -20,15 +20,14 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
 import pytest
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -47,9 +46,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_pool import ModuleManager
         from ansible.modules.network.f5.bigip_pool import ArgumentSpec
     except ImportError:
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("%s requires the python modules for f5/bigip" % __file__)
-
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_provision.py
+++ b/test/units/modules/network/f5/test_bigip_provision.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -40,9 +39,12 @@ try:
     from library.bigip_provision import ModuleManager
     from library.bigip_provision import ArgumentSpec
 except ImportError:
-    from ansible.modules.network.f5.bigip_provision import Parameters
-    from ansible.modules.network.f5.bigip_provision import ModuleManager
-    from ansible.modules.network.f5.bigip_provision import ArgumentSpec
+    try:
+        from ansible.modules.network.f5.bigip_provision import Parameters
+        from ansible.modules.network.f5.bigip_provision import ModuleManager
+        from ansible.modules.network.f5.bigip_provision import ArgumentSpec
+    except ImportError:
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_snmp.py
+++ b/test/units/modules/network/f5/test_bigip_snmp.py
@@ -20,15 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+import json
 import sys
 
 from nose.plugins.skip import SkipTest
-
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
-import os
-import json
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -46,7 +44,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_snmp import ModuleManager
         from ansible.modules.network.f5.bigip_snmp import ArgumentSpec
     except ImportError:
-        raise SkipTest("F5 Ansible modules the f5 python library")
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_snmp_trap.py
+++ b/test/units/modules/network/f5/test_bigip_snmp_trap.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import sys
+
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, DEFAULT, Mock
@@ -51,9 +50,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_snmp_trap import NonNetworkedManager
         from ansible.modules.network.f5.bigip_snmp_trap import ArgumentSpec
     except ImportError:
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("%s requires the python modules for f5/bigip" % __file__)
-
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}

--- a/test/units/modules/network/f5/test_bigip_user.py
+++ b/test/units/modules/network/f5/test_bigip_user.py
@@ -20,19 +20,17 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import sys
-import pytest
-
-if sys.version_info < (2, 7):
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
 import os
 import json
+import pytest
+import sys
 
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import patch
+from ansible.compat.tests.mock import patch, Mock
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.f5_utils import AnsibleF5Client
@@ -52,9 +50,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_user import UnparitionedManager
         from ansible.modules.network.f5.bigip_user import PartitionedManager
     except ImportError:
-        from nose.plugins.skip import SkipTest
-        raise SkipTest("%s requires the python modules for f5/bigip" % __file__)
-
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}
@@ -146,12 +142,11 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.create_on_device = lambda: True
-        pm.exists = lambda: False
+        pm.create_on_device = Mock(return_value=True)
+        pm.exists = Mock(return_value=False)
 
         results = pm.exec_module()
 
@@ -176,12 +171,11 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.create_on_device = lambda: True
-        pm.exists = lambda: False
+        pm.create_on_device = Mock(return_value=True)
+        pm.exists = Mock(return_value=False)
 
         results = pm.exec_module()
 
@@ -207,12 +201,11 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.create_on_device = lambda: True
-        pm.exists = lambda: False
+        pm.create_on_device = Mock(return_value=True)
+        pm.exists = Mock(return_value=False)
 
         msg = "The 'update_password' option " \
               "needs to be set to 'on_create' when creating " \
@@ -238,12 +231,11 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.create_on_device = lambda: True
-        pm.exists = lambda: False
+        pm.create_on_device = Mock(return_value=True)
+        pm.exists = Mock(return_value=False)
 
         msg = "The 'partition_access' option " \
               "is required when creating a resource."
@@ -273,12 +265,11 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.create_on_device = lambda: True
-        pm.exists = lambda: False
+        pm.create_on_device = Mock(return_value=True)
+        pm.exists = Mock(return_value=False)
 
         results = pm.exec_module()
 
@@ -306,12 +297,11 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.create_on_device = lambda: True
-        pm.exists = lambda: False
+        pm.create_on_device = Mock(return_value=True)
+        pm.exists = Mock(return_value=False)
 
         msg = "Shell access is only available to 'admin' or " \
               "'resource-admin' roles"
@@ -341,13 +331,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.exists = lambda: True
-        pm.update_on_device = lambda: True
-        pm.read_current_from_device = lambda: current
+        pm.exists = Mock(return_value=True)
+        pm.update_on_device = Mock(return_value=True)
+        pm.read_current_from_device = Mock(return_value=current)
 
         results = pm.exec_module()
 
@@ -374,13 +363,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.exists = lambda: True
-        pm.update_on_device = lambda: True
-        pm.read_current_from_device = lambda: current
+        pm.exists = Mock(return_value=True)
+        pm.update_on_device = Mock(return_value=True)
+        pm.read_current_from_device = Mock(return_value=current)
 
         results = pm.exec_module()
 
@@ -412,13 +400,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.exists = lambda: True
-        pm.update_on_device = lambda: True
-        pm.read_current_from_device = lambda: current
+        pm.exists = Mock(return_value=True)
+        pm.update_on_device = Mock(return_value=True)
+        pm.read_current_from_device = Mock(return_value=current)
 
         results = pm.exec_module()
 
@@ -452,13 +439,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: False
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=False)
 
         pm = PartitionedManager(client)
-        pm.exists = lambda: True
-        pm.update_on_device = lambda: True
-        pm.read_current_from_device = lambda: current
+        pm.exists = Mock(return_value=True)
+        pm.update_on_device = Mock(return_value=True)
+        pm.read_current_from_device = Mock(return_value=current)
 
         results = pm.exec_module()
 
@@ -493,13 +479,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         results = upm.exec_module()
 
@@ -537,13 +522,12 @@ class TestManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         msg = "Shell access is only available to 'admin' or " \
               "'resource-admin' roles"
@@ -580,12 +564,11 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.create_on_device = lambda: True
-        upm.exists = lambda: False
+        upm.create_on_device = Mock(return_value=True)
+        upm.exists = Mock(return_value=False)
 
         results = upm.exec_module()
 
@@ -610,12 +593,11 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.create_on_device = lambda: True
-        upm.exists = lambda: False
+        upm.create_on_device = Mock(return_value=True)
+        upm.exists = Mock(return_value=False)
 
         results = upm.exec_module()
 
@@ -641,12 +623,11 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.create_on_device = lambda: True
-        upm.exists = lambda: False
+        upm.create_on_device = Mock(return_value=True)
+        upm.exists = Mock(return_value=False)
 
         msg = "The 'update_password' option " \
               "needs to be set to 'on_create' when creating " \
@@ -672,12 +653,11 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.create_on_device = lambda: True
-        upm.exists = lambda: False
+        upm.create_on_device = Mock(return_value=True)
+        upm.exists = Mock(return_value=False)
 
         msg = "The 'partition_access' option " \
               "is required when creating a resource."
@@ -707,12 +687,11 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.create_on_device = lambda: True
-        upm.exists = lambda: False
+        upm.create_on_device = Mock(return_value=True)
+        upm.exists = Mock(return_value=False)
 
         results = upm.exec_module()
 
@@ -740,12 +719,11 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.create_on_device = lambda: True
-        upm.exists = lambda: False
+        upm.create_on_device = Mock(return_value=True)
+        upm.exists = Mock(return_value=False)
 
         msg = "Shell access is only available to 'admin' or " \
               "'resource-admin' roles"
@@ -781,13 +759,12 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         results = upm.exec_module()
 
@@ -819,13 +796,12 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         results = upm.exec_module()
 
@@ -859,13 +835,12 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         results = upm.exec_module()
 
@@ -900,13 +875,12 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         results = upm.exec_module()
 
@@ -944,13 +918,12 @@ class TestLegacyManager(unittest.TestCase):
 
         # Override methods to force specific logic in the module to happen
         mm = ModuleManager(client)
-        mm.is_version_less_than_13 = lambda: True
-        mm.exit_json = lambda x: False
+        mm.is_version_less_than_13 = Mock(return_value=True)
 
         upm = UnparitionedManager(client)
-        upm.exists = lambda: True
-        upm.update_on_device = lambda: True
-        upm.read_current_from_device = lambda: current
+        upm.exists = Mock(return_value=True)
+        upm.update_on_device = Mock(return_value=True)
+        upm.read_current_from_device = Mock(return_value=current)
 
         msg = "Shell access is only available to 'admin' or " \
               "'resource-admin' roles"

--- a/test/units/modules/network/f5/test_bigip_virtual_address.py
+++ b/test/units/modules/network/f5/test_bigip_virtual_address.py
@@ -20,14 +20,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+import json
 import sys
 
 from nose.plugins.skip import SkipTest
 if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
-
-import os
-import json
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, Mock
@@ -45,7 +44,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_virtual_address import ModuleManager
         from ansible.modules.network.f5.bigip_virtual_address import ArgumentSpec
     except ImportError:
-        raise SkipTest("This test requries F5 python libraries")
+        raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}


### PR DESCRIPTION
##### SUMMARY
Just a little cleanup from an earlier patch that makes f5 unit
tests only run if the f5 sdk is installed

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
f5 modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = 
  configured module search path = [u'/Users/trupp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/trupp/src/envs/ansible-2.0/lib/python2.7/site-packages/ansible
  executable location = /Users/trupp/src/envs/ansible-2.0/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
