### PR TITLE
Add openvswitch_db tests

### DIFF
--- a/test/integration/network-all.yaml
+++ b/test/integration/network-all.yaml
@@ -5,7 +5,9 @@
 - { include: iosxr.yaml }
 - { include: nxos.yaml }
 - { include: junos.yaml }
+- { include: vyos.yaml }
 - { include: ops.yaml }
+- { include: ovs.yaml }
 - { include: dellos10.yaml }
 - { include: dellos9.yaml }
 - { include: dellos6.yaml }

--- a/test/integration/ovs.yaml
+++ b/test/integration/ovs.yaml
@@ -1,0 +1,12 @@
+---
+- hosts: ovs
+  gather_facts: no
+  remote_user: ubuntu
+  become: yes
+
+  vars:
+    limit_to: "*"
+    debug: false
+
+  roles:
+    - { role: openvswitch_db, when: "limit_to in ['*', 'openvswitch_db']" }

--- a/test/integration/targets/openvswitch_db/defaults/main.yaml
+++ b/test/integration/targets/openvswitch_db/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/openvswitch_db/meta/main.yaml
+++ b/test/integration/targets/openvswitch_db/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_ovs_tests

--- a/test/integration/targets/openvswitch_db/tasks/main.yml
+++ b/test/integration/targets/openvswitch_db/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- name: collect all test cases
+  find:
+    paths: "{{ role_path }}/tests"
+    patterns: "{{ testcase }}.yaml"
+  delegate_to: localhost
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/openvswitch_db/tests/basic.yaml
+++ b/test/integration/targets/openvswitch_db/tests/basic.yaml
@@ -1,0 +1,83 @@
+---
+
+- command: ovs-vsctl add-br br-test
+
+- name: Create bridge
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    key: disable-in-band
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Create bridge again (idempotent)
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    key: disable-in-band
+    value: true
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Change column value
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    key: disable-in-band
+    value: false
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Change column value again (idempotent)
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    key: disable-in-band
+    value: false
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+
+- name: Remove bridge
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    key: disable-in-band
+    value: false
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+
+- name: Remove bridge again (idempotent)
+  openvswitch_db:
+    table: Bridge
+    record: br-test
+    col: other_config
+    key: disable-in-band
+    value: false
+    state: absent
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"


### PR DESCRIPTION
##### SUMMARY
openvswitch_db tests were added during 2.4 development, though the
module still existed in 2.3, so backport the tests.

This is needed for distributed-ci.


##### ISSUE TYPE
Test

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
