### PR TITLE
2.3bug20202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Ansible Changes By Release
 * Corrected requried on hash_name for dynamodb_table
 * Fix for fetch action plugin not validating correctly
 * Avoid vault view writing display to logs
+* htpasswd: fix passlib module version comparison
 
 ## 2.3.1 "Ramble On" - 2017-06-01
 

--- a/lib/ansible/modules/web_infrastructure/htpasswd.py
+++ b/lib/ansible/modules/web_infrastructure/htpasswd.py
@@ -104,7 +104,7 @@ EXAMPLES = """
 
 import os
 import tempfile
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 
 try:
     from passlib.apache import HtpasswdFile, htpasswd_context
@@ -138,7 +138,7 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         if check_mode:
             return ("Create %s" % dest, True)
         create_missing_directories(dest)
-        if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
+        if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
             ht = HtpasswdFile(dest, new=True, default_scheme=crypt_scheme, context=context)
         else:
             ht = HtpasswdFile(dest, autoload=False, default=crypt_scheme, context=context)
@@ -149,7 +149,7 @@ def present(dest, username, password, crypt_scheme, create, check_mode):
         ht.save()
         return ("Created %s and added %s" % (dest, username), True)
     else:
-        if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
+        if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
             ht = HtpasswdFile(dest, new=False, default_scheme=crypt_scheme, context=context)
         else:
             ht = HtpasswdFile(dest, default=crypt_scheme, context=context)
@@ -176,7 +176,7 @@ def absent(dest, username, check_mode):
     """ Ensures user is absent
 
     Returns (msg, changed) """
-    if StrictVersion(passlib.__version__) >= StrictVersion('1.6'):
+    if LooseVersion(passlib.__version__) >= LooseVersion('1.6'):
         ht = HtpasswdFile(dest, new=False)
     else:
         ht = HtpasswdFile(dest)


### PR DESCRIPTION
##### SUMMARY

Previously, we used StrictVersion which failed to parse some passlib
version strings. For example, Debian currently ship passlib with a
__version__ of '1.7.0.post20161128115349'

StrictVersion throws an exception when parsing this version string.

Change to using LooseVersion which successfully parses version strings
such as this.

Fixes #20199

Original PR https://github.com/ansible/ansible/pull/20202

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
htpasswd

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
