### PR TITLE
Fix that only first 400 ELBs are returned in ec2_elb_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
@@ -214,7 +214,7 @@ class ElbInformation(object):
         get_elb_with_backoff = AWSRetry.backoff(tries=5, delay=5, backoff=2.0)(self.connection.get_all_load_balancers)
         while True:
             all_elbs = get_elb_with_backoff(marker=token)
-            token = all_elbs.next_token
+            token = all_elbs.next_marker
 
             if all_elbs:
                 if self.names:


### PR DESCRIPTION
##### SUMMARY
`ec2_elb_facts` module is using `get_all_load_balancers` of boto to get all ELBs in one account without filtering. This boto call returns first 400 ELBs and a pagination marker if there is more than 400 ELBs. Current logic tries to use the marker to get remaining ELBs, but it is incorrectly using `next_token` instead of the correct one `next_marker`.

[Boto's document](http://boto.cloudhackers.com/en/latest/ref/elb.html#boto.ec2.elb.ELBConnection.get_all_load_balancers) fails to point out this, but [boto3's document](http://boto3.readthedocs.io/en/latest/reference/services/elb.html#ElasticLoadBalancing.Client.describe_load_balancers) did mention in a similar method that `NextMarker` is correct. In addition, [ELB API Reference](http://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html) also shows that `NextMarker` is returned.

There is a similar issue in `ec2_elb` module: https://github.com/ansible/ansible-modules-core/issues/2115. And the pull request fixing that is correctly using `next_marker`: https://github.com/ansible/ansible-modules-core/pull/2484/files#diff-bb0040f25b71a42fa79f277d81cd2bc3R268.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_elb_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 3f17e87c5a) last updated 2017/06/18 10:52:44 (GMT +900)
```


##### ADDITIONAL INFORMATION
```

```