### PR TITLE
openssl_privatekey: check whether exisiting key complies with user values

### DIFF
--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -175,7 +175,8 @@ class PrivateKey(object):
         try:
             privatekey_content = open(self.path, 'r').read()
             privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM, privatekey_content)
-            if self._type_id != privatekey.type():
+            type_id = privatekey.type()
+            if self._type_id != type_id:
                 return
             if self.size != privatekey.bits():
                 return

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -215,7 +215,6 @@ lib/ansible/modules/clustering/consul_session.py
 lib/ansible/modules/clustering/kubernetes.py
 lib/ansible/modules/clustering/pacemaker_cluster.py
 lib/ansible/modules/commands/command.py
-lib/ansible/modules/crypto/openssl_privatekey.py
 lib/ansible/modules/crypto/openssl_publickey.py
 lib/ansible/modules/database/misc/elasticsearch_plugin.py
 lib/ansible/modules/database/misc/kibana_plugin.py


### PR DESCRIPTION
##### SUMMARY
Up until now the `openssl_privatekey` module does only minimal testing for existing files. It does not check whether the type or size of the key fits the requested values nor does it check whether the given file is a private-key at all. This PR changes this behavior to a more thorough test.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

modules/crypto/openssl_privatekey.py

##### ANSIBLE VERSION

```
ansible 2.4.0 (openssl_privatekey_with_checks 8950acf389) last updated 2017/06/27 15:42:49 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/equinox/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/equinox/mgit/ansible/lib/ansible
  executable location = /home/equinox/mgit/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```