### PR TITLE
vca_nat: remove unused imports

### DIFF
--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -47,7 +47,6 @@ lib/ansible/modules/cloud/misc/serverless.py
 lib/ansible/modules/cloud/openstack/os_client_config.py
 lib/ansible/modules/cloud/ovirt/ovirt_disks.py
 lib/ansible/modules/cloud/univention/udm_user.py
-lib/ansible/modules/cloud/vmware/vca_nat.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py
 lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py


### PR DESCRIPTION
##### SUMMARY
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `vca_nat` module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/vmware/vca_nat.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.4.0 (devel 7bc85f9b44) last updated 2017/07/14 11:19:12 (GMT +200)
```