### PR TITLE
Fix version_added for new option in template introduced in #21846

### DIFF
--- a/lib/ansible/modules/windows/win_template.py
+++ b/lib/ansible/modules/windows/win_template.py
@@ -53,32 +53,32 @@ options:
       - Specify the newline sequence to use for templating files.
     choices: [ '\n', '\r', '\r\n' ]
     default: '\r\n'
-    version_added: '2.3'
+    version_added: '2.4'
   block_start_string:
     description:
       - The string marking the beginning of a block.
     default: '{%'
-    version_added: '2.3'
+    version_added: '2.4'
   block_end_string:
     description:
       - The string marking the end of a block.
     default: '%}'
-    version_added: '2.3'
+    version_added: '2.4'
   variable_start_string:
     description:
       - The string marking the beginning of a print statement.
     default: '{{'
-    version_added: '2.3'
+    version_added: '2.4'
   variable_end_string:
     description:
       - The string marking the end of a print statement.
     default: '}}'
-    version_added: '2.3'
+    version_added: '2.4'
   trim_blocks:
     description:
       - If this is set to True the first newline after a block is removed (block, not variable tag!).
     default: "no"
-    version_added: '2.3'
+    version_added: '2.4'
   force:
     description:
       - the default is C(yes), which will replace the remote file when contents
@@ -86,7 +86,7 @@ options:
         if the destination does not exist.
     choices: [ "yes", "no" ]
     default: "yes"
-    version_added: '2.3'
+    version_added: '2.4'
 notes:
   - For other platforms you can use M(template) which uses '\n' as C(newline_sequence).
   - Templates are loaded with C(trim_blocks=True).


### PR DESCRIPTION
##### SUMMARY
In Pull request #21846 its stated that the changes won't be backported to Ansible v2.3.
Now the documentation still shows introduced in v2.3, which needs to be fixed :)

Also see #24307

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_template

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
