### PR TITLE
Fixes #20196 broken pipe when special chars in mysql password

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -137,7 +137,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
         cmd += " --user=%s" % pipes.quote(user)
     if password is not None:
         # do not quote password to avoid passing quotes to mysql auth
-        cmd += " --password=%s" % pipes.quote(password)
+        cmd += " --password=%s" % password
     if ssl_cert is not None:
         cmd += " --ssl-cert=%s" % pipes.quote(ssl_cert)
     if ssl_key is not None:

--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -136,6 +136,7 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
     if user is not None:
         cmd += " --user=%s" % pipes.quote(user)
     if password is not None:
+        # do not quote password to avoid passing quotes to mysql auth
         cmd += " --password=%s" % pipes.quote(password)
     if ssl_cert is not None:
         cmd += " --ssl-cert=%s" % pipes.quote(ssl_cert)
@@ -187,7 +188,8 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
     if user:
         cmd.append("--user=%s" % pipes.quote(user))
     if password:
-        cmd.append("--password=%s" % pipes.quote(password))
+        # do not quote password to avoid passing quotes to mysql auth
+        cmd.append("--password=%s" % password)
     if ssl_cert is not None:
         cmd.append("--ssl-cert=%s" % pipes.quote(ssl_cert))
     if ssl_key is not None:
@@ -217,7 +219,7 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         (stdout2, stderr2) = p2.communicate()
         p1.stdout.close()
         p1.wait()
-        if p1.returncode != 0:
+        if p1.returncode != 0 and p2.returncode == 0:
             stderr1 = p1.stderr.read()
             return p1.returncode, '', stderr1
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When mysql passwords that include special characters are passed to the mysqldump/mysql binaries, ansible's mysql_db is attempting to quote the password using pipes.quote(). This causes passwords with special characters to be surrounded in single quotes, which are interpreted mysql as part of the password, causing access denied errors.

Specifically: mysql_db was running `cmd = ['mysql',"--password='test1234!'"....]` instead of `cmd = ['mysql','--password=test1234!',...]` (note the extra quotes around the former.)

In an effort to improve the misleading and hard to debug 'broken pipe' errors as well, only returning p1.returncode/p1.stderr1 when _only_ the compression program is in error (for example, target not found, out of memory, etc.). All other cases will return the mysql command's error code and message.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module/database/mysql/mysql_db.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Steps to reproduce error in devel branch: 

Try to import any compressed database file with login_password='test1234!'. The current 2.4.0.0.devel branch should fail with broken pipe. This branch should succeed. Non compressed targets would also fail with access denied errors, even though the password was indeed correct.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
