### PR TITLE
make yaml extensions configurable

### DIFF
--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -1404,3 +1404,13 @@ VARIABLE_PRECEDENCE:
   value_type: list
   vars: []
   yaml: {key: defaults.precedence}
+YAML_FILENAME_EXTENSIONS:
+  default: [".yml", ".yaml", ".json"]
+  desc: "check all of these extensions when looking for 'variable' files which should be YAML or JSON or vaulted versions of theses."
+  env:
+    - name: ANSIBLE_YAML_FILENAME_EXT
+  ini:
+    - {key: defaults, section: yaml_valid_extensions}
+  value_type: list
+  vars: []
+  yaml: {key: defaults.yaml_valid_extensions}

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -76,4 +76,3 @@ RESTRICTED_RESULT_KEYS = ['ansible_rsync_path', 'ansible_playbook_python']
 TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
-YAML_FILENAME_EXTENSIONS = [".yml", ".yaml", ".json"]  # check all of these extensions when looking for 'variable' files which should be YAML or JSON.


### PR DESCRIPTION
##### SUMMARY

fixes #25419

users can not set `.vault` or whatever else a as a valid extension for vars files.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
loader
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```