### PR TITLE
win_user_right: add module with tests

### DIFF
--- a/lib/ansible/modules/windows/win_user_right.ps1
+++ b/lib/ansible/modules/windows/win_user_right.ps1
@@ -1,0 +1,354 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2017, Jordan Borean <jborean93@gmail.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$ErrorActionPreference = 'Stop'
+
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+$users = Get-AnsibleParam -obj $params -name "users" -type "list" -failifempty $true
+$action = Get-AnsibleParam -obj $params -name "action" -type "str" -default "set" -validateset "add","remove","set"
+
+$result = @{
+    changed = $false
+    added = @()
+    removed = @()
+}
+
+Function Get-Username($sid) {
+    # converts the SID (if it is one) to a username
+    # this sid is in the form exported by the SecEdit ini file (*S-.-..)
+    if (-not $sid.StartsWith("*S-")) {
+        $sid = Get-SID -account_name $sid
+    } else {
+        $sid = $sid.substring(1)
+    }
+
+    $object = New-Object System.Security.Principal.SecurityIdentifier($sid)
+    $user = $object.Translate([System.Security.Principal.NTAccount])
+    $user.Value
+}
+
+Function Get-SID($account_name) {
+    # Can take in the following account name forms and convert to a SID
+    # UPN:
+    #   username@domain (Domain)
+    # Down-Level Login Name
+    #   domain\username (Domain)
+    #   computername\username (Local)
+    #   .\username (Local)
+    # Login Name
+    #   username (Local)
+
+    if ($account_name -like "*\*") {
+        $account_name_split = $account_name -split "\\"
+        if ($account_name_split[0] -eq ".") {
+            $domain = $env:COMPUTERNAME
+        } else {
+            $domain = $account_name_split[0]
+        }
+        $username = $account_name_split[1]
+    } elseif ($account_name -like "*@*") {
+        $account_name_split = $account_name -split "@"
+        $domain = $account_name_split[1]
+        $username = $account_name_split[0]
+    } else {
+        $domain = $null
+        $username = $account_name
+    }
+
+    if ($domain) {
+        # searching for a local group with the servername prefixed will fail,
+        # need to check for this situation and only use NTAccount(String)
+        if ($domain -eq $env:COMPUTERNAME) {
+            $adsi = [ADSI]("WinNT://$env:COMPUTERNAME,computer")
+            $group = $adsi.psbase.children | Where-Object { $_.schemaClassName -eq "group" } | Where-Object { $_.Name -eq $username }
+        } else {
+            $group = $null
+        }
+        if ($group) {
+            $account = New-Object System.Security.Principal.NTAccount($username)
+        } else {
+            $account = New-Object System.Security.Principal.NTAccount($domain, $username)
+        }
+    } else {
+        # when in a domain NTAccount(String) will favour domain lookups check
+        # if username is a local user and explictly search on the localhost for
+        # that account
+        $adsi = [ADSI]("WinNT://$env:COMPUTERNAME,computer")
+        $user = $adsi.psbase.children | Where-Object { $_.schemaClassName -eq "user" } | Where-Object { $_.Name -eq $username }
+        if ($user) {
+            $account = New-Object System.Security.Principal.NTAccount($env:COMPUTERNAME, $username)
+        } else {
+            $account = New-Object System.Security.Principal.NTAccount($username)
+        }
+    }
+    
+    try {
+        $account_sid = $account.Translate([System.Security.Principal.SecurityIdentifier])
+    } catch {
+        Fail-Json $result "Account Name: $account_name is not a valid account, cannot get SID: $($_.Exception.Message)"
+    }
+    
+    $account_sid.Value
+}
+
+Function Run-SecEdit($arguments) {
+    $rc = $null
+    $stdout = $null
+    $stderr = $null
+    $log_path = [IO.Path]::GetTempFileName()
+    $arguments = $arguments + @("/log", $log_path, "/areas", "USER_RIGHTS")
+
+    try {
+        $stdout = &SecEdit.exe $arguments | Out-String
+    } catch {
+        $stderr = $_.Exception.Message
+    }
+    $log = Get-Content -Path $log_path
+    Remove-Item -Path $log_path -Force
+
+    $return = @{
+        log = ($log -join "`n").Trim()
+        stdout = $stdout
+        stderr = $stderr
+        rc = $LASTEXITCODE
+    }
+
+    $return
+}
+
+Function Compare-List($existing_list, $new_list) {
+    $comparison = @{
+        mismatch = $false
+        added = @()
+        removed = @()
+    }
+
+    foreach ($entry in $existing_list) {
+        if ($new_list -notcontains $entry) {
+            $comparison.removed += Get-Username -sid $entry
+            $comparison.mismatch = $true
+        }
+    }
+    foreach ($entry in $new_list) {
+        if ($existing_list -notcontains $entry) {
+            $comparison.added += Get-Username -sid $entry
+            $comparison.mismatch = $true
+        }
+    }
+
+    $comparison
+}
+
+Function Build-NewUserList($action, $users, $existing_users) {
+    $new_users = @()
+    if ($action -eq "remove") {
+        foreach ($existing_user in $existing_users) {
+            $user_match = $true
+            foreach ($user in $users) {
+                $user_sid = Get-SID -account_name $user
+                if ($existing_user -eq "*$user_sid") {
+                    $user_match = $false
+                }
+            }
+
+            if ($user_match) {
+                $new_users += $existing_user
+            }
+        }
+    } elseif ($action -eq "add") {
+        $new_users = $existing_users
+        foreach ($user in $users) {
+            $user_sid = Get-SID -account_name $user
+            $new_users += "*$user_sid"
+        }
+    } else {
+        foreach ($user in $users) {
+            $user_sid = Get-SID -account_name $user
+            $new_users += "*$user_sid"
+        }
+    }
+
+    ,$new_users
+}
+
+Function Build-ExistingUserList($existing_users) {
+    $users = @()
+    foreach ($existing_user in ($existing_users -split ",")) {
+        if ($existing_user.StartsWith("*S")) {
+            $users += $existing_user
+        } else {
+            $user_sid = Get-SID -account_name $existing_user
+            $users += "*$user_sid"
+        }
+    }
+
+    ,$users
+}
+
+Function ConvertTo-Ini($ini) {
+    $content = @()
+    foreach ($key in $ini.GetEnumerator()) {
+        $section = $key.Name
+        $values = $key.Value
+
+        $content += "[$section]"
+        foreach ($value in $values.GetEnumerator()) {
+            $value_key = $value.Name
+            $value_value = $value.Value
+
+            if ($value_value -ne $null) {
+                $content += "$value_key = $value_value"
+            }
+        }
+    }
+
+    $content -join "`r`n"
+}
+
+Function ConvertFrom-Ini($file_path) {
+    $ini = @{}
+    $contents = Get-Content -Path $file_path -Encoding Unicode
+    foreach ($line in $contents) {
+        switch -Regex ($line) {
+            "^\[(.+)\]" {
+                $section = $matches[1]
+                $ini.$section = @{}
+            }
+            "(.+?)\s*=(.*)" {
+                $name = $matches[1].Trim()
+                $value = $matches[2].Trim()
+                $ini.$section.$name = $value
+            }
+        }
+    }
+
+    $ini
+}
+
+### Main code below ###
+
+$ini_right_key = "Privilege Rights"
+$secedit_ini_path = [IO.Path]::GetTempFileName()
+# while this will technically make a change to the system in check mode by
+# creating a new file, we need these values to be able to do anything
+# substantial in check mode
+$export_result = Run-SecEdit -arguments @("/export", "/cfg", $secedit_ini_path, "/quiet")
+
+# check the return code and if the file has been populated, otherwise error out
+if (($export_result.rc -ne 0) -or ((Get-Item -Path $secedit_ini_path).Length -eq 0)) {
+    Remove-Item -Path $secedit_ini_path
+    Fail-Json $result "Failed to export secedit.ini file to $($secedit_ini_path).`nRC: $($export_result.rc)`nSTDOUT: $($export_result.stdout)`nSTDERR: $($export_result.stderr)`nLOG: $($export_result.log)"
+}
+$secedit_ini = ConvertFrom-Ini -file_path $secedit_ini_path
+Remove-Item -Path $secedit_ini_path
+
+$will_change = $false
+if ($secedit_ini.$ini_right_key.ContainsKey($name)) {
+    $existing_users = Build-ExistingUserList -existing_users $secedit_ini.$ini_right_key.$name
+    $new_users = Build-NewUserList -action $action -users $users -existing_users $existing_users
+
+    # sort the user objects for later comparison and remove duplicates
+    $new_users = $new_users | Sort-Object -Unique
+    $existing_users = $existing_users | Sort-Object -Unique
+
+    # compare the list and make changes as necessary
+    if ($new_users.Length -eq 0) {
+        $will_change = $true
+        $secedit_ini.$ini_right_key.$name = $null
+    }
+
+    $comparison = Compare-List -existing_list $existing_users -new_list $new_users
+    if ($comparison.mismatch -eq $true) {
+        foreach ($added in $comparison.added) {
+            $result.added += $added
+        }
+        foreach ($removed in $comparison.removed) {
+            $result.removed += $removed
+        }
+        $will_change = $true
+        $secedit_ini.$ini_right_key.$name = $new_users -join ","
+    }
+} else {
+    if ($users.Length -gt 0 -and (@("add", "set") -contains $action)) {
+        $will_change = $true
+        $new_users = @()
+        foreach ($user in $users) {
+            $username = Get-Username -sid $user
+            $result.added += $username
+            $new_users += "*$(Get-SID -account_name $user)"
+        }
+        $secedit_ini.$ini_right_key.$name = $new_users -join ","
+    }
+}
+
+if ($will_change) {
+    $ini_contents = ConvertTo-Ini -ini $secedit_ini
+    Set-Content -Path $secedit_ini_path -Value $ini_contents -Encoding Unicode -WhatIf:$check_mode
+    $result.changed = $true
+
+    if (-not $check_mode) {
+        $secedit_db_path = [IO.Path]::GetTempFileName()
+        Remove-Item -Path $secedit_db_path -Force # needs to be deleted for SecEdit.exe /import to work
+
+        $import_result = Run-SecEdit -arguments @("/configure", "/db", $secedit_db_path, "/cfg", $secedit_ini_path, "/quiet")
+        $result.changed = $true
+        $result.import_log = $import_result.log
+        Remove-Item -Path $secedit_ini_path -Force
+        if ($import_result.rc -ne 0) {
+            Fail-Json $result "Failed to import secedit.ini file from $($secedit_ini_path).`nRC: $($import_result.rc)`nSTDOUT: $($import_result.stdout)`nSTDERR: $($import_result.stderr)`nLOG: $($import_result.log)"
+        }
+
+        # secedit doesn't error out on improper entries, re-export and verify
+        # the changes occurred
+        $export_result = Run-SecEdit -arguments @("/export", "/cfg", $secedit_ini_path, "/quiet")
+
+        # check the return code and if the file has been populated, otherwise error out
+        if (($export_result.rc -ne 0) -or ((Get-Item -Path $secedit_ini_path).Length -eq 0)) {
+            Remove-Item -Path $secedit_ini_path # file is empty and we don't need it
+            Fail-Json $result "Failed to export secedit.ini file to $($secedit_ini_path).`nRC: $($export_result.rc)`nSTDOUT: $($export_result.stdout)`nSTDERR: $($export_result.stderr)`nLOG: $($export_result.log)"
+        }
+        $secedit_ini = ConvertFrom-Ini -file_path $secedit_ini_path
+        Remove-Item -Path $secedit_ini_path
+
+        if ($secedit_ini.$ini_right_key.ContainsKey($name)) {
+            $existing_users = Build-ExistingUserList -existing_users $secedit_ini.$ini_right_key.$name
+            $new_users = Build-NewUserList -action $action -users $users -existing_users $existing_users
+
+            # sort the user objects for later comparison and remove duplicates
+            $new_users = $new_users | Sort-Object -Unique
+            $existing_users = $existing_users | Sort-Object -Unique
+
+            $comparison = Compare-List -existing_list $existing_users -new_list $new_users
+            if ($comparison.mismatch -eq $true) {
+                Fail-Json $result "Failed to modify right $name, right membership does not match expected membership"
+            }
+        } else {
+            if ($users.Length -gt 0 -and (@("add", "set") -contains $action)) {
+                Fail-Json $result "Failed to modify right $name, right entry did not exist after import"
+            }
+        }
+    }
+}
+
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -1,22 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright 2017, Jordan Borean <jborean93@gmail.com>
-#
 # This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -28,7 +28,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 DOCUMENTATION = r'''
 ---
