### PR TITLE
Allow setting hash merging per hash

### DIFF
--- a/lib/ansible/parsing/yaml/constructor.py
+++ b/lib/ansible/parsing/yaml/constructor.py
@@ -43,8 +43,9 @@ class AnsibleConstructor(SafeConstructor):
         self._vaults = {}
         self._vaults['default'] = VaultLib(b_password=self._b_vault_password)
 
-    def construct_yaml_map(self, node):
+    def construct_yaml_map(self, node, mergereplace=None):
         data = AnsibleMapping()
+        data.set_mergereplace(mergereplace)
         yield data
         value = self.construct_mapping(node)
         data.update(value)
@@ -119,6 +120,12 @@ class AnsibleConstructor(SafeConstructor):
     def construct_yaml_unsafe(self, node):
         return self.construct_yaml_str(node, unsafe=True)
 
+    def construct_yaml_dict_merge(self, node):
+        return self.construct_yaml_map(node, mergereplace='merge')
+
+    def construct_yaml_dict_replace(self, node):
+        return self.construct_yaml_map(node, mergereplace='replace')
+
     def _node_position_info(self, node):
         # the line number where the previous token has ended (plus empty lines)
         # Add one so that the first line is line 1 rather than line 0
@@ -157,6 +164,14 @@ AnsibleConstructor.add_constructor(
 AnsibleConstructor.add_constructor(
     u'!unsafe',
     AnsibleConstructor.construct_yaml_unsafe)
+
+AnsibleConstructor.add_constructor(
+    u'!merge',
+    AnsibleConstructor.construct_yaml_dict_merge)
+
+AnsibleConstructor.add_constructor(
+    u'!replace',
+    AnsibleConstructor.construct_yaml_dict_replace)
 
 AnsibleConstructor.add_constructor(
     u'!vault',

--- a/lib/ansible/parsing/yaml/objects.py
+++ b/lib/ansible/parsing/yaml/objects.py
@@ -55,7 +55,18 @@ class AnsibleBaseYAMLObject(object):
 
 class AnsibleMapping(AnsibleBaseYAMLObject, dict):
     ''' sub class for dictionaries '''
-    pass
+    mergereplace = None
+
+    def __init__(self, *args, **kwargs):
+        ''' This constructor is here mostly for testing. '''
+        self.mergereplace = kwargs.pop('__mergereplace__', None)
+        super(AnsibleMapping, self).__init__(*args, **kwargs)
+
+    def set_mergereplace(self, mergereplace):
+        '''Set mergereplace, which is a string that indicates merge status.
+
+        Either "merge", "replace" or None, which defaults to the config.'''
+        self.mergereplace = mergereplace
 
 
 class AnsibleUnicode(AnsibleBaseYAMLObject, text_type):

--- a/lib/ansible/utils/vars.py
+++ b/lib/ansible/utils/vars.py
@@ -32,6 +32,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native, to_text
 from ansible.parsing.splitter import parse_kv
+from ansible.parsing.yaml.objects import AnsibleMapping
 
 
 _MAXSIZE = 2 ** 32
@@ -81,7 +82,13 @@ def combine_vars(a, b):
     Return a copy of dictionaries of variables based on configured hash behavior
     """
 
-    if C.DEFAULT_HASH_BEHAVIOUR == "merge":
+    should_merge = C.DEFAULT_HASH_BEHAVIOUR == "merge"
+    if isinstance(a, AnsibleMapping) and a.mergereplace:
+        should_merge = a.mergereplace == 'merge'
+    if isinstance(b, AnsibleMapping) and b.mergereplace:
+        should_merge = b.mergereplace == 'merge'
+
+    if should_merge:
         return merge_hash(a, b)
     else:
         # HASH_BEHAVIOUR == 'replace'


### PR DESCRIPTION
##### SUMMARY
This allows using the "merge" hash behavior for specific hashes.
This way, it is possible to have the base system operate with the default "replace" behavior, so as to not break e.g. roles/playbooks or assumptions, while still being able to take advantage of hash merging when it's useful.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
utils/vars

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/srv/web/infra/ansible/library', u'/usr/share/ansible']
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
This PR allows people to add !merge or !replace to a hash, and that will override the system-wide default hash behavior.