### PR TITLE
New module: Add Pritunl VPN user module (net_tools/pritunl/) (Fixing #26583)

### DIFF
--- a/lib/ansible/module_utils/pritunl.py
+++ b/lib/ansible/module_utils/pritunl.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# (c) 2016, Florian Dambrine <android.florian@gmail.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This module is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import time
+import uuid
+import hmac
+import hashlib
+import base64
+
+from ansible.module_utils.urls import open_url
+
+
+# Taken from https://pritunl.com/api and adaped work with Ansible open_url util
+def pritunl_auth_request(module, method, path, headers=None, data=None):
+    api_token = module.params.get('pritunl_api_token')
+    api_secret = module.params.get('pritunl_api_secret')
+    base_url = module.params.get('pritunl_url')
+    validate_certs = module.params.get('validate_certs')
+
+    auth_timestamp = str(int(time.time()))
+    auth_nonce = uuid.uuid4().hex
+
+    auth_string = '&'.join([api_token, auth_timestamp, auth_nonce,
+                           method.upper(), path] + ([data] if data else []))
+
+    auth_signature = base64.b64encode(hmac.new(api_secret,
+                                               auth_string, hashlib.sha256).digest())
+
+    auth_headers = {
+        'Auth-Token': api_token,
+        'Auth-Timestamp': auth_timestamp,
+        'Auth-Nonce': auth_nonce,
+        'Auth-Signature': auth_signature
+    }
+
+    if headers:
+        auth_headers.update(headers)
+
+    try:
+        uri = "%s%s" % (base_url, path)
+
+        return open_url(uri, method=method.upper(),
+                        headers=auth_headers,
+                        data=data,
+                        validate_certs=validate_certs)
+    except Exception as e:
+        module.fail_json(msg='Could not connect to %s: %s' % (base_url, e))

--- a/lib/ansible/modules/net_tools/pritunl/pritunl_user.py
+++ b/lib/ansible/modules/net_tools/pritunl/pritunl_user.py
@@ -1,0 +1,410 @@
+#!/usr/bin/python
+
+# (c) 2016, Florian Dambrine <android.florian@gmail.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This module is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: pritunl_user
+version_added: "2.4"
+author: "Florian Dambrine (@Lowess)"
+short_description: Manage Pritunl Users using the Pritunl API
+description:
+    - A module to manage Pritunl users using the Pritunl API.
+options:
+    pritunl_url:
+        required: true
+        description:
+            - URL and port of the pritunl server on which the API is enabled
+
+    pritunl_api_token:
+        required: true
+        description:
+            - API Token of a Pritunl admin user (It needs to be enabled in
+              Administrators > USERNAME > Enable Token Authentication).
+
+    pritunl_api_secret:
+        required: true
+        description:
+            - API Secret found in Administrators > USERNAME > API Secret.
+
+    organization:
+        required: true
+        aliases: ['org']
+        description:
+            - The name of the organization the user is part of.
+
+    state:
+        required: false
+        default: list
+        choices: [ list, present, absent ]
+        description:
+            - If C(list) is used, users from the C(organization) will be
+              retrieved from Pritunl, C(user_name) can be used to filter by
+              name, by default all of them will be listed. If C(present), the
+              user C(user_name) will be added to the Pritunl C(organization).
+              If C(absent), the user C(user_name) will be deleted from the
+              Pritunl C(organization).
+
+    user_name:
+        required: false
+        default: null
+        description:
+            - Name of the user to create in Pritunl. The C(user_name) is used
+              when the module is used with C(state=list).
+
+    user_email:
+        required: false
+        default: null
+        description:
+            - Email address associated with the user C(user_name).
+
+    user_type:
+        required: false
+        default: client
+        choices: [ client, server]
+        description:
+            - Type of the user C(user_name).
+
+    user_groups:
+        required: false
+        default: []
+        description:
+            - List of groups associated with the user C(user_name).
+
+    user_disabled:
+        required: false
+        default: False
+        description:
+            - Enable/Disable the user C(user_name).
+
+    user_gravatar:
+        required: false
+        default: True
+        description:
+            - Enable/Disable Gravatar usage for the user C(user_name).
+
+    validate_certs:
+        required: false
+        default : true
+        description:
+            - If certificates should be validated or not.
+'''
+
+EXAMPLES = '''
+# List all existing users part of the organization MyOrg
+- name: List all existing users part of the organization MyOrg
+  pritunl_user:
+    state: list
+    organization: MyOrg
+
+# Search for the user named Florian part of the rganization MyOrg
+- name: Search for the user named Florian part of the rganization MyOrg
+  pritunl_user:
+    state: list
+    organization: MyOrg
+    user_name: Florian
+
+# Make sure the user named Foo with email address foo@bar.com is part of MyOrg
+- name: Create the user Foo with email address foo@bar.com in MyOrg
+  pritunl_user:
+    state: present
+    name: MyOrg
+    user_name: Foo
+    user_email: foo@bar.com
+
+# Make sure the user named Foo with email address foo@bar.com is part of MyOrg
+- name: Disable the user Foo but keep it in Pritunl
+  pritunl_user:
+    state: present
+    name: MyOrg
+    user_name: Foo
+    user_email: foo@bar.com
+    user_disabled: yes
+
+# Make sure the user Foo is not part of MyOrg anymore
+- name: Make sure the user Foo is not part of MyOrg anymore
+  pritunl_user:
+    state: absent
+    name: MyOrg
+    user_name: Foo
+'''
+
+RETURN = '''
+response:
+    description: JSON representation of Pritunl Users
+    returned: success
+    type: list
+    sample:
+
+        "users": [
+            {
+                "audit": false,
+                "auth_type": "google",
+                "bypass_secondary": false,
+                "client_to_client": false,
+                "disabled": false,
+                "dns_mapping": null,
+                "dns_servers": null,
+                "dns_suffix": null,
+                "email": "foo@bar.com",
+                "gravatar": true,
+                "groups": [
+                    "foo", "bar"
+                ],
+                "id": "5d070dafe63q3b2e6s472c3b",
+                "name": "foo@acme.com",
+                "network_links": [],
+                "organization": "58070daee6sf342e6e4s2c36",
+                "organization_name": "Acme",
+                "otp_auth": true,
+                "otp_secret": "35H5EJA3XB2$4CWG",
+                "pin": false,
+                "port_forwarding": [],
+                "servers": [],
+            }
+        ]
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import json
+from ansible.module_utils.pritunl import pritunl_auth_request
+from ansible.module_utils.six import iteritems
+
+
+def _list_pritunl_organization(module, filters=None):
+    orgs = []
+
+    response = pritunl_auth_request(module, 'GET', '/organization')
+
+    if response.getcode() != 200:
+        module.fail_json(msg='Could not retrive organizations from Pritunl')
+    else:
+        for org in json.loads(response.read()):
+            # No filtering
+            if filters is None:
+                orgs.append(org)
+
+            else:
+                filtered_flag = False
+
+                for filter_key, filter_val in iteritems(filters):
+                    if filter_val != org[filter_key]:
+                        filtered_flag = True
+
+                if not filtered_flag:
+                    orgs.append(org)
+
+    return orgs
+
+
+def _list_pritunl_user(module, organization_id, user_id=None, filters=None):
+    users = []
+
+    response = pritunl_auth_request(module, 'GET', "/user/%s" % organization_id)
+
+    if response.getcode() != 200:
+        module.fail_json(msg='Could not retrive users from Pritunl')
+    else:
+        for user in json.loads(response.read()):
+            # No filtering
+            if filters is None:
+                users.append(user)
+
+            else:
+                filtered_flag = False
+
+                for filter_key, filter_val in iteritems(filters):
+                    if filter_val != user[filter_key]:
+                        filtered_flag = True
+
+                if not filtered_flag:
+                    users.append(user)
+
+    return users
+
+
+def get_pritunl_user(module):
+    user_name = module.params.get('user_name')
+    user_type = module.params.get('user_type')
+
+    org_name = module.params.get('organization')
+
+    org_obj_list = _list_pritunl_organization(module, {"name": org_name})
+
+    if len(org_obj_list) == 0:
+        module.fail_json(msg="Can not list users from the organization '%s' which does not exist" % org_name)
+
+    org_id = org_obj_list[0]['id']
+
+    users = _list_pritunl_user(module, org_id, filters=({"type": user_type} if user_name is None else {"name": user_name, "type": user_type}))
+
+    result = {}
+    result['changed'] = False
+    result['users'] = users
+
+    module.exit_json(**result)
+
+
+def post_pritunl_user(module):
+    result = {}
+
+    org_name = module.params.get('organization')
+    user_name = module.params.get('user_name')
+
+    if user_name is None:
+        module.fail_json(msg='Please provide a user name using user_name=<username>')
+
+    user_params = {
+        'name': user_name,
+        'email': module.params.get('user_email'),
+        'groups': module.params.get('user_groups'),
+        'disabled': module.params.get('user_disabled'),
+        'gravatar': module.params.get('user_gravatar'),
+        'type': module.params.get('user_type'),
+    }
+
+    org_obj_list = _list_pritunl_organization(module, {"name": org_name})
+
+    if len(org_obj_list) == 0:
+        module.fail_json(msg="Can not add user to organization '%s' which does not exist" % org_name)
+
+    org_id = org_obj_list[0]['id']
+
+    # Grab existing users from this org
+    users = _list_pritunl_user(module, org_id, filters={"name": user_name})
+
+    # Check if the pritunl user already exists
+    # If yes do nothing
+    if len(users) > 0:
+        # Compare remote user params with local user_params and trigger update if needed
+        user_params_changed = False
+        for key in user_params.keys():
+            # When a param is not specified grab the existing one to prevent from changing it with the PUT request
+            if user_params[key] is None:
+                user_params[key] = users[0][key]
+
+            # groups is a list comparison
+            if key == 'groups':
+                if set(users[0][key]) != set(user_params[key]):
+                    user_params_changed = True
+
+            # otherwise it is either a boolean or a string
+            else:
+                if users[0][key] != user_params[key]:
+                    user_params_changed = True
+
+        # Trigger a PUT on the API to update the current user if settings have changed
+        if user_params_changed:
+            response = pritunl_auth_request(module, 'PUT',
+                                            "/user/%s/%s" % (org_id, users[0]['id']),
+                                            headers={'Content-Type': 'application/json'},
+                                            data=json.dumps(user_params))
+
+            if response.getcode() != 200:
+                module.fail_json(msg="Could not update Pritunl user %s from %s organization" % (user_name, org_name))
+            else:
+                result['changed'] = True
+                result['response'] = json.loads(response.read())
+        else:
+            result['changed'] = False
+            result['response'] = users
+    else:
+        response = pritunl_auth_request(module, 'POST', "/user/%s" % org_id,
+                                        headers={'Content-Type': 'application/json'},
+                                        data=json.dumps(user_params))
+
+        if response.getcode() != 200:
+            module.fail_json(msg="Could not add Pritunl user %s to %s organization" % (user_params['name'], org_name))
+        else:
+            result['changed'] = True
+            result['response'] = json.loads(response.read())
+
+    module.exit_json(**result)
+
+
+def delete_pritunl_user(module):
+    result = {}
+
+    org_name = module.params.get('organization')
+    user_name = module.params.get('user_name')
+
+    org_obj_list = _list_pritunl_organization(module, {"name": org_name})
+
+    if len(org_obj_list) == 0:
+        module.fail_json(msg="Can not remove user from the organization '%s' which does not exist" % org_name)
+
+    org_id = org_obj_list[0]['id']
+
+    # Grab existing users from this org
+    users = _list_pritunl_user(module, org_id, filters={"name": user_name})
+
+    # Check if the pritunl user exists, if not, do nothing
+    if len(users) == 0:
+        result['changed'] = False
+        result['response'] = {}
+
+    # Otherwise remove the org from Pritunl
+    else:
+        response = pritunl_auth_request(module, 'DELETE',
+                                        "/user/%s/%s" % (org_id, users[0]['id']))
+
+        if response.getcode() != 200:
+            module.fail_json(msg="Could not remove user %s from organization %s from Pritunl" % (users[0]['name'], org_name))
+        else:
+            result['changed'] = True
+            result['response'] = json.loads(response.read())
+
+    module.exit_json(**result)
+
+
+def main():
+    argument_spec = {}
+
+    argument_spec.update(dict(
+        pritunl_url=dict(required=True, type='str', defaults='https://localhost:443'),
+        pritunl_api_token=dict(required=True, type='str'),
+        pritunl_api_secret=dict(required=True, type='str'),
+        organization=dict(required=True, type='str', default=None, aliases=['org']),
+        state=dict(required=False, choices=['list', 'present', 'absent'], default=None),
+        user_name=dict(required=False, type='str', default=None),
+        user_type=dict(required=False, choices=['client', 'server'], default='client'),
+        user_email=dict(required=False, type='str', default=None),
+        user_groups=dict(required=False, type='list', default=None),
+        user_disabled=dict(required=False, type='bool', default=None),
+        user_gravatar=dict(required=False, type='bool', default=None),
+        validate_certs=dict(required=False, type='bool', default=True)
+    )),
+
+    module = AnsibleModule(
+        argument_spec=argument_spec
+    )
+
+    state = module.params.get('state')
+
+    if state == 'list' or state is None:
+        get_pritunl_user(module)
+    elif state == 'present':
+        post_pritunl_user(module)
+    elif state == 'absent':
+        delete_pritunl_user(module)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
<!---
Verify first that your issue/request is not already reported on GitHub.
Also test if the latest release, and master branch are affected too.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
pritunl_user.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 44fac2eb5a) last updated 2017/05/04 00:58:43 (GMT -700)
```

##### CONFIGURATION
<!---
Mention any settings you have changed/added/removed in ansible.cfg
(or using the ANSIBLE_* environment variables).
-->

##### SUMMARY
<!--- Explain the problem briefly -->

(Pritunl)[https://pritunl.com/] is an Enterprise Distributed OpenVPN Server. We have been using this technology for about a year and we felt really handy to automate our VPN user management using Ansible.

As Pritunl offers a (REST API)[https://pritunl.com/api], we developed two modules to manage VPN users.

Both modules have been sitting on my laptop for about a year. They have been well tested and they work as expected (respect of idempotency, based on urllib, etc...)

I placed those modules under **net_tools/pritunl** (that's the only point I am not sure about). Feel free to tell me if something needs to updated.

Cheers,
Florian