### PR TITLE
virt_net: Properly error out on modify with unknown xml

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt_net.py
+++ b/lib/ansible/modules/cloud/misc/virt_net.py
@@ -278,7 +278,7 @@ class LibvirtConnection(object):
                     if res == 0:
                         return True
             #  command, section, parentIndex, xml, flags=0
-            self.module.fail_json(msg='updating this is not supported yet '+unicode(xml))
+        self.module.fail_json(msg='updating this is not supported yet '+unicode(xml))
 
     def destroy(self, entryid):
         if not self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY
The code for `virt_net: command=modify` only correctly handles modifications where the root XML element is `<host/>` (and then only partially). There is a `self.module.fail_json()` call to inform the user of unsupported XML input, but due to incorrect indentation it's not (fully) active.

This change makes the module fail if unsupported XML is specified, instead of silently ignoring the error (and leaving the user wondering why nothing happened).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
virt_net

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /home/henryk/prog/central-services/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

Steps to reproduce the problem:

1. Create a task like
````
virt_net:
    name: default
    command: modify
    xml: |
      <network>
      <name>{{ libvirt_net_name }}</name>
      <forward mode='nat'>
        <nat>
          <port start='1024' end='65535'/>
        </nat>
      </forward>
      <bridge name='{{libvirt_net_device}}' stp='on' delay='0'/>
      <ip address='{{libvirt_net_ip_base}}' netmask='{{libvirt_net_ip_mask}}'>
        <dhcp>
          <range start='{{libvirt_net_ip_dhcp_min}}' end='{{libvirt_net_ip_dhcp_max}}'/>
        </dhcp>
      </ip>
      </network>
````
2. Execute the task

###### Actual results

Nothing happens, nothing is changed on the remote system

###### Expected results

Since `<network>` is not supported for `command: modify`, an error should be generated.
