### PR TITLE
fixed issue with using only $env:temp as temp path on windows

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1046,8 +1046,10 @@ class ShellModule(object):
 
     def mkdtemp(self, basefile, system=False, mode=None, tmpdir=None):
         basefile = self._escape(self._unquote(basefile))
-        # FIXME: Support system temp path and passed in tmpdir!
-        return self._encode_script('''(New-Item -Type Directory -Path $env:temp -Name "%s").FullName | Write-Host -Separator '';''' % basefile)
+        if tmpdir is None:
+	    tmpdir = "$env:temp"
+
+        return self._encode_script('''(New-Item -Type Directory -Path %s -Name "%s").FullName | Write-Host -Separator '';''' % (tmpdir, basefile))
 
     def expand_user(self, user_home_path):
         # PowerShell only supports "~" (not "~username").  Resolve-Path ~ does

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1047,7 +1047,7 @@ class ShellModule(object):
     def mkdtemp(self, basefile, system=False, mode=None, tmpdir=None):
         basefile = self._escape(self._unquote(basefile))
         if tmpdir is None:
-	    tmpdir = "$env:temp"
+            tmpdir = "$env:temp"
 
         return self._encode_script('''(New-Item -Type Directory -Path %s -Name "%s").FullName | Write-Host -Separator '';''' % (tmpdir, basefile))
 


### PR DESCRIPTION
##### SUMMARY
* The argument `tmpdir` is not using in `mkdtemp` function.
Every time when ansible is creating temporary folder on remote
machine (which is using Windows as OS) the path has been set
to value of $env:temp (and ignoring the value of `remote_tmp`
from ansible.cfg)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/shell/powershell.py
