### PR TITLE
route53: document state choices added in 2.4 - fixes #25061

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -30,7 +30,7 @@ options:
   state:
     description:
       - Specifies the state of the resource record. As of Ansible 2.4, the I(command) option has been changed
-        to I(state) as default, but I(command) still works as well.
+        to I(state) as default and the choices 'present' and 'absent' have been added, but I(command) still works as well.
     required: true
     aliases: [ 'command' ]
     choices: [ 'present', 'absent', 'get', 'create', 'delete' ]


### PR DESCRIPTION
##### SUMMARY
Fixes #25061

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/route53.py

##### ANSIBLE VERSION
```
2.4.0
```

