### PR TITLE
Fix eos_config defaults logic

### DIFF
--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -288,10 +288,12 @@ def get_candidate(module):
 def get_running_config(module, config=None):
     contents = module.params['running_config']
     if not contents:
-        if not module.params['defaults'] and config:
+        if config:
             contents = config
         else:
-            flags = ['all']
+            flags = []
+            if module.params['defaults']:
+                flags.append('all')
             contents = get_config(module, flags=flags)
     return NetworkConfig(indent=3, contents=contents)
 


### PR DESCRIPTION
Current code is bogus, it was passing flags all unconditionally.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Current code is bogus, it was passing flags all unconditionally.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_eos_config_defaults_logic 5a6e2661be) last updated 2017/07/14 13:34:50 (GMT +200)
```
