### PR TITLE
New Module vmware_host_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2017, Wei Gao <gaowei3@qq.com>
+# Copyright: (c) 2017, Wei Gao <gaowei3@qq.com>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -18,37 +18,32 @@ DOCUMENTATION = '''
 module: vmware_host_facts
 short_description: Gathers facts about remote vmware host
 description:
-    - Gathers facts about remote vmware host
+    - Gathers facts about remote vmware host.
 version_added: 2.5
 author:
     - Wei Gao (@woshihaoren)
-notes:
-    - Tested on vSphere 5.5
 requirements:
-    - "python >= 2.6"
+    - python >= 2.6
     - PyVmomi
 extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
 - name: Gather vmware host facts
-  local_action:
-    module: vmware_host_facts
+  vmware_host_facts:
     hostname: esxi_ip_or_hostname
     username: username
     password: password
+  register: host_facts
+  delegate_to: localhost
 '''
 
 RETURN = '''
 instance:
-    description: system info about the host machine
-    returned: always
-    type: dict
-    sample: None
 '''
 
+from ansible.module_utils.basic import AnsibleModule, bytes_to_human
 from ansible.module_utils.vmware import connect_to_api, vmware_argument_spec, find_obj
-from ansible.module_utils.basic import AnsibleModule
 
 try:
     from pyVmomi import vim, vmodl
@@ -62,7 +57,7 @@ def get_cpu_facts(host):
         'ansible_processor': host.summary.hardware.cpuModel,
         'ansible_processor_cores': host.summary.hardware.numCpuCores,
         'ansible_processor_count': host.summary.hardware.numCpuPkgs,
-        'ansible_processor_vcpus': host.summary.hardware.numCpuThreads
+        'ansible_processor_vcpus': host.summary.hardware.numCpuThreads,
     }
     return facts
 
@@ -81,8 +76,8 @@ def get_datastore_facts(host):
     for store in host.datastore:
         _tmp = {
             'name': store.summary.name,
-            'total': sizeof_fmt(store.summary.capacity),
-            'free': sizeof_fmt(store.summary.freeSpace)
+            'total': bytes_to_human(store.summary.capacity),
+            'free': bytes_to_human(store.summary.freeSpace),
         }
         facts['ansible_datastore'].append(_tmp)
     return facts
@@ -100,10 +95,10 @@ def get_network_facts(host):
             'device': device,
             'ipv4': {
                 'address': nic.spec.ip.ipAddress,
-                'netmask': nic.spec.ip.subnetMask
+                'netmask': nic.spec.ip.subnetMask,
             },
             'macaddress': nic.spec.mac,
-            'mtu': nic.spec.mtu
+            'mtu': nic.spec.mtu,
         }
         facts['ansible_' + device] = _tmp
     return facts
@@ -124,23 +119,9 @@ def get_system_facts(host):
         'ansible_product_name': host.hardware.systemInfo.model,
         'ansible_product_serial': sn,
         'ansible_bios_date': host.hardware.biosInfo.releaseDate,
-        'ansible_bios_version': host.hardware.biosInfo.biosVersion
+        'ansible_bios_version': host.hardware.biosInfo.biosVersion,
     }
     return facts
-
-
-def sizeof_fmt(num):
-    """
-    Returns the human readable version of a file size
-
-    :param num:
-    :return:
-    """
-    for item in ['bytes', 'KB', 'MB', 'GB']:
-        if num < 1024.0:
-            return "%3.1f%s" % (num, item)
-        num /= 1024.0
-    return "%3.1f%s" % (num, 'TB')
 
 
 def all_facts(content):
@@ -162,16 +143,9 @@ def main():
     if not HAS_PYVMOMI:
         module.fail_json(msg='pyvmomi is required for this module')
 
-    try:
-        content = connect_to_api(module)
-        data = all_facts(content)
-        module.exit_json(changed=False, ansible_facts=data)
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        module.fail_json(msg=method_fault.msg)
-    except Exception as e:
-        module.fail_json(msg=str(e))
+    content = connect_to_api(module)
+    data = all_facts(content)
+    module.exit_json(changed=False, ansible_facts=data)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -3,25 +3,12 @@
 
 # (c) 2017, Wei Gao <gaowei3@qq.com>
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -32,7 +19,7 @@ module: vmware_host_facts
 short_description: Gathers facts about remote vmware host
 description:
     - Gathers facts about remote vmware host
-version_added: 2.4
+version_added: 2.5
 author:
     - Wei Gao (@woshihaoren)
 notes:

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -39,7 +39,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-instance:
+ansible_facts:
   description: system info about the host machine
   returned: always
   type: dict

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -40,6 +40,9 @@ EXAMPLES = '''
 
 RETURN = '''
 instance:
+  description: system info about the host machine
+  returned: always
+  type: dict
 '''
 
 from ansible.module_utils.basic import AnsibleModule, bytes_to_human

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -109,8 +109,8 @@ def get_network_facts(host):
         _tmp = {
             'device': device,
             'ipv4': {
-                 'address': nic.spec.ip.ipAddress,
-                 'netmask': nic.spec.ip.subnetMask
+                'address': nic.spec.ip.ipAddress,
+                'netmask': nic.spec.ip.subnetMask
             },
             'macaddress': nic.spec.mac,
             'mtu': nic.spec.mtu

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -109,12 +109,17 @@ def get_network_facts(host):
 
 
 def get_system_facts(host):
+    sn = 'NA'
+    for info in host.hardware.systemInfo.otherIdentifyingInfo:
+        if info.identifierType.key == 'ServiceTag':
+            sn = info.identifierValue
     facts = {
-        'ansible_distribution': host.config.product.name, 
-        'ansible_distribution_version': host.config.product.version, 
-        'ansible_os_type': host.config.product.osType, 
+        'ansible_distribution': host.config.product.name,
+        'ansible_distribution_version': host.config.product.version,
+        'ansible_os_type': host.config.product.osType,
         'ansible_system_vendor': host.hardware.systemInfo.vendor,
         'ansible_system_model': host.hardware.systemInfo.model,
+        'ansible_product_serial': sn,
         'ansible_bios_date': host.hardware.biosInfo.releaseDate,
         'ansible_bios_version': host.hardware.biosInfo.biosVersion
     }

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -64,7 +64,7 @@ def get_cpu_facts(host):
         'ansible_processor_vcpus': host.summary.hardware.numCpuThreads
     }
     return facts
