### PR TITLE
fixes issue with SIGALARM call in network_cli

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -242,7 +242,7 @@ class Connection(Rpc, _Connection):
     def alarm_handler(self, signum, frame):
         """Alarm handler raised in case of command timeout """
         display.display('closing shell due to sigalarm', log_only=True)
-        self.close_shell()
+        self.close()
 
     def exec_command(self, cmd):
         """Executes the cmd on in the shell and returns the output


### PR DESCRIPTION
The alarm_handler method was calling a method close_shell() that doesn't
exist.  This updates the alarm handler to call the current method
close()

