### PR TITLE
Fix of argument error in #25940

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
@@ -110,7 +110,7 @@ def get_instance_info(instance):
 
     instance_info = { 'id': instance.id,
                     'kernel': instance.kernel,
-                    'instance_profile': instance.instance_profile,
+                    'instance_profile': dict(instance.instance_profile),
                     'root_device_type': instance.root_device_type,
                     'private_dns_name': instance.private_dns_name,
                     'public_dns_name': instance.public_dns_name,


### PR DESCRIPTION
##### SUMMARY
This PR fixes the issue referenced in #25940

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
None

After change:
```
TASK [debug] *****************************************************************************************************************************************
task path: /home/Mgmt/test_scripts/ansible/ec2_remote_facts.yml:21
ok: [localhost] => {
    "ec2_list": {
        "changed": false,
        "failed": false,
        "instances": [
            {
                "ami_launch_index": "0",
                "architecture": "x86_64",
                "block_device_mapping": [
                    {
                        "attach_time": "2017-01-03T15:19:52.000Z",
                        "delete_on_termination": true,
                        "device_name": "/dev/sda1",
                        "status": "attached",
                        "volume_id": "vol-0160e50db0107e080"
                    }
                ],
                "client_token": "*********************",
                "ebs_optimized": true,
                "groups": [
                    {
                        "id": "sg-*********",
                        "name": ***********************************"
                    }
                ],
                "hypervisor": "xen",
                "id": "i-*********************",
                "image_id": "ami-*********************",
                "instance_profile": {
                    "arn": "arn:aws:iam::*********************:instance-profile/*********************",
                    "id": "*********************"
                },
                "interfaces": [
                    {
                        "id": "eni-*********************",
                        "mac_address": "*********************"
                    }
                ],
                "kernel": null,
                "key_name": "*********************",
                "launch_time": "2017-06-16T15:44:54.000Z",
                "monitoring_state": "disabled",
                "persistent": false,
                "placement": {
                    "tenancy": "default",
                    "zone": "eu-west-1b"
                },
                "private_dns_name": "ip-*********************",
                "private_ip_address": "*********************",
                "public_dns_name": "",
                "public_ip_address": null,
                "ramdisk": null,
                "region": "eu-west-1",
                "requester_id": null,
                "root_device_type": "ebs",
                "source_destination_check": "true",
                "spot_instance_request_id": null,
                "state": "running",
                "tags": {
                    ....
                },
                "virtualization_type": "hvm",
                "vpc_id": "vpc-*********************"
            }
        ]
    },
    "failed": false
}
META: ran handlers
META: ran handlers

PLAY RECAP *******************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0

```
