### PR TITLE
delete datetime object from RDS cluster responses in ec2.py

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -686,6 +686,8 @@ class Ec2Inventory(object):
                 del c['EarliestRestorableTime']
             if 'LatestRestorableTime' in c:
                 del c['LatestRestorableTime']
+            if 'ClusterCreateTime' in c:
+                del c['ClusterCreateTime']
 
             if self.ec2_instance_filters == {}:
                 matches_filter = True


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
this is to prevent TypeError: x is not JSON serializable when pulling down RDS cluster information

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
