### PR TITLE
Detect UEFI VMware guests, fixes

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -92,7 +92,7 @@ class LinuxVirtual(Virtual):
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts
 
-        if product_name == 'VMware Virtual Platform':
+        if product_name in ['VMware Virtual Platform', 'VMware7,1']:
             virtual_facts['virtualization_type'] = 'VMware'
             virtual_facts['virtualization_role'] = 'guest'
             return virtual_facts


### PR DESCRIPTION
VMware provides a different DMI product name for VMs booted via UEFI vs BIOS, fixes #26517

##### SUMMARY
Add VMware7,1 to the DMI product names for VMware guests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/facts/virtual/linux.py

##### ANSIBLE VERSION
I've just forked from devel. I patched `module_utils/facts.py` locally in 2.3.0.0 but it looks like this has been refactored since then. Do you want me to prepare a pull request for older versions?
