### PR TITLE
changed collection arg to argregate on 2.4 network modules

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -315,7 +315,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection']),
+        users=dict(type='list', aliases=['collection', 'aggregate']),
         username=dict(aliases=['name']),
 
         password=dict(no_log=True),

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -35,7 +35,7 @@ description:
     configuration that are not explicitly defined.
 extends_documentation_fragment: eos
 options:
-  users:
+  aggregate:
     description:
       - The set of username objects to be configured on the remote
         Arista EOS device.  The list entries can either be the username
@@ -45,7 +45,7 @@ options:
     description:
       - The username to be configured on the remote Arista EOS
         device.  This argument accepts a stringv value and is mutually
-        exclusive with the C(users) argument.
+        exclusive with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
   password:
     description:
@@ -115,7 +115,7 @@ EXAMPLES = """
 
 - name: set multiple users to privilege level 15
   eos_user:
-    users:
+    aggregate:
       - username: netop
       - username: netend
     privilege: 15
@@ -263,8 +263,8 @@ def get_param_value(key, item, module):
     return value
 
 def map_params_to_obj(module):
-    users = module.params['users']
-    if not users:
+    aggregate = module.params['aggregate']
+    if not aggregate:
         if not module.params['username'] and module.params['purge']:
             return list()
         elif not module.params['username']:
@@ -273,7 +273,7 @@ def map_params_to_obj(module):
             collection = [{'username': module.params['username']}]
     else:
         collection = list()
-        for item in users:
+        for item in aggregate:
             if not isinstance(item, dict):
                 collection.append({'username': item})
             elif all(u not in item for u in ['username', 'name']):
@@ -315,7 +315,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection', 'aggregate']),
+        aggregate=dict(type='list', aliases=['collection', 'users']),
         username=dict(aliases=['name']),
 
         password=dict(no_log=True),
@@ -332,7 +332,7 @@ def main():
     )
 
     argument_spec.update(eos_argument_spec)
-    mutually_exclusive = [('username', 'users')]
+    mutually_exclusive = [('username', 'aggregate')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -41,6 +41,7 @@ options:
         Arista EOS device.  The list entries can either be the username
         or a hash of username and properties.  This argument is mutually
         exclusive with the C(username) argument.
+    version_added: "2.4"
   username:
     description:
       - The username to be configured on the remote Arista EOS

--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -45,11 +45,11 @@ options:
     description:
       - List of interfaces to check the VLAN has been
         configured correctly.
-  collection:
+  aggregate:
     description: List of VLANs definitions
   purge:
     description:
-      - Purge VLANs not defined in the collections parameter.
+      - Purge VLANs not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -157,7 +157,7 @@ def main():
         vlan_id=dict(required=True, type='int'),
         name=dict(),
         interfaces=dict(),
-        collection=dict(),
+        aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present',
                    choices=['present', 'absent', 'active', 'suspend'])

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -45,11 +45,11 @@ options:
     description:
       - List of interfaces to check the VRF has been
         configured correctly.
-  collection:
+  aggregate:
     description: List of VRFs definitions
   purge:
     description:
-      - Purge VRFs not defined in the collections parameter.
+      - Purge VRFs not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -154,7 +154,7 @@ def main():
         name=dict(required=True),
         interfaces=dict(type='list'),
         rd=dict(),
-        collection=dict(),
+        aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present', choices=['present', 'absent'])
     )

--- a/lib/ansible/modules/network/interface/net_interface.py
+++ b/lib/ansible/modules/network/interface/net_interface.py
@@ -64,11 +64,11 @@ options:
   rx_rate:
     description:
       - Receiver rate
-  collection:
+  aggregate:
     description: List of Interfaces definitions.
   purge:
     description:
-      - Purge Interfaces not defined in the collections parameter.
+      - Purge Interfaces not defined in the aggregates parameter.
         This applies only for logical interface.
     default: no
   state:

--- a/lib/ansible/modules/network/interface/net_linkagg.py
+++ b/lib/ansible/modules/network/interface/net_linkagg.py
@@ -55,11 +55,11 @@ options:
     description:
       - Minimum members that should be up
         before bringing up the link aggregation group.
-  collection:
+  aggregate:
     description: List of link aggregation definitions.
   purge:
     description:
-      - Purge link aggregation groups not defined in the collections parameter.
+      - Purge link aggregation groups not defined in the aggregates parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/ios/ios_static_route.py
+++ b/lib/ansible/modules/network/ios/ios_static_route.py
@@ -47,11 +47,11 @@ options:
     description:
       - Admin distance of the static route.
     default: 1
-  collection:
+  aggregate:
     description: List of static route definitions
   purge:
     description:
-      - Purge static routes not defined in the collections parameter.
+      - Purge static routes not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -74,9 +74,9 @@ EXAMPLES = """
     next_hop: 10.0.0.1
     state: absent
 
