### PR TITLE
win_iis_website: Add integration tests, check mode and better param support

### DIFF
--- a/lib/ansible/modules/windows/win_iis_website.ps1
+++ b/lib/ansible/modules/windows/win_iis_website.ps1
@@ -1,6 +1,7 @@
 #!powershell
 
 # (c) 2015, Henrik Wallström <henrik@wallstroms.nu>
+# (c) 2017, Jordan Borean <jborean93@gmail.com>
 #
 # This file is part of Ansible
 #
@@ -20,177 +21,373 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
-$params = Parse-Args $args;
-
-# Name parameter
-$name = Get-Attr $params "name" $FALSE;
-If ($name -eq $FALSE) {
-    Fail-Json (New-Object psobject) "missing required argument: name";
-}
-
-# State parameter
-$state = Get-Attr $params "state" $FALSE;
-$state.ToString().ToLower();
-If (($state -ne $FALSE) -and ($state -ne 'started') -and ($state -ne 'stopped') -and ($state -ne 'restarted') -and ($state -ne 'absent')) {
-  Fail-Json (New-Object psobject) "state is '$state'; must be 'started', 'restarted', 'stopped' or 'absent'"
-}
-
-# Path parameter
-$physical_path = Get-Attr $params "physical_path" $FALSE;
-$site_id = Get-Attr $params "site_id" $FALSE;
-
-# Application Pool Parameter
-$application_pool = Get-Attr $params "application_pool" $FALSE;
-
-# Binding Parameters
-$bind_port = Get-Attr $params "port" $FALSE;
-$bind_ip = Get-Attr $params "ip" $FALSE;
-$bind_hostname = Get-Attr $params "hostname" $FALSE;
-$bind_ssl = Get-Attr $params "ssl" $FALSE;
-
-# Custom site Parameters from string where properties
-# are separated by a pipe and property name/values by colon.
-# Ex. "foo:1|bar:2"
-$parameters = Get-Attr $params "parameters" $null;
-if($parameters -ne $null) {
-  $parameters = @($parameters -split '\|' | ForEach {
-    return ,($_ -split "\:", 2);
-  })
-}
-
+$ErrorActionPreference = 'Stop'
 
 # Ensure WebAdministration module is loaded
 if ((Get-Module "WebAdministration" -ErrorAction SilentlyContinue) -eq $null) {
-  Import-Module WebAdministration
+    Import-Module WebAdministration
+    $web_admin_dll_path = Join-Path $env:SystemRoot system32\inetsrv\Microsoft.Web.Administration.dll 
+    Add-Type -Path $web_admin_dll_path
 }
 
-# Result
-$result = New-Object psobject @{
-  site = New-Object psobject
-  changed = $false
-};
+$params = Parse-Args -arguments $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
-# Site info
-$site = Get-Website | Where { $_.Name -eq $name }
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "started" -validateset "started","restarted","stopped","absent"
+$physical_path = Get-AnsibleParam -obj $params -name "physical_path" -type "path"
+$site_id = Get-AnsibleParam -obj $params -name "site_id" -type "int"
+$application_pool = Get-AnsibleParam -obj $params -name "application_pool" -type "str"
+$port = Get-AnsibleParam -obj $params -name "port" -type "int"
+$ip = Get-AnsibleParam -obj $params -name "ip" -type "str"
+$hostname = Get-AnsibleParam -obj $params -name "hostname" -type "str"
+$ssl = Get-AnsibleParam -obj $params -name "ssl" -type "bool"
 
