### PR TITLE
ec2_group: fix TypeError bug #26291

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -277,7 +277,7 @@ def get_target_from_rule(module, ec2, rule, name, group, groups, vpc_id):
         module.fail_json(msg="Specify group_name OR cidr_ip, not both")
     elif 'group_id' in rule and 'group_name' in rule:
         module.fail_json(msg="Specify group_id OR group_name, not both")
-    elif 'group_id' in rule and re.match(FOREIGN_SECURITY_GROUP_REGEX, rule['group_id']):
+    elif rule.get('group_id') and re.match(FOREIGN_SECURITY_GROUP_REGEX, rule['group_id']):
         # this is a foreign Security Group. Since you can't fetch it you must create an instance of it
         owner_id, group_id, group_name = re.match(FOREIGN_SECURITY_GROUP_REGEX, rule['group_id']).groups()
         group_instance = SecurityGroup(owner_id=owner_id, name=group_name, id=group_id)


### PR DESCRIPTION
##### SUMMARY
Check for non null value prior to using. Fixes #26291

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_group module

##### ANSIBLE VERSION
```
ansible 2.4.0 (ec2_group_TypeError 2b66f13489) last updated 2017/07/02 22:17:42 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/thertel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/thertel/Code/ansible/lib/ansible
  executable location = /home/thertel/Code/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
