### PR TITLE
openstack: os_volume: add optional scheduler_hints param

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -75,6 +75,12 @@ options:
      description:
        - Ignored. Present for backwards compatibility
      required: false
+   scheduler_hints:
+     description:
+       - Scheduler hints passed to volume API in form of dict
+     required: false
+     default: None
+     version_added: "2.3"
 requirements:
      - "python >= 2.6"
      - "shade"
@@ -92,6 +98,8 @@ EXAMPLES = '''
       availability_zone: az2
       size: 40
       display_name: test_volume
+      scheduler_hints:
+        same_host: 243e8d3c-8f47-4a61-93d6-7215c344b0c0
 '''
 
 try:
@@ -100,6 +108,7 @@ try:
 except ImportError:
     HAS_SHADE = False
 
+from distutils.version import StrictVersion
 
 def _present_volume(module, cloud):
     if cloud.volume_exists(module.params['display_name']):
@@ -123,6 +132,9 @@ def _present_volume(module, cloud):
         if not volume_id:
             module.fail_json(msg="Failed to find volume '%s'" % module.params['volume'])
         volume_args['source_volid'] = volume_id
+
+    if module.params['scheduler_hints']:
+        volume_args['scheduler_hints'] = module.params['scheduler_hints']
 
     volume = cloud.create_volume(
         wait=module.params['wait'], timeout=module.params['timeout'],
@@ -153,6 +165,7 @@ def main():
         snapshot_id=dict(default=None),
         volume=dict(default=None),
         state=dict(default='present', choices=['absent', 'present']),
+        scheduler_hints=dict(default=None, type='dict')
     )
     module_kwargs = openstack_module_kwargs(
         mutually_exclusive=[
@@ -163,6 +176,11 @@ def main():
 
     if not HAS_SHADE:
         module.fail_json(msg='shade is required for this module')
+
+    if (module.params['scheduler_hints'] and
+            StrictVersion(shade.__version__) < StrictVersion('1.22')):
+        module.fail_json(msg="To utilize scheduler_hints, the installed version of"
+                             "the shade library MUST be >= 1.22")
 
     state = module.params['state']
 

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -110,6 +110,7 @@ except ImportError:
 
 from distutils.version import StrictVersion
 
+
 def _present_volume(module, cloud):
     if cloud.volume_exists(module.params['display_name']):
         v = cloud.get_volume(module.params['display_name'])

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -80,7 +80,7 @@ options:
        - Scheduler hints passed to volume API in form of dict
      required: false
      default: None
-     version_added: "2.3"
+     version_added: "2.4"
 requirements:
      - "python >= 2.6"
      - "shade"


### PR DESCRIPTION
##### SUMMARY
This PR adds new parameter to `os_volume` openstack module - `scheduler_hints`. This functionality depends on new version of `shade` library so error is raised when the parameter is used and `shade` version is `<=1.22`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
openstack/os_volume

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```