### PR TITLE
nmcli: this function is responsible only for generating command

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -702,7 +702,7 @@ class Nmcli(object):
         cmd.append('con')
         cmd.append('up')
         cmd.append(self.conn_name)
-        return self.execute_command(cmd)
+        return cmd
 
     def create_connection_team(self):
         cmd=[self.module.get_bin_path('nmcli', True)]


### PR DESCRIPTION
##### SUMMARY
Fixes bug #20925. For unknown reason function generating command was running it and returning program output as command to run instead of simply returning built command.  

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /opt/km-ansible/ansible.cfg
  configured module search path = ['extensions/library']
```
