### PR TITLE
ansible-connection Python3 fix

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -40,7 +40,7 @@ import datetime
 import errno
 
 from ansible import constants as C
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils.connection import send_data, recv_data
@@ -141,7 +141,7 @@ class Server():
                     signal.signal(signal.SIGALRM, self.command_timeout)
                     signal.alarm(self.play_context.timeout)
 
-                    op = data.split(':')[0]
+                    op = to_text(data.split(b':')[0])
                     display.display('socket operation is %s' % op, log_only=True)
 
                     method = getattr(self, 'do_%s' % op, None)

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -23,7 +23,7 @@ import pty
 import subprocess
 import sys
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.six.moves import cPickle
 from ansible.plugins.connection import ConnectionBase
 
@@ -85,4 +85,4 @@ class Connection(ConnectionBase):
 
     def run(self):
         rc, out, err = self._do_it('RUN:')
-        return out
+        return to_text(out, errors='surrogate_or_strict')

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -84,5 +84,11 @@ class Connection(ConnectionBase):
         self._connected = False
 
     def run(self):
+        """Returns the path of the persistent connection socket.
+
+        Attempts to ensure (within playcontext.timeout seconds) that the
+        socket path exists. If the path exists (or the timeout has expired),
+        returns the socket path.
+        """
         rc, out, err = self._do_it('RUN:')
         return to_text(out, errors='surrogate_or_strict')


### PR DESCRIPTION
##### SUMMARY
Fix assorted `bytes` issues in and around ansible-connection

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 95a0fe37da) last updated 2017/07/05 10:48:05 (GMT -400)
  config file = /home/nate/workspace/ansible/test/ansible.cfg
  configured module search path = ['/home/nate/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nate/workspace/ansible/ansible/lib/ansible
  executable location = /home/nate/.local/virtualenvs-Arch/ansible-dev/bin/ansible
  python version = 3.6.1 (default, Mar 27 2017, 00:27:06) [GCC 6.3.1 20170306]
```


##### ADDITIONAL INFORMATION
The change in ansible-connection resolves the socket operation to a native string so that we getattr (for ex.) `do_RUN` instead of `do_b'RUN'`.

In the persistent connection plugin, `run()` only returns the socket path, which cannot later be encoded to json without being converted to a string in python 3.