### PR TITLE
Add external-dir argument for facter module (Issue #25839)

### DIFF
--- a/lib/ansible/modules/system/facter.py
+++ b/lib/ansible/modules/system/facter.py
@@ -39,12 +39,17 @@ from ansible.module_utils.basic import AnsibleModule
 
 def main():
     module = AnsibleModule(
-        argument_spec=dict()
+        argument_spec = dict(
+            external_dir = dict(required=False, type='str')
+        )
     )
 
     facter_path = module.get_bin_path('facter', opt_dirs=['/opt/puppetlabs/bin'])
 
     cmd = [facter_path, "--json"]
+
+    if module.params['external_dir']:
+        cmd += ["--external_dir", module.params['external_dir'].strip()]
 
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))


### PR DESCRIPTION
##### SUMMARY

Fixes #25839 
Adds external_dir argument for facter module

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
facter module

##### ANSIBLE VERSION
```
> ansible --version
ansible 2.2.2.0
  config file =
  configured module search path = Default w/o overrides
```

##### ADDITIONAL INFORMATION

```
> ansible -i hosts test-host -m facter -a 'external_dir=/etc/facts.d'
mytesthost | FAILED >> {
    "failed": true,
    "msg": "unsupported parameter for module: external_dir"
}
```

This feature adds support for gathering facts from facter external_dir