### PR TITLE
Add support for Red Hat Atomic Host

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -637,6 +637,11 @@ class RedHatWorkstationHostname(Hostname):
     distribution = 'Red hat enterprise linux workstation'
     strategy_class = RedHatStrategy
 
+class RedHatAtomicHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Red hat enterprise linux atomic host'
+    strategy_class = RedHatStrategy
+
 class CentOSHostname(Hostname):
     platform = 'Linux'
     distribution = 'Centos'


### PR DESCRIPTION

##### SUMMARY
Fix adds support for Red Hat Enterprise Linux Atomic Host.
RHEL Atomic host uses same RHEL Server strategy for
modifying hostname.

Fixes #25903

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/hostname.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```
