### PR TITLE
Rectify traceback.format_exc() call

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudfront_facts.py
@@ -272,7 +272,7 @@ class CloudFrontServiceManager:
             return self.paginated_response(func)
         except botocore.exceptions.ClientError as e:
             self.module.fail_json(msg="Error describing distribution configuration - " + str(e),
-                                  exception=traceback.format_exec(e),
+                                  exception=traceback.format_exc(),
                                   **camel_dict_to_snake_dict(e.response))
 
     def get_origin_access_identity(self, origin_access_identity_id):


### PR DESCRIPTION
##### SUMMARY
Fix adds correct call to traceback.format_exc method
There is no method called `format_exec`

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudfront_facts.py

##### ANSIBLE VERSION
```
2.4 devel
```