### PR TITLE
script: Add support for chdir argument

### DIFF
--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -50,6 +50,12 @@ options:
     required: no
     default: null
     version_added: "1.5"
+  chdir:
+    description:
+      - cd into this directory on the remote node before running the script
+    version_added: "2.4"
+    required: false
+    default: null
 notes:
   - It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus points!
   - The ssh connection plugin will force pseudo-tty allocation via -tt when scripts are executed. pseudo-ttys do not have a stderr channel and all

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -842,7 +842,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 data['rc'] = res['rc']
         return data
 
-    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='surrogate_then_replace'):
+    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='surrogate_then_replace', chdir=None):
         '''
         This is the function which executes the low level shell command, which
         may be commands to create/remove directories for temporary files, or to
@@ -855,6 +855,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             used as a key or is going to be written back out to a file
             verbatim, then this won't work.  May have to use some sort of
             replacement strategy (python3 could use surrogateescape)
+        :kwarg chdir: cd into this directory before executing the command.
         '''
 
         display.debug("_low_level_execute_command(): starting")
@@ -862,6 +863,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
 #            # this can happen with powershell modules when there is no analog to a Windows command (like chmod)
 #            display.debug("_low_level_execute_command(): no command, exiting")
 #           return dict(stdout='', stderr='', rc=254)
+
+        if chdir:
+            display.debug("_low_level_execute_command(): changing cwd to %s for this command" % chdir)
+            cmd = self._connection._shell.append_command('cd %s' % chdir, cmd)
 
         allow_same_user = C.BECOME_ALLOW_SAME_USER
         same_user = self._play_context.become_user == self._play_context.remote_user


### PR DESCRIPTION
##### SUMMARY
Add support for the `chdir` argument in the `script` module.
This allows setting the current working directory on the remote node before executing a script.
The `shell` and `command` already have this chdir argument in their API.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
core module `script`

##### ANSIBLE VERSION
```
ansible 2.4.0 (feature/script_chdir_support c462e9b666) last updated 2017/07/05 16:43:36 (GMT +200)
  config file = None
  configured module search path = [u'/home/karim/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/karim/ansible/ansible/lib/ansible
  executable location = /home/karim/ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

This *might* be compatible with 2.3.x versions of ansible. I will rebase & test if the feature is accepted.

##### ADDITIONAL INFORMATION
This feature was already asked a few months ago : https://github.com/ansible/ansible/issues/24348

Here is a simple example playbook:
```
---
- hosts: all
  tasks:
    - script: script.sh
      register: no_chdir_result
    - debug: var=no_chdir_result.stdout

    - script: script.sh
      args:
        chdir: /tmp
      register: with_chdir_result
    - debug: var=with_chdir_result.stdout

    - script: script.sh
      register: no_chdir_again_result
    - debug: var=no_chdir_again_result.stdout
```
The script.sh just contains:
```
#!/usr/bin/env bash
pwd
```
And the result of its execution:
```
karim@karim-devstation:~/devenedis/ansible/testcase$ ansible-playbook -i inventory playbook.yml  

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testcase_kben]

TASK [script] ******************************************************************
changed: [testcase_kben]

TASK [debug] *******************************************************************
ok: [testcase_kben] => {
    "failed": false, 
    "no_chdir_result.stdout": "/home/ansibledeployer\r\n"
}

TASK [script] ******************************************************************
changed: [testcase_kben]

TASK [debug] *******************************************************************
ok: [testcase_kben] => {
    "failed": false, 
    "with_chdir_result.stdout": "/tmp\r\n"
}

TASK [script] ******************************************************************
changed: [testcase_kben]

TASK [debug] *******************************************************************
ok: [testcase_kben] => {
    "failed": false, 
    "no_chdir_again_result.stdout": "/home/ansibledeployer\r\n"
}

PLAY RECAP *********************************************************************
testcase_kben              : ok=7    changed=3    unreachable=0    failed=0
```
