### PR TITLE
Mdd utils ec2 no profile fix

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -300,13 +300,13 @@ def ec2_connect(module):
     if region:
         try:
             ec2 = connect_to_aws(boto.ec2, region, **boto_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
             module.fail_json(msg=str(e))
     # Otherwise, no region so we fallback to the old connection method
     elif ec2_url:
         try:
             ec2 = boto.connect_ec2_endpoint(ec2_url, **boto_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="Either region or ec2_url must be specified")

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -278,7 +278,10 @@ def boto_fix_security_token_in_profile(conn, profile_name):
 
 
 def connect_to_aws(aws_module, region, **params):
-    conn = aws_module.connect_to_region(region, **params)
+    try:
+        conn = aws_module.connect_to_region(region, **params)
+    except(boto.provider.ProfileNotFoundError):
+        raise AnsibleAWSError("Profile given for AWS was not found.  Please fix and retry.")
     if not conn:
         if region not in [aws_module_region.name for aws_module_region in aws_module.regions()]:
             raise AnsibleAWSError("Region %s does not seem to be available for aws module %s. If the region definitely exists, you may need to upgrade "


### PR DESCRIPTION
##### SUMMARY

If you set AWS_PROFILE to a profile which doesn't exist then botocore/boto3 throws an exception.  This patch catches that and at least gives an okay message. 

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

module_utils / ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel ee8ce99bed) last updated 2017/07/07 13:29:45 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/mikedd/dev/ansible/ansible-add-modules/library']
  ansible python module location = /home/mikedd/dev/ansible/ansible-add-modules/lib/ansible
  executable location = /home/mikedd/dev/ansible/ansible-add-modules/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

might be nice to use fail_json_aws from my other PR, but I'm not really sure about it's use in ec2.py.