### PR TITLE
Ignore platform_agnostic.yaml in ansible-test.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -373,6 +373,9 @@ class PathMapper(object):
             if self.prefixes.get(name) == 'network' and ext == '.yaml':
                 return minimal  # network integration test playbooks are not used by ansible-test
 
+            if filename == 'platform_agnostic.yaml':
+                return minimal  # network integration test playbook not used by ansible-test
+
             return {
                 'integration': 'all',
                 'windows-integration': 'all',


### PR DESCRIPTION
##### SUMMARY

Ignore platform_agnostic.yaml in ansible-test.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (test-network 85c6893abe) last updated 2017/07/13 09:53:19 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
