### PR TITLE
Handle OSError: file exists exception

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -402,7 +402,7 @@ class Ec2Inventory(object):
             try:
                 os.makedirs(cache_dir)
             except(OSError):
-                print('Cache directory already exists. Skipping the step...')
+                pass
 
         cache_name = 'ansible-ec2'
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -402,7 +402,7 @@ class Ec2Inventory(object):
             try:
                 os.makedirs(cache_dir)
             except(OSError):
-                print "Cache directory already exists. Skipping the step..."
+                print('Cache directory already exists. Skipping the step...')
 
         cache_name = 'ansible-ec2'
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -399,7 +399,10 @@ class Ec2Inventory(object):
         if self.boto_profile:
             cache_dir = os.path.join(cache_dir, 'profile_' + self.boto_profile)
         if not os.path.exists(cache_dir):
-            os.makedirs(cache_dir)
+            try:
+                os.makedirs(cache_dir)
+            except(OSError):
+                print "Cache directory already exists. Skipping the step..."
 
         cache_name = 'ansible-ec2'
         cache_id = self.boto_profile or os.environ.get('AWS_ACCESS_KEY_ID', self.credentials.get('aws_access_key_id'))


### PR DESCRIPTION
##### SUMMARY
I appended the handling of situation where we run multiple inventory cache updates on one host from one user. It's not related to any issue in Github, but it's important anyway.

What's is the issue at all? Let's imagine that I'm running multiple Ansible playbooks on EC2 inventory at a time. There may be used just one node, but might be multiple, it depends on the CI choice. To have my cache fresh, I have to update this running `ec2.py --refresh-cache` command. When cache will become empty, multiple processes will try to create a new directory and will fail doing this simultaneously.

```
Traceback (most recent call last):
  File "inventory/ec2.py", line 1326, in <module>
    Ec2Inventory()
  File "inventory/ec2.py", line 163, in __init__
    self.read_settings()
  File "inventory/ec2.py", line 319, in read_settings
    os.makedirs(cache_dir)
  File "/usr/lib64/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/home/ec2-user/.ansible/tmp/deploy_production_us'
```

My way to fix this is tested. Please, check the accordance to your code style and merge if everything's fine.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

`contrib/inventory/ec2.py`

##### ANSIBLE VERSION

```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Dec  8 2015, 18:25:23) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]
```


##### ADDITIONAL INFORMATION

To reproduce the error, you can run multiple EC2 inventory update processes. I'm not sure how to make it reproduced every time, because process may try to create the directory anytime and then avoid concurrency issue.

```
ec2.py --refresh-cache
```
