### PR TITLE
Ensure hosts aren't duplicated in groups

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -231,7 +231,7 @@ class InventoryData(object):
         else:
             h = self.hosts[host]
 
-        if g and host not in g.get_hosts():
+        if g and h not in g.get_hosts():
             g.add_host(h)
             self._groups_dict_cache = {}
             display.debug("Added host %s to group %s" % (host, group))

--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -112,7 +112,8 @@ class Group:
             raise AnsibleError("The group named '%s' has a recursive dependency loop." % self.name)
 
     def add_host(self, host):
-
+        if host in self.hosts:
+            return
         self.hosts.append(host)
         host.add_group(self)
         self.clear_hosts_cache()


### PR DESCRIPTION
##### SUMMARY

While playing around in inventory, I noticed that the same host was being added numerous times to the list of hosts in a group.

This PR should prevent that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

I'll make some comments directly on the code for some additional insight.