### PR TITLE
In the git module let ssh do its own host checking

### DIFF
--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -43,26 +43,6 @@ except ImportError:
 HASHED_KEY_MAGIC = "|1|"
 
 
-def add_git_host_key(module, url, accept_hostkey=True, create_dir=True):
-
-    """ idempotently add a git url hostkey """
-
-    if is_ssh_url(url):
-
-        fqdn, port = get_fqdn_and_port(url)
-
-        if fqdn:
-            known_host = check_hostkey(module, fqdn)
-            if not known_host:
-                if accept_hostkey:
-                    rc, out, err = add_host_key(module, fqdn, port=port, create_dir=create_dir)
-                    if rc != 0:
-                        module.fail_json(msg="failed to add %s hostkey: %s" % (fqdn, out + err))
-                else:
-                    module.fail_json(msg="%s has an unknown hostkey. Set accept_hostkey to True "
-                                     "or manually add the hostkey prior to running the git module" % fqdn)
-
-
 def is_ssh_url(url):
 
     """ check if url is ssh """

--- a/test/integration/targets/git/tasks/missing_hostkey.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey.yml
@@ -16,7 +16,6 @@
 - assert:
     that:
       - 'git_result.failed'
-      - 'git_result.msg == "github.com has an unknown hostkey. Set accept_hostkey to True or manually add the hostkey prior to running the git module"'
 
 - name: checkout git@github.com repo with accept_hostkey (expected pass)
   git:


### PR DESCRIPTION
##### SUMMARY

There are too many possible special cases for Ansible to be able to
precheck known_hosts files without introducing all kinds of false
failures.

* Alternative known_hosts paths
* Alternative host name aliases
* ssh host certificates
* SSHFP + DNSSEC

Fixes #24860

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
git module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 014bcad35b) last updated 2017/06/25 20:22:15 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/workdir/ma/lib/ansible
  executable location = /home/andreas/workdir/ma/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```