### PR TITLE
azure_rm_storageaccount module: add 'access_tier' module parameter

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -88,6 +88,15 @@ options:
             - Storage
             - StorageBlob
         version_added: "2.2"
+    access_tier:
+        description:
+            - The access tier for this storage account. Required for a storage account of kind 'BlobStorage'.
+        required: false
+        default: 'Storage'
+        choices:
+            - Hot
+            - Cool
+        version_added: "2.4"
 
 extends_documentation_fragment:
     - azure
@@ -179,7 +188,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             state=dict(default='present', choices=['present', 'absent']),
             force=dict(type='bool', default=False),
             tags=dict(type='dict'),
-            kind=dict(type='str', default='Storage', choices=['Storage', 'BlobStorage'])
+            kind=dict(type='str', default='Storage', choices=['Storage', 'BlobStorage']),
+            access_tier=dict(type='str', choices=['Hot', 'Cool'])
         )
 
         for key in SkuName:
@@ -200,6 +210,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         self.tags = None
         self.force = None
         self.kind = None
+        self.access_tier = None
 
         super(AzureRMStorageAccount, self).__init__(self.module_arg_spec,
                                                     supports_check_mode=True)
@@ -280,6 +291,8 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             location=account_obj.location,
             resource_group=self.resource_group,
             type=account_obj.type,
+            access_tier=(account_obj.access_tier.value
+                        if account_obj.access_tier is not None else None),
             sku_tier=account_obj.sku.tier.value,
             sku_name=account_obj.sku.name.value,
             provisioning_state=account_obj.provisioning_state.value,
@@ -360,6 +373,18 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                 except Exception as exc:
                     self.fail("Failed to update custom domain: {0}".format(str(exc)))
 
+        if self.access_tier:
+            if not self.account_dict['access_tier'] or self.account_dict['access_tier'] != self.access_tier:
+                self.results['changed'] = True
+                self.account_dict['access_tier'] = self.access_tier
+
+            if self.results['changed'] and not self.check_mode:
+                parameters = StorageAccountUpdateParameters(access_tier=self.access_tier)
+                try:
+                    self.storage_client.storage_accounts.update(self.resource_group, self.name, parameters)
+                except Exception as exc:
+                    self.fail("Failed to update access tier: {0}".format(str(exc)))
+
         update_tags, self.account_dict['tags'] = self.update_tags(self.account_dict['tags'])
         if update_tags:
             self.results['changed'] = True
@@ -379,6 +404,9 @@ class AzureRMStorageAccount(AzureRMModuleBase):
         if not self.account_type:
             self.fail('Parameter error: account_type required when creating a storage account.')
 
+        if not self.access_tier and self.kind == 'BlobStorage':
+            self.fail('Parameter error: access_tier required when creating a storage account of type BlobStorage.')
+
         self.check_name_availability()
         self.results['changed'] = True
 
@@ -395,7 +423,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
             return account_dict
         sku = Sku(SkuName(self.account_type))
         sku.tier = SkuTier.standard if 'Standard' in self.account_type else SkuTier.premium
-        parameters = StorageAccountCreateParameters(sku, self.kind, self.location, tags=self.tags)
+        parameters = StorageAccountCreateParameters(sku, self.kind, self.location, tags=self.tags, access_tier=self.access_tier)
         self.log(str(parameters))
         try:
             poller = self.storage_client.storage_accounts.create(self.resource_group, self.name, parameters)

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
@@ -359,8 +359,7 @@ class AzureRMStorageAccount(AzureRMModuleBase):
                         self.fail("Failed to update account type: {0}".format(str(exc)))
 
         if self.custom_domain:
-            if not self.account_dict['custom_domain'] or \
-               self.account_dict['custom_domain'] != self.account_dict['custom_domain']:
+            if not self.account_dict['custom_domain'] or self.account_dict['custom_domain'] != self.custom_domain:
                 self.results['changed'] = True
                 self.account_dict['custom_domain'] = self.custom_domain
 


### PR DESCRIPTION
##### SUMMARY

Fixes #25931 

Adds a new `access_tier` module parameter, mandatory for `kind == 'BlobStorage'`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

azure_rm_storageaccount (module)

##### ANSIBLE VERSION

```
ansible 2.3.1.0
```