### PR TITLE
Correct documentation for deployment_mode flag

### DIFF
--- a/lib/ansible/modules/packaging/language/bundler.py
+++ b/lib/ansible/modules/packaging/language/bundler.py
@@ -77,8 +77,8 @@ options:
     default: "no"
   deployment_mode:
     description:
-      - Only applies if state is C(present). If set it will only install gems
-        that are in the default or production groups. Requires a Gemfile.lock
+      - Only applies if state is C(present). If set it will install gems in
+        ./vendor/bundle instead of the default location. Requires a Gemfile.lock
         file to have been created prior
     required: false
     choices: [yes, no]
@@ -126,7 +126,7 @@ EXAMPLES='''
     state: present
     exclude_groups: production
 
-# Only install gems from the default and production groups
+# Install gems into ./vendor/bundle
 - bundler:
     state: present
     deployment_mode: yes


### PR DESCRIPTION
##### SUMMARY
This corrects the documentation for the `deployment_mode` flag in the `bundler` module.

The `deployment_mode` flag passes `--deployment` to the `bundle` command. As per the **Deployment Mode** section of `bundle install --help`, that flag has the following effect:

> Gems are installed to vendor/bundle not your default system location

The *ansible* docs suggest, instead, that this flag only installs production-mode gems. Our testing finds that the results of `deployment_mode: true` match the *bundler* docs, not the *ansible* ones.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
bundler.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /Users/annawiggins/code/coop/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```