### PR TITLE
remove vyos/1.0.5 from test/runner/completion/network.txt

### DIFF
--- a/test/runner/completion/network.txt
+++ b/test/runner/completion/network.txt
@@ -1,5 +1,4 @@
 ios/csr1000v
 junos/vmx
 junos/vsrx
-vyos/1.0.5
 vyos/1.1.0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The vyos 1.0.5 AWS images has a few errors where all of the configs are owned by root instead of vyos. This prevents us from running network integration tests on the vyos 1.0.5 image.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- vyos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (aws-remove-vyos-1-0-5 8b95798597) last updated 2017/07/05 11:23:43 (GMT -400)
  config file = None
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
