### PR TITLE
Do not escape backslashes when using the template lookup plugin

### DIFF
--- a/lib/ansible/plugins/lookup/template.py
+++ b/lib/ansible/plugins/lookup/template.py
@@ -68,7 +68,8 @@ class LookupModule(LookupBase):
                     self._templar.set_available_variables(temp_vars)
 
                     # do the templating
-                    res = self._templar.template(template_data, preserve_trailing_newlines=True, convert_data=convert_data_p)
+                    res = self._templar.template(template_data, preserve_trailing_newlines=True,
+                                                 convert_data=convert_data_p, escape_backslashes=False)
                     ret.append(res)
             else:
                 raise AnsibleError("the template file %s could not be found for the lookup" % term)


### PR DESCRIPTION
This brings the lookup plugin inline with what the template module does.

Fixes #26397

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/lookup/template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.3
```
