### PR TITLE
Adding stderr regex catch for iosxr commit failures

### DIFF
--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -137,6 +137,9 @@ def load_config(module, commands, warnings, commit=False, replace=False, comment
     else:
         cmd = 'abort'
         diff = None
-    exec_command(module, cmd)
+    rc, out, err = exec_command(module, cmd)
+    if rc != 0:
+        exec_command(module, 'abort')
+        module.fail_json(msg=err, commands=commands, rc=rc)
 
     return to_text(diff, errors='surrogate_or_strict')

--- a/lib/ansible/plugins/terminal/iosxr.py
+++ b/lib/ansible/plugins/terminal/iosxr.py
@@ -42,6 +42,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"connection timed out", re.I),
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
+        re.compile(br"Failed to commit", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
Also adding after executing commit command.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There wasn't a regex catch for the commit failure message on iosxr. Added it and found during testing there wasn't anything handling the rc=1 at the end of the module_util for iosxr which is where the commit command was being sent from.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (devel 28c6b226c7) last updated 2017/07/05 18:10:27 (GMT +000)
  config file = /home/jmighion/git/Ansible-Networking/ansible.cfg
  configured module search path = [u'/home/jmighion/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jmighion/git/ansible/lib/ansible
  executable location = /home/jmighion/git/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Valid syntax for config changes, but fails when commiting in a sample playbook : 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- name: dev
  hosts: all
  gather_facts: false
  connection: local
  tasks:
    - iosxr_config:
        provider: "{{ cli }}"
        lines:
          - router bgp 1
```
Running that would result in the error message from the device : 
```
% Failed to commit one or more configuration items during a pseudo-atomic operation. All changes made have been reverted. Please issue 'show configuration failed [inheritance]' from this session to view the errors
```
The module would report as changed, but it should've failed because the commit never happened. This PR fixes that so the module now fails with the message returned from the device.
