### PR TITLE
win_reboot: Use more conforming parameter names

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -15,30 +15,35 @@ description:
      - Reboot a Windows machine, wait for it to go down, come back up, and respond to commands.
 version_added: "2.1"
 options:
-  pre_reboot_delay_sec:
+  pre_reboot_delay:
     description:
     - Seconds for shutdown to wait before requesting reboot
     default: 2
-  post_reboot_delay_sec:
+    aliases: [ pre_reboot_delay_sec ]
+  post_reboot_delay:
     description:
     - Seconds to wait after the reboot was successful and the connection was re-established
     - This is useful if you want wait for something to settle despite your connection already working
     default: 0
     version_added: '2.4'
-  shutdown_timeout_sec:
+    aliases: [ post_reboot_delay_sec ]
+  shutdown_timeout:
     description:
     - Maximum seconds to wait for shutdown to occur
     - Increase this timeout for very slow hardware, large update applications, etc
     default: 600
-  reboot_timeout_sec:
+    aliases: [ shutdown_timeout_sec ]
+  reboot_timeout:
     description:
     - Maximum seconds to wait for machine to re-appear on the network and respond to a test command
     - This timeout is evaluated separately for both network appearance and test command success (so maximum clock time is actually twice this value)
     default: 600
-  connect_timeout_sec:
+    aliases: [ reboot_timeout_sec ]
+  connect_timeout:
     description:
     - Maximum seconds to wait for a single successful TCP connection to the WinRM endpoint before trying again
     default: 5
+    aliases: [ connect_timeout_sec ]
   test_command:
     description:
     - Command to expect success for to determine the machine is ready for management
