### PR TITLE
Fix regression in fetch checksumming behavior

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -107,9 +107,9 @@ class ActionModule(ActionBase):
 
         dest = os.path.expanduser(dest)
         if flat:
-            if dest.endswith(os.sep):
-                # if the path ends with "/", we'll use the source filename as the
-                # destination filename
+            if dest.endswith(os.sep) or os.path.isdir(to_bytes(dest, errors='strict')):
+                # if the path ends with "/", or is a directory
+                # we'll use the source filename as the destination filename
                 base = os.path.basename(source_local)
                 dest = os.path.join(dest, base)
             if not dest.startswith("/"):


### PR DESCRIPTION
##### SUMMARY
In 2.3.1, fetch default value for validate_checksum changed to True.

This caused a fetch to a directory with flat: yes to fail, because the
code tires to checksum the directory, if it already exists, instead of
the file placed in that directory.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/fetch.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
Bug can be spotted by seeing that the local checksum, exposed in the variable `checksum` is null
```
failed: [XXX] (...) => {
    "checksum": null,
    "dest": "/xxx/yyy", 
    "failed": true, 
    "file": "/zzzz", 
    "item": {
...
    }, 
    "md5sum": null, 
    "remote_checksum": "4faeee0a6f42281ea7c5021d220128e6b7652e72", 
    "remote_md5sum": null
}

MSG:

checksum mismatch
```
