### PR TITLE
Add a direct link to the maintainer's file

### DIFF
--- a/MODULE_GUIDELINES.md
+++ b/MODULE_GUIDELINES.md
@@ -49,7 +49,7 @@ A detailed explanation of the PR workflow can be seen here: https://github.com/a
 
 # Extras maintainers list
 
-The full list of maintainers for modules is located here: https://github.com/ansible/ansibullbot
+The full list of maintainers for modules is located here: https://github.com/ansible/ansibullbot/blob/master/MAINTAINERS.txt
 
 ## Changing Maintainership
 


### PR DESCRIPTION
Add a direct link to the MAINTAINERS.txt file.

##### SUMMARY
It is best to link the maintainer's file directly here as the text is talking exactly about the list of maintainers and not the ansibullbot repository.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
None

##### ANSIBLE VERSION
None

##### ADDITIONAL INFORMATION
None