### PR TITLE
Correct usage of fail_json in hg module

### DIFF
--- a/lib/ansible/modules/source_control/hg.py
+++ b/lib/ansible/modules/source_control/hg.py
@@ -157,7 +157,7 @@ class Hg(object):
     def get_remote_revision(self):
         (rc, out, err) = self._command(['id', self.repo])
         if rc != 0:
-            self.module_fail_json(msg=err)
+            self.module.fail_json(msg=err)
         else:
             return to_native(out).strip('\n')
 

--- a/test/integration/targets/hg/tasks/main.yml
+++ b/test/integration/targets/hg/tasks/main.yml
@@ -72,3 +72,15 @@
   assert:
     that:
       - "not hg_result2.changed"
+
+- name: Checkout non-existent repo clone
+  hg: repo=https://bitbucket.org/pyro46/pythonscript_1 clone=no update=no
+  register: hg_result3
+  ignore_errors: true
+
+- name: Verify result of non-existent repo clone
+  assert:
+    that:
+      - hg_result3.msg
+      - "'abort: HTTP Error 404: Not Found' in hg_result3.msg"
+      - "not hg_result3.changed"


### PR DESCRIPTION
##### SUMMARY
Fix adds correct usage for fail_json and also adds
testcases to verify this.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/hg.py
test/integration/targets/hg/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```