### PR TITLE
Use correct variable from response in github_key

### DIFF
--- a/lib/ansible/modules/source_control/github_key.py
+++ b/lib/ansible/modules/source_control/github_key.py
@@ -108,7 +108,7 @@ class GitHubResponse(object):
     def links(self):
         links = {}
         if 'link' in self.info:
-            link_header = re.info['link']
+            link_header = self.info['link']
             matches = re.findall('<([^>]+)>; rel="([^"]+)"', link_header)
             for url, rel in matches:
                 links[rel] = url


### PR DESCRIPTION
##### SUMMARY
Before fix, logic tries to access info from 're' library
which raises AttributeError.
Fix adds correct variable usage for accessing next/previous
search results from github api.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/github_key.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```