### PR TITLE
privilege escalation for eos integration test

### DIFF
--- a/test/integration/targets/prepare_eos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_eos_tests/tasks/main.yml
@@ -4,6 +4,7 @@
      enable_https: yes
      enable_local_http: yes
      enable_socket: yes
+     authorize: yes
      provider: "{{ cli }}"
    register: eos_eapi_output
    connection: local


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add privilege mode for eos integration test
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/prepare_eos_tests/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
stable-2.3
```