### PR TITLE
Set no switchport on ethernet interfaces

### DIFF
--- a/test/integration/targets/prepare_eos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_eos_tests/tasks/main.yml
@@ -13,7 +13,9 @@
      lines:
        - int Ethernet1
        - no shutdown
+       - no switchport
        - int Ethernet2
        - no shutdown
+       - no switchport
    provider: "{{ cli }}"
    connection: local


### PR DESCRIPTION
Otherwise this will silently make vrf tests to not work correctly.