### PR TITLE
Calling connection.close() instead of self.close() to actually close the connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -202,7 +202,7 @@ class Server():
                 self.socket.close()
             if self.connection:
                 display.display('closing the connection', log_only=True)
-                self.close()
+                self.connection.close()
         except:
             pass
         finally:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`ansible-connection` was checking to close the connection, but wasn't calling the connection to close.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (devel 038e090bc1) last updated 2017/06/29 17:11:39 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jmighion/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jmighion/git/ansible/lib/ansible
  executable location = /home/jmighion/git/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
