### PR TITLE
os_client_config: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_client_config.py
+++ b/lib/ansible/modules/cloud/openstack/os_client_config.py
@@ -54,14 +54,23 @@ EXAMPLES = '''
       - mordred
 '''
 
-import os_client_config
-from os_client_config import exceptions
+
+try:
+    import os_client_config
+    from os_client_config import exceptions
+    HAS_OS_CLIENT_CONFIG = True
+except ImportError:
+    HAS_OS_CLIENT_CONFIG = False
 
 
 def main():
     module = AnsibleModule(argument_spec=dict(
         clouds=dict(required=False, type='list', default=[]),
     ))
+
+    if not HAS_OS_CLIENT_CONFIG:
+        module.fail_json(msg='os-client-config is required for this module')
+
     p = module.params
 
     try:

--- a/lib/ansible/modules/cloud/openstack/os_client_config.py
+++ b/lib/ansible/modules/cloud/openstack/os_client_config.py
@@ -1,19 +1,11 @@
 #!/usr/bin/python
 
 # Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
-#
-# This module is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -54,6 +46,7 @@ EXAMPLES = '''
       - mordred
 '''
 
+from ansible.module_utils.basic import AnsibleModule
 
 try:
     import os_client_config
@@ -84,8 +77,6 @@ def main():
     except exceptions.OpenStackConfigException as e:
         module.fail_json(msg=str(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == "__main__":
     main()

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -46,7 +46,6 @@ lib/ansible/modules/cloud/google/gc_storage.py
 lib/ansible/modules/cloud/google/gcdns_record.py
 lib/ansible/modules/cloud/google/gcdns_zone.py
 lib/ansible/modules/cloud/misc/serverless.py
-lib/ansible/modules/cloud/openstack/os_client_config.py
 lib/ansible/modules/cloud/ovirt/ovirt_disks.py
 lib/ansible/modules/cloud/univention/udm_user.py
 lib/ansible/modules/cloud/vmware/vca_nat.py


### PR DESCRIPTION
##### SUMMARY
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `os_client_config` module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/openstack/os_client_config.py

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 7bc85f9b44) last updated 2017/07/14 11:19:12 (GMT +200)
```