### PR TITLE
Revert "Limit yamllint version on python 2.6." (55aec8e)

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -2,6 +2,6 @@ coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance
 pylint >= 1.5.3, < 1.7.0 # 1.4.1 adds JSON output, but 1.5.3 fixes bugs related to JSON output
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
-yamllint < 1.8 ; python_version < '2.7' # yamllint 1.8 and later require python 2.7 or later
+yamllint != 1.8.0 ; python_version < '2.7' # yamllint 1.8.0 requires python 2.7+ while earlier/later versions do not
 isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previously passing pylint tests
 pycrypto >= 2.6 # Need features found in 2.6 and greater


### PR DESCRIPTION
##### SUMMARY

Thanks to the report by Matt Clay at https://github.com/adrienverge/yamllint/issues/55, yamllint now supports Python 2.6. Tests were enabled on Travis for 2.6 to make sure there will be no regressions in the future.

##### ISSUE TYPE

 - Bugfix Pull Request