-    
+
 
 def get_memory_facts(host):
     facts = {
@@ -80,8 +80,8 @@ def get_datastore_facts(host):
     for store in host.datastore:
         _tmp = {
             'name': store.summary.name,
-            'total': store.summary.capacity,
-            'free': store.summary.freeSpace
+            'total': sizeof_fmt(store.summary.capacity),
+            'free': sizeof_fmt(store.summary.freeSpace)
         }
         facts['ansible_datastore'].append(_tmp)
     return facts
@@ -119,6 +119,20 @@ def get_system_facts(host):
         'ansible_bios_version': host.hardware.biosInfo.biosVersion
     }
     return facts
+
+
+def sizeof_fmt(num):
+    """
+    Returns the human readable version of a file size
+
+    :param num:
+    :return:
+    """
+    for item in ['bytes', 'KB', 'MB', 'GB']:
+        if num < 1024.0:
+            return "%3.1f%s" % (num, item)
+        num /= 1024.0
+    return "%3.1f%s" % (num, 'TB')
 
 
 def get_obj(content, vimtype, name=None):

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -57,7 +57,7 @@ instance:
     sample: None
 '''
 
-from ansible.module_utils.vmware import connect_to_api, vmware_argument_spec
+from ansible.module_utils.vmware import connect_to_api, vmware_argument_spec, find_obj
 from ansible.module_utils.basic import AnsibleModule
 
 try:
@@ -151,29 +151,8 @@ def sizeof_fmt(num):
     return "%3.1f%s" % (num, 'TB')
 
 
-def get_obj(content, vimtype, name=None):
-    """
-    Return an object by name, if name is None the
-    first found object is returned
-    """
-    obj = None
-    container = content.viewManager.CreateContainerView(
-        content.rootFolder, vimtype, True)
-    for c in container.view:
-        if name:
-            if c.name == name:
-                obj = c
-                break
-        else:
-            obj = c
-            break
-
-    container.Destroy()
-    return obj
-
-
 def all_facts(content):
-    host = get_obj(content, [vim.HostSystem])
+    host = find_obj(content, [vim.HostSystem], None)
     ansible_facts = {}
     ansible_facts.update(get_cpu_facts(host))
     ansible_facts.update(get_memory_facts(host))

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -127,9 +127,11 @@ def get_system_facts(host):
     facts = {
         'ansible_distribution': host.config.product.name,
         'ansible_distribution_version': host.config.product.version,
+        'ansible_distribution_build': host.config.product.build,
         'ansible_os_type': host.config.product.osType,
         'ansible_system_vendor': host.hardware.systemInfo.vendor,
-        'ansible_system_model': host.hardware.systemInfo.model,
+        'ansible_hostname': host.summary.config.name,
+        'ansible_product_name': host.hardware.systemInfo.model,
         'ansible_product_serial': sn,
         'ansible_bios_date': host.hardware.biosInfo.releaseDate,
         'ansible_bios_version': host.hardware.biosInfo.biosVersion

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -1,0 +1,180 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Wei Gao <gaowei3@qq.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: vmware_host_facts
+short_description: Gathers facts about remote vmware host
+description:
+    - Gathers facts about remote vmware host
+version_added: 2.4
+author:
+    - Wei Gao
+notes:
+    - Tested on vSphere 5.5
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = '''
+- name: Gather vmware host facts
+  local_action:
+    module: vmware_host_facts
+    hostname: esxi_ip_or_hostname
+    username: username
+    password: password
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+def get_cpu_facts(host):
+    facts = {
+        'ansible_processor': host.summary.hardware.cpuModel, 
+        'ansible_processor_cores': host.summary.hardware.numCpuCores, 
+        'ansible_processor_count': host.summary.hardware.numCpuPkgs, 
+        'ansible_processor_vcpus': host.summary.hardware.numCpuThreads
+    }
+    return facts
+    
+
+def get_memory_facts(host):
+    facts = {
+        'ansible_memfree_mb': host.hardware.memorySize // 1024 // 1024 - host.summary.quickStats.overallMemoryUsage, 
+        'ansible_memtotal_mb': host.hardware.memorySize // 1024 // 1024, 
+    }
+    return facts
+
+
+def get_datastore_facts(host):
+    facts = {}
+    facts['ansible_datastore'] = []
+    for store in host.datastore:
+        _tmp = {
+            'name': store.summary.name,
+            'total': store.summary.capacity,
+            'free': store.summary.freeSpace
+        }
+        facts['ansible_datastore'].append(_tmp)
+    return facts
+
+
+def get_network_facts(host):
+    facts = {}
+    facts['ansible_interfaces'] = []
+    facts['ansible_all_ipv4_addresses'] = []
+    for nic in host.config.network.vnic:
+        device = nic.device
+        facts['ansible_interfaces'].append(device)
+        facts['ansible_all_ipv4_addresses'].append(nic.spec.ip.ipAddress)
+        _tmp = {
+            'device': device,
+            'ipv4': {
+                 'address': nic.spec.ip.ipAddress,
+                 'netmask': nic.spec.ip.subnetMask
+             },
+            'macaddress': nic.spec.mac,
+            'mtu': nic.spec.mtu
+        }
+        facts['ansible_' + device] = _tmp
+    return facts
+
+
+def get_system_facts(host):
+    facts = {
+        'ansible_distribution': host.config.product.name, 
+        'ansible_distribution_version': host.config.product.version, 
+        'ansible_os_type': host.config.product.osType, 
+        'ansible_system_vendor': host.hardware.systemInfo.vendor,
+        'ansible_system_model': host.hardware.systemInfo.model,
+        'ansible_bios_date': host.hardware.biosInfo.releaseDate,
+        'ansible_bios_version': host.hardware.biosInfo.biosVersion
+    }
+    return facts
+
+
+def get_obj(content, vimtype, name=None):
+    """
+    Return an object by name, if name is None the
+    first found object is returned
+    """
+    obj = None
+    container = content.viewManager.CreateContainerView(
+        content.rootFolder, vimtype, True)
+    for c in container.view:
+        if name:
+            if c.name == name:
+                obj = c
+                break
+        else:
+            obj = c
+            break
+
+    container.Destroy()
+    return obj
+
+
+def all_facts(content):
+    host = get_obj(content, [vim.HostSystem])
+    ansible_facts = {}
+    ansible_facts.update(get_cpu_facts(host))
+    ansible_facts.update(get_memory_facts(host))
+    ansible_facts.update(get_datastore_facts(host))
+    ansible_facts.update(get_network_facts(host))
+    ansible_facts.update(get_system_facts(host))
+    return ansible_facts
+
+
+def main():
+
+    argument_spec = vmware_argument_spec()
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    if not HAS_PYVMOMI:
+        module.fail_json(msg='pyvmomi is required for this module')
+
+    try:
+        content = connect_to_api(module)
+        data = all_facts(content)
+        module.exit_json(changed=False, ansible_facts=data)
+    except vmodl.RuntimeFault as runtime_fault:
+        module.fail_json(msg=runtime_fault.msg)
+    except vmodl.MethodFault as method_fault:
+        module.fail_json(msg=method_fault.msg)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+from ansible.module_utils.vmware import *
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()
+

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -29,7 +29,7 @@ module: vmware_host_facts
 short_description: Gathers facts about remote vmware host
 description:
     - Gathers facts about remote vmware host
