### PR TITLE
Add missing keyword args in aix_inittab

### DIFF
--- a/lib/ansible/modules/system/aix_inittab.py
+++ b/lib/ansible/modules/system/aix_inittab.py
@@ -235,8 +235,7 @@ def main():
                             [mkitab, new_entry])
 
                 if rc != 0:
-                    module.fail_json(
-                        "could not adjust inittab", rc=rc, err=err)
+                    module.fail_json(msg="could not adjust inittab", rc=rc, err=err)
                 result['msg'] = "add inittab entry" + " " + module.params['name']
                 result['changed'] = True
 


### PR DESCRIPTION
##### SUMMARY
fail_json fails if msg is not provided.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/aix_inittab.py

##### ANSIBLE VERSION
```
2.4devel
```