### PR TITLE
cloudstack: fix KeyError: 'sshkeypair' on ACS 4.5

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -561,36 +561,49 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
             res.append({'networkid': ids[i], 'ip': data['ip']})
         return res
 
+    def get_ssh_keypair(self, key=None, name=None, fail_on_missing=True):
+        ssh_key_name = name or self.module.params.get('ssh_key')
+        if ssh_key_name is None:
+            return
+
+        args = {
+            'domainid': self.get_domain('id'),
+            'account': self.get_account('name'),
+            'projectid': self.get_project('id'),
+            'name': ssh_key_name,
+        }
+        ssh_key_pairs = self.cs.listSSHKeyPairs(**args)
+        if 'errortext' in ssh_key_pairs:
+            self.module.fail_json(msg="Failed: '%s'" % ssh_key_pairs['errortext'])
+
+        elif 'sshkeypair' in ssh_key_pairs:
+            return self._get_by_key(key=key, my_dict=ssh_key_pairs['sshkeypair'][0])
+
+        elif fail_on_missing:
+            self.module.fail_json(msg="SSH key not found: %s" % ssh_key_name)
 
     def ssh_key_has_changed(self):
         ssh_key_name = self.module.params.get('ssh_key')
         if ssh_key_name is None:
             return False
 
+        # Fails if keypair for param is inexistent
+        param_ssh_key_fp = self.get_ssh_keypair(key='fingerprint')
+
+        # CloudStack 4.5 does return keypair on instance for a non existent key.
         instance_ssh_key_name = self.instance.get('keypair')
         if instance_ssh_key_name is None:
             return True
 
-        if ssh_key_name == instance_ssh_key_name:
-            return False
+        # Get fingerprint for keypair of instance but do not fail if inexistent.
+        instance_ssh_key_fp = self.get_ssh_keypair(key='fingerprint', name=instance_ssh_key_name, fail_on_missing=False)
+        if not instance_ssh_key_fp:
+            return True
 
-        args = {
-            'domainid': self.get_domain('id'),
-            'account': self.get_account('name'),
-            'projectid': self.get_project('id')
-        }
-
-        args['name'] = instance_ssh_key_name
-        res = self.cs.listSSHKeyPairs(**args)
-        instance_ssh_key = res['sshkeypair'][0]
-
-        args['name'] = ssh_key_name
-        res = self.cs.listSSHKeyPairs(**args)
-        param_ssh_key = res['sshkeypair'][0]
-        if param_ssh_key['fingerprint'] != instance_ssh_key['fingerprint']:
+        # Compare fingerprints to ensure the keypair changed
+        if instance_ssh_key_fp != param_ssh_key_fp:
             return True
         return False
-
 
     def security_groups_has_changed(self):
         security_groups = self.module.params.get('security_groups')
@@ -710,7 +723,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
         args['name']                = self.module.params.get('name')
         args['displayname']         = self.get_or_fallback('display_name', 'name')
         args['group']               = self.module.params.get('group')
-        args['keypair']             = self.module.params.get('ssh_key')
+        args['keypair']             = self.get_ssh_keypair(key='name')
         args['size']                = self.module.params.get('disk_size')
         args['startvm']             = start_vm
         args['rootdisksize']        = self.module.params.get('root_disk_size')

--- a/test/integration/targets/cs_instance/tasks/main.yml
+++ b/test/integration/targets/cs_instance/tasks/main.yml
@@ -1,11 +1,13 @@
 ---
 - include: setup.yml
+
 - include: present.yml
 - include: tags.yml
 - include: absent.yml
-- include: cleanup.yml
 
-- include: setup.yml
 - include: present_display_name.yml
 - include: absent_display_name.yml
+
+- include: sshkeys.yml
+
 - include: cleanup.yml

