### PR TITLE
prevent decode errors when displaying failures

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -81,7 +81,7 @@ class CallbackBase:
             indent = 4
 
         # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.
-        abridged_result = strip_internal_keys(result)
+        abridged_result = to_text(strip_internal_keys(result))
 
         # remove invocation unless specifically wanting it
         if not keep_invocation and self._display.verbosity < 3 and 'invocation' in result:
@@ -94,9 +94,6 @@ class CallbackBase:
         # remove exception from screen output
         if 'exception' in abridged_result:
             del abridged_result['exception']
-
-        # ensure we don't hit decode errors on displaying errors
-        abridged_result = to_text(abridged_result)
 
         return json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -95,7 +95,6 @@ class CallbackBase:
         if 'exception' in abridged_result:
             del abridged_result['exception']
 
-
         # make an attempt to serialize the result and convert to text on failure
         try:
             jdata = json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -81,7 +81,7 @@ class CallbackBase:
             indent = 4
 
         # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.
-        abridged_result = to_text(strip_internal_keys(result))
+        abridged_result = strip_internal_keys(result)
 
         # remove invocation unless specifically wanting it
         if not keep_invocation and self._display.verbosity < 3 and 'invocation' in result:
@@ -95,7 +95,14 @@ class CallbackBase:
         if 'exception' in abridged_result:
             del abridged_result['exception']
 
-        return json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
+
+        # make an attempt to serialize the result and convert to text on failure
+        try:
+            jdata = json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
+        except UnicodeError:
+            text_result = to_text(abridged_result)
+            jdata = json.dumps(text_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
+        return jdata
 
     def _handle_warnings(self, res):
         ''' display warnings, if enabled and any exist in the result '''

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -95,6 +95,9 @@ class CallbackBase:
         if 'exception' in abridged_result:
             del abridged_result['exception']
 
+        # ensure we don't hit decode errors on displaying errors
+        abridged_result = to_text(abridged_result)
+
         return json.dumps(abridged_result, indent=indent, ensure_ascii=False, sort_keys=sort_keys)
 
     def _handle_warnings(self, res):


### PR DESCRIPTION
##### SUMMARY
Fixes #26256

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
callbacks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
