### PR TITLE
hacking/test-module: fix for python3

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -153,9 +153,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
         task_vars=task_vars
     )
 
-    module_data = to_text(module_data)
-
-    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
+    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in to_text(module_data):
         module_style = 'ansiballz'
 
     modfile2_path = os.path.expanduser(destfile)
@@ -163,7 +161,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
     if module_style not in ('ansiballz', 'old'):
         print("* this may offset any line numbers in tracebacks/debuggers!")
     modfile2 = open(modfile2_path, 'w')
-    modfile2.write(module_data)
+    modfile2.write(to_text(module_data))
     modfile2.close()
     modfile = modfile2_path
 
@@ -181,7 +179,7 @@ def ansiballz_setup(modfile, modname, interpreters):
 
     cmd = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = cmd.communicate()
-    out, err = to_text(out), to_text(err)
+    out, err = to_text(out, errors='surrogate_or_strict'), to_text(err)
     lines = out.splitlines()
     if len(lines) != 2 or 'Module expanded into' not in lines[0]:
         print("*" * 35)
@@ -213,7 +211,7 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
 
     cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = cmd.communicate()
-    out, err = to_text(out), to_text(err)
+    out, err = to_text(out, errors='surrogate_or_strict'), to_text(err)
 
     try:
         print("*" * 35)

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -153,15 +153,15 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
         task_vars=task_vars
     )
 
-    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in to_text(module_data):
+    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
         module_style = 'ansiballz'
 
     modfile2_path = os.path.expanduser(destfile)
     print("* including generated source, if any, saving to: %s" % modfile2_path)
     if module_style not in ('ansiballz', 'old'):
         print("* this may offset any line numbers in tracebacks/debuggers!")
-    modfile2 = open(modfile2_path, 'w')
-    modfile2.write(to_text(module_data))
+    modfile2 = open(modfile2_path, 'wb')
+    modfile2.write(module_data)
     modfile2.close()
     modfile = modfile2_path
 
@@ -211,7 +211,7 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
 
     cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = cmd.communicate()
-    out, err = to_text(out, errors='surrogate_or_strict'), to_text(err)
+    out, err = to_text(out), to_text(err)
 
     try:
         print("*" * 35)

--- a/hacking/test-module
+++ b/hacking/test-module
@@ -42,6 +42,7 @@ from ansible.parsing.utils.jsonify import jsonify
 from ansible.parsing.splitter import parse_kv
 import ansible.executor.module_common as module_common
 import ansible.constants as C
+from ansible.module_utils._text import to_text
 
 try:
     import json
@@ -152,6 +153,8 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
         task_vars=task_vars
     )
 
+    module_data = to_text(module_data)
+
     if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
         module_style = 'ansiballz'
 
@@ -178,6 +181,7 @@ def ansiballz_setup(modfile, modname, interpreters):
 
     cmd = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     out, err = cmd.communicate()
+    out, err = to_text(out), to_text(err)
     lines = out.splitlines()
     if len(lines) != 2 or 'Module expanded into' not in lines[0]:
         print("*" * 35)
@@ -209,6 +213,7 @@ def runtest(modfile, argspath, modname, module_style, interpreters):
 
     cmd = subprocess.Popen(invoke, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (out, err) = cmd.communicate()
+    out, err = to_text(out), to_text(err)
 
     try:
         print("*" * 35)


### PR DESCRIPTION
##### SUMMARY
Allows you to run hacking/test-module while using python3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hacking/test-module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```