### PR TITLE
Adds missing fields for iapp service

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_iapp_service.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_service.py
@@ -159,7 +159,8 @@ from deepdiff import DeepDiff
 class Parameters(AnsibleF5Parameters):
     returnables = []
     api_attributes = [
-        'tables', 'variables', 'template', 'lists'
+        'tables', 'variables', 'template', 'lists', 'deviceGroup',
+        'inheritedDevicegroup', 'inheritedTrafficGroup', 'trafficGroup'
     ]
     updatables = ['tables', 'variables', 'lists']
 
@@ -282,6 +283,14 @@ class Parameters(AnsibleF5Parameters):
             self.variables = value['variables']
         if 'lists' in value:
             self.lists = value['lists']
+        if 'deviceGroup' in value:
+            self.deviceGroup = value['deviceGroup']
+        if 'inheritedDevicegroup' in value:
+            self.inheritedDevicegroup = value['inheritedDevicegroup']
+        if 'inheritedTrafficGroup' in value:
+            self.inheritedTrafficGroup = value['inheritedTrafficGroup']
+        if 'trafficGroup' in value:
+            self.trafficGroup = value['trafficGroup']
 
     @property
     def template(self):

--- a/test/units/modules/network/f5/fixtures/create_iapp_service_parameters_f5_http.json
+++ b/test/units/modules/network/f5/fixtures/create_iapp_service_parameters_f5_http.json
@@ -2,6 +2,10 @@
   "name": "http_example",
   "partition": "Common",
   "template": "/Common/f5.http",
+  "inheritedDevicegroup": "true",
+  "deviceGroup": "none",
+  "inheritedTrafficGroup": "true",
+  "trafficGroup": "/Common/traffic-group-local-only",
   "lists": [
     {
       "name": "irules__irules",

--- a/test/units/modules/network/f5/test_bigip_iapp_service.py
+++ b/test/units/modules/network/f5/test_bigip_iapp_service.py
@@ -83,6 +83,10 @@ class TestParameters(unittest.TestCase):
         assert p.name == 'http_example'
         assert p.partition == 'Common'
         assert p.template == '/Common/f5.http'
+        assert p.deviceGroup == 'none'
+        assert p.inheritedTrafficGroup == 'true'
+        assert p.inheritedDevicegroup == 'true'
+        assert p.trafficGroup == '/Common/traffic-group-local-only'
 
     def test_module_parameters_lists(self):
         args = load_fixture('create_iapp_service_parameters_f5_http.json')
@@ -196,6 +200,34 @@ class TestParameters(unittest.TestCase):
         assert 'row' in p.tables[0]['rows'][1]
         assert p.tables[0]['rows'][0]['row'] == ['12.12.12.12', '80', '0']
         assert p.tables[0]['rows'][1]['row'] == ['13.13.13.13', '443', '10']
+
+    def test_api_parameters_device_group(self):
+        args = dict(
+            deviceGroup='none'
+        )
+        p = Parameters(args)
+        assert p.deviceGroup == 'none'
+
+    def test_api_parameters_inherited_traffic_group(self):
+        args = dict(
+            inheritedTrafficGroup='true'
+        )
+        p = Parameters(args)
+        assert p.inheritedTrafficGroup == 'true'
+
+    def test_api_parameters_inherited_devicegroup(self):
+        args = dict(
+            inheritedDevicegroup='true'
+        )
+        p = Parameters(args)
+        assert p.inheritedDevicegroup == 'true'
+
+    def test_api_parameters_traffic_group(self):
+        args = dict(
+            trafficGroup='/Common/traffic-group-local-only'
+        )
+        p = Parameters(args)
+        assert p.trafficGroup == '/Common/traffic-group-local-only'
 
     def test_module_template_same_partition(self):
         args = dict(


### PR DESCRIPTION
##### SUMMARY
The iApp service module worked fine previously, but this patch
adds enhancements to it to include more fields that can be
specified when creating iapp services.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_iapp_service

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (feature.add-missing-fields 140534bd7c) last updated 2017/07/06 16:13:40 (GMT -700)
  config file = None
  configured module search path = [u'/Users/trupp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/trupp/src/trupp/ansible/lib/ansible
  executable location = /Users/trupp/src/trupp/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
