### PR TITLE
Permissions fix for remote coverage downloads.

### DIFF
--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -315,7 +315,7 @@ def delegate_remote(args, exclude, require):
             manage.ssh(cmd, ssh_options)
             success = True
         finally:
-            manage.ssh('rm -rf /tmp/results && cp -a ansible/test/results /tmp/results')
+            manage.ssh('rm -rf /tmp/results && cp -a ansible/test/results /tmp/results && chmod -R a+r /tmp/results')
             manage.download('/tmp/results', 'test')
     finally:
         if args.remote_terminate == 'always' or (args.remote_terminate == 'success' and success):


### PR DESCRIPTION
##### SUMMARY

Permissions fix for remote coverage downloads.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (coverage-fix e8b56ec3a6) last updated 2017/07/02 13:33:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
