### PR TITLE
Add RHEL 7.3 to ansible-test and CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -20,6 +20,8 @@ matrix:
     - env: TEST=freebsd/10.3-STABLE
     - env: TEST=freebsd/11.0-STABLE
 
+    - env: TEST=rhel/7.3
+
     - env: TEST=windows/1
     - env: TEST=windows/2
     - env: TEST=windows/3

--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,3 +1,4 @@
 freebsd/10.3-STABLE
 freebsd/11.0-STABLE
 osx/10.11
+rhel/7.3

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -58,6 +58,7 @@ class AnsibleCoreCI(object):
             'aws',
             'windows',
             'freebsd',
+            'rhel',
             'vyos',
             'junos',
             'ios',

--- a/test/runner/lib/manage_ci.py
+++ b/test/runner/lib/manage_ci.py
@@ -116,6 +116,8 @@ class ManagePosixCI(object):
             self.become = ['su', '-l', 'root', '-c']
         elif self.core_ci.platform == 'osx':
             self.become = ['sudo', '-in', 'PATH=/usr/local/bin:$PATH']
+        elif self.core_ci.platform == 'rhel':
+            self.become = ['sudo', '-in', 'bash', '-c']
 
     def setup(self):
         """Start instance and wait for it to become ready and respond to an ansible ping."""

--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -28,21 +28,39 @@ if [ "${platform}" = "freebsd" ]; then
         subversion \
         sudo \
         zip
+elif [ "${platform}" = "rhel" ]; then
+    yum update -y
+
+    yum install -y \
+        gcc \
+        git \
+        mercurial \
+        python-devel \
+        python-jinja2 \
+        python-virtualenv \
+        python2-cryptography \
+        rubygems \
+        subversion \
+        unzip \
+
+    pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
 fi
 
-pip install virtualenv
+if [ "${platform}" = "freebsd" ] || [ "${platform}" = "osx" ]; then
+    pip install virtualenv
 
-# Tests assume loopback addresses other than 127.0.0.1 will work.
-# Add aliases for loopback addresses used by tests.
+    # Tests assume loopback addresses other than 127.0.0.1 will work.
+    # Add aliases for loopback addresses used by tests.
 
-for i in 3 4 254; do
-    ifconfig lo0 alias "127.0.0.${i}" up
-done
+    for i in 3 4 254; do
+        ifconfig lo0 alias "127.0.0.${i}" up
+    done
 
-ifconfig lo0
+    ifconfig lo0
+fi
 
 # Since tests run as root, we also need to be able to ssh to localhost as root.
-sed -i '' 's/^# *PermitRootLogin.*$/PermitRootLogin yes/;' /etc/ssh/sshd_config
+sed -i= 's/^# *PermitRootLogin.*$/PermitRootLogin yes/;' /etc/ssh/sshd_config
 
 if [ "${platform}" = "freebsd" ]; then
     # Restart sshd for configuration changes and loopback aliases to work.
@@ -65,5 +83,9 @@ fi
 cat << EOF > ~/.bashrc
 alias ls='ls -G'
 export PS1='\[\e]0;\u@\h: \w\a\]\[\033[01;32m\]\u@\h\[\033[00m\]:\[\033[01;34m\]\w\[\033[00m\]\$ '
-cd ~/ansible/
 EOF
+
+# Make sure ~/ansible/ is the starting directory for interactive shells.
+if [ "${platform}" = "osx" ]; then
+    echo "cd ~/ansible/" >> ~/.bashrc
+fi

--- a/test/utils/shippable/rhel.sh
+++ b/test/utils/shippable/rhel.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eux
+
+set -o pipefail
+
+declare -a args
+IFS='/:' read -ra args <<< "${TEST}"
+
+platform="${args[0]}"
+version="${args[1]}"
+target="posix/ci/"
+
+# shellcheck disable=SC2086
+ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    --exclude "posix/ci/cloud/"


### PR DESCRIPTION
##### SUMMARY

Add RHEL 7.3 to ansible-test and CI.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (ci-rhel 54bf0ff071) last updated 2017/07/07 15:27:15 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
