### PR TITLE
update auth_flag variable after STARTTLS connection is established, f…

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -312,6 +312,7 @@ def main():
                 try:
                     smtp.starttls()
                     smtp.ehlo()
+                    auth_flag = smtp.has_extn('AUTH')
                     secure_state = True
                 except smtplib.SMTPException:
                     e = get_exception()


### PR DESCRIPTION
fixes #26376

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
missing variable update causes starttls mails to fail
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
mail
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /home/my/path/ansibles/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Fot additional info check the issue
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
