### PR TITLE
Use pycrypto backend, rather than python-cryptography, on Ubuntu Trusty

### DIFF
--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -5,3 +5,8 @@ DEB_PYTHON2_MODULE_PACKAGES=ansible
 
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk
+
+ifeq ($(DEB_DIST), trusty)
+  export ANSIBLE_CRYPTO_BACKEND = pycrypto
+endif
+


### PR DESCRIPTION
##### SUMMARY

Fixes #26305 by specifying pycrypto as the ANSIBLE_CRYPTO_BACKEND during the pbuilder deb building process for trusty. Uses the debian rules file rather than shell scripts as in #26500. If there are other distros where this problem exists (e.g. precise, older Debian distros, etc), they can easily be added to the conditional statement.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Makefile

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 27 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

