### PR TITLE
cloudformation - Fix: changes to stack are never applied, just a chan…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -518,7 +518,7 @@ def main():
     if state == 'present':
         if not stack_info:
             result = create_stack(module, stack_params, cfn)
-        elif create_changeset:
+        elif module.params.get('create_changeset'):
             result = create_changeset(module, stack_params, cfn)
         else:
             result = update_stack(module, stack_params, cfn)


### PR DESCRIPTION
…geset is created

##### SUMMARY
Currently the changes to a AWS CloudFormation stack are **never** applied,
just a changeset is created. The source of a bug seems to be a simple programming mistake - see the diff. `elif create_changeset:` is always True since there is function with that name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
amazon/cloudformation module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 95744836e2) last updated 2017/06/28 20:51:55 (GMT +200)
  ... removed local paths...
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
