### PR TITLE
Enforce the _raw_params variable with include_role

### DIFF
--- a/test/integration/ovs.yaml
+++ b/test/integration/ovs.yaml
@@ -18,6 +18,7 @@
     - block:
       - include_role:
           name: openvswitch_db
+          _raw_params: openvswitch_db
         when: "limit_to in ['*', 'openvswitch_db']"
       rescue:
         - set_fact: test_failed=true


### PR DESCRIPTION
##### SUMMARY

Currently, when using this test, it fails with the following error
message:

> AttributeError: 'NoneType' object has no attribute 'rfind'

This is because there is no _raw_params value for parent_include.args
here
https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/included_file.py#L104

This commit ensure the value is specified so it can be reused and hence
not fail at this specific line.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- include_role (in some specific use cases)

##### ANSIBLE VERSION

```
ansible 2.4.0 (specify_raw_params_on_include_role 21e6640655) last updated 2017/07/05 15:05:41 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/spredzy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/spredzy/Projects/github.com/Spredzy/ansible/lib/ansible
  executable location = /home/spredzy/Projects/github.com/Spredzy/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)
```