### PR TITLE
Feature parity for params and force_basic_auth between the 3 jenkins modules

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -70,6 +70,12 @@ options:
     description:
        - User to authenticate with the Jenkins server.
     required: false
+  params:
+    required: false
+    default: null
+    description:
+      - Option used to allow the user to overwrite any of the other options. To
+        remove an option, set the value of the option to C(null).
 '''
 
 EXAMPLES = '''
@@ -120,6 +126,22 @@ EXAMPLES = '''
     enabled: False
     url: http://localhost:8080
     user: admin
+#
+# Example of how to use the params
+#
+# Define a variable and specify all default parameters you want to use across
+# all jenkins_plugin calls:
+#
+# my_jenkins_params:
+#   url_username: admin
+#   url_password: p4ssw0rd
+#   url: https://localhost:8433
+#   validate_certs: no
+#
+- jenkins_job:
+    name: test
+    enabled: False
+    params: "{{ my_jenkins_params }}"
 '''
 
 RETURN = '''
@@ -346,23 +368,35 @@ def job_config_to_string(xml_str):
 
 
 def main():
+    argument_spec = url_argument_spec()
+    argument_spec.update(
+        config=dict(required=False),
+        name=dict(required=True),
+        password=dict(required=False, no_log=True),
+        state=dict(required=False, choices=['present', 'absent'], default="present"),
+        enabled=dict(required=False, type='bool'),
+        token=dict(required=False, no_log=True),
+        url=dict(required=False, default="http://localhost:8080"),
+        params=dict(type='dict'),
+        user=dict(required=False)
+    )
     module = AnsibleModule(
-        argument_spec=dict(
-            config=dict(required=False),
-            name=dict(required=True),
-            password=dict(required=False, no_log=True),
-            state=dict(required=False, choices=['present', 'absent'], default="present"),
-            enabled=dict(required=False, type='bool'),
-            token=dict(required=False, no_log=True),
-            url=dict(required=False, default="http://localhost:8080"),
-            user=dict(required=False)
-        ),
+        argument_spec=argument_spec,
         mutually_exclusive=[
             ['password', 'token'],
             ['config', 'enabled'],
         ],
         supports_check_mode=True,
     )
+
+    # Update module parameters by user's parameters if defined
+    if 'params' in module.params and isinstance(module.params['params'], dict):
+        module.params.update(module.params['params'])
+        # Remove the params
+        module.params.pop('params', None)
+
+    # Force basic authentication
+    module.params['force_basic_auth'] = True
 
     test_dependencies(module)
     jenkins_job = JenkinsJob(module)

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -76,6 +76,7 @@ options:
     description:
       - Option used to allow the user to overwrite any of the other options. To
         remove an option, set the value of the option to C(null).
+    version_added: 2.4
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -186,7 +186,8 @@ EXAMPLES = '''
 # my_jenkins_params:
 #   url_username: admin
 #   url_password: p4ssw0rd
-#   url: http://localhost:8888
+#   url: https://localhost:8433
+#   validate_certs: no
 #
 - name: Install plugin
   jenkins_plugin:

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -76,6 +76,12 @@ options:
       - A dict of key-value pairs used in formatting the script using string.Template (see https://docs.python.org/2/library/string.html#template-strings).
     required: false
     default: null
+  params:
+    required: false
+    default: null
+    description:
+      - Option used to allow the user to overwrite any of the other options. To
+        remove an option, set the value of the option to C(null).
 
 notes:
     - Since the script can do anything this does not report on changes.
@@ -112,6 +118,22 @@ EXAMPLES = '''
     password: admin
     url: https://localhost
     validate_certs: no
+#
+# Example of how to use the params
+#
+# Define a variable and specify all default parameters you want to use across
+# all jenkins_plugin calls:
+#
+# my_jenkins_params:
+#   url_username: admin
+#   url_password: p4ssw0rd
+#   url: https://localhost:8433
+#   validate_certs: no
+#
+- name: Say Hello!
+  jenkins_script:
+    script: "println('Hello, Jenkins!')"
+    params: "{{ my_jenkins_params }}"
 '''
 
 RETURN = '''
@@ -126,7 +148,7 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 
 def is_csrf_protection_enabled(module):
@@ -153,24 +175,35 @@ def get_crumb(module):
 
 def main():
 
-    module = AnsibleModule(
-        argument_spec=dict(
-            script=dict(required=True, type="str"),
-            url=dict(required=False, type="str", default="http://localhost:8080"),
-            validate_certs=dict(required=False, type="bool", default=True),
-            user=dict(required=False, no_log=True, type="str", default=None),
-            password=dict(required=False, no_log=True, type="str", default=None),
-            timeout=dict(required=False, type="int", default=10),
-            args=dict(required=False, type="dict", default=None)
-        )
+    argument_spec = url_argument_spec()
+    argument_spec.update(
+        script=dict(required=True, type="str"),
+        url=dict(required=False, type="str", default="http://localhost:8080"),
+        validate_certs=dict(required=False, type="bool", default=True),
+        user=dict(required=False, no_log=True, type="str", default=None),
+        password=dict(required=False, no_log=True, type="str", default=None),
+        timeout=dict(required=False, type="int", default=10),
+        params=dict(type='dict'),
+        args=dict(required=False, type="dict", default=None)
     )
+    module = AnsibleModule(
+        argument_spec=argument_spec
+    )
+
+    # Update module parameters by user's parameters if defined
+    if 'params' in module.params and isinstance(module.params['params'], dict):
+        module.params.update(module.params['params'])
+        # Remove the params
+        module.params.pop('params', None)
 
     if module.params['user'] is not None:
         if module.params['password'] is None:
             module.fail_json(msg="password required when user provided")
         module.params['url_username'] = module.params['user']
         module.params['url_password'] = module.params['password']
-        module.params['force_basic_auth'] = True
+
+    # Force basic authentication
+    module.params['force_basic_auth'] = True
 
     if module.params['args'] is not None:
         from string import Template

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -82,6 +82,7 @@ options:
     description:
       - Option used to allow the user to overwrite any of the other options. To
         remove an option, set the value of the option to C(null).
+    version_added: 2.4
 
 notes:
     - Since the script can do anything this does not report on changes.


### PR DESCRIPTION

##### SUMMARY
Bring params and force_basic_auth from jenkins_plugin to jenkins_script and jenkins_job for feature parity

With this change, all 3 plugins support the same url parameters, so it is possible to define them once and reuse for all jenkins tasks. The support for existing duplicate parameters is not removed for the sake of backward compatibility.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- jenkins_plugin
- jenkins_script
- jenkins_job

##### ANSIBLE VERSION
```
ansible 2.4.0 (jenkins-params-parity d396f9cb2a) last updated 2017/07/09 02:41:28 (GMT -700)
  config file = None
  configured module search path = [u'/home/hdara/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/hdara/src/ansible/lib/ansible
  executable location = /home/hdara/bin/python/bin/ansible
  python version = 2.7.3 (default, Feb 27 2014, 19:58:35) [GCC 4.6.3]
```


##### ADDITIONAL INFORMATION
This change provides a means to use some parameters consistently across all plugins and should in general help simplify the usage.
