### PR TITLE
Add -F to usermod -p to force user password update

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -2098,6 +2098,7 @@ class HPUX(User):
             cmd.append(self.shell)
 
         if self.update_password == 'always' and self.password is not None and info[1] != self.password:
+            cmd.append('-F')
             cmd.append('-p')
             cmd.append(self.password)
 


### PR DESCRIPTION
When changing root password, usermod will fail with error "Login root is currently in use\n".  -F avoids this

##### SUMMARY

When updating the root password in HP-UX, task will fail with an error "Login root is currently in use".  -F avoids this.  Note this fixes Issue #4389 from ansible-modules-core that was not migrated

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
system/user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (hpux_root_pass 27b18492e4) last updated 2017/06/29 11:48:03 (GMT -600)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/rgroten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rgroten/git/ansible/lib/ansible
  executable location = /home/rgroten/git/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 29 2016, 16:36:36) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]

```


##### ADDITIONAL INFORMATION
```
BEFORE:

PLAY [Change root user password] ************************************************************************

TASK [change-user-pass : Set root password] *************************************************************
fatal: [hpux1.example.com]: FAILED! => {"changed": false, "failed": true, "msg": "Login root is currently in use\n", "name": "root", "rc": 8}
        to retry, use: --limit @/home/rgroten/ansible/root-pass.retry

PLAY RECAP **********************************************************************************************
hpux1.example.com          : ok=0    changed=0    unreachable=0    failed=1

AFTER:

PLAY [Change root user password] ************************************************************************

TASK [change-user-pass : Set root password] *************************************************************
changed: [hpux1.example.com]

PLAY RECAP **********************************************************************************************
hpux1.example.com          : ok=1    changed=1    unreachable=0    failed=0

```
