### PR TITLE
Add retries to remote test package installs.

### DIFF
--- a/test/runner/setup/remote.sh
+++ b/test/runner/setup/remote.sh
@@ -9,33 +9,43 @@ env
 cd ~/
 
 if [ "${platform}" = "freebsd" ]; then
-    pkg install -y \
-        bash \
-        curl \
-        devel/ruby-gems \
-        git \
-        gtar \
-        mercurial \
-        python \
-        rsync \
-        ruby \
-        subversion \
-        sudo \
-        zip \
+    while true; do
+        pkg install -y \
+            bash \
+            curl \
+            devel/ruby-gems \
+            git \
+            gtar \
+            mercurial \
+            python \
+            rsync \
+            ruby \
+            subversion \
+            sudo \
+            zip \
+         && break
+         echo "Failed to install packages. Sleeping before trying again..."
+         sleep 10
+    done
 
     pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
 elif [ "${platform}" = "rhel" ]; then
-    yum install -y \
-        gcc \
-        git \
-        mercurial \
-        python-devel \
-        python-jinja2 \
-        python-virtualenv \
-        python2-cryptography \
-        rubygems \
-        subversion \
-        unzip \
+    while true; do
+        yum install -y \
+            gcc \
+            git \
+            mercurial \
+            python-devel \
+            python-jinja2 \
+            python-virtualenv \
+            python2-cryptography \
+            rubygems \
+            subversion \
+            unzip \
+         && break
+         echo "Failed to install packages. Sleeping before trying again..."
+         sleep 10
+    done
 
     pip --version 2>/dev/null || curl --silent --show-error https://bootstrap.pypa.io/get-pip.py | python
 fi


### PR DESCRIPTION
##### SUMMARY

Add retries to remote test package installs.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (remote-setup-retries eff59ac532) last updated 2017/07/13 21:32:35 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
