### PR TITLE
Python 3 fix for consul_io inventory

### DIFF
--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -133,7 +133,11 @@ import os
 import re
 import argparse
 import sys
-import ConfigParser
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 
 def get_log_filename():
@@ -421,7 +425,7 @@ class ConsulConfig(dict):
 
     def read_settings(self):
         ''' Reads the settings from the consul_io.ini file (or consul.ini for backwards compatibility)'''
-        config = ConfigParser.SafeConfigParser()
+        config = configparser.SafeConfigParser()
         if os.path.isfile(os.path.dirname(os.path.realpath(__file__)) + '/consul_io.ini'):
             config.read(os.path.dirname(os.path.realpath(__file__)) + '/consul_io.ini')
         else:
@@ -469,7 +473,10 @@ class ConsulConfig(dict):
         scheme = 'http'
 
         if hasattr(self, 'url'):
-            from urlparse import urlparse
+            try:
+                from urlparse import urlparse
+            except ImportError:
+                from urllib.parse import urlparse
             o = urlparse(self.url)
             if o.hostname:
                 host = o.hostname

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -132,13 +132,8 @@ be used to access the machine.
 import os
 import re
 import argparse
+import configparser
 import sys
-
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
-
 
 def get_log_filename():
     tty_filename = '/dev/tty'

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -139,6 +139,7 @@ try:
 except ImportError:
     import ConfigParser as configparser
 
+
 def get_log_filename():
     tty_filename = '/dev/tty'
     stdout_filename = '/dev/stdout'

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -132,8 +132,12 @@ be used to access the machine.
 import os
 import re
 import argparse
-import configparser
 import sys
+
+try:
+    import configparser
+except ImportError:
+    import ConfigParser as configparser
 
 def get_log_filename():
     tty_filename = '/dev/tty'


### PR DESCRIPTION
##### SUMMARY
Fix imports for Python 3 including the move to urllib and the case change on configparser.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/contrib/inventory/consul_io.py

##### ANSIBLE VERSION

```
ansible 2.3.1.0
  config file = /home/gdahlman/build/consul/mywork/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.6.1 (default, Mar 22 2017, 06:17:05) [GCC 6.3.0 20170321]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Changes made based on http://docs.ansible.com/ansible/dev_guide/developing_python3.html

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ./consul_io.py --list
Traceback (most recent call last):
  File "./consul_io.py", line 487, in <module>
    ConsulInventory()
  File "./consul_io.py", line 218, in __init__
    config = ConsulConfig()
  File "./consul_io.py", line 413, in __init__
    self.read_settings()
  File "./consul_io.py", line 424, in read_settings
    config = ConfigParser.SafeConfigParser()
NameError: name 'ConfigParser' is not defined

./consul_io.py --list
Traceback (most recent call last):
  File "./consul_io.py", line 487, in <module>
    ConsulInventory()
  File "./consul_io.py", line 221, in __init__
    self.consul_api = config.get_consul_api()
  File "./consul_io.py", line 472, in get_consul_api
    from urlparse import urlparse
ModuleNotFoundError: No module named 'urlparse'

$ ./consul_io.py --list
{
  "_meta": {
    "hostvars": {
      "10.1.42.210": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul1",
        "consul_services": [
          "consul"
        ]
      },
      "10.1.42.220": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul2",
        "consul_services": [
          "consul"
        ]
      },
      "10.1.42.230": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul3",
        "consul_services": [
          "consul"
        ]
      }
    }
  },
  "all": [
    "10.1.42.210",
    "10.1.42.220",
    "10.1.42.230"
  ],
  "consul": [
    "10.1.42.210",
    "10.1.42.220",
    "10.1.42.230"
  ],
  "dc1": [
    "10.1.42.210",
    "10.1.42.220",
    "10.1.42.230"
  ]
}

```
