### PR TITLE
Fixes #25781: add playbook runtime stat in the logstash callback stats

### DIFF
--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -22,6 +22,7 @@ import os
 import json
 import socket
 import uuid
+from datetime import datetime
 
 import logging
 
@@ -86,6 +87,7 @@ class CallbackModule(CallbackBase):
             self.hostname = socket.gethostname()
             self.session = str(uuid.uuid1())
             self.errors = 0
+        self.start_time = datetime.utcnow()
 
     def v2_playbook_on_start(self, playbook):
         self.playbook = playbook._file_name
@@ -99,6 +101,8 @@ class CallbackModule(CallbackBase):
         self.logger.info("ansible start", extra=data)
 
     def v2_playbook_on_stats(self, stats):
+        end_time = datetime.utcnow()
+        runtime = end_time - self.start_time
         summarize_stat = {}
         for host in stats.processed.keys():
             summarize_stat[host] = stats.summarize(host)
@@ -114,6 +118,7 @@ class CallbackModule(CallbackBase):
             'session': self.session,
             'ansible_type': "finish",
             'ansible_playbook': self.playbook,
+            'ansible_playbook_duration': runtime.total_seconds(),
             'ansible_result': json.dumps(summarize_stat),
         }
         self.logger.info("ansible stats", extra=data)


### PR DESCRIPTION
##### SUMMARY
Add the playbook runtime statistic in the logstash plugin statistics.
The playbook runtime computation is based on the timer callback implementation.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
lib/ansible/plugins/callback/logstash.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config_file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
With this patch the event sent to logstash will contain a new field called "ansible_playbook_duration" containing the duration in seconds (float).


