### PR TITLE
Clarify docs for set_stats module

### DIFF
--- a/lib/ansible/modules/utilities/logic/set_stats.py
+++ b/lib/ansible/modules/utilities/logic/set_stats.py
@@ -47,6 +47,7 @@ options:
     default: yes
 notes:
     - This module is also supported for Windows targets.
+    - In order for custom stats to be displayed, you must set C(show_custom_stats) in C(ansible.cfg) or C(ANSIBLE_SHOW_CUSTOM_STATS) to C(true).
 version_added: "2.3"
 '''
 


### PR DESCRIPTION
##### SUMMARY
Fixes #26191

Clarify how to display values set by `set_stats` module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
`set_stats.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
