### PR TITLE
Remove old/obsolete directories from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,9 +77,6 @@ packaging/release/ansible_release
 /test/integration/inventory.remote
 /test/integration/inventory.networking
 /test/integration/inventory.winrm
-# old submodule dirs
-lib/ansible/modules/core
-lib/ansible/modules/extras
 # python 'rope' stuff
 .ropeproject
 # local 'ack' config files


### PR DESCRIPTION
##### SUMMARY
Having old/obsolete directories in .gitignore can be very confusing and
may get people spending needless hours trying to understand what is
going on.

This fixes #26650

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
.gitignore

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4