### PR TITLE
fix win_updates failure with dict-typed args

### DIFF
--- a/lib/ansible/modules/windows/win_updates.ps1
+++ b/lib/ansible/modules/windows/win_updates.ps1
@@ -405,9 +405,7 @@ $common_inject = {
 # source the common code into the current scope so we can call it
 . $common_inject
 
-$parsed_args = Parse-Args $args $true
-# grr, why use PSCustomObject for args instead of just native hashtable?
-$parsed_args.psobject.properties | foreach -begin {$job_args=@{}} -process {$job_args."$($_.Name)" = $_.Value} -end {$job_args}
+$job_args = Parse-Args $args $true
 
 # set the log_path for the global log function we injected earlier
 $log_path = $job_args['log_path']


### PR DESCRIPTION
##### SUMMARY
Switch to dicts in common code caused silent failures during arg translation, so default values and non-check-mode were always used.
* fixes #23653
* fixes #24062
* fixes #22938
* fixes #25156

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
backport to 2.3 for 2.3.2RC2

If only we had a sane way to test this module... :(