### PR TITLE
Fix performance issue while match pattern in large inventory list

### DIFF
--- a/lib/ansible/inventory/__init__.py
+++ b/lib/ansible/inventory/__init__.py
@@ -477,9 +477,8 @@ class Inventory(object):
         results = []
 
         def __append_host_to_results(host):
-            if host.name not in results:
-                if not host.implicit:
-                    results.append(host)
+            if not host.implicit:
+                results.append(host)
 
         groups = self.get_groups()
         for group in groups.values():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I write a dynamic inventory (with top level “_meta” element) for my company, there are about five thousands servers. It's very slow to match any host or groups then start running ad-hoc commands or playbooks.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /Users/keepzero/projects/baishancloud/playbooks/ansible.cfg
  configured module search path = [u'modules']
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I read the code in `inventory/__init__.py`, the `_enumerate_matches` method (in devel branch moved to `inventory/manager.py`) of `Inventory` class, it wasted too much time to match the `all` group then call `__append_host_to_results` to add host to results list.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
def _enumerate_matches(self, pattern):

    results = []

    def __append_host_to_results(host):
        if host.name not in results:
            if not host.implicit:
                results.append(host)

    groups = self.get_groups()
    for group in groups.values():
        if self._match(group.name, pattern):
            for host in group.get_hosts():
                __append_host_to_results(host)
        else:
            matching_hosts = self._match_list(group.get_hosts(), 'name', pattern)
            for host in matching_hosts:
                __append_host_to_results(host)

    if pattern in C.LOCALHOST and len(results) == 0:
        new_host = self._create_implicit_localhost(pattern)
        results.append(new_host)
    return results
```
The `results` list contains `Host` objects, the `host.name` is type of unicode,  `host.name not in results` will always `True`. There is no need to make the `results` list distinct, in the `get_hosts` method of `Inventory` class, it will make the list of hosts distinct.
```Python
seen = set()
self._hosts_patterns_cache[pattern_hash] = [x for x in hosts if x not in seen and not seen.add(x)]
```

Before this fix, it will take many seconds to match patterns:
```
$ time ansible some-group-1 --list-hosts
  hosts (8):
    some-group-host-177
    some-group-host-178
    some-group-host-179
    some-group-host-180
    some-group-host-181
    some-group-host-182
    some-group-host-183
    some-group-host-184
       15.92 real        15.09 user         0.33 sys
```

With this fix, it only take a few seconds:
```
$ time ansible some-group-1 --list-hosts
  hosts (8):
    some-group-host-177
    some-group-host-178
    some-group-host-179
    some-group-host-180
    some-group-host-181
    some-group-host-182
    some-group-host-183
    some-group-host-184
        1.77 real         1.53 user         0.21 sys
```