### PR TITLE
ec2.py inventory copy credentials for each connect to support sts

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -551,6 +551,7 @@ class Ec2Inventory(object):
         return connect_args
 
     def connect_to_aws(self, module, region):
+        # copy credentials on each connect to support sts.
         connect_args = dict(self.credentials)
 
         # only pass the profile name if it's set (as it is not supported by older boto versions)

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -551,7 +551,7 @@ class Ec2Inventory(object):
         return connect_args
 
     def connect_to_aws(self, module, region):
-        connect_args = self.credentials
+        connect_args = dict(self.credentials)
 
         # only pass the profile name if it's set (as it is not supported by older boto versions)
         if self.boto_profile:


### PR DESCRIPTION
##### SUMMARY
Simply causes credentials to be copied on each aws connection, otherwise ec2.py appears to try to assume an sts role again on a second connection. Some kind of connection re-use is probably a better solution. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2.py inventory script

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /Users/mathewhornbeek/src/ch/infrastructure-airflow/infrastructure-base/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

##### ADDITIONAL INFORMATION
Possible fix for #26366 , tested as working.