### PR TITLE
Fixed incorrect parsing of pvs output

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -687,38 +687,39 @@ class LinuxHardware(Hardware):
                     items = lv_line.split()
                     lvs[items[0]] = {'size_g': items[3], 'vg': items[1]}
 
-        pvs_path = self.module.get_bin_path('pvs')
-        # pvs fields: PV VG #Fmt #Attr PSize PFree
-        pvs = {}
-        if pvs_path:
-            pvs_rc, pv_lines, err = self.module.run_command('%s %s' % (pvs_path, lvm_util_options))
-        else:
-            pvs_rc = -1
+            pvs_path = self.module.get_bin_path('pvs')
+            # pvs fields: PV VG #Fmt #Attr PSize PFree
+            pvs = {}
+            if pvs_path:
+                pvs_rc, pv_lines, err = self.module.run_command('%s %s' % (pvs_path, lvm_util_options))
+            else:
+                pvs_rc = -1
 
-        if pvs_rc == 0:
-            # Find a delimiter to use, that does not exist in the normal
-            # output of pvs command.
-            delim = '#'
-            delimfound = re.search(delim, pv_lines)
-            while delimfound is not None:
-                delim = delim + '#'
-                delimfound = re.search(delim, pv_lines)
-
-            pvs_util_options = lvm_util_options + ' --separator ' + "'" + delim + "'"
-            pvs_rc, pv_lines, err = self.module.run_command('%s %s' % (pvs_path, pvs_util_options))
             if pvs_rc == 0:
-                for pv_line in pv_lines.splitlines():
-                    pv_line = pv_line.strip()
-                    items = pv_line.split(delim)
-                    pvs[self._find_mapper_device_name(items[0])] = {
-                        'size_g': items[-2],
-                        'free_g': items[-1],
-                        'vg': items[1]}
+                # Find a delimiter to use, that does not exist in the normal
+                # output of pvs command.
+                delim = '#'
+                delimfound = re.search(delim, pv_lines)
+                while delimfound is not None:
+                    delim = delim + '#'
+                    delimfound = re.search(delim, pv_lines)
 
-        if pvs_rc == 0:
-            lvm_facts['lvm'] = {'lvs': lvs, 'vgs': vgs, 'pvs': pvs}
-        else:
-            lvm_facts['lvm'] = {'lvs': lvs, 'vgs': vgs}
+                pvs_util_options = lvm_util_options + ' --separator ' + "'" + delim + "'"
+                pvs_rc, pv_lines, err = self.module.run_command('%s %s' % (pvs_path, pvs_util_options))
+                if pvs_rc == 0:
+                    for pv_line in pv_lines.splitlines():
+                        pv_line = pv_line.strip()
+                        items = pv_line.split(delim)
+                        pvs[self._find_mapper_device_name(items[0])] = {
+                            'size_g': items[-2],
+                            'free_g': items[-1],
+                            'vgpresent': True if items[1] != "" else False,
+                            'vg': items[1]}
+
+            if pvs_rc == 0:
+                lvm_facts['lvm'] = {'lvs': lvs, 'vgs': vgs, 'pvs': pvs}
+            else:
+                lvm_facts['lvm'] = {'lvs': lvs, 'vgs': vgs}
 
         return lvm_facts
 


### PR DESCRIPTION
##### SUMMARY
The Linux LVM 'pvs' command can have empty VG names in the output,
if there are no VGs on the said PVs. Parsing of such output
was incorrect, when gathering facts, as a result of such an empty VG check missing.

Corrected the same using the provided '--separator' option in the
'pvs' CLI. Further, decided to arrive at a separator that is not by default
present in the 'pvs' output, to avoid incorrect parsing of the fields.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
facts module

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/<username>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 13 2017, 10:15:16) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

##### ADDITIONAL INFORMATION
On a Linux machine, there can be PVs (LVM physical volumes) created, but not
assigned to any VG (volume group) in such cases the 'pvs' output would look
like,
```
# pvs
  PV         VG                Fmt  Attr PSize   PFree  
  /dev/sda2  centos_rhs-srv-01 lvm2 a--  278.91g  60.00m
  /dev/sdf1                    lvm2 ---  279.40g 279.40g
  /dev/sdg1                    lvm2 ---  279.40g 279.40g
  <snip>
```

The code to determine facts from a Linux machine, failed to account for missing
names, thus item[5] would error out with an out of bounds index error.

This error is not visible post gathering facts at the ansible host end. It
manifests as missing pvs (or rather, entire LVM) host facts on the ansible
host.

Before the fix:
```
$ ansible <myremotehost> -m setup -a 'filter=ansible_lvm'
<myremotehost> | SUCCESS => {
    "ansible_facts": {}, 
    "changed": false, 
    "failed": false
}
```

After the fix:
```
$ ansible <myremotehost> -m setup -a 'filter=ansible_lvm'
<myremotehost> | SUCCESS => {
    "ansible_facts": {
        "ansible_lvm": {
            "lvs": {
<snip>
            "pvs": {
                "/dev/sda2": {
                    "free_g": "0.06", 
                    "size_g": "278.91", 
                    "vg": "centos_rhs-srv-01"
                }, 
                "/dev/sdf1": {
                    "free_g": "279.40", 
                    "size_g": "279.40", 
                    "vg": ""
                }, 
                "/dev/sdg1": {
                    "free_g": "279.40", 
                    "size_g": "279.40", 
                    "vg": ""
                },
<snip>
```

Signed-off-by: Shyam <srangana@redhat.com>