### PR TITLE
VMware SPBM Module

### DIFF
--- a/lib/ansible/module_utils/spbm_client.py
+++ b/lib/ansible/module_utils/spbm_client.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Prasanna Nanda < pnanda@cloudsimple.com >
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from pyVmomi import vim, pbm
+from pyVim.connect import SoapStubAdapter
+import time
+import re
+import logging
+
+
+class SPBMClient(object):
+
+    def __init__(self, vc_si, hostname, version="version2"):
+        """
+        Creates a Service Instance for VMware Profile Based Management
+        :param vc_si: vCenter Service Instance
+        :param version: PBM Version
+        """
+        option_manager = vc_si.RetrieveContent().setting
+        hostname_option = option_manager.QueryOptions("config.vpxd.hostnameUrl")
+        client_stub = vc_si._GetStub()
+        session_cookie = client_stub.cookie.split('"')[1]
+        ssl_context = client_stub.schemeArgs.get('context')
+        additional_headers = {'vcSessionCookie': session_cookie}
+        stub = SoapStubAdapter(host=hostname, path="/pbm/sdk", version="pbm.version.version2",
+                               sslContext=ssl_context, requestContext=additional_headers)
+        self.vc_si = vc_si
+        self.pbm_si = pbm.ServiceInstance("ServiceInstance", stub)
+        self.pbm_content = self.pbm_si.PbmRetrieveServiceContent()
+
+    def get_pbmsi(self):
+        """
+        Returns PBM Service Instance
+        :return: PBM Service Instance
+        """
+        return self.pbm_si
+
+    def get_pbmcontent(self):
+        """
+        Returns PBM Content
+        :return: PBM RetrieveContent()
+        """
+        return self.pbm_content
+
+    def get_profilemgr(self):
+        """
+        Gets MoRef to Profile Manager
+        :return: Profile Manager
+        """
+        return self.pbm_content.profileManager
+
+    def get_compliancemgr(self):
+        """
+        Gets MoRef to Profile Compliance Manager
+        """
+        return self.pbm_content.complianceManager
+
+    def get_profiles(self):
+        """
+        Gets list of Storage Profiles on vCenter
+        :return: list of Storage Profiles on vCenter
+        """
+        pm = self.get_profilemgr()
+        profileIds = pm.PbmQueryProfile(resourceType=pbm.profile.ResourceType(resourceType="STORAGE"), profileCategory="REQUIREMENT")
+
+        profiles = []
+        if profileIds:
+            return pm.PbmRetrieveContent(profileIds=profileIds)
+        return None
+
+    def return_cap_meta_data(self, metadatas, keyname):
+        """
+        Return Storage Profile capability metadata
+        """
+        for metadata in metadatas:
+            for capabilityMetadata in metadata.capabilityMetadata:
+                if keyname == capabilityMetadata.id.id:
+                    return capabilityMetadata
+        return None
+
+    def buildCapability(self, capabilityName, value):
+        metadatas = self.get_profilemgr().FetchCapabilityMetadata()
+        capabilityMeta = self.return_cap_meta_data(metadatas=metadatas, keyname=capabilityName)
+        if capabilityMeta is None:
+            raise Exception('capabilityMeta is None')
+        prop = pbm.PbmCapabilityPropertyInstance()
+        prop.id = capabilityName
+        prop.value = value
+        rule = pbm.PbmCapabilityConstraintInstance()
+        rule.propertyInstance.append(prop)
+
+        capability = pbm.PbmCapabilityInstance()
+        capability.id = capabilityMeta.id
+        capability.constraint.append(rule)
+        return capability
+
+    def delete_storage_profile(self, profile_name=None, force=False):
+        """
+        Deletes a Storage Profile
+        """
+        profiles = self.get_profiles()
+        for profile in profiles:
+            if profile.name == profile_name:
+                return self.get_profilemgr().PbmDelete(profileId=[profile.profileId])
+
+    def check_compliance_vm(self, vm):
+        """
+        Checks if a VM is compliant with attached profile
+        """
+        pbm_object_ref = pbm.ServerObjectRef(key=str(vm._moId), objectType="virtualMachine", serverUuid=self.vc_si.content.about.instanceUuid)
+        compliance_status = {}
+        compliance_status['vm_name'] = vm.name
+        results = self.get_compliancemgr().PbmCheckRollupCompliance(entity=[pbm_object_ref])
+        compliance_result = []
+        for result in results:
+            compliance_status['overallComplianceStatus'] = result.overallComplianceStatus
+            if result.result:
+                subresults = result.result
+                for complianceresult in subresults:
+                    individual_compliance = {}
+                    individual_compliance['checkTime'] = complianceresult.checkTime
+                    individual_compliance['complianceStatus'] = complianceresult.complianceStatus
+                    individual_compliance['key'] = complianceresult.entity.key
+                    individual_compliance['objectType'] = complianceresult.entity.objectType
+                    compliance_result.append(individual_compliance)
+        compliance_status['result'] = compliance_result
+        return compliance_status
+
+    def get_ds_default_profile(self, ds):
+        """
+        Get Default Profile for a datastore
+        """
+        placementhub = pbm.placement.PlacementHub(hubId=ds._moId, hubType='Datastore')
+        default_profile = self.get_profilemgr().PbmQueryDefaultRequirementProfile(hub=placementhub)
+        if default_profile:
+            return default_profile
+        return None
+
+    def create_storage_profile(self, profile_name=None, description="Sample Storage Profile", rules=[]):
+        """
+        Creates a Storage Profile
+        """
+        metadatas = self.get_profilemgr().FetchCapabilityMetadata()
+        res_types = self.get_profilemgr().FetchResourceType()
+        # Only supported resource type is storage
+        res_type = res_types[0]
+        create_spec = pbm.profile.CapabilityBasedProfileCreateSpec()
+        create_spec.name = profile_name
+        create_spec.description = description
+        create_spec.resourceType = res_type
+        constraints = pbm.PbmCapabilitySubProfileConstraints()
+        rule_number = 1
+        for rule in rules:
+            ruleSet = pbm.PbmCapabilitySubProfile()
+            capabilities = []
+            for key in rule.keys():
+                capabilities.append(self.buildCapability(key, rule[key]))
+            ruleSet.capability.extend(capabilities)
+            ruleSet.name = 'Rule-Set ' + str(rule_number)
+            rule_number += 1
+            constraints.subProfiles.append(ruleSet)
+        create_spec.constraints = constraints
+        return self.get_profilemgr().PbmCreate(createSpec=create_spec)

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -338,7 +338,7 @@ def vmware_argument_spec():
     )
 
 
