### PR TITLE
ec2_group_facts: fails with groups without tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group_facts.py
@@ -158,7 +158,7 @@ def main():
         # Modify boto3 tags list to be ansible friendly dict
         # but don't camel case tags
         security_group = camel_dict_to_snake_dict(security_group)
-        security_group['tags'] = boto3_tag_list_to_ansible_dict(security_group['tags'], tag_name_key_name='key', tag_value_key_name='value')
+        security_group['tags'] = boto3_tag_list_to_ansible_dict(security_group.get('tags', {}), tag_name_key_name='key', tag_value_key_name='value')
         snaked_security_groups.append(security_group)
 
     module.exit_json(security_groups=snaked_security_groups)


### PR DESCRIPTION
##### SUMMARY
ec2_group_facts fails if returning results for a security group that doesn't have tags.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group_facts.py

##### ANSIBLE VERSION
```
2.4.0
```
