### PR TITLE
Handle exception when capital letter used in S3 bucket name.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -129,7 +129,7 @@ try:
     import boto.ec2
     from boto.s3.connection import OrdinaryCallingFormat, Location, S3Connection
     from boto.s3.tagging import Tags, TagSet
-    from boto.exception import BotoServerError, S3CreateError, S3ResponseError
+    from boto.exception import BotoServerError, S3CreateError, S3ResponseError, BotoClientError
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
@@ -255,7 +255,7 @@ def _create_or_update_bucket(connection, module, location):
         try:
             bucket = connection.create_bucket(name, location=location)
             changed = True
-        except S3CreateError as e:
+        except (S3CreateError,BotoClientError) as e:
             module.fail_json(msg=e.message)
 
     # Versioning
@@ -390,7 +390,7 @@ def _create_or_update_bucket_ceph(connection, module, location):
         try:
             bucket = connection.create_bucket(name, location=location)
             changed = True
-        except S3CreateError as e:
+        except (S3CreateError,BotoClientError) as e:
             module.fail_json(msg=e.message)
 
     if bucket:

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -255,7 +255,7 @@ def _create_or_update_bucket(connection, module, location):
         try:
             bucket = connection.create_bucket(name, location=location)
             changed = True
-        except (S3CreateError,BotoClientError) as e:
+        except (S3CreateError, BotoClientError) as e:
             module.fail_json(msg=e.message)
 
     # Versioning
@@ -390,7 +390,7 @@ def _create_or_update_bucket_ceph(connection, module, location):
         try:
             bucket = connection.create_bucket(name, location=location)
             changed = True
-        except (S3CreateError,BotoClientError) as e:
+        except (S3CreateError, BotoClientError) as e:
             module.fail_json(msg=e.message)
 
     if bucket:


### PR DESCRIPTION
##### SUMMARY
This PR fixes a issue reported in #25996.
Handles properly the exception when capital letters are used in S3 bucket name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/s3_bucket.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_LheTZV/ansible_module_s3_bucket.py", line 450, in <module>
    main()
  File "/tmp/ansible_LheTZV/ansible_module_s3_bucket.py", line 445, in main
    create_or_update_bucket(connection, module, location, flavour=flavour)
  File "/tmp/ansible_LheTZV/ansible_module_s3_bucket.py", line 326, in create_or_update_bucket
    _create_or_update_bucket(connection, module, location)
  File "/tmp/ansible_LheTZV/ansible_module_s3_bucket.py", line 171, in _create_or_update_bucket
    bucket = connection.create_bucket(name, location=location)
  File "/usr/lib/python2.7/site-packages/boto/s3/connection.py", line 603, in create_bucket
    check_lowercase_bucketname(bucket_name)
  File "/usr/lib/python2.7/site-packages/boto/s3/connection.py", line 59, in check_lowercase_bucketname
    raise BotoClientError("Bucket names cannot contain upper-case " \
boto.exception.BotoClientError: BotoClientError: Bucket names cannot contain upper-case characters when using either the sub-domain or virtual hosting calling format.

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_LheTZV/ansible_module_s3_bucket.py\", line 450, in <module>\n    main()\n  File \"/tmp/ansible_LheTZV/ansible_module_s3_bucket.py\", line 445, in main\n    create_or_update_bucket(connection, module, location, flavour=flavour)\n  File \"/tmp/ansible_LheTZV/ansible_module_s3_bucket.py\", line 326, in create_or_update_bucket\n    _create_or_update_bucket(connection, module, location)\n  File \"/tmp/ansible_LheTZV/ansible_module_s3_bucket.py\", line 171, in _create_or_update_bucket\n    bucket = connection.create_bucket(name, location=location)\n  File \"/usr/lib/python2.7/site-packages/boto/s3/connection.py\", line 603, in create_bucket\n    check_lowercase_bucketname(bucket_name)\n  File \"/usr/lib/python2.7/site-packages/boto/s3/connection.py\", line 59, in check_lowercase_bucketname\n    raise BotoClientError(\"Bucket names cannot contain upper-case \" \\\nboto.exception.BotoClientError: BotoClientError: Bucket names cannot contain upper-case characters when using either the sub-domain or virtual hosting calling format.\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 1
}
        to retry, use: --limit @/tmp/s3.retry

PLAY RECAP ********************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1

```


After:
```
TASK [Create S3 bucket] *******************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Bucket names cannot contain upper-case characters when using either the sub-domain or virtual hosting calling format."}
        to retry, use: --limit @/tmp/s3.retry

PLAY RECAP ********************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1

```
