### PR TITLE
ec2.py: filter by client-token if id is specified - fixes #26021

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -698,6 +698,9 @@ def get_reservations(module, ec2, tags=None, state=None, zone=None):
     if zone:
         filters.update({'availability-zone': zone})
 
+    if module.params.get('id'):
+        filters['client-token'] = module.params['id']
+
     results = ec2.get_all_instances(filters=filters)
 
     return results
@@ -1414,6 +1417,8 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
         for key, value in instance_tags.items():
             filters["tag:" + key] = value
 
+    if module.params.get('id'):
+        filters['client-token'] = module.params['id']
     # Check that our instances are not in the state we want to take
 
     # Check (and eventually change) instances attributes and instances state
@@ -1539,6 +1544,8 @@ def restart_instances(module, ec2, instance_ids, state, instance_tags):
     if instance_tags:
         for key, value in instance_tags.items():
             filters["tag:" + key] = value
+    if module.params.get('id'):
+        filters['client-token'] = module.params['id']
 
     # Check that our instances are not in the state we want to take
 


### PR DESCRIPTION

##### SUMMARY
Fixes #26021. The client-token wasn't being used to filter anywhere except in the function to create an instance leading to unpredictable results.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```