### PR TITLE
Fixes list comparison

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1355,7 +1355,7 @@ class Container(DockerBaseClass):
                         self.log("comparing lists: %s" % key)
                         set_a = set(getattr(self.parameters, key))
                         set_b = set(value)
-                        match = (set_a == set_b)
+                        match = (set_b >= set_a)
                 elif isinstance(getattr(self.parameters, key), list) and not len(getattr(self.parameters, key)) \
                         and value is None:
                     # an empty list and None are ==


### PR DESCRIPTION
##### SUMMARY
The comparison in question is meant to insure that the contents of one list are found within the second list. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/clouse/docker/docker_container.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 82e49ec67f) last updated 2017/06/23 08:29:22 (GMT -400)
  config file = /Users/chouseknecht/.ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION

The environment comparison fails and causes an existing container to be destroyed when the container environment has more variables defined than expected by the image environment + the environment option. 

In the case where the image has no variables defined, and the user did not define any, but somehow the container has one or more defined (coming from the network settings, say) the comparison failed, and triggered the recreation of the container.  