### PR TITLE
Fix error with `meta: clear_facts`

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -866,7 +866,8 @@ class StrategyBase:
         elif meta_action == 'clear_facts':
             if _evaluate_conditional(target_host):
                 for host in self._inventory.get_hosts(iterator._play.hosts):
-                    self._variable_manager.clear_facts(host)
+                    hostname = host.get_name()
+                    self._variable_manager.clear_facts(hostname)
                 msg = "facts cleared"
             else:
                 skipped = True


### PR DESCRIPTION
Using `meta: clear_facts` was failing with
`coercing to Unicode: need string or buffer, Host found`

This applies the same fix as 3101e24.

Fixes #26405

##### SUMMARY
Per 3101e24, this retrieves the hostname (string) from the host (Host object) because that is the expected type

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/strategy
clear_facts

##### ADDITIONAL INFORMATION

I’m happy to add a unit test for this, but it was not obvious to me where it would belong − other meta actions do not seem to have tests either. Happy to take pointers :)