### PR TITLE
ec2_scaling_policy boto3 rewrite for step scaling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_scaling_policy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_scaling_policy.py
@@ -18,7 +18,9 @@ description:
   - Can create or delete scaling policies for autoscaling groups
   - Referenced autoscaling groups must already exist
 version_added: "1.6"
-author: "Zacharie Eakin (@zeekin)"
+author:
+  - Zacharie Eakin (@zeekin)
+  - Will Thames (@willthames)
 options:
   state:
     description:
@@ -31,155 +33,327 @@ options:
     required: true
   asg_name:
     description:
-      - Name of the associated autoscaling group
-    required: true
+      - Name of the associated autoscaling group. Required if I(state) is C(present).
   adjustment_type:
     description:
-      - The type of change in capacity of the autoscaling group
-    required: false
-    choices: ['ChangeInCapacity','ExactCapacity','PercentChangeInCapacity']
+      - The type of change in capacity of the autoscaling group. Required if I(state) is C(present).
+    choices:
+      - ChangeInCapacity
+      - ExactCapacity
+      - PercentChangeInCapacity
   scaling_adjustment:
     description:
-      - The amount by which the autoscaling group is adjusted by the policy
-    required: false
+      - The amount by which the autoscaling group is adjusted by the policy.
+        A negative number scales the autoscaling group in. Units are numbers
+        of instances for C(ExactCapacity) or C(ChangeInCapacity) or percent
+        of existing instances for C(PercentChangeInCapacity).
+        Required when I(policy_type) is C(SimpleScaling).
   min_adjustment_step:
     description:
-      - Minimum amount of adjustment when policy is triggered
-    required: false
+      - Minimum amount of adjustment when policy is triggered. Used
+        only when I(adjustment_type) is C(PercentChangeInCapacity)
   cooldown:
     description:
