### PR TITLE
vmware_guest: fix datastore selection on equal sized disks and add tests

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1100,7 +1100,6 @@ class PyVmomiHelper(object):
             elif 'datastore' in self.params['disk'][0]:
                 datastore_name = self.params['disk'][0]['datastore']
                 datastore = self.cache.find_obj(self.content, [vim.Datastore], datastore_name)
-                datastore = find_obj(self.content, [vim.Datastore], datastore_name)
             else:
                 self.module.fail_json(msg="Either datastore or autoselect_datastore should be provided to select datastore")
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1086,7 +1086,7 @@ class PyVmomiHelper(object):
 
                 datastore_freespace = 0
                 for ds in datastores:
-                    if ds.summary.freeSpace > datastore_freespace:
+                    if (ds.summary.freeSpace > datastore_freespace) or (ds.summary.freeSpace == datastore_freespace and not datastore):
                         # If datastore field is provided, filter destination datastores
                         if 'datastore' in self.params['disk'][0] and \
                                 isinstance(self.params['disk'][0]['datastore'], str) and \
@@ -1100,6 +1100,7 @@ class PyVmomiHelper(object):
             elif 'datastore' in self.params['disk'][0]:
                 datastore_name = self.params['disk'][0]['datastore']
                 datastore = self.cache.find_obj(self.content, [vim.Datastore], datastore_name)
+                datastore = find_obj(self.content, [vim.Datastore], datastore_name)
             else:
                 self.module.fail_json(msg="Either datastore or autoselect_datastore should be provided to select datastore")
 

--- a/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/clone_d1_c1_f0.yml
@@ -1,0 +1,40 @@
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim with no folders
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
+  register: vcsim_instance
+
+- name: get a list of VMS from vcsim   
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: set state to poweroff on all VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    template: "{{ item|basename }}"
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: clone_d1_c1_f0
+
+- debug: var=clone_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "clone_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -2,6 +2,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:
@@ -10,3 +11,4 @@
 
 - include: poweroff_d1_c1_f0.yml
 - include: poweroff_d1_c1_f1.yml
+- include: clone_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
Fixes datastore selection of equal size and adds tests

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
