### PR TITLE
ec2_vol: snapshot and volume_size are not mutually exclusive - fixes #26687

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -609,8 +609,8 @@ def main():
     if not volume_size and not (id or name or snapshot):
         module.fail_json(msg="You must specify volume_size or identify an existing volume by id, name, or snapshot")
 
-    if volume_size and (id or snapshot):
-        module.fail_json(msg="Cannot specify volume_size together with id or snapshot")
+    if volume_size and id:
+        module.fail_json(msg="Cannot specify volume_size together with id")
 
     if state == 'present':
         volume, changed = create_volume(module, ec2, zone)


### PR DESCRIPTION
##### SUMMARY
Fixes #26687
I think these may have been made mutually exclusive for fear of users specifying a smaller volume_size than the snapshot would require. I've tested this and it defaults to a reasonable size. Otherwise working as expected.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vol.py

##### ANSIBLE VERSION
```
2.4.0
```


##### ADDITIONAL INFORMATION
This task:
```
      ec2_vol:
        volume_size: 1
        volume_type: standard
        instance: i-00a82414275c980df
        snapshot: snap-0877466881dbbb77d
        device_name: "/dev/xvdf"
```
Results in volume size: 8
```
changed: [localhost] => {
    "changed": true,
     ...
    "volume": {
        "attachment_set": {
            "attach_time": "2017-07-13T16:08:39.000Z",
            "deleteOnTermination": "false",
            "device": "/dev/xvdf",
            "instance_id": "i-00a82414275c980df",
            "status": "attached"
        },
        "create_time": "2017-07-13T16:08:33.508Z",
        "encrypted": false,
        "id": "vol-01789bb87c5de0529",
        "iops": null,
        "size": 8,
        "snapshot_id": "snap-0877466881dbbb77d",
        "status": "in-use",
        "tags": {},
        "type": "standard",
        "zone": "us-east-1d"
    },
    "volume_id": "vol-01789bb87c5de0529",
    "volume_type": "standard"
}
META: ran handlers
META: ran handlers

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```
But replacing volume_size: 1 with volume_size: 10 creates exactly as expected:
```
...
    },
    "volume": {
        "attachment_set": {
            "attach_time": "2017-07-13T15:59:17.000Z",
            "deleteOnTermination": "false",
            "device": "/dev/xvdf",
            "instance_id": "i-00a82414275c980df",
            "status": "attached"
        },
        "create_time": "2017-07-13T15:59:11.046Z",
        "encrypted": false,
        "id": "vol-0e6a90b98098c8701",
        "iops": null,
        "size": 10,
        "snapshot_id": "snap-0877466881dbbb77d",
        "status": "in-use",
        "tags": {},
        "type": "standard",
        "zone": "us-east-1d"
    },
    "volume_id": "vol-0e6a90b98098c8701",
    "volume_type": "standard"
}
...
```