### PR TITLE
Fix ansible ad-hoc to respect ANSIBLE_STDOUT_CALLBACK

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -153,7 +153,7 @@ class AdHocCLI(CLI):
         elif self.options.one_line:
             cb = 'oneline'
         else:
-            cb = 'minimal'
+            cb = 'minimal' if C.DEFAULT_STDOUT_CALLBACK == 'default' else C.DEFAULT_STDOUT_CALLBACK
 
         run_tree = False
         if self.options.tree:

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -152,8 +152,11 @@ class AdHocCLI(CLI):
             cb = self.callback
         elif self.options.one_line:
             cb = 'oneline'
+        # Respect custom 'stdout_callback' only with enabled 'bin_ansible_callbacks'
+        elif C.DEFAULT_LOAD_CALLBACK_PLUGINS and C.DEFAULT_STDOUT_CALLBACK != 'default':
+            cb = C.DEFAULT_STDOUT_CALLBACK
         else:
-            cb = 'minimal' if C.DEFAULT_STDOUT_CALLBACK == 'default' else C.DEFAULT_STDOUT_CALLBACK
+            cb = 'minimal'
 
         run_tree = False
         if self.options.tree:


### PR DESCRIPTION
Fixes https://github.com/ansible/ansible/issues/16194

##### SUMMARY
Stdout callback for `ansible` ad-hoc is hardcoded to `minimal`.

This PR allows overriding the default stdout callback for `ansible` via `stdout_callback` (but only when `bin_ansible_callbacks = True`)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible ad-hoc

##### ANSIBLE VERSION
```
2.4.0
```
