### PR TITLE
Fix yum installroot test releasever lookup.

### DIFF
--- a/test/integration/targets/yum/tasks/yuminstallroot.yml
+++ b/test/integration/targets/yum/tasks/yuminstallroot.yml
@@ -21,9 +21,13 @@
     state: directory
     mode: 0755
 
+- name: get yum releasever
+  shell: python -c 'import yum; yb = yum.YumBase(); print(yb.conf.yumvar["releasever"])' | tail -n 1
+  register: releasever
+
 - name: Populate directory
   copy:
-    content: "{{ ansible_distribution_major_version }}\n"
+    content: "{{ releasever.stdout }}\n"
     dest: "/{{ yumroot.stdout }}/etc/yum/vars/releasever"
 
 # This will drag in > 200 MB.


### PR DESCRIPTION
##### SUMMARY

Fix yum installroot test releasever lookup.

With this change the tests will pass on a RHEL 7.3 AMI.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

yum integration tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-yum 642cbc4134) last updated 2017/07/07 13:08:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
