### PR TITLE
2.3bug25844flowdock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Ansible Changes By Release
 * Fix for fetch action plugin not validating correctly
 * Avoid vault view writing display to logs
 * htpasswd: fix passlib module version comparison
+* Fix for flowdock error message when external_user_name is missing
 
 ## 2.3.1 "Ramble On" - 2017-06-01
 

--- a/lib/ansible/modules/notification/flowdock.py
+++ b/lib/ansible/modules/notification/flowdock.py
@@ -156,7 +156,7 @@ def main():
         else:
             params['external_user_name'] = module.params["external_user_name"]
     elif type == 'chat':
-        module.fail_json(msg="%s is required for the 'inbox' type" % item)
+        module.fail_json(msg="external_user_name is required for the 'chat' type")
 
     # required params for the 'inbox' type
     for item in [ 'from_address', 'source', 'subject' ]:


### PR DESCRIPTION
##### SUMMARY
As per documentation and code, external_user_name is
required parameter is case of type 'chat'.
Fix corrects error message displayed to user.

Cherry picked from https://github.com/ansible/ansible/pull/25844

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
flowdock

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
