### PR TITLE
cs_host: revamp fixes serveral issues

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_host.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_host.py
@@ -36,7 +36,14 @@ options:
     description:
       - Name of the host.
     required: true
-    aliases: [ 'url', 'ip_address' ]
+    aliases: [ 'ip_address' ]
+  url:
+    description:
+      - Url of the host used to create a host.
+      - If not provided, C(http://) and param C(name) is used as url.
+      - Only considered if C(state=present) and host does not yet exist.
+    required: false
+    default: null
   username:
     description:
       - Username for the host.
@@ -301,6 +308,11 @@ resource_state:
   returned: success
   type: string
   sample: Enabled
+allocation_state::
+  description: Allocation state of the host.
+  returned: success
+  type: string
+  sample: enabled
 state:
   description: State of the host.
   returned: success
@@ -335,7 +347,14 @@ zone:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.cloudstack import AnsibleCloudStack, CloudStackException, cs_argument_spec, cs_required_together, CS_HYPERVISORS
+from ansible.module_utils.cloudstack import (
+    AnsibleCloudStack,
+    CloudStackException,
+    cs_argument_spec,
+    cs_required_together,
+    CS_HYPERVISORS
+)
+import time
 
 
 class AnsibleCloudStackHost(AnsibleCloudStack):
@@ -360,7 +379,6 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
             'events': 'events',
             'hahost': 'ha_host',
             'hasenoughcapacity': 'has_enough_capacity',
-            'hosttags': 'host_tags',
             'hypervisor': 'hypervisor',
             'hypervisorversion': 'hypervisor_version',
             'ipaddress': 'ip_address',
@@ -381,12 +399,12 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
             'type': 'host_type',
             'version': 'host_version',
             'gpugroup': 'gpu_group',
-
         }
         self.allocation_states = {
-            'enabled': 'enable',
-            'disabled': 'disable',
+            'enabled': 'Enable',
+            'disabled': 'Disable',
         }
+        self.host = None
 
     def get_pod(self, key=None):
         pod_name = self.module.params.get('pod')
@@ -426,8 +444,10 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
             return None
         return self.allocation_states[allocation_state]
 
