### PR TITLE
AWS lambda: added publish argument

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -118,7 +118,7 @@ options:
       - If set, then changes to configuration only will also be published.  Otherwise, only code changes are published and create new versions.
     required: false
     default: False
-    version_added: "2.3"
+    version_added: "2.4"
 author:
     - 'Steyn Huizinga (@steynovich)'
 extends_documentation_fragment:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, if you do only changes to the configuration, e.g. environment_variables, you cannot trigger a publish to new version.  The new publish argument, if set, will create a new version if only configuration settings are changed.  If a code update is done, then the publish argument doesn't do anything extra as a new version is already created.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module/lambda

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /Users/himyouten/.ansible.cfg
  configured module search path = [u'/Users/himyouten/Documents/git_repos/viceops-vpc-ansible/modules']
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
