### PR TITLE
NEW: Adds a serverless binary path option to the serverless module

### DIFF
--- a/lib/ansible/modules/cloud/misc/serverless.py
+++ b/lib/ansible/modules/cloud/misc/serverless.py
@@ -38,6 +38,11 @@ options:
       - Goal state of given stage/project
     required: false
     default: present
+  serverless_bin_path:
+    description:
+      - The path of a serverless framework binary relative to the 'service_path' eg. node_module/.bin/serverless
+    required: false
+    version_added: "2.4"
   service_path:
     description:
       - The path to the root of the Serverless Service to be operated on.
@@ -94,6 +99,13 @@ EXAMPLES = """
     region: us-east-1
     stack_name: '{{ sls.service_name }}'
     stack_resources: true
+
+# Deploy a project but use a locally installed serverless binary instead of the global serverless binary
+- serverless:
+    stage: dev
+    region: us-east-1
+    service_path: '{{ project_dir }}'
+    serverless_bin_path: node_modules/.bin/serverless
 """
 
 RETURN = """
@@ -153,6 +165,7 @@ def main():
             region       = dict(default='', required=False),
             stage        = dict(default='', required=False),
             deploy       = dict(default=True, type='bool', required=False),
+            serverless_bin_path = dict(required=False, type='path')
         ),
     )
 
@@ -162,8 +175,13 @@ def main():
     region = module.params.get('region')
     stage = module.params.get('stage')
     deploy = module.params.get('deploy', True)
+    serverless_bin_path = module.params.get('serverless_bin_path')
 
-    command = "serverless "
+    if serverless_bin_path is not None:
+        command = serverless_bin_path + " "
+    else:
+        command = "serverless "
+
     if state == 'present':
         command += 'deploy '
     elif state == 'absent':


### PR DESCRIPTION
##### SUMMARY
This PR adds an option to the `serverless` module called `serverless_bin_path` which allows users to specify a serverless installation other than a global installation to use to execute the module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
serverless module

##### ANSIBLE VERSION
```
ansible 2.4.0 (feature/serverless-binary-path acf40ce1f1) last updated 2017/06/30 15:41:52 (GMT -500)
```

##### ADDITIONAL INFORMATION
Serverless module task configuration before and after change.
```
- serverless:
    service_path: "../../my-service"
    stage: "{{ STAGE }}"
    region: "{{ REGION }}"
    state: present
  register: sls_output
```

```
- serverless:
    service_path: "../../my-service"
    stage: "{{ STAGE }}"
    region: "{{ REGION }}"
    state: present
    serverless_bin_path: "node_modules/.bin/serverless"
  register: sls_output
```