### PR TITLE
Add nxos_command IT and generalize UT

### DIFF
--- a/test/integration/targets/nxos_command/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/sanity.yaml
@@ -1,0 +1,74 @@
+---
+- debug: msg="START TRANSPORT:CLI nxos_command sanity test"
+
+- name: "Disable feature BGP"
+  nxos_feature:
+    feature: bgp
+    state: disabled
+    provider: "{{ cli }}"
+
+- block:
+  - name: "Run show running-config bgp - should fail"
+    nxos_command:
+      commands:
+        - sh running-config bgp
+      provider: "{{ cli }}"
+    ignore_errors: yes
+    register: result
+
+  - assert: &fail
+      that:
+        - "result.failed == true"
+        - "'Invalid command' in result.msg"
+
+  - name: "Enable feature BGP"
+    nxos_feature:
+      feature: bgp
+      state: enabled
+      provider: "{{ cli }}"
+
+  - name: "Configure BGP defaults"
+    nxos_bgp: &configure_default
+      asn: 65535
+      router_id: 1.1.1.1
+      state: present
+      provider: "{{ cli }}"
+    register: result
+
+  - assert: &true
+      that:
+        - "result.changed == true"
+
+  - name: "Run show running-config bgp - should pass"
+    nxos_command:
+      commands:
+        - sh running-config bgp
+      provider: "{{ cli }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.failed == false"
+        - "'65535' in result.stdout[0]"
+
+  - name: "Run an invalid command - should fail"
+    nxos_command:
+      commands:
+        - show interface bief
+      provider: "{{ cli }}"
+    ignore_errors: yes
+    register: result
+
+  - assert: *fail
+
+  rescue:
+  - debug: msg="nxos_command sanity test failure detected"
+
+  always:
+  - name: "Disable feature bgp"
+    nxos_feature:
+      feature: bgp
+      state: disabled
+      provider: "{{ cli }}"
+
+  - debug: msg="END TRANSPORT:CLI nxos_command sanity test"

--- a/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
@@ -1,0 +1,74 @@
+---
+- debug: msg="START TRANSPORT:NXAPI nxos_command sanity test"
+
+- name: "Disable feature BGP"
+  nxos_feature:
+    feature: bgp
+    state: disabled
+    provider: "{{ nxapi }}"
+
+- block:
+  - name: "Run show running-config bgp - should fail"
+    nxos_command:
+      commands:
+        - sh running-config bgp
+      provider: "{{ nxapi }}"
+    ignore_errors: yes
+    register: result
+
+  - assert: &fail
+      that:
+        - "result.failed == true"
+        - "'Input CLI command error' in result.msg"
+
+  - name: "Enable feature BGP"
+    nxos_feature:
+      feature: bgp
+      state: enabled
+      provider: "{{ nxapi }}"
+
+  - name: "Configure BGP defaults"
+    nxos_bgp: &configure_default
+      asn: 65535
+      router_id: 1.1.1.1
+      state: present
+      provider: "{{ nxapi }}"
+    register: result
+
+  - assert: &true
+      that:
+        - "result.changed == true"
+
+  - name: "Run show running-config bgp - should pass"
+    nxos_command:
+      commands:
+        - sh running-config bgp
+      provider: "{{ nxapi }}"
+    register: result
+
+  - assert:
+      that:
+        - "result.failed == false"
+        - "'65535' in result.stdout[0]"
+
+  - name: "Run an invalid command - should fail"
+    nxos_command:
+      commands:
+        - show interface bief
+      provider: "{{ nxapi }}"
+    ignore_errors: yes
+    register: result
+
+  - assert: *fail
+
+  rescue:
+  - debug: msg="nxos_command sanity test failure detected"
+
+  always:
+  - name: "Disable feature bgp"
+    nxos_feature:
+      feature: bgp
+      state: disabled
+      provider: "{{ nxapi }}"
+
+  - debug: msg="END TRANSPORT:NXAPI nxos_command sanity test"

--- a/test/units/modules/network/nxos/test_nxos_command.py
+++ b/test/units/modules/network/nxos/test_nxos_command.py
@@ -67,7 +67,7 @@ class TestNxosCommandModule(TestNxosModule):
         self.assertTrue(result['stdout'][0].startswith('Cisco'))
 
     def test_nxos_command_wait_for(self):
-        wait_for = 'result[0] contains "Cisco NX-OS"'
+        wait_for = 'result[0] contains "NX-OS"'
         set_module_args(dict(commands=['show version'], wait_for=wait_for))
         self.execute_module()
 
@@ -91,7 +91,7 @@ class TestNxosCommandModule(TestNxosModule):
 
     def test_nxos_command_match_all(self):
         wait_for = ['result[0] contains "Cisco"',
-                    'result[0] contains "system image file"']
+                    'result[0] contains "image file"']
         set_module_args(dict(commands=['show version'], wait_for=wait_for, match='all'))
         self.execute_module()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This update adds integration tests for the `nxos_command` module. Also, the UT for nxos_command have been generalizes as some platforms have different output for `show version`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Integration Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel fe514b3e28) last updated 2017/07/10 13:00:47 (GMT -400)
  config file = None
  configured module search path = [u'/Users/rahushen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rahushen/cisco/ansible/lib/ansible
  executable location = /Users/rahushen/cisco/ansible/bin/ansible
  python version = 2.7.12 (v2.7.12:d33e0cf91556, Jun 26 2016, 12:10:39) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```