-version_added: 2.4
+version_added: 2.3
 author:
     - Wei Gao
 notes:
@@ -177,4 +177,3 @@ from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -29,9 +29,9 @@ module: vmware_host_facts
 short_description: Gathers facts about remote vmware host
 description:
     - Gathers facts about remote vmware host
-version_added: 2.3
+version_added: 2.4
 author:
-    - Wei Gao
+    - Wei Gao (@woshihaoren)
 notes:
     - Tested on vSphere 5.5
 requirements:
@@ -49,6 +49,17 @@ EXAMPLES = '''
     password: password
 '''
 
+RETURN = '''
+instance:
+    description: system info about the host machine
+    returned: always
+    type: dict
+    sample: None
+'''
+
+from ansible.module_utils.vmware import connect_to_api, vmware_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
 try:
     from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True
@@ -58,9 +69,9 @@ except ImportError:
 
 def get_cpu_facts(host):
     facts = {
-        'ansible_processor': host.summary.hardware.cpuModel, 
-        'ansible_processor_cores': host.summary.hardware.numCpuCores, 
-        'ansible_processor_count': host.summary.hardware.numCpuPkgs, 
+        'ansible_processor': host.summary.hardware.cpuModel,
+        'ansible_processor_cores': host.summary.hardware.numCpuCores,
+        'ansible_processor_count': host.summary.hardware.numCpuPkgs,
         'ansible_processor_vcpus': host.summary.hardware.numCpuThreads
     }
     return facts
