### PR TITLE
Fix for database names that contain colons

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -481,7 +481,7 @@ def privileges_unpack(priv, mode):
     output = {}
     privs = []
     for item in priv.strip().split('/'):
-        pieces = item.strip().split(':')
+        pieces = item.strip().rsplit(':', 1)
         dbpriv = pieces[0].rsplit(".", 1)
         # Do not escape if privilege is for database or table, i.e.
         # neither quote *. nor .*


### PR DESCRIPTION
##### SUMMARY
Permissions were not parsed correctly if the database name contains a colon (:) character. For example, a privilege string of "*.*:USAGE/`lnx-www-prod:wordpress`.*:ALL" would fail with "invalid privileges string: Invalid privileges specified: frozenset(['WORDPRESS`.*'])". This 1-line fix works around the problem.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
Sample playbook to demonstrate the issue:
- hosts: all
  tasks:
  - mysql_user: name="wordpress" host="localhost"
                password="SECRET_PASSWORD" state=present
                priv="*.*:USAGE/`lnx-www-prod:wordpress`.*:ALL"
                append_privs="no"

Before the patch, it would fail like so:

TASK [mysql_user] **************************************************************
fatal: [lnx-www-prod]: FAILED! => {"changed": false, "failed": true, "msg": "invalid privileges string: Invalid privileges specified: frozenset(['WORDPRESS`.*'])"}

After the patch, it succeeds:

TASK [mysql_user] **************************************************************
changed: [lnx-www-prod]

