### PR TITLE
Adds search in template/files/vars relative to the playbook path

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -305,6 +305,7 @@ class DataLoader:
 
             # try to create absolute path for loader basedir + templates/files/vars + filename
             search.append(unfrackpath(os.path.join(dirname, source), follow=False))
+            search.append(self.path_dwim(os.path.join(dirname, source)))
 
             # try to create absolute path for loader basedir + filename
             search.append(self.path_dwim(source))


### PR DESCRIPTION
##### SUMMARY
After PR #25956 landed, the *files/templates/vars* paths relative to the playbook were not being searched for the *src* path. This is specifically causing `synchronize` to fail when the given *src* path is relative the the *files* directory located next to the playbook.

For example, running an Ansible Container project consisting of a single role, `centos`. The project gets mounted to the Conductor container at `/src`. The generated playbook is written to a temp directory, `/tmp/xxxx`. The `/src` directory (which is our project directory) gets bind mounted to `/tmp/xxxx/files`. The entire project is then contained with the *files* path next to the playbook.

The role lives in `/src/roles`, which is part of ansible_roles_path. During playbook execution the role is found, and it attempts to use `synchronize` to copy the directory `foo` to a remote container. The copy fails because dataloader.py never looks in `/tmp/xxxx/files`. It only looks in the following:

```
/src/roles/centos/files/foo
/src/roles/centos/files/foo
/src/roles/centos/tasks/foo
/src/files/foo
/tmp/tmpFchnPe/foo
```

This PR adds the missing path, `/tmp/tmpFchnPe/files/foo`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/dataloader.py 

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 3057b5b698) last updated 2017/07/05 16:57:17 (GMT -400)
  config file = /Users/chouseknecht/.ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
