### PR TITLE
sensu_subscription: Fix return type for 2 cases

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_subscription.py
+++ b/lib/ansible/modules/monitoring/sensu_subscription.py
@@ -112,7 +112,7 @@ def sensu_subscription(module, path, name, state='present', backup=False):
     if 'subscriptions' not in config['client']:
         if state == 'absent':
             reasons.append('`client.subscriptions\' did not exist and state is `absent\'')
-            return changed
+            return changed, reasons
         config['client']['subscriptions'] = []
         changed = True
         reasons.append('`client.subscriptions\' did not exist')
@@ -120,7 +120,7 @@ def sensu_subscription(module, path, name, state='present', backup=False):
     if name not in config['client']['subscriptions']:
         if state == 'absent':
             reasons.append('channel subscription was absent')
-            return changed
+            return changed, reasons
         config['client']['subscriptions'].append(name)
         changed = True
         reasons.append('channel subscription was absent and state is `present\'')


### PR DESCRIPTION
state=absent would cause errors in 2 cases resulting in the error:
"TypeError: 'bool' object is not iterable"

##### SUMMARY
Fix sensu_subscription module when removing subscriptions

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
sensu_subscription

##### ANSIBLE VERSION
```
2.3.1.0
```

