### PR TITLE
module redis: add a check_no_auth option to re-try without password

### DIFF
--- a/lib/ansible/modules/database/misc/redis.py
+++ b/lib/ansible/modules/database/misc/redis.py
@@ -49,6 +49,7 @@ options:
         required: false
         type: bool
         default: no
+        version_added: 2.4
     login_host:
         description:
             - The host running the database

--- a/lib/ansible/modules/database/misc/redis.py
+++ b/lib/ansible/modules/database/misc/redis.py
@@ -45,7 +45,7 @@ options:
         default: null
     check_no_auth:
         description:
-            - [config command] If connection failed with login_password, re-try with no password.
+            - If connection failed with login_password, re-try with no password. [config command]
         required: false
         type: bool
         default: no


### PR DESCRIPTION
##### SUMMARY
This patch adds a `check_no_auth` option to the redis module. 
If this option is set AND the command is `config`, this option will re-try connecting without a password in case of failure during the connection with password. 

The idea behind this option is similar to the `check_implicit_admin` option of the mysql_* modules. 
This is particularly useful when using the `config` command to configure several options thanks to `with_items`. 
Indeed, without this option, if one of the things you want to configure is `requirepass`, all other items will fail.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
module redis

##### ANSIBLE VERSION
HEAD

##### ADDITIONAL INFORMATION
Only effective for the `config` command. My feeling is that, unless you are actually changing the conf of the redis server, you somehow should know whether or not you need a password.