### PR TITLE
Clarify behaviour for unmounted state of `mount` task

### DIFF
--- a/lib/ansible/modules/system/mount.py
+++ b/lib/ansible/modules/system/mount.py
@@ -78,8 +78,9 @@ options:
     default: 0
   state:
     description:
-      - If C(mounted) or C(unmounted), the device will be actively mounted or
-        unmounted as needed and appropriately configured in I(fstab).
+      - If C(mounted), the device will be actively mounted and appropriately
+        configured in I(fstab).
+      - If C(unmounted), the device will be unmounted without changing I(fstab).
       - C(absent) and C(present) only deal with I(fstab) but will not affect
         current mounting.
       - If specifying C(mounted) and the mount point is not present, the mount


### PR DESCRIPTION
##### SUMMARY

Based on the docs, we weren't sure if unmounting an item would change `fstab`. It doesn't, so I've clarified that.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`mount`

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = /Users/craig/code/moj/automation.ansible/ansible.cfg
  configured module search path = ['library']
```
(though I have a few versions installed - this is just the current one active, and the patch is against the docs on the `devel` branch.)

##### ADDITIONAL INFORMATION
N/A