### PR TITLE
win_command, win_shell: Use Fail-Json on failure

### DIFF
--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -159,14 +159,14 @@ $proc.WaitForExit() | Out-Null
 
 $result.rc = $proc.ExitCode
 
-If ($result.rc -ne 0) {
-    $result.failed = $true
-}
-
 $end_datetime = [DateTime]::UtcNow
 
 $result.start = $start_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
 $result.end = $end_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
 $result.delta = $($end_datetime - $start_datetime).ToString("h\:mm\:ss\.ffffff")
+
+If ($result.rc -ne 0) {
+    Fail-Json -obj $result -message "non-zero return code"
+}
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_msg.ps1
+++ b/lib/ansible/modules/windows/win_msg.ps1
@@ -56,7 +56,7 @@ $result.runtime_seconds = $stopwatch.Elapsed.TotalSeconds
 $result.sent_localtime = $endsend_at.Trim()
 
 if ($result.rc -ne 0 ) {
-    Fail-Json $result "$output"
+    Fail-Json -obj $result -message "$output"
 }
   
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -168,14 +168,14 @@ $proc.WaitForExit() | Out-Null
 
 $result.rc = $proc.ExitCode
 
-If ($result.rc -ne 0) {
-    $result.failed = $true
-}
-
 $end_datetime = [DateTime]::UtcNow
 
 $result.start = $start_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
 $result.end = $end_datetime.ToString("yyyy-MM-dd hh:mm:ss.ffffff")
 $result.delta = $($end_datetime - $start_datetime).ToString("h\:mm\:ss\.ffffff")
+
+If ($result.rc -ne 0) {
+    Fail-Json -obj $result -message "non-zero return code"
+}
 
 Exit-Json $result


### PR DESCRIPTION
##### SUMMARY
Two reasons to do this:
- It provides a proper error message indicating why it failed
- It conforms to what is being done in the command and shell modules

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_command, win_shell

##### ANSIBLE VERSION
v2.4