### PR TITLE
Check existence of SSL certs in Foreman callback

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -94,7 +94,7 @@ class CallbackModule(CallbackBase):
             self._display.warning("SSL verification of %s disabled" %
                                   self.FOREMAN_URL)
             verify = False
-        else:  # Set ta a CA bundle:
+        else:  # Set to a CA bundle:
             verify = self.FOREMAN_SSL_VERIFY
         return verify
 

--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -82,6 +82,13 @@ class CallbackModule(CallbackBase):
         else:
             self._disable_plugin('The `requests` python module is not installed.')
 
+        if self.FOREMAN_URL.startswith('https://'):
+            if not os.path.exists(self.FOREMAN_SSL_CERT[0]):
+                self._disable_plugin('FOREMAN_SSL_CERT %s not found.' % self.FOREMAN_SSL_CERT[0])
+
+            if not os.path.exists(self.FOREMAN_SSL_CERT[1]):
+                self._disable_plugin('FOREMAN_SSL_KEY %s not found.' % self.FOREMAN_SSL_CERT[1])
+
     def _disable_plugin(self, msg):
         self.disabled = True
         self._display.warning(msg + ' Disabling the Foreman callback plugin.')


### PR DESCRIPTION
##### SUMMARY
foreman callback: check for certificates upgront

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/foreman.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (foreman-callback 7da1e9e44b) last updated 2017/06/16 15:18:42 (GMT +200)
  config file = /var/scratch/src/ansible/ansible/ansible.cfg
  configured module search path = [u'/home/agx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/scratch/src/ansible/ansible/lib/ansible
  executable location = /var/scratch/src/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

```


##### ADDITIONAL INFORMATION
With out that a incorrect certifcate path fails like

```
 [WARNING]: Failure using method (v2_runner_on_ok) in callback plugin (</src/ansible/ansible/lib/ansible/plugins/callback/foreman.CallbackModule object at
0x7f7dafdfe650>): [('system library', 'fopen', 'No such file or directory'), ('BIO routines', 'file_ctrl', 'system lib'), ('SSL routines', 'SSL_CTX_use_certificate_file',
'system lib')]

```
with no indication which file is missing.
