### PR TITLE
Fix docker ce install for opensuse.

### DIFF
--- a/test/integration/targets/docker_secret/aliases
+++ b/test/integration/targets/docker_secret/aliases
@@ -1,2 +1,3 @@
+posix/ci/group2
 skip/osx
 skip/freebsd

--- a/test/integration/targets/docker_secret/tasks/OpenSuse.yml
+++ b/test/integration/targets/docker_secret/tasks/OpenSuse.yml
@@ -5,7 +5,7 @@
 
 - name: Install docker 17
   zypper:
-    name: docker-17.04.0_ce-203.6.x86_64
+    name: docker-17.04.0_ce
     force: yes
     disable_gpg_check: yes
     update_cache: yes


### PR DESCRIPTION
##### SUMMARY

Fix docker ce install for opensuse.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_secret integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-docker_secret 77a03dd7be) last updated 2017/07/06 12:52:00 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
