### PR TITLE
Add pytest-xdist to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyYAML
 paramiko
 pycrypto >= 2.6
 setuptools
+pytest-xdist


### PR DESCRIPTION
We actually need pytest-xdist installed for tests to run. Add it as a
dependency so a user doesn't need to worry about it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>

##### SUMMARY
Add missing dependency for tox

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
tox