### PR TITLE
add rc service module and sysrc utils

### DIFF
--- a/lib/ansible/module_utils/sysrc.py
+++ b/lib/ansible/module_utils/sysrc.py
@@ -1,0 +1,126 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Mattias Lindvall
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+BOOL_MAP = {
+    True: 'YES',
+    False: 'NO',
+}
+
+
+def get_sysrc_value_bool(value):
+    '''
+    Translate a bool into a string compatbile with sysrc values.
+
+    Args:
+        value: A bool value to translate.
+    Returns:
+        A string, either 'YES' or 'NO'.
+    '''
+
+    return BOOL_MAP[value]
+
+
+def sysrc_check_change_required(module, name, value, file=None):
+    '''
+    Check if given name and value differs from
+    what is currently set in the system using sysrc.
+
+    Args:
+        module: An instance of AnsibleModule.
+        name: Name of sysrc variable.
+        value: Value of sysrc variable.
+        file: Filename to read from.
+    Returns:
+        A bool indicating if change is required.
+    '''
+
+    args = [module.get_bin_path('sysrc', required=True)]
+
+    if file is not None:
+        args.extend(['-f', file])
+
+    args.extend(['-c', '%s=%s' % (name, value)])
+
+    rc, out, err = module.run_command(args)
+
+    return rc != 0
+
+
+def sysrc_set(module, name, value, file=None):
+    '''
+    Set given name and value in the system using sysrc.
+
+    Args:
+        module: An instance of AnsibleModule.
+        name: Name of sysrc variable.
+        value: Value of sysrc variable.
+        file: Filename to write to.
+    Returns:
+        rc, out, err from a run_command call.
+    '''
+
+    args = [module.get_bin_path('sysrc', required=True)]
+
+    if file is not None:
+        args.extend(['-f', file])
+
+    args.append('%s=%s' % (name, value))
+
+    rc, out, err = module.run_command(args)
+
+    if rc != 0:
+        module.fail_json(msg=err)
+
+    return rc, out, err
+
+
+def sysrc_update(module, name, value, file=None):
+    '''
+    Check if given name and value differs
+    from what is currently set in the system,
+    and set value if they are different.
+
+    Args:
+        module: An instance of AnsibleModule.
+        name: Name of sysrc variable.
+        value: Value of sysrc variable.
+        file: Filename to read and write from.
+    Returns:
+        A bool indicating if the value was changed.
+    '''
+
+    change_required = sysrc_check_change_required(module, name, value)
+
+    changed = False
+
+    if change_required:
+        sysrc_set(module, name, value)
+        changed = True
+
+    return changed

--- a/lib/ansible/modules/system/rc_service.py
+++ b/lib/ansible/modules/system/rc_service.py
@@ -74,6 +74,7 @@ def run_service(module, args):
     bin_path = module.get_bin_path('service', required=True)
     return module.run_command([bin_path] + args)
 
+
 def service_is_enabled(module, name):
     rc, out, err = run_service(module, [name, 'enabled'])
     return rc == 0

