### PR TITLE
Enable TLS1.1 and TLS1.2 for win_get_url

### DIFF
--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -93,6 +93,15 @@ Function Download-File($result, $url, $dest, $username, $password, $proxy_url, $
     }
 }
 
+# Enable TLS1.1/TLS1.2 if they're available but disabled (eg. .NET 4.5)
+$security_protcols = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::SystemDefault
+if ([Net.SecurityProtocolType].GetMember("Tls11").Count -gt 0) {
+    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls11
+}
+if ([Net.SecurityProtocolType].GetMember("Tls12").Count -gt 0) {
+    $security_protcols = $security_protcols -bor [Net.SecurityProtocolType]::Tls12
+}
+[Net.ServicePointManager]::SecurityProtocol = $security_protcols
 
 If ($force -or -not (Test-Path -Path $dest)) {
     


### PR DESCRIPTION
##### SUMMARY
By default, .NET4.5 supports TLS1.1 and TLS1.2 but they are disabled.  When systems administrators disable less secure protocols, requests will fail as HTTPS negotiation will fail when the server only supports newer protocols but the client has the support disabled.  This change tries to enable them, but will continue gracefully if they are not available.

Powershell is not something I'd consider one of my strengths.  I'd be happy to refactor with guidance if necessary, but the code does work as is.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/windows/win_get_url

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]
```

##### ADDITIONAL INFORMATION
I first saw this behaviour running the [AlertLogic agent install playbook from Galaxy](https://galaxy.ansible.com/alertlogic/al_agents/).  AlertLogic have obviously disabled SSLv3 and TLS1 on their download server(s) recently.

Before:
```
TASK [alertlogic.al_agents : win_get_url] *************************************************************************************************************************
fatal: [win_ansible_test]: FAILED! => {"changed": false, "failed": true, "msg": "Error when requesting Last-Modified date from https://scc.alertlogic.net/software/al_agent-LATEST.msi Exception calling \"GetResponse\" with \"0\" argument(s): \"The request was aborted: Could not create SSL/TLS secure channel.\"", "win_get_url": {"dest": "C:/TEMP/al_agent-LATEST.msi", "url": "https://scc.alertlogic.net/software/al_agent-LATEST.msi"}}
```
After:
```
TASK [alertlogic.al_agents : win_get_url] *************************************************************************************************************************
ok: [win_ansible_test]
```