### PR TITLE
Fix ClearLinux Pretty Name again

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -80,7 +80,7 @@ class DistributionFiles:
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
-        'ClearLinux': 'Clear Linux Software for Intel Architecture',
+        'ClearLinux': 'Clear Linux',
         'SMGL': 'Source Mage GNU/Linux',
     }
 
@@ -386,7 +386,7 @@ class Distribution(object):
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
-        'ClearLinux': 'Clear Linux Software for Intel Architecture',
+        'ClearLinux': 'Clear Linux',
         'SMGL': 'Source Mage GNU/Linux',
     }
 


### PR DESCRIPTION
##### SUMMARY
013a8f5 Changed the string to match for ClearLinux in os-release file
0b472a3 Replaced lib/ansible/module_utils/facts.py with a directory with
the code splitted in different files. The correpsonding code went to
lib/ansible/module_utils/facts/system/distribution.py but had the old value
for clearlinux previous to 013a8f5

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/system/distribution.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 9fdd07fba8) last updated 2017/06/28 14:53:16 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/albertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/albertom/github/ansible/lib/ansible
  executable location = /Users/albertom/github/ansible/bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```