### PR TITLE
serverless: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/misc/serverless.py
+++ b/lib/ansible/modules/cloud/misc/serverless.py
@@ -69,7 +69,7 @@ options:
     default: true
 notes:
    - Currently, the `serverless` command must be in the path of the node executing the task. In the future this may be a flag.
-requirements: [ "serverless" ]
+requirements: [ "serverless", "yaml" ]
 author: "Ryan Scott Brown @ryansb"
 '''
 
@@ -128,7 +128,12 @@ command:
 
 import os
 import traceback
-import yaml
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    HAS_YAML = False
 
 
 def read_serverless_config(module):
@@ -168,6 +173,9 @@ def main():
             serverless_bin_path = dict(required=False, type='path')
         ),
     )
+
+    if not HAS_YAML:
+        module.fail_json(msg='yaml is required for this module')
 
     service_path = module.params.get('service_path')
     state = module.params.get('state')

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -45,7 +45,6 @@ lib/ansible/modules/cloud/docker/docker_secret.py
 lib/ansible/modules/cloud/google/gc_storage.py
 lib/ansible/modules/cloud/google/gcdns_record.py
 lib/ansible/modules/cloud/google/gcdns_zone.py
-lib/ansible/modules/cloud/misc/serverless.py
 lib/ansible/modules/cloud/openstack/os_client_config.py
 lib/ansible/modules/cloud/openstack/os_ironic.py
 lib/ansible/modules/cloud/ovirt/ovirt_disks.py


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `serverless` module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
could/misc/serverless

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 7bc85f9b44) last updated 2017/07/14 11:19:12 (GMT +200)
```