### PR TITLE
Handle wait_for_deployment_completion during Azure deployment.

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_deployment.py
@@ -456,13 +456,23 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
 
         if self.state == 'present':
             deployment = self.deploy_template()
-            self.results['deployment'] = dict(
-                name=deployment.name,
-                group_name=self.resource_group_name,
-                id=deployment.id,
-                outputs=deployment.properties.outputs,
-                instances=self._get_instances(deployment)
-            )
+            if deployment is None:
+                self.results['deployment'] = dict(
+                    name=self.deployment_name,
+                    group_name=self.resource_group_name,
+                    id=None,
+                    outputs=None,
+                    instances=None
+                )
+            else:
+                self.results['deployment'] = dict(
+                    name=deployment.name,
+                    group_name=self.resource_group_name,
+                    id=deployment.id,
+                    outputs=deployment.properties.outputs,
+                    instances=self._get_instances(deployment)
+                )
+
             self.results['changed'] = True
             self.results['msg'] = 'deployment succeeded'
         else:
@@ -508,8 +518,9 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
                                                                  self.deployment_name,
                                                                  deploy_parameter)
 
-            deployment_result = self.get_poller_result(result)
+            deployment_result = None
             if self.wait_for_deployment_completion:
+                deployment_result = self.get_poller_result(result)
                 while deployment_result.properties is None or deployment_result.properties.provisioning_state not in ['Canceled', 'Failed', 'Deleted',
                                                                               'Succeeded']:
                     time.sleep(self.wait_for_deployment_polling_period)


### PR DESCRIPTION
###### SUMMARY
Pull the get_poller_result inside the if block so that if the caller has
wait_for_deployment_completion=False, it doesnt block and wait for it to
finish.

Also, since the result contains information about the deployment, provide
None values for it in the output.(Not sure if this needs to be documented)

Fixes #26014 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/azure

##### ANSIBLE VERSION
```
ansible 2.4.0 (bug_26014 ab7059b33a) last updated 2017/06/26 13:46:21 (GMT +550)
  config file = None
  configured module search path = ['/Users/raja/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /private/tmp/ansible/lib/ansible
  executable location = /private/tmp/ansible/bin/ansible
  python version = 3.6.0 (default, Dec 30 2016, 23:33:29) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
Since the call is now non-blocking the output has been changed to provide None values for deployment id, instances and properties.
