### PR TITLE
Fix ec2 eip legacy pep8 warnings

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -317,12 +317,12 @@ def ensure_present(ec2, module, domain, address, private_ip_address, device_id,
                     raise EIPException("You must set 'in_vpc' to true to associate an instance with an existing ip in a vpc")
             # Associate address object (provided or allocated) with instance
             assoc_result = associate_ip_and_device(ec2, address, private_ip_address, device_id,
-                                                 check_mode)
+                                                   check_mode)
         else:
             instance = find_device(ec2, module, device_id, isinstance=False)
             # Associate address object (provided or allocated) with instance
             assoc_result = associate_ip_and_device(ec2, address, private_ip_address, device_id,
-                                                 check_mode, isinstance=False)
+                                                   check_mode, isinstance=False)
 
         if instance.vpc_id:
             domain = 'vpc'
@@ -340,10 +340,10 @@ def ensure_absent(ec2, domain, address, device_id, check_mode, isinstance=True):
     if device_id:
         if isinstance:
             return disassociate_ip_and_device(ec2, address, device_id,
-                                                check_mode)
+                                              check_mode)
         else:
             return disassociate_ip_and_device(ec2, address, device_id,
-                                                check_mode, isinstance=False)
+                                              check_mode, isinstance=False)
     # releasing address
     else:
         return release_address(ec2, address, check_mode)
@@ -409,7 +409,7 @@ def main():
         if state == 'present':
             if device_id:
                 result = ensure_present(ec2, module, domain, address, private_ip_address, device_id,
-                                    reuse_existing_ip_allowed, module.check_mode, isinstance=is_instance)
+                                        reuse_existing_ip_allowed, module.check_mode, isinstance=is_instance)
             else:
                 address = allocate_address(ec2, domain, reuse_existing_ip_allowed)
                 result = {'changed': True, 'public_ip': address.public_ip, 'allocation_id': address.allocation_id}

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -15,7 +15,6 @@ lib/ansible/modules/cloud/amazon/ec2_ami.py
 lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
 lib/ansible/modules/cloud/amazon/ec2_ami_find.py
 lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
-lib/ansible/modules/cloud/amazon/ec2_eip.py
 lib/ansible/modules/cloud/amazon/ec2_elb.py
 lib/ansible/modules/cloud/amazon/ec2_elb_facts.py
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
PEP 8: lib/ansible/modules/cloud/amazon/ec2_eip.py:320:50: E128 continuation line under-indented for visual indent (legacy)
PEP 8: lib/ansible/modules/cloud/amazon/ec2_eip.py:325:50: E128 continuation line under-indented for visual indent (legacy)
PEP 8: lib/ansible/modules/cloud/amazon/ec2_eip.py:343:49: E127 continuation line over-indented for visual indent (legacy)
PEP 8: lib/ansible/modules/cloud/amazon/ec2_eip.py:346:49: E127 continuation line over-indented for visual indent (legacy)
PEP 8: lib/ansible/modules/cloud/amazon/ec2_eip.py:412:37: E128 continuation line under-indented for visual indent (legacy)

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_eip

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix-ec2_eip-legacy-PEP8-warnings 4c2c22c179) last updated 2017/07/07 16:39:32 (GMT +100)
  config file = None
  configured module search path = [u'/Users/tom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tom/repos/github/ansible/lib/ansible
  executable location = /Users/tom/repos/github/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
