### PR TITLE
Adds docs/bin/ansible-makepage bash script, to make a single doc page with one command

### DIFF
--- a/docs/bin/ansible-makepage
+++ b/docs/bin/ansible-makepage
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# ansible-makepage [-q|--quiet] module_name|file.rst
+# A small script to make it easier to build a single documentation
+# page during development.
+
+PROG=`basename $0`
+
+if [[ $# -gt 2 ]]; then
+   USAGE="YES"
+fi
+
+while [[ $# -gt 0 ]]
+do
+key="$1"
+
+case $key in
+    -q|--quiet)
+    QUIET="YES"
+    shift
+    ;;
+    *)
+    PAGE="$1"
+    shift
+    ;; 
+esac
+done
+
+if [ "$USAGE" == "YES" ] || [[ -z "$PAGE" ]]; then
+  echo 
+  echo $PROG - build a single page of the ansible documentation.
+  echo 
+  echo "Usage: $PROG [-q|--quiet] module_name|file.rst" 
+  echo "   [-q|--quiet]   do not sound terminal bell when complete."
+  echo "   module name, e.g. setup or rst file e.g. intro_windows.rst" 
+  echo 
+  exit 1
+fi
+
+# append _module.rst if the file doesn't end in '.rst'
+if [[ $PAGE == *".rst"* ]]; then
+  FILE=$PAGE
+else
+  FILE=${PAGE}_module.rst
+fi
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+cd $DIR/../docsite
+
+make clean modules staticmin
+
+# workaround for missing css
+
+cp _themes/srtd/static/css/theme.min.css ./_build/html/_static/css
+
+make htmlsingle rst=$FILE
+
+
+if [ "$QUIET" != "YES" ]; then
+   echo 
+fi
+
+echo "$PROG Done."

--- a/docs/bin/ansible-makepage.sh
+++ b/docs/bin/ansible-makepage.sh
@@ -4,7 +4,7 @@
 # A small script to make it easier to build a single documentation
 # page during development.
 
-PROG=`basename $0`
+PROG=$(basename $0)
 
 if [[ $# -gt 2 ]]; then
    USAGE="YES"
@@ -28,7 +28,7 @@ done
 
 if [ "$USAGE" == "YES" ] || [[ -z "$PAGE" ]]; then
   echo 
-  echo $PROG - build a single page of the ansible documentation.
+  echo "$PROG - build a single page of the ansible documentation."
   echo 
   echo "Usage: $PROG [-q|--quiet] module_name|file.rst" 
   echo "   [-q|--quiet]   do not sound terminal bell when complete."
@@ -46,7 +46,7 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-cd $DIR/../docsite
+cd "$DIR/../docsite"
 
 make clean modules staticmin
 
@@ -54,7 +54,7 @@ make clean modules staticmin
 
 cp _themes/srtd/static/css/theme.min.css ./_build/html/_static/css
 
-make htmlsingle rst=$FILE
+make htmlsingle rst="$FILE"
 
 
 if [ "$QUIET" != "YES" ]; then

--- a/docs/bin/ansible-makepage.sh
+++ b/docs/bin/ansible-makepage.sh
@@ -4,7 +4,7 @@
 # A small script to make it easier to build a single documentation
 # page during development.
 
-PROG=$(basename $0)
+PROG="$(basename $1)"
 
 if [[ $# -gt 2 ]]; then
    USAGE="YES"

--- a/docs/bin/ansible-makepage.sh
+++ b/docs/bin/ansible-makepage.sh
@@ -4,7 +4,7 @@
 # A small script to make it easier to build a single documentation
 # page during development.
 
-PROG="$(basename $1)"
+PROG=$(basename "$0")
 
 if [[ $# -gt 2 ]]; then
    USAGE="YES"

--- a/docs/docsite/README.md
+++ b/docs/docsite/README.md
@@ -14,6 +14,9 @@ such as link references, you may install sphinx and build the documentation by r
 To include module documentation you'll need to run `make webdocs` at the top level of the repository.  The generated
 html files are in docsite/htmlout/.
 
+You can also build a single page of the documentation, or the documentation for one module by 
+running `bin\docs\ansible-makepage.sh` at the top level of the repository.
+
 If you do not want to learn the reStructuredText format, you can also [file issues] about
 documentation problems on the Ansible GitHub project.
 

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -344,6 +344,12 @@ Put your completed module file into the ``lib/ansible/modules/$CATEGORY/`` direc
 run the command: ``make webdocs``. The new 'modules.html' file will be
 built in the ``docs/docsite/_build/html/$MODULENAME_module.html`` directory.
 
+You can speed up the time taken to build the module html page by using the command:
+``bin/docs/ansible-makepage.sh``.  This script will only build the documentation for
+one module (or one page of the documentation).   Be aware that links to other modules and 
+documentation may not work when using ``bin/docs/ansible-makepage.sh``, but all other
+rendering should be the same.
+
 To test your documentation against your ``argument_spec`` you can use ``validate-modules``. Note that this option isn't currently enabled in Shippable due to the time it takes to run.
 
 .. code-block:: bash


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds a bash script, ansible-makepage which can be used to make a single page of the ansible documentation with one command.

Used bash as its a popular shell.
Added a -q|--quiet switch which stops it from sounding the terminal bell when complete.
Script either takes the name of a module, e.g. setup or the name of one of the rst files, for example intro_windows.rst as its input.

Assumptions:

You already have sphinx etc so that you can build docs locally.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Doesn't fix anything, but hopefully helps developers to check they have made documentation that renders correctly during development of modules and ansible documentation changes.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

ansible-makepage (new script)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ansible_makepage 74d6ef2290) last updated 2017/06/16 12:36:11 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before, you would have had to run this long and hard to remember  set of commands to build a single page:

cd docs/docsite
make clean modules staticmin; cp _themes/srtd/static/css/theme.min.css ./_build/html/_static/css; make htmlsingle rst=win_regedit_module.rst; echo ^G

after:
run the following to acheive the same result:

docs/bin/ansible-makepage win_regedit


```
