### PR TITLE
consul: Always fail if no service_name was provided.

### DIFF
--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -397,8 +397,8 @@ def parse_service(module):
             module.params.get('service_port'),
             module.params.get('tags'),
         )
-    elif module.params.get('service_port') and not module.params.get('service_name'):
-        module.fail_json(msg="service_port supplied but no service_name, a name is required to configure a service.")
+    elif not module.params.get('service_name'):
+        module.fail_json(msg="service_name is required to configure a service.")
 
 
 class ConsulService():

--- a/test/integration/roles/test_consul_service/tasks/main.yml
+++ b/test/integration/roles/test_consul_service/tasks/main.yml
@@ -47,6 +47,17 @@
         - basic2_result.service_id == 'service2'
         - basic2_result.service_name == 'Basic Service'
 
+- name: register service without name
+  consul:
+    service_id: this_will_fail
+  register: noname_result
+  ignore_errors: True
+
+- name: verify registering service without name fails
+  assert:
+    that:
+        - noname_result | failed
+
 - name: register very basic service without service_port
   consul:
     service_name: Basic Service Without Port


### PR DESCRIPTION
Fixes a subtile bug introduced in PR #21737
I noticed this after looking at my 4 months old patch again that just got merged :)

##### SUMMARY
Previously, the consul module would only error out if there was a service_port provided, but no service_name.
But service_name is always required, common mistake would be e.g. to provide service_id but no service_name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
consul

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
I also added a test for this behaviour.