### PR TITLE
windows: Two simple errors using Add-Warning

### DIFF
--- a/lib/ansible/modules/windows/win_lineinfile.ps1
+++ b/lib/ansible/modules/windows/win_lineinfile.ps1
@@ -421,7 +421,7 @@ If ($state -eq "present") {
 	}
 
 	If ($insertbefore -and $insertafter) {
-		Add-Warning('Both insertbefore and insertafter parameters found, ignoring "insertafter=$insertafter"');
+		Add-Warning $result "Both insertbefore and insertafter parameters found, ignoring `"insertafter=$insertafter`""
 	}
 
 	If (-not $insertbefore -and -not $insertafter) {

--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -45,7 +45,7 @@ if ($diff_support) {
 
 # Fix HCCC:\ PSDrive for pre-2.3 compatibility
 if ($path -match "^HCCC:\\") {
-    Add-Warning("Please use path: HKCC:\... instead of path: $path")
+    Add-Warning $result "Please use path: HKCC:\... instead of path: $path"
     $path = $path -replace "HCCC:\\","HKCC:\\"
 }
 


### PR DESCRIPTION
##### SUMMARY
I noticed these before, finally nailed them...

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_regedit and win_lineinfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4