### PR TITLE
ec2_group: not idempotent when group_id or cidr_ip in rules is null - fixes 26286

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -615,6 +615,10 @@ def main():
                     rule['from_port'] = None
                     rule['to_port'] = None
 
+                # rule may have empty cidr_id/group_id/group_name in which case a real rule won't be created
+                if not (rule.get('group_id') and rule.get('group_name') and rule.get('cidr_ip')):
+                    continue
+
                 if group_id:
                     rule_id = make_rule_key('in', rule, group.id, group_id)
                     if rule_id in groupRules:
@@ -679,6 +683,10 @@ def main():
                     rule['proto'] = -1
                     rule['from_port'] = None
                     rule['to_port'] = None
+
+                # rule may have empty cidr_id/group_id/group_name in which case a real rule won't be created
+                if not (rule.get('group_id') and rule.get('group_name') and rule.get('cidr_ip')):
+                    continue
 
                 if group_id:
                     rule_id = make_rule_key('out', rule, group.id, group_id)

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -616,7 +616,7 @@ def main():
                     rule['to_port'] = None
 
                 # rule may have empty cidr_id/group_id/group_name in which case a real rule won't be created
-                if not (rule.get('group_id') and rule.get('group_name') and rule.get('cidr_ip')):
+                if not (rule.get('group_id') or rule.get('group_name') or rule.get('cidr_ip')):
                     continue
 
                 if group_id:
@@ -685,7 +685,7 @@ def main():
                     rule['to_port'] = None
 
                 # rule may have empty cidr_id/group_id/group_name in which case a real rule won't be created
-                if not (rule.get('group_id') and rule.get('group_name') and rule.get('cidr_ip')):
+                if not (rule.get('group_id') or rule.get('group_name') or rule.get('cidr_ip')):
                     continue
 
                 if group_id:


### PR DESCRIPTION
##### SUMMARY
If none of group_id, group_name, or cidr_ip are specified with a value the rule will not be created; ignore the rule rather than failing. Still debating whether this should actually fail (with a helpful error) since it may appear as though a security group has been created with an invalid rule (and fails silently to add the invalid rule). Input appreciated. Fixes #26286.

See https://github.com/ansible/ansible/issues/26431 for the discussion that led me to this fix.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
2.4.0
```
