### PR TITLE
powershell.ps1: Validate Windows paths

### DIFF
--- a/lib/ansible/module_utils/powershell.ps1
+++ b/lib/ansible/module_utils/powershell.ps1
@@ -205,6 +205,10 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
         if ($type -eq "path") {
             # Expand environment variables on path-type
             $value = Expand-Environment($value)
+            # Test if a valid path is provided
+            if (-not (Test-Path -IsValid $value)) {
+                Fail-Json -obj $resultobj -message "Get-AnsibleParam: Parameter '$name' has an invalid path '$value' specified."
+            }
         } elseif ($type -eq "str") {
             # Convert str types to real Powershell strings
             $value = $value.ToString()

--- a/lib/ansible/modules/windows/win_shortcut.ps1
+++ b/lib/ansible/modules/windows/win_shortcut.ps1
@@ -26,7 +26,7 @@ $ErrorActionPreference = "Stop"
 $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
-$src = Get-AnsibleParam -obj $params -name "src" -type "path"
+$src = Get-AnsibleParam -obj $params -name "src"
 $dest = Get-AnsibleParam -obj $params -name "dest" -type "path" -failifempty $true
 $state = Get-AnsibleParam -obj $params -name "state" -type "string" -default "present" -validateset "present","absent"
 $orig_args = Get-AnsibleParam -obj $params -name "args" -type "string"


### PR DESCRIPTION
##### SUMMARY
During the writing of Windows path integration tests we discovered that incorrect paths (including escape sequences) cause very cryptic error messages.

This fix ensures that invalid paths cause a proper error message.

The original output for **win_stat** looked like this:
```json
fatal: [computer61]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "An error occurred while creating the pipeline.\r\n    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException\r\n    + FullyQualifiedErrorId : RuntimeException\r\n \r\nException calling \"Run\" with \"1\" argument(s): \"Exception calling \"Invoke\" with \"0\" argument(s): \"The running command st\r\nopped because the preference variable \"ErrorActionPreference\" or common parameter is set to Stop: Ongeldige tekens in p\r\nad.\"\"\r\nAt line:47 char:5\r\n+     $output = $entrypoint.Run($payload)\r\n+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException\r\n    + FullyQualifiedErrorId : ScriptMethodRuntimeException\r\n \r\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1
}
```

After this small change, it looks like this:
```json
fatal: [computer61]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Get-AnsibleParam: Parameter 'path' has an invalid path 'C:\\Windows\temp' specified."
}
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
powershell.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4