### PR TITLE
removed invalid flag from zpool_facts, fixes #26351

### DIFF
--- a/lib/ansible/modules/storage/zfs/zpool_facts.py
+++ b/lib/ansible/modules/storage/zfs/zpool_facts.py
@@ -160,8 +160,6 @@ class ZPoolFacts(object):
         cmd.append('-H')
         if self.parsable:
             cmd.append('-p')
-        cmd.append('-o')
-        cmd.append('name,property,value')
         cmd.append(self.properties)
         if self.name:
             cmd.append(self.name)
@@ -170,7 +168,7 @@ class ZPoolFacts(object):
 
         if rc == 0:
             for line in out.splitlines():
-                pool, property, value = line.split('\t')
+                pool, property, value, source = line.split('\t')
 
                 self._pools[pool].update({property: value})
 


### PR DESCRIPTION
Fix for issue #26351 where the -o flag was being passed to the zpool get command

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
zpool_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
