### PR TITLE
Remove get_exception from zypper

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -183,6 +183,7 @@ import xml
 import re
 from xml.dom.minidom import parseString as parseXML
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 
 
 class Package:
@@ -259,9 +260,8 @@ def parse_zypper_xml(m, cmd, fail_not_found=True, packages=None):
 
     try:
         dom = parseXML(stdout)
-    except xml.parsers.expat.ExpatError:
-        e = get_exception()
-        m.fail_json(msg="Failed to parse zypper xml output: %s" % e,
+    except xml.parsers.expat.ExpatError as exc:
+        m.fail_json(msg="Failed to parse zypper xml output: %s" % to_native(exc),
                     rc=rc, stdout=stdout, stderr=stderr, cmd=cmd)
 
     if rc == 104:


### PR DESCRIPTION
##### SUMMARY
Fix removes get_exception in favor of native Python exception
handling. Also, added to_native to manage exception message.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/zypper.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```