### PR TITLE
Add new event v2_runner_on_task_start to allow callback by host task

### DIFF
--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -55,7 +55,7 @@ class WorkerProcess(multiprocessing.Process):
     for reading later.
     '''
 
-    def __init__(self, rslt_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj):
+    def __init__(self, rslt_q, task_vars, host, task, play_context, loader, variable_manager, shared_loader_obj, tqm):
 
         super(WorkerProcess, self).__init__()
         # takes a task queue manager as the sole param:
@@ -67,6 +67,7 @@ class WorkerProcess(multiprocessing.Process):
         self._loader = loader
         self._variable_manager = variable_manager
         self._shared_loader_obj = shared_loader_obj
+        self._tqm = tqm
 
         if sys.stdin.isatty():
             # dupe stdin, if we have one
@@ -113,7 +114,8 @@ class WorkerProcess(multiprocessing.Process):
                 self._new_stdin,
                 self._loader,
                 self._shared_loader_obj,
-                self._rslt_q
+                self._rslt_q,
+                self._tqm
             ).run()
 
             display.debug("done running TaskExecutor() for %s/%s" % (self._host, self._task))

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -59,7 +59,7 @@ class TaskExecutor:
     # the module
     SQUASH_ACTIONS = frozenset(C.DEFAULT_SQUASH_ACTIONS)
 
-    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, rslt_q):
+    def __init__(self, host, task, job_vars, play_context, new_stdin, loader, shared_loader_obj, rslt_q, tqm):
         self._host = host
         self._task = task
         self._job_vars = job_vars
@@ -70,6 +70,7 @@ class TaskExecutor:
         self._connection = None
         self._rslt_q = rslt_q
         self._loop_eval_error = None
+        self._tqm = tqm
 
         self._task.squash()
 
@@ -82,6 +83,7 @@ class TaskExecutor:
         '''
 
         display.debug("in run()")
+        self._tqm.send_callback('v2_runner_on_task_start', self._host, self._task)
 
         try:
             try:

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -284,7 +284,7 @@ class CallbackBase:
         self.on_any(args, kwargs)
 
     def v2_runner_on_task_start(self, host, task):
-        pass # no v1 correspondence
+        pass  # no v1 correspondence
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
         host = result._host.get_name()

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -283,6 +283,9 @@ class CallbackBase:
     def v2_on_any(self, *args, **kwargs):
         self.on_any(args, kwargs)
 
+    def v2_runner_on_task_start(self, host, task):
+        pass # no v1 correspondence
+
     def v2_runner_on_failed(self, result, ignore_errors=False):
         host = result._host.get_name()
         self.runner_on_failed(host, result._result, ignore_errors)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -217,7 +217,8 @@ class StrategyBase:
             while True:
                 (worker_prc, rslt_q) = self._workers[self._cur_worker]
                 if worker_prc is None or not worker_prc.is_alive():
-                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, shared_loader_obj, self._tqm)
+                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, shared_loader_obj,
+                                               self._tqm)
                     self._workers[self._cur_worker][0] = worker_prc
                     worker_prc.start()
                     display.debug("worker is %d (out of %d available)" % (self._cur_worker + 1, len(self._workers)))

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -217,7 +217,7 @@ class StrategyBase:
             while True:
                 (worker_prc, rslt_q) = self._workers[self._cur_worker]
                 if worker_prc is None or not worker_prc.is_alive():
-                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, shared_loader_obj)
+                    worker_prc = WorkerProcess(self._final_q, task_vars, host, task, play_context, self._loader, self._variable_manager, shared_loader_obj, self._tqm)
                     self._workers[self._cur_worker][0] = worker_prc
                     worker_prc.start()
                     display.debug("worker is %d (out of %d available)" % (self._cur_worker + 1, len(self._workers)))

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -47,6 +47,7 @@ class TestTaskExecutor(unittest.TestCase):
         new_stdin = None
         job_vars = dict()
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
         te = TaskExecutor(
             host=mock_host,
             task=mock_task,
@@ -56,6 +57,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
     def test_task_executor_run(self):
@@ -70,6 +72,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_shared_loader = MagicMock()
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
 
         new_stdin = None
         job_vars = dict()
@@ -83,6 +86,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
         te._get_loop_items = MagicMock(return_value=None)
@@ -117,6 +121,7 @@ class TestTaskExecutor(unittest.TestCase):
         new_stdin = None
         job_vars = dict()
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
 
         te = TaskExecutor(
             host=mock_host,
@@ -127,6 +132,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
         items = te._get_loop_items()
@@ -150,6 +156,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_shared_loader = MagicMock()
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
 
         new_stdin = None
         job_vars = dict()
@@ -163,6 +170,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
         def _execute(variables):
@@ -196,6 +204,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_shared_loader = None
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
 
         new_stdin = None
         job_vars = dict(pkg_mgr='yum')
@@ -209,6 +218,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=mock_shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
         # No replacement
@@ -387,6 +397,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_action = MagicMock()
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
 
         shared_loader = None
         new_stdin = None
@@ -401,6 +412,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
         te._get_connection = MagicMock(return_value=mock_connection)
@@ -440,6 +452,7 @@ class TestTaskExecutor(unittest.TestCase):
 
         mock_action = MagicMock()
         mock_queue = MagicMock()
+        mock_tqm = MagicMock()
 
         shared_loader = MagicMock()
         shared_loader.action_loader = action_loader
@@ -456,6 +469,7 @@ class TestTaskExecutor(unittest.TestCase):
             loader=fake_loader,
             shared_loader_obj=shared_loader,
             rslt_q=mock_queue,
+            tqm=mock_tqm,
         )
 
         te._connection = MagicMock()


### PR DESCRIPTION
Add new event v2_runner_on_task_start to allow callback by host task

##### SUMMARY
This change exposes a new event callback on each runner task start.

The main purpose is to allow a greater control on callback plugins.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
WorkerProcess
TaskExecutor
StrategyBase

##### ANSIBLE VERSION
```
ansible 2.4.0 (runner_on_task_start_callback 4aa8dd48f5) last updated 2017/06/20 17:57:14 (GMT +100)
```


