### PR TITLE
Install passlib before starting lookups test.

### DIFF
--- a/test/integration/targets/lookups/lookups.yml
+++ b/test/integration/targets/lookups/lookups.yml
@@ -1,0 +1,4 @@
+- hosts: testhost
+  gather_facts: yes
+  roles:
+    - { role: lookups }

--- a/test/integration/targets/lookups/runme.sh
+++ b/test/integration/targets/lookups/runme.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -eux
+
+# Requirements have to be installed prior to running ansible-playbook
+# because plugins and requirements are loaded before the task runs
+pip install passlib
+
+ANSIBLE_ROLES_PATH=../ ansible-playbook lookups.yml -i ../../inventory -e @../../integration_config.yml "$@"


### PR DESCRIPTION
##### SUMMARY

Install passlib before starting lookups test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

lookups integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-lookups 3a83ff392c) last updated 2017/07/07 16:06:48 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
