### PR TITLE
Fix network integration test config.

### DIFF
--- a/test/integration/target-prefixes.network
+++ b/test/integration/target-prefixes.network
@@ -9,6 +9,7 @@ eos
 ios
 iosxr
 junos
+net
 nxos
 ops
 pn

--- a/test/integration/targets/eos_vrf/aliases
+++ b/test/integration/targets/eos_vrf/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/junos_interface/aliases
+++ b/test/integration/targets/junos_interface/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/junos_system/aliases
+++ b/test/integration/targets/junos_system/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/net_banner/aliases
+++ b/test/integration/targets/net_banner/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/net_command/aliases
+++ b/test/integration/targets/net_command/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/net_interface/aliases
+++ b/test/integration/targets/net_interface/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/net_system/aliases
+++ b/test/integration/targets/net_system/aliases
@@ -1,2 +1,1 @@
-network/ci
 skip/python3

--- a/test/integration/targets/net_user/aliases
+++ b/test/integration/targets/net_user/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/net_vlan/aliases
+++ b/test/integration/targets/net_vlan/aliases
@@ -1,1 +1,0 @@
-network/ci

--- a/test/integration/targets/net_vrf/aliases
+++ b/test/integration/targets/net_vrf/aliases
@@ -1,1 +1,0 @@
-network/ci


### PR DESCRIPTION
##### SUMMARY

Fix network integration test config:

- Disable unsupported network integration tests in CI.
- Add `net` prefix to network target prefix list.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Network Integration Tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-fixes 2f3c1f9225) last updated 2017/06/23 16:23:37 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
```
