### PR TITLE
Clarify how java_cert checks presence of a certificate in keystore

### DIFF
--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -16,7 +16,7 @@ module: java_cert
 version_added: '2.3'
 short_description: Uses keytool to import/remove key from java keystore(cacerts)
 description:
-  - This is a wrapper module around keytool. Which can be used to import/remove
+  - This is a wrapper module around keytool, which can be used to import/remove
     certificates from a given java keystore.
 options:
   cert_url:
@@ -31,7 +31,8 @@ options:
       - Local path to load certificate from. One of cert_url or cert_path is required to load certificate.
   cert_alias:
     description:
-      - Imported certificate alias.
+      - Imported certificate alias. The alias is used when checking for the
+        presence of a certificate in the keystore.
   pkcs12_path:
     description:
       - Local path to load PKCS12 keystore from.


### PR DESCRIPTION
##### SUMMARY
From the documentation it's not clear how presence of a certificate is checked. One could assume that this is done by using the certificate's fingerprint, which isn't the case. In fact the check just looks for the alias, which is an arbitrary string provided by the user.

see https://github.com/fholzer/ansible/blob/ec965e209b20ce168e7e8c3af742f84dd3dc0452/lib/ansible/modules/system/java_cert.py#L122

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
java_cert

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jun 28 2017, 21:52:05) [GCC 5.3.0]
```