### PR TITLE
udm_user: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/univention/udm_user.py
+++ b/lib/ansible/modules/cloud/univention/udm_user.py
@@ -334,8 +334,7 @@ EXAMPLES = '''
 RETURN = '''# '''
 
 import crypt
-from datetime import date
-from dateutil.relativedelta import relativedelta
+from datetime import date, timedelta
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.univention_umc import (
@@ -347,7 +346,7 @@ from ansible.module_utils.univention_umc import (
 
 
 def main():
-    expiry = date.strftime(date.today() + relativedelta(years=1), "%Y-%m-%d")
+    expiry = date.strftime(date.today() + timedelta(days=365), "%Y-%m-%d")
     module = AnsibleModule(
         argument_spec = dict(
             birthday                = dict(default=None,

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -46,7 +46,6 @@ lib/ansible/modules/cloud/google/gcdns_zone.py
 lib/ansible/modules/cloud/misc/serverless.py
 lib/ansible/modules/cloud/openstack/os_client_config.py
 lib/ansible/modules/cloud/ovirt/ovirt_disks.py
-lib/ansible/modules/cloud/univention/udm_user.py
 lib/ansible/modules/cloud/vmware/vca_nat.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py
 lib/ansible/modules/cloud/webfaction/webfaction_db.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `udm_user` module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/univention/udm_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.4.0 (devel 7bc85f9b44) last updated 2017/07/14 11:19:12 (GMT +200)
```

##### ADDITIONAL INFORMATION
Locally tested with:
```
from datetime import datetime, timedelta
from dateutil.relativedelta import relativedelta
n = datetime.now()
assert n + timedelta(days=365) == n + relativedelta(years=1)
```