### PR TITLE
Update os_security_group.py

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -116,8 +116,9 @@ def main():
     description = module.params['description']
 
     try:
-        cloud = shade.openstack_cloud(**module.params)
-        secgroup = cloud.get_security_group(name)
+        cloud = shade.openstack_cloud(**module.params)        
+        filters = {'tenant_id': cloud.keystone_session.get_project_id()}
+        secgroup = cloud.get_security_group(name, filters=filters)
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, secgroup))

--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -116,7 +116,7 @@ def main():
     description = module.params['description']
 
     try:
-        cloud = shade.openstack_cloud(**module.params)        
+        cloud = shade.openstack_cloud(**module.params)
         filters = {'tenant_id': cloud.keystone_session.get_project_id()}
         secgroup = cloud.get_security_group(name, filters=filters)
 


### PR DESCRIPTION
##### SUMMARY
Patch lack of project_id filtering.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/openstack/os_security_group.py

##### ANSIBLE VERSION
```
2.2.1
```


##### ADDITIONAL INFORMATION
Openstack with Ansible - steps to reproduce:
1. Create security group in one tenant/project called "example"
2. Try to create security group in another tenant with the same name "example"
3. Due to lack of filtering it will detect that it already exists and fail to create. 

This is silent failure. It is more apparent when you try to add rules and it fails to to non existing SG.