### PR TITLE
Add possibility to interpret global parameters value as JSON with ric…

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -145,6 +145,13 @@ want_facts = True
 # the script for stand-alone Foreman.
 want_hostcollections = False
 
+# Whether to interpret global parameters value as JSON (if possible, else
+# take as is). Only tested with Katello (Red Hat Satellite).
+# This allows to define lists and dictionaries (and more complicated structures)
+# variables by entering them as JSON string in Foreman parameters.
+# Disabled by default as the change would else not be backward compatible.
+rich_params = False
+
 [cache]
 path = .
 max_age = 60

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -113,6 +113,12 @@ class ForemanInventory(object):
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             self.want_hostcollections = False
 
+        # Do we want parameters to be interpreted if possible as JSON? (no by default)
+        try:
+            self.rich_params = config.getboolean('ansible', 'rich_params')
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            self.rich_params = False
+
         try:
             self.host_filters = config.get('foreman', 'host_filters')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
@@ -209,7 +215,13 @@ class ForemanInventory(object):
 
         for param in host_params:
             name = param['name']
-            params[name] = param['value']
+            if self.rich_params:
+                try:
+                    params[name] = json.loads(param['value'])
+                except ValueError:
+                    params[name] = param['value']
+            else:
+                params[name] = param['value']
 
         return params
 


### PR DESCRIPTION
…h_params flag

##### SUMMARY
Add the possibility to interpret host parameters value as JSON (if possible, else take as is). Only tested with Katello (Red Hat Satellite).

This allows to define lists and dictionaries (and more complicated structures) variables by entering them as JSON string in Foreman parameters.

Disabled by default as the change would else not be backward compatible.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.{py,ini}

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION

Foreman doesn't offer the possibility to create complex parameters/variables, only simple strings.

Entering the parameters like this in Foreman/Satellite 6, you'll get the below result.

![image](https://user-images.githubusercontent.com/3105685/27635393-0f3817dc-5c07-11e7-8060-8b65446732d2.png)

Before (or with `rich_params = False`):

```
        "foreman_params": {
          "MyJSONValue": "[ \"value1\", \"value2\" ]", 
          "MyTest": "My-Value?", 
          "YourTest": "Your Value!", 
          "ansible_user": "admin"
        }
```

After:

```
        "foreman_params": {
          "MyJSONValue": [
            "value1", 
            "value2"
          ], 
          "MyTest": "My-Value?", 
          "YourTest": "Your Value!", 
          "ansible_user": "admin"
        }
```

(notice that the parameters that can't be interpreted as JSON remain as is)