### PR TITLE
Updates docs to match module behavior

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -42,10 +42,10 @@ options:
     dest:
         required: true
         description:
-            - Relative or absolute path of where the repository should be
-              checked out to. This parameter is required, unless C(clone)
-              is set to C(no). This change was made in version 1.8.3. Prior
-              to this version, the C(dest) parameter was always required.
+            - The path of where the repository should be checked out. This
+              parameter is required, unless C(clone) is set to C(no). This
+              change was made in version 1.8.3. Prior to this version, the
+              C(dest) parameter was always required.
     version:
         required: false
         default: "HEAD"

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -43,9 +43,7 @@ options:
         required: true
         description:
             - The path of where the repository should be checked out. This
-              parameter is required, unless C(clone) is set to C(no). This
-              change was made in version 1.8.3. Prior to this version, the
-              C(dest) parameter was always required.
+              parameter is required, unless C(clone) is set to C(no).
     version:
         required: false
         default: "HEAD"

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -42,10 +42,10 @@ options:
     dest:
         required: true
         description:
-            - Absolute path of where the repository should be checked out to.
-              This parameter is required, unless C(clone) is set to C(no)
-              This change was made in version 1.8.3. Prior to this version,
-              the C(dest) parameter was always required.
+            - Relative or absolute path of where the repository should be
+              checked out to. This parameter is required, unless C(clone)
+              is set to C(no). This change was made in version 1.8.3. Prior
+              to this version, the C(dest) parameter was always required.
     version:
         required: false
         default: "HEAD"


### PR DESCRIPTION
##### SUMMARY
I noticed the docs for the git module don't indicate you can use a relative path for `dest`. This PR updates the docs to reflect current behavior, which does allow you to use a relative path. You can test with this snippet:

```
---
- hosts: all
  tasks:
    - name: Clone all the repos
      git:
        repo: "https://github.com/ansible/lightbulb"
        dest: "lightbulb"
    - name: Clone all the repos
      git:
        repo: "https://github.com/ansible/community"
        dest: "./community"
```

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
/lib/ansible/modules/source_control/git.py

##### ANSIBLE VERSION
The docs have been inaccurate since at least:
```
$ ansible --version
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
n/a
