### PR TITLE
Enable custom_data parameter to be pased to azure virtual machines at time of provision

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -644,7 +644,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.module_arg_spec = dict(
             resource_group=dict(type='str', required=True),
             name=dict(type='str', required=True),
-            custom_data = dict(type='str'),
+            custom_data=dict(type='str'),
             state=dict(choices=['present', 'absent'], default='present', type='str'),
             location=dict(type='str'),
             short_hostname=dict(type='str'),
@@ -1128,7 +1128,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if vm_dict['properties']['osProfile'].get('customData'):
                         custom_data = vm_dict['properties']['osProfile']['customData']
                         vm_resource.os_profile.custom_data = str(base64.b64encode(custom_data.encode()).decode('utf-8'))
-
 
                     # Add admin password, if one provided
                     if vm_dict['properties']['osProfile'].get('adminPassword'):
@@ -1695,6 +1694,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
 def main():
     AzureRMVirtualMachine()
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -991,7 +991,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                         vm_resource.os_profile.admin_password = self.admin_password
 
                     if self.custom_data:
-                        vm_resource.os_profile.custom_data = base64.b64encode(self.custom_data)
+                        vm_resource.os_profile.custom_data = str(base64.b64encode(self.custom_data.encode()).decode('utf-8'))
 
                     if self.os_type == 'Linux':
                         vm_resource.os_profile.linux_configuration = LinuxConfiguration(
@@ -1126,7 +1126,9 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
                     # Add custom_data, if provided
                     if vm_dict['properties']['osProfile'].get('customData'):
-                        vm_resource.os_profile.custom_data = base64.b64encode(vm_dict['properties']['osProfile']['customData'])
+                        custom_data = vm_dict['properties']['osProfile']['customData']
+                        vm_resource.os_profile.custom_data = str(base64.b64encode(custom_data.encode()).decode('utf-8'))
+
 
                     # Add admin password, if one provided
                     if vm_dict['properties']['osProfile'].get('adminPassword'):

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -44,6 +44,20 @@
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
       name: testvm001
+      purge_rules: yes
+      rules:
+        - name: ALLOW_SSH
+          protocol: Tcp
+          destination_port_range: 22
+          access: Allow
+          priority: 100
+          direction: Inbound
+        - name: ALLOW_HTTP
+          protocol: Tcp
+          destination_port_range: 80
+          access: Allow
+          priority: 110
+          direction: Inbound
 
 - name: Create NIC
   azure_rm_networkinterface:
@@ -55,6 +69,7 @@
       security_group: testvm001
 
 - name: Create virtual machine
+  register: output
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
       name: testvm002
@@ -75,12 +90,38 @@
         version: latest
       custom_data: |
         #!/bin/sh
-        echo "custom_data was executed" > /custom_data.txt
-  register: output
+        apt-get update
+        apt-get install -y nginx
+        echo "custom_data was executed" > /var/www/html/index.nginx-debian.html
 
 - assert:
       that:
         - azure_vm.properties.availabilitySet.id
+
+- name: Wait for nginx to come up
+  wait_for: host={{ output.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.publicIPAddress.properties.ipAddress }}
+            port=80
+            delay=20
+            timeout=180
+            state=started
+
+- name: Wait for nginx to serve our custom_data text
+  pause:
+      seconds: 10
+
+- name: Download file served from virtual machine
+  get_url:
+      url: http://{{ output.ansible_facts.azure_vm.properties.networkProfile.networkInterfaces[0].properties.ipConfigurations[0].properties.publicIPAddress.properties.ipAddress }}
+      dest: /tmp/custom_data_was_executed.txt
+
+- name: Check the value of /custom_data.txt on the newly created VM
+  command: cat /tmp/custom_data_was_executed.txt
+  register: custom_data_result
+
+- name: Verify that custom_data was executed and /custom_data.txt was created
+  assert:
+      that:
+          - custom_data_result.stdout == "custom_data was executed"
 
 - name: Restart the virtual machine
   azure_rm_virtualmachine:

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -73,6 +73,9 @@
         publisher: Canonical
         sku: 16.04-LTS
         version: latest
+      custom_data: |
+        #!/bin/sh
+        echo "custom_data was executed" > /custom_data.txt
   register: output
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change enables [custom_data](https://azure.microsoft.com/en-us/blog/custom-data-and-cloud-init-on-windows-azure/?v=17.23h) to be pased to azure virtual machines at time of provision.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloud/azure

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 0b0e641de6) last updated 2017/06/20 20:59:14 (GMT +200)
  config file = None
  configured module search path = [u'/home/dlevin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dlevin/Documents/Coding/ansible/lib/ansible
  executable location = /home/dlevin/Documents/Coding/ansible/bin/ansible
  python version = 2.7.12+ (default, Sep 17 2016, 12:08:02) [GCC 6.2.0 20160914]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example Usage:
```
- name: Launch an instance in azure
  azure_rm_virtualmachine:
    resource_group: "{{ resource_group }}"
    name: "{{ hostname }}"
    vm_size: "{{ azure_instance_type }}"
    admin_username: ubuntu
    ssh_password_enabled: false
    ssh_public_keys:
      - path: '/home/ubuntu/.ssh/authorized_keys'
        key_data: "{{ lookup('file', ssh_public_key_file) }}"
    image: "{{ azure_image }}"
    network_interfaces: "{{ hostname }}-nic"

    custom_data: |
      #!/bin/sh
      cat /home/ubuntu/.ssh/authorized_keys > /root/.ssh/authorized_keys
```
