### PR TITLE
Remove xml return for junos declarative modules

### DIFF
--- a/lib/ansible/modules/network/interface/net_interface.py
+++ b/lib/ansible/modules/network/interface/net_interface.py
@@ -107,22 +107,9 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device.
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - interface 20
     - name test-interface
-
-rpc:
-  description: load-configuration RPC send to the device
-  returned: C(rpc) is returned only for junos device
-            when configuration is changed on device
-  type: string
-  sample: >
-            <interfaces>
-                <interface>
-                    <name>ge-0/0/0</name>
-                    <description>test interface</description>
-                </interface>
-            </interfaces>
 """

--- a/lib/ansible/modules/network/interface/net_linkagg.py
+++ b/lib/ansible/modules/network/interface/net_linkagg.py
@@ -82,7 +82,7 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - set interfaces bonding bond0

--- a/lib/ansible/modules/network/junos/junos_banner.py
+++ b/lib/ansible/modules/network/junos/junos_banner.py
@@ -101,16 +101,13 @@ EXAMPLES = """
 """
 
 RETURN = """
-rpc:
-  description: load-configuration RPC send to the device
-  returned: when configuration is changed on device
+diff:
+  description: Configuration difference before and after applying change.
+  returned: when configuration is changed.
   type: string
   sample: >
-          <system>
-            <login>
-                <message>this is my login banner</message>
-            </login>
-          </system>"
+          [edit system login]
+          +   message \"this is my login banner\";
 """
 import collections
 
@@ -182,8 +179,7 @@ def main():
     if diff:
         result.update({
             'changed': True,
-            'diff': {'prepared': diff},
-            'rpc': tostring(ele)
+            'diff': diff,
         })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/junos/junos_interface.py
+++ b/lib/ansible/modules/network/junos/junos_interface.py
@@ -129,17 +129,15 @@ EXAMPLES = """
 """
 
 RETURN = """
-rpc:
-  description: load-configuration RPC send to the device
-  returned: when configuration is changed on device
+diff:
+  description: Configuration difference before and after applying change.
+  returned: when configuration is changed.
   type: string
   sample: >
-            <interfaces>
-                <interface>
-                    <name>ge-0/0/0</name>
-                    <description>test interface</description>
-                </interface>
-            </interfaces>
+        [edit interfaces]
+        +   ge-0/0/1 {
+        +       description test-interface;
+        +   }
 """
 import collections
 
@@ -240,8 +238,7 @@ def main():
     if diff:
         result.update({
             'changed': True,
-            'diff': {'prepared': diff},
-            'rpc': tostring(ele)
+            'diff': diff,
         })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/junos/junos_logging.py
+++ b/lib/ansible/modules/network/junos/junos_logging.py
@@ -111,18 +111,17 @@ EXAMPLES = """
 """
 
 RETURN = """
-rpc:
-  description: load-configuration RPC send to the device
-  returned: when configuration is changed on device
+diff:
+  description: Configuration difference before and after applying change.
+  returned: when configuration is changed.
   type: string
   sample: >
-         <system>
-            <syslog>
-                <console replace=\"replace\" active=\"active\">
-                    <name>pfe</name><error/>
-                </console>
-            </syslog>
-         </system>
+          [edit system syslog]
+          +    [edit system syslog]
+               file interactive-commands { ... }
+          +    file test {
+          +        pfe critical;
+          +    }
 """
 import collections
 
@@ -186,11 +185,8 @@ def main():
                    ('dest', 'user', ['name', 'facility', 'level']),
                    ('dest', 'console', ['facility', 'level'])]
 
-    mutually_exclusive = [('console', 'name')]
-
     module = AnsibleModule(argument_spec=argument_spec,
                            required_if=required_if,
-                           mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
 
     warnings = list()
@@ -240,8 +236,7 @@ def main():
     if diff:
         result.update({
             'changed': True,
-            'diff': {'prepared': diff},
-            'rpc': tostring(ele)
+            'diff': diff,
         })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/junos/junos_system.py
+++ b/lib/ansible/modules/network/junos/junos_system.py
@@ -100,17 +100,18 @@ EXAMPLES = """
 """
 
 RETURN = """
-rpc:
-  description: load-configuration RPC send to the device
-  returned: when configuration is changed on device
+diff:
+  description: Configuration difference before and after applying change.
+  returned: when configuration is changed.
   type: string
   sample: >