-Try {
-  # Add site
-  If(($state -ne 'absent') -and (-not $site)) {
-    If ($physical_path -eq $FALSE) {
-      Fail-Json (New-Object psobject) "missing required arguments: physical_path"
+$result = @{
+    changed = $false
+    attributes = @{}
+    info = @{
+        attributes = @{}
+        bindings = @()
+        limits = @{}
+        logFile = @{}
+        traceFailedRequestsLogging = @{}
+        applicationDefaults = @{}
+        virtualDirectoryDefaults = @{}
     }
-    ElseIf (-not (Test-Path $physical_path)) {
-      Fail-Json (New-Object psobject) "specified folder must already exist: physical_path"
+    # Deprecated use info instead
+    site = @{}
+}
+
+# These variables are only used when creating a new site and cannot modify existing bindings
+# use win_iis_webbinding to modify these parameter instead. Will be removed in future
+# versions.
+if ($port) {
+    Add-DeprecationWarning -obj $result -message "port is deprecated, use win_iis_webbinding to modify a site bindings" -version 2.6
+}
+if ($ip) {
+    Add-DeprecationWarning -obj $result -message "ip is deprecated, use win_iis_webbinding to modify a site bindings" -version 2.6
+}
+if ($hostname) {
+    Add-DeprecationWarning -obj $result -message "hostname is deprecated, use win_iis_webbinding to modify a site bindings" -version 2.6
+}
+if ($ssl) {
+    Add-DeprecationWarning -obj $result -message "ssl is deprecated, use win_iis_webbinding to modify a site bindings" -version 2.6
+}
+
+# Verify we can set the Site ID (it isn't already taken)
+if ($site_id) {
+    $existing_id = Get-ChildItem -Path IIS:\sites | Where-Object { ($_.id -eq $site_id) -and ($_.name -ne $name) }
+    if ($existing_id) {
+        Fail-Json $result "Cannot set ID of site $name to $site_id, this ID is already taken by $($existing_id.Name)"
     }
+}
 
-    $site_parameters = New-Object psobject @{
-      Name = $name
-      PhysicalPath = $physical_path
-    };
-
-    If ($application_pool) {
-      $site_parameters.ApplicationPool = $application_pool
+# Validate physical_path if set
+if ($physical_path) {
+    if (-not (Test-Path -Path $physical_path)) {
+        Fail-Json $result "physical_path is not a valid path: $physical_path"
     }
+}
 
-    If ($site_id) {
-        $site_parameters.ID = $site_id
+# Get attributes (originally parameters in a string form)
+$attributes = Get-AnsibleParam -obj $params -name "attributes" -default @{}
+if ($attributes) {
+    if (-not ($attributes -is [System.Collections.Hashtable])) {
+        Fail-Json $result "Expecting a dict for 'attributes' but got $($attributes.GetType())"
     }
+}
 
-    If ($bind_port) {
-      $site_parameters.Port = $bind_port
-    }
-
-    If ($bind_ip) {
-      $site_parameters.IPAddress = $bind_ip
-    }
-
-    If ($bind_hostname) {
-      $site_parameters.HostHeader = $bind_hostname
-    }
-
-    # Fix for error "New-Item : Index was outside the bounds of the array."
-    # This is a bug in the New-WebSite commandlet. Apparently there must be at least one site configured in IIS otherwise New-WebSite crashes.
-    # For more details, see http://stackoverflow.com/questions/3573889/ps-c-new-website-blah-throws-index-was-outside-the-bounds-of-the-array
-    $sites_list = get-childitem -Path IIS:\sites
-    if ($sites_list -eq $null) { $site_parameters.ID = 1 }
-
-    $site = New-Website @site_parameters -Force
-    $result.changed = $true
-  }
-
-  # Remove site
-  If ($state -eq 'absent' -and $site) {
-    $site = Remove-Website -Name $name
-    $result.changed = $true
-  }
-
-  $site = Get-Website | Where { $_.Name -eq $name }
-  If($site) {
-    # Change Physical Path if needed
-    if($physical_path) {
-      If (-not (Test-Path $physical_path)) {
-        Fail-Json (New-Object psobject) "specified folder must already exist: physical_path"
-      }
-
-      $folder = Get-Item $physical_path
-      If($folder.FullName -ne $site.PhysicalPath) {
-        Set-ItemProperty "IIS:\Sites\$($site.Name)" -name physicalPath -value $folder.FullName
-        $result.changed = $true
-      }
-    }
-
-    # Change Application Pool if needed
-    if($application_pool) {
-      If($application_pool -ne $site.applicationPool) {
-        Set-ItemProperty "IIS:\Sites\$($site.Name)" -name applicationPool -value $application_pool
-        $result.changed = $true
-      }
-    }
-
-    # Set properties
-    if($parameters) {
-      $parameters | foreach {
-        $parameter_value = Get-ItemProperty "IIS:\Sites\$($site.Name)" $_[0]
-        if((-not $parameter_value) -or ($parameter_value.Value -as [String]) -ne $_[1]) {
-          Set-ItemProperty "IIS:\Sites\$($site.Name)" $_[0] $_[1]
-          $result.changed = $true
+# Parse the deprecated parameters param, convert to newer style attributes if necessary
+$parameters = Get-AnsibleParam -obj $params -name "parameters" -type "str"
+if ($parameters) {
+    if ($attributes.count -gt 0) {
+        Add-Warning -obj $result -message "Both the parameters (deprecated) and attributes parameter is set, ignoring parameters"
+    } else {
+        Add-DeprecationWarning -obj $result -message "The parameter parameters is deprecated, use attributes with a dict value" -version 2.6
+        $parameters -split '\|' | ForEach-Object {
+            $key, $value = $_ -split "\:"
+            $attributes.$key = $value
         }
-      }
     }
-
-    # Set run state
-    if (($state -eq 'stopped') -and ($site.State -eq 'Started'))
-    {
-      Stop-Website -Name $name -ErrorAction Stop
-      $result.changed = $true
-    }
-    if ((($state -eq 'started') -and ($site.State -eq 'Stopped')) -or ($state -eq 'restarted'))
-    {
-      Start-Website -Name $name -ErrorAction Stop
-      $result.changed = $true
-    }
-  }
 }
-Catch
-{
-  Fail-Json (New-Object psobject) $_.Exception.Message
+$result.attributes = $attributes
+
+Function Get-DotNetClassForAttribute($attribute_parent) {
+    switch ($attribute_parent) {
+        "attributes" { [Microsoft.Web.Administration.Site] }
+        "bindings" { [Microsoft.Web.Administration.Binding] }
+        "limits" { [Microsoft.Web.Administration.SiteLimits] }
+        "logFile" { [Microsoft.Web.Administration.SiteLogFile] }
+        "traceFailedRequestsLogging" { [Microsoft.Web.Administration.SiteTraceFailedRequestsLogging] }
+        "applicationDefaults" { [Microsoft.Web.Administration.ApplicationDefaults] }
+        "virtualDirectoryDefaults" { [Microsoft.Web.Administration.VirtualDirectory] }
+        default { [Microsoft.Web.Administration.Site] }
+    }
 }
 
-if ($state -ne 'absent')
-{
-  $site = Get-Website | Where { $_.Name -eq $name }
+Function Convert-ToPropertyValue($site, $attribute_key, $attribute_value) {
+    # Will convert the new value to the enum value expected and cast accordingly to the type
+    if ([bool]($attribute_value.PSobject.Properties -match "Value")) {
+        $attribute_value = $attribute_value.Value
+    }
+    $attribute_key_split = $attribute_key -split "\."
+    if ($attribute_key_split.Length -eq 1) {
+        $attribute_parent = "attributes"
+        $attribute_child = $attribute_key
+        $attribute_meta = $site.Attributes | Where-Object { $_.Name -eq $attribute_child }
+    } elseif ($attribute_key_split.Length -eq 2) {
+        $attribute_parent = $attribute_key_split[0]
+        $attribute_child = $attribute_key_split[1]
+        $attribute_meta = $site.$attribute_parent.Attributes | Where-Object { $_.Name -eq $attribute_child }
+    }
+
+    if ($attribute_meta) {
+        $type = $attribute_meta.Schema.Type
+        $value = $attribute_value
+        if ($type -eq "enum") {
+            # Convert the value from human friendly to enum value
+            $dot_net_class = Get-DotNetClassForAttribute -attribute_parent $attribute_parent
+            $enum_attribute_name = $attribute_child.Substring(0,1).ToUpper() + $attribute_child.Substring(1)
+            $enum = $dot_net_class.GetProperty($enum_attribute_name).PropertyType.FullName
+            if ($enum) {
+                $enum_values = [Enum]::GetValues($enum)
+                foreach ($enum_value in $enum_values) {
+                    if ($attribute_value.GetType() -is $enum_value.GetType()) {
+                        if ($enum_value -eq $attribute_value) {
+                            $value = $enum_value
+                            break
+                        }
+                    } else {
+                        if ([System.String]$enum_value -eq [System.String]$attribute_value) {
+                            $value = $enum_value
+                            break
+                        }
+                    }
+                }
+            }            
+        }
+        # Try and cast the variable using the chosen type, revert to the default if it fails
+        Set-Variable -Name casted_value -Value ($value -as ([type] $attribute_meta.TypeName))
+        if ($casted_value -eq $null) {
+            $value
+        } else {
+            $casted_value
+        }
+    } else {
+        $attribute_value
+    }
 }
 
-if ($site)
-{
-  $result.site = New-Object psobject @{
-    Name = $site.Name
-    ID = $site.ID
-    State = $site.State
-    PhysicalPath = $site.PhysicalPath
-    ApplicationPool = $site.applicationPool
-    Bindings = @($site.Bindings.Collection | ForEach-Object { $_.BindingInformation })
-  }
+Function Remove-IISSite($name) {
+    try {
+        Remove-Website -Name $name -WhatIf:$check_mode
+    } catch {
+        Fail-Json $result "Failed to remove web site $($name): $($_.Exception.Message)"
+    }
+    $result.changed = $true
 }
+
+Function New-IISSite($name, $physical_path, $application_pool, $site_id, $port, $ip, $hostname, $ssl) {
+    if (-not $physical_path) {
+        Fail-Json $result "physical_path is required to be set when creating a new website"
+    }
+
+    $site_attributes = @{
+        Name = $name
+        PhysicalPath = $physical_path
+    }
+
+    if (-not $site_id) {
+        # Fix for error "New-Item : Index was outside the bounds of the array."
+        # This is a bug in the New-WebSite commandlet. Apparently there must be at least one site configured in IIS otherwise New-WebSite crashes.
+        # For more details, see http://stackoverflow.com/questions/3573889/ps-c-new-website-blah-throws-index-was-outside-the-bounds-of-the-array
+        if ((Get-ChildItem -Path IIS:\sites) -eq $null) {
+            $site_id = 1
+        }
+    }
+
+    $optional_attributes = @{
+        ApplicationPool = $application_pool
+        ID = $site_id
+        Port = $port
+        IPAddress = $ip
+        HostHeader = $hostname
+        Ssl = $ssl
+    }
+    foreach ($optional_attribute in $optional_attributes.GetEnumerator()) {
+        $key = $optional_attribute.Name
+        $value = $optional_attribute.Value
+        if ($value) {
+            $site_attributes.$key = $value
+        }
+    }
+
+    if (-not $check_mode) {
+        try {
+            $site = New-Website @site_attributes -Force
+        } catch {
+            Fail-Json $result "Failed to created new website $($name): $($_.Exception.Message)"
+        }
+    } else {
+        # need to set a null value when running in check mode
+        $site = $null
+    }
+    $result.changed = $true
+
+    $site
+}
+
+$site = Get-Website | Where-Object { $_.Name -eq $name }
+if ($state -eq "absent") {
+    if ($site) {
+        Remove-IISSite -name $name
+    }
+} else {
+    # create the site if it doesn't exist
+    if (-not $site) {
+        $site = New-IISSite -name $name -physical_path $physical_path -application_pool $application_pool -site_id $site_id -port $port -ip $ip -hostname $hostname -ssl $ssl
+    }
+
+    # recreate the site if the ID's don't match
+    if ($site_id) {
+        if ($site.ID -ne $site_id) {
+            Remove-IISSite -name $name
+            $site = New-IISSite -name $name -physical_path $physical_path -application_pool $application_pool -site_id $site_id -port $port -ip $ip -hostname $hostname -ssl $ssl
+        }
+    }
+
+    # need to put the following here for when running in check mode and
+    # the site doesn't exist
+    if ($site) {
+        # set the physical path of site
+        if ($physical_path) {
+            $folder = Get-Item -Path $physical_path
+            if ($folder.FullName -ne $site.PhysicalPath) {
+                try {
+                    Set-ItemProperty -Path IIS:\Sites\$name -Name PhysicalPath -Value $folder.FullName -WhatIf:$check_mode
+                } catch {
+                    Fail-Json $result "Failed to set PhysicalPath for site. Site: $name, Path: $($folder.FullName), Exception: $($_.Exception.Message)"
+                }
+                $result.changed = $true
+            }
+        }
+
+        # set the application_pool of the site
+        if ($application_pool) {
+            if ($application_pool -ne $site.ApplicationPool) {
+                try {
+                    Set-ItemProperty -Path IIS:\Sites\$name -Name ApplicationPool -Value $application_pool -WhatIf:$check_mode
+                } catch {
+                    Fail-Json $result "Failed to set ApplicationPool for site. Site: $name, Pool: $($application_pool), Exception: $($_.Exception.Message)"
+                }
+            }
+        }
+
+        # modify site based on attributes
+        foreach ($attribute in $attributes.GetEnumerator()) {
+            $attribute_key = $attribute.Name
+            $new_raw_value = $attribute.Value
+            $new_value = Convert-ToPropertyValue -site $site -attribute_key $attribute_key -attribute_value $new_raw_value
+
+            $current_raw_value = $site
+            foreach ($split_entry in ($attribute_key -split "\.")) {
+                $current_raw_value = $current_raw_value.$split_entry
+            }
+            $current_value = Convert-ToPropertyValue -site $site -attribute_key $attribute_key -attribute_value $current_raw_value
+
+            if (($current_value -eq $null) -or ($current_value -ne $new_value)) {
+                try {
+                    Set-ItemProperty -Path IIS:\Sites\$name -Name $attribute_key -Value $new_value -WhatIf:$check_mode
+                } catch {
+                    Fail-Json $result "Failed to set attribute to site $name. Attribute: $attribute_key, Value: $new_value, Exception: $($_.Exception.Message)"
+                }
+                $result.changed = $true
+            }
+        }
+    }
+
+    if ($site.State -eq "Stopped") {
+        if ($state -eq "started" -or $state -eq "restarted") {
+            if (-not $check_mode) {
+                try {
+                    Start-WebSite -Name $name
+                } catch {
+                    Fail-Json $result "Failed to start web site $($name): $($_.Exception.Message)"
+                }
+            }
+            $result.changed = $true
+        }
+    } else {
+        if ($state -eq "stopped") {
+            if (-not $check_mode) {
+                try {
+                    Stop-WebSite -Name $name
+                } catch {
+                    Fail-Json $result "Failed to stop web site $($name): $($_.Exception.Message)"
+                }
+            }
+            $result.changed = $true
+        } elseif ($state -eq "restarted") {
+            if (-not $check_mode) {
+                try {
+                    Stop-WebSite -Name $name
+                    Start-WebSite -Name $name
+                } catch {
+                    Fail-Json $result "Failed to restart web site $($name): $($_.Exception.Message)"
+                }
+            }
+            $result.changed = $true
+        }
+    }
+}
+
+# set the return values
+$site = Get-Website | Where-Object { $_.Name -eq $name }
+
+# return values under site is deprecated, still return them for backward compatibility
+if ($site) {
+    $result.site.Name
+    $result.site.ID = $site.ID
+    $result.site.State = $site.State
+    $result.site.PhysicalPath = $site.PhysicalPath
+    $result.site.ApplicationPool = $site.ApplicationPool
+    $result.site.Bindings = $($site.Bindings.Collection | ForEach-Object { $_.BindingInformation })
+}
+
+# populate the new return values under info
+$elements = @("attributes", "limits", "logFile", "traceFailedRequestsLogging", "applicationDefaults", "virtualDirectoryDefaults")
+foreach ($element in $elements) {
+    if ($element -eq "attributes") {
+        $attribute_collection = $site.Attributes
+        $attribute_parent = $site
+    } else {
+        $attribute_collection = $site.$element.Attributes
+        $attribute_parent = $site.$element
+    }
+    
+    foreach ($attribute in $attribute_collection) {
+        $attribute_name = $attribute.Name
+        $attribute_value = $attribute_parent.$attribute_name
+
+        $result.info.$element.Add($attribute_name, $attribute_value)
+    }
+}
+# manually get some leftover variables not set above
+$site_bindings = $site.Bindings.Collection
+if ($site_bindings) {
+    foreach ($binding in $site_bindings) {
+        $binding_info = @{}
+        foreach ($binding_attribute in $binding.Attributes) {
+            $binding_key = $binding_attribute.Name
+            $binding_value = $binding.$binding_key
+            $binding_info.Add($binding_key, $binding_value)
+        }
+        $result.info.bindings += $binding_info
+    }
+}
+
+$result.info.attributes.physicalPath = $site.physicalPath
+$result.info.attributes.applicationPool = $site.applicationPool
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_iis_website.py
+++ b/lib/ansible/modules/windows/win_iis_website.py
@@ -22,129 +22,228 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-
 DOCUMENTATION = r'''
 ---
 module: win_iis_website
 version_added: "2.0"
-short_description: Configures a IIS Web site.
+short_description: Configures an IIS Web site.
 description:
-     - Creates, Removes and configures a IIS Web site
+  - Creates, removes and configures an IIS Web site.
+  - If you wish to modify the bindings for a site, please use
+    M(win_iis_webbinding) to perform these tasks.
 options:
   name:
-    description:
-      - Names of web site
+    description: The name of the web site.
     required: true
-    default: null
-    aliases: []
   site_id:
     description:
-      - Explicitly set the IIS numeric ID for a site. Note that this value cannot be changed after the website has been created.
-    required: false
+      - Explicitly set the IIS numeric ID for a site. Note that if this ID does
+        not match a site.
+      - If the site ID does not match then the site will be deleted and
+        recreated with the new ID set.
+      - The module will throw an error if the ID is already used by another
+        site that is not called C(name).
     version_added: "2.1"
-    default: null
   state:
-    description:
-      - State of the web site
+    description: The state of the web site.
     choices:
       - started
       - restarted
       - stopped
       - absent
-    required: false
-    default: null
-    aliases: []
+    default: started
   physical_path:
     description:
-      - The physical path on the remote host to use for the new site. The specified folder must already exist.
-    required: false
-    default: null
-    aliases: []
+      - The physical path on the remote host to use for the new site.
+      - The specified folder must already exist.
+      - This must be set when creating a new web site.
   application_pool:
     description:
-      - The application pool in which the new site executes.
-    required: false
-    default: null
-    aliases: []
+      - The application pool in which the site executes.
+      - If a new site is created and this is not set, the app pool used will
+        be the default on the server.
   port:
     description:
-      - The port to bind to / use for the new site.
-    required: false
-    default: null
-    aliases: []
+      - The port to bind to.
+      - This is only set if the site does not exist and will be created by
+        the module execution.
+      - DEPRECATED as of Ansible 2.4, will be removed in Ansible 2.6.
+      - Use M(win_iis_webbinding) instead to modify the bindings of a site.
   ip:
     description:
-      - The IP address to bind to / use for the new site.
-    required: false
-    default: null
-    aliases: []
+      - The IP address to bind to.
+      - This is only set if the site does not exist and will be created by
+        the module execution.
+      - DEPRECATED as of Ansible 2.4, will be removed in Ansible 2.6.
+      - Use M(win_iis_webbinding) instead to modify the bindings of a site.
   hostname:
     description:
-      - The host header to bind to / use for the new site.
-    required: false
-    default: null
-    aliases: []
+      - The host header to bind to.
+      - This is only set if the site does not exist and will be created by
+        the module execution.
+      - DEPRECATED as of Ansible 2.4, will be removed in Ansible 2.6.
+      - Use M(win_iis_webbinding) instead to modify the bindings of a site.
   ssl:
     description:
-      - Enables HTTPS binding on the site..
-    required: false
-    default: null
-    aliases: []
+      - Enables HTTPS binding on the site.
+      - This is only set if the site does not exist and will be created by
+        the module execution.
+      - DEPRECATED as of Ansible 2.4, will be removed in Ansible 2.6.
+      - Use M(win_iis_webbinding) instead to modify the bindings of a site.
+  attributes:
+    description:
+      - Custom site attributes to set in a dict form.
+      - These attributes are based on the naming standard at
+        U(https://www.iis.net/configreference/system.applicationhost/sites/site#005).
+      - You can also set attributes of child elements like application, limits
+        and other by setting the full path like 'limits.maxBandwidth'.
+      - If setting an enum value, this can be either the enum value or the enum
+        name itself.
+    version_added: "2.4"
   parameters:
     description:
-      - Custom site Parameters from string where properties are separated by a pipe and property name/values by colon Ex. "foo:1|bar:2"
-    required: false
-    default: null
-    aliases: []
-author: Henrik Wallström
+      - DEPRECATED as of Ansible 2.4, use C(attributes) instead, this will be
+        removed in Ansible 2.6.
+      - Custom site parameters in a string where each parameter is separated by
+        a pip and property name/values by colon, e.g. "foo:1|bar:2"
+author:
+  - "Henrik Wallström (@henrikwallstrom)"
+  - "Jordan Borean (@jborean93)"
 '''
 
 EXAMPLES = r'''
-
-# Start a website
-
-- name: Acme IIS site
+- name: create and start a website with defaults
   win_iis_website:
-    name: "Acme"
+    name: Acme
     state: started
-    port: 80
-    ip: 127.0.0.1
-    hostname: acme.local
-    application_pool: "acme"
-    physical_path: c:\sites\acme
-    parameters: logfile.directory:c:\sites\logs
-  register: website
 
-# Remove Default Web Site and the standard port 80 binding
-- name: Remove Default Web Site
+- name: create and start a website with custom attributes
   win_iis_website:
-    name: "Default Web Site"
+    name: Acme
+    state: started
+    application_pool: acme
+    physical_path: C:\sites\acme
+    attributes:
+      serverAutoStart: True
+      # timespan format is "days:hours:minutes:seconds.milliseconds" or "hours:minutes:seconds"
+      limits.connectionTimeout: "00:02:00"
+      logFile.directory: C:\sites\logs
+      logFile.logFormat: IIS
+
+# Note the below is the older format for setting attributes
+# this is only set as a reference for older users and should
+# not be followed for future implementations
+- name: create and start a website with custom attributes
+  win_iis_website:
+    name: Acme
+    state: started
+    application_pool: acme
+    physical_path: C:\sites\acme
+    parameters: "logFile.directory:C:\sites\logs"
+
+- name: remove the Default Web Site
+  win_iis_website:
+    name: Default Web Site
     state: absent
+'''
 
-# Some commandline examples:
-
-# This return information about an existing host
-# $ ansible -i vagrant-inventory -m win_iis_website -a "name='Default Web Site'" window
-# host | success >> {
-#     "changed": false,
-#     "site": {
-#         "ApplicationPool": "DefaultAppPool",
-#         "Bindings": [
-#             "*:80:"
-#         ],
-#         "ID": 1,
-#         "Name": "Default Web Site",
-#         "PhysicalPath": "%SystemDrive%\\inetpub\\wwwroot",
-#         "State": "Stopped"
-#     }
-# }
-
-# This stops an existing site.
-# $ ansible -i hosts -m win_iis_website -a "name='Default Web Site' state=stopped" host
-
-# This creates a new site.
-# $ ansible -i hosts -m win_iis_website -a "name=acme physical_path=c:\\sites\\acme" host
-
-# Change logfile.
-# $ ansible -i hosts -m win_iis_website -a "name=acme physical_path=c:\\sites\\acme" host
+RETURN = r'''
+attributes:
+  description: The attributes that are set when calling the module and parsed
+    during execution.
+  returned: success
+  type: dictionary
+  sample:
+    "serverAutoStart": True
+    "limits.connectionTimeout": "00:02:00"
+    "logFile.directory": "C:\\sites\\logs"
+    "logFile.logFormat": IIS
+info:
+  description: Information about the web site, these are all the attributes
+    that are set and retrieved from the Site. See
+    "https://www.iis.net/configreference/system.applicationhost/sites/site#005"
+    for a full list of attributes that are returned, the below is just a
+    sample.
+  returned: success
+  type: complex
+  contains:
+    applicationDefaults:
+      description: Attributes of the default configuration settings for
+        applications in the site.
+      returned: success
+      type: dictionary
+      sample:
+        applicationPool: ""
+        enabledProtocols: http
+        path: ""
+        preloadEnabled: False
+        serviceAutoStartEnabled: False
+        serviceAutoStartProvider: ""
+    attributes:
+      description: Attributes for the basic site settings.
+      returned: success
+      type: dictionary
+      sample:
+        applicationPool: "AppPool"
+        id: 1
+        name: Acme
+        physicalPath: C:\ansible\win_iis_website
+        serverAutoStart: True
+        state: Started
+    bindings:
+      description: A list of bindings to access the site.
+      returned: success
+      type: list
+      sample: [
+        { 
+          "bindingInformation": "*:80:", "certificateHash": "",
+           "certificateStoreName": "", "isDsMapperEnabled": False,
+           "protocol": "http", "sslFlags": 0
+        }
+      ]
+    limits:
+      description: Attributes to limit the amount of bandwidth, the number of
+        connections, or the amount of time for connections to a site.
+      returned: success
+      type: dictionary
+      sample:
+        connectionTimeout: { "TotalSeconds": 120 }
+        maxBandwidth: 2048
+        maxConnections: 1000
+        maxUrlSegments: 32
+    logFile:
+      description: Attributes for handling and storage of log files for the
+        site.
+      returned: success
+      type: dictionary
+      sample:
+        directory: "%SystemDrive%\\inetpub\\logs\\LogFiles"
+        enabled: true
+    traceFailedRequestsLogging:
+      description: Attributes for logging failed-request traces for the site.
+      returned: success
+      type: dictionary
+      sample:
+        directory: "%SystemDrive%\\inetpub\\logs\\FailedReqLogFiles"
+        enabled: False
+    virtualDirectoryDefaults:
+      description: Attributes for all virtual directories in the site.
+      returned: success
+      type: dictionary
+      sample:
+        logonMethod: "Batch"
+        path: ""
+        userName: "User"
+site:
+  description: Basic information about the web site, this is deprecated and
+    kept for backwards compatibility, use the info key as it contains more
+    info of the site.
+  returned: success
+  type: dictionary
+  sample:
+    ApplicationPool: "AppPool"
+    Bindings: "*:80:"
+    ID: 1
+    PhysicalPath: "C:\\ansible\\win_iis_website"
+    State: "Started"
 '''

--- a/lib/ansible/modules/windows/win_iis_website.py
+++ b/lib/ansible/modules/windows/win_iis_website.py
@@ -139,7 +139,7 @@ EXAMPLES = r'''
     state: started
     application_pool: acme
     physical_path: C:\sites\acme
-    parameters: "logFile.directory:C:\sites\logs"
+    parameters: "logFile.directory:C:\\sites\\logs"
 
 - name: remove the Default Web Site
   win_iis_website:
@@ -195,7 +195,7 @@ info:
       returned: success
       type: list
       sample: [
-        { 
+        {
           "bindingInformation": "*:80:", "certificateHash": "",
            "certificateStoreName": "", "isDsMapperEnabled": False,
            "protocol": "http", "sslFlags": 0

--- a/test/integration/targets/win_iis_website/aliases
+++ b/test/integration/targets/win_iis_website/aliases
@@ -1,0 +1,1 @@
+windows/ci/group1

--- a/test/integration/targets/win_iis_website/defaults/main.yml
+++ b/test/integration/targets/win_iis_website/defaults/main.yml
@@ -1,0 +1,4 @@
+test_iis_website_name: TestSite
+test_iis_application_pool: AppPool
+test_iis_website_path: C:\ansible\win_iis_website
+test_iis_website_path2: C:\ansible\win_iis_website2

--- a/test/integration/targets/win_iis_website/tasks/main.yml
+++ b/test/integration/targets/win_iis_website/tasks/main.yml
@@ -1,0 +1,72 @@
+---
+# Cannot use win_feature to install IIS on Server 2008.
+# Run a brief check and skip hosts that don't support
+# that operation
+- name: check if win_feature will work on test host
+  win_command: powershell.exe "Get-WindowsFeature"
+  register: module_available
+  failed_when: False
+
+# Run actual tests
+- block:
+  # Setup for tests
+  - name: this is too finicky reboot before feature install
+    win_reboot:
+
+  - name: ensure IIS features are installed
+    win_feature:
+      name: Web-Server
+      state: present
+      includ_sub_features: True
+      include_management_tools: True
+    register: feature_install
+
+  - name: reboot after feature install
+    win_reboot:
+    when: feature_install.reboot_required
+  
+  - name: ensure test path is present
+    win_file:
+      path: '{{item}}'
+      state: directory
+    with_items:
+    - '{{test_iis_website_path}}'
+    - '{{test_iis_website_path2}}'
+
+  - name: ensure the app pool is present
+    win_iis_webapppool:
+      name: '{{test_iis_application_pool}}'
+      state: started
+  
+  - name: ensure test site is removed before test
+    win_iis_website:
+      name: '{{item}}'
+      state: absent
+    with_items:
+    - '{{test_iis_website_name}}'
+    - Default Web Site
+
+  # Tests
+  - name: run tests on hosts that support it
+    include_tasks: tests.yml
+  
+  always:
+  # cleanup
+  - name: ensure test site is deleted
+    win_iis_website:
+      name: '{{test_iis_website_name}}'
+      state: absent
+
+  - name: remove IIS features after test
+    win_feature:
+      name: Web-Server
+      state: absent
+      includ_sub_features: True
+      include_management_tools: True
+    register: feature_uninstall
+  
+  - name: reboot after feature install
+    win_reboot:
+    when: feature_uninstall.reboot_required
+
+  when: module_available.rc == 0

--- a/test/integration/targets/win_iis_website/tasks/tests.yml
+++ b/test/integration/targets/win_iis_website/tasks/tests.yml
@@ -1,0 +1,503 @@
+---
+- name: try and create web site without path
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+  register: create_fail_no_path
+  failed_when: create_fail_no_path.msg != 'physical_path is required to be set when creating a new website'
+
+- name: try and create web site with invalid path
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: T:\fakepath
+  register: create_fail_invalid_path
+  failed_when: "create_fail_invalid_path.msg != 'physical_path is not a valid path: T:\\\\fakepath'"
+
+- name: try and create a web site with a non dict form
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+    attributes: "string"
+  register: create_fail_invalid_attributes
+  failed_when: create_fail_invalid_attributes.msg != 'Expecting a dict for \'attributes\' but got string'
+
+- name: create default web site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+  register: create_default_check
+  check_mode: yes
+
+- name: get actual of create default web site check
+  win_shell: Import-Module WebAdministration; (Get-Website | Where-Object { $_.Name -eq '{{test_iis_website_name}}' }).Count
+  register: create_default_actual_check
+
+- name: assert create default web site check
+  assert:
+    that:
+    - create_default_check|changed
+    - create_default_actual_check.stdout == "0\r\n"
+
+- name: create default web site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+  register: create_default
+
+- name: get actual of create default web site
+  win_shell: Import-Module WebAdministration; (Get-Website | Where-Object { $_.Name -eq '{{test_iis_website_name}}' }).Count
+  register: create_default_actual
+
+- name: assert create default web site check
+  assert:
+    that:
+    - create_default|changed
+    - create_default.info.applicationDefaults.enabledProtocols == 'http'
+    - create_default.info.attributes.id == 1
+    - create_default.info.attributes.name == test_iis_website_name
+    - create_default.info.attributes.serverAutoStart == True
+    - create_default.info.attributes.state == 'Started'
+    - create_default.info.attributes.physicalPath == test_iis_website_path
+    - create_default.info.attributes.applicationPool == 'DefaultAppPool'
+    - create_default.info.bindings[0].bindingInformation == '*:80:'
+    - create_default_actual.stdout == "1\r\n"
+
+- name: create default web site again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+  register: create_default_again
+
+- name: assert create default web site check again
+  assert:
+    that:
+    - not create_default_again|changed
+    - create_default_again.info == create_default.info
+
+- name: fail to create new site with an existing id
+  win_iis_website:
+    name: FailSite
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+    site_id: '{{create_default_again.info.attributes.id}}'
+  register: fail_existing_id
+  failed_when: fail_existing_id.msg != 'Cannot set ID of site FailSite to ' + create_default_again.info.attributes.id|string + ', this ID is already taken by ' + test_iis_website_name
+
+- name: change the ID of an existing site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+    site_id: 25
+  register: change_site_id_check
+  check_mode: yes
+
+- name: assert change the ID of an existing site check
+  assert:
+    that:
+    - change_site_id_check|changed
+    - change_site_id_check.info == create_default_again.info
+
+- name: change the ID of an existing site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+    site_id: 25
+  register: change_site_id
+
+- name: assert change the ID of an existing site
+  assert:
+    that:
+    - change_site_id|changed
+    - change_site_id.info.attributes.id == 25
+
+- name: change the ID of an existing site again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    physical_path: '{{test_iis_website_path}}'
+    site_id: 25
+  register: change_site_id_again
+
+- name: assert change the ID of an existing site again
+  assert:
+    that:
+    - not change_site_id_again|changed
+    - change_site_id_again.info == change_site_id.info
+
+- name: remove site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: absent
+  register: remove_site_check
+  check_mode: yes
+
+- name: get actual of remove site check
+  win_shell: Import-Module WebAdministration; (Get-Website | Where-Object { $_.Name -eq '{{test_iis_website_name}}' }).Count
+  register: remove_site_actual_check
+
+- name: assert remote site check
+  assert:
+    that:
+    - remove_site_check|changed
+    - remove_site_actual_check.stdout == "1\r\n"
+
+- name: remove site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: absent
+  register: remove_site
+
+- name: get actual of remove site
+  win_shell: Import-Module WebAdministration; (Get-Website | Where-Object { $_.Name -eq '{{test_iis_website_name}}' }).Count
+  register: remove_site_actual
+
+- name: assert remote site check
+  assert:
+    that:
+    - remove_site|changed
+    - remove_site_actual.stdout == "0\r\n"
+
+- name: remove site again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: absent
+  register: remove_site_again
+
+- name: get actual of remove site again
+  win_shell: Import-Module WebAdministration; (Get-Website | Where-Object { $_.Name -eq '{{test_iis_website_name}}' }).Count
+  register: remove_site_actual_again
+
+- name: assert remote site check again
+  assert:
+    that:
+    - not remove_site_again|changed
+    - remove_site_actual_again.stdout == "0\r\n"
+
+- name: change attributes of the site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    application_pool: '{{test_iis_application_pool}}'
+    physical_path: '{{test_iis_website_path2}}'
+    attributes:
+      serverAutoStart: False
+      limits.maxBandwidth: 1024
+      logFile.logFormat: 0
+      virtualDirectoryDefaults.logonMethod: ClearText
+      virtualDirectoryDefaults.userName: '{{ansible_user}}'
+      virtualDirectoryDefaults.password: '{{ansible_password}}'
+  register: change_attributes_check
+  check_mode: yes
+
+- name: get actual of change attributes of the site check
+  win_shell: Import-Module WebAdministration; (Get-Website | Where-Object { $_.Name -eq '{{test_iis_website_name}}' }).Count
+  register: change_attributes_actual_check
+
+- name: assert change attributes of the site check
+  assert:
+    that:
+    - change_attributes_check|changed
+    - change_attributes_actual_check.stdout == "0\r\n"
+
+- name: change attributes of the site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    application_pool: '{{test_iis_application_pool}}'
+    physical_path: '{{test_iis_website_path2}}'
+    attributes:
+      serverAutoStart: False
+      limits.maxBandwidth: 1024
+      logFile.logFormat: 0
+      virtualDirectoryDefaults.logonMethod: ClearText
+      virtualDirectoryDefaults.userName: '{{ansible_user}}'
+      virtualDirectoryDefaults.password: '{{ansible_password}}'
+  register: change_attributes
+
+- name: assert change attributes of the site
+  assert:
+    that:
+    - change_attributes|changed
+    - change_attributes.info.attributes.serverAutoStart == False
+    - change_attributes.info.limits.maxBandwidth == 1024
+    - change_attributes.info.logFile.logFormat == 'IIS'
+    - change_attributes.info.virtualDirectoryDefaults.logonMethod == 'ClearText'
+    - change_attributes.info.virtualDirectoryDefaults.userName == ansible_user
+    - change_attributes.info.virtualDirectoryDefaults.password == ansible_password
+
+- name: change attributes of the site again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    application_pool: '{{test_iis_application_pool}}'
+    physical_path: '{{test_iis_website_path2}}'
+    attributes:
+      serverAutoStart: False
+      limits.maxBandwidth: 1024
+      logFile.logFormat: 0
+      virtualDirectoryDefaults.logonMethod: ClearText
+      virtualDirectoryDefaults.userName: '{{ansible_user}}'
+      virtualDirectoryDefaults.password: '{{ansible_password}}'
+  register: change_attributes_again
+
+- name: assert change attributes of the site again
+  assert:
+    that:
+    - not change_attributes_again|changed
+    - change_attributes_again.info == change_attributes.info
+
+- name: change attributes of the site again with enums swapped
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    application_pool: '{{test_iis_application_pool}}'
+    physical_path: '{{test_iis_website_path2}}'
+    attributes:
+      serverAutoStart: False
+      limits.maxBandwidth: 1024
+      logFile.logFormat: IIS # equates to 3
+      virtualDirectoryDefaults.logonMethod: 3 # Equates to ClearText
+      virtualDirectoryDefaults.userName: '{{ansible_user}}'
+      virtualDirectoryDefaults.password: '{{ansible_password}}'
+  register: change_attributes_enum_swapped
+
+- name: assert change attributes of the site again with enums swapped
+  assert:
+    that:
+    - not change_attributes_enum_swapped|changed
+    - change_attributes_enum_swapped.info == change_attributes_again.info
+
+- name: change attributes of the site with deprecated string style check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    parameters: "serverAutoStart:True|limits.maxBandwidth:2048|logFile.logFormat:W3C|virtualDirectoryDefaults.logonMethod:1"
+  register: change_attributes_old_style_check
+  check_mode: yes
+
+- name: assert change attributes of the site with deprecated string style check
+  assert:
+    that:
+    - change_attributes_old_style_check|changed
+    - change_attributes_old_style_check.info == change_attributes_enum_swapped.info
+
+- name: change attributes of the site with deprecated string style
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    parameters: "serverAutoStart:True|limits.maxBandwidth:2048|logFile.logFormat:W3C|virtualDirectoryDefaults.logonMethod:1"
+  register: change_attributes_old_style
+
+- name: assert change attributes of the site with deprecated string style
+  assert:
+    that:
+    - change_attributes_old_style|changed
+    - change_attributes_old_style.info.attributes.serverAutoStart == True
+    - change_attributes_old_style.info.limits.maxBandwidth == 2048
+    - change_attributes_old_style.info.logFile.logFormat == 'W3C'
+    - change_attributes_old_style.info.virtualDirectoryDefaults.logonMethod == 'Batch'
+
+- name: change attributes of the site with deprecated string style again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    parameters: "serverAutoStart:True|limits.maxBandwidth:2048|logFile.logFormat:W3C|virtualDirectoryDefaults.logonMethod:1"
+  register: change_attributes_old_style_again
+
+- name: assert change attributes of the site with deprecated string style again
+  assert:
+    that:
+    - not change_attributes_old_style_again|changed
+    - change_attributes_old_style_again.info == change_attributes_old_style.info
+
+- name: change attribute override string
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+    parameters: "virtualDirectoryDefaults.allowSubDirConfig:True"
+    attributes:
+      virtualDirectoryDefaults.allowSubDirConfig: False
+  register: change_attributes_old_override
+
+- name: assert change attribute override string
+  assert:
+    that:
+    - change_attributes_old_override|changed
+    - change_attributes_old_override.attributes["virtualDirectoryDefaults.allowSubDirConfig"] == False
+    - change_attributes_old_override.info.virtualDirectoryDefaults.allowSubDirConfig == False
+
+- name: stop site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: stopped
+  register: stop_site_check
+  check_mode: yes
+
+- name: get actual stop site check
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: stop_site_actual_check
+
+- name: assert stop site check
+  assert:
+    that:
+    - stop_site_check|changed
+    - stop_site_actual_check.stdout == "Started\r\n"
+
+- name: stop site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: stopped
+  register: stop_site
+
+- name: get actual stop site
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: stop_site_actual
+
+- name: assert stop site
+  assert:
+    that:
+    - stop_site|changed
+    - stop_site_actual.stdout == "Stopped\r\n"
+
+- name: stop site again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: stopped
+  register: stop_site_again
+
+- name: get actual stop site again
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: stop_site_actual_again
+
+- name: assert stop site again
+  assert:
+    that:
+    - not stop_site_again|changed
+    - stop_site_actual_again.stdout == "Stopped\r\n"
+
+- name: start site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+  register: start_site_check
+  check_mode: yes
+
+- name: get actual start site check
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: start_site_actual_check
+
+- name: assert start site check
+  assert:
+    that:
+    - start_site_check|changed
+    - start_site_actual_check.stdout == "Stopped\r\n"
+
+- name: start site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+  register: start_site
+
+- name: get actual start site
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: start_site_actual
+
+- name: assert start site
+  assert:
+    that:
+    - start_site|changed
+    - start_site_actual.stdout == "Started\r\n"
+
+- name: start site again
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: started
+  register: start_site_again
+
+- name: get actual start site again
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: start_site_actual_again
+
+- name: assert start site again
+  assert:
+    that:
+    - not start_site_again|changed
+    - start_site_actual_again.stdout == "Started\r\n"
+
+- name: restart site check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: restarted
+  register: restart_site_check
+  check_mode: yes
+
+- name: get actual restart site check
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: restart_site_actual_check
+
+- name: assert restart site check
+  assert:
+    that:
+    - restart_site_check|changed
+    - restart_site_actual_check.stdout == "Started\r\n"
+
+- name: restart site
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: restarted
+  register: restart_site
+
+- name: get actual restart site
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: restart_site_actual
+
+- name: assert restart site
+  assert:
+    that:
+    - restart_site|changed
+    - restart_site_actual.stdout == "Started\r\n"
+
+- name: stop site before restart from stop tests
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: stopped
+
+- name: restart site from stop check
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: restarted
+  register: restart_from_stop_site_check
+  check_mode: yes
+
+- name: get actual restart site from stop check
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: restart_from_stopsite_actual_check
+
+- name: assert restart site from stop check
+  assert:
+    that:
+    - restart_from_stop_site_check|changed
+    - restart_from_stopsite_actual_check.stdout == "Stopped\r\n"
+
+- name: restart site from stop
+  win_iis_website:
+    name: '{{test_iis_website_name}}'
+    state: restarted
+  register: restart_from_stop_site
+
+- name: get actual restart site from stop
+  win_command: powershell.exe "Import-Module WebAdministration; (Get-Item -Path IIS:\Sites\{{test_iis_website_name}}).state"
+  register: restart_from_stop_site_actual
+
+- name: assert restart site from stop
+  assert:
+    that:
+    - restart_from_stop_site|changed
+    - restart_from_stop_site_actual.stdout == "Started\r\n"


### PR DESCRIPTION
##### SUMMARY
Brings the following to win_iis_website

* check mode
* integration tests
* better handling of attributes
* better idempotency checks
* updated documentation
* more return values
* deprecations to parameters that shouldn't be used

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
win_iis_website

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel e08f068dca) last updated 2017/06/20 07:00:17 (GMT +1100)
  config file = None
  configured module search path = [u'/home/jordan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/dev/linux-ansible/lib/ansible
  executable location = /mnt/c/dev/linux-ansible/bin/ansible
  python version = 2.7.13 (default, Jun 18 2017, 20:35:39) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
In lieu with the changes to win_iis_webapppool, this will continue to align the win_iis_* modules and fix bugs that have been reported and make them easier to use.