### PR TITLE
Fix wait_for with newer versions of psutil.

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -250,10 +250,16 @@ class TCPConnectionInfo(object):
             for conn in connections:
                 if conn.status not in self.module.params['active_connection_states']:
                     continue
-                (local_ip, local_port) = conn.local_address
+                if hasattr(conn, 'local_address'):
+                    (local_ip, local_port) = conn.local_address
+                else:
+                    (local_ip, local_port) = conn.laddr
                 if self.port != local_port:
                     continue
-                (remote_ip, remote_port) = conn.remote_address
+                if hasattr(conn, 'remote_address'):
+                    (remote_ip, remote_port) = conn.remote_address
+                else:
+                    (remote_ip, remote_port) = conn.raddr
                 if (conn.family, remote_ip) in self.exclude_ips:
                     continue
                 if any((

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -243,7 +243,10 @@ class TCPConnectionInfo(object):
     def get_active_connections_count(self):
         active_connections = 0
         for p in psutil.process_iter():
-            connections = p.get_connections(kind='inet')
+            if hasattr(p, 'get_connections'):
+                connections = p.get_connections(kind='inet')
+            else:
+                connections = p.connections(kind='inet')
             for conn in connections:
                 if conn.status not in self.module.params['active_connection_states']:
                     continue

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -30,8 +30,8 @@
     that:
       - waitfor|success
       - "waitfor.path == '/tmp/wait_for_file'"
-      - waitfor.elapsed <= 10
-      - waitfor.elapsed > 0
+      - waitfor.elapsed >= 9
+      - waitfor.elapsed <= 15
 
 - name: setup create a file after 10s
   shell: sleep 10 && touch /tmp/wait_for_file
@@ -48,8 +48,8 @@
     that:
       - waitfor|success
       - "waitfor.path == '/tmp/wait_for_file'"
-      - waitfor.elapsed <= 10
-      - waitfor.elapsed > 0
+      - waitfor.elapsed >= 9
+      - waitfor.elapsed <= 15
 
 - name: setup write keyword to file after 10s
   shell: rm -f /tmp/wait_for_keyword && sleep 10 && echo completed > /tmp/wait_for_keyword
@@ -67,8 +67,8 @@
     that:
       - waitfor|success
       - "waitfor.search_regex == 'completed'"
-      - waitfor.elapsed <= 10
-      - waitfor.elapsed > 0
+      - waitfor.elapsed >= 9
+      - waitfor.elapsed <= 15
 
 - name: test wait for port timeout
   wait_for:

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -114,22 +114,24 @@
       - not waitfor|changed
       - "waitfor.port == {{ http_port }}"
 
-# TODO: fix drain test for freebsd and macOS, ubuntu-py3
-- name: setup install psutil
+- name: install psutil using package (if available)
   package:
     name: python-psutil
-  when: ansible_system == "Linux" and not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "16.04")
+  ignore_errors: yes
+
+- name: install psutil using pip (if not already installed)
+  pip:
+    name: psutil
 
 - name: test wait for port drained
   wait_for:
     port: "{{ http_port }}"
     state: drained
   register: waitfor
-  when: ansible_system == "Linux" and not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "16.04")
+
 - name: verify test wait for port
   assert:
     that:
       - waitfor|success
       - not waitfor|changed
       - "waitfor.port == {{ http_port }}"
-  when: ansible_system == "Linux" and not (ansible_distribution == "Ubuntu" and ansible_distribution_version == "16.04")

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -30,7 +30,7 @@
     that:
       - waitfor|success
       - "waitfor.path == '/tmp/wait_for_file'"
-      - waitfor.elapsed >= 9
+      - waitfor.elapsed >= 5
       - waitfor.elapsed <= 15
 
 - name: setup create a file after 10s
@@ -48,7 +48,7 @@
     that:
       - waitfor|success
       - "waitfor.path == '/tmp/wait_for_file'"
-      - waitfor.elapsed >= 9
+      - waitfor.elapsed >= 5
       - waitfor.elapsed <= 15
 
 - name: setup write keyword to file after 10s
@@ -67,7 +67,7 @@
     that:
       - waitfor|success
       - "waitfor.search_regex == 'completed'"
-      - waitfor.elapsed >= 9
+      - waitfor.elapsed >= 5
       - waitfor.elapsed <= 15
 
 - name: test wait for port timeout

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -114,9 +114,16 @@
       - not waitfor|changed
       - "waitfor.port == {{ http_port }}"
 
-- name: install psutil using package (if available)
+- name: install psutil for python 2 using package (if available)
   package:
     name: python-psutil
+  when: ansible_python_version | version_compare('3', '<')
+  ignore_errors: yes
+
+- name: install psutil for python 3 using package (if available)
+  package:
+    name: python3-psutil
+  when: ansible_python_version | version_compare('3', '>=')
   ignore_errors: yes
 
 - name: install psutil using pip (if not already installed)

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -114,21 +114,10 @@
       - not waitfor|changed
       - "waitfor.port == {{ http_port }}"
 
-- name: install psutil for python 2 using package (if available)
-  package:
-    name: python-psutil
-  when: ansible_python_version | version_compare('3', '<')
-  ignore_errors: yes
-
-- name: install psutil for python 3 using package (if available)
-  package:
-    name: python3-psutil
-  when: ansible_python_version | version_compare('3', '>=')
-  ignore_errors: yes
-
-- name: install psutil using pip (if not already installed)
+- name: install psutil using pip (non-Linux only)
   pip:
     name: psutil
+  when: ansible_system != 'Linux'
 
 - name: test wait for port drained
   wait_for:


### PR DESCRIPTION
##### SUMMARY

The API for `psutil` has changed over time, causing `wait_for` to fail with newer versions. This does not affect Linux systems, as procfs is used there instead.

Using `state=drained` is one way to trigger a traceback:

```
Traceback (most recent call last):
  File "/tmp/ansible_R8D4Ye/ansible_module_wait_for.py", line 610, in <module>
    main()
  File "/tmp/ansible_R8D4Ye/ansible_module_wait_for.py", line 595, in main
    if tcpconns.get_active_connections_count() == 0:
  File "/tmp/ansible_R8D4Ye/ansible_module_wait_for.py", line 246, in get_active_connections_count
    connections = p.get_connections(kind='inet')
AttributeError: 'Process' object has no attribute 'get_connections'
````

This PR updates the module to support both old and new versions of the API. It also enables the integration tests on platforms which were previously untested:

- macOS
- FreeBSD
- Python 3

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

wait_for integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-wait_for edf0448b70) last updated 2017/07/05 13:23:56 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
