### PR TITLE
added integration tests for rpm_key

### DIFF
--- a/test/integration/targets/rpm_key/aliases
+++ b/test/integration/targets/rpm_key/aliases
@@ -1,0 +1,2 @@
+destructive
+posix/ci/group1

--- a/test/integration/targets/rpm_key/tasks/main.yaml
+++ b/test/integration/targets/rpm_key/tasks/main.yaml
@@ -1,0 +1,2 @@
+ - include: 'rpm_key.yaml'
+   when: ansible_os_family == "RedHat"

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -1,0 +1,83 @@
+---
+- name: download EPEL GPG key
+  get_url:
+    url: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+    dest: /tmp/RPM-GPG-KEY-EPEL-7
+
+- name: download sl rpm
+  get_url:
+    url: https://download.fedoraproject.org/pub/epel/7/x86_64/s/sl-5.02-1.el7.x86_64.rpm
+    dest: /tmp/sl.rpm
+
+- name: remove EPEL GPG key from keyring
+  rpm_key:
+    state: absent
+    key: /tmp/RPM-GPG-KEY-EPEL-7
+
+- name: check GPG signature of sl. Should fail
+  shell: "rpm --checksig /tmp/sl.rpm"
+  register: sl_check
+  ignore_errors: yes
+
+- name: confirm that signature check failed
+  assert:
+    that:
+      - "'MISSING KEYS' in sl_check.stdout"
+      - "sl_check.failed"
+
+- name: remove EPEL GPG key from keyring (Idempotant)
+  rpm_key:
+    state: absent
+    key: /tmp/RPM-GPG-KEY-EPEL-7
+  register: idempotant_test
+
+- name: check Idempotant
+  assert:
+    that: "not idempotant_test.changed"
+
+- name: add EPEL GPG key to key ring
+  rpm_key:
+    state: present
+    key: /tmp/RPM-GPG-KEY-EPEL-7
+
+- name: add EPEL GPG key to key ring (Idempotant)
+  rpm_key:
+    state: present
+    key: /tmp/RPM-GPG-KEY-EPEL-7
+
+- name: check GPG signature of sl. Should return okay
+  shell: "rpm --checksig /tmp/sl.rpm"
+  register: sl_check
+
+- name: confirm that signature check succeeded
+  assert:
+    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout"
+
+- name: remove GPG key from url
+  rpm_key:
+    state: absent
+    key: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+- name: Confirm key is missing
+  shell: "rpm --checksig /tmp/sl.rpm"
+  register: sl_check
+  ignore_errors: yes
+
+- name: confirm that signature check failed
+  assert:
+    that:
+      - "'MISSING KEYS' in sl_check.stdout"
+      - "sl_check.failed"
+
+- name: add GPG key from url
+  rpm_key:
+    state: present
+    key: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+- name: check GPG signature of sl. Should return okay
+  shell: "rpm --checksig /tmp/sl.rpm"
+  register: sl_check
+
+- name: confirm that signature check succeeded
+  assert:
+    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added missing integration tests for rpm_key: https://codecov.io/gh/ansible/ansible/src/devel/lib/ansible/modules/packaging/os/rpm_key.py
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
-test pull request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module: rpm_key

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ci-rpm-key 3d491d3979) last updated 2017/06/27 09:01:53 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
