### PR TITLE
Added additional output information to ec2_remote_facts module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_remote_facts.py
@@ -113,6 +113,8 @@ def get_instance_info(instance):
     instance_info = { 'id': instance.id,
                     'kernel': instance.kernel,
                     'instance_profile': instance_profile,
+                    'instance_type': instance.instance_type,
+                    'root_device_name': instance.root_device_name,
                     'root_device_type': instance.root_device_type,
                     'private_dns_name': instance.private_dns_name,
                     'public_dns_name': instance.public_dns_name,
@@ -142,6 +144,7 @@ def get_instance_info(instance):
                     'private_ip_address': instance.private_ip_address,
                     'public_ip_address': instance.ip_address,
                     'state': instance._state.name,
+                    'subnet_id': instance.subnet_id,
                     'vpc_id': instance.vpc_id,
                     'block_device_mapping': bdm_dict,
                   }


### PR DESCRIPTION
##### SUMMARY
Added additional information to output of ec2_remote_facts module:

- instance_type
- root_device_name
- subnet_id

This information could be useful for people, who uses Ansible for AWS, but it's not available in module output now.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_remote_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
```


##### ADDITIONAL INFORMATION

Module output doesn't contain one of the important parameters of ec2 instance - type of instance. I think that other parameters also could be useful.

- instance_type – The type of instance (e.g. m1.small).
- root_device_name – The name of the root device (e.g. /dev/sda1).
- subnet_id – The VPC Subnet ID, if running in VPC (e.g. subnet-abcd223d).