### PR TITLE
Bump EOS EAPI set hostname timeout param

### DIFF
--- a/test/integration/targets/eos_system/tests/eapi/set_hostname.yaml
+++ b/test/integration/targets/eos_system/tests/eapi/set_hostname.yaml
@@ -5,11 +5,13 @@
   eos_config:
     lines: hostname switch
     match: none
+    timeout: 30
     provider: "{{ eapi }}"
 
 - name: configure hostname
   eos_system:
     hostname: foo
+    timeout: 30
     provider: "{{ eapi }}"
   register: result
 
@@ -20,6 +22,7 @@
 - name: verify hostname
   eos_system:
     hostname: foo
+    timeout: 30
     provider: "{{ eapi }}"
   register: result
 
@@ -31,6 +34,7 @@
   eos_config:
     lines: "hostname {{ inventory_hostname }}"
     match: none
+    timeout: 30
     provider: "{{ eapi }}"
 
 - debug: msg="END eapi/set_hostname.yaml"


### PR DESCRIPTION
For some reason, it's taking longer as usual in CI, bumping it
makes the tests to pass on my manual testing.