### PR TITLE
properly track delegated host in loops

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -628,7 +628,7 @@ class TaskExecutor:
         delegated_vars = variables.get('ansible_delegated_vars', dict()).get(self._task.delegate_to, dict()).copy()
         if len(delegated_vars) > 0:
             result["_ansible_delegated_vars"] = dict()
-            for k in ('ansible_delegated_host', 'ansible_host' ):
+            for k in ('ansible_delegated_host', 'ansible_host'):
                 result["_ansible_delegated_vars"][k] = delegated_vars.get(k)
 
         # and return

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -628,7 +628,7 @@ class TaskExecutor:
         delegated_vars = variables.get('ansible_delegated_vars', dict()).get(self._task.delegate_to, dict()).copy()
         if len(delegated_vars) > 0:
             result["_ansible_delegated_vars"] = dict()
-            for k in ('ansible_host', ):
+            for k in ('ansible_delegated_host', 'ansible_host' ):
                 result["_ansible_delegated_vars"][k] = delegated_vars.get(k)
 
         # and return

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -245,7 +245,7 @@ class StrategyBase:
         return host_list
 
     def get_delegated_hosts(self, result, task):
-        host_name = result.get('_ansible_delegated_vars', {}).get('ansible_host', None)
+        host_name = result.get('_ansible_delegated_vars', {}).get('ansible_delegated_host', None)
         if host_name is not None:
             actual_host = self._inventory.get_host(host_name)
             if actual_host is None:

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -525,7 +525,7 @@ class VariableManager:
 
             new_delegated_host_vars = dict(
                 ansible_delegated_host=delegated_host_name,
-                ansible_host=delegated_host_name, #  not redundant as other sources can change ansible_host
+                ansible_host=delegated_host_name,  # not redundant as other sources can change ansible_host
                 ansible_port=new_port,
                 ansible_user=C.DEFAULT_REMOTE_USER,
                 ansible_connection=C.DEFAULT_TRANSPORT,

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -524,7 +524,8 @@ class VariableManager:
                 new_port = 5986
 
             new_delegated_host_vars = dict(
-                ansible_host=delegated_host_name,
+                ansible_delegated_host=delegated_host_name,
+                ansible_host=delegated_host_name, #  not redundant as other sources can change ansible_host
                 ansible_port=new_port,
                 ansible_user=C.DEFAULT_REMOTE_USER,
                 ansible_connection=C.DEFAULT_TRANSPORT,


### PR DESCRIPTION
##### SUMMARY
`ansible_host` can be pulled from inventory and not match `inventory_hostname`,
this can "lose" vars to a new host named by `ansible_host` vs the delegated host
fixes #25770


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
  - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
delegate_to
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

##### ADDITIONAL INFORMATION
Builds on previous fix for `delegate_to` depending on `with_`, avoids corner case