--- a/lib/ansible/modules/system/rc_service.py
+++ b/lib/ansible/modules/system/rc_service.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+
+# (c) Mattias Lindvall
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '0.1',
+    'status': ['preview'],
+    'supported_by': 'community',
+}
+
+DOCUMENTATION = '''
+module: rc_service
+author:
+    - "Mattias Lindvall"
+version_added: "2.4"
+short_description: Manages services.
+description:
+    - Manages services with rc style init scripts, and sysrc based configuration.
+options:
+    name:
+        required: true
+        description:
+            - Name of the service.
+        aliases: ['unit', 'service']
+    state:
+        required: false
+        default: null
+        choices: ['started', 'stopped', 'restarted']
+        description:
+            - C(started)/C(stopped) are idempotent actions that will not run commands unless necessary.
+              C(restarted) will always restart the service.
+    enabled:
+        required: false
+        default: null
+        choices: ['yes', 'no']
+        description:
+            - Whether the service should be enabled using sysrc.
+requirements:
+    - A system with rc style init scripts, and sysrc based configuration.
+'''
+
+EXAMPLES = '''
+- name: Enable nginx
+  rc_service: name=nginx enabled=yes
+
+- name: Start nginx
+  rc_service name=nginx state=started
+
+- name: Start and enable nginx
+  rc_service: name=nginx enabled=yes state=stopped
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.sysrc import get_sysrc_value_bool, sysrc_update
+
+
+def run_service(module, args):
+    bin_path = module.get_bin_path('service', required=True)
+    return module.run_command([bin_path] + args)
+
+def service_is_enabled(module, name):
+    rc, out, err = run_service(module, [name, 'enabled'])
+    return rc == 0
+
+
+def service_is_running(module, name):
+    rc, out, err = run_service(module, [name, 'status'])
+    return rc == 0
+
+
+def handle_enabled(module, result):
+    name = module.params.get('name')
+    enabled = module.params.get('enabled')
+
+    if enabled is None:
+        return
+
+    # set <service>_enabled using sysrc
+    changed = sysrc_update(
+        module,
+        '%s_enable' % name,
+        get_sysrc_value_bool(enabled),
+    )
+
+    if changed:
+        result['changed'] = True
+
+
+def handle_state(module, result):
+    name = module.params.get('name')
+    state = module.params.get('state')
+
+    if state is None:
+        return
+
+    # ensure service is enabled
+    if not service_is_enabled(module, name):
+        module.fail_json(msg='Service %s is not enabled' % name)
+
+    command = None
+
+    if state == 'started':
+        if not service_is_running(module, name):
+            command = 'start'
+
+    elif state == 'stopped':
+        if service_is_running(module, name):
+            command = 'stop'
+
+    elif state == 'restarted':
+        command = 'restart'
+
+    if command:
+        rc, out, err = run_service(module, [name, command])
+
+        if rc != 0:
+            module.fail_json(msg='Failed to %s service %s' % (command, name))
+
+        result['changed'] = True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(
+                type='str',
+                required=True,
+                aliases=['unit', 'service'],
+            ),
+            state=dict(
+                type='str',
+                required=False,
+                choices=[
+                    'started',
+                    'stopped',
+                    'restarted',
+                ],
+            ),
+            enabled=dict(
+                type='bool',
+                required=False,
+            ),
+        ),
+    )
+
+    result = {
+        'changed': False,
+    }
+
+    handle_enabled(module, result)
+    handle_state(module, result)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/system/rc_service.py
+++ b/lib/ansible/modules/system/rc_service.py
@@ -19,7 +19,7 @@
 
 
 ANSIBLE_METADATA = {
-    'metadata_version': '0.1',
+    'metadata_version': '1.0',
     'status': ['preview'],
     'supported_by': 'community',
 }

--- a/lib/ansible/modules/system/rc_service.py
+++ b/lib/ansible/modules/system/rc_service.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
   rc_service: name=nginx enabled=yes
 
 - name: Start nginx
-  rc_service name=nginx state=started
+  rc_service: name=nginx state=started
 
 - name: Start and enable nginx
   rc_service: name=nginx enabled=yes state=stopped


### PR DESCRIPTION
##### SUMMARY
Adds a new module `rc_service`. This follows along the lines of separating modules from `service.py` into new service modules, as previously done with the `systemd` module.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
- `modules/system/rc_service`
- `module_utils/sysrc`

##### ANSIBLE VERSION
```
ansible 2.4.0 (rc_service e00e6fa58d) last updated 2017/06/29 16:50:44 (GMT +200)
  config file = /path/to/project/playbooks/ansible.cfg
  configured module search path = [u'/path/to/project/library']
  ansible python module location = /path/to/ansible/lib/ansible
  executable location = /path/to/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 13:38:23) [GCC 4.2.1 Compatible FreeBSD Clang 3.8.0 (tags/RELEASE_380/final 262564)]
```

##### ADDITIONAL INFORMATION
