### PR TITLE
module redis: add a write_config option to make config changes persistent

### DIFF
--- a/lib/ansible/modules/database/misc/redis.py
+++ b/lib/ansible/modules/database/misc/redis.py
@@ -196,7 +196,8 @@ def main():
             db=dict(default=None, type='int'),
             flush_mode=dict(default='all', choices=['all', 'db']),
             name=dict(default=None),
-            value=dict(default=None)
+            value=dict(default=None),
+            config_write=dict(default=False, type='bool')
         ),
         supports_check_mode = True
     )
@@ -336,6 +337,8 @@ def main():
         else:
             try:
                 r.config_set(name, value)
+                if module.params['config_write']:
+                    r.config_rewrite()
             except Exception:
                 e = get_exception()
                 module.fail_json(msg="unable to write config: %s" % e)

--- a/lib/ansible/modules/database/misc/redis.py
+++ b/lib/ansible/modules/database/misc/redis.py
@@ -93,6 +93,13 @@ options:
             - A redis config value.
         required: false
         default: null
+    config_write:
+        version_added: 2.4
+        description:
+            - If set to yes, this module will issue a CONFIG REWRITE after changing configuration with the config command (i.e. the redis server will save its running conf) 
+        required: false
+        default: no
+        
 
 
 notes:

--- a/lib/ansible/modules/database/misc/redis.py
+++ b/lib/ansible/modules/database/misc/redis.py
@@ -96,10 +96,11 @@ options:
     config_write:
         version_added: 2.4
         description:
-            - If set to yes, this module will issue a CONFIG REWRITE after changing configuration with the config command (i.e. the redis server will save its running conf) 
+            - If set to yes, this module will issue a CONFIG REWRITE after changing configuration with the config command
+              (i.e. the redis server will save its running conf)
         required: false
         default: no
-        
+
 
 
 notes:


### PR DESCRIPTION
##### SUMMARY
Currently, any use of the `config` command of the redis module will change the configuration of the redis server, but will NOT make those changes persistent to a redis restart. 
This patch adds a `config_write` option to do so.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
redis module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
Applies to today's HEAD


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
