### PR TITLE
Correct failure message in flowdock

### DIFF
--- a/lib/ansible/modules/notification/flowdock.py
+++ b/lib/ansible/modules/notification/flowdock.py
@@ -156,7 +156,7 @@ def main():
         else:
             params['external_user_name'] = module.params["external_user_name"]
     elif type == 'chat':
-        module.fail_json(msg="%s is required for the 'inbox' type" % item)
+        module.fail_json(msg="external_user_name is required for the 'chat' type")
 
     # required params for the 'inbox' type
     for item in [ 'from_address', 'source', 'subject' ]:


### PR DESCRIPTION
##### SUMMARY
As per documentation and code, external_user_name is
required parameter is case of type 'chat'.
Fix corrects error message displayed to user.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/notification/flowdock.py

##### ANSIBLE VERSION
```
2.4 devel
```