### PR TITLE
metadata and doc generator optimization and fixes

### DIFF
--- a/hacking/metadata-tool.py
+++ b/hacking/metadata-tool.py
@@ -205,7 +205,8 @@ def write_metadata(filename, new_metadata, version=None, overwrite=False):
         module_data = f.read()
 
     try:
-        current_metadata, start_line, start_col, end_line, end_col, targets = extract_metadata(module_data)
+        current_metadata, start_line, start_col, end_line, end_col, targets = \
+            extract_metadata(module_data=module_data, offsets=True)
     except SyntaxError:
         if filename.endswith('.py'):
             raise
@@ -257,7 +258,7 @@ def return_metadata(plugins):
         if name not in metadata or metadata[name] is not None:
             with open(filename, 'rb') as f:
                 module_data = f.read()
-            metadata[name] = extract_metadata(module_data)[0]
+            metadata[name] = extract_metadata(module_data=module_data, offsets=True)[0]
     return metadata
 
 
@@ -408,7 +409,7 @@ def upgrade_metadata(version=None):
         # For each plugin, read the existing metadata
         with open(filename, 'rb') as f:
             module_data = f.read()
-        metadata = extract_metadata(module_data)[0]
+        metadata = extract_metadata(module_data=module_data, offsets=True)[0]
 
         # If the metadata isn't the requested version, convert it to the new
         # version

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -224,6 +224,7 @@ class DocCLI(CLI):
             if os.path.isdir(filename):
                 continue
 
+            doc = None
             try:
                 doc, plainexamples, returndocs, metadata = plugin_docs.get_docstring(filename)
             except:

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -155,7 +155,7 @@ def get_docstring(filename, verbose=False):
                                     data[varkey] = child.value.s
                             display.debug('assigned :%s' % varkey)
 
-        data['metadata'] = extract_metadata(b_module_data)[0]
+        data['metadata'] = extract_metadata(module_ast=M)[0]
         # add fragments to documentation
         if data['doc']:
             add_fragments(data['doc'], filename)
@@ -165,7 +165,7 @@ def get_docstring(filename, verbose=False):
             for x in ('version', 'metadata_version'):
                 if x in data['metadata']:
                     del data['metadata'][x]
-    except:
+    except Exception as e:
         display.error("unable to parse %s" % filename)
         if verbose is True:
             display.display("unable to parse %s" % filename)

--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -103,6 +103,17 @@ def get_docstring(filename, verbose=False):
     directory.
     """
 
+    # FIXME: Should refactor this so that we have a docstring parsing
+    # function and a separate variable parsing function
+    # Can have a function one higher that invokes whichever is needed
+    #
+    # Should look roughly like this:
+    # get_plugin_doc(filename, verbose=False)
+    #   documentation = extract_docstring(plugin_ast, identifier, verbose=False)
+    #   if not documentation and not (filter or test):
+    #       documentation = extract_variables(plugin_ast)
+    #   documentation['metadata'] = extract_metadata(plugin_ast)
+
     data = {
         'doc': None,
         'plainexamples': None,
@@ -114,7 +125,6 @@ def get_docstring(filename, verbose=False):
         'DOCUMENTATION': 'doc',
         'EXAMPLES': 'plainexamples',
         'RETURN': 'returndocs',
-        'ANSIBLE_METADATA': 'metadata'
     }
 
     try:
@@ -155,7 +165,9 @@ def get_docstring(filename, verbose=False):
                                     data[varkey] = child.value.s
                             display.debug('assigned :%s' % varkey)
 
+        # Metadata is per-file rather than per-plugin/function
         data['metadata'] = extract_metadata(module_ast=M)[0]
+
         # add fragments to documentation
         if data['doc']:
             add_fragments(data['doc'], filename)


### PR DESCRIPTION
* Fix ansible-doc traceback when a plugin doesn't parse correctly
* Change extract_metadata ivocation to take either an ast or source
  code.  When given source code, it can find file offsets for the start
  and end of dict.  When given the ast, it is quicker as it doesn't have
  to reparse the source.  Requires changing the call to the function to
  use a keyword arg.
* Fix reading of metadata to find the last occurrence of
  ANSIBLE_METADATA instead of the first.
* Add some more unittests to get closer to complete coverage

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parsing/metadata.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
