### PR TITLE
Windows: A module for creating Toast notifications on Modern Windows versions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -537,6 +537,7 @@ Ansible Changes By Release
   * win_rabbitmq_plugin
   * win_route
   * win_security_policy
+  * win_toast
   * win_user_right
   * win_wakeonlan
 

--- a/lib/ansible/modules/windows/win_toast.ps1
+++ b/lib/ansible/modules/windows/win_toast.ps1
@@ -36,20 +36,20 @@ $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 # $expire_at = Get-AnsibleParam -obj $params -name "msg" -type "str"
-$expire_mins = Get-AnsibleParam -obj $params -name "expire_mins" -type "int" -default 5
+$expire_secs = Get-AnsibleParam -obj $params -name "expire_secs" -type "int" -default 45
 $group = Get-AnsibleParam -obj $params -name "group" -type "str" -default "Powershell"
 $msg = Get-AnsibleParam -obj $params -name "msg" -type "str" -default "Hello world!"
 $popup = Get-AnsibleParam -obj $params -name "popup" -type "bool" -default $true
 $tag = Get-AnsibleParam -obj $params -name "tag" -type "str" -default "Ansible"
 $title = Get-AnsibleParam -obj $params -name "title" -type "str" -default $default_title
 
-$timespan = New-TimeSpan -Minutes $expire_mins
+$timespan = New-TimeSpan -Seconds $expire_secs
 $expire_at = $now + $timespan
 $expire_at_utc = $($expire_at.ToUniversalTime()|Out-String).Trim()
 
 $result = @{
     changed = $false
-    expire_mins = $expire_mins
+    expire_secs = $expire_secs
     expire_at = $expire_at.ToString()
     expire_at_utc = $expire_at_utc
     group = $group    
@@ -81,7 +81,8 @@ $toast.SuppressPopup = -not $popup
 try {
    $notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($msg)
    if (-not $check_mode) {
-      $notifier.Show($toast);
+      $notifier.Show($toast)
+      Start-Sleep -Seconds $expire_secs
    }
 } catch {
   $excep= $_

--- a/lib/ansible/modules/windows/win_toast.ps1
+++ b/lib/ansible/modules/windows/win_toast.ps1
@@ -1,23 +1,11 @@
 #!powershell
 # This file is part of Ansible
-#
-# Copyright 2017, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# Copyright (c) 2017, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
 
 $ErrorActionPreference = "Stop"
 
@@ -36,20 +24,20 @@ $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
 # $expire_at = Get-AnsibleParam -obj $params -name "msg" -type "str"
-$expire_secs = Get-AnsibleParam -obj $params -name "expire_secs" -type "int" -default 45
+$expire_seconds = Get-AnsibleParam -obj $params -name "expire_seconds" -type "int" -default 45
 $group = Get-AnsibleParam -obj $params -name "group" -type "str" -default "Powershell"
 $msg = Get-AnsibleParam -obj $params -name "msg" -type "str" -default "Hello world!"
 $popup = Get-AnsibleParam -obj $params -name "popup" -type "bool" -default $true
 $tag = Get-AnsibleParam -obj $params -name "tag" -type "str" -default "Ansible"
 $title = Get-AnsibleParam -obj $params -name "title" -type "str" -default $default_title
 
-$timespan = New-TimeSpan -Seconds $expire_secs
+$timespan = New-TimeSpan -Seconds $expire_seconds
 $expire_at = $now + $timespan
 $expire_at_utc = $($expire_at.ToUniversalTime()|Out-String).Trim()
 
 $result = @{
     changed = $false
-    expire_secs = $expire_secs
+    expire_seconds = $expire_seconds
     expire_at = $expire_at.ToString()
     expire_at_utc = $expire_at_utc
     group = $group    
@@ -82,14 +70,12 @@ try {
    $notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($msg)
    if (-not $check_mode) {
       $notifier.Show($toast)
-      Start-Sleep -Seconds $expire_secs
+      Start-Sleep -Seconds $expire_seconds
    }
 } catch {
   $excep= $_
   Fail-Json $result "Failed to create toast notifier, exception was $($excep.Exception.Message) stack trace $($excep.ScriptStackStrace)".
 }
-
-
 
 
 $endsend_at = Get-Date| Out-String

--- a/lib/ansible/modules/windows/win_toast.ps1
+++ b/lib/ansible/modules/windows/win_toast.ps1
@@ -23,8 +23,7 @@ $default_title = "Notification: " + $now.ToShortTimeString()
 $params = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
 
-# $expire_at = Get-AnsibleParam -obj $params -name "msg" -type "str"
-$expire_seconds = Get-AnsibleParam -obj $params -name "expire_seconds" -type "int" -default 45
+$expire_seconds = Get-AnsibleParam -obj $params -name "expire" -type "int" -default 45
 $group = Get-AnsibleParam -obj $params -name "group" -type "str" -default "Powershell"
 $msg = Get-AnsibleParam -obj $params -name "msg" -type "str" -default "Hello world!"
 $popup = Get-AnsibleParam -obj $params -name "popup" -type "bool" -default $true
@@ -37,14 +36,8 @@ $expire_at_utc = $($expire_at.ToUniversalTime()|Out-String).Trim()
 
 $result = @{
     changed = $false
-    expire_seconds = $expire_seconds
     expire_at = $expire_at.ToString()
     expire_at_utc = $expire_at_utc
-    group = $group    
-    msg = $msg
-    popup = $popup
-    tag = $tag
-    title = $title
     toast_sent = $false
 }
 
@@ -92,7 +85,7 @@ if ((get-process -name explorer -EA silentlyContinue).Count -gt 0){
 $endsend_at = Get-Date| Out-String
 $stopwatch.Stop()
 
-$result.runtime_seconds = $stopwatch.Elapsed.TotalSeconds
+$result.time_taken = $stopwatch.Elapsed.TotalSeconds
 $result.sent_localtime = $endsend_at.Trim()
   
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_toast.ps1
+++ b/lib/ansible/modules/windows/win_toast.ps1
@@ -80,8 +80,9 @@ if ((get-process -name explorer -EA silentlyContinue).Count -gt 0){
         Start-Sleep -Seconds $expire_seconds
      }
   } catch {
-    $excep= $_
-    Fail-Json $result "Failed to create toast notifier, exception was $($excep.Exception.Message) stack trace $($excep.ScriptStackStrace)".
+    $excep = $_
+    $result.exception = $excep.ScriptStackTrace
+    Fail-Json -obj $result -message "Failed to create toast notifier: $($excep.Exception.Message)"
   }
 } else {
    $result.toast_sent = $false

--- a/lib/ansible/modules/windows/win_toast.ps1
+++ b/lib/ansible/modules/windows/win_toast.ps1
@@ -1,0 +1,100 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2017, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$ErrorActionPreference = "Stop"
+
+# version check
+$osversion = [Environment]::OSVersion
+$lowest_version = 10
+if ($osversion.Version.Major -lt $lowest_version ) {
+   Fail-Json $result "Sorry, this version of windows, $osversion, does not support Toast notifications.  Toast notifications are available from version $lowest_version" 
+}
+
+$stopwatch = [system.diagnostics.stopwatch]::startNew()
+$now = [DateTime]::Now
+$default_title = "Notification: " + $now.ToShortTimeString()
+
+$params = Parse-Args $args -supports_check_mode $true
+$check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "bool" -default $false
+
+# $expire_at = Get-AnsibleParam -obj $params -name "msg" -type "str"
+$expire_mins = Get-AnsibleParam -obj $params -name "expire_mins" -type "int" -default 5
+$group = Get-AnsibleParam -obj $params -name "group" -type "str" -default "Powershell"
+$msg = Get-AnsibleParam -obj $params -name "msg" -type "str" -default "Hello world!"
+$popup = Get-AnsibleParam -obj $params -name "popup" -type "bool" -default $true
+$tag = Get-AnsibleParam -obj $params -name "tag" -type "str" -default "Ansible"
+$title = Get-AnsibleParam -obj $params -name "title" -type "str" -default $default_title
+
+$timespan = New-TimeSpan -Minutes $expire_mins
+$expire_at = $now + $timespan
+$expire_at_utc = $($expire_at.ToUniversalTime()|Out-String).Trim()
+
+$result = @{
+    changed = $false
+    expire_mins = $expire_mins
+    expire_at = $expire_at.ToString()
+    expire_at_utc = $expire_at_utc
+    group = $group    
+    msg = $msg
+    popup = $popup
+    tag = $tag
+    title = $title
+}
+
+
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] > $null
+$template = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText01)
+
+#Convert to .NET type for XML manipulation
+$toastXml = [xml] $template.GetXml()
+$toastXml.GetElementsByTagName("text").AppendChild($toastXml.CreateTextNode($title)) > $null
+# TODO add subtitle
+
+#Convert back to WinRT type
+$xml = New-Object Windows.Data.Xml.Dom.XmlDocument
+$xml.LoadXml($toastXml.OuterXml)
+
+$toast = [Windows.UI.Notifications.ToastNotification]::new($xml)
+$toast.Tag = $tag
+$toast.Group = $group
+$toast.ExpirationTime = $expire_at
+$toast.SuppressPopup = -not $popup
+
+try {
+   $notifier = [Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier($msg)
+   if (-not $check_mode) {
+      $notifier.Show($toast);
+   }
+} catch {
+  $excep= $_
+  Fail-Json $result "Failed to create toast notifier, exception was $($excep.Exception.Message) stack trace $($excep.ScriptStackStrace)".
+}
+
+
+
+
+$endsend_at = Get-Date| Out-String
+$stopwatch.Stop()
+
+$result.runtime_seconds = $stopwatch.Elapsed.TotalSeconds
+$result.sent_localtime = $endsend_at.Trim()
+  
+Exit-Json $result

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -21,7 +21,7 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -16,7 +16,7 @@ DOCUMENTATION = r'''
 ---
 module: win_toast
 version_added: "2.4"
-short_description: Sends Toast windows notification to Windows 10 or later hosts
+short_description: Sends Toast windows notification to logged in users on Windows 10 or later hosts
 description:
     - Sends alerts which appear in the Action Center area of the windows desktop.
 options:
@@ -49,6 +49,7 @@ author:
 - Jon Hawkesworth (@jhawkesworth)
 notes:
    - This module must run on a windows 10 or Server 2016 host, so ensure your play targets windows hosts, or delegates to a windows host.
+   - The module does not fail if there are no logged in users to notify.
    - Messages are only sent to the local host where the module is run.
    - You must run this module with async, otherwise it will hang until the expire_seconds period has passed.
 '''
@@ -84,6 +85,11 @@ msg:
     returned: allways
     type: string
     sample: Automated upgrade about to start.\nPlease save your work and log off before 22 July 2017 18:00:00
+no_toast_sent_reason:
+    description: Text containing the reason why a notification was not sent.
+    returned: when no logged in users are detected
+    type: string
+    sample: No logged in users to notify
 popup:
     description: Whether notification pop up was requested or not.
     returned: allways
@@ -110,4 +116,9 @@ title:
     returned: success
     type: string
     sample: Notification 05:45
+toast_sent:
+    description: Whether the module was able to send a toast notification or not.
+    returned: allways
+    type: boolean
+    sample: false
 '''

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -20,7 +20,7 @@ short_description: Sends Toast windows notification to logged in users on Window
 description:
     - Sends alerts which appear in the Action Center area of the windows desktop.
 options:
-  expire_seconds:
+  expire:
     description:
       - How long in seconds before the notification expires.
     default: 45
@@ -51,13 +51,13 @@ notes:
    - This module must run on a windows 10 or Server 2016 host, so ensure your play targets windows hosts, or delegates to a windows host.
    - The module does not fail if there are no logged in users to notify.
    - Messages are only sent to the local host where the module is run.
-   - You must run this module with async, otherwise it will hang until the expire_seconds period has passed.
+   - You must run this module with async, otherwise it will hang until the expire period has passed.
 '''
 
 EXAMPLES = r'''
 - name: Warn logged in users of impending upgrade (note use of async to stop the module from waiting until notification expires).
   win_toast:
-    expire_seconds: 60
+    expire: 60
     title: System Upgrade Notification
     msg: Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time }}
   async: 60
@@ -65,57 +65,26 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-expire_seconds:
-    description: Requested time in seconds before notification expires.
-    returned: allways
-    type: int
-    sample: 5
 expire_at_utc:
     description: Calculated utc date time when the notification expires.
     returned: allways
     type: string
     sample: 07 July 2017 04:50:54
-group:
-    description: Requested group for the notification to belong to.
-    returned: allways
-    type: string
-    sample: Powershell
-msg:
-    description: Text of the message that was sent.
-    returned: allways
-    type: string
-    sample: Automated upgrade about to start.\nPlease save your work and log off before 22 July 2017 18:00:00
 no_toast_sent_reason:
     description: Text containing the reason why a notification was not sent.
     returned: when no logged in users are detected
     type: string
     sample: No logged in users to notify
-popup:
-    description: Whether notification pop up was requested or not.
-    returned: allways
-    type: boolean
-    sample: true
-runtime_seconds:
-    description: How long the module took to run on the remote windows host.
-    returned: allways
-    type: float
-    sample: 0.3706631999999997
 sent_localtime:
     description: local date time when the notification was sent.
     returned: allways
     type: string
     sample: 07 July 2017 05:45:54
-tag:
-    description: Requested tag to associated with the notification.
-
+time_taken:
+    description: How long the module took to run on the remote windows host in seconds.
     returned: allways
-    type: string
-    sample: Ansible
-title:
-    description: The requested text for the notification title, which appears in the popup and Action Center if specified.
-    returned: success
-    type: string
-    sample: Notification 05:45
+    type: float
+    sample: 0.3706631999999997
 toast_sent:
     description: Whether the module was able to send a toast notification or not.
     returned: allways

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -2,21 +2,8 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2017, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
@@ -33,7 +20,7 @@ short_description: Sends Toast windows notification to Windows 10 or later hosts
 description:
     - Sends alerts which appear in the Action Center area of the windows desktop.
 options:
-  expire_secs:
+  expire_seconds:
     description:
       - How long in seconds before the notification expires.
     default: 45
@@ -49,7 +36,7 @@ options:
     description:
       - If false, the notification will not pop up and will only appear in the Action Center.
     type: bool
-    default: 'Yes'
+    default: yes
   tag:
     description:
       - The tag to add to the notification.
@@ -63,13 +50,13 @@ author:
 notes:
    - This module must run on a windows 10 or Server 2016 host, so ensure your play targets windows hosts, or delegates to a windows host.
    - Messages are only sent to the local host where the module is run.
-   - You must run this module with async, otherwise it will hang until the expire_secs period has passed.
+   - You must run this module with async, otherwise it will hang until the expire_seconds period has passed.
 '''
 
 EXAMPLES = r'''
 - name: Warn logged in users of impending upgrade (note use of async to stop the module from waiting until notification expires).
   win_toast:
-    expire_secs: 60
+    expire_seconds: 60
     title: System Upgrade Notification
     msg: Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time }}
   async: 60
@@ -77,7 +64,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-expire_secs:
+expire_seconds:
     description: Requested time in seconds before notification expires.
     returned: allways
     type: int

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -33,10 +33,10 @@ short_description: Sends Toast windows notification to Windows 10 or later hosts
 description:
     - Sends alerts which appear in the Action Center area of the windows desktop.
 options:
-  expire_mins:
+  expire_secs:
     description:
-      - How long in minutes before the notification expires.
-    default: 5
+      - How long in seconds before the notification expires.
+    default: 45
   group:
     description:
       - Which notification group to add the notification to.
@@ -63,19 +63,22 @@ author:
 notes:
    - This module must run on a windows 10 or Server 2016 host, so ensure your play targets windows hosts, or delegates to a windows host.
    - Messages are only sent to the local host where the module is run.
+   - You must run this module with async, otherwise it will hang until the expire_secs period has passed.
 '''
 
 EXAMPLES = r'''
-- name: Warn logged in users of impending upgrade
+- name: Warn logged in users of impending upgrade (note use of async to stop the module from waiting until notification expires).
   win_toast:
-    expire_mins: 60
+    expire_secs: 60
     title: System Upgrade Notification
     msg: Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time }}
+  async: 60
+  poll: 0
 '''
 
 RETURN = r'''
-expire_mins:
-    description: Requested time in minutes before notification expires.
+expire_secs:
+    description: Requested time in seconds before notification expires.
     returned: allways
     type: int
     sample: 5

--- a/lib/ansible/modules/windows/win_toast.py
+++ b/lib/ansible/modules/windows/win_toast.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: win_toast
+version_added: "2.4"
+short_description: Sends Toast windows notification to Windows 10 or later hosts
+description:
+    - Sends alerts which appear in the Action Center area of the windows desktop.
+options:
+  expire_mins:
+    description:
+      - How long in minutes before the notification expires.
+    default: 5
+  group:
+    description:
+      - Which notification group to add the notification to.
+    default: Powershell
+  msg:
+    description:
+      - The message to appear inside the notification.  May include \n to format the message to appear within the Action Center.
+    default: 'Hello, World!'
+  popup:
+    description:
+      - If false, the notification will not pop up and will only appear in the Action Center.
+    type: bool
+    default: 'Yes'
+  tag:
+    description:
+      - The tag to add to the notification.
+    default: Ansible
+  title:
+    description:
+      - The notification title, which appears in the pop up..
+    default: Notification HH:mm
+author:
+- Jon Hawkesworth (@jhawkesworth)
+notes:
+   - This module must run on a windows 10 or Server 2016 host, so ensure your play targets windows hosts, or delegates to a windows host.
+   - Messages are only sent to the local host where the module is run.
+'''
+
+EXAMPLES = r'''
+- name: Warn logged in users of impending upgrade
+  win_toast:
+    expire_mins: 60
+    title: System Upgrade Notification
+    msg: Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time }}
+'''
+
+RETURN = r'''
+expire_mins:
+    description: Requested time in minutes before notification expires.
+    returned: allways
+    type: int
+    sample: 5
+expire_at_utc:
+    description: Calculated utc date time when the notification expires.
+    returned: allways
+    type: string
+    sample: 07 July 2017 04:50:54
+group:
+    description: Requested group for the notification to belong to.
+    returned: allways
+    type: string
+    sample: Powershell
+msg:
+    description: Text of the message that was sent.
+    returned: allways
+    type: string
+    sample: Automated upgrade about to start.\nPlease save your work and log off before 22 July 2017 18:00:00
+popup:
+    description: Whether notification pop up was requested or not.
+    returned: allways
+    type: boolean
+    sample: true
+runtime_seconds:
+    description: How long the module took to run on the remote windows host.
+    returned: allways
+    type: float
+    sample: 0.3706631999999997
+sent_localtime:
+    description: local date time when the notification was sent.
+    returned: allways
+    type: string
+    sample: 07 July 2017 05:45:54
+tag:
+    description: Requested tag to associated with the notification.
+
+    returned: allways
+    type: string
+    sample: Ansible
+title:
+    description: The requested text for the notification title, which appears in the popup and Action Center if specified.
+    returned: success
+    type: string
+    sample: Notification 05:45
+'''

--- a/test/integration/targets/win_toast/aliases
+++ b/test/integration/targets/win_toast/aliases
@@ -1,0 +1,1 @@
+windows/ci/group2

--- a/test/integration/targets/win_toast/tasks/main.yml
+++ b/test/integration/targets/win_toast/tasks/main.yml
@@ -1,0 +1,13 @@
+- name: Set up tests
+  include_tasks: setup.yml
+
+- name: Test in normal mode
+  include_tasks: tests.yml
+  vars:
+    in_check_mode: no
+
+- name: Test in check mode
+  include_tasks: tests.yml
+  vars:
+    in_check_mode: yes
+  check_mode: yes

--- a/test/integration/targets/win_toast/tasks/setup.yml
+++ b/test/integration/targets/win_toast/tasks/setup.yml
@@ -25,9 +25,3 @@
   set_fact:
     can_toast: True
   when: os_version.stdout|int >= 10
-
-#- name: Set fact if toast cannot be made because no one is logged in
-#  set_fact:
-#    can_toast: False
-#  when: user_count.stdout|int < 1
-

--- a/test/integration/targets/win_toast/tasks/setup.yml
+++ b/test/integration/targets/win_toast/tasks/setup.yml
@@ -26,8 +26,8 @@
     can_toast: True
   when: os_version.stdout|int >= 10
 
-- name: Set fact if toast cannot be made because no one is logged in
-  set_fact:
-    can_toast: False
-  when: user_count.stdout|int < 1
+#- name: Set fact if toast cannot be made because no one is logged in
+#  set_fact:
+#    can_toast: False
+#  when: user_count.stdout|int < 1
 

--- a/test/integration/targets/win_toast/tasks/setup.yml
+++ b/test/integration/targets/win_toast/tasks/setup.yml
@@ -1,0 +1,33 @@
+- name: Get OS version
+  win_shell: '[Environment]::OSVersion.Version.Major'
+  register: os_version
+
+- name: Get logged in user count (using explorer exe as a proxy)
+  win_shell: (get-process -name explorer -EA silentlyContinue).Count
+  register: user_count
+
+- name: debug os_version
+  debug:
+    var: os_version
+    verbosity: 2
+
+- name: debug user_count
+  debug:
+    var: user_count
+    verbosity: 2
+
+- name: Set fact if toast cannot be made
+  set_fact:
+    can_toast: False
+  when: os_version.stdout|int < 10
+
+- name: Set fact if toast can be made
+  set_fact:
+    can_toast: True
+  when: os_version.stdout|int >= 10
+
+- name: Set fact if toast cannot be made because no one is logged in
+  set_fact:
+    can_toast: False
+  when: user_count.stdout|int < 1
+

--- a/test/integration/targets/win_toast/tasks/tests.yml
+++ b/test/integration/targets/win_toast/tasks/tests.yml
@@ -9,7 +9,7 @@
   assert:
     that:
     - not msg_result|failed
-    - msg_result.runtime_seconds > 10
+    - msg_result.time_taken > 10
   when: 
     - can_toast == True
     - in_check_mode == False
@@ -19,7 +19,7 @@
   assert:
     that:
     - not msg_result|failed
-    - msg_result.runtime_seconds > 0.1
+    - msg_result.time_taken > 0.1
     - msg_result.toast_sent == False
   when: 
     - can_toast == True
@@ -30,7 +30,7 @@
   assert:
     that:
     - not msg_result|failed
-    - msg_result.runtime_seconds > 0.1
+    - msg_result.time_taken > 0.1
   when: 
     - can_toast == True
     - in_check_mode == True
@@ -39,7 +39,7 @@
   assert:
     that:
     - not msg_result|failed
-    - msg_result.runtime_seconds > 0.1
+    - msg_result.time_taken > 0.1
     - msg_result.toast_sent == False
   when: 
     - can_toast == True
@@ -63,7 +63,7 @@
   assert:
     that:
     - not msg_result2|failed
-    - msg_result2.runtime_seconds > 10
+    - msg_result2.time_taken > 10
   when: 
     - can_toast == True
     - in_check_mode == False
@@ -73,7 +73,7 @@
   assert:
     that:
     - not msg_result2|failed
-    - msg_result2.runtime_seconds > 0.1
+    - msg_result2.time_taken > 0.1
   when: 
     - can_toast == True
     - in_check_mode == False
@@ -83,7 +83,7 @@
   assert:
     that:
     - not msg_result2|failed
-    - msg_result2.runtime_seconds > 0.1
+    - msg_result2.time_taken > 0.1
   when: 
     - can_toast == True
     - in_check_mode == False
@@ -93,7 +93,7 @@
   assert:
     that:
     - not msg_result2|failed
-    - msg_result2.runtime_seconds > 0.1
+    - msg_result2.time_taken > 0.1
   when: 
     - can_toast == True
     - in_check_mode == False

--- a/test/integration/targets/win_toast/tasks/tests.yml
+++ b/test/integration/targets/win_toast/tasks/tests.yml
@@ -5,7 +5,7 @@
   register: msg_result
   ignore_errors: True
 
-- name: Test msg_result when can_toast is true (normal mode)
+- name: Test msg_result when can_toast is true (normal mode, users)
   assert:
     that:
     - not msg_result|failed
@@ -13,8 +13,20 @@
   when: 
     - can_toast == True
     - in_check_mode == False
+    - user_count.stdout|int > 0
 
-- name: Test msg_result when can_toast is true (check mode)
+- name: Test msg_result when can_toast is true (normal mode, no users)
+  assert:
+    that:
+    - not msg_result|failed
+    - msg_result.runtime_seconds > 0.1
+    - msg_result.toast_sent == False
+  when: 
+    - can_toast == True
+    - in_check_mode == False
+    - user_count.stdout|int == 0
+
+- name: Test msg_result when can_toast is true (check mode, users)
   assert:
     that:
     - not msg_result|failed
@@ -22,6 +34,17 @@
   when: 
     - can_toast == True
     - in_check_mode == True
+
+- name: Test msg_result when can_toast is true (check mode, no users)
+  assert:
+    that:
+    - not msg_result|failed
+    - msg_result.runtime_seconds > 0.1
+    - msg_result.toast_sent == False
+  when: 
+    - can_toast == True
+    - in_check_mode == True
+    - user_count.stdout|int == 0
 
 - name: Test msg_result when can_toast is false
   assert:
@@ -36,7 +59,7 @@
   register: msg_result2
   ignore_errors: True
 
-- name: Test msg_result2 when can_toast is true (normal mode)
+- name: Test msg_result2 when can_toast is true (normal mode, users)
   assert:
     that:
     - not msg_result2|failed
@@ -44,8 +67,9 @@
   when: 
     - can_toast == True
     - in_check_mode == False
+    - user_count.stdout|int > 0
 
-- name: Test msg_result2 when can_toast is true (check mode)
+- name: Test msg_result2 when can_toast is true (normal mode, no users)
   assert:
     that:
     - not msg_result2|failed
@@ -53,6 +77,27 @@
   when: 
     - can_toast == True
     - in_check_mode == False
+    - user_count.stdout|int == 0
+
+- name: Test msg_result2 when can_toast is true (check mode, users)
+  assert:
+    that:
+    - not msg_result2|failed
+    - msg_result2.runtime_seconds > 0.1
+  when: 
+    - can_toast == True
+    - in_check_mode == False
+    - user_count.stdout|int > 0
+
+- name: Test msg_result2 when can_toast is true (check mode, no users)
+  assert:
+    that:
+    - not msg_result2|failed
+    - msg_result2.runtime_seconds > 0.1
+  when: 
+    - can_toast == True
+    - in_check_mode == False
+    - user_count.stdout|int == 0
 
 - name: Test msg_result2 when can_toast is false
   assert:

--- a/test/integration/targets/win_toast/tasks/tests.yml
+++ b/test/integration/targets/win_toast/tasks/tests.yml
@@ -1,0 +1,61 @@
+- name: Warn user
+  win_toast:
+    expire_seconds: 10
+    msg: Keep calm and carry on.
+  register: msg_result
+  ignore_errors: True
+
+- name: Test msg_result when can_toast is true (normal mode)
+  assert:
+    that:
+    - not msg_result|failed
+    - msg_result.runtime_seconds > 10
+  when: 
+    - can_toast == True
+    - in_check_mode == False
+
+- name: Test msg_result when can_toast is true (check mode)
+  assert:
+    that:
+    - not msg_result|failed
+    - msg_result.runtime_seconds > 0.1
+  when: 
+    - can_toast == True
+    - in_check_mode == True
+
+- name: Test msg_result when can_toast is false
+  assert:
+    that:
+    - msg_result|failed
+  when: can_toast == False
+
+- name: Warn user again
+  win_toast:
+    expire_seconds: 10
+    msg: Keep calm and carry on.
+  register: msg_result2
+  ignore_errors: True
+
+- name: Test msg_result2 when can_toast is true (normal mode)
+  assert:
+    that:
+    - not msg_result2|failed
+    - msg_result2.runtime_seconds > 10
+  when: 
+    - can_toast == True
+    - in_check_mode == False
+
+- name: Test msg_result2 when can_toast is true (check mode)
+  assert:
+    that:
+    - not msg_result2|failed
+    - msg_result2.runtime_seconds > 0.1
+  when: 
+    - can_toast == True
+    - in_check_mode == False
+
+- name: Test msg_result2 when can_toast is false
+  assert:
+    that:
+    - msg_result2|failed
+  when: can_toast == False


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - New Module Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_toast
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_toast 924e87f6b7) last updated 2017/07/12 08:24:37 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
So I thought it would be nice to be able to send modern UWP style notifications to newer windows hosts, as an alternative to win_msg.

Since this only works on Windows 10 and Server 2016 I put a windows version check in.

Testing seems to have shown that the notification service is only available when there is a logged in user, further reducing the utility of this module. :-(

Currently a work in progress as I have not found a way to make the notifications persist in Action Center.
Without this the notifications disappear after a couple of seconds, making them so ephemeral as to be useless.

Also setting popup to false does not have the intended effect of making the notification only appear in Action Center - the module runs but doesn't appear to do anything.

Likely would want to pick some better defaults for the group and tag.
Maybe also select the toast template to use (see https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Notifications.ToastTemplateType) , and add a way to specify the image to use.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 10 -m win_toast -a "expire_mins=17 msg='Hi, it looks like you were doing something\nimportant, but now I have interupted you.\nAm I clever, or what?' title='Notification from Ansible' popup=False"
TENSY | SUCCESS => {
    "changed": false,
    "expire_at": "12/07/2017 08:35:24",
    "expire_at_utc": "12 July 2017 07:35:24",
    "expire_mins": 17,
    "failed": false,
    "group": "Powershell",
    "msg": "Hi, it looks like you were doing something\nimportant, but now I have interupted you.\nAm I clever, or what?",
    "popup": false,
    "runtime_seconds": 0.1881824,
    "sent_localtime": "12 July 2017 08:18:24",
    "tag": "Ansible",
    "title": "Notification from Ansible"
}
```
