### PR TITLE
Docker image updates for integration tests.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -21,4 +21,5 @@ omit =
     */python*/dist-packages/*
     */python*/site-packages/*
     */python*/distutils/*
+    */pyshared/*
     */pytest

--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -19,6 +19,7 @@ RUN yum clean all && \
     openssh-clients \
     openssh-server \
     openssl-devel \
+    python-argparse \
     python-coverage \
     python-devel \
     python-httplib2 \

--- a/test/utils/docker/centos6/Dockerfile
+++ b/test/utils/docker/centos6/Dockerfile
@@ -20,7 +20,6 @@ RUN yum clean all && \
     openssh-server \
     openssl-devel \
     python-argparse \
-    python-coverage \
     python-devel \
     python-httplib2 \
     python-jinja2 \
@@ -57,6 +56,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -29,7 +29,6 @@ RUN yum clean all && \
     openssh-clients \
     openssh-server \
     openssl-devel \
-    python-coverage \
     python-cryptography \
     python-devel \
     python-httplib2 \
@@ -64,6 +63,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/centos7/Dockerfile
+++ b/test/utils/docker/centos7/Dockerfile
@@ -30,6 +30,7 @@ RUN yum clean all && \
     openssh-server \
     openssl-devel \
     python-coverage \
+    python-cryptography \
     python-devel \
     python-httplib2 \
     python-jinja2 \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -36,6 +36,7 @@ RUN dnf clean all && \
     openssl-devel \
     procps \
     python-coverage \
+    python-cryptography \
     python-devel \
     python-httplib2 \
     python-jinja2 \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -35,7 +35,6 @@ RUN dnf clean all && \
     openssh-server \
     openssl-devel \
     procps \
-    python2-dnf \
     python-coverage \
     python-devel \
     python-httplib2 \
@@ -49,6 +48,7 @@ RUN dnf clean all && \
     python-pip \
     python-setuptools \
     python-virtualenv \
+    python2-dnf \
     PyYAML \
     rpm-build \
     rubygems \

--- a/test/utils/docker/fedora24/Dockerfile
+++ b/test/utils/docker/fedora24/Dockerfile
@@ -35,7 +35,6 @@ RUN dnf clean all && \
     openssh-server \
     openssl-devel \
     procps \
-    python-coverage \
     python-cryptography \
     python-devel \
     python-httplib2 \
@@ -73,6 +72,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -31,7 +31,6 @@ RUN dnf clean all && \
     openssh-server \
     openssl-devel \
     procps \
-    python-coverage \
     python-cryptography \
     python-devel \
     python-httplib2 \
@@ -69,6 +68,6 @@ RUN ssh-keygen -q -t dsa -N '' -f /etc/ssh/ssh_host_dsa_key && \
     ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/usr/sbin/init"]

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -30,7 +30,6 @@ RUN dnf clean all && \
     openssh-server \
     openssl-devel \
     procps \
-    python2-dnf \
     python-coverage \
     python-httplib2 \
     python-jinja2 \
@@ -43,6 +42,7 @@ RUN dnf clean all && \
     python-pip \
     python-setuptools \
     python-virtualenv \
+    python2-dnf \
     PyYAML \
     rpm-build \
     rubygems \

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -17,6 +17,7 @@ RUN dnf clean all && \
     dbus-python \
     file \
     findutils \
+    gcc \
     git \
     glibc-locale-source \
     iproute \
@@ -31,6 +32,7 @@ RUN dnf clean all && \
     openssl-devel \
     procps \
     python-coverage \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/fedora25/Dockerfile
+++ b/test/utils/docker/fedora25/Dockerfile
@@ -32,6 +32,7 @@ RUN dnf clean all && \
     openssl-devel \
     procps \
     python-coverage \
+    python-cryptography \
     python-devel \
     python-httplib2 \
     python-jinja2 \

--- a/test/utils/docker/opensuse42.1/Dockerfile
+++ b/test/utils/docker/opensuse42.1/Dockerfile
@@ -20,7 +20,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     mercurial \
     openssh \
     postgresql-server \
-    python-coverage \
     python-cryptography \
     python-devel \
     python-httplib2 \
@@ -72,6 +71,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/opensuse42.2/Dockerfile
+++ b/test/utils/docker/opensuse42.2/Dockerfile
@@ -20,7 +20,6 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     mercurial \
     openssh \
     postgresql-server \
-    python-coverage \
     python-cryptography \
     python-devel \
     python-httplib2 \
@@ -72,6 +71,6 @@ RUN ssh-keygen -q -t rsa1 -N '' -f /etc/ssh/ssh_host_key && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 # explicitly enable the service, opensuse default to disabled services
 RUN systemctl enable sshd.service
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/opensuse42.2/Dockerfile
+++ b/test/utils/docker/opensuse42.2/Dockerfile
@@ -22,6 +22,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     postgresql-server \
     python-coverage \
     python-cryptography \
