### PR TITLE
Add 'mac_address' to the attributes returned from the vmware_vm_facts module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -68,12 +68,17 @@ def get_all_virtual_machines(content):
             _ip_address = summary.guest.ipAddress
             if _ip_address is None:
                 _ip_address = ""
-
+        _mac_address = []
+        for dev in vm.config.hardware.device:
+            if isinstance(dev, vim.vm.device.VirtualEthernetCard):
+                _mac_address.append(dev.macAddress)
+                
         virtual_machine = {
             summary.config.name: {
                 "guest_fullname": summary.config.guestFullName,
                 "power_state": summary.runtime.powerState,
                 "ip_address": _ip_address,
+                "mac_address": _mac_address,
                 "uuid": summary.config.uuid
             }
         }

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -72,7 +72,7 @@ def get_all_virtual_machines(content):
         for dev in vm.config.hardware.device:
             if isinstance(dev, vim.vm.device.VirtualEthernetCard):
                 _mac_address.append(dev.macAddress)
-                
+
         virtual_machine = {
             summary.config.name: {
                 "guest_fullname": summary.config.guestFullName,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
More info for vm.
some vm system (like windows)  return uuid not equal to system command get uuid,so need more info like mac address  to relation
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
vmware_vm_facts 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
        "winserver": {
            "guest_fullname": "Microsoft Windows Server 2012 (64-bit)",
            "ip_address": "",
            "mac_address": [
                "00:0c:29:1d:d6:14"
            ],
            "power_state": "poweredOn",
            "uuid": "564d8fde-8325-1810-4b79-a1db321dd614"
        }
```
```
PS C:\Users\Administrator>  (get-wmiobject Win32_ComputerSystemProduct).UUID
DE8F4D56-2583-1018-4B79-A1DB321DD614
```
