### PR TITLE
Improve sanity import test messaging.

### DIFF
--- a/test/runner/importer.py
+++ b/test/runner/importer.py
@@ -23,7 +23,8 @@ def main():
             message = str(ex)
             results = list(reversed(traceback.extract_tb(exc_tb)))
             source = None
-            line = None
+            line = 0
+            offset = 0
 
             for result in results:
                 if result[0].startswith(base_dir):
@@ -32,11 +33,24 @@ def main():
                     break
 
             if not source:
+                # If none of our source files are found in the traceback, report the file we were testing.
+                # I haven't been able to come up with a test case that encounters this issue yet.
                 source = path
-                line = 0
                 message += ' (in %s:%d)' % (results[-1][0], results[-1][1])
+            elif isinstance(ex, SyntaxError):
+                if ex.filename.endswith(path):
+                    # A SyntaxError in the source we're importing will have the correct path, line and offset.
+                    # However, the traceback will report the path to this importer.py script instead.
+                    # We'll use the details from the SyntaxError in this case, as it's more accurate.
+                    source = path
+                    line = ex.lineno
+                    offset = ex.offset
+                    message = str(ex)
 
-            error = '%s:%d:0: %s: %s' % (source, line, exc_type.__name__, message)
+                    # Hack to remove the filename and line number from the message, if present.
+                    message = message.replace(' (%s, line %d)' % (os.path.basename(path), line), '')
+
+            error = '%s:%d:%d: %s: %s' % (source, line, offset, exc_type.__name__, message)
 
             if error not in messages:
                 messages.add(error)

--- a/test/runner/importer.py
+++ b/test/runner/importer.py
@@ -38,13 +38,13 @@ def main():
                 source = path
                 message += ' (in %s:%d)' % (results[-1][0], results[-1][1])
             elif isinstance(ex, SyntaxError):
-                if ex.filename.endswith(path):
+                if ex.filename.endswith(path):  # pylint: disable=locally-disabled, no-member
                     # A SyntaxError in the source we're importing will have the correct path, line and offset.
                     # However, the traceback will report the path to this importer.py script instead.
                     # We'll use the details from the SyntaxError in this case, as it's more accurate.
                     source = path
-                    line = ex.lineno
-                    offset = ex.offset
+                    line = ex.lineno  # pylint: disable=locally-disabled, no-member
+                    offset = ex.offset  # pylint: disable=locally-disabled, no-member
                     message = str(ex)
 
                     # Hack to remove the filename and line number from the message, if present.


### PR DESCRIPTION
##### SUMMARY

Improve sanity import test messaging.

This will yield more accurate messages when there is a syntax error in the file being imported.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-import-fix 6343dd218c) last updated 2017/07/13 22:25:15 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
