### PR TITLE
Apt-key absent requires ID, does not use URL

### DIFF
--- a/lib/ansible/modules/packaging/os/apt_key.py
+++ b/lib/ansible/modules/packaging/os/apt_key.py
@@ -103,11 +103,6 @@ EXAMPLES = '''
     url: "https://ftp-master.debian.org/keys/archive-key-6.0.asc"
     state: present
 
-# Remove an Apt signing key, uses whichever key is at the URL
-- apt_key:
-    url: "https://ftp-master.debian.org/keys/archive-key-6.0.asc"
-    state: absent
-
 # Remove a Apt specific signing key, leading 0x is valid
 - apt_key:
     id: 0x473041FA


### PR DESCRIPTION
##### SUMMARY

Absent apt-key with URL failed, code requires ID.
By reading code https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/packaging/os/apt_key.py#L360 , I see there is no code to handle URL when run absent apt-key (and it also wasted effort when trying to get a key from URL to know its ID then remove it). So I think using id is better behavior, remove the wrong document.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt_key_module

##### ANSIBLE VERSION
```
ansible --version
ansible 2.2.1.0
  config file =
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION

```
  tasks:
    - name: Remove apt key
      apt_key:
        url: 'https://pkg.jenkins.io/debian/jenkins.io.key'
        state: absent
```