### PR TITLE
ensure all groups inherit from 'all'

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -133,6 +133,10 @@ class InventoryData(object):
             group = self.groups[g]
             group_names.add(group.name)
 
+            # ensure all groups inherit from 'all'
+            if group.name != 'all' and not group.get_ancestors():
+                self.add_child('all', group.name)
+
         host_names = set()
         # get host vars from host_vars/ files and vars plugins
         for host in self.hosts.values():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ensure all is always 'top' group even if bug in plugin/script misses this

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
invenotry

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```