@@ -65,16 +70,16 @@ EXAMPLES = r'''
 
 # Reboot a slow machine that might have lots of updates to apply
 - win_reboot:
-    shutdown_timeout_sec: 3600
-    reboot_timeout_sec: 3600
+    shutdown_timeout: 3600
+    reboot_timeout: 3600
 '''
 
 RETURN = r'''
 rebooted:
-    description: true if the machine was rebooted
-    returned: always
-    type: boolean
-    sample: true
+  description: true if the machine was rebooted
+  returned: always
+  type: boolean
+  sample: true
 elapsed:
   description: The number of seconds that elapsed waiting for the system to be rebooted.
   returned: always

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -25,16 +25,16 @@ class TimedOutException(Exception):
 class ActionModule(ActionBase):
     TRANSFERS_FILES = False
 
-    DEFAULT_SHUTDOWN_TIMEOUT_SEC = 600
-    DEFAULT_REBOOT_TIMEOUT_SEC = 600
-    DEFAULT_CONNECT_TIMEOUT_SEC = 5
-    DEFAULT_PRE_REBOOT_DELAY_SEC = 2
-    DEFAULT_POST_REBOOT_DELAY_SEC = 0
+    DEFAULT_SHUTDOWN_TIMEOUT = 600
+    DEFAULT_REBOOT_TIMEOUT = 600
+    DEFAULT_CONNECT_TIMEOUT = 5
+    DEFAULT_PRE_REBOOT_DELAY = 2
+    DEFAULT_POST_REBOOT_DELAY = 0
     DEFAULT_TEST_COMMAND = 'whoami'
     DEFAULT_REBOOT_MESSAGE = 'Reboot initiated by Ansible.'
 
-    def do_until_success_or_timeout(self, what, timeout_sec, what_desc, fail_sleep_sec=1):
-        max_end_time = datetime.utcnow() + timedelta(seconds=timeout_sec)
+    def do_until_success_or_timeout(self, what, timeout, what_desc, fail_sleep=1):
+        max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
         e = None
         while datetime.utcnow() < max_end_time:
@@ -45,8 +45,8 @@ class ActionModule(ActionBase):
                 return
             except Exception as e:
                 if what_desc:
-                    display.debug("win_reboot: %s fail (expected), retrying in %d seconds..." % (what_desc, fail_sleep_sec))
-                time.sleep(fail_sleep_sec)
+                    display.debug("win_reboot: %s fail (expected), retrying in %d seconds..." % (what_desc, fail_sleep))
+                time.sleep(fail_sleep)
 
         raise TimedOutException("timed out waiting for %s: %s" % (what_desc, e))
 
@@ -69,16 +69,37 @@ class ActionModule(ActionBase):
         winrm_host = self._connection._winrm_host
         winrm_port = self._connection._winrm_port
 
-        shutdown_timeout_sec = int(self._task.args.get('shutdown_timeout_sec', self.DEFAULT_SHUTDOWN_TIMEOUT_SEC))
-        reboot_timeout_sec = int(self._task.args.get('reboot_timeout_sec', self.DEFAULT_REBOOT_TIMEOUT_SEC))
-        connect_timeout_sec = int(self._task.args.get('connect_timeout_sec', self.DEFAULT_CONNECT_TIMEOUT_SEC))
-        pre_reboot_delay_sec = int(self._task.args.get('pre_reboot_delay_sec', self.DEFAULT_PRE_REBOOT_DELAY_SEC))
-        post_reboot_delay_sec = int(self._task.args.get('post_reboot_delay_sec', self.DEFAULT_POST_REBOOT_DELAY_SEC))
+        # Handle timeout parameters and its alias
+        if self._task.args.get('shutdown_timeout') is not None:
+            shutdown_timeout = int(self._task.args.get('shutdown_timeout', self.DEFAULT_SHUTDOWN_TIMEOUT))
+        else:
+            shutdown_timeout = int(self._task.args.get('shutdown_timeout_sec', self.DEFAULT_SHUTDOWN_TIMEOUT))
+
+        if self._task.args.get('reboot_timeout') is not None:
+            reboot_timeout = int(self._task.args.get('reboot_timeout', self.DEFAULT_REBOOT_TIMEOUT))
+        else:
+            reboot_timeout = int(self._task.args.get('reboot_timeout_sec', self.DEFAULT_REBOOT_TIMEOUT))
+
+        if self._task.args.get('connect_timeout') is not None:
+            connect_timeout = int(self._task.args.get('connect_timeout', self.DEFAULT_CONNECT_TIMEOUT))
+        else:
+            connect_timeout = int(self._task.args.get('connect_timeout_sec', self.DEFAULT_CONNECT_TIMEOUT))
+
+        if self._task.args.get('pre_reboot_delay') is not None:
+            pre_reboot_delay = int(self._task.args.get('pre_reboot_delay', self.DEFAULT_PRE_REBOOT_DELAY))
+        else:
+            pre_reboot_delay = int(self._task.args.get('pre_reboot_delay_sec', self.DEFAULT_PRE_REBOOT_DELAY))
+
+        if self._task.args.get('post_reboot_delay') is not None:
+            post_reboot_delay = int(self._task.args.get('post_reboot_delay', self.DEFAULT_POST_REBOOT_DELAY))
+        else:
+            post_reboot_delay = int(self._task.args.get('post_reboot_delay_sec', self.DEFAULT_POST_REBOOT_DELAY))
+
         test_command = str(self._task.args.get('test_command', self.DEFAULT_TEST_COMMAND))
         msg = str(self._task.args.get('msg', self.DEFAULT_REBOOT_MESSAGE))
 
         # Initiate reboot
-        (rc, stdout, stderr) = self._connection.exec_command('shutdown /r /t %d /c "%s"' % (pre_reboot_delay_sec, msg))
+        (rc, stdout, stderr) = self._connection.exec_command('shutdown /r /t %d /c "%s"' % (pre_reboot_delay, msg))
 
         # Test for "A system shutdown has already been scheduled. (1190)" and handle it gracefully
         if rc == 1190:
@@ -88,7 +109,7 @@ class ActionModule(ActionBase):
             (rc, stdout1, stderr1) = self._connection.exec_command('shutdown /a')
 
             # Initiate reboot again
-            (rc, stdout2, stderr2) = self._connection.exec_command('shutdown /r /t %d' % pre_reboot_delay_sec)
+            (rc, stdout2, stderr2) = self._connection.exec_command('shutdown /r /t %d' % pre_reboot_delay)
             stdout += stdout1 + stdout2
             stderr += stderr1 + stderr2
 
@@ -100,7 +121,7 @@ class ActionModule(ActionBase):
 
         def raise_if_port_open():
             try:
-                sock = socket.create_connection((winrm_host, winrm_port), connect_timeout_sec)
+                sock = socket.create_connection((winrm_host, winrm_port), connect_timeout)
                 sock.close()
             except:
                 return False
@@ -110,13 +131,13 @@ class ActionModule(ActionBase):
         start = datetime.now()
 
         try:
-            self.do_until_success_or_timeout(raise_if_port_open, shutdown_timeout_sec, what_desc="winrm port down")
+            self.do_until_success_or_timeout(raise_if_port_open, shutdown_timeout, what_desc="winrm port down")
 
             def connect_winrm_port():
-                sock = socket.create_connection((winrm_host, winrm_port), connect_timeout_sec)
+                sock = socket.create_connection((winrm_host, winrm_port), connect_timeout)
                 sock.close()
 
-            self.do_until_success_or_timeout(connect_winrm_port, reboot_timeout_sec, what_desc="winrm port up")
+            self.do_until_success_or_timeout(connect_winrm_port, reboot_timeout, what_desc="winrm port up")
 
             def run_test_command():
                 display.vvv("attempting post-reboot test command '%s'" % test_command)
@@ -134,7 +155,7 @@ class ActionModule(ActionBase):
             # FUTURE: ensure that a reboot has actually occurred by watching for change in last boot time fact
             # FUTURE: add a stability check (system must remain up for N seconds) to deal with self-multi-reboot updates
 
-            self.do_until_success_or_timeout(run_test_command, reboot_timeout_sec, what_desc="post-reboot test command success")
+            self.do_until_success_or_timeout(run_test_command, reboot_timeout, what_desc="post-reboot test command success")
 
             result['rebooted'] = True
             result['changed'] = True
@@ -144,9 +165,9 @@ class ActionModule(ActionBase):
             result['rebooted'] = True
             result['msg'] = toex.message
 
-        if post_reboot_delay_sec != 0:
-            display.vvv("win_reboot: waiting an additional %d seconds" % post_reboot_delay_sec)
-            time.sleep(post_reboot_delay_sec)
+        if post_reboot_delay != 0:
+            display.vvv("win_reboot: waiting an additional %d seconds" % post_reboot_delay)
+            time.sleep(post_reboot_delay)
 
         elapsed = datetime.now() - start
         result['elapsed'] = elapsed.seconds


### PR DESCRIPTION
##### SUMMARY
This is part of the effort to make windows parameters conform to
other modules. Usually parameters don't include the unit in the
parameter name.

See also #20160

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_reboot

##### ANSIBLE VERSION
v2.4