### PR TITLE
route53_health_check: bugfix: port comparison

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -189,9 +189,9 @@ def health_check_diff(a, b):
         b_val = b.get(key)
         a_type = type(a_val)
         b_type = type(b_val)
-        if (a_type is int and b_type is unicode):
+        if (a_type is int and b_type is not int):
             b_val = int(b_val)
-        elif (a_type is unicode and b_type is int):
+        elif (a_type is not int and b_type is int):
             a_val = int(a_val)
         if a_val != b_val:
             diff[key] = b_val

--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -190,9 +190,9 @@ def health_check_diff(a, b):
         a_type = type(a_val)
         b_type = type(b_val)
         if (a_type is int and b_type is unicode):
-            a_val = str(a_val)
+            b_val = int(b_val)
         elif (a_type is unicode and b_type is int):
-            b_val = str(b_val)
+            a_val = int(a_val)
         if a_val != b_val:
             diff[key] = b_val
     return diff

--- a/lib/ansible/modules/cloud/amazon/route53_health_check.py
+++ b/lib/ansible/modules/cloud/amazon/route53_health_check.py
@@ -185,8 +185,16 @@ def health_check_diff(a, b):
         return {}
     diff = {}
     for key in set(a.keys()) | set(b.keys()):
-        if a.get(key) != b.get(key):
-            diff[key] = b.get(key)
+        a_val = a.get(key)
+        b_val = b.get(key)
+        a_type = type(a_val)
+        b_type = type(b_val)
+        if (a_type is int and b_type is unicode):
+            a_val = str(a_val)
+        elif (a_type is unicode and b_type is int):
+            b_val = str(b_val)
+        if a_val != b_val:
+            diff[key] = b_val
     return diff
 
 def to_template_params(health_check):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bug Report

##### COMPONENT NAME
route53_health_check

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```

##### CONFIGURATION
(none)

##### OS / ENVIRONMENT
N/A

##### SUMMARY

The `route53_health_check` module is mistakenly comparing `unicode` and `int` values for `port` and in so doing always thinks an update is required when one may not be.

When an existing health check configuration is fetched and stored locally for comparison, the `port` is represented as `unicode`, but the local ansible configuration represents `port` as `int`, which results in `!=` always returning `True` even when one is `u'80'` and the other is `80`.

This fix simply checks to see if the existing/wanted comparison is comparing `unicode` and `int` values, and, if so, uses `str(...)` for the value of the given `int` value instead.

##### STEPS TO REPRODUCE

Create a health check with the `route53_health_check` module.

Make sure you have the update fix from https://github.com/ansible/ansible/pull/25976

Don't change anything in your definition, and re-run your original `route53_health_check` and you'll see the health check be needlessly updated.

##### EXPECTED RESULTS

Updates when changes are present, no updates when no changes are present.

##### ACTUAL RESULTS

Updates always applied and executed even when no configuration has changed.