### PR TITLE
Small fix in the error output

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -78,10 +78,10 @@ Function Copy-File($src, $dest) {
     if ($src_checksum -ne $dest_checksum) {
         try {
             Copy-Item -Path $src -Destination $dest -Force -WhatIf:$check_mode
-            $result.changed = $true
         } catch {
-            Fail-Json $result "Failed to copy file $($_.Exception.Message)"
+            Fail-Json $result "Failed to copy file: $($_.Exception.Message)"
         }
+        $result.changed = $true
     }
 
     # Verify the file we copied is the same


### PR DESCRIPTION
##### SUMMARY
So I noticed this when doing integration tests:

    Failed to copy file Could not find a part of the path

and this change turns it into:

    Failed to copy file: Could not find a part of the path

I also moved something out of the exception handling.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_copy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4