-            <interfaces>
-                <interface>
-                    <name>ge-0/0/0</name>
-                    <description>test interface</description>
-                </interface>
-            </interfaces>
+          [edit system]
+          +  host-name test;
+          +  domain-name ansible.com;
+          +  domain-search redhat.com;
+          [edit system name-server]
+              172.26.1.1 { ... }
+          +   8.8.8.8;
 """
 import collections
 
@@ -190,8 +191,7 @@ def main():
     if diff:
         result.update({
             'changed': True,
-            'diff': {'prepared': diff},
-            'rpc': tostring(ele)
+            'diff': diff,
         })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -118,6 +118,16 @@ EXAMPLES = """
 """
 
 RETURN = """
+diff:
+  description: Configuration difference before and after applying change.
+  returned: when configuration is changed.
+  type: string
+  sample: >
+          [edit system login]
+          +    user test-user {
+          +        uid 2005;
+          +        class read-only;
+          +    }
 """
 from functools import partial
 
@@ -265,7 +275,7 @@ def main():
     if diff:
         result.update({
             'changed': True,
-            'diff': {'prepared': diff}
+            'diff': diff
         })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -98,11 +98,15 @@ EXAMPLES = """
 """
 
 RETURN = """
-rpc:
-  description: load-configuration RPC send to the device
-  returned: when configuration is changed on device
+diff:
+  description: Configuration difference before and after applying change.
+  returned: when configuration is changed.
   type: string
-  sample: "<vlans><vlan><name>test-vlan-4</name></vlan></vlans>"
+  sample: >
+         [edit vlans]
+         +   test-vlan-1 {
+         +       vlan-id 60;
+         +   }
 """
 import collections
 
@@ -181,8 +185,7 @@ def main():
     if diff:
         result.update({
             'changed': True,
-            'diff': {'prepared': diff},
-            'rpc': tostring(ele)
+            'diff': diff,
         })
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/layer2/net_vlan.py
+++ b/lib/ansible/modules/network/layer2/net_vlan.py
@@ -76,16 +76,9 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - vlan 20
     - name test-vlan
-
-rpc:
-  description: load-configuration RPC send to the device
-  returned: C(rpc) is returned only for junos device
-            when configuration is changed on device
-  type: string
-  sample: "<vlans><vlan><name>test-vlan-4</name></vlan></vlans>"
 """

--- a/lib/ansible/modules/network/layer3/net_vrf.py
+++ b/lib/ansible/modules/network/layer3/net_vrf.py
@@ -67,7 +67,7 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - vrf definition MANAGEMENT

--- a/lib/ansible/modules/network/system/net_banner.py
+++ b/lib/ansible/modules/network/system/net_banner.py
@@ -78,22 +78,11 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - banner login
     - this is my login banner
     - that contains a multiline
     - string
-
-rpc:
-  description: load-configuration RPC send to the device
-  returned: when configuration is changed on device
-  type: string
-  sample: >
-          <system>
-            <login>
-                <message>this is my login banner</message>
-            </login>
-          </system>"
 """

--- a/lib/ansible/modules/network/system/net_logging.py
+++ b/lib/ansible/modules/network/system/net_logging.py
@@ -84,22 +84,8 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - logging console critical
-
-rpc:
-  description: load-configuration RPC send to the device
-  returned: C(rpc) is returned only for junos device
-            when configuration is changed on device
-  type: string
-  sample: >
-         <system>
-            <syslog>
-                <console replace=\"replace\" active=\"active\">
-                    <name>pfe</name><error/>
-                </console>
-            </syslog>
-         </system>
 """

--- a/lib/ansible/modules/network/system/net_system.py
+++ b/lib/ansible/modules/network/system/net_system.py
@@ -102,22 +102,9 @@ EXAMPLES = """
 RETURN = """
 commands:
   description: The list of configuration mode commands to send to the device
-  returned: always
+  returned: always, except for the platforms that use Netconf transport to manage the device.
   type: list
   sample:
     - hostname ios01
     - ip domain name test.example.com
-
-rpc:
-  description: load-configuration RPC send to the device
-  returned: C(rpc) is returned only for junos device
-            when configuration is changed on device
-  type: string
-  sample: >
-            <interfaces>
-                <interface>
-                    <name>ge-0/0/0</name>
-                    <description>test interface</description>
-                </interface>
-            </interfaces>
 """


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Remove xml return
*  Add diff return
*  Related doc changes
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_banner
junos_interface
junos_logging
junos_system
junos_user
junos_vlan
net_banner
net_interface
net_logging
net_system
net_vlan

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
