### PR TITLE
openwrt_init / opkg: clearly state that python is required

### DIFF
--- a/lib/ansible/modules/packaging/os/opkg.py
+++ b/lib/ansible/modules/packaging/os/opkg.py
@@ -66,6 +66,9 @@ options:
         default: "no"
         choices: [ "yes", "no" ]
 notes:  []
+requirements:
+    - opkg
+    - python
 '''
 EXAMPLES = '''
 - opkg:

--- a/lib/ansible/modules/system/openwrt_init.py
+++ b/lib/ansible/modules/system/openwrt_init.py
@@ -59,7 +59,7 @@ options:
 notes:
     - One option other than name is required.
 requirements:
-    - An OpenWrt system
+    - An OpenWrt system (with python)
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
As OpenWrt/LEDE does not provide python by default, clearly state that python is required

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
 - openwrt_init
 - opkg

##### ANSIBLE VERSION
latest

##### ADDITIONAL INFORMATION

