### PR TITLE
INI inventory plugin: add documentation about variable types

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -60,6 +60,10 @@ Suppose you have just static IPs and want to set up some aliases that live in yo
 In the above example, trying to ansible against the host alias "jumper" (which may not even be a real hostname) will contact 192.0.2.50 on port 5555.  Note that this is using a feature of the inventory file to define some special variables.  Generally speaking this is not the best
 way to define variables that describe your system policy, but we'll share suggestions on doing this later.  We're just getting started.
 
+.. note:: Values passed in using the ``key=value`` syntax are interpreted as Python literal structure (strings, numbers, tuples, lists, dicts,
+          booleans, None), alternatively as string. For example ``var=FALSE`` would create a string equal to 'FALSE'. Do not rely on types set
+          during definition, always make sure you specify type with a filter when needed when consuming the variable.
+
 Adding a lot of hosts?  If you have a lot of hosts following similar patterns you can do this rather than listing each hostname:
 
 .. code-block:: ini

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -27,6 +27,9 @@ DOCUMENTATION:
         - The C(children) modifier indicates that the section contains groups.
         - The C(vars) modifier indicates that the section contains variables assigned to members of the group.
         - Anything found outside a section is considered an 'ungrouped' host.
+        - Values passed in using the C(key=value) syntax are interpreted as Python literal structure (strings, numbers, tuples, lists, dicts,
+          booleans, None), alternatively as string. For example C(var=FALSE) would create a string equal to 'FALSE'. Do not rely on types set
+          during definition, always make sure you specify type with a filter when needed when consuming the variable.
     notes:
         - It takes the place of the previously hardcoded INI inventory.
         - To function it requires being whitelisted in configuration.


### PR DESCRIPTION
##### SUMMARY
Fixes #25784. INI inventory plugin [performs](https://github.com/ansible/ansible/blob/43468b825d19c5990c07d19f5f269d8352f084f8/lib/ansible/plugins/inventory/ini.py#L346) some undocumented processing on values of variables. This pull request aims to document and test the current behavior.

##### ISSUE TYPE
 - Test Pull Request
 - Docs Pull Request

##### COMPONENT NAME
Ini inventory plugin

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel a38e727380) last updated 2017/06/16 15:40:05 (GMT +200)
```