### PR TITLE
Workaround to deprecation warning when password is used as arg for *_user 

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -52,8 +52,12 @@ def get_argspec():
 def check_args(module, warnings):
     provider = module.params['provider'] or {}
     for key in ios_argument_spec:
-        if key not in ['provider', 'authorize'] and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
+        if module._name == 'ios_user':
+            if key not in ['password', 'provider', 'authorize'] and module.params[key]:
+                warnings.append('argument %s has been deprecated and will be in a future version' % key)
+        else:
+            if key not in ['provider', 'authorize'] and module.params[key]:
+                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
 
     if provider:
         for param in ('auth_pass', 'password'):

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -51,8 +51,12 @@ def get_argspec():
 def check_args(module, warnings):
     provider = module.params['provider'] or {}
     for key in iosxr_argument_spec:
-        if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
+        if module._name == 'iosxr_user':
+            if key not in ['password', 'provider'] and module.params[key]:
+                warnings.append('argument %s has been deprecated and will be in a future version' % key)
+        else:
+            if key != 'provider' and module.params[key]:
+                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
 
     if provider:
         for param in ('password',):

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -52,8 +52,12 @@ def get_argspec():
 def check_args(module, warnings):
     provider = module.params['provider'] or {}
     for key in vyos_argument_spec:
-        if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
+        if module._name == 'vyos_user':
+            if key not in ['password', 'provider'] and module.params[key]:
+                warnings.append('argument %s has been deprecated and will be in a future version' % key)
+        else:
+            if key != 'provider' and module.params[key]:
+                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
 
     if provider:
         for param in ('password',):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
workaround to deprecation warning when `password` is used as arg for *_user which is part of its *_user argspec.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/vyos/vyos_user
modules/network/ios/ios_user
modules/network/iosxr/iosxr_user
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.4
```