### PR TITLE
Improve handling of network test changes.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -352,6 +352,9 @@ class PathMapper(object):
             }
 
         if path.startswith('test/integration/'):
+            if self.prefixes.get(name) == 'network' and ext == '.yaml':
+                return minimal  # network integration test playbooks are not used by ansible-test
+
             return {
                 'integration': 'all',
                 'windows-integration': 'all',


### PR DESCRIPTION
##### SUMMARY

The network integration test playbooks `test/integration/{network-prefix}.yaml` are not used by ansible-test. They should be ignored for purposes of running integration tests via ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
nsible 2.4.0 (at-network a6652982be) last updated 2017/07/06 11:34:36 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
