### PR TITLE
Fix NX-API json handling

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -375,11 +375,9 @@ def to_command(module, commands):
 
     commands = transform(to_list(commands))
 
-    for index, item in enumerate(commands):
+    for item in commands:
         if is_json(item['command']):
             item['output'] = 'json'
-        elif is_text(item['command']):
-            item['output'] = 'text'
 
     return commands
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #26544.

Default outputs are specified, but entirely ignored as `is_text()` is the inverse of `is_json()`, meaning output will be overridden regardless of specified or default values. ComplexList handles providing the default values, so no issue with undefined output propagating out.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

