### PR TITLE
Update docker_secret test for RHEL 7.3 on AWS.

### DIFF
--- a/test/integration/targets/docker_secret/tasks/RedHat.yml
+++ b/test/integration/targets/docker_secret/tasks/RedHat.yml
@@ -1,3 +1,6 @@
+# The RHEL extras repository must be enabled to provide the container-selinux package.
+# See: https://docs.docker.com/engine/installation/linux/docker-ee/rhel/#install-using-the-repository
+
 - name: Install Docker pre-reqs
   yum:
     name: "{{ item }}"
@@ -6,8 +9,10 @@
     - yum-utils
     - device-mapper-persistent-data
     - lvm2
-    - python-crypto
     - libseccomp
+
+- name: Enable extras repository for RHEL on AWS
+  command: yum-config-manager --enable rhui-REGION-rhel-server-extras
 
 - name: Add repository
   command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
@@ -19,3 +24,9 @@
   yum:
     name: docker-ce
     state: present
+
+- name: Make sure the docker daemon is running (failure expected inside docker container)
+  service:
+    name: docker
+    state: started
+  ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

Update docker_secret test for RHEL 7.3 on AWS.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_secret integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-docker_secret a8337d12ad) last updated 2017/07/07 14:55:13 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
