### PR TITLE
Split Eth1 and Eth2 configs of prepare_eos_tests

### DIFF
--- a/test/integration/targets/prepare_eos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_eos_tests/tasks/main.yml
@@ -8,14 +8,20 @@
    register: eos_eapi_output
    connection: local
 
- - name: enable ethernet interfaces
-   eos_config:
-     lines:
-       - int Ethernet1
-       - no shutdown
-       - no switchport
-       - int Ethernet2
-       - no shutdown
-       - no switchport
-     provider: "{{ cli }}"
-   connection: local
+- name: Enable Ethernet1 interface and disable switchport
+  eos_config:
+    lines:
+      - no shutdown
+      - no switchport
+    parents: int Ethernet1
+    authorize: yes
+  connection: local
+
+- name: Enable Ethernet2 interface and disable switchport
+  eos_config:
+    lines:
+      - no shutdown
+      - no switchport
+    parents: int Ethernet2
+    authorize: yes
+  connection: local


### PR DESCRIPTION
Previous single block wasn't working for Eth2, despite not erroring
out.