### PR TITLE
Fix JSON parsing for Python3

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
@@ -108,6 +108,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_text
 
 
 class Response(object):
@@ -122,10 +123,10 @@ class Response(object):
     def json(self):
         if not self.body:
             if "body" in self.info:
-                return json.loads(self.info["body"])
+                return json.loads(to_text(self.info["body"], errors='surrogate_or_strict'))
             return None
         try:
-            return json.loads(self.body)
+            return json.loads(to_text(self.body, errors='surrogate_or_strict'))
         except ValueError:
             return None
 
@@ -213,6 +214,8 @@ def core(module):
             # Check if resource is already tagged or not
             found = False
             url = "{0}?tag_name={1}".format(resource_type, name)
+            if resource_type == 'droplet':
+                url = "droplets?tag_name={0}".format(name)
             response = rest.get(url)
             status_code = response.status_code
             resp_json = response.json


### PR DESCRIPTION

##### SUMMARY
Fix corrects the parsing of JSON output in Python 3
environment by using to_text API.

Fixes: #26489

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py

##### ANSIBLE VERSION
```
2.4devel
```