### PR TITLE
Revert "postgresql_user: fix bugs related to 'expires' option (backport #23862)"

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -274,7 +274,7 @@ def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expir
             return False
 
     # Handle passwords.
-    if not no_password_changes and (password is not None or role_attr_flags != '' or expires is not None):
+    if not no_password_changes and (password is not None or role_attr_flags != ''):
         # Select password and all flag-like columns in order to verify changes.
         query_password_data = dict(password=password, expires=expires)
         select = "SELECT * FROM pg_authid where rolname=%(user)s"
@@ -314,12 +314,7 @@ def user_alter(cursor, module, user, password, role_attr_flags, encrypted, expir
                 if current_role_attrs[PRIV_TO_AUTHID_COLUMN[role_attr_name]] != role_attr_value:
                     role_attr_flags_changing = True
 
-        if expires is not None:
-            cursor.execute("SELECT %s::timestamptz;", (expires,))
-            expires_with_tz = cursor.fetchone()[0]
-            expires_changing = expires_with_tz != current_role_attrs.get('rolvaliduntil')
-        else:
-            expires_changing = False
+        expires_changing = (expires is not None and expires == current_role_attrs['rolvaliduntil'])
 
         if not pwchanging and not role_attr_flags_changing and not expires_changing:
             return False


### PR DESCRIPTION
Reverts ansible/ansible#26539

Forgot that we're in the middle of a release process and so merging to stable-2.3 will interfere with that.