### PR TITLE
Correct usage of FindByUuid in vmware module util

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -182,7 +182,8 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
         if isinstance(vm, vim.VirtualMachine):
             vm = None
     elif vm_id_type == 'uuid':
-        vm = si.FindByUuid(datacenter=datacenter, instanceUuid=vm_id, vmSearch=True)
+        # Search By BIOS UUID rather than instance UUID
+        vm = si.FindByUuid(datacenter=datacenter, instanceUuid=False, uuid=vm_id, vmSearch=True)
     elif vm_id_type == 'ip':
         vm = si.FindByIp(datacenter=datacenter, ip=vm_id, vmSearch=True)
     elif vm_id_type == 'vm_name':


### PR DESCRIPTION
##### SUMMARY
This fix corrects the usage of function FindByUuid by
specifying correct parameter 'uuid' and 'instanceUuid'
as documentation of VMWare's API.

Fixes: #24398, #24835, #25713

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
```
2.4devel
```