### PR TITLE
npm module compatible with npm5

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -534,7 +534,7 @@ files:
   $modules/packaging/language/maven_artifact.py: chrisisbeef tumbl3w33d
   $modules/packaging/language/npm.py:
     ignored: chrishoffman
-    maintainers: shane-walker
+    maintainers: shane-walker xcambar
   $modules/packaging/language/pear.py:
   $modules/packaging/language/pip.py: lujeni robinro
   $modules/packaging/os/apk.py:

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -185,7 +185,7 @@ class Npm(object):
         return ''
 
     def list(self):
-        cmd = ['list', '--json']
+        cmd = ['list', '--json', '--long']
 
         installed = list()
         missing = list()

--- a/test/integration/targets/npm/aliases
+++ b/test/integration/targets/npm/aliases
@@ -1,0 +1,3 @@
+posix/ci/group2
+destructive
+skip/freebsd

--- a/test/integration/targets/npm/tasks/main.yml
+++ b/test/integration/targets/npm/tasks/main.yml
@@ -1,0 +1,33 @@
+# test code for the npm module
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# -------------------------------------------------------------
+# Setup steps
+
+# expand remote path
+- command: 'echo {{ output_dir }}'
+  register: echo
+- set_fact:
+    remote_dir: '{{ echo.stdout }}'
+
+- include_tasks: run.yml
+  vars:
+    nodejs_version: '{{ item }}'
+  with_items:
+    - 8.0.0 # provides npm 5.0.0
+    - 8.2.0 # provides npm 5.3.0 (output change with this version)

--- a/test/integration/targets/npm/tasks/main.yml
+++ b/test/integration/targets/npm/tasks/main.yml
@@ -28,6 +28,7 @@
 - include_tasks: run.yml
   vars:
     nodejs_version: '{{ item }}'
+    nodejs_path: 'node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}'
   with_items:
     - 7.10.1 # provides npm 4.2.0 (last npm < 5 released)
     - 8.0.0 # provides npm 5.0.0

--- a/test/integration/targets/npm/tasks/main.yml
+++ b/test/integration/targets/npm/tasks/main.yml
@@ -29,5 +29,6 @@
   vars:
     nodejs_version: '{{ item }}'
   with_items:
+    - 7.10.1 # provides npm 4.2.0 (last npm < 5 released)
     - 8.0.0 # provides npm 5.0.0
     - 8.2.0 # provides npm 5.3.0 (output change with this version)

--- a/test/integration/targets/npm/tasks/run.yml
+++ b/test/integration/targets/npm/tasks/run.yml
@@ -1,0 +1,2 @@
+- include_tasks: setup.yml
+- include_tasks: test.yml

--- a/test/integration/targets/npm/tasks/setup.yml
+++ b/test/integration/targets/npm/tasks/setup.yml
@@ -1,0 +1,6 @@
+- name: 'Download NPM'
+  unarchive:
+    src: 'https://nodejs.org/dist/v{{ nodejs_version }}/node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}.tar.gz'
+    dest: '{{ output_dir }}'
+    remote_src: yes
+    creates: '{{ output_dir }}/node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}.tar.gz'

--- a/test/integration/targets/npm/tasks/setup.yml
+++ b/test/integration/targets/npm/tasks/setup.yml
@@ -1,6 +1,6 @@
 - name: 'Download NPM'
   unarchive:
-    src: 'https://nodejs.org/dist/v{{ nodejs_version }}/node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}.tar.gz'
+    src: 'https://nodejs.org/dist/v{{ nodejs_version }}/{{ nodejs_path }}.tar.gz'
     dest: '{{ output_dir }}'
     remote_src: yes
-    creates: '{{ output_dir }}/node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}.tar.gz'
+    creates: '{{ output_dir }}/{{ nodejs_path }}.tar.gz'

