### PR TITLE
added option to ansible-test to run test playbooks using the debug strategy

### DIFF
--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, print_function
 import os
 
 from lib.util import common_environment
-
+from lib.config import IntegrationConfig
 
 def ansible_environment(args, color=True):
     """
@@ -35,5 +35,9 @@ def ansible_environment(args, color=True):
 
     if args.debug:
         env.update(dict(ANSIBLE_DEBUG='true'))
+
+    if isinstance(args, IntegrationConfig):
+        if args.debug_strategy:
+            env.update(dict(ANSIBLE_STRATEGY='debug'))
 
     return env

--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -7,6 +7,7 @@ import os
 from lib.util import common_environment
 from lib.config import IntegrationConfig
 
+
 def ansible_environment(args, color=True):
     """
     :type args: CommonConfig

--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import, print_function
 import os
 
 from lib.util import common_environment
-from lib.config import IntegrationConfig
 
 
 def ansible_environment(args, color=True):
@@ -36,9 +35,5 @@ def ansible_environment(args, color=True):
 
     if args.debug:
         env.update(dict(ANSIBLE_DEBUG='true'))
-
-    if isinstance(args, IntegrationConfig):
-        if args.debug_strategy:
-            env.update(dict(ANSIBLE_STRATEGY='debug'))
 
     return env

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -140,6 +140,7 @@ class IntegrationConfig(TestConfig):
         self.start_at_task = args.start_at_task  # type: str
         self.allow_destructive = args.allow_destructive if 'allow_destructive' in args else False  # type: bool
         self.retry_on_error = args.retry_on_error  # type: bool
+        self.debug_strategy = args.debug_strategy  # type: bool
         self.tags = args.tags
         self.skip_tags = args.skip_tags
         self.diff = args.diff

--- a/test/runner/lib/delegation.py
+++ b/test/runner/lib/delegation.py
@@ -183,7 +183,7 @@ def delegate_docker(args, exclude, require):
 
     cmd_options = []
 
-    if isinstance(args, ShellConfig):
+    if isinstance(args, ShellConfig) or (isinstance(args, IntegrationConfig) and args.debug_strategy):
         cmd_options.append('-it')
 
     with tempfile.NamedTemporaryFile(prefix='ansible-source-', suffix='.tgz') as local_source_fd:

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -595,6 +595,9 @@ def integration_environment(args, target, cmd):
         ANSIBLE_CALLBACK_WHITELIST='junit',
     )
 
+    if args.debug_strategy:
+        env.update(dict(ANSIBLE_STRATEGY='debug'))
+
     env.update(integration)
 
     cloud_environment = get_cloud_environment(args, target)

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -216,6 +216,10 @@ def parse_args():
                              action='store_true',
                              help='retry failed test with increased verbosity')
 
+    integration.add_argument('--debug-strategy',
+                             action='store_true',
+                             help='run test playbooks using the debug strategy')
+
     subparsers = parser.add_subparsers(metavar='COMMAND')
     subparsers.required = True  # work-around for python 3 bug which makes subparsers optional
 


### PR DESCRIPTION
Allows for easier debugging of integration tests. 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (debug-strategy 29b83225db) last updated 2017/07/06 16:00:19 (GMT -400)
  config file = None
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
