### PR TITLE
Add identity_api_version opt in OpenStack modules

### DIFF
--- a/lib/ansible/module_utils/openstack.py
+++ b/lib/ansible/module_utils/openstack.py
@@ -90,6 +90,9 @@ def openstack_full_argument_spec(**kwargs):
         api_timeout=dict(default=None, type='int'),
         endpoint_type=dict(
             default='public', choices=['public', 'internal', 'admin']
+        ),
+        identity_api_version=dict(
+            default=None, choices=['2.0', '3']
         )
     )
     spec.update(kwargs)

--- a/lib/ansible/utils/module_docs_fragments/openstack.py
+++ b/lib/ansible/utils/module_docs_fragments/openstack.py
@@ -93,6 +93,12 @@ options:
     choices: [public, internal, admin]
     required: false
     default: public
+  identity_api_version:
+    description:
+        - The identity API version
+    choices: [2.0, 3]
+    required: false
+    default: None
 requirements:
   - python >= 2.7
   - shade


### PR DESCRIPTION
Fix #26092 : OpenStack modules does not work with identity v3

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Some OpenStack modules does not work with identity v3 when `auth` instead of `cloud` option is  provided because in that case v2.0 client will be used.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
* `modules/cloud/openstack/os_keystone_domain.py`
* `module_utils/openstack.py`

And I believe most OpenStack modules which need to call domain API are affected too.

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /root/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov 20 2015, 02:00:19) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
See #26092 for more detail
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->