### PR TITLE
win_regedit: fix for same dword value

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -82,14 +82,14 @@ Function Compare-Data {
         } else {
             return $false
         }
-    } elseif ($ReferenceData -is [string] -or $ReferenceData -is [int]) {
-        if ($ReferenceData -ceq $DifferenceData) {
+    } elseif ($ReferenceData -is [object[]]) {
+        if (@(Compare-Object $ReferenceData $DifferenceData -SyncWindow 0).Length -eq 0) {
             return $true
         } else {
             return $false
         }
-    } elseif ($ReferenceData -is [object[]]) {
-        if (@(Compare-Object $ReferenceData $DifferenceData -SyncWindow 0).Length -eq 0) {
+    } else {
+        if ($ReferenceData -ceq $DifferenceData) {
             return $true
         } else {
             return $false

--- a/test/integration/targets/win_regedit/tasks/main.yml
+++ b/test/integration/targets/win_regedit/tasks/main.yml
@@ -440,6 +440,28 @@
     that:
       - "check72_result.changed == false"
 
+# https://github.com/ansible/ansible/issues/26049
+# module reports change on dword with hex value even with same value
+- name: create hex value with prepending 0x
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: full_hex_dword
+    data: 0xffffffff
+    datatype: dword
+  register: dword_create
+
+- name: change hex value and report no changes
+  win_regedit:
+    key: HKCU:\Software\Cow Corp
+    value: full_hex_dword
+    data: 0xffffffff
+    datatype: dword
+  register: dword_create_again
+
+- assert:
+    that:
+    - not dword_create_again|changed
+
 # tear down
 
 - name: remove registry key used for testing


### PR DESCRIPTION
##### SUMMARY
Fix for https://github.com/ansible/ansible/issues/26049. Fixes the issue where the module doesn't compare 2 values if the existing data is a uint32.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_regedit

##### ANSIBLE VERSION
```
ansible 2.4.0 (win_regedit-int-type 54e2c6ae54) last updated 2017/07/05 06:57:53 (GMT +1000)
  config file = None
  configured module search path = [u'/home/jborean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jborean/dev/ansible/lib/ansible
  executable location = /home/jborean/dev/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```