-- name: configure collections of static routes
+- name: configure aggregates of static routes
   ios_static_route:
-    collection:
+    aggregate:
       - { prefix: 192.168.2.0, mask 255.255.255.0, next_hop: 10.0.0.1 }
       - { prefix: 192.168.3.0, mask 255.255.255.0, next_hop: 10.0.2.1 }
 """
@@ -146,8 +146,8 @@ def map_config_to_obj(module):
 def map_params_to_obj(module):
     obj = []
 
-    if 'collection' in module.params and module.params['collection']:
-        for c in module.params['collection']:
+    if 'aggregate' in module.params and module.params['aggregate']:
+        for c in module.params['aggregate']:
             d = c.copy()
 
             if 'state' not in d:
@@ -182,15 +182,15 @@ def main():
         mask=dict(type='str'),
         next_hop=dict(type='str'),
         admin_distance=dict(default=1, type='int'),
-        collection=dict(type='list'),
+        aggregate=dict(type='list'),
         purge=dict(type='bool'),
         state=dict(default='present', choices=['present', 'absent'])
     )
 
     argument_spec.update(ios_argument_spec)
-    required_one_of = [['collection', 'prefix']]
+    required_one_of = [['aggregate', 'prefix']]
     required_together = [['prefix', 'mask', 'next_hop']]
-    mutually_exclusive = [['collection', 'prefix']]
+    mutually_exclusive = [['aggregate', 'prefix']]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=required_one_of,

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -28,11 +28,11 @@ DOCUMENTATION = """
 module: ios_user
 version_added: "2.4"
 author: "Trishna Guha (@trishnag)"
-short_description: Manage the collection of local users on Cisco IOS device
+short_description: Manage the aggregate of local users on Cisco IOS device
 description:
   - This module provides declarative management of the local usernames
     configured on network devices. It allows playbooks to manage
-    either individual usernames or the collection of usernames in the
+    either individual usernames or the aggregate of usernames in the
     current running config. It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
@@ -46,7 +46,7 @@ options:
     description:
       - The username to be configured on the Cisco IOS device.
         This argument accepts a string value and is mutually exclusive
-        with the C(collection) argument.
+        with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
   password:
     description:
@@ -256,20 +256,20 @@ def map_params_to_obj(module):
         elif not module.params['name']:
             module.fail_json(msg='username is required')
         else:
-            collection = [{'name': module.params['name']}]
+            aggregate = [{'name': module.params['name']}]
     else:
-        collection = list()
+        aggregate = list()
         for item in users:
             if not isinstance(item, dict):
-                collection.append({'name': item})
+                aggregate.append({'name': item})
             elif 'name' not in item:
                 module.fail_json(msg='name is required')
             else:
-                collection.append(item)
+                aggregate.append(item)
 
     objects = list()
 
-    for item in collection:
+    for item in aggregate:
         get_value = partial(get_param_value, item=item, module=module)
         item['password'] = get_value('password')
         item['nopassword'] = get_value('nopassword')
