### PR TITLE
fix vyos_banner multiline string issue

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_banner.py
+++ b/lib/ansible/modules/network/vyos/vyos_banner.py
@@ -100,11 +100,9 @@ def spec_to_commands(updates, module):
             commands.append('delete system login banner %s' % module.params['banner'])
 
     elif state == 'present':
-        if want['text'] and (want['text'] != have.get('text')):
+        if want['text'] and want['text'].encode().decode('unicode_escape') != have.get('text'):
             banner_cmd = 'set system login banner %s ' % module.params['banner']
-            banner_cmd += "'"
             banner_cmd += want['text'].strip()
-            banner_cmd += "'"
             commands.append(banner_cmd)
 
     return commands
@@ -119,9 +117,8 @@ def config_to_dict(module):
         if line.startswith('set system login banner %s' % obj['banner']):
             match = re.findall(r'%s (.*)' % obj['banner'], line, re.M)
             output = match
-
     if output:
-        obj['text'] = output[0][1:-1]
+        obj['text'] = output[0].encode().decode('unicode_escape')
         obj['state'] = 'present'
 
     return obj
@@ -130,7 +127,7 @@ def config_to_dict(module):
 def map_params_to_obj(module):
     text = module.params['text']
     if text:
-        text = str(text).strip()
+        text = "%r" % (str(text).strip())
 
     return {
         'banner': module.params['banner'],

--- a/test/integration/targets/vyos_banner/tests/cli/basic-post-login.yaml
+++ b/test/integration/targets/vyos_banner/tests/cli/basic-post-login.yaml
@@ -22,8 +22,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'this is my post-login banner' in result.commands"
-      - "'that has a multiline' in result.commands"
+      - "'this is my post-login banner' in result.commands[0]"
+      - "'that has a multiline' in result.commands[0]"
 
 - name: Set post-login again (idempotent)
   vyos_banner:

--- a/test/integration/targets/vyos_banner/tests/cli/basic-pre-login.yaml
+++ b/test/integration/targets/vyos_banner/tests/cli/basic-pre-login.yaml
@@ -22,8 +22,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'this is my pre-login banner' in result.commands"
-      - "'that has a multiline' in result.commands"
+      - "'this is my pre-login banner' in result.commands[0]"
+      - "'that has a multiline' in result.commands[0]"
 
 - name: Set pre-login again (idempotent)
   vyos_banner:

--- a/test/units/modules/network/vyos/test_vyos_banner.py
+++ b/test/units/modules/network/vyos/test_vyos_banner.py
@@ -44,7 +44,7 @@ class TestVyosBannerModule(TestVyosModule):
 
     def test_vyos_banner_create(self):
         set_module_args(dict(banner='pre-login', text='test\nbanner\nstring'))
-        commands = ["set system login banner pre-login 'test\nbanner\nstring'"]
+        commands = ["set system login banner pre-login 'test\\nbanner\\nstring'"]
         self.execute_module(changed=True, commands=commands)
 
     def test_vyos_banner_remove(self):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Pass text to vyos as raw string to avoid multiline string issue.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/vyos/vyos_banner
test/integration/targets/vyos_banner/test/cli
test/units/modules/network/vyos/test_vyos_banner
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.4
```