### PR TITLE
win_chocolatey: Ensure chocolatey to fail

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -153,7 +153,7 @@ Function Choco-Upgrade
         throw "$package is not installed, you cannot upgrade"
     }
 
-    $cmd = "$executable upgrade -dv -y $package -timeout $timeout"
+    $cmd = "$executable upgrade -dv -y $package -timeout $timeout --failonunfound"
 
     if ($check_mode)
     {
@@ -265,7 +265,7 @@ Function Choco-Install
         }
     }
 
-    $cmd = "$executable install -dv -y $package -timeout $timeout"
+    $cmd = "$executable install -dv -y $package -timeout $timeout --failonunfound"
 
     if ($check_mode)
     {


### PR DESCRIPTION
##### SUMMARY
Currently chocolatey is not failing when the user requests version X,
but version X is not available in the repository.

Obviously the module should fail in this case.

This fixes #25393

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey

##### ANSIBLE VERSION
v2.4