### PR TITLE
fix deprecation for transport param when not used eos

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -54,11 +54,12 @@ eos_argument_spec = {
     'timeout': dict(type='int'),
 
     'provider': dict(type='dict'),
-    'transport': dict(choices=['cli', 'eapi'], default='cli')
+    'transport': dict(choices=['cli', 'eapi'])
 }
 
 # Add argument's default value here
 ARGS_DEFAULT_VALUE = {
+    'transport': 'cli',
     'port': 443,
     'use_ssl': True,
     'validate_certs': True


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #25779 .
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/eos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
stable-2.3
```