### PR TITLE
Remove redundant switch_name param

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -110,7 +110,6 @@ class VMwareDVSwitch(object):
         self.uplink_quantity = self.module.params['uplink_quantity']
         self.discovery_proto = self.module.params['discovery_proto']
         self.discovery_operation = self.module.params['discovery_operation']
-        self.switch_name = self.module.params['switch_name']
         self.state = self.module.params['state']
         self.content = connect_to_api(module)
 


### PR DESCRIPTION
##### SUMMARY
Class uses a redundant switch_name param, which can be
removed safely.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_dvswitch.py

##### ANSIBLE VERSION
```
2.4devel
```