### PR TITLE
Adds hotfix id and caption to windows facts

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -122,6 +122,14 @@ Foreach ($ip in $netcfg.IPAddress) {
     }
 }
 
+$hotfixes = @{}
+foreach ($hotfix in Get-Hotfix) {
+   $hotfixid = $hotfix | select -ExpandProperty hotfixid
+   $caption = $hotfix | select -ExpandProperty caption
+   $hotfixes.Add($hotfixid, $caption)
+}
+
+
 $env_vars = @{ }
 foreach ($item in Get-ChildItem Env:) {
     $name = $item | select -ExpandProperty Name
@@ -149,6 +157,7 @@ $ansible_facts = @{
     ansible_machine_id = $user.User.AccountDomainSid.Value
     ansible_nodename = ($ip_props.HostName + "." + $ip_props.DomainName)
     ansible_os_family = "Windows"
+    ansible_os_hotfix = $hotfixes
     ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()
     ansible_owner_contact = ([string] $win32_cs.PrimaryOwnerContact)
     ansible_owner_name = ([string] $win32_cs.PrimaryOwnerName)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I noticed this comment https://github.com/ansible/ansible/issues/17002#issuecomment-309560625 and thought it might be an idea to just add hotfix information into windows facts.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

setup setup.ps1 
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (hotfixes-in-windows-facts 4d72a11948) last updated 2017/06/20 17:26:05 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Adding which hotfixes have been applied will make it easier to apply relevant patches on hosts, and make it easier to ensure hosts have a consistent set of fixes applied to them.

One potential disadvantage is that it adds a little more to time taken to gather facts - 2-3 seconds on my laptop.

<!--- Paste verbatim command output below, e.g. before and after your change -->
``
`extract of setup output before

       "ansible_os_family": "Windows",
        "ansible_os_name": "Microsoft Windows 10 Enterprise",

extract of setup output after

       "ansible_os_family": "Windows",
        "ansible_os_hotfix": {
            "KB3150513": "http://support.microsoft.com/?kbid=3150513",
            "KB3176935": "http://support.microsoft.com/?kbid=3176935",
            "KB3176936": "http://support.microsoft.com/?kbid=3176936",
            "KB3176937": "http://support.microsoft.com/?kbid=3176937",
            "KB3199209": "http://support.microsoft.com/?kbid=3199209",
            "KB3199986": "http://support.microsoft.com/?kbid=3199986",
            "KB3211320": "http://support.microsoft.com/?kbid=3211320",
            "KB4013418": "http://support.microsoft.com/?kbid=4013418",
            "KB4020821": "http://support.microsoft.com/?kbid=4020821",
            "KB4022715": "http://support.microsoft.com/?kbid=4022715",
            "KB4022730": "http://support.microsoft.com/?kbid=4022730",
            "KB4023834": "http://support.microsoft.com/?kbid=4023834"
        },
        "ansible_os_name": "Microsoft Windows 10 Enterprise",


```
