### PR TITLE
script: Add support for chdir argument (Ansible 2.3)

### DIFF
--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -49,6 +49,12 @@ options:
     required: no
     default: null
     version_added: "1.5"
+  chdir:
+    description:
+      - cd into this directory on the remote node before running the script
+    version_added: "2.3.3"
+    required: false
+    default: null
 notes:
   - It is usually preferable to write Ansible modules than pushing scripts. Convert your script to an Ansible module for bonus points!
   - The ssh connection plugin will force psuedo-tty allocation via -tt when scripts are executed. psuedo-ttys do not have a stderr channel and all stderr is sent to stdout. If you depend on separated stdout and stderr result keys, please switch to a copy+command set of tasks instead of using script.

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -837,7 +837,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 data['rc'] = res['rc']
         return data
 
-    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='surrogate_then_replace'):
+    def _low_level_execute_command(self, cmd, sudoable=True, in_data=None, executable=None, encoding_errors='surrogate_then_replace', chdir=None):
         '''
         This is the function which executes the low level shell command, which
         may be commands to create/remove directories for temporary files, or to
@@ -850,6 +850,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             used as a key or is going to be written back out to a file
             verbatim, then this won't work.  May have to use some sort of
             replacement strategy (python3 could use surrogateescape)
+        :kwarg chdir: cd into this directory before executing the command.
         '''
 
         display.debug("_low_level_execute_command(): starting")
@@ -863,6 +864,10 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         if sudoable and self._play_context.become and (allow_same_user or not same_user):
             display.debug("_low_level_execute_command(): using become for this command")
             cmd = self._play_context.make_become_cmd(cmd, executable=executable)
+
+        if chdir:
+            display.debug("_low_level_execute_command(): changing cwd to %s for this command" % chdir)
+            cmd = self._connection._shell.append_command('cd %s' % chdir, cmd)
 
         if self._connection.allow_executable:
             if executable is None:

--- a/lib/ansible/plugins/action/script.py
+++ b/lib/ansible/plugins/action/script.py
@@ -55,6 +55,10 @@ class ActionModule(ActionBase):
                 self._remove_tmp_path(tmp)
                 return dict(skipped=True, msg=("skipped, since %s does not exist" % removes))
 
+        chdir = self._task.args.get('chdir')
+        if chdir:
+            chdir = os.path.abspath(chdir)
+
         # the script name is the first item in the raw params, so we split it
         # out now so we know the file name we need to transfer to the remote,
         # and everything else is an argument to the script which we need later
@@ -86,7 +90,7 @@ class ActionModule(ActionBase):
         if self._connection.transport == "winrm":
             exec_data = self._connection._create_raw_wrapper_payload(script_cmd, env_dict)
 
-        result.update(self._low_level_execute_command(cmd=script_cmd, in_data=exec_data, sudoable=True))
+        result.update(self._low_level_execute_command(cmd=script_cmd, in_data=exec_data, sudoable=True, chdir=chdir))
 
         # clean up after
         self._remove_tmp_path(tmp)


### PR DESCRIPTION
##### SUMMARY
Add support for the `chdir` argument in the `scrip`t module.
This allows setting the current working directory on the remote node before executing a script.
The `shell` and `command` already have this chdir argument in their API.

This PR is a cherry-pick of https://github.com/ansible/ansible/pull/26436 with a small additionnal doc edit (version change)

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
core module `script`

##### ANSIBLE VERSION
```
ansible 2.3.2.0 (feature/script_chdir_support_ansible2.3 a2e1d93179) last updated 2017/07/05 21:57:41 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
This feature was already asked a few months ago : https://github.com/ansible/ansible/issues/24348

Here is a simple example playbook:
```
---
- hosts: all
  tasks:
    - script: script.sh
      register: no_chdir_result
    - debug: var=no_chdir_result.stdout

    - script: script.sh
      args:
        chdir: /tmp
      register: with_chdir_result
    - debug: var=with_chdir_result.stdout

    - script: script.sh
      register: no_chdir_again_result
    - debug: var=no_chdir_again_result.stdout
```
The script.sh just contains:
```
#!/usr/bin/env bash
pwd
```
And the result of its execution:
```
karim@karim-devstation:~/devenedis/ansible/testcase$ ansible-playbook -i inventory playbook.yml  

PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [testcase_kben]

TASK [script] ******************************************************************
changed: [testcase_kben]

TASK [debug] *******************************************************************
ok: [testcase_kben] => {
    "failed": false, 
    "no_chdir_result.stdout": "/home/ansibledeployer\r\n"
}

TASK [script] ******************************************************************
changed: [testcase_kben]

TASK [debug] *******************************************************************
ok: [testcase_kben] => {
    "failed": false, 
    "with_chdir_result.stdout": "/tmp\r\n"
}

TASK [script] ******************************************************************
changed: [testcase_kben]

TASK [debug] *******************************************************************
ok: [testcase_kben] => {
    "failed": false, 
    "no_chdir_again_result.stdout": "/home/ansibledeployer\r\n"
}

PLAY RECAP *********************************************************************
testcase_kben              : ok=7    changed=3    unreachable=0    failed=0
```
