### PR TITLE
win_get_url: Replace skip_certificate_validation with validate_certs

### DIFF
--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -24,7 +24,8 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 
 $url = Get-AnsibleParam -obj $params -name "url" -type "str" -failifempty $true
 $dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true
-$skip_certificate_validation = Get-AnsibleParam -obj $params -name "skip_certificate_validation" -type "bool" -default $false
+$skip_certificate_validation = Get-AnsibleParam -obj $params -name "skip_certificate_validation" -type "bool"
+$validate_certs = Get-AnsibleParam -obj $params -name "validate_certs" -type "bool" -default $true
 $username = Get-AnsibleParam -obj $params -name "username" -type "str"
 $password = Get-AnsibleParam -obj $params -name "password" -type "str"
 $proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
@@ -40,7 +41,13 @@ $result = @{
     }
 }
 
-if($skip_certificate_validation){
+# If skip_certificate_validation was specified, use validate_certs
+if ($skip_certificate_validation -ne $null) {
+    Add-DeprecationWarning -obj $result -msg "The parameter 'skip_vertificate_validation' is being replaced with 'validate_certs'" -version 2.8
+    $validate_certs = -not $skip_certificate_validation
+}
+
+if (-not $validate_certs) {
     [System.Net.ServicePointManager]::ServerCertificateValidationCallback = {$true}
 }
 

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -25,7 +25,6 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
 
-
 DOCUMENTATION = r'''
 ---
 module: win_get_url
@@ -73,9 +72,19 @@ options:
     default: null
   skip_certificate_validation:
     description:
-      - Skip SSL certificate validation if true
-    required: false
-    default: false
+    - This option is deprecated since v2.4, please use C(validate_certs) instead.
+    - If C(yes), SSL certificates will not be validated. This should only be used
+      on personally controlled sites using self-signed certificates.
+    default: 'no'
+    type: bool
+  validate_certs:
+    description:
+    - If C(no), SSL certificates will not be validated. This should only be used
+      on personally controlled sites using self-signed certificates.
+    - If C(skip_certificate_validation) was set, it overrides this option.
+    default: 'yes'
+    type: bool
+    version_added: '2.4'
   proxy_url:
     description:
       - The full URL of the proxy server to download through.


### PR DESCRIPTION
##### SUMMARY
This is part of the effort to make win_get_url parameters conform to
other modules. The option `validate_certs` is the common option for
this.

See also #20160

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_get_url

##### ANSIBLE VERSION
v2.4