--- a/test/integration/targets/cs_instance/tasks/sshkeys.yml
+++ b/test/integration/targets/cs_instance/tasks/sshkeys.yml
@@ -1,0 +1,168 @@
+---
+- name: test update instance ssh key non existent
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey2"
+    template: "{{ test_cs_instance_template }}"
+    force: true
+  register: instance
+  ignore_errors: true
+- name: verify  update instance ssh key non existent
+  assert:
+    that:
+    - instance|failed
+    - 'instance.msg == "SSH key not found: {{ cs_resource_prefix }}-sshkey2"'
+
+- name: test create instance without keypair in check mode
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    template: "{{ test_cs_instance_template }}"
+    service_offering: "{{ test_cs_instance_offering_1 }}"
+  check_mode: true
+  register: instance
+- name: verify create instance without keypair in check mode
+  assert:
+    that:
+    - instance|success
+    - instance|changed
+
+- name: test create instance without keypair
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    template: "{{ test_cs_instance_template }}"
+    service_offering: "{{ test_cs_instance_offering_1 }}"
+  register: instance
+- name: verify create instance without keypair
+  assert:
+    that:
+    - instance|success
+    - instance|changed
+    - instance.ssh_key is not defined
+
+- name: test create instance without keypair idempotence
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    template: "{{ test_cs_instance_template }}"
+    service_offering: "{{ test_cs_instance_offering_1 }}"
+  register: instance
+- name: verify create instance without keypair idempotence
+  assert:
+    that:
+    - instance|success
+    - not instance|changed
+    - instance.ssh_key is not defined
+
+- name: setup ssh key2
+  cs_sshkeypair: name={{ cs_resource_prefix }}-sshkey2
+  register: sshkey
+- name: verify setup ssh key2
+  assert:
+    that:
+    - sshkey|success
+
+- name: test update instance ssh key2 in check mode
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey2"
+    force: true
+  check_mode: true
+  register: instance
+- name: verify update instance ssh key2 in check mode
+  assert:
+    that:
+    - instance|changed
+    - instance.ssh_key is not defined
+
+- name: test update instance ssh key2
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey2"
+    force: true
+  register: instance
+- name: verify update instance ssh key2
+  assert:
+    that:
+    - instance|changed
+    - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey2"
+
+- name: test update instance ssh key2 idempotence
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey2"
+    force: true
+  register: instance
+- name: verify update instance ssh key2 idempotence
+  assert:
+    that:
+    - not instance|changed
+    - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey2"
+
+- name: cleanup ssh key2
+  cs_sshkeypair:
+    name: "{{ cs_resource_prefix }}-sshkey2"
+    state: absent
+  register: sshkey2
+- name: verify cleanup ssh key2
+  assert:
+    that:
+    - sshkey2|success
+
+- name: test update instance ssh key2 idempotence2
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey2"
+    force: true
+  register: instance
+  ignore_errors: true
+- name: verify update instance ssh key2 idempotence2
+  assert:
+    that:
+    - instance|failed
+    - 'instance.msg == "SSH key not found: {{ cs_resource_prefix }}-sshkey2"'
+
+- name: test update instance ssh key in check mode
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey"
+    force: true
+  check_mode: true
+  register: instance
+- name: verify update instance ssh key in check mode
+  assert:
+    that:
+    - instance|changed
+    - instance.ssh_key is not defined
+
+- name: test update instance ssh key
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey"
+    force: true
+  register: instance
+- name: verify update instance ssh key
+  assert:
+    that:
+    - instance|changed
+    - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey"
+
+- name: test update instance ssh key idempotence
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    ssh_key: "{{ cs_resource_prefix }}-sshkey"
+    force: true
+  register: instance
+- name: verify update instance ssh key idempotence
+  assert:
+    that:
+    - not instance|changed
+    - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey"
+
+- name: cleanup expunge instance
+  cs_instance:
+    name: "{{ cs_resource_prefix }}-vm-sshkey"
+    state: expunged
+  register: instance
+- name: verify cleanup expunge instance
+  assert:
+    that:
+    - instance|success


### PR DESCRIPTION
##### SUMMARY
There was a undocumented API change after 4.5 which causes the module to fail in a certain condition handling a non existent key once used for a deployment. Tests extended.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cs_instance

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
