### PR TITLE
Fix Python3 Errors in Azure Cloud Module

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -451,7 +451,7 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
         if PREREQ_IMPORT_ERROR:
             self.fail(PREREQ_IMPORT_ERROR)
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         if self.state == 'present':

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -336,7 +336,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         results = dict()

--- a/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
@@ -182,7 +182,7 @@ class AzureRMPublicIPAddress(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         results = dict()

--- a/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_resourcegroup.py
@@ -153,7 +153,7 @@ class AzureRMResourceGroup(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         results = dict()

--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -548,7 +548,7 @@ class AzureRMSecurityGroup(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         changed = False

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -206,7 +206,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         resource_group = self.get_resource_group(self.resource_group)

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -267,7 +267,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         self.results['check_mode'] = self.check_mode

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -555,7 +555,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         # make sure options are lower case

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
@@ -221,7 +221,7 @@ class AzureRMVirtualNetwork(AzureRMModuleBase):
 
     def exec_module(self, **kwargs):
 
-        for key in self.module_arg_spec.keys() + ['tags']:
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
             setattr(self, key, kwargs[key])
 
         self.results['check_mode'] = self.check_mode


### PR DESCRIPTION
##### SUMMARY

When using Python3, the exec_module function errors out with a
unsupported operand type(s) for +: 'dict_keys' and 'list'
error when adding the .keys() to a static list. Use the explicit
list function to make a list of keys and then add to the ['tags'] list.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - cloud/azure

##### ANSIBLE VERSION
```
ansible 2.4.0 (python3_azure e9f6d02e69) last updated 2017/06/26 11:44:44 (GMT +550)
  config file = None
  configured module search path = ['/Users/raja/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /private/tmp/ansible/lib/ansible
  executable location = /private/tmp/ansible/bin/ansible
  python version = 3.6.0 (default, Dec 30 2016, 23:33:29) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
When running azure modules under Python3, there are errors of the form:
```
TypeError: unsupported operand type(s) for +: 'dict_keys' and 'list'
```
This is because of calls like
```
self.module_arg_spec.keys() + ['tags']:
```
Replacing them with
```
list(self.module_arg_spec.keys()) + ['tags']:
```
fixes the issue. This is now done in the pull request for various azure sub commands