-def connect_to_api(module, disconnect_atexit=True):
+def connect_to_api(module, disconnect_atexit=True, return_service_instance=False):
 
     hostname = module.params['hostname']
     username = module.params['username']
@@ -370,6 +370,8 @@ def connect_to_api(module, disconnect_atexit=True):
     # Also removal significantly speeds up the return of the module
     if disconnect_atexit:
         atexit.register(connect.Disconnect, service_instance)
+    if return_service_instance:
+        return service_instance, service_instance.RetrieveContent()
     return service_instance.RetrieveContent()
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_spbm.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_spbm.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Prasanna Nanda <pnanda@cloudsimple.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: vmware_spbm
+short_description: VMware Storage Profile Utilities
+description:
+    - Create, Destroy VM Storage Profiles
+version_added: 2.4
+author:
+    - Prasanna Nanda <pnanda@cloudsimple.com>
+notes:
+    - Tested on vSphere 6.5
+requirements:
+    - "python >= 2.7"
+    - PyVmomi
+options:
+    profile_name:
+        description:
+            - Name of the storage profile to Create
+        required: True
+    state:
+        description:
+            - Valid values are present or absent
+        required: True
+    description:
+        description:
+            - Some Text Describing the Storage profile
+        required: False
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = r'''
+  - name: Create a Storage Profile
+    vmware_spbm:
+      hostname: A vCenter host
+      username: vCenter username
+      password: vCenter password
+      profile_name: Name of the storage profile to create
+      description: Text Describing Storage Profile
+      state: present|absent
+'''
+
+RETURN = ''' # '''
+
+try:
+    from pyVmomi import vim, pbm, vmodl
+    from pyVim.connect import SoapStubAdapter
+    from pyVim.connect import SmartConnect, Disconnect
+    from ansible.module_utils.spbm_client import SPBMClient
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+from ansible.module_utils.vmware import vmware_argument_spec, connect_to_api
+import ssl
+import atexit
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+class vmware_spbm(object):
+    def __init__(self, module):
+        self.module = module
+        self.name = module.params['profile_name']
+        self.description = module.params['description']
+        self.desiredstate = module.params['state']
+        self.rules = module.params['rules']
+        self.currentstate = 'absent'
+        try:
+            si, content = connect_to_api(module=module, disconnect_atexit=True, return_service_instance=True)
+            self.spbmclient = SPBMClient(vc_si=si, hostname=module.params['hostname'])
+        except vmodl.RuntimeFault as runtime_fault:
+            module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            module.fail_json(msg=method_fault.msg)
+        except Exception as e:
+            module.fail_json(msg=to_native(e))
+
+    def process_state(self):
+        profiles = self.spbmclient.get_profiles()
+        if not profiles:
+            self.module.fail_json(changed=False, msg="Could not retrieve Storage Profile Information from vCenter")
+        else:
+            for profile in profiles:
+                if self.module.params['profile_name'] == profile.name:
+                    self.currentstate = 'present'
+        # Current State of System and Desired State are same
+        if self.currentstate == self.desiredstate:
+            self.module.exit_json(changed=False)
+
+        # Profile is absent and you need to create one
+        if self.currentstate == 'absent' and self.desiredstate == 'present':
+            profileId = self.spbmclient.create_storage_profile(profile_name=self.name, description=self.description, rules=self.rules)
+            if profileId:
+                self.module.exit_json(changed=True, msg="Created Storage Profile {} and ID {}".format(self.name, profileId.uniqueId))
+            else:
+                self.module.fail_json(changed=False, msg="Failed to create Storage Profile {}".format(self.name))
+
+        # Profile is Present and you need to delete one
+        if self.currentstate == 'present' and self.desiredstate == 'absent':
+            results = self.spbmclient.delete_storage_profile(profile_name=self.name)
+            if len(results) == 0:
+                self.module.exit_json(changed=True, msg="Deleted Storage Profile {}".format(self.name))
+            else:
+                profile_op_outcome = results[0]
+                if profile_op_outcome.fault is not None:
+                    self.module.fail_json(changed=False, msg=str(profile_op_outcome.fault))
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(profile_name=dict(required=True, type='str'),
+                         description=dict(required=False, type='str', default='Sample Storage Profile'),
+                         rules=dict(required=False, type='list', default=[{'stripeWidth': 1}]),
+                         state=dict(default='present', choices=['present', 'absent'], type='str')))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    if not HAS_PYVMOMI:
+        module.fail_json(msg="pyvmomi is required for this module")
+    spbm = vmware_spbm(module)
+    spbm.process_state()
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_sp.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_sp.py
@@ -1,0 +1,200 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Prasanna Nanda <pnanda@cloudsimple.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: vmware_vm_sp
+short_description: VM Storage Profile Utilities
+description:
+    - Attach/Detach a Storage Profile to a VM
+version_added: 2.4
+author:
+    - Prasanna Nanda <pnanda@cloudsimple.com>
+notes:
+    - Tested on vSphere 6.5
+requirements:
+    - "python >= 2.7"
+    - PyVmomi
+options:
+    vmname:
+        description:
+            - Name of the VM to which Storage Profile will be attached/detached/check
+        required: True
+    profilename:
+        description:
+            - Name of the Storage Profile which will be attached/detached
+        required: True
+    action:
+        description:
+            - Valid values are attach/detach/check
+        required: True
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = '''
+  - name: Attach/Detach a VM to a Storage Profile or Check Compliance
+    vmware_vm_sp:
+      hostname: A vCenter host
+      username: vCenter username
+      password: vCenter password
+      vmname: Name of the VM to which Storage Profile will be attached/detached/check
+      profilename: Name of the Storage Profile which will be attached/detached/check
+      action: attach|detach|check
+'''
+
+RETURN = ''' # '''
+
+try:
+    from pyVmomi import vim, pbm, vmodl
+    from pyVim.connect import SoapStubAdapter
+    from pyVim.connect import SmartConnect, Disconnect
+    from ansible.module_utils.spbm_client import SPBMClient
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+import time
+from ansible.module_utils.vmware import vmware_argument_spec, find_vm_by_name, find_datastore_by_name, wait_for_task, connect_to_api
+import ssl
+import atexit
+from ansible.module_utils.basic import AnsibleModule
+
+
+class vmware_vm_sp(object):
+    def __init__(self, module):
+        self.module = module
+        self.vmname = module.params['vmname']
+        self.profilename = module.params['profilename']
+        self.action = module.params['action']
+        self.profile = None
+        try:
+            si, content = connect_to_api(module=module, disconnect_atexit=True, return_service_instance=True)
+            self.spbmclient = SPBMClient(vc_si=si, hostname=module.params['hostname'])
+            self.content = content
+        except vmodl.RuntimeFault as runtime_fault:
+            module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            module.fail_json(msg=method_fault.msg)
+        except Exception as e:
+            module.fail_json(msg=str(e))
+
+    def attach_sp_to_vm(self):
+        profiles = self.spbmclient.get_profiles()
+        if not profiles:
+            self.module.fail_json(changed=False, msg="Could not retrieve Storage Profile Information from vCenter")
+        else:
+            for profile in profiles:
+                if self.module.params['profilename'] == profile.name:
+                    self.profile = profile
+                    break
+            if self.profile is None:
+                self.module.fail_json(changed=False, msg="Did not find Storage Profile {} in vCenter".format(self.profilename))
+            vm = find_vm_by_name(content=self.content, vm_name=self.vmname)
+            if vm is None:
+                self.module.fail_json(changed=False, msg="Did not find VM {} in vCenter".format(self.vmname))
+            # For attaching a storage Profile to a VM, you need to attach the
+            # profile to VM Home and individual disks.
+            disks = []
+            devices = vm.config.hardware.device
+            for device in devices:
+                if device:
+                    if device and isinstance(device, vim.vm.device.VirtualDisk):
+                        disks.append(device)
+            device_change = []
+            for disk in disks:
+                profile = vim.VirtualMachineDefinedProfileSpec(profileId=self.profile.profileId.uniqueId)
+                device_change.append(vim.VirtualDeviceConfigSpec(device=disk, operation=vim.VirtualDeviceConfigSpecOperation.edit, profile=[profile]))
+            profile = vim.VirtualMachineDefinedProfileSpec(profileId=self.profile.profileId.uniqueId)
+            vmSpec = vim.VirtualMachineConfigSpec(vmProfile=[profile], deviceChange=device_change)
+            state, error = wait_for_task(vm.ReconfigVM_Task(spec=vmSpec))
+            if state:
+                self.module.exit_json(changed=True, msg="Attached Profile {} to VM {}".format(self.profilename, self.vmname))
+            else:
+                self.module.fail_json(changed=False, msg="Failed to attach Profile {} to VM {}. Error {}".format(self.profilename, self.vmname, error))
+
+    def reset_sp_vm(self):
+        profiles = self.spbmclient.get_profiles()
+        if not profiles:
+            self.module.fail_json(changed=False, msg="Could not retrieve Storage Profile Information from vCenter")
+        else:
+            vm = find_vm_by_name(content=self.content, vm_name=self.vmname)
+            if vm is None:
+                self.module.fail_json(changed=False, msg="Did not find VM {} in vCenter".format(self.vmname))
+
+            # Find Where VM Home is Residing
+            vmPathName = vm.config.files.vmPathName
+            vmx_datastore = vmPathName.partition(']')[0].replace('[', '')
+            vmx_profile = self.spbmclient.get_ds_default_profile(find_datastore_by_name(content=self.content, datastore_name=vmx_datastore))
+
+            disks = []
+            devices = vm.config.hardware.device
+            for device in devices:
+                if device:
+                    if device and isinstance(device, vim.vm.device.VirtualDisk):
+                        disks.append(device)
+            device_change = []
+            for disk in disks:
+                datastore_profile = self.spbmclient.get_ds_default_profile(disk.backing.datastore)
+                profile = vim.VirtualMachineDefinedProfileSpec(profileId=datastore_profile.uniqueId)
+                device_change.append(vim.VirtualDeviceConfigSpec(device=disk, operation=vim.VirtualDeviceConfigSpecOperation.edit, profile=[profile]))
+            profile = vim.VirtualMachineDefinedProfileSpec(profileId=vmx_profile.uniqueId)
+            vmSpec = vim.VirtualMachineConfigSpec(vmProfile=[profile], deviceChange=device_change)
+            state, error = wait_for_task(vm.ReconfigVM_Task(spec=vmSpec))
+            if state:
+                self.module.exit_json(changed=True, msg="Detached Profile {} from VM {}".format(self.profilename, self.vmname))
+            else:
+                self.module.fail_json(changed=False, msg="Failed to Detach Profile from VM {}. Error {}".format(self.vmname, error))
+
+    def check_compliance_vm(self):
+            profiles = self.spbmclient.get_profiles()
+            if not profiles:
+                self.module.fail_json(changed=False, msg="Could not retrieve Storage Profile Information from vCenter")
+            vm = find_vm_by_name(content=self.content, vm_name=self.vmname)
+            if vm is None:
+                self.module.fail_json(changed=False, msg="Did not find VM {} in vCenter".format(self.vmname))
+            compliance_status = self.spbmclient.check_compliance_vm(vm)
+            if compliance_status is None:
+                self.module.fail_json(changed=False, msg="Failed to find compliance status for VM {}".format(self.vmname))
+            else:
+                self.module.exit_json(changed=False, compliance_status=compliance_status)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(vmname=dict(required=True, type='str'),
+                         profilename=dict(required=False, type='str'),
+                         action=dict(default='attach', choices=['attach', 'check', 'detach'], type='str')))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    if not HAS_PYVMOMI:
+        module.fail_json(msg="pyvmomi is required for this module")
+    spbm = vmware_vm_sp(module)
+    if module.params['action'] == 'attach':
+        spbm.attach_sp_to_vm()
+    if module.params['action'] == 'check':
+        spbm.check_compliance_vm()
+    if module.params['action'] == 'detach':
+        spbm.reset_sp_vm()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
VMware SPBM Module to Create/Delete storage Profile and attach/compliance check for VM

Example
-------
```
  - name: Create a Storage Profile
    vmware_spbm:
      hostname: A vCenter host
      username: vCenter username
      password: vCenter password
      name: Name of the storage profile to create
      description: Text Describing Storage Profile
      state: present|absent
  - name: Attach/Detach/Compliance Check a SP to a VM
    vmware_vm_sp:
      hostname: A vCenter host
      username: vCenter username
      password: vCenter password
      vmname: Name of the VM to which Storage Profile will be attached/detached
      profilename: Name of the Storage Profile which will be attached/detached
      action: attach|detach|check
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
VMware SPBM Module to Create/Delete storage Profile and attach/compliance check for VM

Why I could not use connect_to_api of vmware.py, because SPBM needs to
have access to ServiceInstance for Stub Generation. connect_to_api returns
a ServiceContent
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_spbm
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 27b8a6f913) last updated 2017/07/07 20:23:26 (GMT -700)
  config file = None
  configured module search path = [u'/Users/pnanda/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pnanda/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```