@@ -298,7 +298,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection']),
+        users=dict(type='list', aliases=['aggregate']),
         name=dict(),
 
         password=dict(no_log=True),

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -28,11 +28,11 @@ DOCUMENTATION = """
 module: iosxr_user
 version_added: "2.4"
 author: "Trishna Guha (@trishnag)"
-short_description: Manage the collection of local users on Cisco IOS XR device
+short_description: Manage the aggregate of local users on Cisco IOS XR device
 description:
   - This module provides declarative management of the local usernames
     configured on network devices. It allows playbooks to manage
-    either individual usernames or the collection of usernames in the
+    either individual usernames or the aggregate of usernames in the
     current running config. It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
@@ -41,12 +41,12 @@ options:
       - The set of username objects to be configured on the remote
         Cisco IOS XR device. The list entries can either be the username
         or a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument, alias C(collection).
+        exclusive with the C(name) argument, alias C(aggregate).
   name:
     description:
       - The username to be configured on the Cisco IOS XR device.
         This argument accepts a string value and is mutually exclusive
-        with the C(collection) argument.
+        with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
   password:
     description:
@@ -218,20 +218,20 @@ def map_params_to_obj(module):
         elif not module.params['name']:
             module.fail_json(msg='username is required')
         else:
-            collection = [{'name': module.params['name']}]
+            aggregate = [{'name': module.params['name']}]
     else:
-        collection = list()
+        aggregate = list()
         for item in users:
             if not isinstance(item, dict):
-                collection.append({'name': item})
+                aggregate.append({'name': item})
             elif 'name' not in item:
                 module.fail_json(msg='name is required')
             else:
-                collection.append(item)
+                aggregate.append(item)
 
     objects = list()
 
-    for item in collection:
+    for item in aggregate:
         get_value = partial(get_param_value, item=item, module=module)
         item['password'] = get_value('password')
         item['group'] = get_value('group')
@@ -258,7 +258,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection']),
+        users=dict(type='list', aliases=['aggregate']),
         name=dict(),
 
         password=dict(no_log=True),

--- a/lib/ansible/modules/network/junos/junos_interface.py
+++ b/lib/ansible/modules/network/junos/junos_interface.py
@@ -61,11 +61,11 @@ options:
   rx_rate:
     description:
       - Receiver rate.
-  collection:
+  aggregate:
     description: List of Interfaces definitions.
   purge:
     description:
-      - Purge Interfaces not defined in the collections parameter.
+      - Purge Interfaces not defined in the aggregates parameter.
         This applies only for logical interface.
     default: no
   state:
@@ -179,7 +179,7 @@ def main():
         duplex=dict(choices=['full', 'half', 'auto']),
         tx_rate=dict(),
         rx_rate=dict(),
-        collection=dict(),
+        aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present',
                    choices=['present', 'absent', 'up', 'down']),

--- a/lib/ansible/modules/network/junos/junos_logging.py
+++ b/lib/ansible/modules/network/junos/junos_logging.py
@@ -49,11 +49,11 @@ options:
   level:
     description:
       - Set logging severity levels.
-  collection:
+  aggregate:
     description: List of logging definitions.
   purge:
     description:
-      - Purge logging not defined in the collections parameter.
+      - Purge logging not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -173,7 +173,7 @@ def main():
         size=dict(type='int'),
         files=dict(type='int'),
         src_addr=dict(),
-        collection=dict(),
+        aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')

--- a/lib/ansible/modules/network/junos/junos_static_route.py
+++ b/lib/ansible/modules/network/junos/junos_static_route.py
@@ -54,11 +54,11 @@ options:
   qualified_preference:
     description:
       - Assign preference for qualified next hop.
-  collection:
+  aggregate:
     description: List of static route definitions
   purge:
     description:
-      - Purge static routes not defined in the collections parameter.
+      - Purge static routes not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -161,15 +161,15 @@ def main():
         preference=dict(type='int', aliases=['admin_distance']),
         qualified_next_hop=dict(type='str'),
         qualified_preference=dict(type='int'),
-        collection=dict(type='list'),
+        aggregate=dict(type='list'),
         purge=dict(type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')
     )
 
     argument_spec.update(junos_argument_spec)
-    required_one_of = [['collection', 'address']]
-    mutually_exclusive = [['collection', 'address']]
+    required_one_of = [['aggregate', 'address']]
+    mutually_exclusive = [['aggregate', 'address']]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=required_one_of,

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -34,9 +34,9 @@ description:
     defined accounts
 extends_documentation_fragment: junos
 options:
-  users:
+  aggregate:
     description:
-      - The C(users) argument defines a list of users to be configured
+      - The C(aggregate) argument defines a list of users to be configured
         on the remote device.  The list of users will be compared against
         the current users and only changes will be added or removed from
         the device configuration.  This argument is mutually exclusive with
@@ -48,7 +48,7 @@ options:
       - The C(name) argument defines the username of the user to be created
         on the system.  This argument must follow appropriate usernaming
         conventions for the target device running JUNOS.  This argument is
-        mutually exclusive with the C(users) argument.
+        mutually exclusive with the C(aggregate) argument.
     required: false
     default: null
   full_name:
@@ -206,8 +206,8 @@ def get_param_value(key, item, module):
 
 
 def map_params_to_obj(module):
-    users = module.params['users']
-    if not users:
+    aggregate = module.params['aggregate']
+    if not aggregate:
         if not module.params['name'] and module.params['purge']:
             return list()
         elif not module.params['name']:
@@ -216,7 +216,7 @@ def map_params_to_obj(module):
             collection = [{'name': module.params['name']}]
     else:
         collection = list()
-        for item in users:
+        for item in aggregate:
             if not isinstance(item, dict):
                 collection.append({'username': item})
             elif 'name' not in item:
@@ -251,7 +251,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection', 'aggregate']),
+        aggregate=dict(type='list', aliases=['collection', 'users']),
         name=dict(),
 
         full_name=dict(),
@@ -264,7 +264,7 @@ def main():
         active=dict(default=True, type='bool')
     )
 
-    mutually_exclusive = [('users', 'name')]
+    mutually_exclusive = [('aggregate', 'name')]
 
     argument_spec.update(junos_argument_spec)
 

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -251,7 +251,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection']),
+        users=dict(type='list', aliases=['collection', 'aggregate']),
         name=dict(),
 
         full_name=dict(),

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -41,6 +41,7 @@ options:
         the current users and only changes will be added or removed from
         the device configuration.  This argument is mutually exclusive with
         the name argument.
+    version_added: "2.4"
     required: False
     default: null
   name:

--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -49,11 +49,11 @@ options:
     description:
       - List of interfaces to check the VLAN has been
         configured correctly.
-  collection:
+  aggregate:
     description: List of VLANs definitions.
   purge:
     description:
-      - Purge VLANs not defined in the collections parameter.
+      - Purge VLANs not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -144,7 +144,7 @@ def main():
         vlan_id=dict(required=True, type='int'),
         description=dict(),
         interfaces=dict(),
-        collection=dict(),
+        aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')

--- a/lib/ansible/modules/network/layer2/net_l2_interface.py
+++ b/lib/ansible/modules/network/layer2/net_l2_interface.py
@@ -36,7 +36,7 @@ options:
   name:
     description:
       - Name of the interface excluding any logical unit number.
-  collection:
+  aggregate:
     description:
       - List of Layer-2 interface definitions.
   mode:

--- a/lib/ansible/modules/network/layer2/net_vlan.py
+++ b/lib/ansible/modules/network/layer2/net_vlan.py
@@ -43,11 +43,11 @@ options:
   interfaces:
     description:
       - List of interfaces the VLAN should be configured on.
-  collection:
+  aggregate:
     description: List of VLANs definitions.
   purge:
     description:
-      - Purge VLANs not defined in the collections parameter.
+      - Purge VLANs not defined in the aggregates parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/layer3/net_l3_interface.py
+++ b/lib/ansible/modules/network/layer3/net_l3_interface.py
@@ -43,11 +43,11 @@ options:
   ipv6:
     description:
       - IPv6 of the L3 interface.
-  collection:
+  aggregate:
     description: List of L3 interfaces definitions
   purge:
     description:
-      - Purge L3 interfaces not defined in the collections parameter.
+      - Purge L3 interfaces not defined in the aggregates parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/layer3/net_vrf.py
+++ b/lib/ansible/modules/network/layer3/net_vrf.py
@@ -40,11 +40,11 @@ options:
   interfaces:
     description:
       - List of interfaces the VRF should be configured on.
-  collection:
+  aggregate:
     description: List of VRFs definitions
   purge:
     description:
-      - Purge VRFs not defined in the collections parameter.
+      - Purge VRFs not defined in the aggregates parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -35,7 +35,7 @@ description:
     current running config.  It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
-  users:
+  aggregate:
     description:
       - The set of username objects to be configured on the remote
         Cisco Nexus device.  The list entries can either be the username
@@ -47,7 +47,7 @@ options:
     description:
       - The username to be configured on the remote Cisco Nexus
         device.  This argument accepts a stringv value and is mutually
-        exclusive with the C(users) argument.
+        exclusive with the C(aggregate) argument.
     required: false
     default: null
   update_password:
@@ -106,7 +106,7 @@ EXAMPLES = """
     purge: yes
 
 - name: set multiple users role