+    python-devel \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -55,6 +55,7 @@ RUN apt-get update -y && \
     apt-get clean
 
 RUN pip install --upgrade pycrypto cryptography
+
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile
 ADD init-fake.conf /etc/init/fake-container-events.conf

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update -y && \
     mysql-server \
     openssh-client \
     openssh-server \
-    python-coverage \
     python-dev \
     python-httplib2 \
     python-jinja2 \
@@ -92,6 +91,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1204/Dockerfile
+++ b/test/utils/docker/ubuntu1204/Dockerfile
@@ -91,6 +91,7 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
+RUN pip install pip --upgrade
 RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -26,7 +26,6 @@ RUN apt-get update -y && \
     mysql-server \
     openssh-client \
     openssh-server \
-    python-coverage \
     python-dev \
     python-httplib2 \
     python-jinja2 \
@@ -91,6 +90,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -53,6 +53,8 @@ RUN apt-get update -y && \
     && \
     apt-get clean
 
+RUN pip install --upgrade pycrypto cryptography
+
 # helpful things taken from the ubuntu-upstart Dockerfile:
 # https://github.com/tianon/dockerfiles/blob/4d24a12b54b75b3e0904d8a285900d88d3326361/sbin-init/ubuntu/upstart/14.04/Dockerfile
 ADD init-fake.conf /etc/init/fake-container-events.conf

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y && \
     dpkg-dev \
     fakeroot \
     gawk \
+    gcc \
     git \
     libffi-dev \
     libssl-dev \
@@ -26,6 +27,7 @@ RUN apt-get update -y && \
     openssh-client \
     openssh-server \
     python-coverage \
+    python-dev \
     python-httplib2 \
     python-jinja2 \
     python-keyczar \

--- a/test/utils/docker/ubuntu1404/Dockerfile
+++ b/test/utils/docker/ubuntu1404/Dockerfile
@@ -90,6 +90,7 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
+RUN pip install pip --upgrade
 RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update -y && \
     mysql-server \
     openssh-client \
     openssh-server \
-    python-coverage \
     python-cryptography \
     python-dev \
     python-dbus \
@@ -67,6 +66,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip install junit-xml
+RUN pip install coverage junit-xml
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update -y && \
     dpkg-dev \
     fakeroot \
     gawk \
+    gcc \
     git \
     iproute2 \
     libffi-dev \
@@ -28,6 +29,7 @@ RUN apt-get update -y && \
     openssh-client \
     openssh-server \
     python-coverage \
+    python-dev \
     python-dbus \
     python-httplib2 \
     python-jinja2 \

--- a/test/utils/docker/ubuntu1604/Dockerfile
+++ b/test/utils/docker/ubuntu1604/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update -y && \
     openssh-client \
     openssh-server \
     python-coverage \
+    python-cryptography \
     python-dev \
     python-dbus \
     python-httplib2 \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -y && \
     dpkg-dev \
     fakeroot \
     gawk \
+    gcc \
     git \
     iproute2 \
     libffi-dev \
@@ -25,6 +26,7 @@ RUN apt-get update -y && \
     openssh-client \
     openssh-server \
     python3-coverage \
+    python3-dev \
     python3-dbus \
     python3-httplib2 \
     python3-jinja2 \

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update -y && \
     mysql-server \
     openssh-client \
     openssh-server \
-    python3-coverage \
     python3-cryptography \
     python3-dev \
     python3-dbus \
@@ -63,6 +62,6 @@ RUN ssh-keygen -q -t rsa -N '' -f /root/.ssh/id_rsa && \
     cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
     for key in /etc/ssh/ssh_host_*_key.pub; do echo "localhost $(cat ${key})" >> /root/.ssh/known_hosts; done
 VOLUME /sys/fs/cgroup /run/lock /run /tmp
-RUN pip3 install junit-xml python3-keyczar
+RUN pip3 install coverage junit-xml python3-keyczar
 ENV container=docker
 CMD ["/sbin/init"]

--- a/test/utils/docker/ubuntu1604py3/Dockerfile
+++ b/test/utils/docker/ubuntu1604py3/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && \
     openssh-client \
     openssh-server \
     python3-coverage \
+    python3-cryptography \
     python3-dev \
     python3-dbus \
     python3-httplib2 \


### PR DESCRIPTION
##### SUMMARY

Docker image updates for integration tests:

- Sort packages to install.
- Add python-argparse to centos6 docker image.
- Add gcc and python dev lib to docker images.
- Add python cryptography to docker images.
- Add coverage using pip instead of OS packages.
- Update old pip versions in docker images.

Also exclude `*/pyshared/*` from coverage reporting now that coverage has been updated.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

docker images

##### ANSIBLE VERSION

```
ansible 2.4.0 (docker-update 6c555ba263) last updated 2017/06/23 12:02:42 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
