### PR TITLE
Fix expect timeout test.

### DIFF
--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -70,10 +70,10 @@
 
 - name: test timeout option
   expect:
-    command: "cat"
+    command: "sleep 10"
     responses:
       foo: bar
-    timeout: 0
+    timeout: 1
   ignore_errors: true
   register: timeout_result
 


### PR DESCRIPTION
##### SUMMARY

Fix expect timeout test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

expect integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-expect cfab594dad) last updated 2017/07/05 21:33:51 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
