### PR TITLE
Include error message when ansiballz_setup fails

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -183,7 +183,7 @@ def ansiballz_setup(modfile, modname, interpreters):
         print("*" * 35)
         print("INVALID OUTPUT FROM ANSIBALLZ MODULE WRAPPER")
         print(out)
-        sys.exit(1)
+        sys.exit(err)
     debug_dir = lines[1].strip()
 
     argsfile = os.path.join(debug_dir, 'args')


### PR DESCRIPTION
It is quite difficult to pinpoint what is wrong without it

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

hacking

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel b41c42cf0d) last updated 2017/06/27 11:33:24 (GMT +800)
  config file = None
  configured module search path = [u'/Users/yujunz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/yujunz/Develop/workon/ansible/lib/ansible
  executable location = /Users/yujunz/Develop/workon/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 10 2016, 16:10:04) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
