### PR TITLE
Fix Connection#reset in Python 3

### DIFF
--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -893,7 +893,7 @@ class Connection(ConnectionBase):
 
     def reset(self):
         # If we have a persistent ssh connection (ControlPersist), we can ask it to stop listening.
-        cmd = map(to_bytes, self._build_command(self._play_context.ssh_executable, '-O', 'stop', self.host))
+        cmd = list(map(to_bytes, self._build_command(self._play_context.ssh_executable, '-O', 'stop', self.host)))
         controlpersist, controlpath = self._persistence_controls(cmd)
         if controlpersist:
             display.vvv(u'sending stop: %s' % cmd)


### PR DESCRIPTION
##### SUMMARY
`Connection#reset` raises `IndexError` when running ansible with Python 3. This can be seen when using `reset_connection` from the `meta` module.

The bug occurs [here](https://github.com/ansible/ansible/blob/5ceabe939d0820e7b6a5938ab689064a03ed1d9b/lib/ansible/plugins/connection/ssh.py#L896-L897):
```python
cmd = map(to_bytes, self._build_command(self._play_context.ssh_executable, '-O', 'stop', self.host))
controlpersist, controlpath = self._persistence_controls(cmd)
if controlpersist:
    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
```
In Python 3, `cmd` is an iterable, which is immediately consumed by `_persistence_controls`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`meta` module

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 3.6.1 (default, Jun  2 2017, 11:08:26) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION

###### playbook.yml
```
---

- hosts: all
  tasks:
  - name: reset connection
    meta: reset_connection
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
# Before
```
PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [default]
ERROR! Unexpected Exception: list index out of range
the full traceback was:

Traceback (most recent call last):
  File "/Users/jrvidal/test/.virtualenv/bin/ansible-playbook", line 109, in <module>
    exit_code = cli.run()
  File "/Users/jrvidal/test/.virtualenv/lib/python3.6/site-packages/ansible/cli/playbook.py", line 154, in run
    results = pbex.run()
  File "/Users/jrvidal/test/.virtualenv/lib/python3.6/site-packages/ansible/executor/playbook_executor.py", line 153, in run
    result = self._tqm.run(play=play)
  File "/Users/jrvidal/test/.virtualenv/lib/python3.6/site-packages/ansible/executor/task_queue_manager.py", line 284, in run
    play_return = strategy.run(iterator, play_context)
  File "/Users/jrvidal/test/.virtualenv/lib/python3.6/site-packages/ansible/plugins/strategy/linear.py", line 221, in run
    results.extend(self._execute_meta(task, play_context, iterator, host))
  File "/Users/jrvidal/test/.virtualenv/lib/python3.6/site-packages/ansible/plugins/strategy/__init__.py", line 905, in _execute_meta
    connection.reset()
  File "/Users/jrvidal/test/.virtualenv/lib/python3.6/site-packages/ansible/plugins/connection/ssh.py", line 816, in reset
    p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
  File "/Users/jrvidal/.pyenv/versions/3.6.1/lib/python3.6/subprocess.py", line 707, in __init__
    restore_signals, start_new_session)
  File "/Users/jrvidal/.pyenv/versions/3.6.1/lib/python3.6/subprocess.py", line 1218, in _execute_child
    executable = args[0]
IndexError: list index out of range
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

# After
```
PLAY [all] *********************************************************************

TASK [Gathering Facts] *********************************************************
ok: [default]

PLAY RECAP *********************************************************************
default                    : ok=1    changed=0    unreachable=0    failed=0
```

