### PR TITLE
Minor change for py3 compliance for junos module

### DIFF
--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -79,7 +79,7 @@ def exec_command(module, command):
 
     sf.close()
 
-    return rc, to_native(stdout), to_native(stderr)
+    return rc, to_native(stdout, errors='surrogate_or_strict'), to_native(stderr, errors='surrogate_or_strict')
 
 
 def request_builder(method, *args, **kwargs):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Convert return value of `execute_command` to appropriate type
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/connection.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