-    def get_host(self):
-        host = None
+    def get_host(self, refresh=False):
+        if self.host is not None and not refresh:
+            return self.host
+
         name = self.module.params.get('name')
         args = {
             'zoneid': self.get_zone(key='id'),
@@ -436,8 +456,8 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
         if res:
             for h in res['host']:
                 if name in [h['ipaddress'], h['name']]:
-                    host = h
-        return host
+                    self.host = h
+        return self.host
 
     def present_host(self):
         host = self.get_host()
@@ -446,6 +466,13 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
         else:
             host = self._update_host(host)
         return host
+
+    def _get_url(self):
+        url = self.module.params.get('url')
+        if url:
+            return url
+        else:
+            return "http://%s" % self.module.params.get('name')
 
     def _create_host(self, host):
         required_params = [
@@ -458,7 +485,7 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
         self.result['changed'] = True
         args = {
             'hypervisor': self.module.params.get('hypervisor'),
-            'url': self.module.params.get('name'),
+            'url': self._get_url(),
             'username': self.module.params.get('username'),
             'password': self.module.params.get('password'),
             'podid': self.get_pod(key='id'),
@@ -471,24 +498,24 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
             host = self.cs.addHost(**args)
             if 'errortext' in host:
                 self.module.fail_json(msg="Failed: '%s'" % host['errortext'])
-            host = host['host']
+            host = host['host'][0]
         return host
 
     def _update_host(self, host):
         args = {
             'id': host['id'],
             'hosttags': self.get_host_tags(),
-            'allocationstate': self.module.params.get('allocation_state'),
+            'allocationstate': self.get_allocation_state()
         }
-        host['allocationstate'] = host['resourcestate'].lower()
+        host['allocationstate'] = self.allocation_states[host['resourcestate'].lower()]
         if self.has_changed(args, host):
-            args['allocationstate'] = self.get_allocation_state()
             self.result['changed'] = True
             if not self.module.check_mode:
                 host = self.cs.updateHost(**args)
                 if 'errortext' in host:
                     self.module.fail_json(msg="Failed: '%s'" % host['errortext'])
                 host = host['host']
+
         return host
 
     def absent_host(self):
@@ -499,16 +526,51 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
                 'id': host['id'],
             }
             if not self.module.check_mode:
-                res = self.cs.deleteHost(**args)
+                res = self.enable_maintenance()
+                if res:
+                    res = self.cs.deleteHost(**args)
+                    if 'errortext' in res:
+                        self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+        return host
+
+    def enable_maintenance(self):
+        host = self.get_host()
+        if host['resourcestate'] not in ['PrepareForMaintenance', 'Maintenance']:
+            self.result['changed'] = True
+            args = {
+                'id': host['id'],
+            }
+            if not self.module.check_mode:
+                res = self.cs.prepareHostForMaintenance(**args)
                 if 'errortext' in res:
                     self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+                host = self.poll_job(res, 'host')
+                self._poll_for_maintenance()
         return host
+
+    def _poll_for_maintenance(self):
+        for i in range(0, 300):
+            time.sleep(2)
+            host = self.get_host(refresh=True)
+            if not host:
+                return None
+            elif host['resourcestate'] != 'PrepareForMaintenance':
+                return host
+        self.fail_json("Polling for maintenance timed out")
+
+    def get_result(self, host):
+        super(AnsibleCloudStackHost, self).get_result(host)
+        if host:
+            self.result['allocation_state'] = host['resourcestate'].lower()
+            self.result['host_tags'] = host['hosttags'].split(',') if host.get('hosttags') else []
+        return self.result
 
 
 def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
-        name=dict(required=True, aliases=['url', 'ip_address']),
+        name=dict(required=True, aliases=['ip_address']),
+        url=dict(),
         password=dict(default=None, no_log=True),
         username=dict(default=None),
         hypervisor=dict(choices=CS_HYPERVISORS, default=None),

--- a/test/integration/targets/cs_host/aliases
+++ b/test/integration/targets/cs_host/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+posix/ci/cloud/cs

--- a/test/integration/targets/cs_host/meta/main.yml
+++ b/test/integration/targets/cs_host/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_host/tasks/main.yml
+++ b/test/integration/targets/cs_host/tasks/main.yml
@@ -1,0 +1,296 @@
+---
+- name: test fail missing params
+  cs_host:
+  register: host
+  ignore_errors: true
+- name: verify test fail missing url if host is not existent
+  assert:
+    that:
+      - host|failed
+      - 'host.msg == "missing required arguments: name"'
+
+- name: test fail missing params if host is not existent
+  cs_host:
+    name: sim
+  register: host
+  ignore_errors: true
+- name: verify test fail missing params if host is not existent
+  assert:
+    that:
+      - host|failed
+      - 'host.msg == "missing required arguments: password,username,hypervisor,pod"'
+
+- name: test create a host in check mode
+  cs_host:
+    name: sim
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: root
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags:
+    - perf
+    - gpu
+  register: host
+  check_mode: true
+- name: verify test create a host in check mode
+  assert:
+    that:
+      - host|changed
+
+- name: test create a host
+  cs_host:
+    name: sim
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: root
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags:
+    - perf
+    - gpu
+  register: host
+- name: verify test create a host
+  assert:
+    that:
+      - host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - "host.name.startswith('SimulatedAgent.')"
+      - host.host_tags == ['perf', 'gpu']
+
+# This is special in simulator mode, we can not predict the full hostname.
+# That is why we gather the infos from the returns and use a fact.
+- name: assume the sim would resolve to the IP address
+  set_fact:
+    host_hostname: "{{ host.name }}"
+    host_ip_address: "{{ host.ip_address }}"
+
+- name: test create a host idempotence
+  cs_host:
+    name: "{{ host_hostname }}"
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: admin
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags:
+    - perf
+    - gpu
+  register: host
+- name: verify test create a host idempotence
+  assert:
+    that:
+      - not host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+      - host.host_tags == ['perf', 'gpu']
+
+- name: test update host in check mode
+  cs_host:
+    name: "{{ host_hostname }}"
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: admin
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags:
+    - perf
+    - gpu
+    - x2
+  register: host
+  check_mode: true
+- name: verify test update a host in check mode
+  assert:
+    that:
+      - host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+      - host.host_tags == ['perf', 'gpu']
+
+- name: test update host
+  cs_host:
+    name: "{{ host_hostname }}"
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: admin
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags:
+    - perf
+    - gpu
+    - x2
+  register: host
+- name: verify test update a host in check mode
+  assert:
+    that:
+      - host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+      - host.host_tags == ['perf', 'gpu', 'x2']
+
+- name: test update host idempotence
+  cs_host:
+    name: "{{ host_hostname }}"
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: admin
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags:
+    - perf
+    - gpu
+    - x2
+  register: host
+- name: verify test update a host idempotence
+  assert:
+    that:
+      - not host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+      - host.host_tags == ['perf', 'gpu', 'x2']
+
+# FIXME: Removing by empty list seems to be an issue in the used lib cs underneath, disabled
+- name: test update host remove host_tags
+  cs_host:
+    name: "{{ host_hostname }}"
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: admin
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags: []
+  register: host
+  when: false
+- name: verify test update host remove host_tags
+  assert:
+    that:
+      - host|changed
+      - host.host_tags|length == 0
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+  when: false
+
+# FIXME: Removing by empty list seems to be an issue in the used lib cs underneath, disabled
+- name: test update host remove host_tags idempotence
+  cs_host:
+    name: "{{ host_hostname }}"
+    url: "http://sim/c0-basic/h2"
+    cluster: C0-basic
+    pod: POD0-basic
+    username: admin
+    password: password
+    hypervisor: Simulator
+    allocation_state: enabled
+    host_tags: []
+  register: host
+  when: false
+- name: verify test update host remove host_tags idempotence
+  assert:
+    that:
+      - not host|changed
+      - len(host.host_tags) == 0
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+  when: false
+
+- name: test remove host in check mode
+  cs_host:
+    name: "{{ host_hostname }}"
+    cluster: C0-basic
+    pod: POD0-basic
+    state: absent
+  check_mode: true
+  register: host
+- name: verify test remove a host in check mode
+  assert:
+    that:
+      - host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+      - host.host_tags == ['perf', 'gpu', 'x2']
+
+- name: test remove host
+  cs_host:
+    name: "{{ host_hostname }}"
+    cluster: C0-basic
+    pod: POD0-basic
+    state: absent
+  register: host
+- name: verify test remove a host
+  assert:
+    that:
+      - host|changed
+      - host.cluster == 'C0-basic'
+      - host.pod == 'POD0-basic'
+      - host.hypervisor == 'Simulator'
+      - host.allocation_state == 'enabled'
+      - host.zone == 'Sandbox-simulator-basic'
+      - host.state == 'Up'
+      - host.name == '{{ host_hostname }}'
+      - host.host_tags == ['perf', 'gpu', 'x2']
+
+- name: test remove host idempotence
+  cs_host:
+    name: "{{ host_hostname }}"
+    cluster: C0-basic
+    pod: POD0-basic
+    state: absent
+  register: host
+- name: verify test remove a host idempotenc
+  assert:
+    that:
+      - not host|changed


### PR DESCRIPTION
##### SUMMARY
After having a proper CI for creating hosts, several issues has been identified and fixed. This fix has been kept as small as possible and will be backported to 2.3. stable (excluding tests).

There are disabled tests cases for host tags due to issues with the library cs underneath. These tests will be enabled, as soon as the issue is fixed upstream.

- Allocation state could not be changed. closes #25645 fixes #25644 
- Fix Host idempotency, url only used for creation and not returned from API. (That is why I separated out this param) closes #25641 fixes #25642 
- Remove Host error-ed out due to host not in maintenance. 
- When adding a host, the result is return as list.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cs_host

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
