### PR TITLE
Limit yamllint version on python 2.6.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -2,5 +2,6 @@ coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance
 pylint >= 1.5.3, < 1.7.0 # 1.4.1 adds JSON output, but 1.5.3 fixes bugs related to JSON output
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
+yamllint < 1.8 ; python_version < '2.7' # yamllint 1.8 and later require python 2.7 or later
 isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previously passing pylint tests
 pycrypto >= 2.6 # Need features found in 2.6 and greater


### PR DESCRIPTION
##### SUMMARY

Limit yamllint version on python 2.6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (yamllint-fix 2a1ea98268) last updated 2017/06/28 07:59:35 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
