### PR TITLE
Set license GPLv3+ ("or any later version") in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     author=__author__,
     author_email='info@ansible.com',
     url='https://ansible.com/',
-    license='GPLv3',
+    license='GPLv3+',
     # Ansible will also make use of a system copy of python-six and
     # python-selectors2 if installed but use a Bundled copy if it's not.
     install_requires=install_requirements,


### PR DESCRIPTION
Most file headers in the project contain the standard
> either version 3 of the License, or (at your option) any later version
https://github.com/ansible/ansible/search?utf8=%E2%9C%93&q=%22any+later+version%22

So this project appears to be GPLv3+, as stated in the classifiers function.