### PR TITLE
Set Ethernet2 to no switchport

### DIFF
--- a/test/integration/targets/prepare_eos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_eos_tests/tasks/main.yml
@@ -16,5 +16,6 @@
        - no switchport
        - int Ethernet2
        - no shutdown
+       - no switchport
      provider: "{{ cli }}"
    connection: local


### PR DESCRIPTION
Missed this in earlier commit, otherwise eos_vrf tests fail.