### PR TITLE
Added rounds parameter support for lookup password

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -34,7 +34,7 @@ from ansible.utils.path import makedirs_safe
 
 
 DEFAULT_LENGTH = 20
-VALID_PARAMS = frozenset(('length', 'encrypt', 'chars'))
+VALID_PARAMS = frozenset(('length', 'encrypt', 'rounds', 'chars'))
 
 
 def _parse_parameters(term):
@@ -72,6 +72,7 @@ def _parse_parameters(term):
     # Set defaults
     params['length'] = int(params.get('length', DEFAULT_LENGTH))
     params['encrypt'] = params.get('encrypt', None)
+    params['rounds'] = params.get('rounds', None)
 
     params['chars'] = params.get('chars', None)
     if params['chars']:
@@ -249,7 +250,7 @@ class LookupModule(LookupBase):
                 _write_password_file(b_path, content)
 
             if params['encrypt']:
-                password = do_encrypt(plaintext_password, params['encrypt'], salt=salt)
+                password = do_encrypt(plaintext_password, params['encrypt'], salt=salt, rounds=params['rounds'])
                 ret.append(password)
             else:
                 ret.append(plaintext_password)

--- a/test/units/plugins/lookup/test_password.py
+++ b/test/units/plugins/lookup/test_password.py
@@ -43,7 +43,7 @@ old_style_params_data = (
     dict(
         term=u'/path/to/file',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
 
@@ -51,38 +51,38 @@ old_style_params_data = (
     dict(
         term=u'/path/with/embedded spaces and/file',
         filename=u'/path/with/embedded spaces and/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     dict(
         term=u'/path/with/equals/cn=com.ansible',
         filename=u'/path/with/equals/cn=com.ansible',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     dict(
         term=u'/path/with/unicode/くらとみ/file',
         filename=u'/path/with/unicode/くらとみ/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     # Mix several special chars
     dict(
         term=u'/path/with/utf 8 and spaces/くらとみ/file',
         filename=u'/path/with/utf 8 and spaces/くらとみ/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     dict(
         term=u'/path/with/encoding=unicode/くらとみ/file',
         filename=u'/path/with/encoding=unicode/くらとみ/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     dict(
         term=u'/path/with/encoding=unicode/くらとみ/and spaces file',
         filename=u'/path/with/encoding=unicode/くらとみ/and spaces file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
 
@@ -90,25 +90,25 @@ old_style_params_data = (
     dict(
         term=u'/path/to/file length=42',
         filename=u'/path/to/file',
-        params=dict(length=42, encrypt=None, chars=DEFAULT_CHARS),
+        params=dict(length=42, encrypt=None, chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     dict(
         term=u'/path/to/file encrypt=pbkdf2_sha256',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt='pbkdf2_sha256', chars=DEFAULT_CHARS, rounds=None),
         candidate_chars=DEFAULT_CANDIDATE_CHARS,
     ),
     dict(
         term=u'/path/to/file chars=abcdefghijklmnop',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop']),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abcdefghijklmnop'], rounds=None),
         candidate_chars=u'abcdefghijklmnop',
     ),
     dict(
         term=u'/path/to/file chars=digits,abc,def',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def'])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc', u'def']), rounds=None),
         candidate_chars=u'abcdef0123456789',
     ),
 
@@ -116,13 +116,13 @@ old_style_params_data = (
     dict(
         term=u'/path/to/file chars=abcdefghijklmnop,,digits',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits'])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'abcdefghijklmnop', u',', u'digits']), rounds=None),
         candidate_chars=u',abcdefghijklmnop0123456789',
     ),
     dict(
         term=u'/path/to/file chars=,,',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u',']),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u','], rounds=None),
         candidate_chars=u',',
     ),
 
@@ -130,13 +130,13 @@ old_style_params_data = (
     dict(
         term=u'/path/to/file chars=digits,=,,',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u','])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'=', u',']), rounds=None),
         candidate_chars=u',=0123456789',
     ),
     dict(
         term=u'/path/to/file chars=digits,abc=def',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def'])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'abc=def']), rounds=None),
         candidate_chars=u'abc=def0123456789',
     ),
 
@@ -144,14 +144,14 @@ old_style_params_data = (
     dict(
         term=u'/path/to/file chars=digits,くらとみ,,',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u','])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'digits', u'くらとみ', u',']), rounds=None),
         candidate_chars=u',0123456789くらとみ',
     ),
     # Including only unicode in chars
     dict(
         term=u'/path/to/file chars=くらとみ',
         filename=u'/path/to/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ'])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'くらとみ']), rounds=None),
         candidate_chars=u'くらとみ',
     ),
 
@@ -159,7 +159,7 @@ old_style_params_data = (
     dict(
         term=u'/path/to/file_with:colon chars=ascii_letters,digits',
         filename=u'/path/to/file_with:colon',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits'])),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=sorted([u'ascii_letters', u'digits']), rounds=None),
         candidate_chars=u'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',
     ),
 
@@ -168,19 +168,19 @@ old_style_params_data = (
     dict(
         term=u'/path/with/embedded spaces and/file chars=abc=def',
         filename=u'/path/with/embedded spaces and/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'], rounds=None),
         candidate_chars=u'abc=def',
     ),
     dict(
         term=u'/path/with/equals/cn=com.ansible chars=abc=def',
         filename=u'/path/with/equals/cn=com.ansible',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def']),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'abc=def'], rounds=None),
         candidate_chars=u'abc=def',
     ),
     dict(
         term=u'/path/with/unicode/くらとみ/file chars=くらとみ',
         filename=u'/path/with/unicode/くらとみ/file',
-        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ']),
+        params=dict(length=password.DEFAULT_LENGTH, encrypt=None, chars=[u'くらとみ'], rounds=None),
         candidate_chars=u'くらとみ',
     ),
 )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
By default python-passlib used for password hashing in `lookup password` plugin.
Because in python-passlib `rounds` parameter is set to 656000 by default, on slow (embedded) systems user need to wait extremly long for login (about 20 seconds on BeagleBone Black).
To support setting `rounds` parameter from `lookup password` module, some changes was made. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/lookup/password

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/sanchox/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
