### PR TITLE
Improve ansible-test support for shared test roles.

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -310,6 +310,43 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None)
             yield TestTarget(os.path.join(root, file_name), module_path, prefix, path)
 
 
+def analyze_integration_target_dependencies(integration_targets):
+    """
+    :type: list[IntegrationTarget]
+    :rtype: dict[str,set[str]]
+    """
+    hidden_role_target_names = set(t.name for t in integration_targets if t.type == 'role' and 'hidden/' in t.aliases)
+    normal_role_targets = [t for t in integration_targets if t.type == 'role' and 'hidden/' not in t.aliases]
+    dependencies = dict((target_name, set()) for target_name in hidden_role_target_names)
+
+    # intentionally primitive analysis of role meta to avoid a dependency on pyyaml
+    for role_target in normal_role_targets:
+        meta_dir = os.path.join(role_target.path, 'meta')
+
+        if not os.path.isdir(meta_dir):
+            continue
+
+        meta_paths = sorted([os.path.join(meta_dir, name) for name in os.listdir(meta_dir)])
+
+        for meta_path in meta_paths:
+            if os.path.exists(meta_path):
+                with open(meta_path, 'r') as meta_fd:
+                    meta_lines = meta_fd.read().splitlines()
+
+                for meta_line in meta_lines:
+                    if re.search(r'^ *#.*$', meta_line):
+                        continue
+
+                    if not meta_line.strip():
+                        continue
+
+                    for hidden_target_name in hidden_role_target_names:
+                        if hidden_target_name in meta_line:
+                            dependencies[hidden_target_name].add(role_target.name)
+
+    return dependencies
+
+
 class CompletionTarget(object):
     """Command-line argument completion target base class."""
     __metaclass__ = abc.ABCMeta
@@ -435,7 +472,7 @@ class IntegrationTarget(CompletionTarget):
             self.script_path = os.path.join(path, runme_files[0])
         elif test_files:
             self.type = 'special'
-        elif os.path.isdir(os.path.join(path, 'tasks')):
+        elif os.path.isdir(os.path.join(path, 'tasks')) or os.path.isdir(os.path.join(path, 'defaults')):
             self.type = 'role'
         else:
             self.type = 'unknown'


### PR DESCRIPTION
##### SUMMARY

This enables `ansible-test` to run only relevant tests when a shared role (`setup_*`, `prepare_*`, etc.) is changed, instead of running all tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-test-role-deps 9703175fa0) last updated 2017/07/10 17:26:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
