### PR TITLE
Expose docker socket to test containers.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -211,6 +211,11 @@ def delegate_docker(args, exclude, require):
                 '--privileged=%s' % str(privileged).lower(),
             ]
 
+            docker_socket = '/var/run/docker.sock'
+
+            if os.path.exists(docker_socket):
+                test_options += ['--volume', '%s:%s' % (docker_socket, docker_socket)]
+
             if util_id:
                 test_options += [
                     '--link', '%s:ansible.http.tests' % util_id,


### PR DESCRIPTION
##### SUMMARY

Expose docker socket to test containers. This will permit testing of docker modules and connections within docker test containers.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (docker-ci 19bae0595c) last updated 2017/06/30 14:07:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
