### PR TITLE
Proxmox set number of cores for vm/ct

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -98,6 +98,7 @@ options:
       - 0 is unlimited.
     required: false
     default: 0
+    version_added: 2.4
   cpus:
     description:
       - numbers of allocated cpus for instance
@@ -270,7 +271,7 @@ EXAMPLES = '''
     hostname: example.org
     ostemplate: local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
     mounts: '{"mp0":"local:8,mp=/mnt/test/"}'
-    
+
 # Create new container with minimal options defining a cpu core limit
 - proxmox:
     vmid: 100

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -95,9 +95,8 @@ options:
   cores:
     description:
       - Specify number of cores per socket.
-      - 0 is unlimited.
     required: false
-    default: 0
+    default: 1
     version_added: 2.4
   cpus:
     description:
@@ -464,7 +463,7 @@ def main():
             hostname=dict(),
             ostemplate=dict(),
             disk=dict(type='str', default='3'),
-            cores=dict(type='int', default=0),
+            cores=dict(type='int', default=1),
             cpus=dict(type='int', default=1),
             memory=dict(type='int', default=512),
             swap=dict(type='int', default=0),
@@ -544,7 +543,7 @@ def main():
                                  % (module.params['ostemplate'], node, template_store))
 
             create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout,
-                            cores=module.params['cores'] or None,
+                            cores=module.params['cores'],
                             pool=module.params['pool'],
                             password=module.params['password'],
                             hostname=module.params['hostname'],

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -92,6 +92,12 @@ options:
       - hard disk size in GB for instance
     default: 3
     required: false
+  cores:
+    description:
+      - Specify number of cores per socket.
+      - 0 is unlimited.
+    required: false
+    default: 0
   cpus:
     description:
       - numbers of allocated cpus for instance
@@ -264,6 +270,18 @@ EXAMPLES = '''
     hostname: example.org
     ostemplate: local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
     mounts: '{"mp0":"local:8,mp=/mnt/test/"}'
+    
+# Create new container with minimal options defining a cpu core limit
+- proxmox:
+    vmid: 100
+    node: uk-mc02
+    api_user: root@pam
+    api_password: 1q2w3e
+    api_host: node1
+    password: 123456
+    hostname: example.org
+    ostemplate: local:vztmpl/ubuntu-14.04-x86_64.tar.gz'
+    cores: 2
 
 # Start container
 - proxmox:
@@ -445,6 +463,7 @@ def main():
             hostname=dict(),
             ostemplate=dict(),
             disk=dict(type='str', default='3'),
+            cores=dict(type='int', default=0),
             cpus=dict(type='int', default=1),
             memory=dict(type='int', default=512),
             swap=dict(type='int', default=0),
@@ -524,6 +543,7 @@ def main():
                                  % (module.params['ostemplate'], node, template_store))
 
             create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, swap, timeout,
+                            cores=module.params['cores'] or None,
                             pool=module.params['pool'],
                             password=module.params['password'],
                             hostname=module.params['hostname'],


### PR DESCRIPTION
Argument to limit the number of assigned core to a vm/ct

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add an argument to the proxmox module

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/could/misc/proxmox.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (proxmox-cores d5506abe41) last updated 2017/06/20 13:29:36 (GMT +200)
  config file = None
  configured module search path = ['/home/xxx/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/xxx/Projects/Perso/ansible-ansible/lib/ansible
  executable location = /home/xxx/Projects/Perso/ansible-ansible/.pyvenv/bin/ansible
  python version = 3.6.1 (default, Apr 14 2017, 10:31:51) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Proxmox api doc: https://pve.proxmox.com/pve-docs/api-viewer/index.html
<!--- Paste verbatim command output below, e.g. before and after your change -->

