### PR TITLE
FIX: ipa modules never updated to use 'name' attributes such as cn, uid, f…

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_group.py
+++ b/lib/ansible/modules/identity/ipa/ipa_group.py
@@ -207,7 +207,7 @@ def get_group_diff(client, ipa_group, module_group):
 
 def ensure(module, client):
     state = module.params['state']
-    name = module.params['name']
+    name = module.params['cn']
     group = module.params['group']
     user = module.params['user']
 

--- a/lib/ansible/modules/identity/ipa/ipa_hbacrule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hbacrule.py
@@ -241,7 +241,7 @@ def get_hbcarule_diff(client, ipa_hbcarule, module_hbcarule):
 
 
 def ensure(module, client):
-    name = module.params['name']
+    name = module.params['cn']
     state = module.params['state']
 
     if state in ['present', 'enabled']:

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -222,7 +222,7 @@ def get_host_diff(client, ipa_host, module_host):
 
 
 def ensure(module, client):
-    name = module.params['name']
+    name = module.params['fqdn']
     state = module.params['state']
 
     ipa_host = client.host_find(name=name)

--- a/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_hostgroup.py
@@ -170,7 +170,7 @@ def get_hostgroup_diff(client, ipa_hostgroup, module_hostgroup):
 
 
 def ensure(module, client):
-    name = module.params['name']
+    name = module.params['cn']
     state = module.params['state']
     host = module.params['host']
     hostgroup = module.params['hostgroup']

--- a/lib/ansible/modules/identity/ipa/ipa_role.py
+++ b/lib/ansible/modules/identity/ipa/ipa_role.py
@@ -237,7 +237,7 @@ def get_role_diff(client, ipa_role, module_role):
 
 def ensure(module, client):
     state = module.params['state']
-    name = module.params['name']
+    name = module.params['cn']
     group = module.params['group']
     host = module.params['host']
     hostgroup = module.params['hostgroup']

--- a/lib/ansible/modules/identity/ipa/ipa_sudocmdgroup.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudocmdgroup.py
@@ -150,7 +150,7 @@ def get_sudocmdgroup_diff(client, ipa_sudocmdgroup, module_sudocmdgroup):
 
 
 def ensure(module, client):
-    name = module.params['name']
+    name = module.params['cn']
     state = module.params['state']
     sudocmd = module.params['sudocmd']
 

--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -273,7 +273,7 @@ def category_changed(module, client, category_name, ipa_sudorule):
 
 def ensure(module, client):
     state = module.params['state']
-    name = module.params['name']
+    name = module.params['cn']
     cmd = module.params['cmd']
     cmdcategory = module.params['cmdcategory']
     host = module.params['host']

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -252,7 +252,7 @@ def get_ssh_key_fingerprint(ssh_key):
 
 def ensure(module, client):
     state = module.params['state']
-    name = module.params['name']
+    name = module.params['uid']
     nsaccountlock = state == 'disabled'
 
     module_user = get_user_dict(displayname=module.params.get('displayname'),


### PR DESCRIPTION
##### SUMMARY
When using the 'ipa' modules recently I noticed that many of them were broken. It seems that at some point, there was an update to the modules that changed the 'name' attribute of the module to more specific things, such as:
```python
uid=dict(type='str', required=True, aliases=['name']),
```
In the ipa_user.py module. 

However ensure() was never updated to use the new attribute and would fail. Changing ensure() in that module to:
```python
def ensure(module, client):
    state = module.params['state']
    name = module.params['uid']
```

Fixes the problem.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/identity/ipa/ipa_group.py
lib/ansible/modules/identity/ipa/ipa_hbacrule.py
lib/ansible/modules/identity/ipa/ipa_host.py
lib/ansible/modules/identity/ipa/ipa_hostgroup.py
lib/ansible/modules/identity/ipa/ipa_role.py
lib/ansible/modules/identity/ipa/ipa_sudocmdgroup.py
lib/ansible/modules/identity/ipa/ipa_sudorule.py
lib/ansible/modules/identity/ipa/ipa_user.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
```


##### ADDITIONAL INFORMATION
I also have another path to the ipa_host module that adds support for one time passwords. It just adds the user_password attribute to the host in support of otp with an alias. I thought it best to open a feature enhancement pr for that instead of combining it into this bugfix.