### PR TITLE
Load action plugins with complex args formatted task

### DIFF
--- a/lib/ansible/parsing/mod_args.py
+++ b/lib/ansible/parsing/mod_args.py
@@ -23,7 +23,7 @@ from ansible.errors import AnsibleParserError, AnsibleError
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_text
 from ansible.parsing.splitter import parse_kv, split_args
-from ansible.plugins import module_loader
+from ansible.plugins import module_loader, action_loader
 from ansible.template import Templar
 
 
@@ -286,7 +286,7 @@ class ModuleArgsParser:
 
         # walk the input dictionary to see we recognize a module name
         for (item, value) in iteritems(self._task_ds):
-            if item in module_loader or item in ['meta', 'include', 'include_tasks', 'include_role', 'import_tasks', 'import_role']:
+            if item in module_loader or item in action_loader or item in ['meta', 'include', 'include_tasks', 'include_role', 'import_tasks', 'import_role']:
                 # finding more than one module name is a problem
                 if action is not None:
                     raise AnsibleParserError("conflicting action statements: %s, %s" % (action, item), obj=self._task_ds)


### PR DESCRIPTION
ansible/ansible/issues/20513

##### SUMMARY
Makes parser consider action_plugins by including ansible.plugins.action_loader in condition.

Possible fix for #20513
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parsing/mod_args

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 3ddfc35b08) last updated 2017/07/13 09:44:52 (GMT +200)
  config file = None
  configured module search path = [u'/Users/eml1/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/eml1/git/ansible/lib/ansible
  executable location = /Users/eml1/git/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```
