### PR TITLE
Handlers and host variables

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -271,11 +271,11 @@ class StrategyBase:
             else:
                 return self._inventory.get_host(host_name)
 
-        def search_handler_blocks_by_name(handler_name, handler_blocks):
+        def search_handler_blocks_by_name(handler_name, handler_blocks, host):
             for handler_block in handler_blocks:
                 for handler_task in handler_block.block:
                     if handler_task.name:
-                        handler_vars = self._variable_manager.get_vars(play=iterator._play, task=handler_task)
+                        handler_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=handler_task)
                         templar = Templar(loader=self._loader, variables=handler_vars)
                         try:
                             # first we check with the full result of get_name(), which may
@@ -447,7 +447,7 @@ class StrategyBase:
                                 # dependency chain of the current task (if it's from a role), otherwise
                                 # we just look through the list of handlers in the current play/all
                                 # roles and use the first one that matches the notify name
-                                target_handler = search_handler_blocks_by_name(handler_name, iterator._play.handlers)
+                                target_handler = search_handler_blocks_by_name(handler_name, iterator._play.handlers, original_host)
                                 if target_handler is not None:
                                     found = True
                                     if original_host not in self._notified_handlers[target_handler._uuid]:

--- a/test/integration/targets/handlers/inventory.handlers
+++ b/test/integration/targets/handlers/inventory.handlers
@@ -1,5 +1,5 @@
 [testgroup]
-A
+A testvar=testvalue
 B
 C
 D

--- a/test/integration/targets/handlers/runme.sh
+++ b/test/integration/targets/handlers/runme.sh
@@ -54,3 +54,6 @@ grep -q "ERROR! The requested handler 'notify_inexistent_handler' was not found 
 # Notify inexistent handlers without errors when ANSIBLE_ERROR_ON_MISSING_HANDLER=false
 ANSIBLE_ERROR_ON_MISSING_HANDLER=false ansible-playbook test_handlers_inexistent_notify.yml -i inventory.handlers -v "$@"
 
+# Check that host variables are available while evaluating handler names
+[ "$(ansible-playbook test_current_host_variables_availability.yml -i inventory.handlers -v "$@" -l A \
+| egrep -o 'RUNNING HANDLER \[test handler: .*?]')" = "RUNNING HANDLER [test handler: {{ testvar }}]" ]

--- a/test/integration/targets/handlers/test_current_host_variables_availability.yml
+++ b/test/integration/targets/handlers/test_current_host_variables_availability.yml
@@ -1,0 +1,12 @@
+---
+- hosts: A
+  gather_facts: false
+  tasks:
+    - assert:
+        that: 'testvar == "testvalue"'
+      changed_when: true
+      notify: 'test handler: testvalue'
+  handlers:
+    - name: 'test handler: {{ testvar }}'
+      debug:
+        msg: 'handler "test handler: testvalue" called'


### PR DESCRIPTION
##### SUMMARY
Fix `AnsibleUndefinedVariable` error when handler names use host variables. First commit adds an integration test. Affected version: 2.4 only (backport isn't needed).

Fixes #25334.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
StrategyBase

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook --version
ansible-playbook 2.4.0 (devel 52c1a1936d) last updated 2017/07/10 02:28:52 (GMT +200)
  config file = None
  configured module search path = [u'$HOMe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = src/ansible/lib/ansible
  executable location = src/ansible/bin/ansible-playbook
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```