### PR TITLE
fix for ec2 module terminating instances outside of inventory -- Fixes #19427

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -674,7 +674,7 @@ def get_reservations(module, ec2, tags=None, state=None, zone=None):
                 pass
 
         # if not a string type, convert and make sure it's a text string
-        if not isinstance(tags, string_types):
+        if isinstance(tags, int):
             tags = to_text(tags)
 
         # if string, we only care that a tag of that name exists

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -673,9 +673,9 @@ def get_reservations(module, ec2, tags=None, state=None, zone=None):
             except:
                 pass
 
-        # if int, we need to convert to a string
-        if isinstance(tags, int):
-            tags = str(tags)
+        # if not a string type, convert and make sure it's a text string
+        if not isinstance(tags, string_types):
+            tags = to_text(tags)
 
         # if string, we only care that a tag of that name exists
         if isinstance(tags, str):
@@ -696,7 +696,7 @@ def get_reservations(module, ec2, tags=None, state=None, zone=None):
             filters.update(dict(("tag:" + tn, tv) for (tn, tv) in tags.items()))
 
         # lets check to see if the filters dict is empty, if so then stop
-        if bool(filters) is False:
+        if not filters:
             module.fail_json(msg="Filters based on tag is empty => tags: %s" % (tags))
 
     if state:

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -673,6 +673,10 @@ def get_reservations(module, ec2, tags=None, state=None, zone=None):
             except:
                 pass
 
+        # if int, we need to convert to a string
+        if isinstance(tags, int):
+            tags = str(tags)
+
         # if string, we only care that a tag of that name exists
         if isinstance(tags, str):
             filters.update({"tag-key": tags})
@@ -690,6 +694,10 @@ def get_reservations(module, ec2, tags=None, state=None, zone=None):
         if isinstance(tags, dict):
             tags = _set_none_to_blank(tags)
             filters.update(dict(("tag:" + tn, tv) for (tn, tv) in tags.items()))
+
+        # lets check to see if the filters dict is empty, if so then stop
+        if bool(filters) is False:
+            module.fail_json(msg="Filters based on tag is empty => tags: %s" % (tags))
 
     if state:
         # http://stackoverflow.com/questions/437511/what-are-the-valid-instancestates-for-the-amazon-ec2-api


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is the fix for terminated instances based on #19427. We insure that the tags filter is populated and that if an int is passed it's converted to a string.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
This should be a straight-forward change.
```
