### PR TITLE
Don't use _raw_params for IncludeRole objects

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -22,6 +22,7 @@ __metaclass__ = type
 import os
 
 from ansible.playbook.task_include import TaskInclude
+from ansible.playbook.role_include import IncludeRole
 from ansible.template import Templar
 
 try:
@@ -101,7 +102,10 @@ class IncludedFile:
                                 if not isinstance(parent_include, TaskInclude):
                                     parent_include = parent_include._parent
                                     continue
-                                parent_include_dir = os.path.dirname(templar.template(parent_include.args.get('_raw_params')))
+                                if isinstance(parent_include, IncludeRole):
+                                    parent_include_dir = os.path.dirname(parent_include._role_path)
+                                else:
+                                    parent_include_dir = os.path.dirname(templar.template(parent_include.args.get('_raw_params')))
                                 if cumulative_path is None:
                                     cumulative_path = parent_include_dir
                                 elif not os.path.isabs(cumulative_path):

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -58,6 +58,7 @@ class IncludeRole(TaskInclude):
         self._from_files = {}
         self._parent_role = role
         self._role_name = None
+        self._role_path = None
 
     def get_block_list(self, play=None, variable_manager=None, loader=None):
 
@@ -73,6 +74,9 @@ class IncludeRole(TaskInclude):
         # build role
         actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files)
         actual_role._metadata.allow_duplicates = self.allow_duplicates
+
+        # save this for later use
+        self._role_path = actual_role._role_path
 
         # compile role with parent roles as dependencies to ensure they inherit
         # variables


### PR DESCRIPTION
IncludeRole objects don't use _raw_params for the name/etc. of roles
like regular incudes, but the code for finding relative includes assumed
that all includes had a _raw_params field. This fixes that by correctly
checking the parent object type and using the appropriate field.

Fixes #26525
