### PR TITLE
Update playbook_best_practices.rst, range notation

### DIFF
--- a/docs/docsite/rst/playbooks_best_practices.rst
+++ b/docs/docsite/rst/playbooks_best_practices.rst
@@ -296,8 +296,8 @@ What about just my webservers in Boston?::
 
 What about just the first 10, and then the next 10?::
    
-    ansible-playbook -i production webservers.yml --limit boston[1-10]
-    ansible-playbook -i production webservers.yml --limit boston[11-20]
+    ansible-playbook -i production webservers.yml --limit boston[1:10]
+    ansible-playbook -i production webservers.yml --limit boston[11:20]
 
 And of course just basic ad-hoc stuff is also possible.::
 


### PR DESCRIPTION
##### SUMMARY
Update --limit range notation.

Current notation triggers;

"[WARNING]: Use [x:y] inclusive subscripts instead of [x-y] which has been removed"

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Best Practices document

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Please comment if additional information is required.