### PR TITLE
Add ansible-test options and docs.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/compile/index.rst
+++ b/docs/docsite/rst/dev_guide/testing/compile/index.rst
@@ -1,0 +1,4 @@
+Compile Tests
+=============
+
+See :doc:`testing_compile` for more information.

--- a/test/runner/lib/config.py
+++ b/test/runner/lib/config.py
@@ -140,6 +140,7 @@ class IntegrationConfig(TestConfig):
         self.start_at_task = args.start_at_task  # type: str
         self.allow_destructive = args.allow_destructive if 'allow_destructive' in args else False  # type: bool
         self.retry_on_error = args.retry_on_error  # type: bool
+        self.continue_on_error = args.continue_on_error  # type: bool
         self.debug_strategy = args.debug_strategy  # type: bool
         self.tags = args.tags
         self.skip_tags = args.skip_tags
@@ -181,6 +182,7 @@ class NetworkIntegrationConfig(IntegrationConfig):
         super(NetworkIntegrationConfig, self).__init__(args, 'network-integration')
 
         self.platform = args.platform  # type: list [str]
+        self.inventory = args.inventory  # type: str
 
 
 class UnitsConfig(TestConfig):

--- a/test/runner/lib/test.py
+++ b/test/runner/lib/test.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 
 import datetime
 import json
+import os
 
 from lib.util import (
     display,
@@ -260,6 +261,7 @@ class TestFailure(TestResult):
         """
         message = self.format_title()
         output = self.format_block()
+        docs = self.find_docs()
 
         if self.messages:
             verified = all((m.confidence or 0) >= 50 for m in self.messages)
@@ -268,6 +270,7 @@ class TestFailure(TestResult):
 
         bot_data = dict(
             verified=verified,
+            docs=docs,
             results=[
                 dict(
                     message=message,
@@ -306,6 +309,25 @@ class TestFailure(TestResult):
             command += ' --python %s' % self.python_version
 
         return command
+
+    def find_docs(self):
+        """
+        :rtype: str
+        """
+        testing_docs_url = 'https://docs.ansible.com/ansible/devel/dev_guide/testing'
+        testing_docs_dir = 'docs/docsite/rst/dev_guide/testing'
+
+        url = '%s/%s/' % (testing_docs_url, self.command)
+        path = os.path.join(testing_docs_dir, self.command)
+
+        if self.test:
+            url += '%s.html' % self.test
+            path = os.path.join(path, '%s.rst' % self.test)
+
+        if os.path.exists(path):
+            return url
+
+        return None
 
     def format_title(self):
         """

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -216,6 +216,10 @@ def parse_args():
                              action='store_true',
                              help='retry failed test with increased verbosity')
 
+    integration.add_argument('--continue-on-error',
+                             action='store_true',
+                             help='continue after failed test')
+
     integration.add_argument('--debug-strategy',
                              action='store_true',
                              help='run test playbooks using the debug strategy')
@@ -245,6 +249,10 @@ def parse_args():
                                      metavar='PLATFORM',
                                      action='append',
                                      help='network platform/version').completer = complete_network_platform
+
+    network_integration.add_argument('--inventory',
+                                     metavar='PATH',
+                                     help='path to inventory used for tests')
 
     windows_integration = subparsers.add_parser('windows-integration',
                                                 parents=[integration],


### PR DESCRIPTION
##### SUMMARY

Add ansible-test options and docs:

- All `integration` commands support `--continue-on-error`
- The `network-integration` command supports `--inventory`
- Add compile test documentation landing page.
- Documentation links are now added to bot files when available.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-options-and-docs 8f2772970d) last updated 2017/07/14 11:20:29 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
