### PR TITLE
ec2_elb_lb check mode

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -18,7 +18,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'curated'}
 
-
 DOCUMENTATION = """
 ---
 module: ec2_elb_lb
@@ -1278,8 +1277,8 @@ class ElbManager(object):
             for i, key in enumerate(dictact):
                 params['Tags.member.%d.Key' % (i + 1)] = key
 
-              if not self.module.check_mode:
-                self.elb_conn.make_request('RemoveTags', params)
+                if not self.module.check_mode:
+                    self.elb_conn.make_request('RemoveTags', params)
             self.changed=True
 
     def _get_health_check_target(self):

--- a/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
@@ -741,7 +741,7 @@ class ElbManager(object):
                                                           scheme=self.scheme)
         else:
             self.changed = True
-            self.staus = 'created'
+            self.status = 'created'
         if self.elb:
             # HACK: Work around a boto bug in which the listeners attribute is
             # always set to the listeners argument to create_load_balancer, and
@@ -1115,8 +1115,7 @@ class ElbManager(object):
                         self._set_stickiness_policy(elb_info, listeners_dict, policy, **policy_attrs)
                 elif not self.module.boolean(self.stickiness['enabled']):
                     if len(elb_info.policies.lb_cookie_stickiness_policies):
-                        if elb_info.policies.lb_cookie_stickiness_policies[0].policy_name == self._policy_name(
-                                policy_type):
+                        if elb_info.policies.lb_cookie_stickiness_policies[0].policy_name == self._policy_name(policy_type):
                             self.changed = True
                     else:
                         self.changed = False
@@ -1144,8 +1143,7 @@ class ElbManager(object):
                         self._set_stickiness_policy(elb_info, listeners_dict, policy, **policy_attrs)
                 elif not self.module.boolean(self.stickiness['enabled']):
                     if len(elb_info.policies.app_cookie_stickiness_policies):
-                        if elb_info.policies.app_cookie_stickiness_policies[0].policy_name == self._policy_name(
-                                policy_type):
+                        if elb_info.policies.app_cookie_stickiness_policies[0].policy_name == self._policy_name(policy_type):
                             self.changed = True
                     if not self.module.check_mode:
                         self._set_listener_policy(listeners_dict)

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -18,7 +18,6 @@ lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
 lib/ansible/modules/cloud/amazon/ec2_eip.py
 lib/ansible/modules/cloud/amazon/ec2_elb.py
 lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
-lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
 lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
 lib/ansible/modules/cloud/amazon/ec2_key.py
 lib/ansible/modules/cloud/amazon/ec2_lc.py


### PR DESCRIPTION
ec2_elb_lb check_mode

Fixes https://github.com/ansible/ansible/issues/26428

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
add check mode support to ec2_elb_lb

Due to some weakness with my python, there are 4 occasions where I am setting `changed=True`, with no check against the existing state. This is means check_mode is *safe*, but not necessarily accurate for the following 4 actions:
- create ELB
- delete ELB
- create ELB listeners
- delete ELB listeners

These 4 instances are commented as such. Help to make these remaining 4 tasks report `changed` correctly would be appreciated.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes https://github.com/ansible/ansible/issues/26428

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_elb_lb

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /Users/tom/repos/aws-codecommit/ansible-tower/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
