### PR TITLE
Add mac address to windows facts

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -74,6 +74,7 @@ foreach ($adapter in $ActiveNetcfg)
         dns_domain = $adapter.dnsdomain
         interface_index = $adapter.InterfaceIndex
         interface_name = $adapter.description
+        macaddress = $adapter.macaddress
     }
 
     if ($adapter.defaultIPGateway)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Windows facts were missing mac address
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #25748
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
setup
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (return_of_the_mac 16158c67a3) last updated 2017/06/16 17:23:49 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Not much to say here, this change just adds mac address for windows hosts.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before (extract from setup output)

        "ansible_interfaces": [
            {
                "default_gateway": "192.168.137.1",
                "dns_domain": "mshome.net",
                "interface_index": 9,
                "interface_name": "Realtek RTL8723BE Wireless LAN 802.11n PCI-E NIC"
            }
        ]

After:

        "ansible_interfaces": [
            {
                "default_gateway": "192.168.137.1",
                "dns_domain": "mshome.net",
                "interface_index": 9,
                "interface_name": "Realtek RTL8723BE Wireless LAN 802.11n PCI-E NIC",
                "macaddress": "38:B1:DB:21:2D:8D"
            }
        ],,
```
