### PR TITLE
imc_rest: Increase default timeout, add elapsed time

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -562,7 +562,7 @@ files:
   $modules/packaging/os/zypper_repository.py: matze robinro
   $modules/remote_management/foreman/: ehelms
   $modules/remote_management/hpilo/: dagwieers haad
-  $modules/remote_management/imc/imc_xml.py: dagwieers
+  $modules/remote_management/imc/: dagwieers
   $modules/remote_management/ipmi/: cloudnull
   $modules/remote_management/stacki/stacki_host.py: bbyhuy bsanders
   $modules/remote_management/wakeonlan.py: dagwieers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,7 +279,7 @@ Ansible Changes By Release
   * purefa_pg
   * purefa_volume
 - imc
-  * imc_xml
+  * imc_rest
 - rundeck
   * rundeck_acl_policy
   * rundeck_project


### PR DESCRIPTION
##### SUMMARY
The IMC interface can be quite slow depending on the XML fragments used.
So we increase the default timeout to 60 seconds, and return the elapsed
time so it is easier to determine what timeout value makes sense from
earlier runs.

We also renamed **imc_xml** to **imc_rest**, now that we still can.



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
imc_xml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4