### PR TITLE
vmware_guest: fixes for cache objects and datacenter association

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -449,16 +449,16 @@ class PyVmomiCache(object):
         result = find_obj(content, types, name)
         if result and confine_to_datacenter:
             if self.get_parent_datacenter(result).name != self.dc_name:
+                result = None
                 objects = self.get_all_objs(content, types, confine_to_datacenter=True)
                 for obj in objects:
-                    if obj.name == name:
+                    if name is None or obj.name == name:
                         return obj
-
         return result
 
     def get_all_objs(self, content, types, confine_to_datacenter=True):
         """ Wrapper around get_all_objs to set datacenter context """
-        objects = get_all_objs(content, [vim.Datastore])
+        objects = get_all_objs(content, types)
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -1,7 +1,7 @@
-#- name: make sure pyvmomi is installed
-#  pip:
-#    name: pyvmomi
-#    state: latest
+- name: make sure pyvmomi is installed
+  pip:
+    name: pyvmomi
+    state: latest
 
 - name: store the vcenter container ip
   set_fact:


### PR DESCRIPTION
##### SUMMARY

* find_all_objs was only looking for datastores
* Clear the result if it's datacenter is not correct.

Addresses #25011
Addresses #26511

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
