### PR TITLE
JBoss module now supports HTTP and CLI deployments

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -79,6 +79,7 @@ options:
     required: false
     description:
       - Path to jboss-cli.sh
+    version_added: 2.4
 notes:
   - "The filesystem deployment strategy requires the deployment scanner to be enabled."
   - "The http deployment strategy requires the requests package to be installed on each host."
@@ -373,7 +374,6 @@ def cli_undeploy(module, deployed):
 
 
 def cli_run_commands(module, commands):
-    command_string = ','.join(commands)
     return module.run_command([
         module.params['cli_path'],
         '--connect',

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -392,15 +392,15 @@ def main():
             deploy_path=dict(type='path', default='/var/lib/jbossas/standalone/deployments'),
             deployment_strategy=dict(choices=['http', 'filesystem', 'jboss-cli'], default='filesystem'),
             state=dict(choices=['deployed', 'undeployed', 'present', 'absent'], default='deployed'),
-            url_username=dict(required=True),
-            url_password=dict(required=True),
+            url_username=dict(default='admin'),
+            url_password=dict(default='admin'),
             hostname=dict(default='localhost'),
             port=dict(default=9990),
             cli_path=dict(type='path')
         ),
         required_if=[
             ('state', ('deployed', 'present'), ('src',), True),
-            ('deployment_strategy', ('http',), ('hostname', 'port')),
+            ('deployment_strategy', ('http',), ('hostname', 'port', 'url_username', 'url_password')),
             ('deployment_strategy', ('jboss-cli',), ('cli_path'))
         ]
     )

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -40,35 +40,90 @@ options:
     default: /var/lib/jbossas/standalone/deployments
     description:
       - The location in the filesystem where the deployment scanner listens
+  deployment_strategy:
+    required: false
+    choices: [ http, filesystem ]
+    default: filesystem
+    description:
+      - Whether the application should be deployed through the HTTP management API or filesystem
   state:
     required: false
-    choices: [ present, absent ]
-    default: "present"
+    choices: [ deployed, undeployed, present, absent ]
+    default: deployed
     description:
-      - Whether the application should be deployed or undeployed
+      - Whether the application should be deployed or undeployed. Present and absent have been deprecated.
+  url_username:
+    required: false
+    description:
+      - Username for JBoss management user
+  url_password:
+    required: false
+    description:
+      - Password for JBoss management user
+  hostname:
+    required: false
+    default: localhost
+    description:
+      - Hostname of JBoss instance running HTTP management API
+  port:
+    required: false
+    default: 9990
+    description:
+      - Port binding for HTTP management API
 notes:
-  - "The JBoss standalone deployment-scanner has to be enabled in standalone.xml"
+  - "The filesystem deployment strategy requires the deployment scanner to be enabled."
   - "Ensure no identically named application is deployed through the JBoss CLI"
+  - "At a minimum, url_password should be vaulted."
+  - "HTTP management API is supported in JBoss AS 7.1, Wildfly >= 8, and JBoss EAP >= 6."
+  - "JBoss 5 supports filesystem deployments only."
+  - "Filesystem deployments should be avoided in production environments where possible."
 author: "Jeroen Hoekx (@jhoekx)"
 """
 
 EXAMPLES = """
-# Deploy a hello world application
+# Deploy a hello world application using filesystem
 - jboss:
     src: /tmp/hello-1.0-SNAPSHOT.war
     deployment: hello.war
-    state: present
+    state: deployed
 
-# Update the hello world application
+# Update the hello world application using filesystem
 - jboss:
     src: /tmp/hello-1.1-SNAPSHOT.war
     deployment: hello.war
-    state: present
+    state: deployed
 
-# Undeploy the hello world application
+# Undeploy the hello world application using filesystem
 - jboss:
     deployment: hello.war
