### PR TITLE
use `docker exec` instead of `docker cp` .

### DIFF
--- a/lib/ansible/plugins/connection/docker.py
+++ b/lib/ansible/plugins/connection/docker.py
@@ -260,8 +260,25 @@ class Connection(ConnectionBase):
                              stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         p.communicate()
 
-        # Rename if needed
         actual_out_path = os.path.join(out_dir, os.path.basename(in_path))
+
+        if p.returncode != 0:
+            # Older docker doesn't have native support for fetching files command `cp`
+            # If `cp` fails, try to use `dd` instead
+            args = self._build_exec_cmd([self._play_context.executable, "-c", "dd if=%s bs=%s" % (in_path, BUFSIZE)])
+            args = [to_bytes(i, errors='surrogate_or_strict') for i in args]
+            with open(to_bytes(actual_out_path, errors='surrogate_or_strict'), 'wb') as out_file:
+                try:
+                    p = subprocess.Popen(args, stdin=subprocess.PIPE,
+                                         stdout=out_file, stderr=subprocess.PIPE)
+                except OSError:
+                    raise AnsibleError("docker connection requires dd command in the container to put files")
+                stdout, stderr = p.communicate()
+
+                if p.returncode != 0:
+                    raise AnsibleError("failed to fetch file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+
+        # Rename if needed
         if actual_out_path != out_path:
             os.rename(to_bytes(actual_out_path, errors='strict'), to_bytes(out_path, errors='strict'))
 


### PR DESCRIPTION
##### SUMMARY
Use `docker exec` instead of `docker cp` in case some versions of docker not support `cp`.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker connection plugin

##### ANSIBLE VERSION

```
devel
```

##### ADDITIONAL INFORMATION
In some old version, docker did not support `cp` command. So, I use `exec -i dd` instead of `cp` to support fetch file.