### PR TITLE
vars: fixed missing path in splitext()

### DIFF
--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -123,7 +123,7 @@ class VarsModule(BaseVarsPlugin):
         for spath in os.listdir(path):
             if not spath.startswith('.'):  # skip hidden
 
-                ext = os.path.splitext()[-1]
+                ext = os.path.splitext(path)[-1]
                 full_spath = os.path.join(path, spath)
 
                 if os.path.isdir(full_spath) and not ext:  # recursive search if dir


### PR DESCRIPTION
##### SUMMARY
fixes ERROR! splitext() takes exactly 1 argument (0 given)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
host_group_vars

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
