### PR TITLE
Show where a file was searched for when showing it couldnt be found 

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -973,6 +973,17 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 
         return diff
 
+    def _name_slug(self, action_type):
+        _name_slug = action_type
+
+        # _load_name is set by plugin loader, potentially after init or not at all if
+        # plugin loader isnt used
+        try:
+            _name_slug = '%s action' % self._load_name
+        except AttributeError:
+            pass
+        return _name_slug
+
     def _find_needle(self, dirname, needle):
         '''
             find a needle in haystack of paths, optionally using 'dirname' as a subdir.
@@ -983,9 +994,14 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # dwim already deals with playbook basedirs
         path_stack = self._task.get_search_path()
 
-        result = self._loader.path_dwim_relative_stack(path_stack, dirname, needle)
+        b_candidate_paths = self._loader.get_path_dwim_relative_stack(path_stack, dirname, needle)
+        b_candidate_paths = self._loader.uniq_path_list(b_candidate_paths)
+
+        result = self._loader.path_dwim_relative_stack(b_candidate_paths, needle)
 
         if result is None:
-            raise AnsibleError("Unable to find '%s' in expected paths." % to_native(needle))
+            paths_msg = ','.join([to_native(b_path) for b_path in b_candidate_paths])
+            raise AnsibleError("%s unable to find '%s' in expected locations: %s" %
+                               (self._name_slug('Action'), to_native(needle), paths_msg))
 
         return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Include the paths we searched for a file in
the error message if an action cant find a file
(_find_needle).

Before:

```
fatal: [vegetarian]: FAILED! => {
    "ansible_facts": {}, 
    "changed": false, 
    "failed": true, 
    "message": "Unable to find 'some_vars/some_vars.yaml' in expected paths."
}
```

After:

```
fatal: [vegetarian]: FAILED! => {
    "ansible_facts": {}, 
    "changed": false, 
    "failed": true, 
    "message": "include_vars action unable to find 'some_vars/some_vars.yaml' in expected locations /home/adrian/src/ansible/vars/some_vars/some_vars.yaml:/home/adrian/src/ansible/some_vars/some_vars.yaml"
```


Also include the name of the action if we
know it.

split path_dwim_relative_stack into two methods

get_path_dwim_relative_stack() and
path_dwim_relative_stack()

get_path_dwim_relative_stack() just builds up the
list of candidate file locations (b_candidate_paths)

path_dwim_relative_stack() now takes a b_candidate_paths
for its first arg instead of a list of path strings.

path_wim_relative_stack() will check those candidate
paths to see where file actually lives.

This is so we can call get_path_dwim_relative_stack()
seperately, and get just the list of candidate paths
so we can include them in error messages.

callers should use it like:

``` python
  b_candidate_paths = get_path_dwim_relative_stack(path_list, dirnames, source, is_role)
  results = path_dwim_relative_stack(b_candidate_paths)

  if results is None:
        raise AnsibleError("Couldnt find %s. Looked in %s' %
                           (source,
                           os.path.pathsep.join(b_candidate_paths)))
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/parsing/dataloader.py
lib/ansible/plugins/action/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

ansible 2.4.0 (show_where_failed_file_search_failed ecf44cf7f1) last updated 2017/06/20 16:36:40 (GMT -400)
  config file = /home/adrian/src/ansible-setup/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
