### PR TITLE
Deprecate monolithic logicmonitor modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,8 @@ Ansible Changes By Release
   * cl_interface_policy
   * cl_license
   * cl_ports
+  * logicmonitor
+  * logicmonitor_facts
   * nxos_mtu, use nxos_system instead
 
 #### New: Callbacks

--- a/lib/ansible/modules/monitoring/_logicmonitor.py
+++ b/lib/ansible/modules/monitoring/_logicmonitor.py
@@ -29,7 +29,7 @@ success:
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -41,6 +41,7 @@ description:
   - LogicMonitor is a hosted, full-stack, infrastructure monitoring platform.
   - This module manages hosts, host groups, and collectors within your LogicMonitor account.
 version_added: "2.2"
+deprecated: Deprecated in 2.4. Use M(logicmonitor_device) instead.
 author: [Ethan Culler-Mayeno (@ethanculler), Jeff Wozniak (@woz5999)]
 notes:
   - You must have an existing LogicMonitor account for this module to function.

--- a/lib/ansible/modules/monitoring/_logicmonitor.py
+++ b/lib/ansible/modules/monitoring/_logicmonitor.py
@@ -556,7 +556,6 @@ except ImportError:
         HAS_LIB_JSON = False
 
 
-
 class LogicMonitor(object):
 
     def __init__(self, module, **params):
@@ -1037,18 +1036,18 @@ class Collector(LogicMonitor):
             else:
                 self.fail(msg="Error: Unable to retrieve timezone offset")
 
-        offsetend = offsetstart + datetime.timedelta(0, int(duration)*60)
+        offsetend = offsetstart + datetime.timedelta(0, int(duration) * 60)
 
         h = {"agentId": self.id,
              "type": 1,
              "notifyCC": True,
              "year": offsetstart.year,
-             "month": offsetstart.month-1,
+             "month": offsetstart.month - 1,
              "day": offsetstart.day,
              "hour": offsetstart.hour,
              "minute": offsetstart.minute,
              "endYear": offsetend.year,
-             "endMonth": offsetend.month-1,
+             "endMonth": offsetend.month - 1,
              "endDay": offsetend.day,
              "endHour": offsetend.hour,
              "endMinute": offsetend.minute}
@@ -1478,7 +1477,7 @@ class Host(LogicMonitor):
                     self.fail(
                         msg="Error: Unable to retrieve timezone offset")
 
-            offsetend = offsetstart + datetime.timedelta(0, int(duration)*60)
+            offsetend = offsetstart + datetime.timedelta(0, int(duration) * 60)
 
             h = {"hostId": self.info["id"],
                  "type": 1,
@@ -1712,18 +1711,18 @@ class Datasource(LogicMonitor):
             else:
                 self.fail(msg="Error: Unable to retrieve timezone offset")
 
-        offsetend = offsetstart + datetime.timedelta(0, int(duration)*60)
+        offsetend = offsetstart + datetime.timedelta(0, int(duration) * 60)
 
         h = {"hostDataSourceId": self.id,
              "type": 1,
              "notifyCC": True,
              "year": offsetstart.year,
-             "month": offsetstart.month-1,
+             "month": offsetstart.month - 1,
              "day": offsetstart.day,
              "hour": offsetstart.hour,
              "minute": offsetstart.minute,
              "endYear": offsetend.year,
-             "endMonth": offsetend.month-1,
+             "endMonth": offsetend.month - 1,
              "endDay": offsetend.day,
              "endHour": offsetend.hour,
              "endMinute": offsetend.minute}
@@ -1974,17 +1973,17 @@ class Hostgroup(LogicMonitor):
                 self.fail(
                     msg="Error: Unable to retrieve timezone offset")
 
-        offsetend = offsetstart + datetime.timedelta(0, int(duration)*60)
+        offsetend = offsetstart + datetime.timedelta(0, int(duration) * 60)
 
         h = {"hostGroupId": self.info["id"],
              "type": 1,
              "year": offsetstart.year,
-             "month": offsetstart.month-1,
+             "month": offsetstart.month - 1,
              "day": offsetstart.day,
              "hour": offsetstart.hour,
              "minute": offsetstart.minute,
              "endYear": offsetend.year,
-             "endMonth": offsetend.month-1,
+             "endMonth": offsetend.month - 1,
              "endDay": offsetend.day,
              "endHour": offsetend.hour,
              "endMinute": offsetend.minute}

--- a/lib/ansible/modules/monitoring/_logicmonitor_facts.py
+++ b/lib/ansible/modules/monitoring/_logicmonitor_facts.py
@@ -18,7 +18,7 @@
 # Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301  USA
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -30,6 +30,7 @@ description:
     - LogicMonitor is a hosted, full-stack, infrastructure monitoring platform.
     - This module collects facts about hosts and host groups within your LogicMonitor account.
 version_added: "2.2"
+deprecated: Deprecated in 2.4. Use M(logicmonitor_device) instead.
 author: [Ethan Culler-Mayeno (@ethanculler), Jeff Wozniak (@woz5999)]
 notes:
   - You must have an existing LogicMonitor account for this module to function.

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -266,7 +266,6 @@ lib/ansible/modules/monitoring/honeybadger_deployment.py
 lib/ansible/modules/monitoring/icinga2_feature.py
 lib/ansible/modules/monitoring/librato_annotation.py
 lib/ansible/modules/monitoring/logentries.py
-lib/ansible/modules/monitoring/_logicmonitor.py
 lib/ansible/modules/monitoring/logstash_plugin.py
 lib/ansible/modules/monitoring/nagios.py
 lib/ansible/modules/monitoring/newrelic_deployment.py

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -266,7 +266,7 @@ lib/ansible/modules/monitoring/honeybadger_deployment.py
 lib/ansible/modules/monitoring/icinga2_feature.py
 lib/ansible/modules/monitoring/librato_annotation.py
 lib/ansible/modules/monitoring/logentries.py
-lib/ansible/modules/monitoring/logicmonitor.py
+lib/ansible/modules/monitoring/_logicmonitor.py
 lib/ansible/modules/monitoring/logstash_plugin.py
 lib/ansible/modules/monitoring/nagios.py
 lib/ansible/modules/monitoring/newrelic_deployment.py


### PR DESCRIPTION
##### SUMMARY
We are preparing to submit PRs to refactor our modules for logicmonitor. Getting the ball rolling by submitting PR to deprecate old modules.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
logicmonitor
logicmonitor_facts


##### ADDITIONAL INFORMATION
First PR for new modules is here: https://github.com/ansible/ansible/pull/25886