### PR TITLE
module_utils/ec2: fix policy sorting for python 3

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -592,7 +592,7 @@ def sort_json_policy_dict(policy_dict):
 
         # Sort list. If it's a list of dictionaries, sort by tuple of key-value
         # pairs, since Python 3 doesn't allow comparisons such as `<` between dictionaries.
-        checked_list.sort(key=lambda x: sorted(set(x.items())) if isinstance(x, dict) else x)
+        checked_list.sort(key=lambda x: sorted(list(x.items())) if isinstance(x, dict) else x)
         return checked_list
 
     ordered_policy_dict = {}

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -592,7 +592,7 @@ def sort_json_policy_dict(policy_dict):
 
         # Sort list. If it's a list of dictionaries, sort by tuple of key-value
         # pairs, since Python 3 doesn't allow comparisons such as `<` between dictionaries.
-        checked_list.sort(key=lambda x: sorted(x.items()) if isinstance(x, dict) else x)
+        checked_list.sort(key=lambda x: sorted(set(x.items())) if isinstance(x, dict) else x)
         return checked_list
 
     ordered_policy_dict = {}


### PR DESCRIPTION
##### SUMMARY
Cannot do sorted(dict.items()) while using Python 3 since it's not a list.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```

