### PR TITLE
Fix encoding error on grp.gr_name, which can contain non-ascii chars at domain PCs

### DIFF
--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -87,7 +87,7 @@ def file_props(root, path):
     except KeyError:
         ret['owner'] = st.st_uid
     try:
-        ret['group'] = grp.getgrgid(st.st_gid).gr_name
+        ret['group'] = unicode(grp.getgrgid(st.st_gid).gr_name, "utf-8")
     except KeyError:
         ret['group'] = st.st_gid
     ret['mode'] = '0%03o' % (stat.S_IMODE(st.st_mode))

--- a/lib/ansible/plugins/lookup/filetree.py
+++ b/lib/ansible/plugins/lookup/filetree.py
@@ -30,7 +30,7 @@ except ImportError:
     pass
 
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 
 try:
     from __main__ import display
@@ -87,7 +87,7 @@ def file_props(root, path):
     except KeyError:
         ret['owner'] = st.st_uid
     try:
-        ret['group'] = unicode(grp.getgrgid(st.st_gid).gr_name, "utf-8")
+        ret['group'] = to_text(grp.getgrgid(st.st_gid).gr_name)
     except KeyError:
         ret['group'] = st.st_gid
     ret['mode'] = '0%03o' % (stat.S_IMODE(st.st_mode))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Default callback plugin fails on decoding non-ascii characters comes from lookup.filetree plugin.
For example, if with_filetree applied on directory with group name DOMAIN\\{cyrillic characters} (see reproduction below)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
filetree lookup plugin (plugins/lookup/filetree.py)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
``` 
ansible 2.4.0 (fix_filetree_grp_encoding fde1f4d08e) last updated 2017/06/16 18:45:50 (GMT +300)

forked from devel:3aa41ed https://github.com/ansible/ansible/commit/3aa41eda0bfbd7eef2b327c61e44521b3587b0f8
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
To reproduce:

Create a directory owned by domain group:

```
scherbakov@jellyfish:~# ls -lah
drwxr-xr-x   4 scherbakov  YAMONEY\Пользователи домена   136B 16 июн 19:00 .
drwx------  26 scherbakov  YAMONEY\Пользователи домена   884B 16 июн 17:48 ..
drwxr-xr-x   2 scherbakov  YAMONEY\Пользователи домена    68B 16 июн 19:00 some_another_directory
drwxr-xr-x   2 scherbakov  YAMONEY\Пользователи домена    68B 16 июн 19:00 some_directory
```

Run playbook contains with_filetree against this directory:

<!--- Paste verbatim command output below, e.g. before and after your change -->
```site.yml
- hosts: all
  gather_facts: no
  tasks:
  - debug:
      msg: "{{ item }}"
    with_filetree:
      - "/home/scherbakov/"
```

Playbook output will contain this warning instead of normal output:

```
 [WARNING]: Failure using method (v2_runner_item_on_ok) in callback plugin (<... .CallbackModule object at 0x10f3d2c90>): 'ascii'
codec can't encode characters in position 102-113: ordinal not in range(128)
```

If task fails, error wont be displayed either