### PR TITLE
Linode replace parameter checks

### DIFF
--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -334,7 +334,6 @@ def getInstanceDetails(api, server):
                                         'ip_id': ip['IPADDRESSID']})
     return instance
 
-
 def param_satisfier(module, paramdict, provision_step):
     '''
     Verifies that the supplied set of API parameters have been included,
@@ -348,14 +347,13 @@ def param_satisfier(module, paramdict, provision_step):
                     "create")
     '''
     unsatisfied_param_list = [
-        key for key, parameter in paramdict.iteritems()
+        key for key, parameter in paramdict.items()
         if not parameter
     ]
     if unsatisfied_param_list:
         module.fail_json(msg="{0}: required for create step".format(
             ",".join(unsatisfied_param_list)
         ))
-
 
 def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_threshold, alert_bwout_enabled, alert_bwout_threshold,
                   alert_bwquota_enabled, alert_bwquota_threshold, alert_cpu_enabled, alert_cpu_threshold, alert_diskio_enabled,

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -356,7 +356,7 @@ def param_satisfier(module, paramdict, provision_step):
             ",".join(unsatisfied_param_list)
         ))
 
-       
+
 def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_threshold, alert_bwout_enabled, alert_bwout_threshold,
                   alert_bwquota_enabled, alert_bwquota_threshold, alert_cpu_enabled, alert_cpu_threshold, alert_diskio_enabled,
                   alert_diskio_threshold,backupweeklyday, backupwindow, displaygroup, plan, additional_disks, distribution,

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -334,7 +334,7 @@ def getInstanceDetails(api, server):
                                         'ip_id': ip['IPADDRESSID']})
     return instance
 
-def param_satisfier(module, paramdict, provision_step):
+def param_satisfier(module, paramdict, linode_state):
     '''
     Verifies that the supplied set of API parameters have been included,
     and returns an error message, with the provisioning step
@@ -351,8 +351,8 @@ def param_satisfier(module, paramdict, provision_step):
         if not parameter
     ]
     if unsatisfied_param_list:
-        module.fail_json(msg="{0}: required for create step".format(
-            ",".join(unsatisfied_param_list)
+        module.fail_json(msg="{0}: required for {1} state".format(
+            ",".join(unsatisfied_param_list, linode_state)
         ))
 
 def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_threshold, alert_bwout_enabled, alert_bwout_threshold,
@@ -397,7 +397,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                              "plan": plan,
                              "distribution": distribution,
                              "datacenter": datacenter},
-                            "create")
+                            state)
             # Create linode entity
             new_server = True
 
@@ -435,7 +435,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                             {"name":name,
                              "linodeid":linode_id,
                              "distribution":distribution},
-                            "create")
+                            state)
             # Create disks (1 from distrib, 1 for SWAP)
             new_server = True
             try:
@@ -479,7 +479,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                             {"name": name,
                              "linodeid": linode_id,
                              "distribution": distribution},
-                            "create")
+                            state)
             # Check architecture
             for distrib in api.avail_distributions():
                 if distrib['DISTRIBUTIONID'] != distribution:
@@ -567,7 +567,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
         param_satisfier(module,
                         {"name": name,
                          "linodeid": linode_id},
-                        "create")
+                        state)
 
         if not servers:
             module.fail_json(msg = 'Server %s (lid: %s) not found' % (name, linode_id))
@@ -587,12 +587,11 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
 
     elif state in ('restarted'):
         param_satisfier(module,
-                        {"name": name,
-                         "linodeid": linode_id},
-                        "create")
+                        {"linodeid": linode_id},
+                        state)
 
         if not servers:
-            module.fail_json(msg = 'Server %s (lid: %s) not found' % (name, linode_id))
+            module.fail_json(msg = 'Server with linode_ID %s not found' % (linode_id))
 
         for server in servers:
             instance = getInstanceDetails(api, server)

--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -369,6 +369,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
         #  - need config_id for linode_id - create config (need kernel)
 
         # Any create step triggers a job that need to be waited for.
+        # if no linode_id is provided, we assume that you would like to create a new linode
         if not servers:
             # Any creation step requires a name, plan, distribution and datacenter
             module.fail_on_missing_params(["name", "plan", "distribution", "datacenter"])
@@ -406,9 +407,10 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                 module.fail_json(msg = '%s' % e.value[0]['ERRORMESSAGE'])
 
         if not disks:
-            module.fail_on_missing_params(["name", "linodeid", "distribution"])
-            # Create disks (1 from distrib, 1 for SWAP)
-            new_server = True
+            if new_server:
+                module.fail_on_missing_params(["name", "distribution"])
+            else:
+                module.fail_on_missing_params(["name", "linode_id", "distribution"])
             try:
                 if not password:
                     # Password is required on creation, if not provided generate one
@@ -446,7 +448,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
                 module.fail_json(msg = '%s' % e.value[0]['ERRORMESSAGE'])
 
         if not configs:
-            module.fail_on_missing_params(["name", "linodeid", "distribution"])
+            module.fail_on_missing_params(["name", "distribution"])
             # Check architecture
             for distrib in api.avail_distributions():
                 if distrib['DISTRIBUTIONID'] != distribution:
@@ -550,7 +552,7 @@ def linodeServers(module, api, state, name, alert_bwin_enabled, alert_bwin_thres
             instances.append(instance)
 
     elif state in ('restarted'):
-        module.fail_on_missing_params(["linodeid"])
+        module.fail_on_missing_params(["linode_id"])
 
         if not servers:
             module.fail_json(msg = 'Server with linode_ID %s not found' % (linode_id))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Previous method of reporting missing parameters would consistently return None values because it would be returning the value of parameters that had not been called. This was minimally helpful
when trying to debug a provisioning playbook. Instead, my intention with
these suggestions is to return the names of the parameters that need to
be included instead of the variables that were not there, while still keeping with the original intention of being able to require arguments for specific API utilities.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - Linode module
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (linode_more_helpful_errors 0076a8aeb1) last updated 2017/06/15 18:51:05 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/demos/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/demos/dev/ansible/lib/ansible
  executable location = /home/demos/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Feb 11 2017, 12:22:40) [GCC 6.3.1 20170109]

```


##### ADDITIONAL INFORMATION
* First PR to ansible, so not sure if I followed all of the right guidelines with this PR, happy to take suggestions!
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->