### PR TITLE
cloudstack: add missing zone name to result

### DIFF
--- a/lib/ansible/module_utils/cloudstack.py
+++ b/lib/ansible/module_utils/cloudstack.py
@@ -431,6 +431,7 @@ class AnsibleCloudStack(object):
         # use the first zone if no zone param given
         if not zone:
             self.zone = zones['zone'][0]
+            self.result['zone'] = self.zone['name']
             return self._get_by_key(key, self.zone)
 
         if zones:


### PR DESCRIPTION
##### SUMMARY
if zone param is not given, first zone is used but it was not set in returns.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
