### PR TITLE
Improve fish environment setup

### DIFF
--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -5,7 +5,7 @@ set HACKING_DIR (dirname (status -f))
 set FULL_PATH (python -c "import os; print(os.path.realpath('$HACKING_DIR'))")
 set ANSIBLE_HOME (dirname $FULL_PATH)
 set PREFIX_PYTHONPATH $ANSIBLE_HOME/lib
-set PREFIX_PATH $ANSIBLE_HOME/bin
+set PREFIX_PATH $ANSIBLE_HOME/bin $ANSIBLE_HOME/test/runner
 set PREFIX_MANPATH $ANSIBLE_HOME/docs/man
 
 # set quiet flag

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -59,19 +59,37 @@ end
 
 set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
 
+#
 # Generate egg_info so that pkg_resources works
-pushd $ANSIBLE_HOME
-if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
-    rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
-end
-if [ $QUIET ]
-    eval $PYTHON_BIN setup.py -q egg_info
-else
-    eval $PYTHON_BIN setup.py egg_info
-end
-find . -type f -name "*.pyc" -exec rm -f '{}' ';'
-popd
+#
 
+# Do the work in a fuction
+function gen_egg_info
+
+    if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
+        rm -rf "$PREFIX_PYTHONPATH/ansible*.egg-info"
+    end
+
+    if [ $QUIET ]
+        set options '-q'
+    end
+
+    eval $PYTHON_BIN setup.py $options egg_info
+
+end
+
+
+pushd $ANSIBLE_HOME
+
+if [ $QUIET ]
+    gen_egg_info ^ /dev/null
+    find . -type f -name "*.pyc" -exec rm -f '{}' ';' ^ /dev/null
+else
+    gen_egg_info
+    find . -type f -name "*.pyc" -exec rm -f '{}' ';'
+end
+
+popd
 
 if not [ $QUIET ]
     echo ""

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -69,7 +69,7 @@ if [ $QUIET ]
 else
     eval $PYTHON_BIN setup.py egg_info
 end
-find . -type f -name "*.pyc" -delete
+find . -type f -name "*.pyc" -exec rm -f '{}' ';'
 popd
 
 

--- a/hacking/env-setup.fish
+++ b/hacking/env-setup.fish
@@ -45,6 +45,18 @@ if not contains $PREFIX_MANPATH $MANPATH
     end
 end
 
+# Set PYTHON_BIN
+if not set -q PYTHON_BIN
+    if test (which python)
+        set -gx PYTHON_BIN (which python)
+    else if test (which python3)
+        set -gx PYTHON_BIN (which python3)
+    else
+        echo "No valid Python found"
+        exit 1
+    end
+end
+
 set -gx ANSIBLE_LIBRARY $ANSIBLE_HOME/library
 
 # Generate egg_info so that pkg_resources works
@@ -53,9 +65,9 @@ if test -e $PREFIX_PYTHONPATH/ansible*.egg-info
     rm -r $PREFIX_PYTHONPATH/ansible*.egg-info
 end
 if [ $QUIET ]
-    python setup.py -q egg_info
+    eval $PYTHON_BIN setup.py -q egg_info
 else
-    python setup.py egg_info
+    eval $PYTHON_BIN setup.py egg_info
 end
 find . -type f -name "*.pyc" -delete
 popd
@@ -67,6 +79,7 @@ if not [ $QUIET ]
     echo ""
     echo "PATH=$PATH"
     echo "PYTHONPATH=$PYTHONPATH"
+    echo "PYTHON_BIN=$PYTHON_BIN"
     echo "ANSIBLE_LIBRARY=$ANSIBLE_LIBRARY"
     echo "MANPATH=$MANPATH"
     echo ""


### PR DESCRIPTION
##### SUMMARY

Port recent changes made to `env-setup` into `env-setup.fish` to bring feature parity. Started out just adding the test runner to `PATH` but I got carried away.

- add `test/runner` to `PATH`
- Python3 support
- Add function for generating egg info
- Truly silence all output when run with `-q`

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
`env-setup.fish`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.4.0 (sdoran-fish-hacking 0302d9e1f6) last updated 2017/06/27 12:17:19 (GMT -400)
  config file = /Users/sdoran/.ansible.cfg
  ansible python module location = /Users/sdoran/Source/ansible/lib/ansible
  executable location = /Users/sdoran/Source/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
None