### PR TITLE
Fix type for 'attributes' field

### DIFF
--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -350,7 +350,7 @@ stat:
         attributes:
             description: list of file attributes
             returned: success, path exists and user can execute the path
-            type: boolean
+            type: list
             sample: [ immutable, extent ]
             version_added: 2.3
 '''


### PR DESCRIPTION
##### SUMMARY
Update type of field in documentation of 'stat' module

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
stat

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
