### PR TITLE
fix searched paths in DataLoader.path_dwim_relative (avoid AnsibleFileNotFound)

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -304,6 +304,7 @@ class DataLoader:
                 search.append(unfrackpath(os.path.join(basedir, 'tasks', source), follow=False))
 
             # try to create absolute path for loader basedir + templates/files/vars + filename
+            search.append(unfrackpath(os.path.join(basedir, source), follow=False))
             search.append(unfrackpath(os.path.join(dirname, source), follow=False))
             search.append(self.path_dwim(os.path.join(dirname, source)))
 

--- a/test/integration/targets/includes/roles/test_includes/tasks/branch_toplevel.yml
+++ b/test/integration/targets/includes/roles/test_includes/tasks/branch_toplevel.yml
@@ -1,0 +1,9 @@
+# 'canary2' used instead of 'canary', otherwise a "recursive loop detected in
+# template string" occurs when both includes use static=yes
+- include: 'leaf_sublevel.yml canary2={{ canary }}'
+  static: yes
+  when: 'nested_include_static|bool' # value for 'static' can not be a variable, hence use 'when'
+
+- include: 'leaf_sublevel.yml canary2={{ canary }}'
+  static: no
+  when: 'not nested_include_static|bool'

--- a/test/integration/targets/includes/roles/test_includes/tasks/leaf_sublevel.yml
+++ b/test/integration/targets/includes/roles/test_includes/tasks/leaf_sublevel.yml
@@ -1,0 +1,2 @@
+- set_fact:
+    canary_fact: '{{ canary2 }}'

--- a/test/integration/targets/includes/roles/test_includes/tasks/main.yml
+++ b/test/integration/targets/includes/roles/test_includes/tasks/main.yml
@@ -80,3 +80,27 @@
     # both these via a handler include
     - included_handler
     - verify_handler
+
+- include: branch_toplevel.yml canary=value1 nested_include_static=no
+  static: no
+- assert:
+    that:
+      - 'canary_fact == "value1"'
+
+- include: branch_toplevel.yml canary=value2 nested_include_static=yes
+  static: no
+- assert:
+    that:
+      - 'canary_fact == "value2"'
+
+- include: branch_toplevel.yml canary=value3 nested_include_static=no
+  static: yes
+- assert:
+    that:
+      - 'canary_fact == "value3"'
+
+- include: branch_toplevel.yml canary=value4 nested_include_static=yes
+  static: yes
+- assert:
+    that:
+      - 'canary_fact == "value4"'

--- a/test/units/parsing/test_dataloader.py
+++ b/test/units/parsing/test_dataloader.py
@@ -19,11 +19,16 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import os
+
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, mock_open
 from ansible.errors import AnsibleParserError, yaml_strings
+from ansible.module_utils._text import to_text
 from ansible.module_utils.six import PY3
 from ansible.parsing.dataloader import DataLoader
+
+from units.mock.path import mock_unfrackpath_noop
 
 
 class TestDataLoader(unittest.TestCase):
@@ -68,6 +73,45 @@ class TestDataLoader(unittest.TestCase):
             self._loader.load_from_file('dummy_yaml_text.txt')
         self.assertIn(yaml_strings.YAML_COMMON_LEADING_TAB_ERROR, str(cm.exception))
         self.assertIn('foo: bar', str(cm.exception))
+
+    @patch('ansible.parsing.dataloader.unfrackpath', mock_unfrackpath_noop)
+    @patch.object(DataLoader, '_is_role')
+    def test_path_dwim_relative(self, mock_is_role):
+        """
+        simulate a nested dynamic include:
+
+        playbook.yml:
+        - hosts: localhost
+          roles:
+            - { role: 'testrole' }
+
+        testrole/tasks/main.yml:
+        - include: "include1.yml"
+          static: no
+
+        testrole/tasks/include1.yml:
+        - include: include2.yml
+          static: no
+
+        testrole/tasks/include2.yml:
+        - debug: msg="blah"
+        """
+        mock_is_role.return_value = False
+        with patch('os.path.exists') as mock_os_path_exists:
+            mock_os_path_exists.return_value = False
+            self._loader.path_dwim_relative('/tmp/roles/testrole/tasks', 'tasks', 'included2.yml')
+
+            # Fetch first args for every call
+            # mock_os_path_exists.assert_any_call isn't used because os.path.normpath must be used in order to compare paths
+            called_args = [os.path.normpath(to_text(call[0][0])) for call in mock_os_path_exists.call_args_list]
+
+            # 'path_dwim_relative' docstrings say 'with or without explicitly named dirname subdirs':
+            self.assertIn('/tmp/roles/testrole/tasks/included2.yml', called_args)
+            self.assertIn('/tmp/roles/testrole/tasks/tasks/included2.yml', called_args)
+
+            # relative directories below are taken in account too:
+            self.assertIn('tasks/included2.yml', called_args)
+            self.assertIn('included2.yml', called_args)
 
 
 class TestDataLoaderWithVault(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
Before 8f758204cf379a743332bc9865fb3c002b6c3a6a, at the end of [`DataLoader.path_dwim_relative(self, path, dirname, source, is_role=False)`](https://github.com/pilou-/ansible/blob/c9ba085252e23e3803ac17c1f02e4bb43eb66639/lib/ansible/parsing/dataloader.py#L269) method, the `search` variable contained amongst others paths:

- `os.path.join(path, dirname, source)` (for example: `/tmp/roles/testrole/tasks/tasks/included.yml`)
- `os.path.join(path, source)` (for example: `/tmp/roles/testrole/tasks/included.yml`)

The commit mentioned before removed the last one, despite the `path_dwim_relative` docstrings specifies `with or without explicitly named dirname subdirs`.

The fixed error was:
```
Unable to retrieve file contents
Could not find or access 'included.yml'
```

This pull-request adds unit and integration tests (both fail without this pull-request).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/parsing/dataloader.py

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 374ea94dc3) last updated 2017/07/13 02:08:28 (GMT +200)
```

##### ADDITIONAL INFORMATION
Related: e2b340dfe0a652ec655d86b46bd39e764fc91852 and #26460.