### PR TITLE
added ansible_remote_tmp inventory var

### DIFF
--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -847,7 +847,8 @@ DEFAULT_REMOTE_TMP:
   env: [{name: ANSIBLE_REMOTE_TEMP}]
   ini:
   - {key: remote_tmp, section: defaults}
-  vars: []
+  vars:
+    - name: ansible_remote_tmp
   yaml: {key: defaults.remote_tmp}
 DEFAULT_REMOTE_USER:
   default: 

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -57,6 +57,7 @@ MAGIC_VARIABLE_MAPPING = dict(
     connection=('ansible_connection', ),
     remote_addr=('ansible_ssh_host', 'ansible_host'),
     remote_user=('ansible_ssh_user', 'ansible_user'),
+    remote_tmp_dir=('ansible_remote_tmp', ),
     port=('ansible_ssh_port', 'ansible_port'),
     timeout=('ansible_ssh_timeout', 'ansible_timeout'),
     ssh_executable=('ansible_ssh_executable', ),
@@ -168,6 +169,7 @@ class PlayContext(Base):
     # (connection, port, remote_user, environment, no_log)
     _docker_extra_args = FieldAttribute(isa='string')
     _remote_addr = FieldAttribute(isa='string')
+    _remote_tmp_dir = FieldAttribute(isa='string', default=C.DEFAULT_REMOTE_TMP)
     _password = FieldAttribute(isa='string')
     _private_key_file = FieldAttribute(isa='string', default=C.DEFAULT_PRIVATE_KEY_FILE)
     _timeout = FieldAttribute(isa='int', default=C.DEFAULT_TIMEOUT)

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -241,11 +241,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             use_system_tmp = True
 
         tmp_mode = 0o700
-
-        if use_system_tmp:
-            tmpdir = None
-        else:
-            tmpdir = self._remote_expand_user(C.DEFAULT_REMOTE_TMP, sudoable=False)
+        tmpdir = self._remote_expand_user(self._play_context.remote_tmp_dir, sudoable=False)
 
         cmd = self._connection._shell.mkdtemp(basefile, use_system_tmp, tmp_mode, tmpdir)
         result = self._low_level_execute_command(cmd, sudoable=False)

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -110,7 +110,7 @@ class ShellBase(object):
         # /var/tmp is not).
 
         if system:
-            #FIXME: create 'system tmp dirs' config/var and check tmpdir is in those values to allow for /opt/tmp, etc
+            # FIXME: create 'system tmp dirs' config/var and check tmpdir is in those values to allow for /opt/tmp, etc
             if tmpdir.startswith('/var/tmp'):
                 basetmpdir = '/var/tmp'
             else:

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -110,14 +110,16 @@ class ShellBase(object):
         # /var/tmp is not).
 
         if system:
-            if C.DEFAULT_REMOTE_TMP.startswith('/var/tmp'):
+            #FIXME: create 'system tmp dirs' config/var and check tmpdir is in those values to allow for /opt/tmp, etc
+            if tmpdir.startswith('/var/tmp'):
                 basetmpdir = '/var/tmp'
             else:
                 basetmpdir = '/tmp'
-        elif tmpdir is None:
-            basetmpdir = C.DEFAULT_REMOTE_TMP
         else:
-            basetmpdir = tmpdir
+            if tmpdir is None:
+                basetmpdir = C.DEFAULT_REMOTE_TMP
+            else:
+                basetmpdir = tmpdir
 
         basetmp = self.join_path(basetmpdir, basefile)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows setting the remote tmp dir as an inventory variable, still defaults to the config.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