@@ -68,8 +79,8 @@ def get_cpu_facts(host):
 
 def get_memory_facts(host):
     facts = {
-        'ansible_memfree_mb': host.hardware.memorySize // 1024 // 1024 - host.summary.quickStats.overallMemoryUsage, 
-        'ansible_memtotal_mb': host.hardware.memorySize // 1024 // 1024, 
+        'ansible_memfree_mb': host.hardware.memorySize // 1024 // 1024 - host.summary.quickStats.overallMemoryUsage,
+        'ansible_memtotal_mb': host.hardware.memorySize // 1024 // 1024,
     }
     return facts
 
@@ -100,7 +111,7 @@ def get_network_facts(host):
             'ipv4': {
                  'address': nic.spec.ip.ipAddress,
                  'netmask': nic.spec.ip.subnetMask
-             },
+            },
             'macaddress': nic.spec.mac,
             'mtu': nic.spec.mtu
         }
@@ -191,8 +202,6 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e))
 
-from ansible.module_utils.vmware import *
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_host_facts.py
@@ -18,6 +18,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -68,12 +68,17 @@ def get_all_virtual_machines(content):
             _ip_address = summary.guest.ipAddress
             if _ip_address is None:
                 _ip_address = ""
+        _mac_address = []
+        for dev in vm.config.hardware.device:
+            if isinstance(dev, vim.vm.device.VirtualEthernetCard):
+                _mac_address.append(dev.macAddress)
 
         virtual_machine = {
             summary.config.name: {
                 "guest_fullname": summary.config.guestFullName,
                 "power_state": summary.runtime.powerState,
                 "ip_address": _ip_address,
+                "mac_address": _mac_address,
                 "uuid": summary.config.uuid
             }
         }

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -68,17 +68,12 @@ def get_all_virtual_machines(content):
             _ip_address = summary.guest.ipAddress
             if _ip_address is None:
                 _ip_address = ""
