### PR TITLE
bigip_iapp_service: Support full path templates

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_iapp_service.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_service.py
@@ -289,6 +289,8 @@ class Parameters(AnsibleF5Parameters):
             return None
         if self._values['template'].startswith("/" + self.partition):
             return self._values['template']
+        elif self._values['template'].startswith("/"):
+            return self._values['template']
         else:
             return '/{0}/{1}'.format(
                 self.partition, self._values['template']

--- a/test/units/modules/network/f5/test_bigip_iapp_service.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_service.py
@@ -197,6 +197,30 @@ class TestParameters(unittest.TestCase):
         assert p.tables[0]['rows'][0]['row'] == ['12.12.12.12', '80', '0']
         assert p.tables[0]['rows'][1]['row'] == ['13.13.13.13', '443', '10']
 
+    def test_module_template_same_partition(self):
+        args = dict(
+            template='foo',
+            partition='bar'
+        )
+        p = Parameters(args)
+        assert p.template == '/bar/foo'
+
+    def test_module_template_same_partition_full_path(self):
+        args = dict(
+            template='/bar/foo',
+            partition='bar'
+        )
+        p = Parameters(args)
+        assert p.template == '/bar/foo'
+
+    def test_module_template_different_partition_full_path(self):
+        args = dict(
+            template='/Common/foo',
+            partition='bar'
+        )
+        p = Parameters(args)
+        assert p.template == '/Common/foo'
+
 
 @patch('ansible.module_utils.f5_utils.AnsibleF5Client._get_mgmt_root',
        return_value=True)


### PR DESCRIPTION
##### SUMMARY
This patch allows the iapp service module to support full path
templates instead of only relative templates

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_iapp_service

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (bugfix.ensure-different-partitions-work-with-templates 80b08fdb9b) last updated 2017/06/26 14:57:02 (GMT -700)
  config file = None
  configured module search path = [u'/Users/trupp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/trupp/src/trupp/ansible/lib/ansible
  executable location = /Users/trupp/src/trupp/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
