### PR TITLE
Fix vmware guest clone from template

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1155,8 +1155,10 @@ class PyVmomiHelper(object):
 
                 if self.params['resource_pool']:
                     relospec.pool = resource_pool
-                else:
+                elif self.params['esxi_hostname'] or self.params['cluster']:
                     relospec.pool = self.select_resource_pool_by_host(self.select_host())
+                else:
+                    self.module.fail_json(msg='Either esxi_hostname or cluster must be specified when cloning from a template and not specifying a resource_pool')
 
                 if self.params['snapshot_src'] is not None and self.params['linked_clone']:
                     relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1158,7 +1158,7 @@ class PyVmomiHelper(object):
                 elif self.params['esxi_hostname'] or self.params['cluster']:
                     relospec.pool = self.select_resource_pool_by_host(self.select_host())
                 else:
-                    self.module.fail_json(msg='Either esxi_hostname or cluster must be specified when cloning from a template and not specifying a resource_pool')
+                    self.module.fail_json(msg='esxi_hostname or cluster must be specified when cloning from a template and not specifying a resource_pool')
 
                 if self.params['snapshot_src'] is not None and self.params['linked_clone']:
                     relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1155,6 +1155,8 @@ class PyVmomiHelper(object):
 
                 if self.params['resource_pool']:
                     relospec.pool = resource_pool
+                else:
+                    relospec.pool = self.select_resource_pool_by_host(self.select_host())
 
                 if self.params['snapshot_src'] is not None and self.params['linked_clone']:
                     relospec.diskMoveType = vim.vm.RelocateSpec.DiskMoveOptions.createNewChildDiskBacking


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes a bug that was introduced that breaks cloning a VM from a template.

According to https://github.com/vmware/pyvmomi/blob/master/docs/vim/vm/RelocateSpec.rst
the pool parameter is required when cloning from a template. This fix specifies the root
resource pool when one is not explicitly specified in the parameters. It also enforces the module to be passed either resource_pool, esxi_hostname or cluster when cloning from a template.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix-vmware-guest-clone-from-template ee74c8752e) last updated 2017/07/07 10:38:46 (GMT -500)
  config file = /home/<user>/.ansible.cfg
  configured module search path = [u'/home/<user>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/<user>/ansible/lib/ansible
  executable location = /home/<user>/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
The following error occurs in the current devel branch when cloning from a template without specifying a resource pool.
```
fatal: [localhost]: FAILED! => {
    "ansible_job_id": "348838360094.5041",
    "attempts": 3,
    "changed": true,
    "failed": true,
    "finished": 1,
    "invocation": {
        "module_args": {
            "annotation": null,
            "cluster": null,
            "customization": {
                "domainadmin": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "domainadminpassword": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "joindomain": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "timezone": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "customvalues": [],
            "datacenter": "MyDataCenter",
            "disk": [
                {
                    "autoselect_datastore": true,
                    "datastore": "VM_DataStore*",
                    "size_gb": "100",
                    "type": "thin"
                }
            ],
            "esxi_hostname": "hostname1",
            "folder": "/vm/Folder",
            "force": false,
            "guest_id": null,
            "hardware": {},
            "hostname": "vcenterhostname",
            "is_template": false,
            "linked_clone": false,
            "name": "vm01",
            "name_match": "first",
            "networks": [
                {
                    "name": "DHCP",
                    "type": "dhcp"
                }
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "resource_pool": null,
            "snapshot_src": null,
            "state": "poweredon",
            "template": "Windows16Server",
            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "uuid": null,
            "validate_certs": false,
            "wait_for_ip_address": false
        }
    },
    "msg": "A specified parameter was not correct. \nspec.location.pool"
}
```
