### PR TITLE
add the duplex info for interfaces and fix two display bug for network

### DIFF
--- a/lib/ansible/module_utils/facts/network/generic_bsd.py
+++ b/lib/ansible/module_utils/facts/network/generic_bsd.py
@@ -235,7 +235,7 @@ class GenericBsdIfconfigNetwork(Network):
                 address['broadcast'] = socket.inet_ntoa(struct.pack('!L', address_bin | (~netmask_bin & 0xffffffff)))
 
         # add to our list of addresses
-        if not words[1].startswith('127.'):
+        if not words[1].startswith('127.') and address['address'] not in ips['all_ipv4_addresses']:
             ips['all_ipv4_addresses'].append(address['address'])
         current_if['ipv4'].append(address)
 
@@ -258,7 +258,7 @@ class GenericBsdIfconfigNetwork(Network):
                 address['scope'] = words[5]
 
         localhost6 = ['::1', '::1/128', 'fe80::1%lo0']
-        if address['address'] not in localhost6:
+        if address['address'] not in localhost6 + ips['all_ipv6_addresses']:
             ips['all_ipv6_addresses'].append(address['address'])
         current_if['ipv6'].append(address)
 

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -147,9 +147,13 @@ class LinuxNetwork(Network):
                 interfaces[device]['perm_macaddress'] = get_file_content(os.path.join(path, 'bonding_slave', 'perm_hwaddr'), default='')
             if os.path.exists(os.path.join(path, 'device')):
                 interfaces[device]['pciid'] = os.path.basename(os.readlink(os.path.join(path, 'device')))
+            if os.path.exists(os.path.join(path, 'duplex')):
+                duplex = get_file_content(os.path.join(path, 'duplex'))
+                if duplex is not None and duplex != 'unknown':
+                    interfaces[device]['duplex'] = duplex
             if os.path.exists(os.path.join(path, 'speed')):
                 speed = get_file_content(os.path.join(path, 'speed'))
-                if speed is not None:
+                if speed is not None and duplex is not None and duplex != 'unknown':
                     interfaces[device]['speed'] = int(speed)
 
             # Check whether an interface is in promiscuous mode
@@ -224,7 +228,7 @@ class LinuxNetwork(Network):
                             default_ipv4['mtu'] = interfaces[device]['mtu']
                             default_ipv4['type'] = interfaces[device].get("type", "unknown")
                             default_ipv4['alias'] = words[-1]
-                        if not address.startswith('127.'):
+                        if not address.startswith('127.') and address not in ips['all_ipv4_addresses']:
                             ips['all_ipv4_addresses'].append(address)
                     elif words[0] == 'inet6':
                         if 'peer' == words[2]:
@@ -248,7 +252,7 @@ class LinuxNetwork(Network):
                             default_ipv6['macaddress'] = macaddress
                             default_ipv6['mtu'] = interfaces[device]['mtu']
                             default_ipv6['type'] = interfaces[device].get("type", "unknown")
-                        if not address == '::1':
+                        if not address == '::1' and address not in ips['all_ipv6_addresses']:
                             ips['all_ipv6_addresses'].append(address)
 
             ip_path = self.module.get_bin_path("ip")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- add the duplex info for interfaces
- fix the display bug of speed when the interface is unnormal or unconfigured
- fix the repeat display of ansible_all_ipv4_addresses and ansible_all_ipv6_addresses when sometimes like bonding
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
setup

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
- The duplex mode of the network card is also important, i think some people will like it.
- When the interface is unnormal or unconfigured, we should not show its speed, Fortunately, we can judge one interface is normal or not by the added duplex.
- Sometimes like network card bonding or unclean network configuration, we will get repetitive ip address from ansible_all_ipv4_addresses and ansible_all_ipv6_addresses, anyway i think unrepeated is better.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
