### PR TITLE
Fixes #25402 - bad handshake failure

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -170,28 +170,30 @@ except ImportError:
 # Exclude insecure ssl protocols if possible
 
 if HAS_SSL:
-    # If we can't find extra tls methods, ssl.PROTOCOL_TLSv1_2 is sufficient
-    PROTOCOL = ssl.PROTOCOL_TLSv1_2
-if not HAS_SSLCONTEXT and HAS_SSL:
-    try:
-        import ctypes
-        import ctypes.util
-    except ImportError:
-        # python 2.4 (likely rhel5 which doesn't have tls1.1 support in its openssl)
-        pass
+    if HAS_SSLCONTEXT:
+        PROTOCOL = ssl.PROTOCOL_TLSv1_2
     else:
-        libssl_name = ctypes.util.find_library('ssl')
-        libssl = ctypes.CDLL(libssl_name)
-        for method in ('TLSv1_1_method', 'TLSv1_2_method'):
-            try:
-                libssl[method]
-                # Found something - we'll let openssl autonegotiate and hope
-                # the server has disabled sslv2 and 3.  best we can do.
-                PROTOCOL = ssl.PROTOCOL_SSLv23
-                break
-            except AttributeError:
-                pass
-        del libssl
+        # If we can't find extra tls methods, ssl.PROTOCOL_TLSv1 is sufficient
+        PROTOCOL = ssl.PROTOCOL_TLSv1_2
+        try:
+            import ctypes
+            import ctypes.util
+        except ImportError:
+            # python 2.4 (likely rhel5 which doesn't have tls1.1 support in its openssl)
+            pass
+        else:
+            libssl_name = ctypes.util.find_library('ssl')
+            libssl = ctypes.CDLL(libssl_name)
+            for method in ('TLSv1_1_method', 'TLSv1_2_method'):
+                try:
+                    libssl[method]
+                    # Found something - we'll let openssl autonegotiate and hope
+                    # the server has disabled sslv2 and 3.  best we can do.
+                    PROTOCOL = ssl.PROTOCOL_SSLv23
+                    break
+                except AttributeError:
+                    pass
+            del libssl
 
 
 LOADED_VERIFY_LOCATIONS = set()

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -170,8 +170,8 @@ except ImportError:
 # Exclude insecure ssl protocols if possible
 
 if HAS_SSL:
-    # If we can't find extra tls methods, ssl.PROTOCOL_TLSv1 is sufficient
-    PROTOCOL = ssl.PROTOCOL_TLSv1
+    # If we can't find extra tls methods, ssl.PROTOCOL_TLSv1_2 is sufficient
+    PROTOCOL = ssl.PROTOCOL_TLSv1_2
 if not HAS_SSLCONTEXT and HAS_SSL:
     try:
         import ctypes

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -174,7 +174,7 @@ if HAS_SSL:
         PROTOCOL = ssl.PROTOCOL_TLSv1_2
     else:
         # If we can't find extra tls methods, ssl.PROTOCOL_TLSv1 is sufficient
-        PROTOCOL = ssl.PROTOCOL_TLSv1_2
+        PROTOCOL = ssl.PROTOCOL_TLSv1
         try:
             import ctypes
             import ctypes.util


### PR DESCRIPTION
##### SUMMARY

This is a patch candidate for the #25402 issue.

This modifies the PROTOCOL floor value in `urls.py`, so that modules like `get_url` could validate certificates for website accepting only TLSv1_2 and no less.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`module_utils/urls.py`

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION

* BEFORE
```
ansible -m get_url -a "url=https://releases.hashicorp.com dest=/tmp/hashicorp_index.html" localhost
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Failed to validate the SSL certificate for releases.hashicorp.com:443. Make sure your managed systems have a valid CA certificate installed. You can use validate_certs=False if you do not need to confirm the servers identity but this is unsafe and not recommended. Paths checked for this platform: /etc/ssl/certs, /etc/pki/ca-trust/extracted/pem, /etc/pki/tls/certs, /usr/share/ca-certificates/cacert.org, /etc/ansible. The exception msg was: (\"bad handshake: Error([('SSL routines', 'ssl3_read_bytes', 'tlsv1 alert protocol version')],)\",)."
}
```

* AFTER
```
ansible -m get_url -a "url=https://releases.hashicorp.com dest=/tmp/hashicorp_index.html" localhost
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

localhost | SUCCESS => {
    "changed": true,
    "checksum_dest": null,
    "checksum_src": "afdac380532e75798fa0afc46d06d3cd0a9e6b84",
    "dest": "/tmp/hashicorp_index.html",
    "gid": 0,
    "group": "root",
    "md5sum": "e978f533ad1eefc5110b6354760e12f5",
    "mode": "0644",
    "msg": "OK (7998 bytes)",
    "owner": "root",
    "size": 7998,
    "src": "/tmp/tmpRL_auy",
    "state": "file",
    "status_code": 200,
    "uid": 0,
    "url": "https://releases.hashicorp.com"
}
```