### PR TITLE
New module 'win_certificate'

### DIFF
--- a/lib/ansible/modules/windows/win_certificate.ps1
+++ b/lib/ansible/modules/windows/win_certificate.ps1
@@ -1,0 +1,159 @@
+#!powershell
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args -supports_check_mode $true
+
+$result = [PSCustomObject]@{
+    changed = $false
+    state = $null
+    thumbprint = $null
+    subject = $null
+    hasPrivateKey = $null
+	notValidBefore = $null
+	notValidAfter = $null
+    store = $null
+    msg = $null
+}
+
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+$state = Get-AnsibleParam -obj $params -name "state" -type "string" -validateSet "present","absent" -failifempty $true -resultobj $result
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true -resultobj $result
+$store = Get-AnsibleParam -obj $params -name "store" -type "string" -failifempty $true -validateSet "My","TrustedPublisher","Root","CA" -resultobj $result
+$password = Get-AnsibleParam -obj $params -name "password" -type "string"
+$exportable = Get-AnsibleParam -obj $params -name "privatekey_exportable" -type "bool" -default $false
+$force = Get-AnsibleParam -obj $params -name "force" -type "bool" -default $false
+
+Function ConvertTo-UnixDate ($DateTimeObj) {
+   $epoch = [timezone]::CurrentTimeZone.ToLocalTime([datetime]'1/1/1970')
+   (New-TimeSpan -Start $epoch -End $PSdate).TotalSeconds
+}
+
+#update result object with AnsibleParams
+$result.state = $state
+$result.store = $store
+
+#check if certificate file is available and gather details about it like type, thumbprint, subject
+if (Test-Path -Path $path) {
+    $certExtension = ([IO.Path]::GetExtension($path)).ToLower()
+
+    #proceed according to the file extension
+    if ($certExtension -eq ".pfx" -or $certExtension -eq ".p12") {
+        try {
+            $certObj = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($path,(ConvertTo-SecureString -String $password -AsPlainText -Force))
+        }
+        catch {
+            #unable to load the certificate object, either the certificate is damaged or the password is incorrect
+            Fail-Json $result "Unable to gather certificate properties. Either the provided password is incorrect or the certificate file is corrupted. exception: $($error[0].Exception.Message)"
+        }
+    } elseif ($certExtension -eq ".cer" -or $certExtension -eq ".crt" -or $certExtension -eq ".p7b" -or $certExtension -eq ".spc") {
+        try {
+            $certObj = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2($path)
+        }
+        catch {
+            #unable to load the certificate object, either the certificate is damaged or the password is incorrect
+            Fail-Json $result "Unable to gather certificate properties. exception: $($error[0].Exception.Message)"
+        }
+        
+    } else {
+        #unkown or unsupported file extension
+        Fail-Json $result "Unkown or unsupported certificate file extension. extension: $($certExtension)"
+    }
+    $certThumbprint = $certObj.Thumbprint
+    $certSubject = $certObj.Subject
+    $certHasPK = $certObj.HasPrivateKey
+	$certNotValidBefore = ConvertTo-UnixDate($certObj.NotBefore)
+	$certNotValidAfter = ConvertTo-UnixDate($certObj.NotAfter)
+} else {
+    #certificate file not found
+    Fail-Json $result "Certificate file not found. path: $($path)"
+}
+
+#update result object with gathered cert facts
+$result.thumbprint = $certThumbprint
+$result.subject = $certSubject
+$result.hasPrivateKey = $certHasPK
+$result.notValidBefore = $certNotValidBefore
+$result.notValidAfter = $certNotValidAfter
+
+#choose action depending on desired state
+switch ($state) {
+    "present" {
+        #check if certificate is already imported
+        if (Test-Path -Path "Cert:\LocalMachine\$($store)\$($certThumbprint)") {
+            if (!$force) {
+                #the certificate is already present and we dont want to reimport (force = false)
+                $result.changed = $false
+                $result.msg = "Certificate is already present."
+                Exit-Json $result
+            }
+        }
+        if ($certExtension -eq ".pfx" -or $certExtension -eq ".p12") {
+            try {
+                #import the certificate to the desired store
+                if (!$check_mode) { $returnObj = Import-PfxCertificate -Exportable:$exportable -Password (ConvertTo-SecureString -String $password -AsPlainText -Force) `
+                            -CertStoreLocation "Cert:\LocalMachine\$($store)" -FilePath $path }
+                #complete module execution
+               	$result.changed = $true
+                $result.msg = "Certificate $($certThumbprint) successfully imported to store $($store)"
+                Exit-Json $result
+            }
+            catch {
+                #certificate import failed
+                Fail-Json $result "Certificate import failed. exception: $($error[0].Exception.Message)"
+            }
+                
+        } else {
+            try {
+                #import the certificate to the desired store
+                if (!$check_mode) { $returnObj = Import-Certificate -FilePath $path -CertStoreLocation "Cert:\LocalMachine\$($store)" }
+                #complete module execution
+                $result.changed = $true
+                $result.msg = "Certificate $($certThumbprint) successfully imported to store $($store)"
+        	    Exit-Json $result
+            }
+            catch {
+                #certificate import failed
+                Fail-Json $result "Certificate import failed. exception: $($error[0].Exception.Message)"
+            }        
+        }
+    }
+    "absent" {
+        #check if certificate is already imported
+        if (Test-Path -Path "Cert:\LocalMachine\$($store)\$($certThumbprint)") {
+            #certificate is present but the desired state is 'absent' - we're going to remove it
+            try {
+                if (!$check_mode) { $returnObj = Remove-Item -Path "Cert:\LocalMachine\$($store)\$($certThumbprint)" -Force }
+                #complete module execution
+                $result.changed = $true
+                $result.msg = "Certificate $($certThumbprint) successfully removed from the store $($store)"
+                Exit-Json $result
+            }
+            catch {
+                #certificate removal failed
+                Fail-Json $result "Certificate removal failed. exception: $($error[0].Exception.Message)"
+            }
+            
+        } else {
+            #complete module execution
+            $result.changed = $false
+            $result.msg = "Certificate $($certThumbprint) not present in store $($store)"
+            Exit-Json $result
+        }
+    }
+}

--- a/lib/ansible/modules/windows/win_certificate.py
+++ b/lib/ansible/modules/windows/win_certificate.py
@@ -27,10 +27,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = r'''
 ---
 module: win_certificate
-version_added: "2.3.1.0"
+version_added: "2.3"
 short_description: Manages certificates on a Windows machine
 description:
-  - The C(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store. 
+  - The M(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store. 
     The certificate needs to be copied to the node before you try to import/delte the certificate object, as the module needs to extract
     certificate facts from the cert file
     The following filetypes are supported *.pfx, *.p12, *.cer, *.crt, *.p7b, *.spc
@@ -125,10 +125,10 @@ thumbprint:
     type: string
     sample: 058C31261C8C5FD55831E0EC9E2E1041E4A03238
 subject:
-    description: sha1 checksum of the file after running copy
+    description: the certificate subject
     returned: success
     type: string
-    sample: *.myansible-demo.int
+    sample: "*.myansible-demo.int"
 hasPrivateKey:
     description: whether the certificate has a private key embedded
     returned: success

--- a/lib/ansible/modules/windows/win_certificate.py
+++ b/lib/ansible/modules/windows/win_certificate.py
@@ -27,17 +27,17 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = r'''
 ---
 module: win_certificate
-version_added: "2.3"
+version_added: "2.4"
 short_description: Manages certificates on a Windows machine
 description:
-  - The M(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store. 
+  - The M(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store.
     The certificate needs to be copied to the node before you try to import/delte the certificate object, as the module needs to extract
     certificate facts from the cert file
     The following filetypes are supported *.pfx, *.p12, *.cer, *.crt, *.p7b, *.spc
     If you want to import a certificate with private key included (PFX), you have to provide the certificate password.
 options:
   state:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - Specifies the desired state of the provided certificate.
     required: true
@@ -45,13 +45,13 @@ options:
       - present
       - absent
   path:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - The host local path to the certificate file.
         Usage "C:\Install\MyCert.pfx"
     required: true
   store:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - Specifies the path of the store to which certificates will be imported/deleted.
     required: true
@@ -61,12 +61,12 @@ options:
       - Root
       - CA
   password:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - Specifies the password for the imported certificate file.
     required: false
   privatekey_exportable:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - Specifies whether the imported private key can be exported. If this parameter is not specified, then the private key cannot be exported.
     required: false
@@ -75,7 +75,7 @@ options:
       - true
       - false
   force:
-    version_added: "2.3"
+    version_added: "2.4"
     description:
       - Defines if the certificate should be overwritten.
     required: false

--- a/lib/ansible/modules/windows/win_certificate.py
+++ b/lib/ansible/modules/windows/win_certificate.py
@@ -30,11 +30,11 @@ module: win_certificate
 version_added: "2.3.1.0"
 short_description: Manages certificates on a Windows machine
 description:
-- The C(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store. 
-  The certificate needs to be copied to the node before you try to import/delte the certificate object, as the module needs to extract
-  certificate facts from the cert file.abs
-  The following filetypes are supported: *.pfx, *.p12, *.cer, *.crt, *.p7b, *.spc
-  If you want to import a certificate with private key included (PFX), you have to provide the certificate password.
+  - The C(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store. 
+    The certificate needs to be copied to the node before you try to import/delte the certificate object, as the module needs to extract
+    certificate facts from the cert file
+    The following filetypes are supported *.pfx, *.p12, *.cer, *.crt, *.p7b, *.spc
+    If you want to import a certificate with private key included (PFX), you have to provide the certificate password.
 options:
   state:
     version_added: "2.3"
@@ -48,7 +48,7 @@ options:
     version_added: "2.3"
     description:
       - The host local path to the certificate file.
-        Usage: "C:\Install\MyCert.pfx"
+        Usage "C:\Install\MyCert.pfx"
     required: true
   store:
     version_added: "2.3"

--- a/lib/ansible/modules/windows/win_certificate.py
+++ b/lib/ansible/modules/windows/win_certificate.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Andre Bindewald(@tiwood)
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: win_certificate
+version_added: "2.3.1.0"
+short_description: Manages certificates on a Windows machine
+description:
+- The C(win_certificate) module can be used to import or remove certificates from the internal LocalMachine certificate store. 
+  The certificate needs to be copied to the node before you try to import/delte the certificate object, as the module needs to extract
+  certificate facts from the cert file.abs
+  The following filetypes are supported: *.pfx, *.p12, *.cer, *.crt, *.p7b, *.spc
+  If you want to import a certificate with private key included (PFX), you have to provide the certificate password.
+options:
+  state:
+    version_added: "2.3"
+    description:
+      - Specifies the desired state of the provided certificate.
+    required: true
+    choices:
+      - present
+      - absent
+  path:
+    version_added: "2.3"
+    description:
+      - The host local path to the certificate file.
+        Usage: "C:\Install\MyCert.pfx"
+    required: true
+  store:
+    version_added: "2.3"
+    description:
+      - Specifies the path of the store to which certificates will be imported/deleted.
+    required: true
+    choices:
+      - My
+      - TrustedPublisher
+      - Root
+      - CA
+  password:
+    version_added: "2.3"
+    description:
+      - Specifies the password for the imported certificate file.
+    required: false
+  privatekey_exportable:
+    version_added: "2.3"
+    description:
+      - Specifies whether the imported private key can be exported. If this parameter is not specified, then the private key cannot be exported.
+    required: false
+    default: false
+    choices:
+      - true
+      - false
+  force:
+    version_added: "2.3"
+    description:
+      - Defines if the certificate should be overwritten.
+    required: false
+    default: false
+    choices:
+      - true
+      - false
+author: "Andre Bindewald (@tiwood)"
+'''
+
+EXAMPLES = r'''
+- name: Import a certificate with embedded private key to the personal local machine store.
+  win_certificate:
+      state: present
+      path: C:\foo\Certificate.pfx
+      store: My
+      password: mypasswd
+- name: Import a certificate with embedded private key to the personal local machine store. (Private key exportable)
+  win_certificate:
+      state: present
+      path: C:\foo\Certificate.pfx
+      store: TrustedPublisher
+      password: mypasswd
+      privatekey_exportable: true
+- name: Import a trusted Root CA certificate.
+  win_certificate:
+      state: present
+      path: C:\foo\TrustedRootCertificate.cer
+      store: TrustedPublisher
+- name: Ensure a specific certificate is absent on the personal machine store.
+  win_certificate:
+      state: absent
+      path: C:\foo\Certificate.pfx
+      store: My
+      password: mypasswd
+'''
+
+RETURN = r'''
+state:
+    description: whether the certificate should be present or absent
+    returned: always
+    type: string
+    sample: present
+thumbprint:
+    description: thumbprint of the certificate
+    returned: success
+    type: string
+    sample: 058C31261C8C5FD55831E0EC9E2E1041E4A03238
+subject:
+    description: sha1 checksum of the file after running copy
+    returned: success
+    type: string
+    sample: *.myansible-demo.int
+hasPrivateKey:
+    description: whether the certificate has a private key embedded
+    returned: success
+    type: bool
+    sample: true
+store:
+    description: the store where the certificate is located
+    returned: success
+    type: string
+    sample: My
+notValidBefore:
+    description: unix timestamp of the ValidBefore certificate property
+    returned: success
+    type: string
+    sample: 1639440000
+notValidAfter:
+    description: tunix timestamp of the ValidBefore certificate property
+    returned: success
+    type: string
+    sample: 1639440000
+'''


### PR DESCRIPTION
##### SUMMARY
PowerShell based module 'win_certificate' for Windows certificate management.
The win_certificate module can be used to import or remove certificates from the internal LocalMachine certificate store. 
The following filetypes are supported: *.pfx, *.p12, *.cer, *.crt, *.p7b, *.spc

Example:
```yaml
- name: Import a certificate with embedded private key to the personal local machine store.
  win_certificate:
      state: present
      path: C:\foo\Certificate.pfx
      store: My
      password: mypasswd
```

##### ISSUE TYPE
New Module Pull Request


##### COMPONENT NAME
win_certificate

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION