### PR TITLE
Missing prepare_ovs_tests directory

### DIFF
--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+
+- name: Install openvswitch-switch package if we are on Ubuntu
+  apt:
+    name: openvswitch-switch
+    state: installed
+    update_cache: yes
+  when: ansible_distribution == 'Ubuntu'
+
+- name: Install openvswitch package if we are on Fedora
+  yum:
+    name: openvswitch
+    state: installed
+    update_cache: yes
+  when: ansible_distribution == 'Fedora'


### PR DESCRIPTION
##### SUMMARY

openvswitch_db tests have been backported from devel to stable-2.3[1],
but the role to prepare_ovs_tests was missing from the backport, hence
the test, when run complained about missing roles.

This commit aims to bring this directory into stable-2.3 tree.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- ovs integration test suite

##### ANSIBLE VERSION

- stable-2.3

##### ADDITIONAL INFORMATION

- N/A