### PR TITLE
[DOC]Add an example for files/unarchive to clear the usage of `extra_opts`

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -128,6 +128,14 @@ EXAMPLES = r'''
     src: https://example.com/example.zip
     dest: /usr/local/bin
     remote_src: yes
+
+- name: Unarchive a file with extra options
+- unarchive:
+    src: /tmp/foo.zip
+    dest: /usr/local/bin
+    extra_opts:
+      - --transform
+      - s/^xxx/yyy/
 '''
 
 import binascii


### PR DESCRIPTION
##### SUMMARY
Add an example to clear the usage of `extra_opts`

Fixes #26173, seems that ansible changed its behavior of `extra_opts`, it's essential to make it clearer for users.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`files/unarchive`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
```


##### ADDITIONAL INFORMATION
None