### PR TITLE
github release management for github_release module

### DIFF
--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -59,32 +59,32 @@ options:
         description:
             - Release tag name
             - Used when state=present|absent for release look up
-	version_added: "2.4"
+        version_added: "2.4"
     state:
         required: false
         description:
             - Desired state of the release
             - Must not be used with `action`
         choices: [ 'absent', 'present' ]
-	version_added: "2.4"
+        version_added: "2.4"
     target_commitish:
         required: false
         description:
             - Commit/branch ref
             - Required when state=present|absent
-	version_added: "2.4"
+        version_added: "2.4"
     draft:
         required: false
         default: False
         description:
             - Specifies draft status for release (see GitHub release docs)
-	version_added: "2.4"
+        version_added: "2.4"
     prerelease:
         required: false
         default: False
         description:
             - Specifies prerelease status for release (see GitHub release docs)
-	version_added: "2.4"
+        version_added: "2.4"
 
 author:
     - "Adrian Moisey (@adrianmoisey)"

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -128,16 +128,11 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-action: latest_release
----
 latest_release:
     description: Version of the latest release
     type: string
     returned: success
     sample: 1.1.0
-
-state: present
----
 release:
     description: Release details provided by GitHub
     type: dict

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -212,7 +212,7 @@ def main():
             draft=dict(required=False, type='bool', default=False),
             prerelease=dict(type='bool', default=False)
         ),
-        supports_check_mode=True,
+        supports_check_mode=False,
         required_one_of=(('password', 'token'),),
         mutually_exclusive=(
             ('password', 'token'),

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -150,10 +150,12 @@ except ImportError:
 import time
 from ansible.module_utils.basic import AnsibleModule, get_exception
 
+
 def find_release(module, repository):
     tag_name = module.params.get('tag_name')
 
     return repository.release_from_tag(tag_name)
+
 
 def create_release(module, repository):
     params = module.params
@@ -167,13 +169,14 @@ def create_release(module, repository):
 
     return repository.create_release(tag_name, target_commitish, name, body, draft, prerelease)
 
+
 def update_release(module, release):
     params = module.params
 
-    requires_update=False
+    requires_update = False
     for attr_name in ['tag_name', 'target_commitish', 'name', 'body', 'draft', 'prerelease']:
         if getattr(release, attr_name) != params.get(attr_name):
-            requires_update=True
+            requires_update = True
             break
 
     if requires_update:
@@ -188,8 +191,10 @@ def update_release(module, release):
     else:
         return None
 
+
 def delete_release(_module, release):
     return release.delete()
+
 
 def main():
     module = AnsibleModule(
@@ -279,7 +284,7 @@ def main():
                 if update is None:
                     module.exit_json(changed=False, release=release.as_dict())
                 elif update:
-                    time.sleep(1) # Remote change is quick, but not immediate
+                    time.sleep(1)  # Remote change is quick, but not immediate
                     release = find_release(module, repository)
                     module.exit_json(changed=True, updated=True, release=release.as_dict())
                 else:


### PR DESCRIPTION
##### SUMMARY

Adds release management functionality to the github_release module. Prior to this change the module provided discovery features, but no means of creating/removing releases.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

source_control/github_release

##### ANSIBLE VERSION

```
└─▪ ansible --version
ansible 2.4.0 (devel 455b7e583c) last updated 2017/07/12 14:46:31 (GMT -600)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/src/ansible/lib/ansible
  executable location = /Users/james/Documents/src/ansible/bin/ansible
  python version = 2.7.12 (default, Jun 29 2016, 14:05:02) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```
