### PR TITLE
add 2 quota variables for openstack: loadbalancer and pool

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -99,6 +99,7 @@ options:
         required: False
         default: None
         description: Number of load balancers to allow.
+        version_added: "2.4"
     network:
         required: False
         default: None
@@ -111,6 +112,7 @@ options:
         required: False
         default: None
         description: Number of load balancer pools to allow.
+        version_added: "2.4"
     port:
         required: False
         default: None

--- a/lib/ansible/modules/cloud/openstack/os_quota.py
+++ b/lib/ansible/modules/cloud/openstack/os_quota.py
@@ -95,6 +95,10 @@ options:
         required: False
         default: None
         description: Number of key pairs to allow.
+    loadbalancer:
+        required: False
+        default: None
+        description: Number of load balancers to allow.
     network:
         required: False
         default: None
@@ -103,6 +107,10 @@ options:
         required: False
         default: None
         description: Maximum size in GB's of individual volumes.
+    pool:
+        required: False
+        default: None
+        description: Number of load balancer pools to allow.
     port:
         required: False
         default: None
@@ -215,9 +223,11 @@ EXAMPLES = '''
     injected_files: "{{ item.injected_files }}"
     injected_path_size: "{{ item.injected_path_size }}"
     instances: "{{ item.instances }}"
-    port: "{{ item.port }}"
     key_pairs: "{{ item.key_pairs }}"
+    loadbalancer: "{{ item.loadbalancer }}"
     per_volume_gigabytes: "{{ item.per_volume_gigabytes }}"
+    pool: "{{ item.pool }}"
+    port: "{{ item.port }}"
     properties: "{{ item.properties }}"
     ram: "{{ item.ram }}"
     security_group_rule: "{{ item.security_group_rule }}"
@@ -262,7 +272,9 @@ openstack_quotas:
             },
             network: {
                 floatingip: 50,
+                loadbalancer: 10,
                 network: 10,
+                pool: 10,
                 port: 160,
                 rbac_policy: 10,
                 router: 10,
@@ -398,8 +410,10 @@ def main():
         injected_path_size=dict(required=False, type='int', default=None),
         instances=dict(required=False, type='int', default=None),
         key_pairs=dict(required=False, type='int', default=None),
+        loadbalancer=dict(required=False, type='int', default=None),
         network=dict(required=False, type='int', default=None),
         per_volume_gigabytes=dict(required=False, type='int', default=None),
+        pool=dict(required=False, type='int', default=None),
         port=dict(required=False, type='int', default=None),
         project=dict(required=False, type='int', default=None),
         properties=dict(required=False, type='int', default=None),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In neutron, loadbalancer and pool are set to 10 by default. So in the real production environment, you would hit this limit very soon.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openstack module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
Ansible 2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

In the current os_quota of openstack module, you can't adjust quotas of load balancer and pool. And their default value is both 10. So I would like to add 2 additional vars for loadbalancer and pool.

I've personally tested the fix in our environment and worked.

In case you have some questions, let me know.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
