### PR TITLE
Fix win_nssm credentials quoting (#26226)

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -428,7 +428,7 @@ Function Nssm-Update-Credentials
             }
 
             If ($results -ne $fullUser) {
-                $cmd = "set ""$name"" ObjectName $fullUser $password"
+                $cmd = "set ""$name"" ObjectName $fullUser '$password'"
                 $results = Nssm-Invoke $cmd
 
                 if ($LastExitCode -ne 0)


### PR DESCRIPTION
##### SUMMARY
Quote password to avoid Powershell special characters being interpreted.

Issue #26226 is caused by `Nssm-Update-Credentials` not quoting the password when it invokes NSSM to set ObjectName.

Surrounding the password in single quotes avoids passwords with Powershell special characters like double quotes and `@` from being interpreted.

There may still be conditions where the quoting does not work, like if the password contains a single quote. I could not find an elegant solution for dynamically escaping characters in Powershell. Maybe other Ansible modules has solved this problem?

Another possibility is to change `Nssm-Invoke` to use a better way of spawning nssm.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME

win_nssm


##### ANSIBLE VERSION

```
ansible 2.3.1.0
  config file = /home/user/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

Before:
```
TASK [foobar: Install foobar service] ************************************************************************
task path: /home/user/ansible/roles/foobar/tasks/main.yml:2
Using module file /home/user/ansible/venv/local/lib/python2.7/site-packages/ansible/modules/windows/win_nssm.ps1
<localhost> ESTABLISH WINRM CONNECTION FOR USER: user@domain on PORT 5986 TO remotehost
EXEC (via pipeline wrapper)
fatal: [remotehost]: FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "an exception occurred when invoking NSSM: Setting \"ObjectName\" requires both a username and password!",
    "nssm_app_parameters": "",
    "nssm_app_parameters_free_form": "arg1",
    "nssm_single_line_app_parameters": "arg1"
}
        to retry, use: --limit @/home/user/ansible/dev-nssm.retry
```

After:
```
TASK [foobar: Install foobar service] ************************************************************************
changed: [remotehost]
```
