### PR TITLE
Add support for direct http template uploading.

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -536,17 +536,17 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
         template = self.get_template()
         if not template:
             self.result['changed'] = True
-            args                    = self._get_args()
-            args['zoneid']          = self.get_zone(key='id')
-            args['format']          = self.module.params.get('format')
-            args['checksum']        = self.module.params.get('checksum')
-            args['isextractable']   = self.module.params.get('is_extractable')
-            args['isrouting']       = self.module.params.get('is_routing')
-            args['sshkeyenabled']   = self.module.params.get('sshkey_enabled')
-            args['hypervisor']      = self.get_hypervisor()
-            args['domainid']        = self.get_domain(key='id')
-            args['account']         = self.get_account(key='name')
-            args['projectid']       = self.get_project(key='id')
+            args = self._get_args()
+            args['zoneid'] = self.get_zone(key='id')
+            args['format'] = self.module.params.get('format')
+            args['checksum'] = self.module.params.get('checksum')
+            args['isextractable'] = self.module.params.get('is_extractable')
+            args['isrouting'] = self.module.params.get('is_routing')
+            args['sshkeyenabled'] = self.module.params.get('sshkey_enabled')
+            args['hypervisor'] = self.get_hypervisor()
+            args['domainid'] = self.get_domain(key='id')
+            args['account'] = self.get_account(key='name')
+            args['projectid'] = self.get_project(key='id')
 
             if not self.module.check_mode:
                 res = self.cs.getUploadParamsForTemplate(**args)

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -59,7 +59,6 @@ options:
       - Zone is required when using direct http upload.
       - Compatible with CloudStack 4.6 and above.
     version_added: '2.4'
-    requirements: requests_toolbelt
     required: false
     default: null
   snapshot:

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -59,7 +59,7 @@ options:
       - Zone is required when using direct http upload.
       - Compatible with CloudStack 4.6 and above.
     version_added: '2.4'
-    requirements: "[ requests, requests_toolbelt ]"
+    requirements: requests_toolbelt
     required: false
     default: null
   snapshot:

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -59,9 +59,7 @@ options:
       - Zone is required when using direct http upload.
       - Compatible with CloudStack 4.6 and above.
     version_added: '2.4'
-    requirements:
-        - requests
-        - requests_toolbelt
+    requirements: "[ requests, requests_toolbelt ]"
     required: false
     default: null
   snapshot:

--- a/lib/ansible/modules/cloud/cloudstack/cs_template.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_template.py
@@ -59,7 +59,9 @@ options:
       - Zone is required when using direct http upload.
       - Compatible with CloudStack 4.6 and above.
     version_added: '2.4'
-    requirements: [ requests, requests_toolbelt ]
+    requirements:
+        - requests
+        - requests_toolbelt
     required: false
     default: null
   snapshot:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is a new feature that allows direct http uploading of CloudStack templates.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/cloudstack/cs_template.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /home/john/.ansible.cfg
  configured module search path = [u'/home/john/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
As an alternative to specifying *url* or *vm*, specify a *file*, which is a path to a local template.
<!--- Paste verbatim command output below, e.g. before and after your change -->
Sample playbook:
```
---
- name: Upload Templates
  hosts: host1
  tasks:
  - local_action:
      module: cs_template
      name: "{{ item.name }}"
      display_text: "{{ item.name }}"
      file: "{{ item.file }}"
      zone: London
      hypervisor: KVM
      format: QCOW2
      is_featured: no
      is_public: yes
      is_extractable: yes
      sshkey_enabled: no
      password_enabled: no
      requires_hvm: yes
      os_type: "{{ item.type }}"
    with_items:
    - { type: "Other 2.6x Linux (32-bit)", name: "OpenWRT", file: "openwrt-x86-kvm_guest-combined-ext4.qcow2" }
```
