### PR TITLE
fix win_shell/win_command nonzero RC failure setting

### DIFF
--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -159,6 +159,10 @@ $proc.WaitForExit() | Out-Null
 
 $result.rc = $proc.ExitCode
 
+If ($result.rc -ne 0) {
+    $result.failed = $true
+}
+
 $end_datetime = [DateTime]::UtcNow
 
 $result.start = $start_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -168,6 +168,10 @@ $proc.WaitForExit() | Out-Null
 
 $result.rc = $proc.ExitCode
 
+If ($result.rc -ne 0) {
+    $result.failed = $true
+}
+
 $end_datetime = [DateTime]::UtcNow
 
 $result.start = $start_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")

--- a/test/integration/targets/win_command/tasks/main.yml
+++ b/test/integration/targets/win_command/tasks/main.yml
@@ -120,6 +120,7 @@
   assert:
     that:
     - cmdout|failed
+    - cmdout.failed == True # check the failure key explicitly, since failed does magic with RC
     - cmdout.rc == 254
 
 - name: interleave large writes between stdout/stderr (check for buffer consumption deadlock)

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -47,6 +47,7 @@
   assert:
     that:
     - shellout|failed
+    - shellout.failed == true # check the failure key explicitly, since failed does magic with RC
     - shellout|changed
     - shellout.cmd == 'bogus_command1234'
     - shellout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
@@ -147,6 +148,7 @@
   assert:
     that:
     - shellout|failed
+    - shellout.failed == True # check the failure key explicitly, since failed does magic with RC
     - shellout.rc == 254
 
 - name: run something via cmd that will fail in powershell


### PR DESCRIPTION
##### SUMMARY
* as a result of recent core engine changes to ignore rc, modules are responsible to set `failed` on nonzero RC if they want that behavior
* the `failed` filter currently triggers on nonzero RC, which caused the tests to false-pass
* updated tests to explicitly check both rc and failed keys, as well as using the failed filter.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_shell / win_command

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
