### PR TITLE
Add ANSIBLE_TEST_CI env var to integration tests.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -593,6 +593,7 @@ def integration_environment(args, target, cmd):
     integration = dict(
         JUNIT_OUTPUT_DIR=os.path.abspath('test/results/junit'),
         ANSIBLE_CALLBACK_WHITELIST='junit',
+        ANSIBLE_TEST_CI=args.metadata.ci_provider,
     )
 
     if args.debug_strategy:

--- a/test/runner/lib/metadata.py
+++ b/test/runner/lib/metadata.py
@@ -5,6 +5,7 @@ import json
 
 from lib.util import (
     display,
+    is_shippable,
 )
 
 from lib.diff import (
@@ -18,6 +19,11 @@ class Metadata(object):
         """Initialize metadata."""
         self.changes = {}  # type: dict [str, tuple[tuple[int, int]]
         self.cloud_config = None  # type: dict [str, str]
+
+        if is_shippable():
+            self.ci_provider = 'shippable'
+        else:
+            self.ci_provider = ''
 
     def populate_changes(self, diff):
         """
@@ -47,6 +53,7 @@ class Metadata(object):
         return dict(
             changes=self.changes,
             cloud_config=self.cloud_config,
+            ci_provider=self.ci_provider,
         )
 
     def to_file(self, path):
@@ -80,5 +87,6 @@ class Metadata(object):
         metadata = Metadata()
         metadata.changes = data['changes']
         metadata.cloud_config = data['cloud_config']
+        metadata.ci_provider = data['ci_provider']
 
         return metadata


### PR DESCRIPTION
##### SUMMARY

Add ANSIBLE_TEST_CI env var to integration tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-env d8c1f0dd22) last updated 2017/07/12 14:16:57 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
