### PR TITLE
refactor firewalld module with object abstraction

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -750,7 +750,10 @@ def main():
     )
 
     if import_failure:
-        module.fail_json(msg='firewalld and its python 2 module are required for this module, version 2.0.11 or newer required (3.0.9 or newer for offline operations) \n %s' % e)
+        module.fail_json(
+            msg='firewalld and its python 2 module are required for this module, version 2.0.11 or newer required (3.0.9 or newer for offline operations) \n %s'
+            % e
+        )
 
     if fw_offline:
         # Pre-run version checking

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -426,7 +426,6 @@ lib/ansible/modules/system/crypttab.py
 lib/ansible/modules/system/debconf.py
 lib/ansible/modules/system/facter.py
 lib/ansible/modules/system/filesystem.py
-lib/ansible/modules/system/firewalld.py
 lib/ansible/modules/system/gconftool2.py
 lib/ansible/modules/system/getent.py
 lib/ansible/modules/system/gluster_volume.py


### PR DESCRIPTION
##### SUMMARY
This change refactors the firewalld code and creates a FirewallTransaction object that each individual transaction type is a sub-class of as they all follow the same pattern to enable or disable something in the firewall.

Also, there's a few bugfixes here:
    - Fix the "source" type to handle permanent operations
    - Remove ambiguity of required parameters for only specific use
      cases that can lead to transactions effectively being a no-op.
      Instead, pick sane defaults and document them.
    - Change how imports are done so globals are no longer needed

This is based on the original feedback by Toshio from the last
refactor attempt:

    https://github.com/ansible/ansible-modules-extras/pull/3383

Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
firewalld

##### ANSIBLE VERSION
```
ansible 2.4.0 (oo-refactor-firewalld 8796b5271c) last updated 2017/07/06 09:24:19 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
```
BEFORE:
$ ansible net -m firewalld -a "service=https state=disabled permanent=true immediate=true" -i /tmp/inventory.txt
192.168.86.100 | SUCCESS => {
    "changed": false,
    "msg": "Permanent and Non-Permanent(immediate) operation"
}

AFTER:
$ ansible net -m firewalld -a "service=https state=disabled permanent=true immediate=true" -i /tmp/inventory.txt
192.168.86.100 | SUCCESS => {
    "changed": false,
    "failed": false,
    "msg": "Permanent and Non-Permanent(immediate) operation"
}

```
