### PR TITLE
Replace Ethernet5 for Ethernet2 on eos integration tests

### DIFF
--- a/test/integration/targets/eos_config/config.txt
+++ b/test/integration/targets/eos_config/config.txt
@@ -13,16 +13,6 @@ interface Ethernet1
 !
 interface Ethernet2
 !
-interface Ethernet3
-!
-interface Ethernet4
-!
-interface Ethernet5
-!
-interface Ethernet6
-!
-interface Ethernet7
-!
 !
 no ip routing
 !

--- a/test/integration/targets/eos_config/templates/basic/config.j2
+++ b/test/integration/targets/eos_config/templates/basic/config.j2
@@ -1,4 +1,4 @@
-interface Ethernet5
+interface Ethernet2
    description this is a test
    shutdown
 

--- a/test/integration/targets/eos_config/templates/config.js
+++ b/test/integration/targets/eos_config/templates/config.js
@@ -1,4 +1,4 @@
-interface Ethernet5
+interface Ethernet2
    description test description from ansible
    shutdown
 

--- a/test/integration/targets/eos_config/templates/defaults/config.j2
+++ b/test/integration/targets/eos_config/templates/defaults/config.j2
@@ -1,3 +1,3 @@
-interface Ethernet5
+interface Ethernet2
    description this is a test
    no shutdown

--- a/test/integration/targets/eos_config/templates/defaults/test.j2
+++ b/test/integration/targets/eos_config/templates/defaults/test.j2
@@ -1,4 +1,4 @@
-interface Ethernet5
+interface Ethernet2
    description this is a test
    shutdown
 

--- a/test/integration/targets/eos_config/tests/cli/backup.yaml
+++ b/test/integration/targets/eos_config/tests/cli/backup.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_config/tests/cli/defaults.yaml
+++ b/test/integration/targets/eos_config/tests/cli/defaults.yaml
@@ -7,7 +7,7 @@
       - no description
       - shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_config/tests/cli/save.yaml
+++ b/test/integration/targets/eos_config/tests/cli/save.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/eos_config/tests/cli/src_basic.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_config/tests/cli/src_match_none.yaml
+++ b/test/integration/targets/eos_config/tests/cli/src_match_none.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/backup.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/backup.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/defaults.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/defaults.yaml
@@ -7,7 +7,7 @@
       - no description
       - shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/save.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/save.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/src_basic.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/src_basic.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_config/tests/eapi/src_match_none.yaml
+++ b/test/integration/targets/eos_config/tests/eapi/src_match_none.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_template/templates/basic/config.j2
+++ b/test/integration/targets/eos_template/templates/basic/config.j2
@@ -1,4 +1,4 @@
-interface Ethernet5
+interface Ethernet2
    description this is a test
    shutdown
 

--- a/test/integration/targets/eos_template/templates/config.js
+++ b/test/integration/targets/eos_template/templates/config.js
@@ -1,4 +1,4 @@
-interface Ethernet5
+interface Ethernet2
    description test description from ansible
    shutdown
 

--- a/test/integration/targets/eos_template/templates/defaults/config.j2
+++ b/test/integration/targets/eos_template/templates/defaults/config.j2
@@ -1,3 +1,3 @@
-interface Ethernet5
+interface Ethernet2
    description this is a test
    no shutdown

--- a/test/integration/targets/eos_template/templates/defaults/test.j2
+++ b/test/integration/targets/eos_template/templates/defaults/test.j2
@@ -1,4 +1,4 @@
-interface Ethernet5
+interface Ethernet2
    description this is a test
    shutdown
 

--- a/test/integration/targets/eos_template/tests/cli/backup.yaml
+++ b/test/integration/targets/eos_template/tests/cli/backup.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_template/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_template/tests/cli/basic.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_template/tests/cli/defaults.yaml
+++ b/test/integration/targets/eos_template/tests/cli/defaults.yaml
@@ -7,7 +7,7 @@
       - no description
       - shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_template/tests/cli/force.yaml
+++ b/test/integration/targets/eos_template/tests/cli/force.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ cli }}"
 

--- a/test/integration/targets/eos_template/tests/eapi/backup.yaml
+++ b/test/integration/targets/eos_template/tests/eapi/backup.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_template/tests/eapi/basic.yaml
+++ b/test/integration/targets/eos_template/tests/eapi/basic.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_template/tests/eapi/defaults.yaml
+++ b/test/integration/targets/eos_template/tests/eapi/defaults.yaml
@@ -7,7 +7,7 @@
       - no description
       - shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 

--- a/test/integration/targets/eos_template/tests/eapi/force.yaml
+++ b/test/integration/targets/eos_template/tests/eapi/force.yaml
@@ -7,7 +7,7 @@
       - no description
       - no shutdown
     parents:
-      - interface Ethernet5
+      - interface Ethernet2
     match: none
     provider: "{{ eapi }}"
 


### PR DESCRIPTION
In our CI, we only have 3 NICS: Management1, Ethernet1 and
Ethernet2.