### PR TITLE
ec2_remote_facts: ensure instance.instance_profile is not None before casting

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
@@ -108,9 +108,11 @@ def get_instance_info(instance):
     except AttributeError:
         pass
 
+    instance_profile = dict(instance.instance_profile) if instance.instance_profile is not None else None
+
     instance_info = { 'id': instance.id,
                     'kernel': instance.kernel,
-                    'instance_profile': dict(instance.instance_profile),
+                    'instance_profile': instance_profile,
                     'root_device_type': instance.root_device_type,
                     'private_dns_name': instance.private_dns_name,
                     'public_dns_name': instance.public_dns_name,


### PR DESCRIPTION
##### SUMMARY
re: https://github.com/ansible/ansible/issues/26045
This simple change avoids a TypeError by preventing an iteration attempt on None.

```
Traceback (most recent call last):
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_jGgoay/ansible_module_ec2_remote_facts.py", line 194, in <module>
    main()
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_jGgoay/ansible_module_ec2_remote_facts.py", line 190, in main
    list_ec2_instances(connection, module)
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_jGgoay/ansible_module_ec2_remote_facts.py", line 161, in list_ec2_instances
    instance_dict_array.append(get_instance_info(instance))
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_jGgoay/ansible_module_ec2_remote_facts.py", line 113, in get_instance_info
    'instance_profile': dict(instance.instance_profile),
TypeError: 'NoneType' object is not iterable
```


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_remote_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (a26045_ec2_remote_facts_cast_check 89cd1bc52f) last updated 2017/06/23 11:02:04 (GMT -400)
```