--- a/test/integration/targets/npm/tasks/test.yml
+++ b/test/integration/targets/npm/tasks/test.yml
@@ -1,0 +1,72 @@
+- name: 'Remove any node modules'
+  file:
+    path: '{{ remote_dir }}/node_modules'
+    state: absent
+
+- vars:
+    # sample: node-v8.2.0-linux-x64.tar.xz
+    node_path: '{{ remote_dir }}/node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}/bin'
+  block:
+    - shell: echo $PATH
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+
+    - shell: npm --version
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_version
+
+    - debug:
+        var: npm_version.stdout
+
+    - name: 'Install simple package without dependency'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        state: present
+        name: iconv-lite
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_install
+
+    - assert:
+        that:
+          - npm_install|success
+          - npm_install|changed
+
+    - name: 'Reinstall simple package without dependency'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        state: present
+        name: iconv-lite
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_reinstall
+
+    - name: Check there is no change
+      assert:
+        that:
+          - npm_reinstall|success
+          - not (npm_reinstall|changed)
+
+    - name: 'Manually delete package'
+      file:
+        path: '{{ remote_dir }}/node_modules/iconv-lite'
+        state: absent
+
+    - name: 'reinstall simple package'
+      npm:
+        path: '{{ remote_dir }}'
+        executable: '{{ node_path }}/npm'
+        state: present
+        name: iconv-lite
+      environment:
+        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
+      register: npm_fix_install
+
+    - name: Check result is changed and successful
+      assert:
+        that:
+          - npm_fix_install|success
+          - npm_fix_install|changed

--- a/test/integration/targets/npm/tasks/test.yml
+++ b/test/integration/targets/npm/tasks/test.yml
@@ -28,8 +28,8 @@
 
     - assert:
         that:
-          - npm_install|success
-          - npm_install|changed
+          - npm_install is success
+          - npm_install is changed
 
     - name: 'Reinstall simple package without dependency'
       npm:
@@ -44,8 +44,8 @@
     - name: Check there is no change
       assert:
         that:
-          - npm_reinstall|success
-          - not (npm_reinstall|changed)
+          - npm_reinstall is success
+          - not (npm_reinstall is changed)
 
     - name: 'Manually delete package'
       file:
@@ -65,5 +65,5 @@
     - name: Check result is changed and successful
       assert:
         that:
-          - npm_fix_install|success
-          - npm_fix_install|changed
+          - npm_fix_install is success
+          - npm_fix_install is changed

--- a/test/integration/targets/npm/tasks/test.yml
+++ b/test/integration/targets/npm/tasks/test.yml
@@ -5,12 +5,9 @@
 
 - vars:
     # sample: node-v8.2.0-linux-x64.tar.xz
-    node_path: '{{ remote_dir }}/node-v{{ nodejs_version }}-{{ ansible_system|lower }}-x{{ ansible_userspace_bits }}/bin'
+    node_path: '{{ remote_dir }}/{{ nodejs_path }}/bin'
+    package: 'iconv-lite'
   block:
-    - shell: echo $PATH
-      environment:
-        PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
-
     - shell: npm --version
       environment:
         PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
@@ -24,7 +21,7 @@
         path: '{{ remote_dir }}'
         executable: '{{ node_path }}/npm'
         state: present
-        name: iconv-lite
+        name: '{{ package }}'
       environment:
         PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_install
@@ -39,7 +36,7 @@
         path: '{{ remote_dir }}'
         executable: '{{ node_path }}/npm'
         state: present
-        name: iconv-lite
+        name: '{{ package }}'
       environment:
         PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_reinstall
@@ -52,7 +49,7 @@
 
     - name: 'Manually delete package'
       file:
-        path: '{{ remote_dir }}/node_modules/iconv-lite'
+        path: '{{ remote_dir }}/node_modules/{{ package }}'
         state: absent
 
     - name: 'reinstall simple package'
@@ -60,7 +57,7 @@
         path: '{{ remote_dir }}'
         executable: '{{ node_path }}/npm'
         state: present
-        name: iconv-lite
+        name: '{{ package }}'
       environment:
         PATH: '{{ node_path }}:{{ ansible_env.PATH }}'
       register: npm_fix_install


### PR DESCRIPTION
Uses the `--long` flag in `npm list` to get the `missing` key back.

##### SUMMARY

The new npm 5.x series introduced a breaking change for the npm module: in prior versions, the command `npm list --json` had a `missing` key that that was used by the module to induce the `changed` state, yet now this key is only available with the `--long` option.

Adding this option solves the issue for the 5.x series of npm and *is backward compatible* for all previous versions of npm.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

Module: npm

##### ANSIBLE VERSION

```
ansible 2.3.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
