### PR TITLE
add generated password to win_owner test user

### DIFF
--- a/test/integration/targets/win_owner/tasks/main.yml
+++ b/test/integration/targets/win_owner/tasks/main.yml
@@ -172,6 +172,7 @@
 - name: create test user
   win_user:
     name: test win owner
+    password: TtPp!@#$%^ + {{ lookup('password', '/dev/null length=15') }}
 
 - name: set owner with space recurse
   win_owner:


### PR DESCRIPTION
##### SUMMARY
* previous test without a password failed on hosts that had strict password policy

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
win_owner

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
