### PR TITLE
Pip flexible versions

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -162,7 +162,7 @@ EXAMPLES = '''
 # Install (Docker) python package with a complex version spec.
 - pip:
     name: docker
-    version: >=2.2.0,!=2.4.0,!=2.4.1
+    version: ">=2.2.0,!=2.4.0,!=2.4.1"
 
 # Install (MyApp) using one of the remote protocols (bzr+,hg+,git+,svn+). You do not have to supply '-e' option in extra_args.
 - pip:

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -257,7 +257,9 @@ def _get_full_name(name, version=None):
         return name
 
     # recast as string since we'll need the char index
-    version = str(version) if not isinstance(version, basestring) else version
+    # py2/3 compatible basestring style string check
+    if not isinstance(version, ("".__class__, u"".__class__)):
+        version = str(version)
 
     # if the version starts with a number, it's not a version spec and we can
     # assume they mean to use '=='. otherwise, we'll depend on the user to

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -260,13 +260,13 @@ def _get_full_name(name, version=None):
     version = str(version) if not isinstance(version, basestring) else version
 
     # if the version starts with a number, it's not a version spec and we can
-    # assume they mean ==
-    if version[0].isdigit():
-        return name + '==' + version
+    # assume they mean to use '=='. otherwise, we'll depend on the user to
+    # supply a valid separator
+    sep = '==' if version[0].isdigit() else ''
 
-    # if the user passed in a version that doesn't begin with a number then
-    # it's probably a version spec. let's not muck with it.
-    return name + version
+    # if the version spec contains a comma, it *must* be quoted, so let's just
+    # play it safe and always quote it
+    return '"' + name + sep + version + '"'
 
 
 def _get_packages(module, pip, chdir):

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -161,3 +161,14 @@
   assert:
     that:
       - "not q_check_mode.changed"
+
+- name: install package with complex version
+  pip:
+    name: docker
+    version: ">=2.2.0,!=2.4.0,!=2.4.1"
+  register: package_complex_version
+
+- name: make sure package with complex version reported changed
+  assert:
+    that:
+      - "package_complex_version.changed"


### PR DESCRIPTION
##### SUMMARY
Allow users to use version specs when installing pip packages (eg: `>=1.2.3,!=1.2.4`) as well as plain version numbers.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/packaging/languages/pip

##### ANSIBLE VERSION
```
devel
```


##### ADDITIONAL INFORMATION
Added this line to docs but don't know what version to list, so TODO I guess: `As of ... you can use version comparisons in this parameter.` 
