### PR TITLE
Handle pip/python errors in ansible-test better.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -1262,7 +1262,11 @@ class EnvironmentDescription(object):
         :type command: list[str]
         :rtype: str
         """
-        stdout, stderr = raw_command(command, capture=True, cmd_verbosity=2)
+        try:
+            stdout, stderr = raw_command(command, capture=True, cmd_verbosity=2)
+        except SubprocessError:
+            return None  # all failures are equal, we don't care why it failed, only that it did
+
         return (stdout or '').strip() + (stderr or '').strip()
 
     @staticmethod


### PR DESCRIPTION
##### SUMMARY

Handle pip/python errors in ansible-test better.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-env-fix 76c3c1e30d) last updated 2017/07/11 16:00:38 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
