### PR TITLE
Added datacenter as variable to example block in vmware_guest_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -63,11 +63,12 @@ extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
-- name: Gather VM facts
+- name: Gather facts from standalone ESXi server having datacenter as 'ha-datacenter'
   vmware_guest_facts:
     hostname: 192.168.1.209
     username: administrator@vsphere.local
     password: vmware
+    datacenter: ha-datacenter
     validate_certs: no
     uuid: 421e4592-c069-924d-ce20-7e7533fab926
   delegate_to: localhost


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pullrequest

##### SUMMARY
The minimal working example should contain the "datacenter" variable, since its a required variable.

This is a fresh version of PR #23178, that I closed due to some errors in my fork.

I also included suggestions from @Akasurde 
@nerzhul 