### PR TITLE
Adding admin option for iosxr_config

### DIFF
--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -102,9 +102,12 @@ def run_commands(module, commands, check_rc=True):
     return responses
 
 
-def load_config(module, commands, warnings, commit=False, replace=False, comment=None):
+def load_config(module, commands, warnings, commit=False, replace=False, comment=None, admin=False):
+    cmd = 'configure terminal'
+    if admin:
+        cmd = 'admin ' + cmd
 
-    rc, out, err = exec_command(module, 'configure terminal')
+    rc, out, err = exec_command(module, cmd)
     if rc != 0:
         module.fail_json(msg='unable to enter configuration mode', err=to_text(err, errors='surrogate_or_strict'))
 
@@ -137,6 +140,7 @@ def load_config(module, commands, warnings, commit=False, replace=False, comment
     else:
         cmd = 'abort'
         diff = None
+
     rc, out, err = exec_command(module, cmd)
     if rc != 0:
         exec_command(module, 'abort')

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -146,6 +146,14 @@ options:
     required: false
     default: 'configured by iosxr_config'
     version_added: "2.2"
+  admin:
+    description:
+      - Enters into administration configuration mode for making config
+        changes to the device.
+    required: false
+    default: false
+    choices: [ "yes", "no" ]
+    version_added: "2.4"
 """
 
 EXAMPLES = """
@@ -218,6 +226,7 @@ def run(module, result):
     replace_config = replace == 'config'
     path = module.params['parents']
     comment = module.params['comment']
+    admin = module.params['admin']
     check_mode = module.check_mode
 
     candidate = get_candidate(module)
@@ -243,7 +252,7 @@ def run(module, result):
             result['commands'] = commands
 
         diff = load_config(module, commands, result['warnings'],
-                           not check_mode, replace_config, comment)
+                           not check_mode, replace_config, comment, admin)
         if diff:
             result['diff'] = dict(prepared=diff)
             result['changed'] = True
@@ -270,6 +279,7 @@ def main():
         config=dict(),
         backup=dict(type='bool', default=False),
         comment=dict(default=DEFAULT_COMMIT_COMMENT),
+        admin=dict(type='bool', default=False)
     )
 
     argument_spec.update(iosxr_argument_spec)

--- a/test/units/modules/network/iosxr/test_iosxr_config.py
+++ b/test/units/modules/network/iosxr/test_iosxr_config.py
@@ -107,6 +107,11 @@ class TestIosxrConfigModule(TestIosxrModule):
         set_module_args(dict(lines=lines, force=True))
         self.execute_module(changed=True, commands=lines)
 
+    def test_iosxr_config_admin(self):
+        lines = ['username admin', 'group root-system', 'secret P@ssw0rd']
+        set_module_args(dict(lines=lines, admin=True))
+        self.execute_module(changed=True, commands=lines)
+ 
     def test_iosxr_config_match_none(self):
         lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
         parents = ['interface GigabitEthernet0/0']

--- a/test/units/modules/network/iosxr/test_iosxr_config.py
+++ b/test/units/modules/network/iosxr/test_iosxr_config.py
@@ -111,7 +111,7 @@ class TestIosxrConfigModule(TestIosxrModule):
         lines = ['username admin', 'group root-system', 'secret P@ssw0rd']
         set_module_args(dict(lines=lines, admin=True))
         self.execute_module(changed=True, commands=lines)
- 
+
     def test_iosxr_config_match_none(self):
         lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
         parents = ['interface GigabitEthernet0/0']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR allows the `iosxr_config` module to enter into administrative configuration mode. The module_util appends `admin ` to `configure terminal` based on the new boolean option from the module.
Fixes #24308
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
iosxr_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (devel 10233ef3b5) last updated 2017/07/06 18:23:01 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jmighion/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jmighion/git/ansible/lib/ansible
  executable location = /home/jmighion/git/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