-module: win_share
+module: win_user_right
 version_added: '2.4'
 short_description: Manage Windows User Rights
 description:

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2017, Jordan Borean <jborean93@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: win_share
+version_added: '2.4'
+short_description: Manage Windows User Rights
+description:
+- Add, remove or set User Rights for a group or users or groups.
+- You can set user rights for both local and domain accounts.
+notes:
+- If the server is domain joined this module can change a right but if a GPO
+  governs this right then the changes won't last.
+options:
+  name:
+    description:
+    - The name of the User Right as shown by the Constant name here
+      U(https://technet.microsoft.com/en-us/library/dd349804.aspx).
+    - If this right is not a valid entry then the module will return an error.
+    required: True
+  users:
+    description:
+    - A list of users or groups to add/remove on the User Right.
+    - These can be in the form DOMAIN\user-group, user-group@DOMAIN.COM for
+      domain users/groups.
+    - For local users/groups it can be in the form user-group, .\user-group,
+      SERVERNAME\user-group where SERVERNAME is the name of the remote server.
+    - You can also add special local accounts like SYSTEM and others.
+    required: True
+  action:
+    description:
+    - C(add) will add the users/groups to the existing right.
+    - C(remove) will remove the users/groups from the existing right.
+    - C(set) will replace the users/groups of the existing right.
+    default: set
+    choices: [set, add, remove]
+author:
+- Jordan Borean (@jborean93)
+'''
+
+EXAMPLES = r'''
+---
+- name: replace the entries of Deny log on locally
+  win_user_right:
+    name: SeDenyInteractiveLogonRight
+    users:
+    - Guest
+    - Users
+    action: set
+
+- name: add account to Log on as a service
+  win_user_right:
+    name: SeServiceLogonRight
+    users:
+    - .\Administrator
+    - '{{ansible_hostname}}\local-user'
+    action: add
+
+- name: remove accounts who can create Symbolic links
+  win_user_right:
+    name: SeCreateSymbolicLinkPrivilege
+    users:
+    - SYSTEM
+    - Administrators
+    - DOMAIN\User
+    - group@DOMAIN.COM
+    action: remove
+'''
+
+RETURN = r'''
+added:
+  description: A list of accounts that were added to the right, this is empty
+    if no accounts were added.   
+  returned: success
+  type: list
+  sample: ["NT AUTHORITY\\SYSTEM", "DOMAIN\\User"]
+removed:
+  description: A list of accounts that were removed from the right, this is
+    empty if no accounts were removed.
+  returned: success
+  type: list
+  sample: ["SERVERNAME\\Administrator", "BUILTIN\\Administrators"]
+import_log:
+  description: The log of the SecEdit.exe /configure job that configured the
+    user rights. This is used for debugging purposes on failures.
+  returned: success and change occurred
+  type: string
+  sample: Completed 6 percent (0/15) \tProcess Privilege Rights area.
+'''

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -42,7 +42,7 @@ options:
     description:
     - The name of the User Right as shown by the C(Constant Name) value from
       U(https://technet.microsoft.com/en-us/library/dd349804.aspx).
-    - If this right is not a valid entry then the module will return an error.
+    - The module will return an error if the right is invalid.
     required: True
   users:
     description:
@@ -100,33 +100,10 @@ added:
   returned: success
   type: list
   sample: ["NT AUTHORITY\\SYSTEM", "DOMAIN\\User"]
-import_log:
-  description: The log of the SecEdit.exe /configure job that configured the
-    user rights. This is used for debugging purposes on failures.
-  returned: change occurred
-  type: string
-  sample: Completed 6 percent (0/15) \tProcess Privilege Rights area.
-rc:
-  description: The return code after a failure when running SecEdit.exe.
-  returned: failure with secedit calls
-  type: int
-  sample: -1
 removed:
   description: A list of accounts that were removed from the right, this is
     empty if no accounts were removed.
   returned: success
   type: list
   sample: ["SERVERNAME\\Administrator", "BUILTIN\\Administrators"]
-stderr:
-  description: The output of the STDERR buffer after a failure when running
-    SecEdit.exe.
-  returned: failure with secedit calls
-  type: string
-  sample: failed to import security policy
-stdout:
-  description: The output of the STDOUT buffer after a failure when running
-    SecEdit.exe.
-  returned: failure with secedit calls
-  type: string
-  sample: check log for error details
 '''

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -96,7 +96,7 @@ EXAMPLES = r'''
 RETURN = r'''
 added:
   description: A list of accounts that were added to the right, this is empty
-    if no accounts were added.   
+    if no accounts were added.
   returned: success
   type: list
   sample: ["NT AUTHORITY\\SYSTEM", "DOMAIN\\User"]

--- a/lib/ansible/modules/windows/win_user_right.py
+++ b/lib/ansible/modules/windows/win_user_right.py
@@ -40,7 +40,7 @@ notes:
 options:
   name:
     description:
-    - The name of the User Right as shown by the Constant name here
+    - The name of the User Right as shown by the C(Constant Name) value from
       U(https://technet.microsoft.com/en-us/library/dd349804.aspx).
     - If this right is not a valid entry then the module will return an error.
     required: True
@@ -100,16 +100,33 @@ added:
   returned: success
   type: list
   sample: ["NT AUTHORITY\\SYSTEM", "DOMAIN\\User"]
+import_log:
+  description: The log of the SecEdit.exe /configure job that configured the
+    user rights. This is used for debugging purposes on failures.
+  returned: change occurred
+  type: string
+  sample: Completed 6 percent (0/15) \tProcess Privilege Rights area.
+rc:
+  description: The return code after a failure when running SecEdit.exe.
+  returned: failure with secedit calls
+  type: int
+  sample: -1
 removed:
   description: A list of accounts that were removed from the right, this is
     empty if no accounts were removed.
   returned: success
   type: list
   sample: ["SERVERNAME\\Administrator", "BUILTIN\\Administrators"]
-import_log:
-  description: The log of the SecEdit.exe /configure job that configured the
-    user rights. This is used for debugging purposes on failures.
-  returned: success and change occurred
+stderr:
+  description: The output of the STDERR buffer after a failure when running
+    SecEdit.exe.
+  returned: failure with secedit calls
   type: string
-  sample: Completed 6 percent (0/15) \tProcess Privilege Rights area.
+  sample: failed to import security policy
+stdout:
+  description: The output of the STDOUT buffer after a failure when running
+    SecEdit.exe.
+  returned: failure with secedit calls
+  type: string
+  sample: check log for error details
 '''

--- a/test/integration/targets/win_user_right/aliases
+++ b/test/integration/targets/win_user_right/aliases
@@ -1,0 +1,1 @@
+windows/ci/group1

--- a/test/integration/targets/win_user_right/defaults/main.yml
+++ b/test/integration/targets/win_user_right/defaults/main.yml
@@ -1,0 +1,1 @@
+test_win_user_right_name: SeRelabelPrivilege

--- a/test/integration/targets/win_user_right/library/test_get_right.ps1
+++ b/test/integration/targets/win_user_right/library/test_get_right.ps1
@@ -1,0 +1,45 @@
+#!powershell
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+# basic script to get the lsit of users in a particular right
+# this is quite complex to put as a simple script so this is
+# just a simple module
+
+$ErrorActionPreference = 'Stop'
+
+$params = Parse-Args $args -supports_check_mode $false
+$name = Get-AnsibleParam -obj $params -name "name" -type "str" -failifempty $true
+
+$result = @{
+    changed = $false
+    users = @()
+}
+
+Function Get-Username($sid) {
+    $object = New-Object System.Security.Principal.SecurityIdentifier($sid)
+    $user = $object.Translate([System.Security.Principal.NTAccount])
+    $user.Value
+}
+
+$secedit_ini_path = [IO.Path]::GetTempFileName()
+&SecEdit.exe /export /cfg $secedit_ini_path /quiet
+$secedit_ini = Get-Content -Path $secedit_ini_path
+Remove-Item -Path $secedit_ini_path -Force
+
+foreach ($line in $secedit_ini) {
+    if ($line.ToLower().StartsWith("$($name.ToLower()) = ")) {
+        $right_split = $line -split "="
+        $existing_users = $right_split[-1].Trim() -split ","
+        foreach ($user in $existing_users) {
+            if ($user.StartsWith("*S")) {
+                $result.users += Get-Username -sid $user.substring(1)
+            } else {
+                $result.users += $user
+            }
+        }
+    }
+}
+
+Exit-Json $result

--- a/test/integration/targets/win_user_right/library/test_get_right.ps1
+++ b/test/integration/targets/win_user_right/library/test_get_right.ps1
@@ -1,7 +1,6 @@
 #!powershell
 
-# WANT_JSON
-# POWERSHELL_COMMON
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
 
 # basic script to get the lsit of users in a particular right
 # this is quite complex to put as a simple script so this is

--- a/test/integration/targets/win_user_right/tasks/main.yml
+++ b/test/integration/targets/win_user_right/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: get current entries for right
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: actual_users
+
+- name: get facts
+  setup:
+
+- block:
+  - name: ensure right is empty before test
+    win_user_right:
+      name: '{{test_win_user_right_name}}'
+      users: []
+      action: set
+  
+  - name: run tests
+    include_tasks: tests.yml
+
+  always:
+  - name: reset entries for test right
+    win_user_right:
+      name: '{{test_win_user_right_name}}'
+      users: '{{actual_users.users}}'
+      action: set

--- a/test/integration/targets/win_user_right/tasks/tests.yml
+++ b/test/integration/targets/win_user_right/tasks/tests.yml
@@ -4,7 +4,7 @@
     name: FailRight
     users: Administrator
   register: fail_invalid_right
-  failed_when: fail_invalid_right.msg != 'Failed to modify right FailRight, invalid right name'
+  failed_when: fail_invalid_right.msg != 'the specified right FailRight is not a valid right'
 
 - name: fail with invalid username
   win_user_right:

--- a/test/integration/targets/win_user_right/tasks/tests.yml
+++ b/test/integration/targets/win_user_right/tasks/tests.yml
@@ -4,7 +4,7 @@
     name: FailRight
     users: Administrator
   register: fail_invalid_right
-  failed_when: fail_invalid_right.msg != 'Failed to modify right FailRight, right entry did not exist after import'
+  failed_when: fail_invalid_right.msg != 'Failed to modify right FailRight, invalid right name'
 
 - name: fail with invalid username
   win_user_right:
@@ -60,7 +60,7 @@
   assert:
     that:
     - set_administrator_check|changed
-    - set_administrator_check.added == ['{{ansible_hostname}}\Administrator']
+    - set_administrator_check.added == ["{{ansible_hostname}}\\Administrator"]
     - set_administrator_check.removed == []
     - set_administrator_actual_check.users == []
 
@@ -80,7 +80,7 @@
   assert:
     that:
     - set_administrator|changed
-    - set_administrator.added == ['{{ansible_hostname}}\Administrator']
+    - set_administrator.added == ["{{ansible_hostname}}\\Administrator"]
     - set_administrator.removed == []
     - set_administrator_actual.users == ['Administrator']
 
@@ -115,7 +115,7 @@
   assert:
     that:
     - remove_right_check|changed
-    - remove_right_check.removed == ['{{ansible_hostname}}\Administrator']
+    - remove_right_check.removed == ["{{ansible_hostname}}\\Administrator"]
     - remove_right_check.added == []
     - remove_right_actual_check.users == ['Administrator']
 
@@ -135,7 +135,7 @@
   assert:
     that:
     - remove_right|changed
-    - remove_right.removed == ['{{ansible_hostname}}\Administrator']
+    - remove_right.removed == ["{{ansible_hostname}}\\Administrator"]
     - remove_right.added == []
     - remove_right_actual.users == []
 
@@ -171,7 +171,7 @@
     that:
     - add_right_on_empty_check|changed
     - add_right_on_empty_check.removed == []
-    - add_right_on_empty_check.added == ['{{ansible_hostname}}\Administrator', 'BUILTIN\Administrators']
+    - add_right_on_empty_check.added == ["{{ansible_hostname}}\\Administrator", "BUILTIN\\Administrators"]
     - add_right_on_empty_actual_check.users == []
 
 - name: add to empty right
@@ -191,8 +191,8 @@
     that:
     - add_right_on_empty|changed
     - add_right_on_empty.removed == []
-    - add_right_on_empty.added == ['{{ansible_hostname}}\Administrator', 'BUILTIN\Administrators']
-    - add_right_on_empty_actual.users == ['Administrator', 'BUILTIN\Administrators']
+    - add_right_on_empty.added == ["{{ansible_hostname}}\\Administrator", "BUILTIN\\Administrators"]
+    - add_right_on_empty_actual.users == ["Administrator", "BUILTIN\\Administrators"]
 
 - name: add to empty right again
   win_user_right:
@@ -226,8 +226,8 @@
     that:
     - add_right_on_existing_check|changed
     - add_right_on_existing_check.removed == []
-    - add_right_on_existing_check.added == ["BUILTIN\\Users", "BUILTIN\\Guests"]
-    - add_right_on_existing_actual_check.users == ['Administrator', 'BUILTIN\Administrators']
+    - add_right_on_existing_check.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
+    - add_right_on_existing_actual_check.users == ["Administrator", "BUILTIN\\Administrators"]
 
 - name: add to existing right
   win_user_right:
@@ -246,8 +246,8 @@
     that:
     - add_right_on_existing|changed
     - add_right_on_existing.removed == []
-    - add_right_on_existing.added == ["BUILTIN\\Users", "BUILTIN\\Guests"]
-    - add_right_on_existing_actual.users == ['Administrator', 'BUILTIN\Administrators', "BUILTIN\\Users", "BUILTIN\\Guests"]
+    - add_right_on_existing.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
+    - add_right_on_existing_actual.users == ["Administrator", "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
 
 - name: add to existing right again
   win_user_right:
@@ -280,9 +280,9 @@
   assert:
     that:
     - remove_on_existing_check|changed
-    - remove_on_existing_check.removed == ['{{ansible_hostname}}\Administrator', "BUILTIN\\Guests"]
+    - remove_on_existing_check.removed == ["BUILTIN\\Guests", "{{ansible_hostname}}\\Administrator"]
     - remove_on_existing_check.added == []
-    - remove_on_existing_actual_check.users == ['Administrator', 'BUILTIN\Administrators', "BUILTIN\\Users", "BUILTIN\\Guests"]
+    - remove_on_existing_actual_check.users == ["Administrator", "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
 
 - name: remove from existing
   win_user_right:
@@ -300,9 +300,9 @@
   assert:
     that:
     - remove_on_existing|changed
-    - remove_on_existing.removed == ['{{ansible_hostname}}\Administrator', "BUILTIN\\Guests"]
+    - remove_on_existing.removed == ["BUILTIN\\Guests", "{{ansible_hostname}}\\Administrator"]
     - remove_on_existing.added == []
-    - remove_on_existing_actual.users == ['BUILTIN\Administrators', "BUILTIN\\Users"]
+    - remove_on_existing_actual.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
 
 - name: remove from existing again
   win_user_right:
@@ -337,7 +337,7 @@
     - set_on_existing_check|changed
     - set_on_existing_check.removed == ["BUILTIN\\Users"]
     - set_on_existing_check.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
-    - set_on_existing_actual_check.users == ['BUILTIN\Administrators', "BUILTIN\\Users"]
+    - set_on_existing_actual_check.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
 
 - name: set to existing
   win_user_right:
@@ -357,7 +357,7 @@
     - set_on_existing|changed
     - set_on_existing.removed == ["BUILTIN\\Users"]
     - set_on_existing.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
-    - set_on_existing_actual.users == ["NT AUTHORITY\\SYSTEM", 'BUILTIN\Administrators', "BUILTIN\\Backup Operators"]
+    - set_on_existing_actual.users == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Administrators", "BUILTIN\\Backup Operators"]
 
 - name: set to existing again
   win_user_right:

--- a/test/integration/targets/win_user_right/tasks/tests.yml
+++ b/test/integration/targets/win_user_right/tasks/tests.yml
@@ -1,0 +1,374 @@
+---
+- name: fail to set invalid right
+  win_user_right:
+    name: FailRight
+    users: Administrator
+  register: fail_invalid_right
+  failed_when: fail_invalid_right.msg != 'Failed to modify right FailRight, right entry did not exist after import'
+
+- name: fail with invalid username
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: FakeUser
+  register: fail_invalid_user
+  failed_when: "'Account Name: FakeUser is not a valid account, cannot get SID' not in fail_invalid_user.msg"
+
+- name: remove from empty right check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Administrators']
+    action: remove
+  register: remove_empty_right_check
+  check_mode: yes
+
+- name: assert remove from empty right check
+  assert:
+    that:
+    - not remove_empty_right_check|changed
+    - remove_empty_right_check.added == []
+    - remove_empty_right_check.removed == []
+
+- name: remove from empty right
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Administrators']
+    action: remove
+  register: remove_empty_right
+  check_mode: yes
+
+- name: assert remove from empty right
+  assert:
+    that:
+    - not remove_empty_right|changed
+    - remove_empty_right.added == []
+    - remove_empty_right.removed == []
+
+- name: set administrator check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: Administrator
+    action: set
+  register: set_administrator_check
+  check_mode: yes
+
+- name: get actual set administrator check
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: set_administrator_actual_check
+
+- name: assert set administrator check
+  assert:
+    that:
+    - set_administrator_check|changed
+    - set_administrator_check.added == ['{{ansible_hostname}}\Administrator']
+    - set_administrator_check.removed == []
+    - set_administrator_actual_check.users == []
+
+- name: set administrator
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: Administrator
+    action: set
+  register: set_administrator
+
+- name: get actual set administrator
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: set_administrator_actual
+
+- name: assert set administrator check
+  assert:
+    that:
+    - set_administrator|changed
+    - set_administrator.added == ['{{ansible_hostname}}\Administrator']
+    - set_administrator.removed == []
+    - set_administrator_actual.users == ['Administrator']
+
+- name: set administrator again
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: Administrator
+    action: set
+  register: set_administrator_again
+
+- name: assert set administrator check
+  assert:
+    that:
+    - not set_administrator_again|changed
+    - set_administrator_again.added == []
+    - set_administrator_again.removed == []
+
+- name: remove from right check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Guests', '{{ansible_hostname}}\Users', '.\Backup Operators']
+    action: remove
+  register: remove_right_check
+  check_mode: yes
+
+- name: get actual remove from right check
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: remove_right_actual_check
+
+- name: assert remove from right check
+  assert:
+    that:
+    - remove_right_check|changed
+    - remove_right_check.removed == ['{{ansible_hostname}}\Administrator']
+    - remove_right_check.added == []
+    - remove_right_actual_check.users == ['Administrator']
+
+- name: remove from right
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Guests', '{{ansible_hostname}}\Users', '.\Backup Operators']
+    action: remove
+  register: remove_right
+
+- name: get actual remove from right
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: remove_right_actual
+
+- name: assert remove from right
+  assert:
+    that:
+    - remove_right|changed
+    - remove_right.removed == ['{{ansible_hostname}}\Administrator']
+    - remove_right.added == []
+    - remove_right_actual.users == []
+
+- name: remove from right again
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Guests', '{{ansible_hostname}}\Users', '.\Backup Operators']
+    action: remove
+  register: remove_right_again
+
+- name: assert remove from right
+  assert:
+    that:
+    - not remove_right_again|changed
+    - remove_right_again.removed == []
+    - remove_right_again.added == []
+
+- name: add to empty right check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Administrators']
+    action: add
+  register: add_right_on_empty_check
+  check_mode: yes
+
+- name: get actual add to empty right check
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: add_right_on_empty_actual_check
+
+- name: assert add to empty right check
+  assert:
+    that:
+    - add_right_on_empty_check|changed
+    - add_right_on_empty_check.removed == []
+    - add_right_on_empty_check.added == ['{{ansible_hostname}}\Administrator', 'BUILTIN\Administrators']
+    - add_right_on_empty_actual_check.users == []
+
+- name: add to empty right
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Administrators']
+    action: add
+  register: add_right_on_empty
+
+- name: get actual add to empty right
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: add_right_on_empty_actual
+
+- name: assert add to empty right
+  assert:
+    that:
+    - add_right_on_empty|changed
+    - add_right_on_empty.removed == []
+    - add_right_on_empty.added == ['{{ansible_hostname}}\Administrator', 'BUILTIN\Administrators']
+    - add_right_on_empty_actual.users == ['Administrator', 'BUILTIN\Administrators']
+
+- name: add to empty right again
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Administrators']
+    action: add
+  register: add_right_on_empty_again
+
+- name: assert add to empty right
+  assert:
+    that:
+    - not add_right_on_empty_again|changed
+    - add_right_on_empty_again.removed == []
+    - add_right_on_empty_again.added == []
+
+- name: add to existing right check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Guests', '{{ansible_hostname}}\Users']
+    action: add
+  register: add_right_on_existing_check
+  check_mode: yes
+
+- name: get actual add to existing right check
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: add_right_on_existing_actual_check
+
+- name: assert add to existing right check
+  assert:
+    that:
+    - add_right_on_existing_check|changed
+    - add_right_on_existing_check.removed == []
+    - add_right_on_existing_check.added == ["BUILTIN\\Users", "BUILTIN\\Guests"]
+    - add_right_on_existing_actual_check.users == ['Administrator', 'BUILTIN\Administrators']
+
+- name: add to existing right
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Guests', '{{ansible_hostname}}\Users']
+    action: add
+  register: add_right_on_existing
+
+- name: get actual add to existing right
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: add_right_on_existing_actual
+
+- name: assert add to existing right
+  assert:
+    that:
+    - add_right_on_existing|changed
+    - add_right_on_existing.removed == []
+    - add_right_on_existing.added == ["BUILTIN\\Users", "BUILTIN\\Guests"]
+    - add_right_on_existing_actual.users == ['Administrator', 'BUILTIN\Administrators', "BUILTIN\\Users", "BUILTIN\\Guests"]
+
+- name: add to existing right again
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrator', 'Guests', '{{ansible_hostname}}\Users']
+    action: add
+  register: add_right_on_existing_again
+
+- name: assert add to existing right
+  assert:
+    that:
+    - not add_right_on_existing_again|changed
+    - add_right_on_existing_again.removed == []
+    - add_right_on_existing_again.added == []
+
+- name: remove from existing check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Guests', 'Administrator']
+    action: remove
+  register: remove_on_existing_check
+  check_mode: yes
+
+- name: get actual remove from existing check
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: remove_on_existing_actual_check
+
+- name: assert remove from existing check
+  assert:
+    that:
+    - remove_on_existing_check|changed
+    - remove_on_existing_check.removed == ['{{ansible_hostname}}\Administrator', "BUILTIN\\Guests"]
+    - remove_on_existing_check.added == []
+    - remove_on_existing_actual_check.users == ['Administrator', 'BUILTIN\Administrators', "BUILTIN\\Users", "BUILTIN\\Guests"]
+
+- name: remove from existing
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Guests', 'Administrator']
+    action: remove
+  register: remove_on_existing
+
+- name: get actual remove from existing
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: remove_on_existing_actual
+
+- name: assert remove from existing
+  assert:
+    that:
+    - remove_on_existing|changed
+    - remove_on_existing.removed == ['{{ansible_hostname}}\Administrator', "BUILTIN\\Guests"]
+    - remove_on_existing.added == []
+    - remove_on_existing_actual.users == ['BUILTIN\Administrators', "BUILTIN\\Users"]
+
+- name: remove from existing again
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Guests', 'Administrator']
+    action: remove
+  register: remove_on_existing_again
+
+- name: assert remove from existing again
+  assert:
+    that:
+    - not remove_on_existing_again|changed
+    - remove_on_existing_again.removed == []
+    - remove_on_existing_again.added == []
+
+- name: set to existing check
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrators', 'SYSTEM', 'Backup Operators']
+    action: set
+  register: set_on_existing_check
+  check_mode: yes
+
+- name: get actual set to existing check
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: set_on_existing_actual_check
+
+- name: assert set to existing check
+  assert:
+    that:
+    - set_on_existing_check|changed
+    - set_on_existing_check.removed == ["BUILTIN\\Users"]
+    - set_on_existing_check.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
+    - set_on_existing_actual_check.users == ['BUILTIN\Administrators', "BUILTIN\\Users"]
+
+- name: set to existing
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrators', 'SYSTEM', 'Backup Operators']
+    action: set
+  register: set_on_existing
+
+- name: get actual set to existing
+  test_get_right:
+    name: '{{test_win_user_right_name}}'
+  register: set_on_existing_actual
+
+- name: assert set to existing
+  assert:
+    that:
+    - set_on_existing|changed
+    - set_on_existing.removed == ["BUILTIN\\Users"]
+    - set_on_existing.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
+    - set_on_existing_actual.users == ["NT AUTHORITY\\SYSTEM", 'BUILTIN\Administrators', "BUILTIN\\Backup Operators"]
+
+- name: set to existing again
+  win_user_right:
+    name: '{{test_win_user_right_name}}'
+    users: ['Administrators', 'SYSTEM', 'Backup Operators']
+    action: set
+  register: set_on_existing_again
+
+- name: assert set to existing
+  assert:
+    that:
+    - not set_on_existing_again|changed
+    - set_on_existing_again.removed == []
+    - set_on_existing_again.added == []


### PR DESCRIPTION
##### SUMMARY
Added a new module win_user_right that allows you to add/remove/set user rights for either local or domain accounts.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
win_user_right

##### ANSIBLE VERSION
```
ansible 2.4.0 (win_user_right-module d5bfe4cf93) last updated 2017/06/30 18:20:08 (GMT +1000)
  config file = None
  configured module search path = [u'/home/jborean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jborean/dev/ansible/lib/ansible
  executable location = /home/jborean/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 28 2017, 21:13:49) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

##### ADDITIONAL INFORMATION
This module is to extend https://github.com/ansible/ansible/pull/22775 where it allows you to idempotently set users/groups on user rights without knowing the SID for said account.