### PR TITLE
Correct doc about the Git module verify_commit param

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -183,7 +183,7 @@ options:
             - if C(yes), when cloning or checking out a C(version) verify the
               signature of a GPG signed commit. This requires C(git) version>=2.1.0
               to be installed. The commit MUST be signed and the public key MUST
-              be trusted in the GPG trustdb.
+              be present in the GPG keyring.
 
     archive:
         required: false


### PR DESCRIPTION
##### SUMMARY
All that is required to verify the signature is that the matching
public key is present in the remote user's keyring. There is no need
for GnuPG to explicitly trust the authenticity of the key.

Not Ansible specific, but rather the behavior of the `git verify-commit`
and the `git verify-tag` command line invocations.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
git module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 554423cf04) last updated 2017/07/01 22:33:45 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/workdir/ansible/lib/ansible
  executable location = /home/andreas/workdir/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```