### PR TITLE
Add integration test for fact delegation

### DIFF
--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -47,3 +47,6 @@ overridden_in_parent=2000
 
 [amazon]
 localhost ansible_ssh_host=127.0.0.1 ansible_connection=local
+
+[delegation_hosts]
+facthost[0:5]

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -105,3 +105,8 @@
         that:
           - "'delegated' in testfact2"
       when: inventory_hostname == 'facthost2'
+
+    - assert:
+        that:
+          - testfact2 is not defined
+      when: inventory_hostname != 'facthost2'

--- a/test/integration/targets/delegate_to/test_delegate_to.yml
+++ b/test/integration/targets/delegate_to/test_delegate_to.yml
@@ -1,9 +1,11 @@
 - hosts: testhost3
+
   vars:
-    - template_role: ./roles/test_template
-    - output_dir: "{{ playbook_dir }}"
-    - templated_var: foo
-    - templated_dict: { 'hello': 'world' }
+    template_role: ./roles/test_template
+    output_dir: "{{ playbook_dir }}"
+    templated_var: foo
+    templated_dict: { 'hello': 'world' }
+
   tasks:
     - name: Test no delegate_to
       setup:
@@ -34,23 +36,72 @@
 # Smoketest some other modules do not error as a canary
 #
     - name: Test file works with delegate_to and a host in inventory
-      file: path={{ output_dir }}/foo.txt mode=0644 state=touch
+      file:
+        path: "{{ output_dir }}/foo.txt"
+        mode: 0644
+        state: touch
       delegate_to: testhost4
 
     - name: Test file works with delegate_to and a host not in inventory
-      file: path={{ output_dir }}/tmp.txt mode=0644 state=touch
+      file:
+        path: "{{ output_dir }}/tmp.txt"
+        mode: 0644
+        state: touch
       delegate_to: 127.0.0.254
 
     - name: Test template works with delegate_to and a host in inventory
-      template: src={{ template_role }}/templates/foo.j2 dest={{ output_dir }}/foo.txt
+      template:
+        src: "{{ template_role }}/templates/foo.j2"
+        dest: "{{ output_dir }}/foo.txt"
       delegate_to: testhost4
 
     - name: Test template works with delegate_to and a host not in inventory
-      template: src={{ template_role }}/templates/foo.j2 dest={{ output_dir }}/foo.txt
+      template:
+        src: "{{ template_role }}/templates/foo.j2"
+        dest: "{{ output_dir }}/foo.txt"
       delegate_to: 127.0.0.254
 
     - name: remove test file
-      file: path={{ output_dir }}/foo.txt state=absent
+      file:
+        path: "{{ output_dir }}/foo.txt"
+        state: absent
 
     - name: remove test file
-      file: path={{ output_dir }}/tmp.txt state=absent
+      file:
+        path: "{{ output_dir }}/tmp.txt"
+        state: absent
+
+
+- name: Test fact delegation
+  hosts: localhost
+  gather_facts: no
+  become: no
+
+  tasks:
+    - name: Set some delegated facts in a loop to hosts outside this play
+      set_fact:
+        testfact: "{{ item }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: yes
+      with_items: "{{ groups['delegation_hosts'] }}"
+
+    - name: Set some delegated facts directly to a host outside this play
+      set_fact:
+        testfact2: delegated
+      delegate_to: facthost2
+      delegate_facts: yes
+
+- name: Validate fact delegation
+  hosts: delegation_hosts
+  gather_facts: no
+  become: no
+
+  tasks:
+    - assert:
+        that:
+          - inventory_hostname in testfact
+
+    - assert:
+        that:
+          - "'delegated' in testfact2"
+      when: inventory_hostname == 'facthost2'


### PR DESCRIPTION
##### SUMMARY
Related to issue #20508, issue #20980 where delegated facts are not set correctly, probably more.

Fixed in PR #25880

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
test/integration/targets/delegate_to/test_delegate_to.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (sdoran-delegate-tests 0531deac50) last updated 2017/06/29 11:55:11 (GMT -400)
  config file = /Users/sdoran/.ansible.cfg
  configured module search path = [u'/Users/sdoran/Source/ansible/library']
  ansible python module location = /Users/sdoran/Source/ansible/lib/ansible
  executable location = /Users/sdoran/Source/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
