### PR TITLE
Fix pycrypto setting to work with multiple distros in DEB_DIST

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Section: admin
 Priority: optional
 Standards-Version: 3.9.3
 Maintainer: Ansible, Inc. <info@ansible.com>
-Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python | python-support, python-setuptools
+Build-Depends: cdbs, debhelper (>= 5.0.0), asciidoc, python, dh-python | python-support, python-setuptools, lsb-release
 Homepage: http://ansible.github.com/
 
 Package: ansible

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -6,7 +6,7 @@ DEB_PYTHON2_MODULE_PACKAGES=ansible
 include /usr/share/cdbs/1/rules/debhelper.mk
 include /usr/share/cdbs/1/class/python-distutils.mk
 
-ifeq ($(DEB_DIST), trusty)
+ifeq ($(shell lsb_release -cs), trusty)
   export ANSIBLE_CRYPTO_BACKEND = pycrypto
 endif
 


### PR DESCRIPTION
##### SUMMARY

The recent change in https://github.com/ansible/ansible/pull/26705 only fixes #26305 when a single distro is being built (e.g. `DEB_DIST=trusty make deb`), but not when multiple distros are being built in a single Makefile invocation (e.g. `DEB_DIST="trusty xenial" make deb`).

To solve this, instead of looking at DEB_DIST, we use `lsb_release` to get the distro codename from within the pbuilder chroot. This also requires adding `lsb-release` as a build-time dependency in the control file.


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
Makefile

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 27 2016, 20:30:19) [GCC 4.8.4]
```