-      - The minimum period of time between which autoscaling actions can take place
-    required: false
+      - The minimum period of time between which autoscaling actions can take place.
+        Used only when I(policy_type) is C(SimpleScaling).
+  policy_type:
+    description:
+      - Auto scaling adjustment policy
+    choices:
+      - StepScaling
+      - SimpleScaling
+    version_added: "2.7"
+    default: SimpleScaling
+  metric_aggregation:
+    description:
+      - The aggregation type for the CloudWatch metrics.
+      - For use when I(policy_type) is not C(SimpleScaling)
+    default: Average
+    choices:
+      - Minimum
+      - Maximum
+      - Average
+    version_added: "2.7"
+  step_adjustments:
+    description:
+      - list of dicts containing I(lower_bound), I(upper_bound) and I(scaling_adjustment)
+      - One item can not have a lower bound, and one item can not have an upper bound.
+      - Intervals must not overlap
+      - The bounds are the amount over the alarm threshold at which the adjustment will trigger.
+        This means that for an alarm threshold of 50, triggering at 75 requires a lower bound of 25.
+        See U(http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_StepAdjustment.html).
+    version_added: "2.7"
+  estimated_instance_warmup:
+    description:
+      - The estimated time, in seconds, until a newly launched instance can contribute to the CloudWatch metrics.
+    version_added: "2.7"
 extends_documentation_fragment:
     - aws
     - ec2
 """
 
 EXAMPLES = '''
-- ec2_scaling_policy:
+- name: Simple Scale Down policy
+  ec2_scaling_policy:
     state: present
     region: US-XXX
     name: "scaledown-policy"
     adjustment_type: "ChangeInCapacity"
-    asg_name: "slave-pool"
+    asg_name: "application-asg"
     scaling_adjustment: -1
     min_adjustment_step: 1
     cooldown: 300
+
+# For an alarm with a breach threshold of 20, the
+# following creates a stepped policy:
+# From 20-40 (0-20 above threshold), increase by 50% of existing capacity
+# From 41-infinity, increase by 100% of existing capacity
+- ec2_scaling_policy:
+    state: present
+    region: US-XXX
+    name: "step-scale-up-policy"
+    policy_type: StepScaling
+    metric_aggregation: Maximum
+    step_adjustments:
+      - upper_bound: 20
+        scaling_adjustment: 50
+      - lower_bound: 20
+        scaling_adjustment: 100
+    adjustment_type: "PercentChangeInCapacity"
+    asg_name: "application-asg"
 '''
 
-try:
-    import boto.ec2.autoscale
-    import boto.exception
-    from boto.ec2.autoscale import ScalingPolicy
-    from boto.exception import BotoServerError
-except ImportError:
-    pass  # Taken care of by ec2.HAS_BOTO
+RETURN = '''
+adjustment_type:
+  description: Scaling policy adjustment type
+  returned: always
+  type: string
+  sample: PercentChangeInCapacity
+alarms:
+  description: Cloudwatch alarms related to the policy
+  returned: always
+  type: complex
+  contains:
+    alarm_name:
+      description: name of the Cloudwatch alarm
+      returned: always
+      type: string
+      sample: cpu-very-high
+    alarm_arn:
+      description: ARN of the Cloudwatch alarm
+      returned: always
+      type: string
+      sample: arn:aws:cloudwatch:us-east-2:1234567890:alarm:cpu-very-high
+arn:
+  description: ARN of the scaling policy. Provided for backward compatibility, value is the same as I(policy_arn)
+  returned: always
+  type: string
+  sample: arn:aws:autoscaling:us-east-2:123456789012:scalingPolicy:59e37526-bd27-42cf-adca-5cd3d90bc3b9:autoScalingGroupName/app-asg:policyName/app-policy
+as_name:
+  description: Auto Scaling Group name. Provided for backward compatibility, value is the same as I(auto_scaling_group_name)
+  returned: always
+  type: string
+  sample: app-asg
+auto_scaling_group_name:
+  description: Name of Auto Scaling Group
+  returned: always
+  type: string
+  sample: app-asg
+metric_aggregation_type:
+  description: Method used to aggregate metrics
+  returned: when I(policy_type) is C(StepScaling)
+  type: string
+  sample: Maximum
+name:
+  description: Name of the scaling policy. Provided for backward compatibility, value is the same as I(policy_name)
+  returned: always
+  type: string
+  sample: app-policy
+policy_arn:
+  description: ARN of scaling policy.
+  returned: always
+  type: string
+  sample: arn:aws:autoscaling:us-east-2:123456789012:scalingPolicy:59e37526-bd27-42cf-adca-5cd3d90bc3b9:autoScalingGroupName/app-asg:policyName/app-policy
+policy_name:
+  description: Name of scaling policy
+  returned: always
+  type: string
+  sample: app-policy
+policy_type:
+  description: Type of auto scaling policy
+  returned: always
+  type: string
+  sample: StepScaling
+scaling_adjustment:
+  description: Adjustment to make when alarm is triggered
+  returned: When I(policy_type) is C(SimpleScaling)
+  type: int
+  sample: 1
+step_adjustments:
+  description: List of step adjustments
+  returned: always
+  type: complex
+  contains:
+    metric_interval_lower_bound:
+      description: Lower bound for metric interval
+      returned: if step has a lower bound
+      type: float
+      sample: 20.0
+    metric_interval_upper_bound:
+      description: Upper bound for metric interval
+      returned: if step has an upper bound
+      type: float
+      sample: 40.0
+    scaling_adjustment:
+      description: Adjustment to make if this step is reached
+      returned: always
+      type: int
+      sample: 50
+'''
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import (AnsibleAWSError, HAS_BOTO, connect_to_aws, ec2_argument_spec,
-                                      get_aws_connection_info)
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by imported AnsibleAWSModule
 
 
 def create_scaling_policy(connection, module):
-    sp_name = module.params.get('name')
-    adjustment_type = module.params.get('adjustment_type')
-    asg_name = module.params.get('asg_name')
-    scaling_adjustment = module.params.get('scaling_adjustment')
-    min_adjustment_step = module.params.get('min_adjustment_step')
-    cooldown = module.params.get('cooldown')
+    changed = False
+    asg_name = module.params['asg_name']
+    policy_type = module.params['policy_type']
+    policy_name = module.params['name']
 
-    scalingPolicies = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])
+    params = dict(PolicyName=policy_name,
+                  PolicyType=policy_type,
+                  AutoScalingGroupName=asg_name,
+                  AdjustmentType=module.params['adjustment_type'])
 
-    if not scalingPolicies:
-        sp = ScalingPolicy(
-            name=sp_name,
-            adjustment_type=adjustment_type,
-            as_name=asg_name,
-            scaling_adjustment=scaling_adjustment,
-            min_adjustment_step=min_adjustment_step,
-            cooldown=cooldown)
+    # min_adjustment_step attribute is only relevant if the adjustment_type
+    # is set to percentage change in capacity, so it is a special case
+    if module.params['adjustment_type'] == 'PercentChangeInCapacity':
+        if module.params['min_adjustment_step']:
+            params['MinAdjustmentMagnitude'] = module.params['min_adjustment_step']
 
-        try:
-            connection.create_scaling_policy(sp)
-            policy = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])[0]
-            module.exit_json(changed=True, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment,
-                             cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-        except BotoServerError as e:
-            module.fail_json(msg=str(e))
+    if policy_type == 'SimpleScaling':
+        # can't use required_if because it doesn't allow multiple criteria -
+        # it's only required if policy is SimpleScaling and state is present
+        if not module.params['scaling_adjustment']:
+            module.fail_json(msg='scaling_adjustment is required when policy_type is SimpleScaling '
+                             'and state is present')
+        params['ScalingAdjustment'] = module.params['scaling_adjustment']
+        if module.params['cooldown']:
+            params['Cooldown'] = module.params['cooldown']
+
+    if policy_type == 'StepScaling':
+        if not module.params['step_adjustments']:
+            module.fail_json(msg='step_adjustments is required when policy_type is StepScaling '
+                             'and state is present')
+        params['StepAdjustments'] = []
+        for step_adjustment in module.params['step_adjustments']:
+            step_adjust_params = dict(ScalingAdjustment=step_adjustment['scaling_adjustment'])
+            # Although empty bounds are allowed, not setting the 0 end of the bound seems
+            # to cause problems in the UI. We'll leave the +/- infinity end unset if not set
+            if not step_adjustment.get('lower_bound') and step_adjustment.get('upper_bound') > 0:
+                step_adjustment['lower_bound'] = 0
+            if step_adjustment.get('lower_bound'):
+                step_adjust_params['MetricIntervalLowerBound'] = step_adjustment['lower_bound']
+            if not step_adjustment.get('upper_bound') and step_adjustment.get('lower_bound') < 0:
+                step_adjustment['upper_bound'] = 0
+            if step_adjustment.get('upper_bound'):
+                step_adjust_params['MetricIntervalUpperBound'] = step_adjustment['upper_bound']
+            params['StepAdjustments'].append(step_adjust_params)
+        if module.params['metric_aggregation']:
+            params['MetricAggregationType'] = module.params['metric_aggregation']
+        if module.params['estimated_instance_warmup']:
+            params['EstimatedInstanceWarmup'] = module.params['estimated_instance_warmup']
+
+    try:
+        policies = connection.describe_policies(AutoScalingGroupName=asg_name,
+                                                PolicyNames=[policy_name])['ScalingPolicies']
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to obtain autoscaling policy %s" % policy_name)
+
+    before = after = {}
+    if not policies:
+        changed = True
     else:
-        policy = scalingPolicies[0]
-        changed = False
-
-        # min_adjustment_step attribute is only relevant if the adjustment_type
-        # is set to percentage change in capacity, so it is a special case
-        if getattr(policy, 'adjustment_type') == 'PercentChangeInCapacity':
-            if getattr(policy, 'min_adjustment_step') != module.params.get('min_adjustment_step'):
+        policy = policies[0]
+        for key in params:
+            if params[key] != policy.get(key):
                 changed = True
+                before[key] = params[key]
+                after[key] = policy.get(key)
 
-        # set the min adjustment step in case the user decided to change their
-        # adjustment type to percentage
-        setattr(policy, 'min_adjustment_step', module.params.get('min_adjustment_step'))
-
-        # check the remaining attributes
-        for attr in ('adjustment_type', 'scaling_adjustment', 'cooldown'):
-            if getattr(policy, attr) != module.params.get(attr):
-                changed = True
-                setattr(policy, attr, module.params.get(attr))
-
+    if changed:
         try:
-            if changed:
-                connection.create_scaling_policy(policy)
-                policy = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])[0]
-            module.exit_json(changed=changed, name=policy.name, arn=policy.policy_arn, as_name=policy.as_name, scaling_adjustment=policy.scaling_adjustment,
-                             cooldown=policy.cooldown, adjustment_type=policy.adjustment_type, min_adjustment_step=policy.min_adjustment_step)
-        except BotoServerError as e:
-            module.fail_json(msg=str(e))
+            connection.put_scaling_policy(**params)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to create autoscaling policy")
+        try:
+            policies = connection.describe_policies(AutoScalingGroupName=asg_name,
+                                                    PolicyNames=[policy_name])['ScalingPolicies']
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(msg="Failed to obtain autoscaling policy %s" % policy_name)
+
+    policy = camel_dict_to_snake_dict(policies[0])
+    # Backward compatible return values
+    policy['arn'] = policy['policy_arn']
+    policy['as_name'] = policy['auto_scaling_group_name']
+    policy['name'] = policy['policy_name']
+
+    if before and after:
+        module.exit_json(changed=changed, diff=dict(before=before, after=after), **policy)
+    else:
+        module.exit_json(changed=changed, **policy)
 
 
 def delete_scaling_policy(connection, module):
-    sp_name = module.params.get('name')
-    asg_name = module.params.get('asg_name')
+    policy_name = module.params.get('name')
 
-    scalingPolicies = connection.get_all_policies(as_group=asg_name, policy_names=[sp_name])
+    try:
+        policy = connection.describe_policies(PolicyNames=[policy_name])
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to obtain autoscaling policy %s" % policy_name)
 
-    if scalingPolicies:
+    if policy['ScalingPolicies']:
         try:
-            connection.delete_policy(sp_name, asg_name)
+            connection.delete_policy(AutoScalingGroupName=policy['ScalingPolicies'][0]['AutoScalingGroupName'],
+                                     PolicyName=policy_name)
             module.exit_json(changed=True)
-        except BotoServerError as e:
-            module.exit_json(changed=False, msg=str(e))
-    else:
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to delete autoscaling policy")
         module.exit_json(changed=False)
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            name=dict(required=True, type='str'),
-            adjustment_type=dict(type='str', choices=['ChangeInCapacity', 'ExactCapacity', 'PercentChangeInCapacity']),
-            asg_name=dict(required=True, type='str'),
-            scaling_adjustment=dict(type='int'),
-            min_adjustment_step=dict(type='int'),
-            cooldown=dict(type='int'),
-            state=dict(default='present', choices=['present', 'absent']),
-        )
+    step_adjustment_spec = dict(
+        lower_bound=dict(type='int'),
+        upper_bound=dict(type='int'),
+        scaling_adjustment=dict(type='int', required=True))
+
+    argument_spec = dict(
+        name=dict(required=True),
+        adjustment_type=dict(choices=['ChangeInCapacity', 'ExactCapacity', 'PercentChangeInCapacity']),
+        asg_name=dict(),
+        scaling_adjustment=dict(type='int'),
+        min_adjustment_step=dict(type='int'),
+        cooldown=dict(type='int'),
+        state=dict(default='present', choices=['present', 'absent']),
+        metric_aggregation=dict(default='Average', choices=['Minimum', 'Maximum', 'Average']),
+        policy_type=dict(default='SimpleScaling', choices=['SimpleScaling', 'StepScaling']),
+        step_adjustments=dict(type='list', options=step_adjustment_spec),
+        estimated_instance_warmup=dict(type='int')
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              required_if=[['state', 'present', ['asg_name', 'adjustment_type']]])
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
-
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    connection = module.client('autoscaling')
 
     state = module.params.get('state')
-
-    try:
-        connection = connect_to_aws(boto.ec2.autoscale, region, **aws_connect_params)
-    except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-        module.fail_json(msg=str(e))
-
     if state == 'present':
         create_scaling_policy(connection, module)
     elif state == 'absent':

--- a/test/integration/targets/ec2_scaling_policy/aliases
+++ b/test/integration/targets/ec2_scaling_policy/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+unsupported

--- a/test/integration/targets/ec2_scaling_policy/defaults/main.yml
+++ b/test/integration/targets/ec2_scaling_policy/defaults/main.yml
@@ -1,0 +1,6 @@
+scaling_policy_prefix: ansible_test_
+scaling_policy_lc_name: "{{ scaling_policy_prefix }}_lc"
+scaling_policy_asg_name: "{{ scaling_policy_prefix }}_asg"
+scaling_policy_image_id:
+  us-east-1: ami-1d4e7a66 # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170811
+  us-east-2: ami-dbbd9dbe # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20170811

--- a/test/integration/targets/ec2_scaling_policy/meta/main.yml
+++ b/test/integration/targets/ec2_scaling_policy/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/test/integration/targets/ec2_scaling_policy/tasks/main.yml
+++ b/test/integration/targets/ec2_scaling_policy/tasks/main.yml
@@ -1,0 +1,203 @@
+---
+# __Test Outline__
+#
+# __ec2_scaling_policy__
+# create simplescaling scaling policy
+# update simplescaling scaling policy
+# remove simplescaling scaling policy
+# create stepscaling scaling policy
+# update stepscaling scaling policy
+# remove stepscaling scaling policy
+
+- block:
+    - name: setup AWS connection info
+      set_fact:
+        aws_connection_info: &aws_connection_info
+          region: "{{ ec2_region }}"
+          ec2_access_key: "{{ ec2_access_key }}"
+          ec2_secret_key: "{{ ec2_secret_key }}"
+          security_token: "{{ security_token }}"
+      no_log: yes
+
+    - name: create trivial launch_configuration
+      ec2_lc:
+        name: "{{ scaling_policy_lc_name }}"
+        state: present
+        instance_type: t2.nano
+        image_id: "{{ scaling_policy_image_id[ec2_region] }}"
+        <<: *aws_connection_info
+
+    - name: create trivial ASG
+      ec2_asg:
+        name: "{{ scaling_policy_asg_name }}"
+        state: present
+        launch_config_name: "{{ scaling_policy_lc_name }}"
+        min_size: 1
+        max_size: 1
+        desired_capacity: 1
+        <<: *aws_connection_info
+
+    - name: Create Simple Scaling policy using implicit defaults
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: ChangeInCapacity
+        scaling_adjustment: 1
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ scaling_policy_prefix }}_simplescaling_policy"
+          - result.changed
+
+    - name: Update Simple Scaling policy using explicit defaults
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: ChangeInCapacity
+        scaling_adjustment: 1
+        policy_type: SimpleScaling
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ scaling_policy_prefix }}_simplescaling_policy"
+          - not result.changed
+
+    - name: min_adjustment_step is ignored with ChangeInCapacity
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: ChangeInCapacity
+        scaling_adjustment: 1
+        min_adjustment_step: 1
+        policy_type: SimpleScaling
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ scaling_policy_prefix }}_simplescaling_policy"
+          - not result.changed
+          - result.adjustment_type == "ChangeInCapacity"
+
+    - name: Change Simple Scaling policy adjustment_type to PercentChangeInCapacity
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        adjustment_type: PercentChangeInCapacity
+        scaling_adjustment: 1
+        min_adjustment_step: 1
+        policy_type: SimpleScaling
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ scaling_policy_prefix }}_simplescaling_policy"
+          - result.changed
+          - result.adjustment_type == "PercentChangeInCapacity"
+
+    - name: Remove Simple Scaling policy
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_simplescaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed
+
+    - name: Create Step Scaling policy
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        policy_type: StepScaling
+        metric_aggregation: Maximum
+        step_adjustments:
+        - upper_bound: 20
+          scaling_adjustment: 50
+        - lower_bound: 20
+          scaling_adjustment: 100
+        adjustment_type: "PercentChangeInCapacity"
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ scaling_policy_prefix }}_stepscaling_policy"
+          - result.changed
+
+    - name: Add another step
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: present
+        policy_type: StepScaling
+        metric_aggregation: Maximum
+        step_adjustments:
+        - upper_bound: 20
+          scaling_adjustment: 50
+        - lower_bound: 20
+          upper_bound: 40
+          scaling_adjustment: 75
+        - lower_bound: 40
+          scaling_adjustment: 100
+        adjustment_type: "PercentChangeInCapacity"
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.policy_name == "{{ scaling_policy_prefix }}_stepscaling_policy"
+          - result.changed
+          - result.adjustment_type == "PercentChangeInCapacity"
+
+    - name: Remove Step Scaling policy
+      ec2_scaling_policy:
+        name: "{{ scaling_policy_prefix }}_stepscaling_policy"
+        asg_name: "{{ scaling_policy_asg_name }}"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+
+    - assert:
+        that:
+          - result.changed
+
+  always:
+
+    # ============================================================
+    - name: remove the scaling policies
+      ec2_scaling_policy:
+        name: "{{ item }}"
+        state: absent
+        <<: *aws_connection_info
+      register: result
+      with_items:
+        - "{{ scaling_policy_prefix }}_simplescaling_policy"
+        - "{{ scaling_policy_prefix }}_stepscaling_policy"
+      ignore_errors: yes
+
+    - name: remove the ASG
+      ec2_asg:
+        name: "{{ scaling_policy_asg_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: remove the Launch Configuration
+      ec2_lc:
+        name: "{{ scaling_policy_lc_name }}"
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
Convert ec2_scaling_policy to boto3 and implement step scaling

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_scaling_policy

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel e612d0be12) last updated 2017/07/05 16:42:21 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Tests require IAM privileges to create LaunchConfigs, AutoScalingGroups and Scaling Polices