### PR TITLE
Replace - Clarified regex docs

### DIFF
--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -56,7 +56,7 @@ options:
       - Does not use DOTALL, which means the C(.) special character matches
         any character I(except newlines). A common mistake is to assume that
         a negated character set like C([^#]) will also not match newlines.
-        In order to exclude newlines, they must be added to the set like C([^#\n]).
+        In order to exclude newlines, they must be added to the set like C([^#\\n]).
       - Note that, as of ansible 2, short form tasks should have any escape
         sequences backslash-escaped in order to prevent them being parsed
         as string literal escapes. See the examples.

--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -50,12 +50,16 @@ options:
       - The regular expression to look for in the contents of the file.
         Uses Python regular expressions; see
         U(http://docs.python.org/2/library/re.html).
-        Uses multiline mode, which means C(^) and C($) match the beginning
-        and end respectively of I(each line) of the file.
+        Uses MULTILINE mode, which means C(^) and C($) match the beginning
+        and end of the file, as well as the beginning and end respectively
+        of I(each line) of the file.
+      - Does not use DOTALL, which means the C(.) special character matches
+        any character I(except newlines). A common mistake is to assume that
+        a negated character set like C([^#]) will also not match newlines.
+        In order to exclude newlines, they must be added to the set like C([^#\n]).
       - Note that, as of ansible 2, short form tasks should have any escape
         sequences backslash-escaped in order to prevent them being parsed
         as string literal escapes. See the examples.
-
   replace:
     required: false
     description:


### PR DESCRIPTION
##### SUMMARY

Clarified the ramifications of python's [MULTILINE modifier](https://docs.python.org/2/library/re.html#re.MULTILINE), as well as negated character sets and the unexpected effects they can have in matching across multiple lines (see #26712).

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

`replace` module

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /Users/ekaufman/.ansible.cfg
  configured module search path = Default w/o overrides
```