### PR TITLE
Fix eos_config config test

### DIFF
--- a/test/integration/targets/eos_config/tests/cli/config.yaml
+++ b/test/integration/targets/eos_config/tests/cli/config.yaml
@@ -25,6 +25,12 @@
       - "result.changed == true"
       - "'hostname foo' in result.updates"
 
+- name: get current running-config
+  eos_command:
+    commands: show running-config
+    provider: "{{ cli }}"
+  register: config
+
 - name: configure hostname again
   eos_config:
     lines: hostname foo


### PR DESCRIPTION
We needed to re-register show-running config before doing the
idempotency test.