### PR TITLE
Fix performance issue while match pattern in large inventory list for devel branch #26559

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -515,9 +515,8 @@ class InventoryManager(object):
         results = []
 
         def __append_host_to_results(host):
-            if host.name not in results:
-                if not host.implicit:
-                    results.append(host)
+            if not host.implicit:
+                results.append(host)
 
         matched = False
         for group in self._inventory.groups.values():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Same as #26559
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (devel a66bd8f7c3) last updated 2017/07/08 19:34:11 (GMT +800)
  config file = /Users/keepzero/projects/baishancloud/playbooks/ansible.cfg
  configured module search path = [u'/Users/keepzero/projects/baishancloud/playbooks/.ansible/library']
  ansible python module location = /Users/keepzero/projects/baishancloud/playbooks/.ansible/lib/ansible
  executable location = /Users/keepzero/projects/baishancloud/playbooks/.ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
WIth the same fix, although some faster, but much slower than the previous version (ansible 2.3).

Before:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ time ansible some-group-1 --list-hosts
  hosts (8):
    some-group-host-177
    some-group-host-178
    some-group-host-179
    some-group-host-180
    some-group-host-181
    some-group-host-182
    some-group-host-183
    some-group-host-184
      100.00 real        95.34 user         1.16 sys
```

After fix:
```
$ time ansible some-group-1 --list-hosts
  hosts (8):
    some-group-host-177
    some-group-host-178
    some-group-host-179
    some-group-host-180
    some-group-host-181
    some-group-host-182
    some-group-host-183
    some-group-host-184
       84.33 real        80.75 user         1.12 sys
```
