### PR TITLE
pkg5_publisher: Fix on failed, PEP8 compliancy

### DIFF
--- a/lib/ansible/modules/packaging/os/pkg5_publisher.py
+++ b/lib/ansible/modules/packaging/os/pkg5_publisher.py
@@ -75,6 +75,7 @@ EXAMPLES = '''
     origin: 'https://pkg.example.com/site/'
 '''
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -145,11 +146,13 @@ def set_publisher(module, params):
         'msg': err,
         'changed': True,
     }
+    if rc != 0:
+        module.fail_json(**response)
     module.exit_json(**response)
 
 
 def unset_publisher(module, publisher):
-    if not publisher in get_publishers(module):
+    if publisher not in get_publishers(module):
         module.exit_json()
 
     rc, out, err = module.run_command(
@@ -162,6 +165,8 @@ def unset_publisher(module, publisher):
         'msg': err,
         'changed': True,
     }
+    if rc != 0:
+        module.fail_json(**response)
     module.exit_json(**response)
 
 
@@ -176,7 +181,7 @@ def get_publishers(module):
         values = dict(zip(keys, map(unstringify, line.split("\t"))))
         name = values['publisher']
 
-        if not name in publishers:
+        if name not in publishers:
             publishers[name] = dict(
                 (k, values[k]) for k in ['sticky', 'enabled']
             )

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -412,7 +412,6 @@ lib/ansible/modules/packaging/os/openbsd_pkg.py
 lib/ansible/modules/packaging/os/opkg.py
 lib/ansible/modules/packaging/os/pacman.py
 lib/ansible/modules/packaging/os/pkg5.py
-lib/ansible/modules/packaging/os/pkg5_publisher.py
 lib/ansible/modules/packaging/os/pkgin.py
 lib/ansible/modules/packaging/os/pkgng.py
 lib/ansible/modules/packaging/os/pkgutil.py


### PR DESCRIPTION
##### SUMMARY
This includes:
- PEP8 compliancy
- Fixes to call fail_json() explicitly

Related to PR #25950

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pkg5_publisher

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4