### PR TITLE
Remote get_exception from crypto namespace

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -167,7 +167,7 @@ else:
     pyopenssl_found = True
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 class CertificateSigningRequestError(Exception):
@@ -230,9 +230,8 @@ class CertificateSigningRequest(object):
                 csr_file = open(self.path, 'w')
                 csr_file.write(crypto.dump_certificate_request(crypto.FILETYPE_PEM, self.request))
                 csr_file.close()
-            except (IOError, OSError):
-                e = get_exception()
-                raise CertificateSigningRequestError(e)
+            except (IOError, OSError) as exc:
+                raise CertificateSigningRequestError(exc)
         else:
             self.changed = False
 
@@ -245,10 +244,9 @@ class CertificateSigningRequest(object):
 
         try:
             os.remove(self.path)
-        except OSError:
-            e = get_exception()
-            if e.errno != errno.ENOENT:
-                raise CertificateSigningRequestError(e)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise CertificateSigningRequestError(exc)
             else:
                 self.changed = False
 
@@ -305,9 +303,8 @@ def main():
 
         try:
             csr.generate(module)
-        except CertificateSigningRequestError:
-            e = get_exception()
-            module.fail_json(msg=str(e))
+        except CertificateSigningRequestError as exc:
+            module.fail_json(msg=to_native(exc))
 
     else:
 
@@ -318,9 +315,8 @@ def main():
 
         try:
             csr.remove()
-        except CertificateSigningRequestError:
-            e = get_exception()
-            module.fail_json(msg=str(e))
+        except CertificateSigningRequestError as exc:
+            module.fail_json(msg=to_native(exc))
 
     result = csr.dump()
 

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -99,6 +99,7 @@ else:
 
 
 import os
+from ansible.module_utils._text import to_native
 
 
 class PublicKeyError(Exception):
@@ -127,10 +128,9 @@ class PublicKey(object):
                 publickey_file = open(self.path, 'w')
                 publickey_file.write(crypto.dump_publickey(crypto.FILETYPE_PEM, privatekey))
                 publickey_file.close()
-            except (IOError, OSError):
-                e = get_exception()
-                raise PublicKeyError(e)
-            except AttributeError:
+            except (IOError, OSError) as exc:
+                raise PublicKeyError(exc)
+            except AttributeError as exc:
                 self.remove()
                 raise PublicKeyError('You need to have PyOpenSSL>=16.0.0 to generate public keys')
         else:
@@ -145,10 +145,9 @@ class PublicKey(object):
 
         try:
             os.remove(self.path)
-        except OSError:
-            e = get_exception()
-            if e.errno != errno.ENOENT:
-                raise PublicKeyError(e)
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise PublicKeyError(exc)
             else:
                 self.changed = False
 
@@ -205,9 +204,8 @@ def main():
 
         try:
             public_key.generate(module)
-        except PublicKeyError:
-            e = get_exception()
-            module.fail_json(msg=str(e))
+        except PublicKeyError as exc:
+            module.fail_json(msg=to_native(exc))
     else:
 
         if module.check_mode:
@@ -217,9 +215,8 @@ def main():
 
         try:
             public_key.remove()
-        except PublicKeyError:
-            e = get_exception()
-            module.fail_json(msg=str(e))
+        except PublicKeyError as exc:
+            module.fail_json(msg=to_native(exc))
 
     result = public_key.dump()
 


### PR DESCRIPTION
##### SUMMARY

Fix removes get_exception in favor of native Python exception
handling. Also, added to_native to manage exception message.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `modules/crypto/*`

##### ANSIBLE VERSION

- 2.4devel