### PR TITLE
Update FreeBSD pg test to use postgresql95-server.

### DIFF
--- a/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
@@ -1,10 +1,10 @@
 postgresql_packages:
-  - "postgresql93-server"
+  - "postgresql95-server"
   - "py27-psycopg2"
 
 pg_hba_location: "/usr/local/pgsql/data/pg_hba.conf"
 pg_dir: "/usr/local/pgsql/data"
-pg_ver: 9.3
+pg_ver: 9.5
 pg_user: pgsql
 pg_group: pgsql
 


### PR DESCRIPTION
##### SUMMARY

The py-psycopg2 package now requires postgresql95-server instead of
postgresql93-server. Installing py-psycopg2 will automatically remove
postgresql93-server if it is installed, breaking integration tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

postgresql integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (pg-freebsd 1cb79cff41) last updated 2017/06/24 19:03:18 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
