### PR TITLE
Update the doc fragment to contain 4 new devices that are added

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/cnos.py
+++ b/lib/ansible/utils/module_docs_fragments/cnos.py
@@ -80,6 +80,6 @@ options:
             - This specifies the type of device where the method is executed.
         required: Yes
         default: null
-        choices: [g8272_cnos,g8296_cnos,g8332_cnos]
+        choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T_cnos,NE1032_cnos,NE1032T_cnos,NE10032_cnos,NE2572_cnos]
         version_added: 2.3
 '''


### PR DESCRIPTION
The devices are NE1072T, NE1032, NE1032T, NE10032, NE2572

SUMMARY  
Adding support to more devices on 2.4 The newly supported devices are NE1072T, NE1032 , NE1032T ,NE10032 and NE2572. This is included in dodumenation
ISSUE TYPE  
•	Feature Pull Request
COMPONENT NAME  
lib\ansible\utils\module_docs_fragments\cnos.py
ANSIBLE VERSION  
ansible 2.4.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
ADDITIONAL INFORMATION  
Adding support to new devices from Lenovo which are supported from Ansible 2.4.0 onwards

             - This specifies the type of device where the method is executed.
         required: Yes
         default: null
-        choices: [g8272_cnos,g8296_cnos,g8332_cnos]
+        choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T_cnos,NE1032_cnos,NE1032T_cnos,NE10032_cnos,NE2572_cnos]
         version_added: 2.4