-  users:
+  aggregate:
     - name: netop
     - name: netend
   role: network-operator
@@ -242,8 +242,8 @@ def get_param_value(key, item, module):
     return value
 
 def map_params_to_obj(module):
-    users = module.params['users']
-    if not users:
+    aggregate = module.params['aggregate']
+    if not aggregate:
         if not module.params['name'] and module.params['purge']:
             return list()
         elif not module.params['name']:
@@ -252,7 +252,7 @@ def map_params_to_obj(module):
             collection = [{'name': module.params['name']}]
     else:
         collection = list()
-        for item in users:
+        for item in aggregate:
             if not isinstance(item, dict):
                 collection.append({'name': item})
             elif 'name' not in item:
@@ -298,7 +298,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', no_log=True, aliases=['collection', 'aggregate']),
+        aggregate=dict(type='list', no_log=True, aliases=['collection', 'users']),
         name=dict(),
 
         password=dict(no_log=True),
@@ -314,7 +314,7 @@ def main():
 
     argument_spec.update(nxos_argument_spec)
 
-    mutually_exclusive = [('name', 'users')]
+    mutually_exclusive = [('name', 'aggregate')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -298,7 +298,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', no_log=True, aliases=['collection']),
+        users=dict(type='list', no_log=True, aliases=['collection', 'aggregate']),
         name=dict(),
 
         password=dict(no_log=True),

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -41,6 +41,7 @@ options:
         Cisco Nexus device.  The list entries can either be the username
         or a hash of username and properties.  This argument is mutually
         exclusive with the C(name) argument.
+    version_added: "2.4"
     required: false
     default: null
   name:

--- a/lib/ansible/modules/network/routing/net_static_route.py
+++ b/lib/ansible/modules/network/routing/net_static_route.py
@@ -49,11 +49,11 @@ options:
   admin_distance:
     description:
       - Admin distance of the static route.
-  collection:
+  aggregate:
     description: List of static route definitions
   purge:
     description:
-      - Purge static routes not defined in the collections parameter.
+      - Purge static routes not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -76,9 +76,9 @@ EXAMPLES = """
     next_hop: 10.0.0.1
     state: absent
 
-- name: configure collections of static routes
+- name: configure aggregates of static routes
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 192.168.2.0, mask 255.255.255.0, next_hop: 10.0.0.1 }
       - { prefix: 192.168.3.0, mask 255.255.255.0, next_hop: 10.0.2.1 }
 """

--- a/lib/ansible/modules/network/system/net_logging.py
+++ b/lib/ansible/modules/network/system/net_logging.py
@@ -48,11 +48,11 @@ options:
   level:
     description:
       - Set logging severity levels.
-  collection:
+  aggregate:
     description: List of logging definitions.
   purge:
     description:
-      - Purge logging not defined in the collections parameter.
+      - Purge logging not defined in the aggregates parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/system/net_user.py
+++ b/lib/ansible/modules/network/system/net_user.py
@@ -28,15 +28,15 @@ DOCUMENTATION = """
 module: net_user
 version_added: "2.4"
 author: "Trishna Guha (@trishnag)"
-short_description: Manage the collection of local users on network device
+short_description: Manage the aggregate of local users on network device
 description:
   - This module provides declarative management of the local usernames
     configured on network devices. It allows playbooks to manage
-    either individual usernames or the collection of usernames in the
+    either individual usernames or the aggregate of usernames in the
     current running config. It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
-  collection:
+  aggregate:
     description:
       - The set of username objects to be configured on the remote
         network device. The list entries can either be the username
@@ -46,7 +46,7 @@ options:
     description:
       - The username to be configured on the remote network device.
         This argument accepts a string value and is mutually exclusive
-        with the C(collection) argument.
+        with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
   password:
     description:
@@ -114,7 +114,7 @@ EXAMPLES = """
     purge: yes
 - name: set multiple users to privilege level 15
   net_user:
-    collection:
+    aggregate:
       - name: netop
       - name: netend
     privilege: 15

--- a/lib/ansible/modules/network/vyos/vyos_linkagg.py
+++ b/lib/ansible/modules/network/vyos/vyos_linkagg.py
@@ -47,11 +47,11 @@ options:
   members:
     description:
       - List of members of the link aggregation group.
-  collection:
+  aggregate:
     description: List of link aggregation definitions.
   purge:
     description:
-      - Purge link aggregation groups not defined in the collections parameter.
+      - Purge link aggregation groups not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -174,8 +174,8 @@ def map_config_to_obj(module):
 def map_params_to_obj(module):
     obj = []
 
-    if 'collection' in module.params and module.params['collection']:
-        for c in module.params['collection']:
+    if 'aggregate' in module.params and module.params['aggregate']:
+        for c in module.params['aggregate']:
             d = c.copy()
 
             if 'state' not in d:
@@ -205,7 +205,7 @@ def main():
                            'adaptive-load-balance', 'xor-hash', 'on'],
                   default='802.3ad'),
         members=dict(type='list'),
