### PR TITLE
Fix nxos_system name-server parsing

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_system.py
+++ b/lib/ansible/modules/network/nxos/nxos_system.py
@@ -251,8 +251,9 @@ def parse_name_servers(config, vrf_config):
             objects.append({'server': addr, 'vrf': None})
 
     for vrf, cfg in iteritems(vrf_config):
-        for item in re.findall('ip name-server (\S+)', cfg, re.M):
-            for addr in match.group(1).split(' '):
+        vrf_match = re.search('ip name-server (.+)', cfg, re.M)
+        if vrf_match:
+            for addr in vrf_match.group(1).split(' '):
                 objects.append({'server': addr, 'vrf': vrf})
 
     return objects

--- a/lib/ansible/modules/network/nxos/nxos_system.py
+++ b/lib/ansible/modules/network/nxos/nxos_system.py
@@ -87,10 +87,6 @@ EXAMPLES = """
   nxos_system:
     state: absent
 
-- name: configure DNS lookup sources
-  nxos_system:
-    lookup_source: Management1
-
 - name: configure name servers
   nxos_system:
     name_servers:
@@ -335,7 +331,7 @@ def main():
         name_servers=dict(type='list'),
 
         system_mtu=dict(type='int'),
-
+        lookup_source=dict(),
         state=dict(default='present', choices=['present', 'absent'])
     )
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #25513

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_system

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
`ip name-server [...]` parsing was different between vrf and non-vrf states. This rectifies that problem.