### PR TITLE
Use response.content instead of response object

### DIFF
--- a/lib/ansible/module_utils/vca.py
+++ b/lib/ansible/module_utils/vca.py
@@ -141,7 +141,7 @@ class VcaAnsibleModule(AnsibleModule):
             login_org = self.params['org']
 
         if not self.vca.login(password=password, org=login_org):
-            self.fail('Login to VCA failed', response=self.vca.response)
+            self.fail('Login to VCA failed', response=self.vca.response.content)
 
         try:
             method_name = 'login_%s' % service_type
@@ -150,7 +150,7 @@ class VcaAnsibleModule(AnsibleModule):
         except AttributeError:
             self.fail('no login method exists for service_type %s' % service_type)
         except VcaError as e:
-            self.fail(e.message, response=self.vca.response, **e.kwargs)
+            self.fail(e.message, response=self.vca.response.content, **e.kwargs)
 
     def login_vca(self):
         instance_id = self.params['instance_id']


### PR DESCRIPTION

##### SUMMARY
vca module utility uses response object instead of
response.content which raises exception in while fail_json
call. Use content attribute from response object instead which
is exact description of HTTP Response error.

Fixes #25378

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vca.py

##### ANSIBLE VERSION
```
2.4devel
```