### PR TITLE
Openssl csr fixes

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -201,9 +201,7 @@ class CertificateSigningRequest(object):
         if self.subjectAltName is None:
             self.subjectAltName = 'DNS:%s' % self.subject['CN']
 
-        for (key, value) in self.subject.items():
-            if value is None:
-                del self.subject[key]
+        self.subject = {k: v for k,v in self.subject.items() if v}
 
     def generate(self, module):
         '''Generate the certificate signing request.'''

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -201,7 +201,7 @@ class CertificateSigningRequest(object):
         if self.subjectAltName is None:
             self.subjectAltName = 'DNS:%s' % self.subject['CN']
 
-        self.subject = {k: v for k, v in self.subject.items() if v}
+        self.subject = dict((k, v) for k, v in self.subject.items() if v)
 
     def generate(self, module):
         '''Generate the certificate signing request.'''
@@ -215,7 +215,7 @@ class CertificateSigningRequest(object):
                     setattr(subject, key, value)
 
             if self.subjectAltName is not None:
-                req.add_extensions([crypto.X509Extension("subjectAltName", False, self.subjectAltName)])
+                req.add_extensions([crypto.X509Extension(b"subjectAltName", False, self.subjectAltName.encode('ascii'))])
 
             privatekey_content = open(self.privatekey_path).read()
             self.privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM, privatekey_content)
@@ -225,7 +225,7 @@ class CertificateSigningRequest(object):
             self.request = req
 
             try:
-                csr_file = open(self.path, 'w')
+                csr_file = open(self.path, 'wb')
                 csr_file.write(crypto.dump_certificate_request(crypto.FILETYPE_PEM, self.request))
                 csr_file.close()
             except (IOError, OSError):

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -286,6 +286,9 @@ def main():
         required_one_of=[['commonName', 'subjectAltName']],
     )
 
+    if not pyopenssl_found:
+        module.fail_json(msg='the python pyOpenSSL module is required')
+
     path = module.params['path']
     base_dir = os.path.dirname(module.params['path'])
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -201,7 +201,7 @@ class CertificateSigningRequest(object):
         if self.subjectAltName is None:
             self.subjectAltName = 'DNS:%s' % self.subject['CN']
 
-        self.subject = {k: v for k,v in self.subject.items() if v}
+        self.subject = {k: v for k, v in self.subject.items() if v}
 
     def generate(self, module):
         '''Generate the certificate signing request.'''


### PR DESCRIPTION
##### SUMMARY

This fixes two minor issues in the openssl_csr module (python 3 support and missing check for dependency on pyOpenSSL)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

modules/crypto/openssl_csr.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (openssl_csr_fixes 3e494f12bf) last updated 2017/06/26 18:06:55 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/equinox/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/equinox/mgit/ansible/lib/ansible
  executable location = /home/equinox/mgit/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```