-        collection=dict(type='list'),
+        aggregate=dict(type='list'),
         purge=dict(default=False, type='bool'),
         state=dict(default='present',
                    choices=['present', 'absent', 'up', 'down'])
@@ -213,8 +213,8 @@ def main():
 
     argument_spec.update(vyos_argument_spec)
 
-    required_one_of = [['name', 'collection']]
-    mutually_exclusive = [['name', 'collection']]
+    required_one_of = [['name', 'aggregate']]
+    mutually_exclusive = [['name', 'aggregate']]
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=required_one_of,
                            supports_check_mode=True)

--- a/lib/ansible/modules/network/vyos/vyos_static_route.py
+++ b/lib/ansible/modules/network/vyos/vyos_static_route.py
@@ -48,11 +48,11 @@ options:
   admin_distance:
     description:
       - Admin distance of the static route.
-  collection:
+  aggregate:
     description: List of static route definitions
   purge:
     description:
-      - Purge static routes not defined in the collections parameter.
+      - Purge static routes not defined in the aggregates parameter.
     default: no
   state:
     description:
@@ -77,9 +77,9 @@ EXAMPLES = """
     mask: 16
     next_hop: 10.0.0.1
     state: absent
-- name: configure collections of static routes
+- name: configure aggregates of static routes
   vyos_static_route:
-    collection:
+    aggregate:
       - { prefix: 192.168.2.0, mask: 24, next_hop: 10.0.0.1 }
       - { prefix: 192.168.3.0, mask: 16, next_hop: 10.0.2.1 }
       - { prefix: 192.168.3.0/16, next_hop: 10.0.2.1 }
@@ -159,8 +159,8 @@ def config_to_dict(module):
 def map_params_to_obj(module):
     obj = []
 
-    if 'collection' in module.params and module.params['collection']:
-        for c in module.params['collection']:
+    if 'aggregate' in module.params and module.params['aggregate']:
+        for c in module.params['aggregate']:
             d = c.copy()
             if '/' in d['prefix']:
                 d['mask'] = d['prefix'].split('/')[1]
@@ -202,15 +202,15 @@ def main():
         mask=dict(type='str'),
         next_hop=dict(type='str'),
         admin_distance=dict(type='int'),
-        collection=dict(type='list'),
+        aggregate=dict(type='list'),
         purge=dict(type='bool'),
         state=dict(default='present', choices=['present', 'absent'])
     )
 
     argument_spec.update(vyos_argument_spec)
-    required_one_of = [['collection', 'prefix']]
+    required_one_of = [['aggregate', 'prefix']]
     required_together = [['prefix', 'next_hop']]
-    mutually_exclusive = [['collection', 'prefix']]
+    mutually_exclusive = [['aggregate', 'prefix']]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=required_one_of,

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -46,7 +46,7 @@ options:
     description:
       - The username to be configured on the VyOS device.
         This argument accepts a string value and is mutually exclusive
-        with the C(collection) argument.
+        with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
   full_name:
     description:
@@ -238,20 +238,20 @@ def map_params_to_obj(module):
         elif not module.params['name']:
             module.fail_json(msg='username is required')
         else:
-            collection = [{'name': module.params['name']}]
+            aggregate = [{'name': module.params['name']}]
     else:
-        collection = list()
+        aggregate = list()
         for item in users:
             if not isinstance(item, dict):
-                collection.append({'name': item})
+                aggregate.append({'name': item})
             elif 'name' not in item:
                 module.fail_json(msg='name is required')
             else:
-                collection.append(item)
+                aggregate.append(item)
 
     objects = list()
 
-    for item in collection:
+    for item in aggregate:
         get_value = partial(get_param_value, item=item, module=module)
         item['password'] = get_value('password')
         item['full_name'] = get_value('full_name')
@@ -279,7 +279,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['collection']),
+        users=dict(type='list', aliases=['aggregate']),
         name=dict(),
 
         full_name=dict(),

--- a/test/integration/targets/eos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_user/tests/cli/basic.yaml
@@ -16,7 +16,7 @@
 
 - name: Collection of users
   eos_user:
-    users:
+    aggregate:
       - username: test1
       - username: test2
     authorize: yes

--- a/test/integration/targets/ios_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_static_route/tests/cli/basic.yaml
@@ -90,9 +90,9 @@
     that:
       - 'result.changed == false'
 
-- name: Add static route collections
+- name: Add static route aggregates
   ios_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: present
@@ -105,9 +105,9 @@
       - 'result.changed == true'
       - 'result.commands == ["ip route 172.16.32.0 255.255.255.0 10.0.0.8 1", "ip route 172.16.33.0 255.255.255.0 10.0.0.8 1"]'
 
-- name: Add and remove static route collections with overrides
+- name: Add and remove static route aggregates with overrides
   ios_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8, state: absent }
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
@@ -121,9 +121,9 @@
       - 'result.changed == true'
       - 'result.commands == ["no ip route 172.16.33.0 255.255.255.0 10.0.0.8", "ip route 172.16.34.0 255.255.255.0 10.0.0.8 1"]'
 
-- name: Remove static route collections
+- name: Remove static route aggregates
   ios_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -16,7 +16,7 @@
 
 - name: Collection of users (SetUp)
   ios_user:
-    users:
+    aggregate:
       - name: ansibletest2
       - name: ansibletest3
     authorize: yes
@@ -47,7 +47,7 @@
 
 - name: Add collection of users again (Idempotent)
   ios_user:
-    users:
+    aggregate:
       - name: anisbletest2
       - name: ansibletest3
     authorize: yes
@@ -63,7 +63,7 @@
 
 - name: tearDown
   ios_user:
-    users:
+    aggregate:
       - name: ansibletest1
       - name: ansibletest2
       - name: ansibletest3

--- a/test/integration/targets/iosxr_user/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/basic.yaml
@@ -52,7 +52,7 @@
 
 - name: Collection of users (SetUp)
   iosxr_user:
-    users:
+    aggregate:
       - name: ansibletest2
       - name: ansibletest3
     state: present
@@ -67,7 +67,7 @@
 
 - name: Add collection of users again with update_password always (not idempotent)
   iosxr_user:
-    users:
+    aggregate:
       - name: ansibletest2
       - name: ansibletest3
     state: present
@@ -82,7 +82,7 @@
 
 - name: Add collection of users again with update_password on_create (idempotent)
   iosxr_user:
-    users:
+    aggregate:
       - name: ansibletest2
       - name: ansibletest3
     update_password: on_create
@@ -98,7 +98,7 @@
 
 - name: Delete collection of users
   iosxr_user:
-    users:
+    aggregate:
       - name: ansibletest1
       - name: ansibletest2
       - name: ansibletest3
@@ -113,7 +113,7 @@
 
 - name: Delete collection of users again (idempotent)
   iosxr_user:
-    users:
+    aggregate:
       - name: ansibletest1
       - name: ansibletest2
       - name: ansibletest3

--- a/test/integration/targets/junos_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_user/tests/netconf/basic.yaml
@@ -123,7 +123,7 @@
 
 - name: Teardown list of users
   junos_user:
-    collection:
+    aggregate:
       - {name: test_user1, state: absent}
       - {name: test_user2, state: absent}
     provider: "{{ netconf }}"
@@ -131,7 +131,7 @@
 
 - name: Create list of users
   junos_user:
-    collection:
+    aggregate:
       - {name: test_user1, full_name: test_user2, role: operator, state: present}
       - {name: test_user2, full_name: test_user2, role: read-only, state: present}
     provider: "{{ netconf }}"
@@ -151,7 +151,7 @@
 
 - name: Delete list of users
   junos_user:
-    collection:
+    aggregate:
       - {name: test_user1, full_name: test_user2, role: operator, state: absent}
       - {name: test_user2, full_name: test_user2, role: read-only, state: absent}
     provider: "{{ netconf }}"

--- a/test/integration/targets/net_linkagg/tests/vyos/basic.yaml
+++ b/test/integration/targets/net_linkagg/tests/vyos/basic.yaml
@@ -126,7 +126,7 @@
 
 - name: Create collection of linkagg definitions
   net_linkagg:
-    collection:
+    aggregate:
         - { name: bond0, members: [eth1, eth2] }
         - { name: bond1, members: [eth3, eth4] }
     state: present
@@ -144,7 +144,7 @@
 
 - name: Create collection of linkagg definitions again (idempotent)
   net_linkagg:
-    collection:
+    aggregate:
         - { name: bond0, members: [eth1, eth2] }
         - { name: bond1, members: [eth3, eth4] }
     state: present
@@ -156,7 +156,7 @@
 
 - name: Remove collection of linkagg definitions
   net_linkagg:
-    collection:
+    aggregate:
       - { name: bond0 }
       - { name: bond1 }
     state: absent
@@ -174,7 +174,7 @@
 
 - name: Remove collection of linkagg definitions again (idempotent)
   net_linkagg:
-    collection:
+    aggregate:
       - { name: bond0 }
       - { name: bond1 }
     state: absent

--- a/test/integration/targets/net_logging/tests/vyos/basic.yaml
+++ b/test/integration/targets/net_logging/tests/vyos/basic.yaml
@@ -86,7 +86,7 @@
 
 - name: Add logging collections
   net_logging:
-    collection:
+    aggregate:
       - { dest: file, name: test1, facility: all, level: info }
       - { dest: file, name: test2, facility: news, level: debug }
     state: present
@@ -101,7 +101,7 @@
 
 - name: Add and remove logging collections with overrides
   net_logging:
-    collection:
+    aggregate:
       - { dest: console, facility: all, level: info }
       - { dest: file, name: test1, facility: all, level: info, state: absent }
       - { dest: console, facility: daemon, level: warning }
@@ -117,7 +117,7 @@
 
 - name: Remove logging collections
   net_logging:
-    collection:
+    aggregate:
       - { dest: console, facility: all, level: info }
       - { dest: console, facility: daemon, level: warning }
       - { dest: file, name: test2, facility: news, level: debug }

--- a/test/integration/targets/net_static_route/tests/ios/basic.yaml
+++ b/test/integration/targets/net_static_route/tests/ios/basic.yaml
@@ -94,7 +94,7 @@
 
 - name: Add static route collections
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: present
@@ -109,7 +109,7 @@
 
 - name: Add and remove static route collections with overrides
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8, state: absent }
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
@@ -125,7 +125,7 @@
 
 - name: Remove static route collections
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.16.32.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }

--- a/test/integration/targets/net_static_route/tests/vyos/basic.yaml
+++ b/test/integration/targets/net_static_route/tests/vyos/basic.yaml
@@ -82,7 +82,7 @@
 
 - name: Add static route collections
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.2.0, mask: 24, next_hop: 192.168.42.64 }
     state: present
@@ -97,7 +97,7 @@
 
 - name: Add and remove static route collections with overrides
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.2.0/24, next_hop: 192.168.42.64, state: absent }
       - { prefix: 172.24.3.0/24, next_hop: 192.168.42.64 }
@@ -113,7 +113,7 @@
 
 - name: Remove static route collections
   net_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.3.0/24, next_hop: 192.168.42.64 }
     state: absent

--- a/test/integration/targets/net_user/tests/eos/userrole.yaml
+++ b/test/integration/targets/net_user/tests/eos/userrole.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set multiple users role
   net_user:
-    collection:
+    aggregate:
       - name: netop
       - name: netend
     role: network-operator

--- a/test/integration/targets/net_user/tests/junos/basic.yaml
+++ b/test/integration/targets/net_user/tests/junos/basic.yaml
@@ -73,7 +73,7 @@
 
 - name: Teardown list of users
   net_user:
-    collection:
+    aggregate:
       - {name: test_user1, state: absent}
       - {name: test_user2, state: absent}
     provider: "{{ netconf }}"
@@ -81,7 +81,7 @@
 
 - name: Create list of users
   net_user:
-    collection:
+    aggregate:
       - {name: test_user1, role: operator, state: present}
       - {name: test_user2, role: read-only, state: present}
     provider: "{{ netconf }}"
@@ -101,7 +101,7 @@
 
 - name: Delete list of users
   net_user:
-    collection:
+    aggregate:
       - {name: test_user1, role: operator, state: absent}
       - {name: test_user2, role: read-only, state: absent}
     provider: "{{ netconf }}"

--- a/test/integration/targets/net_user/tests/nxos/userrole.yaml
+++ b/test/integration/targets/net_user/tests/nxos/userrole.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Set multiple users role
   net_user:
-    collection:
+    aggregate:
       - name: netop
       - name: netend
     role: network-operator

--- a/test/integration/targets/nxos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/nxos_user/tests/cli/basic.yaml
@@ -15,7 +15,7 @@
 
 - name: Collection of users
   nxos_user:
-    users:
+    aggregate:
       - name: test1
       - name: test2
     authorize: yes

--- a/test/integration/targets/nxos_user/tests/nxapi/basic.yaml
+++ b/test/integration/targets/nxos_user/tests/nxapi/basic.yaml
@@ -15,7 +15,7 @@
 
 - name: Collection of users
   nxos_user:
-    users:
+    aggregate:
       - name: test1
       - name: test2
     authorize: yes

--- a/test/integration/targets/vyos_linkagg/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_linkagg/tests/cli/basic.yaml
@@ -127,7 +127,7 @@
 
 - name: Create collection of linkagg definitions
   vyos_linkagg:
-    collection:
+    aggregate:
         - { name: bond0, members: [eth1] }
         - { name: bond1, members: [eth2] }
     state: present
@@ -143,7 +143,7 @@
 
 - name: Create collection of linkagg definitions again (idempotent)
   vyos_linkagg:
-    collection:
+    aggregate:
         - { name: bond0, members: [eth1] }
         - { name: bond1, members: [eth2] }
     state: present
@@ -155,7 +155,7 @@
 
 - name: Remove collection of linkagg definitions
   vyos_linkagg:
-    collection:
+    aggregate:
       - { name: bond0 }
       - { name: bond1 }
     state: absent
@@ -171,7 +171,7 @@
 
 - name: Remove collection of linkagg definitions again (idempotent)
   vyos_linkagg:
-    collection:
+    aggregate:
       - { name: bond0 }
       - { name: bond1 }
     state: absent

--- a/test/integration/targets/vyos_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_logging/tests/cli/basic.yaml
@@ -86,7 +86,7 @@
 
 - name: Add logging collections
   vyos_logging:
-    collection:
+    aggregate:
       - { dest: file, name: test1, facility: all, level: info }
       - { dest: file, name: test2, facility: news, level: debug }
     state: present
@@ -101,7 +101,7 @@
 
 - name: Add and remove logging collections with overrides
   vyos_logging:
-    collection:
+    aggregate:
       - { dest: console, facility: all, level: info }
       - { dest: file, name: test1, facility: all, level: info, state: absent }
       - { dest: console, facility: daemon, level: warning }
@@ -117,7 +117,7 @@
 
 - name: Remove logging collections
   vyos_logging:
-    collection:
+    aggregate:
       - { dest: console, facility: all, level: info }
       - { dest: console, facility: daemon, level: warning }
       - { dest: file, name: test2, facility: news, level: debug }

--- a/test/integration/targets/vyos_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_static_route/tests/cli/basic.yaml
@@ -82,7 +82,7 @@
 
 - name: Add static route collections
   vyos_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.2.0, mask: 24, next_hop: 192.168.42.64 }
     state: present
@@ -97,7 +97,7 @@
 
 - name: Add and remove static route collections with overrides
   vyos_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.2.0/24, next_hop: 192.168.42.64, state: absent }
       - { prefix: 172.24.3.0/24, next_hop: 192.168.42.64 }
@@ -113,7 +113,7 @@
 
 - name: Remove static route collections
   vyos_static_route:
-    collection:
+    aggregate:
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.3.0/24, next_hop: 192.168.42.64 }
     state: absent

--- a/test/integration/targets/vyos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/basic.yaml
@@ -15,7 +15,7 @@
 
 - name: Collection of users (SetUp)
   vyos_user:
-    users:
+    aggregate:
       - name: ansibletest2
       - name: ansibletest3
     level: operator
@@ -44,7 +44,7 @@
 
 - name: Add collection of users (Idempotent)
   vyos_user:
-    users:
+    aggregate:
       - name: ansibletest2
       - name: ansibletest3
     level: operator


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Network Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- network modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (collection-to-agregate 0eb6ecb932) last updated 2017/07/11 11:17:03 (GMT -400)
  config file = None
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