-        _mac_address = []
-        for dev in vm.config.hardware.device:
-            if isinstance(dev, vim.vm.device.VirtualEthernetCard):
-                _mac_address.append(dev.macAddress)
 
         virtual_machine = {
             summary.config.name: {
                 "guest_fullname": summary.config.guestFullName,
                 "power_state": summary.runtime.powerState,
                 "ip_address": _ip_address,
-                "mac_address": _mac_address,
                 "uuid": summary.config.uuid
             }
         }

--- a/test/integration/targets/vmware_host_facts/aliases
+++ b/test/integration/targets/vmware_host_facts/aliases
@@ -1,0 +1,3 @@
+posix/ci/cloud/vcenter
+cloud/vcenter
+

--- a/test/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_facts/tasks/main.yml
@@ -1,0 +1,27 @@
+- name: make sure pyvmomi is installed
+  pip:
+    name: pyvmomi
+    state: latest
+
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- debug: var=vcsim
+
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?cluster=2' }}"
+  register: vcsim_instance
+
+- name: get host facts
+  vmware_host_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+  register: facts
+
+- debug: var=facts

--- a/test/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_facts/tasks/main.yml
@@ -25,3 +25,15 @@
   register: facts
 
 - debug: var=facts
+
+- name: get host info
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_host_info' }}"
+  register: host_info_result
+
+- name: verify some data,for example: ansible_processor
+  assert:
+    that:
+      - facts['ansible_facts']['ansible_hostname'] in host_info_result['json']
+      - facts['ansible_facts']['ansible_processor'] == host_info_result['json'][facts['ansible_facts']['ansible_hostname']]['Processor type']
+

--- a/test/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_host_facts/tasks/main.yml
@@ -31,9 +31,8 @@
     url: "{{ 'http://' + vcsim + ':5000/govc_host_info' }}"
   register: host_info_result
 
-- name: verify some data,for example: ansible_processor
+- name: verify some data,like ansible_processor
   assert:
     that:
       - facts['ansible_facts']['ansible_hostname'] in host_info_result['json']
       - facts['ansible_facts']['ansible_processor'] == host_info_result['json'][facts['ansible_facts']['ansible_hostname']]['Processor type']
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This module can get remote vmware host system info like setup module
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_host_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Sep  1 2016, 15:44:32) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
127.0.0.1 | SUCCESS => {
    "ansible_facts": {
        "ansible_all_ipv4_addresses": [
            "10.255.22.105"
        ],
        "ansible_bios_date": "2014-07-09T00:00:00+00:00",
        "ansible_bios_version": "2.4.3",
        "ansible_datastore": [
            {
                "free": "1.1TB",
                "name": "datastore-22.105",
                "total": "5.4TB"
            }
        ],
        "ansible_distribution": "VMware ESXi",
        "ansible_distribution_build": "1331820",
        "ansible_distribution_version": "5.5.0",
        "ansible_hostname": "VM-111",
        "ansible_interfaces": [
            "vmk0"
        ],
        "ansible_memfree_mb": 4261,
        "ansible_memtotal_mb": 65490,
        "ansible_os_type": "vmnix-x86",
        "ansible_processor": "Intel(R) Xeon(R) CPU E5-2630 v2 @ 2.60GHz",
        "ansible_processor_cores": 12,
        "ansible_processor_count": 2,
        "ansible_processor_vcpus": 24,
        "ansible_product_serial": "74M4Z41",
        "ansible_product_name": "PowerEdge R720",
        "ansible_system_vendor": "Dell Inc.",
        "ansible_vmk0": {
            "device": "vmk0",
            "ipv4": {
                "address": "10.255.22.105",
                "netmask": "255.255.255.0"
            },
            "macaddress": "b0:83:fe:e6:f4:1d",
            "mtu": 1500
        }
    },
    "changed": false,
    "invocation": {
        "module_args": {
            "hostname": "10.255.22.105",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "root",
            "validate_certs": false
        }
    }
}

```
