### PR TITLE
Added -F option to HPUX method update_password so root can change its password

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1964,6 +1964,11 @@ class AIX(User):
 class HPUX(User):
     """
     This is a HP-UX User manipulation class.
+    
+    NOTE: for a password change you should use the following command on an 
+    HPUX machine to create an encrypted password
+    
+        echo"<password>"$(date +%S) | /usr/lbin/makekey
 
     This overrides the following methods from the generic class:-
       - create_user()
@@ -2096,6 +2101,8 @@ class HPUX(User):
             cmd.append(self.shell)
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
+            if self.force:
+                cmd.append('-F')
             cmd.append('-p')
             cmd.append(self.password)
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added note to HPUX class on how to create the encrypted password. Also, added '-F' to the command used in update_password for HPUX class. This is needed to change the root password. Without the '-F' root cannot change its own password.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
user.py