### PR TITLE
Add support for Virtuozzo Linux Host

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -665,6 +665,13 @@ class OracleLinuxHostname(Hostname):
     distribution = 'Oracle linux server'
     strategy_class = RedHatStrategy
 
+
+class VirtuozzoLinuxHostname(Hostname):
+    platform = 'Linux'
+    distribution = 'Virtuozzo linux'
+    strategy_class = RedHatStrategy
+
+
 class AmazonLinuxHostname(Hostname):
     platform = 'Linux'
     distribution = 'Amazon'


### PR DESCRIPTION
This fix adds support for Virtuozzo Linux hosts. Virtuozzo Linux is a CentOS-based distribution used as an underlying system for Virtuozzo/OpenVZ 7. Currently hostame module fails to work on such systems.

VzLinux  host uses same RHEL Server strategy for modifying hostname.

Signed-off-by: Denis Silakov dsilakov@virtuozzo.com

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/hostname.py

##### ANSIBLE VERSION
2.4devel
