### PR TITLE
Add missing aliases to vyos_linkagg integration test target

### DIFF
--- a/test/integration/targets/vyos_linkagg/aliases
+++ b/test/integration/targets/vyos_linkagg/aliases
@@ -1,0 +1,1 @@
+network/ci


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add missing aliases to vyos_linkagg integration test target
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vyos_linkagg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (add_aliases_to_vyos_linkagg_target 1dbc7c8448) last updated 2017/07/07 10:43:19 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
