### PR TITLE
Add vendor neutral parameter fail_on_missing_module

### DIFF
--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -67,12 +67,19 @@ class ActionModule(ActionBase):
         socket_path = self._start_connection(play_context)
         task_vars['ansible_socket'] = socket_path
 
+        if 'fail_on_missing_module' not in self._task.args:
+            self._task.args['fail_on_missing_module'] = False
+
         result = super(ActionModule, self).run(tmp, task_vars)
 
         module = self._get_implementation_module(play_context.network_os, self._task.action)
 
         if not module:
-            result['failed'] = True
+            if self._task.args['fail_on_missing_module']:
+                result['failed'] = True
+            else:
+                result['failed'] = False
+
             result['msg'] = ('Could not find implementation module %s for %s' %
                              (self._task.action, play_context.network_os))
         else:
@@ -82,6 +89,8 @@ class ActionModule(ActionBase):
             # already started
             if 'network_os' in new_module_args:
                 del new_module_args['network_os']
+
+            del new_module_args['fail_on_missing_module']
 
             display.vvvv('Running implementation module %s' % module)
             result.update(self._execute_module(module_name=module,


### PR DESCRIPTION
##### SUMMARY

By default, the vendor neutral modules will just go on if no
implementation module is found.
If user specifies the task argument fail_on_missing_module and
sets it to True, then we bail out the play early and report that
to the user.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/action/net_base

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.4.0 (add_fail_on_missing_module_logic 349fdb0d3e) last updated 2017/07/06 13:02:15 (GMT +200)

```
