### PR TITLE
Remove commented out chdir

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -61,7 +61,6 @@ def do_fork():
         if pid > 0:
             return pid
 
-        #os.chdir("/")
         os.setsid()
         os.umask(0)
 


### PR DESCRIPTION
Commit 77ce83fe removed chdir during "daemonization" by commenting it
out.  While I'm not sure how the ansible project deals with this, the
obvious thing to do is remove it and rely on source code history
instead.

Signed-off-by: Cleber Rosa <crosa@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Commented out code that was intended for removal is just bloat, should be removed.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 5f23aa69c6) last updated 2017/06/16 19:19:58 (GMT -400)
  config file = None
  configured module search path = [u'/home/cleber/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /disposable/cleber/src/ansible/lib/ansible
  executable location = /disposable/cleber/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
No additional information.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
