### PR TITLE
updated ansible tests to create valid host names in inventory.networking

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -327,7 +327,7 @@ def network_inventory(remotes):
 
         groups[remote.platform].append(
             '%s %s' % (
-                remote.name.replace('.', '_'),
+                remote.name.replace('.', '-'),
                 ' '.join('%s="%s"' % (k, options[k]) for k in sorted(options)),
             )
         )

--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -78,7 +78,7 @@ class ManageNetworkCI(object):
             'ansible_ssh_private_key_file=%s' % self.core_ci.ssh_key.key,
         ]
 
-        name = '%s-%s' % (self.core_ci.platform, self.core_ci.version.replace('.', '_'))
+        name = '%s-%s' % (self.core_ci.platform, self.core_ci.version.replace('.', '-'))
 
         env = ansible_environment(self.core_ci.args)
         cmd = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ansible-test was creating invalid host names in inventory.networking by replacing "." with "_". This would lead to inventory files like this one when certain tests such as `ansible-test network-integration vyos_config --platform vyos/1.1.0 -vvvv` were being run.
```
[vyos]
vyos-1_1_0 ansible_connection="local" ansible_host="ec2-107-22-134-95.compute-1.amazonaws.com" ansible_network_os="vyos" ansible_ssh_private_key_file="/Users/dnewswan/.ansible/test/id_rsa" ansible_user="vyos"
```

In this case the '.' in the version number gets replaces with "_" to form vyos-1_0_0. This doesn't seem like much of a problem, but in the unit tests for most of the networking modules we try to change host name on the device to {{ inventory_hostname_short }}, which would resolve to vyos-1_1_0 and breaks because underscores aren't permitted in valid host names.

This patch should change the host names to something like vyos-1-1-0, which is a valid host name and won't break our integration tests.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
dnewswan-OSX:ansible dnewswan$ ansible --version
ansible 2.4.0 (at-valid-hostname 89142b4d36) last updated 2017/07/03 18:00:16 (GMT -400)
  config file = None
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
