### PR TITLE
python3k compatibility for ec2_vpc_net_facts module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -121,8 +121,6 @@ def main():
     if region:
         try:
             connection = connect_to_aws(boto.vpc, region, **aws_connect_params)
-        except (StopIteration, GeneratorExit, KeyboardInterrupt, SystemExit):
-            raise
         except (boto.exception.NoAuthHandlerFound, Exception) as e:
             module.fail_json(msg=str(e))
     else:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net_facts.py
@@ -121,7 +121,9 @@ def main():
     if region:
         try:
             connection = connect_to_aws(boto.vpc, region, **aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, StandardError) as e:
+        except (StopIteration, GeneratorExit, KeyboardInterrupt, SystemExit):
+            raise
+        except (boto.exception.NoAuthHandlerFound, Exception) as e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="region must be specified")


### PR DESCRIPTION
##### SUMMARY
python3k compatibility for ec2_vpc_net_facts module

The `StandardError` exception is no longer present in python 3.
Use `Exception` instead, re-raising in case the exception was
not also part of `StandardError`.

See https://docs.python.org/2/library/exceptions.html#exceptions.StandardError

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_net_facts

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel b880ad8566) last updated 2017/07/11 18:53:06 (GMT +200)
  config file = /.../.../redacted/ansible.cfg
  configured module search path = ['/.../.../.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /.../.../redacted/lib/ansible
  executable location = /.../.../redacted/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```
