### PR TITLE
re-enable win_chocolatey tests, add win_template to smoketest

### DIFF
--- a/test/integration/targets/connection_winrm/aliases
+++ b/test/integration/targets/connection_winrm/aliases
@@ -1,1 +1,2 @@
 windows/ci/group3
+windows/ci/smoketest

--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -16,53 +16,46 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: simple failure smoke test # NB: this is the only test that runs under shippable until others can use non-internet endpoints
+- name: install sysinternals
   win_chocolatey:
-  register: choco_fail
-  failed_when: "not choco_fail.msg | regex_search('Missing required argument: name')"
+    name: sysinternals
+    state: present
+  register: install_sysinternals
 
-- when: lookup('env', 'ANSIBLE_TEST_CI') != 'shippable'
-  block:
-  - name: install sysinternals
-    win_chocolatey:
-      name: sysinternals
-      state: present
-    register: install_sysinternals
+- name: verify install sysinternals
+  assert:
+    that:
+    - 'install_sysinternals.changed == true'
 
-  - name: verify install sysinternals
-    assert:
-      that:
-      - 'install_sysinternals.changed == true'
+- name: install sysinternals again
+  win_chocolatey:
+    name: sysinternals
+    state: present
+  register: install_sysinternals_again
 
-  - name: install sysinternals again
-    win_chocolatey:
-      name: sysinternals
-      state: present
-    register: install_sysinternals_again
+- name: verify install sysinternals again
+  assert:
+    that:
+    - 'install_sysinternals_again.changed == false'
 
-  - name: verify install sysinternals again
-    assert:
-      that:
-      - 'install_sysinternals_again.changed == false'
+- name: remove sysinternals
+  win_chocolatey:
+    name: sysinternals
+    state: absent
+  register: remove_sysinternals
 
-  - name: remove sysinternals
-    win_chocolatey:
-      name: sysinternals
-      state: absent
-    register: remove_sysinternals
+- name: verify remove sysinternals
+  assert:
+    that:
+    - 'remove_sysinternals.changed == true'
 
-  - name: verify remove sysinternals
-    assert:
-      that:
-      - 'remove_sysinternals.changed == true'
+- name: remove sysinternals again
+  win_chocolatey:
+    name: sysinternals
+    state: absent
+  register: remove_sysinternals_again
 
-  - name: remove sysinternals again
-    win_chocolatey:
-      name: sysinternals
-      state: absent
-    register: remove_sysinternals_again
-
-  - name: verify remove sysinternals again
-    assert:
-      that:
-      - 'remove_sysinternals_again.changed == false'
+- name: verify remove sysinternals again
+  assert:
+    that:
+    - 'remove_sysinternals_again.changed == false'

--- a/test/integration/targets/win_template/aliases
+++ b/test/integration/targets/win_template/aliases
@@ -1,1 +1,2 @@
 windows/ci/group2
+windows/ci/smoketest


### PR DESCRIPTION
##### SUMMARY
* reenable win_chocolatey tests now that they're not being run during `all/smoketest` changesets
* add win_template to smoke test (since we don't have action plugin change detection yet)
* add winrm connection tests to smoke test

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
win_chocolatey 

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
