### PR TITLE
enabled aws vyos banner and config tests

### DIFF
--- a/test/integration/targets/vyos_banner/aliases
+++ b/test/integration/targets/vyos_banner/aliases
@@ -1,0 +1,2 @@
+network/ci
+skip/python3

--- a/test/integration/targets/vyos_config/aliases
+++ b/test/integration/targets/vyos_config/aliases
@@ -1,0 +1,2 @@
+network/ci
+skip/python3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 #26373 #26383 fixed a couple of bugs that were preventing us from enabling networking AWS tests. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New integration tests

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- vyos_banner
- vyos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (aws-vyos 1097255f2c) last updated 2017/07/05 11:03:09 (GMT -400)
  config file = None
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
