### PR TITLE
Add last line of LLDP data

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -210,6 +210,8 @@ class Neighbors(FactsBase):
                 if values:
                     parsed.append(values)
                 values = line
+        if values:
+            parsed.append(values)
         return parsed
 
     def parse_neighbors(self, data):


### PR DESCRIPTION
##### SUMMARY
vyos_facts did not return the last line of parsed data from the command output.  This change ensures that the last line is not thrown away.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vyos_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (detached HEAD b9b5183644) last updated 2017/07/05 15:07:05 (GMT -400)
  config file = /home/ben/git/vyos-facts-recreate/ansible.cfg
  configured module search path = [u'/home/ben/git/vyos-facts-recreate/library']
  ansible python module location = /home/ben/env/vyos-facts-recreate/src/ansible/lib/ansible
  executable location = /home/ben/env/vyos-facts-recreate/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Set up a two node Vyos topology and run the vyos_facts module with -vvv option to ansible-playbook.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
In the debug output you will see:
Before:
        "ansible_net_neighbors": {}, 
After:
        "ansible_net_neighbors": {
            "eth1": [
                {
                    "host": "Switch2", 
                    "port": "eth1"
                }
            ]
        }, 

```