### PR TITLE
Ensure only server w/ no active task_state is returned

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -147,20 +147,23 @@ def get_host_groups_from_cloud(inventory):
             continue
         firstpass[server['name']].append(server)
     for name, servers in firstpass.items():
-        if len(servers) == 1 and use_hostnames:
+        if len(servers) == 1 and use_hostnames and \
+                servers[0]['OS-EXT-STS:task_state'] is None:
             append_hostvars(hostvars, groups, name, servers[0])
         else:
             server_ids = set()
             # Trap for duplicate results
             for server in servers:
                 server_ids.add(server['id'])
-            if len(server_ids) == 1 and use_hostnames:
+            if len(server_ids) == 1 and use_hostnames and \
+                    servers[0]['OS-EXT-STS:task_state'] is None:
                 append_hostvars(hostvars, groups, name, servers[0])
             else:
                 for server in servers:
-                    append_hostvars(
-                        hostvars, groups, server['id'], server,
-                        namegroup=True)
+                    if server['OS-EXT-STS:task_state'] is None:
+                        append_hostvars(
+                            hostvars, groups, server['id'], server,
+                            namegroup=True)
     groups['_meta'] = {'hostvars': hostvars}
     return groups
 


### PR DESCRIPTION
##### SUMMARY

Currently, all the servers that are found by the API are returned.
This include nodes, currently spawning or currently being deleted.

This can lead Ansible to try to run job against servers that are actually
not available, and hence the job will fail with an unreachable host
error message.

This commit aims to make sure that only servers that are fully
operational are returned has part of the inventory.

Fix #26317

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `contrib/inventory/openstack.py`

##### ANSIBLE VERSION

```
ansible 2.4.0 (active_none_task_only_openstack 8e94a6c271) last updated 2017/07/02 00:02:00 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/spredzy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/spredzy/Projects/github.com/Spredzy/ansible/lib/ansible
  executable location = /home/spredzy/Projects/github.com/Spredzy/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION

- N/A