### PR TITLE
Fix assert on eos_vrf integration test

### DIFF
--- a/test/integration/targets/eos_vrf/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_vrf/tests/cli/basic.yaml
@@ -108,7 +108,7 @@
       - "result.changed == false"
       - "result.commands | length == 0"
       # Ensure sessions contains epoc. Will fail after 18th May 2033
-      - "result.session_name is not defined"
+      - "'session_name' not in result.commands"
 
 
 # FIXME add in tests for everything defined in docs


### PR DESCRIPTION
We need to check the session_name key is not in the dict, rather
than checking it has no value, otherwise the test fails.