### PR TITLE
Fix exception in firewalld when using masquerade

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -1009,7 +1009,7 @@ def main():
                     action_handler(set_masquerade_permanent, (zone, True))
                     changed=True
                 if not is_enabled_immediate:
-                    action_handler(set_masquerade_enabled, (zone))
+                    action_handler(set_masquerade_enabled, (zone,))
                     changed=True
                 if changed:
                     msgs.append("Added masquerade to zone %s" % (zone))
@@ -1022,7 +1022,7 @@ def main():
                     action_handler(set_masquerade_permanent, (zone, False))
                     changed=True
                 if is_enabled_immediate:
-                    action_handler(set_masquerade_disabled, (zone))
+                    action_handler(set_masquerade_disabled, (zone,))
                     changed=True
                 if changed:
                     msgs.append("Removed masquerade from zone %s" % (zone))


### PR DESCRIPTION
The following snippet:
```
  - name: Let the DMZ connect to internet
  firewalld:
    zone: dmz
    masquerade: True
    permanent: True
    immediate: True
    state: enabled
```
will fail with this error message:
```
  Exception caught: set_masquerade_enabled() takes 1 positional argument but 3 were given
```
It turn out that it treat 'zone' as a array of string instead of 1 string.
I only tested on Python 3 with a Fedora 25.

##### SUMMARY

Firewalld module do not work when enabling masquerade

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
firewalld

