### PR TITLE
add PHP Executable path for Composer

### DIFF
--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -50,7 +50,7 @@ options:
             - Composer arguments like required package, version and so on.
         required: false
         default: null
-    php_executable:
+    executable:
         version_added: "2.4"
         description:
             - Path to PHP Executable on the remote host, if PHP is not in PATH
@@ -185,10 +185,10 @@ def composer_command(module, command, arguments="", options=None, global_command
     if options is None:
         options = []
 
-    if module.params['php_path'] is None:
+    if module.params['executable'] is None:
         php_path = module.get_bin_path("php", True, ["/usr/local/bin"])
     else:
-        php_path = module.params['php_path']
+        php_path = module.params['executable']
 
     composer_path = module.get_bin_path("composer", True, ["/usr/local/bin"])
     cmd = "%s %s %s %s %s %s" % (php_path, composer_path, "global" if global_command else "", command, " ".join(options), arguments)
@@ -200,7 +200,7 @@ def main():
         argument_spec=dict(
             command=dict(default="install", type="str", required=False),
             arguments=dict(default="", type="str", required=False),
-            php_path=dict(type="path", required=False, aliases=["php_path"]),
+            executable=dict(type="path", required=False, aliases=["php_path"]),
             working_dir=dict(type="path", aliases=["working-dir"]),
             global_command=dict(default=False, type="bool", aliases=["global-command"]),
             prefer_source=dict(default=False, type="bool", aliases=["prefer-source"]),

--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -50,6 +50,12 @@ options:
             - Composer arguments like required package, version and so on.
         required: false
         default: null
+    php_path:
+        version_added: "2.4"
+        description:
+            - Path to PHP Executable on the remote host, if PHP is not in PATH
+        required: false
+        default: null
     working_dir:
         description:
             - Directory of your project (see --working-dir). This is required when
@@ -177,7 +183,12 @@ def get_available_options(module, command='install'):
 def composer_command(module, command, arguments="", options=None, global_command=False):
     if options is None:
         options = []
-    php_path = module.get_bin_path("php", True, ["/usr/local/bin"])
+
+    if module.params['php_path'] is None:
+        php_path = module.get_bin_path("php", True, ["/usr/local/bin"])
+    else:
+        php_path = module.params['php_path']
+
     composer_path = module.get_bin_path("composer", True, ["/usr/local/bin"])
     cmd = "%s %s %s %s %s %s" % (php_path, composer_path, "global" if global_command else "", command, " ".join(options), arguments)
     return module.run_command(cmd)
@@ -188,6 +199,7 @@ def main():
         argument_spec=dict(
             command=dict(default="install", type="str", required=False),
             arguments=dict(default="", type="str", required=False),
+            php_path=dict(type="path", required=False),
             working_dir=dict(type="path", aliases=["working-dir"]),
             global_command=dict(default=False, type="bool", aliases=["global-command"]),
             prefer_source=dict(default=False, type="bool", aliases=["prefer-source"]),

--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -50,12 +50,13 @@ options:
             - Composer arguments like required package, version and so on.
         required: false
         default: null
-    php_path:
+    php_executable:
         version_added: "2.4"
         description:
             - Path to PHP Executable on the remote host, if PHP is not in PATH
         required: false
         default: null
+        aliases: [ "php_path" ]
     working_dir:
         description:
             - Directory of your project (see --working-dir). This is required when
@@ -199,7 +200,7 @@ def main():
         argument_spec=dict(
             command=dict(default="install", type="str", required=False),
             arguments=dict(default="", type="str", required=False),
-            php_path=dict(type="path", required=False),
+            php_path=dict(type="path", required=False, aliases=["php_path"]),
             working_dir=dict(type="path", aliases=["working-dir"]),
             global_command=dict(default=False, type="bool", aliases=["global-command"]),
             prefer_source=dict(default=False, type="bool", aliases=["prefer-source"]),


### PR DESCRIPTION
##### SUMMARY
Add PHP Executable path parameter for composer module, so a user could specify custom php path #21129

##### ISSUE TYPE
Feature Idea

##### COMPONENT NAME
lib/ansible/modules/packaging/language/composer.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0
```
