### PR TITLE
include_role handlers bug fix

### DIFF
--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -118,7 +118,7 @@ class WorkerProcess(multiprocessing.Process):
                 self._rslt_q
             ).run()
 
-            display.debug("done running TaskExecutor() for %s/%s" % (self._host, self._task))
+            display.debug("done running TaskExecutor() for %s/%s [%s]" % (self._host, self._task, self._task._uuid))
             self._host.vars = dict()
             self._host.groups = []
             task_result = TaskResult(
@@ -129,9 +129,9 @@ class WorkerProcess(multiprocessing.Process):
             )
 
             # put the result on the result queue
-            display.debug("sending task result")
+            display.debug("sending task result for task %s" % self._task._uuid)
             self._rslt_q.put(task_result)
-            display.debug("done sending task result")
+            display.debug("done sending task result for task %s" % self._task._uuid)
 
         except AnsibleConnectionFailure:
             self._host.vars = dict()

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -81,7 +81,7 @@ class TaskExecutor:
         returned as a dict.
         '''
 
-        display.debug("in run()")
+        display.debug("in run() - task %s" % self._task._uuid)
 
         try:
             try:

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -137,10 +137,13 @@ class TaskQueueManager:
         handler_list = []
         for handler_block in play.handlers:
             handler_list.extend(_process_block(handler_block))
-
         # then initialize it with the given handler list
+        self.update_handler_list(handler_list)
+
+    def update_handler_list(self, handler_list):
         for handler in handler_list:
             if handler._uuid not in self._notified_handlers:
+                display.debug("Adding handler %s to notified list" % handler.name)
                 self._notified_handlers[handler._uuid] = []
             if handler.listen:
                 listeners = handler.listen
@@ -149,6 +152,7 @@ class TaskQueueManager:
                 for listener in listeners:
                     if listener not in self._listening_handlers:
                         self._listening_handlers[listener] = []
+                    display.debug("Adding handler %s to listening list" % handler.name)
                     self._listening_handlers[listener].append(handler._uuid)
 
     def load_callbacks(self):

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -319,7 +319,8 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                 if is_static:
                     # uses compiled list from object
-                    t = task_list.extend(ir.get_block_list(variable_manager=variable_manager, loader=loader))
+                    blocks, _ = ir.get_block_list(variable_manager=variable_manager, loader=loader)
+                    t = task_list.extend(blocks)
                 else:
                     # passes task object itself for latter generation of list
                     t = task_list.append(ir)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -87,9 +87,9 @@ class IncludeRole(TaskInclude):
             b._parent = self
 
         # updated available handlers in play
-        myplay.handlers = myplay.handlers + actual_role.get_handler_blocks(play=myplay)
-
-        return blocks
+        handlers = actual_role.get_handler_blocks(play=myplay)
+        myplay.handlers = myplay.handlers + handlers
+        return blocks, handlers
 
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -450,6 +450,8 @@ class StrategyBase:
                                 target_handler = search_handler_blocks_by_name(handler_name, iterator._play.handlers)
                                 if target_handler is not None:
                                     found = True
+                                    if target_handler._uuid not in self._notified_handlers:
+                                        self._notified_handlers[target_handler._uuid] = []
                                     if original_host not in self._notified_handlers[target_handler._uuid]:
                                         self._notified_handlers[target_handler._uuid].append(original_host)
                                         # FIXME: should this be a callback?
@@ -761,6 +763,8 @@ class StrategyBase:
         host_results = []
         for host in notified_hosts:
             if not handler.has_triggered(host) and (not iterator.is_failed(host) or play_context.force_handlers):
+                if handler._uuid not in iterator._task_uuid_cache:
+                    iterator._task_uuid_cache[handler._uuid] = handler
                 task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=handler)
                 self.add_tqm_variables(task_vars, play=iterator._play)
                 self._queue_task(host, handler, task_vars, play_context)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -315,7 +315,9 @@ class StrategyModule(StrategyBase):
                             if loop_var and loop_var in include_result:
                                 new_ir.vars[loop_var] = include_result[loop_var]
 
-                            all_role_blocks.extend(new_ir.get_block_list(play=iterator._play, variable_manager=self._variable_manager, loader=self._loader))
+                            blocks, handler_blocks = new_ir.get_block_list(play=iterator._play, variable_manager=self._variable_manager, loader=self._loader)
+                            all_role_blocks.extend(blocks)
+                            self._tqm.update_handler_list([handler for handler_block in handler_blocks for handler in handler_block.block])
 
                 if len(all_role_blocks) > 0:
                     for host in hosts_left:

--- a/test/integration/targets/handlers/aliases
+++ b/test/integration/targets/handlers/aliases
@@ -1,1 +1,2 @@
 posix/ci/group3
+handlers

--- a/test/integration/targets/handlers/roles/test_handlers_include_role/handlers/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_include_role/handlers/main.yml
@@ -1,0 +1,5 @@
+- name: set handler fact
+  set_fact:
+    handler_called: True
+- name: test handler
+  debug: msg="handler called"

--- a/test/integration/targets/handlers/roles/test_handlers_include_role/meta/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_include_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/test/integration/targets/handlers/roles/test_handlers_include_role/tasks/main.yml
+++ b/test/integration/targets/handlers/roles/test_handlers_include_role/tasks/main.yml
@@ -1,0 +1,47 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+- name: reset handler_called variable to false for all hosts
+  set_fact:
+    handler_called: False
+  tags: scenario1
+
+- name: notify the handler for host A only
+  shell: echo
+  notify:
+    - set handler fact
+  when: inventory_hostname == 'A'
+  tags: scenario1
+
+- name: force handler execution now
+  meta: "flush_handlers"
+  tags: scenario1
+
+- debug: var=handler_called
+  tags: scenario1
+
+- name: validate the handler only ran on one host
+  assert:
+    that:
+    - "inventory_hostname == 'A' and handler_called == True or handler_called == False"
+  tags: scenario1
+
+# item below is passed in by the playbook that calls this
+- name: 'test notify with loop'
+  debug: msg='a task'
+  changed_when: item == 1
+  notify: test handler
+  tags: scenario2

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -42,6 +42,9 @@ ansible-playbook test_listening_handlers.yml -i inventory.handlers -v "$@"
 [ "$(ansible-playbook test_handlers_include.yml -i ../../inventory -v "$@" --tags role_include_handlers \
 | egrep -o 'RUNNING HANDLER \[test_handlers_include : .*?]')" = "RUNNING HANDLER [test_handlers_include : test handler]" ]
 
+[ "$(ansible-playbook test_handlers_include_role.yml -i ../../inventory -v "$@" \
+| egrep -o 'RUNNING HANDLER \[test_handlers_include_role : .*?]')" = "RUNNING HANDLER [test_handlers_include_role : test handler]" ]
+
 # Notify handler listen
 ansible-playbook test_handlers_listen.yml -i inventory.handlers -v "$@"
 

--- a/test/integration/targets/handlers/test_handlers_include_role.yml
+++ b/test/integration/targets/handlers/test_handlers_include_role.yml
@@ -1,0 +1,8 @@
+- name: verify that play can include handler
+  hosts: testhost
+  tasks:
+    - include_role:
+        name: test_handlers_include_role
+      with_items:
+        - 1
+        - 2


### PR DESCRIPTION
##### SUMMARY
Ensure handlers fire correctly when using include_role

When including roles, the handlers need to be added to the TaskQueueManager `_notified_handlers` and `listening_handlers` lists. They also need to be added to the uuid cache

A separate commit adds tests for this that fail before the change and succeed after the change.

Fixes #18411 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 483346d94b) last updated 2017/07/03 09:52:26 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
In addition to the KeyError issue associated with #18411, if you fix that by updating `_notified_handlers` and `_listening_handlers`, and add some of the extra uuid debug statements in this PR, you get this instead:
```
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /home/will/.ansible/tmp/ansible-tmp-1499048621.83-88801615818650/command.py; rm -rf "/home/will/.ansible/tmp/ansible-tmp-1499048621.83-88801615818650/" > /dev/null 2>&1 && sleep 0'
 24783 1499048621.96776: opening command with Popen()
 24783 1499048621.98646: done running command with Popen()
 24783 1499048621.98772: getting output with communicate()
 24783 1499048622.63462: done communicating
 24783 1499048622.63526: done with local.exec_command()
 24783 1499048622.63585: _low_level_execute_command() done: rc=0, stdout=
{"changed": true, "end": "2017-07-03 12:23:42.573293", "stdout": "handler", "cmd": ["echo", "handler"], "start": "2017-07-03 12:23:42.562968", "delta": "0:00:00.010325", "stderr": "", "rc": 0, "invocation": {"module_args": {"warn": true, "executable": null, "_uses_shell": false, "_raw_params": "echo handler", "removes": null, "creates": null, "chdir": null}}, "warnings": []}
, stderr=
 24783 1499048622.63711: done with _execute_module (command, {'_ansible_version': '2.4.0', '_ansible_selinux_special_fs': ['fuse', 'nfs', 'vboxsf', 'ramfs', '9p'], '_ansible_no_log': False, '_ansible_module_name': u'command', u'_raw_params': u'echo handler', '_ansible_verbosity': 3, '_ansible_syslog_facility': u'LOG_USER', '_ansible_socket': None, '_ansible_diff': False, '_ansible_debug': True, '_ansible_check_mode': False})
 24783 1499048622.63771: handler run complete
 24783 1499048622.63816: attempt loop complete, returning result
 24783 1499048622.63849: _execute() done
 24783 1499048622.63867: dumping result to json
 24783 1499048622.63909: done dumping result, returning
 24783 1499048622.63964: done running TaskExecutor() for localhost/HANDLER: handlertest : Running handler [9cb6d012-9901-7bcf-cf94-000000000024]
 24783 1499048622.64048: sending task result for task 9cb6d012-9901-7bcf-cf94-000000000024
 24783 1499048622.64272: done sending task result for task 9cb6d012-9901-7bcf-cf94-000000000024
 24783 1499048622.64324: WORKER PROCESS EXITING
 24733 1499048622.64828: RUNNING CLEANUP
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'copy'
the full traceback was:

Traceback (most recent call last):
  File "/home/will/src/ansible/bin/ansible-playbook", line 106, in <module>
    exit_code = cli.run()
  File "/home/will/src/ansible/lib/ansible/cli/playbook.py", line 130, in run
    results = pbex.run()
  File "/home/will/src/ansible/lib/ansible/executor/playbook_executor.py", line 153, in run
    result = self._tqm.run(play=play)
  File "/home/will/src/ansible/lib/ansible/executor/task_queue_manager.py", line 289, in run
    play_return = strategy.run(iterator, play_context)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/linear.py", line 235, in run
    results.extend(self._execute_meta(task, play_context, iterator, host))
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/__init__.py", line 865, in _execute_meta
    self.run_handlers(iterator, play_context)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/__init__.py", line 733, in run_handlers
    result = self._do_handler_run(handler, handler.get_name(), iterator=iterator, play_context=play_context)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/__init__.py", line 768, in _do_handler_run
    task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=handler)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/__init__.py", line 584, in _wait_on_pending_results
    results = self._process_pending_results(iterator)
  File "/home/will/src/ansible/lib/ansible/plugins/strategy/__init__.py", line 339, in _process_pending_results
    original_task = found_task.copy(exclude_parent=True, exclude_tasks=True)
AttributeError: 'NoneType' object has no attribute 'copy'

```

The above is because the handler that just ran (9cb6d012-9901-7bcf-cf94-000000000024) is not in the uuid cache.
