### PR TITLE
Zpool facts 26351

### DIFF
--- a/lib/ansible/modules/storage/zfs/zpool_facts.py
+++ b/lib/ansible/modules/storage/zfs/zpool_facts.py
@@ -183,7 +183,8 @@ class ZPoolFacts(object):
                     pool, property, value = line.split('\t')
                 else:
                     pool, property, value, source = line.split('\t')
-                    if pool == "NAME": continue
+                    if pool == "NAME":
+                        continue
 
                 self._pools[pool].update({property: value})
 

--- a/lib/ansible/modules/storage/zfs/zpool_facts.py
+++ b/lib/ansible/modules/storage/zfs/zpool_facts.py
@@ -166,7 +166,7 @@ class ZPoolFacts(object):
         if self.parsable:
             cmd.append('-p')
         if self.is_freebsd:
-            # freebsd does not support -o
+            # -o is supported on freebsd
             cmd.append('-o')
             cmd.append('name,property,value')
         cmd.append(self.properties)

--- a/lib/ansible/modules/storage/zfs/zpool_facts.py
+++ b/lib/ansible/modules/storage/zfs/zpool_facts.py
@@ -177,7 +177,6 @@ class ZPoolFacts(object):
 
         if rc == 0:
             for line in out.splitlines():
-		print "DEBUG line: {0}".format(line)
                 if self.is_sunos:
                     line = "\t".join(line.split())
                 if self.is_freebsd:


### PR DESCRIPTION
##### SUMMARY
Helps handle how zpool_facts passes options for different zfs versions.

Fixes #26351

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/storage/zfs/zpool_facts.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /usr/lib/python2.6/site-packages/ansible-2.4.0-py2.6.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.6.6 (r266:84292, Aug 18 2016, 15:13:37) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```


##### ADDITIONAL INFORMATION
```
I tested the patch against Solaris 11.3, Fedora 23, and FreeBSD 11.
```
