### PR TITLE
allow input plugins to be py3 compat

### DIFF
--- a/lib/ansible/executor/process/worker.py
+++ b/lib/ansible/executor/process/worker.py
@@ -26,6 +26,8 @@ import traceback
 
 from jinja2.exceptions import TemplateNotFound
 
+from ansible.module_utils.six import PY3
+
 HAS_PYCRYPTO_ATFORK = False
 try:
     from Crypto.Random import atfork
@@ -77,7 +79,10 @@ class WorkerProcess(multiprocessing.Process):
                 fileno = sys.stdin.fileno()
                 if fileno is not None:
                     try:
-                        self._new_stdin = os.fdopen(os.dup(fileno))
+                        if PY3: # needed for recognizing Enter in 'pause' module
+                            self._new_stdin = os.fdopen(os.dup(fileno), newline='\r\n')
+                        else:
+                            self._new_stdin = os.fdopen(os.dup(fileno))
                     except OSError:
                         # couldn't dupe stdin, most likely because it's
                         # not a valid file descriptor, so we just rely on


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes #26278


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
python3

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

