### PR TITLE
[WIP] ecs_taskdefinition idempotency - fixes 22547

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -42,7 +42,6 @@ lib/ansible/modules/cloud/amazon/ecs_cluster.py
 lib/ansible/modules/cloud/amazon/ecs_service.py
 lib/ansible/modules/cloud/amazon/ecs_service_facts.py
 lib/ansible/modules/cloud/amazon/ecs_task.py
-lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
 lib/ansible/modules/cloud/amazon/efs.py
 lib/ansible/modules/cloud/amazon/elasticache.py
 lib/ansible/modules/cloud/amazon/elasticache_subnet_group.py


### PR DESCRIPTION
##### SUMMARY
* Fixes #22547; essential and port_mapping['protocol'] don't need to be specified and default to True and 'tcp' respectively; compare default values if they are omitted
* Removed unused requirements (boto, json)
* Pep8
* TODO - add testing for comparison checking

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py

##### ANSIBLE VERSION
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
