### PR TITLE
Disable skipped tests for remote platforms.

### DIFF
--- a/test/integration/targets/apt/aliases
+++ b/test/integration/targets/apt/aliases
@@ -1,2 +1,5 @@
 destructive
 posix/ci/group1
+skip/freebsd
+skip/osx
+skip/rhel

--- a/test/integration/targets/apt_key/aliases
+++ b/test/integration/targets/apt_key/aliases
@@ -1,1 +1,4 @@
 posix/ci/group1
+skip/freebsd
+skip/osx
+skip/rhel

--- a/test/integration/targets/apt_repository/aliases
+++ b/test/integration/targets/apt_repository/aliases
@@ -1,3 +1,6 @@
 apt_key
 destructive
 posix/ci/group1
+skip/freebsd
+skip/osx
+skip/rhel

--- a/test/integration/targets/dnf/aliases
+++ b/test/integration/targets/dnf/aliases
@@ -1,2 +1,4 @@
 destructive
 posix/ci/group1
+skip/freebsd
+skip/osx

--- a/test/integration/targets/dpkg_selections/aliases
+++ b/test/integration/targets/dpkg_selections/aliases
@@ -1,2 +1,5 @@
 posix/ci/group1
 destructive
+skip/freebsd
+skip/osx
+skip/rhel

--- a/test/integration/targets/zypper/aliases
+++ b/test/integration/targets/zypper/aliases
@@ -1,2 +1,5 @@
 destructive
 posix/ci/group1
+skip/freebsd
+skip/osx
+skip/rhel

--- a/test/integration/targets/zypper_repository/aliases
+++ b/test/integration/targets/zypper_repository/aliases
@@ -1,2 +1,5 @@
 destructive
 posix/ci/group1
+skip/freebsd
+skip/osx
+skip/rhel


### PR DESCRIPTION
##### SUMMARY

Disable skipped tests for remote platforms. This will avoid provisioning of remote instances for these tests. It will also speed up tests on the affected platforms and reduce log size.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

integration tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (ci-perf 169711325c) last updated 2017/07/10 12:14:21 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
