### PR TITLE
Add log only config variable

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -291,9 +291,12 @@ def main():
         sys.stderr.write(traceback.format_exc())
         sys.exit("FAIL: %s" % e)
 
+    C.DEFAULT_LOG_ONLY = True
+
     ssh = connection_loader.get('ssh', class_only=True)
     cp = ssh._create_control_path(pc.remote_addr, pc.connection, pc.remote_user)
 
+    C.DEFAULT_LOG_ONLY = False
     # create the persistent connection dir if need be and create the paths
     # which we will be using later
     tmp_path = unfrackpath(C.PERSISTENT_CONTROL_PATH_DIR)
@@ -333,7 +336,7 @@ def main():
     timeout = pc.timeout
     while bool(timeout):
         if os.path.exists(socket_path):
-            display.vvvv('connected to local socket in %s' % (pc.timeout - timeout), pc.remote_addr)
+            display.display('connected to local socket in %s' % (pc.timeout - timeout), pc.remote_addr, log_only=True)
             break
         time.sleep(1)
         timeout -= 1

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -291,6 +291,8 @@ def main():
         sys.stderr.write(traceback.format_exc())
         sys.exit("FAIL: %s" % e)
 
+    # disable logging on stdout, to avoid spurious debug logs to
+    # be outputted on stdout.
     C.DEFAULT_LOG_ONLY = True
 
     ssh = connection_loader.get('ssh', class_only=True)

--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -700,6 +700,15 @@ DEFAULT_LOG_PATH:
   value_type: path
   vars: []
   yaml: {key: defaults.log_path}
+DEFAULT_LOG_ONLY:
+  default: False
+  desc: 'TODO: write it'
+  env: [{name: ANSIBLE_LOG_ONLY}]
+  ini:
+  - {key: log_only, section: defaults}
+  value_type: boolean
+  vars: []
+  yaml: {key: defaults.log_only}
 DEFAULT_LOOKUP_PLUGIN_PATH:
   default: ~/.ansible/plugins/lookup:/usr/share/ansible/plugins/lookup
   desc: 'TODO: write it'

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -113,7 +113,7 @@ class Display:
         if color:
             msg = stringc(msg, color)
 
-        if not log_only:
+        if not log_only and not C.DEFAULT_LOG_ONLY:
             if not msg.endswith(u'\n'):
                 msg2 = msg + u'\n'
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #25544

When `ANISBLE_DEBUG` is set, the call to `connection_loader` plugin triggers a debug message which is written on stdout of `ansible-connection` that runs as background process.

This debug message is interpreted as socket path resulting in `AF_UNIX path too long error`.

Adding a config variable to temporary disable writing logs on `ansible-connection` stdout. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
data/config.yml
utils/display.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
