### PR TITLE
Integration tests requirements

### DIFF
--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -15,6 +15,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+- name: Install test requirements
+  pip:
+    name: pexpect
+    state: latest
 
 - name: record the test_command file
   set_fact: test_command_file={{output_dir | expanduser}}/test_command.py

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Install test requirements
   pip:
     name: pexpect
-    state: latest
+    state: present
 
 - name: record the test_command file
   set_fact: test_command_file={{output_dir | expanduser}}/test_command.py

--- a/test/integration/targets/filters/filters.yml
+++ b/test/integration/targets/filters/filters.yml
@@ -1,0 +1,5 @@
+- hosts: testhost
+  gather_facts: yes
+  roles:
+    - { role: filters }
+

--- a/test/integration/targets/filters/filters.yml
+++ b/test/integration/targets/filters/filters.yml
@@ -2,4 +2,3 @@
   gather_facts: yes
   roles:
     - { role: filters }
-

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -6,5 +6,4 @@ set -eux
 # because plugins and requirements are loaded before the task runs
 pip install jmespath
 
-
 ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/runme.sh
+++ b/test/integration/targets/filters/runme.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Requirements have to be installed prior to running ansible-playbook
+# because plugins and requirements are loaded before the task runs
+pip install jmespath
+
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook filters.yml -i ../../inventory -e @../../integration_config.yml "$@"

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -16,6 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: Install test requirements
+  pip:
+    name: jmespath
+    state: latest
+
 - name: a dummy task to test the changed and success filters
   shell: echo hi
   register: some_registered_var

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -16,11 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: Install test requirements
-  pip:
-    name: jmespath
-    state: latest
-
 - name: a dummy task to test the changed and success filters
   shell: echo hi
   register: some_registered_var

--- a/test/runner/requirements/integration.txt
+++ b/test/runner/requirements/integration.txt
@@ -1,9 +1,7 @@
 cryptography
 jinja2
-jmespath
 junit-xml
 ordereddict ; python_version < '2.7'
 paramiko
 passlib
-pexpect
 pyyaml

--- a/test/runner/requirements/integration.txt
+++ b/test/runner/requirements/integration.txt
@@ -3,5 +3,4 @@ jinja2
 junit-xml
 ordereddict ; python_version < '2.7'
 paramiko
-passlib
 pyyaml


### PR DESCRIPTION
##### SUMMARY
This removes pexpect, jmespath and passlib dependencies from the requirements.txt file. 
The dependencies should be installed by the test itself and not expect the environment to have them already installed. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`tests`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (integration_tests_requirements bd0dd0b677) last updated 2017/07/07 19:01:39 (GMT +100)
  config file = None
  configured module search path = [u'/Users/shaps/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shaps/PycharmProjects/ansible/lib/ansible
  executable location = /Users/shaps/PycharmProjects/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
N/A