### PR TITLE
Correct note syntax so Docker on non-Linux note shows up

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -45,7 +45,7 @@ outside of those test subdirectories.  They will also not reconfigure or bounce 
 
    To protect your system from any potential changes caused by integration tests, and to ensure the a sensible set of dependencies are available we recommend that you always run integration tests with the ``--docker`` option. See the `list of supported docker images <https://github.com/ansible/ansible/blob/devel/test/runner/completion/docker.txt>`_ for options.
 
-.. note:: Avoiding pulling new Docker images:
+.. note:: Avoiding pulling new Docker images
 
    Use the ``--docker-no-pull`` option to avoid pulling the latest container image. This is required when using custom local images that are not available for download.
 
@@ -98,9 +98,9 @@ Tests in Docker containers
 If you have a Linux system with Docker installed, running integration tests using the same Docker containers used by
 the Ansible continuous integration (CI) system is recommended.
 
-.. note: Docker on non-Linux::
+.. note:: Docker on non-Linux
 
-   Using Docker Engine to run Docker on a non-Linux host is not recommended.
+   Using Docker Engine to run Docker on a non-Linux (such as macOS) host is not recommended.
    Some tests may fail, depending on the image used for testing.
    Using the ``--docker-privileged`` option may resolve the issue.
 


### PR DESCRIPTION
##### SUMMARY
The note only had one colon instead of two, which allowed it to pass rstcheck but failed to actually generate the note in the HTML.

Also remove an unnecessary trailing colon.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
testing_integration.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (sdoran-test-docs-fix 1e623fdbb3) last updated 2017/06/27 16:59:58 (GMT -400)
  config file = /Users/sdoran/.ansible.cfg
  configured module search path = [u'/Users/sdoran/Source/ansible/library']
  ansible python module location = /Users/sdoran/Source/ansible/lib/ansible
  executable location = /Users/sdoran/Source/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION

None