### PR TITLE
added integration tests for vyos_facts

### DIFF
--- a/test/integration/targets/vyos_facts/defaults/main.yaml
+++ b/test/integration/targets/vyos_facts/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/vyos_facts/tasks/cli.yaml
+++ b/test/integration/targets/vyos_facts/tasks/cli.yaml
@@ -1,0 +1,15 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/vyos_facts/tasks/main.yaml
+++ b/test/integration/targets/vyos_facts/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/vyos_facts/tests/cli/basic_facts.yaml
+++ b/test/integration/targets/vyos_facts/tests/cli/basic_facts.yaml
@@ -1,0 +1,36 @@
+- name: get host name
+  vyos_command:
+    commands:
+      - show host name
+  register: vyos_host
+
+- name: get version info
+  vyos_command:
+    commands:
+      - show version
+  register: vyos_version
+
+- name: collect all facts from the device
+  vyos_facts:
+    gather_subset: all
+  register: result
+
+- name: "check that all the fields which are always returned are present"
+  assert:
+    that:
+      # hostname
+      - result.ansible_facts.ansible_net_hostname == vyos_host.stdout[0]
+
+      # subsets
+      - "'neighbors' in result.ansible_facts.ansible_net_gather_subset"
+      - "'default' in result.ansible_facts.ansible_net_gather_subset"
+      - "'config' in result.ansible_facts.ansible_net_gather_subset"
+
+      # version info
+      - result.ansible_facts.ansible_net_version in vyos_version.stdout_lines[0][0]
+      - result.ansible_facts.ansible_net_model in vyos_version.stdout_lines[0][9]
+      - result.ansible_facts.ansible_net_serialnum in vyos_version.stdout_lines[0][10]
+
+      # config info
+      - result.ansible_facts.ansible_net_commits is defined
+      - result.ansible_facts.ansible_net_config is defined

--- a/test/integration/targets/vyos_facts/tests/cli/basic_facts.yaml
+++ b/test/integration/targets/vyos_facts/tests/cli/basic_facts.yaml
@@ -15,22 +15,31 @@
     gather_subset: all
   register: result
 
-- name: "check that all the fields which are always returned are present"
+- name: "check that hostname is present"
   assert:
     that:
       # hostname
       - result.ansible_facts.ansible_net_hostname == vyos_host.stdout[0]
 
+- name: "check that subsets are present"
+  assert:
+    that:
       # subsets
       - "'neighbors' in result.ansible_facts.ansible_net_gather_subset"
       - "'default' in result.ansible_facts.ansible_net_gather_subset"
       - "'config' in result.ansible_facts.ansible_net_gather_subset"
 
+- name: "check that version info is present"
+  assert:
+    that:
       # version info
       - result.ansible_facts.ansible_net_version in vyos_version.stdout_lines[0][0]
       - result.ansible_facts.ansible_net_model in vyos_version.stdout_lines[0][9]
       - result.ansible_facts.ansible_net_serialnum in vyos_version.stdout_lines[0][10]
 
+- name: "check that config info is present"
+  assert:
+    that:
       # config info
       - result.ansible_facts.ansible_net_commits is defined
       - result.ansible_facts.ansible_net_config is defined

--- a/test/integration/targets/vyos_facts/tests/cli/neighbors_facts.yaml
+++ b/test/integration/targets/vyos_facts/tests/cli/neighbors_facts.yaml
@@ -1,0 +1,42 @@
+- block:
+    - name: start LLDP
+      vyos_config:
+        lines:
+          - set service lldp
+          - set service lldp management-address {{ vyos_lldp_node }}
+
+    - debug: var=vyos_lldp_node
+
+    - name: wait for LLDP to start up. If this fails check that vyos_lldp_node is a valid ip address
+      vyos_command:
+        commands:
+          - show lldp neighbors detail
+      register: neighbors
+      until: neighbors.stdout_lines[0]|length > 3
+      retries: 5
+      delay: 5
+
+    - name: collect neighbor facts from the device
+      vyos_facts:
+        gather_subset: neighbors
+        # provider: {{ cli }}
+      register: result
+
+    - debug: var=result.ansible_facts.ansible_net_neighbors
+
+
+    - name: check ansible_net_neighbors
+      assert:
+        that:
+          - result.ansible_facts.ansible_net_neighbors is defined
+          # - result.ansible_facts.ansible_net_neighbors.eth0 is defined
+          - result.ansible_facts.ansible_net_neighbors|length > 0
+
+  always:
+    - name: stop lldp
+      vyos_config:
+        lines:
+          - delete service lldp
+          - delete service lldp management-address {{ vyos_lldp_node }}
+
+  when: vyos_lldp_node is defined

--- a/test/integration/targets/vyos_facts/tests/cli/neighbors_facts.yaml
+++ b/test/integration/targets/vyos_facts/tests/cli/neighbors_facts.yaml
@@ -1,4 +1,14 @@
+- name: get eth0 ip address
+  vyos_command:
+    commands:
+      - show interfaces ethernet eth0
+  register: eth0_ip
+
+# if there is no ip assigned to eth0, skip this
 - block:
+    - set_fact:
+        vyos_lldp_node: "{{ eth0_ip.stdout_lines[0][2] | regex_replace('.*inet ', '') | regex_replace('/.*', '') }}"
+
     - name: start LLDP
       vyos_config:
         lines:
@@ -38,5 +48,4 @@
         lines:
           - delete service lldp
           - delete service lldp management-address {{ vyos_lldp_node }}
-
-  when: vyos_lldp_node is defined
+  when: "'inet' in eth0_ip.stdout[0]"

--- a/test/integration/vyos.yaml
+++ b/test/integration/vyos.yaml
@@ -114,6 +114,13 @@
             failed_modules: "{{ failed_modules }} + [ 'vyos_interface' ]"
             test_failed: true
 
+    - block:
+      - include_role:
+          { name: vyos_facts, vyos_lldp_node: 172.26.4.35 }
+        when: "limit_to in ['*', 'vyos_facts']"
+      rescue:
+        - set_fact: test_failed=true
+
 ###########
     - debug: var=failed_modules
       when: test_failed

--- a/test/integration/vyos.yaml
+++ b/test/integration/vyos.yaml
@@ -116,7 +116,7 @@
 
     - block:
       - include_role:
-          { name: vyos_facts, vyos_lldp_node: 172.26.4.35 }
+          name: vyos_facts
         when: "limit_to in ['*', 'vyos_facts']"
       rescue:
         - set_fact:

--- a/test/integration/vyos.yaml
+++ b/test/integration/vyos.yaml
@@ -119,7 +119,9 @@
           { name: vyos_facts, vyos_lldp_node: 172.26.4.35 }
         when: "limit_to in ['*', 'vyos_facts']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'vyos_facts' ]"
+            test_failed: true
 
 ###########
     - debug: var=failed_modules


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Tests were missing for vyos_facts and were needed in order to verify #26451. 

Note, these test will currently fail if run on a vyos platform that has LLDP configured because of #26451.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - test pull request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vyos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ci-vyos-facts f97eb49974) last updated 2017/07/13 07:46:53 (GMT -400)
  config file = None
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