-    state: absent
+    state: undeployed
+
+# Deploy the hello world application using HTTP management API
+- jboss:
+    src: /tmp/hello-1.0-SNAPSHOT.war
+    deployment: hello.war
+    deployment_strategy: http
+    state: deployed
+    url_username: admin
+    url_password: admin
+
+# Update the hello world application using HTTP management API
+- jboss:
+    src: /tmp/hello-1.0-SNAPSHOT.war
+    deployment: hello.war
+    deployment_strategy: http
+    state: deployed
+    url_username: admin
+    url_password: admin
+
+# Undeploy the hello world application using HTTP management API
+- jboss:
+    deployment: hello.war
+    deployment_strategy: http
+    state: undeployed
+    url_username: admin
+    url_password: admin
+
 """
 
 import os

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -8,13 +8,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-import os
-import shutil
-import time
-import json
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.urls import fetch_url
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -68,13 +68,13 @@ options:
     default: localhost
     description:
       - Hostname of JBoss instance running HTTP management API
-    version_added:2.4
+    version_added: 2.4
   port:
     required: false
     default: 9990
     description:
       - Port binding for HTTP management API
-    version_added:2.4
+    version_added: 2.4
 notes:
   - "The filesystem deployment strategy requires the deployment scanner to be enabled."
   - "The http deployment strategy requires the requests package to be installed on each host."

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -75,6 +75,10 @@ options:
     description:
       - Port binding for HTTP management API
     version_added: 2.4
+  cli_path:
+    required: false
+    description:
+      - Path to jboss-cli.sh
 notes:
   - "The filesystem deployment strategy requires the deployment scanner to be enabled."
   - "The http deployment strategy requires the requests package to be installed on each host."
@@ -168,7 +172,7 @@ def is_deployed(module):
     elif module.params['deployment_strategy'] == 'filesystem':
         return os.path.exists(os.path.join(module.params['deploy_path'], "%s.deployed" % module.params['deployment']))
     else:
-        rc, stdout, stderr = cli_run_commands(module, ['deployment-info', '--name=%s' module.params['deployment']])
+        rc, stdout, stderr = cli_run_commands(module, ['deployment-info', '--name=%s' % module.params['deployment']])
 
         if rc != 0:
             return False
@@ -368,7 +372,6 @@ def cli_undeploy(module, deployed):
         module.fail_json(msg=stdout)
 
 
-# commands arg should be a list of strings that includes the command and any args, i.e. ['command [args]',]
 def cli_run_commands(module, commands):
     command_string = ','.join(commands)
     return module.run_command([

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -8,6 +8,13 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
+import os
+import shutil
+import time
+import json
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -73,12 +80,12 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 
 
-def is_deployed(module, deploy_path, deployment):
+def is_deployed(module):
 
     data_dict = {
         "operation": "read-resource",
         "address": {
-            "deployment": deployment
+            "deployment": module.params['deployment']
         },
         "include-runtime": True
     }
@@ -94,7 +101,7 @@ def is_deployed(module, deploy_path, deployment):
     try:
         assert info['status'] == 200
     except AssertionError:
-        return os.path.exists(os.path.join(deploy_path, "%s.deployed" % deployment))
+        return os.path.exists(os.path.join(module.params['deploy_path'], "%s.deployed" % module.params['deployment']))
 
     resp_data = resp.read()
     resp_json = json.loads(resp_data)
@@ -110,55 +117,44 @@ def is_failed(deploy_path, deployment):
     return os.path.exists(os.path.join(deploy_path, "%s.failed" % deployment))
 
 
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            src=dict(type='path'),
-            deployment=dict(required=True),
-            deploy_path=dict(type='path', default='/var/lib/jbossas/standalone/deployments'),
-            state=dict(choices=['absent', 'present'], default='present'),
-            url_password=dict(required=True),
-            url_username=dict(required=True),
-            hostname=dict(default='localhost')
-        ),
-        required_if=[('state', 'present', ('src',))]
-    )
+def fs_deploy(module, deployed):
 
-    result = dict(changed=False)
-
-    src = module.params['src']
-    deployment = module.params['deployment']
-    deploy_path = module.params['deploy_path']
-    state = module.params['state']
-    hostname = module.params['hostname']
-    username = module.params['url_username']
-    password = module.params['url_password']
-
-    if not os.path.exists(deploy_path):
-        module.fail_json(msg="deploy_path does not exist.")
-
-    deployed = is_deployed(module, deploy_path, deployment)
-
-    if state == 'present' and not deployed:
-        if not os.path.exists(src):
-            module.fail_json(msg='Source file %s does not exist.' % src)
-        if is_failed(deploy_path, deployment):
+    if not deployed:
+        if not os.path.exists(module.params['src']):
+            module.fail_json(msg='Source file %s does not exist.' % module.params['src'])
+        if is_failed(module.params['deploy_path'], module.params['deployment']):
             # Clean up old failed deployment
-            os.remove(os.path.join(deploy_path, "%s.failed" % deployment))
+            os.remove(os.path.join(module.params['deploy_path'], "%s.failed" % module.params['deployment']))
 
-        shutil.copyfile(src, os.path.join(deploy_path, deployment))
+        shutil.copyfile(module.params['src'], os.path.join(module.params['deploy_path'], module.params['deployment']))
+
         while not deployed:
-            deployed = is_deployed(module, deploy_path, deployment)
-            if is_failed(deploy_path, deployment):
-                module.fail_json(msg='Deploying %s failed.' % deployment)
+            deployed = is_deployed(module)
+            if is_failed(module.params['deploy_path'], module.params['deployment']):
+                module.fail_json(msg='Deploying %s failed.' % module.params['deployment'])
             time.sleep(1)
-        result['changed'] = True
+        return True
+    else:
+        if module.sha1(module.params['src']) != module.sha1(os.path.join(module.params['deploy_path'], module.params['deployment'])):
+            os.remove(os.path.join(module.params['deploy_path'], "%s.deployed" % module.params['deployment']))
+            shutil.copyfile(module.params['src'], os.path.join(module.params['deploy_path'], module.params['deployment']))
+            deployed = False
+            while not deployed:
+                deployed = is_deployed(module)
+                if is_failed(module.params['deploy_path'], module.params['deployment']):
+                    module.fail_json(msg='Deploying %s failed.' % module.params['deployment'])
+                time.sleep(1)
+            return True
+        return False
 
-    if state == 'present' and deployed:
+
+def http_deploy(module, deployed):
+
+    if deployed:
         data_dict = {
             'operation': 'read-resource',
             'address': {
-                'deployment': deployment
+                'deployment': module.params['deployment']
             },
             'include-runtime': True
         }
@@ -168,27 +164,12 @@ def main():
         }
         data = json.dumps(data_dict)
 
-        resp, info = fetch_url(module, 'http://%s:9990/management' % hostname, data=data, headers=headers)
+        resp, info = fetch_url(module, 'http://%s:%s/management' % (module.params['hostname'], module.params['port']), data=data, headers=headers)
 
         try:
             assert info['status'] == 200
         except AssertionError:
-            if info['status'] != -1:
-                module.fail_json(msg=info['msg'])
-            else:
-                if module.sha1(src) != module.sha1(os.path.join(deploy_path, deployment)):
-                    module.exit_json(**result)
-
-                    os.remove(os.path.join(deploy_path, "%s.deployed" % deployment))
-                    shutil.copyfile(src, os.path.join(deploy_path, deployment))
-                    deployed = False
-                    while not deployed:
-                        deployed = is_deployed(module, deploy_path, deployment)
-                        if is_failed(deploy_path, deployment):
-                            module.fail_json(msg='Deploying %s failed.' % deployment)
-                        time.sleep(1)
-                    result['changed'] = True
-                    module.exit_json(**result)
+            module.fail_json(msg=info)
 
         resp_json = json.loads(resp.read())
 
@@ -197,27 +178,156 @@ def main():
         deployment_hash_base64 = deployment_hash_dict['hash']['BYTES_VALUE']
         deployment_hash_hex = deployment_hash_base64.decode('base64').encode('hex')
 
-        if module.sha1(src) != deployment_hash_hex:
+        if module.sha1(module.params['src']) != deployment_hash_hex:
 
+            import requests
             resp = requests.post(
-                'http://%s/management/add-content',
-                files={'file': open(src, 'rb')},
-                auth=requests.auth.HTTPDigestAuth(username, password)
+                'http://%s:%s/management/add-content' % (module.params['hostname'], module.params['port']),
+                files={'file': open(module.params['src'], 'rb')},
+                auth=requests.auth.HTTPDigestAuth(module.params['url_username'], module.params['url_password'])
             )
 
             if resp.status_code < 400:
-                result['changed'] = True
+                return True
             else:
                 module.fail_json(msg={'status': 'HTTP %s %s' % (resp.status_code, resp.reason)})
+    else:
 
-    if state == 'absent' and deployed:
-        os.remove(os.path.join(deploy_path, "%s.deployed" % deployment))
-        while deployed:
-            deployed = not is_undeployed(deploy_path, deployment)
-            if is_failed(deploy_path, deployment):
-                module.fail_json(msg='Undeploying %s failed.' % deployment)
-            time.sleep(1)
-        result['changed'] = True
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        import requests
+        auth = requests.auth.HTTPDigestAuth(module.params['url_username'], module.params['url_password'])
+        resp = requests.post(
+            'http://%s:%s/management/add-content' % (module.params['hostname'], module.params['port']),
+            files={'file': open(module.params['src'], 'rb')},
+            auth=auth
+        )
+
+        try:
+            assert resp.status_code == 200
+        except AssertionError:
+            module.fail_json(msg=resp.text)
+
+        resp_json = resp.json()
+
+        data_dict = {
+            'operation': 'add',
+            'address': [{
+                'deployment': module.params['deployment']
+            }],
+            'enabled': True,
+            'content': [{'hash': {'BYTES_VALUE': resp_json['result']['BYTES_VALUE']}}]
+        }
+
+        resp = requests.post(
+            'http://%s:%s/management' % (module.params['hostname'], module.params['port']),
+            json=data_dict,
+            headers=headers,
+            auth=auth
+        )
+
+        try:
+            assert resp.status_code == 200
+        except AssertionError:
+            module.fail_json(msg=resp.text)
+
+        return True
+
+    return False
+
+
+def fs_undeploy(module, deployed):
+
+    if not deployed:
+        return False
+
+    os.remove(os.path.join(module.params['deploy_path'], "%s.deployed" % module.params['deployment']))
+    while deployed:
+        deployed = not is_undeployed(module.params['deploy_path'], module.params['deployment'])
+        if is_failed(module.params['deploy_path'], module.params['deployment']):
+            module.fail_json(msg='Undeploying %s failed.' % module.params['deployment'])
+        time.sleep(1)
+    return True
+
+
+def http_undeploy(module, deployed):
+
+    if not deployed:
+        return False
+
+    data_dict = {
+        'operation': 'remove',
+        'address': {
+            'deployment': module.params['deployment']
+        },
+        'include-runtime': True
+    }
+
+    headers = {
+        'Content-Type': 'application/json'
+    }
+    data = json.dumps(data_dict)
+
+    resp, info = fetch_url(module, 'http://%s:%s/management' % (module.params['hostname'], module.params['port']), data=data, headers=headers)
+
+    return True
+
+
+DEPLOY_CALLABLES = {
+    'http': {
+        'deployed': http_deploy,
+        'present': http_deploy,
+        'undeployed': http_undeploy,
+        'absent': http_undeploy
+    },
+    'filesystem': {
+        'deployed': fs_deploy,
+        'present': fs_deploy,
+        'undeployed': fs_undeploy,
+        'absent': fs_undeploy
+    }
+}
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            src=dict(type='path'),
+            deployment=dict(required=True),
+            deploy_path=dict(type='path', default='/var/lib/jbossas/standalone/deployments'),
+            deployment_strategy=dict(choices=['http', 'filesystem'], default='filesystem'),
+            state=dict(choices=['deployed', 'undeployed', 'present', 'absent'], default='deployed'),
+            url_username=dict(required=True),
+            url_password=dict(required=True),
+            hostname=dict(default='localhost'),
+            port=dict(default=9990)
+        ),
+        required_if=[
+            ('state', ('deployed', 'present'), ('src',), True),
+            ('deployment_strategy', ('http'), ('hostname', 'port'))
+        ]
+    )
+
+    result = dict(changed=False)
+
+    deployment_strategy = module.params['deployment_strategy']
+    deploy_path = module.params['deploy_path']
+    state = module.params['state']
+
+    if state == 'present' or state == 'absent':
+        module.deprecate('The "present" and "absent" values for the state key are deprecated in favor of "deployed" and "undeployed", respectively')
+
+    if deployment_strategy == 'filesystem':
+        module.warn('Filesystem deployments are not recommended for production use.')
+
+    if not os.path.exists(deploy_path):
+        module.fail_json(msg="deploy_path does not exist.")
+
+    action = DEPLOY_CALLABLES[deployment_strategy][state]
+    deployed = is_deployed(module)
+    result = dict(changed=action(module, deployed))
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -161,7 +161,7 @@ def is_deployed(module):
 
         data = json.dumps(data_dict)
 
-        resp, info = fetch_url(module, 'http://%s:9990/management' % module.params['hostname'], data=data, headers=headers)
+        resp, info = fetch_url(module, 'http://%s:%s/management' % (module.params['hostname'], module.params['port']), data=data, headers=headers)
 
         return info['status'] == 200
 

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -72,6 +72,7 @@ options:
       - Port binding for HTTP management API
 notes:
   - "The filesystem deployment strategy requires the deployment scanner to be enabled."
+  - "The http deployment strategy requires the requests package to be installed on each host."
   - "Ensure no identically named application is deployed through the JBoss CLI"
   - "At a minimum, url_password should be vaulted."
   - "HTTP management API is supported in JBoss AS 7.1, Wildfly >= 8, and JBoss EAP >= 6."

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -46,6 +46,7 @@ options:
     default: filesystem
     description:
       - Whether the application should be deployed through the HTTP management API or filesystem
+    version_added: 2.4
   state:
     required: false
     choices: [ deployed, undeployed, present, absent ]
@@ -56,20 +57,24 @@ options:
     required: false
     description:
       - Username for JBoss management user
+    version_added: 2.4
   url_password:
     required: false
     description:
       - Password for JBoss management user
+    version_added: 2.4
   hostname:
     required: false
     default: localhost
     description:
       - Hostname of JBoss instance running HTTP management API
+    version_added:2.4
   port:
     required: false
     default: 9990
     description:
       - Port binding for HTTP management API
+    version_added:2.4
 notes:
   - "The filesystem deployment strategy requires the deployment scanner to be enabled."
   - "The http deployment strategy requires the requests package to be installed on each host."
@@ -131,7 +136,10 @@ import os
 import shutil
 import time
 import json
+<<<<<<< HEAD
 import requests
+=======
+>>>>>>> Added version_added for new options, moved imports back
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 

--- a/lib/ansible/modules/web_infrastructure/jboss.py
+++ b/lib/ansible/modules/web_infrastructure/jboss.py
@@ -141,10 +141,6 @@ import os
 import shutil
 import time
 import json
-<<<<<<< HEAD
-import requests
-=======
->>>>>>> Added version_added for new options, moved imports back
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updates JBoss module to support deployment through HTTP management API and JBoss CLI.

As it currently stands, the module only supports filesystem deployments using the deployment scanner, which is not recommended for production in the latest versions of JBoss/Wildfly. These updates provide more flexibility by supporting deployment through the HTTP management API and the JBoss CLI, either of which is preferred over filesystem deployments.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
JBoss module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 03710c1092) last updated 2017/07/03 20:55:17 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'$HOME/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = $HOME/ansible/lib/ansible
  executable location = $HOME/ansible/.venv/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
