### PR TITLE
cloudformation module - show only relevant events

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -518,7 +518,7 @@ def main():
     if state == 'present':
         if not stack_info:
             result = create_stack(module, stack_params, cfn)
-        elif create_changeset:
+        elif module.params.get('create_changeset'):
             result = create_changeset(module, stack_params, cfn)
         else:
             result = update_stack(module, stack_params, cfn)

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -292,13 +292,12 @@ def get_stack_events(cfn, stack_name, started_at):
             # e.g. `UPDATE_ROLLBACK_IN_PROGRESS The following resource(s) failed to update: [DNSRecord2,`
             # the only problem - the property is not always set, so ensure default:
             e.setdefault('ResourceStatusReason', '')
-            eventline = 'StackEvent {ResourceType} {LogicalResourceId} {ResourceStatus} {ResourceStatusReason}'.format(**e)
+            eventline = '{ResourceType} {LogicalResourceId} {ResourceStatus} {ResourceStatusReason}'.format(**e)
             ret['events'].append(eventline)
 
             if e['ResourceStatus'].endswith('FAILED'):
                 failline = '{ResourceType} {LogicalResourceId} {ResourceStatus}: {ResourceStatusReason}'.format(**e)
                 ret['log'].append(failline)
-
     return ret
 
 def start_time():
@@ -317,7 +316,7 @@ def start_time():
         utc = timezone.utc
     except ImportError:
         #Hi there python2 user
-        from datetime import tzinfo
+        from datetime import tzinfo, timedelta
         class UTC(tzinfo):
             def utcoffset(self, dt):
                 return timedelta(0)
@@ -326,10 +325,7 @@ def start_time():
             def dst(self, dt):
                 return timedelta(0)
         utc = UTC()
-
-    now = datetime.now()
-    now.replace(tzinfo=utc)
-    return now
+    return datetime.utcnow().replace(tzinfo=utc)
 
 def create_stack(module, stack_params, cfn):
     if 'TemplateBody' not in stack_params and 'TemplateURL' not in stack_params:
@@ -592,7 +588,7 @@ def main():
                 result = {'changed': False, 'output': 'Stack not found.'}
             else:
                 cfn.delete_stack(StackName=stack_params['StackName'])
-                result = stack_operation(cfn, stack_params['StackName'], 'DELETE')
+                result = stack_operation(cfn, stack_params['StackName'], 'DELETE', started_at)
         except Exception as err:
             module.fail_json(msg=boto_exception(err), exception=traceback.format_exc())
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The output of cloudformation module can be overwhelming, including
hundred(s) of events. But most interesting are 2-5 events caused by the
last update.

Suggesting improvement:

1. filter events by 'Timestamp', only show events happened since last update
2. since we now have less entries, show all the details for an entry, which are
   also visible in aws console, especially the "Status reason" if any

I've put both changes to a single commit, since they touch the same place in the implementation of `get_stack_events`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
amazon/cloudformation module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (feature-cloudformation-show-only-relevant-events f68a0b7032) last updated 2017/06/29 10:19:44 (GMT +200)
  configured module search path - without overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```

##### ADDITIONAL INFORMATION

Example - before:

```
running ansible-playbook ver2/ensure-stack.playbook.yaml --extra-vars='stage=preprod' -vv

PLAYBOOK: ensure-stack.playbook.yaml *******************************************

PLAY [Wrapper playbook for idempotent cloudformation stack handling] ***********

TASK [ensure cloudformation stack for .....] ***********************************
task path: /D/vd-home/projects/kaufhof/assets-hosting/ver2/ensure-stack.playbook.yaml:13
changed: [localhost] => {"changed": true, "events": ["StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS",
"StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS", "StackEvent 
AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent 
AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack 
UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE", "StackEvent AWS::CloudFront::Distribution TheFacade 
UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack 
UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack 
UPDATE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_COMPLETE", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_IN_PROGRESS", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy DELETE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy DELETE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::IAM::Policy TheBucketPolicy DELETE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::IAM::Policy TheBucketPolicy CREATE_FAILED", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_FAILED", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE", "StackEvent AWS::S3::Bucket TheBucket DELETE_FAILED", "StackEvent AWS::S3::Bucket TheBucket DELETE_IN_PROGRESS", "StackEvent AWS::S3::Bucket TheBucket DELETE_FAILED", "StackEvent AWS::S3::Bucket TheBucket DELETE_IN_PROGRESS", "StackEvent AWS::S3::Bucket TheBucket DELETE_FAILED", "StackEvent AWS::S3::Bucket TheBucket DELETE_IN_PROGRESS", "StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS", "StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE"], "output": "Stack UPDATE complete", "stack_outputs": {"AccessKeyId": "AKIAJSPYJG3GLKSU7O2Q", "DomainName": "d2mbdlmp34a5nw.cloudfront.net", "S3BucketSecureURL": "https://media.preprod.gkh-setu.de.s3.amazonaws.com", "SecretAccessKey": "InmYfTscH5EefTOA8a4ZfYyCmxhx1rsxLNM55QfX"}, "stack_resources": [{"last_updated_time": null, "logical_resource_id": "DeployUser", "physical_resource_id": "deploy-media-preprod", "resource_type": "AWS::IAM::User", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "DeployUserKey", "physical_resource_id": "AKIAJSPYJG3GLKSU7O2Q", "resource_type": "AWS::IAM::AccessKey", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "TheBucket", "physical_resource_id": "media.preprod.gkh-setu.de", "resource_type": "AWS::S3::Bucket", "status": "UPDATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "TheBucketPolicy", "physical_resource_id": "media-preprod-stack-TheBucketPolicy-EEMRZQ75W7E8", "resource_type": "AWS::S3::BucketPolicy", "status": "CREATE_COMPLETE", "status_reason": null}, {"last_updated_time": null, "logical_resource_id": "TheFacade", "physical_resource_id": "EHVZG9G5C7YPM", "resource_type": "AWS::CloudFront::Distribution", "status": "UPDATE_COMPLETE", "status_reason": null}]}
```

And even using `human_log` plugin (parses json, prints subset of attributes as plain text)
the output is very lengthy and not very readable:

```
events: 
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE 
StackEvent AWS::Route53::RecordSet DNSRecord1 UPDATE_COMPLETE 
StackEvent AWS::Route53::RecordSet DNSRecord1 UPDATE_IN_PROGRESS 
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE 
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS 
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS User Initiated
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE_CLEANUP_IN_PROGRESS
StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_COMPLETE
StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_IN_PROGRESS
StackEvent AWS::S3::BucketPolicy TheBucketPolicy CREATE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE
StackEvent AWS::S3::BucketPolicy TheBucketPolicy DELETE_COMPLETE
StackEvent AWS::S3::BucketPolicy TheBucketPolicy DELETE_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_COMPLETE_CLEANUP_IN_PROGRESS
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_ROLLBACK_IN_PROGRESS
```

Example after - only events caused by this ansible run are shown:

```
events: 
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_COMPLETE 
StackEvent AWS::Route53::RecordSet DNSRecord1 UPDATE_COMPLETE 
StackEvent AWS::Route53::RecordSet DNSRecord1 UPDATE_IN_PROGRESS 
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_COMPLETE 
StackEvent AWS::CloudFront::Distribution TheFacade UPDATE_IN_PROGRESS 
StackEvent AWS::CloudFormation::Stack media-preprod-stack UPDATE_IN_PROGRESS User Initiated

```