### PR TITLE
Add setfacl option --no-mask (#26796)

### DIFF
--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -14,6 +14,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+ANSIBLE_METADATA = {'metadata_version': '2.0',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
 
 DOCUMENTATION = '''
 ---

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -92,7 +92,7 @@ options:
       - Recursively sets the specified ACL (added in Ansible 2.0). Incompatible with C(state=query).
 
   no_mask:
-    version_added: "2.3"
+    version_added: "2.4"
     required: false
     default: null
     description:

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -92,7 +92,7 @@ options:
       - Recursively sets the specified ACL (added in Ansible 2.0). Incompatible with C(state=query).
 
   no_mask:
-    version_added: "2.3.1.0"
+    version_added: "2.3"
     required: false
     default: null
     description:

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -325,7 +325,7 @@ def main():
             module.fail_json(msg="'entry' MUST NOT be set when 'state=query'.")
 
         default_flag, etype, entity, permissions = split_entry(entry)
-        if default_flag is None:
+        if default_flag is not None:
             default = default_flag
 
     if get_platform().lower() == 'freebsd':

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -50,7 +50,8 @@ options:
     default: no
     choices: [ 'yes', 'no' ]
     description:
-      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory. It causes an error if name is a file.
+      - if the target is a directory, setting this to yes will make it the default acl for entities created inside the directory.
+        It causes an error if name is a file.
 
   entity:
     version_added: "1.5"
@@ -78,7 +79,9 @@ options:
     required: false
     default: null
     description:
-      - DEPRECATED. The acl to set or remove.  This must always be quoted in the form of '<etype>:<qualifier>:<perms>'.  The qualifier may be empty for some types, but the type and perms are always required. '-' can be used as placeholder when you do not care about permissions. This is now superseded by entity, type and permissions fields.
+      - DEPRECATED. The acl to set or remove.  This must always be quoted in the form of '<etype>:<qualifier>:<perms>'.  
+        The qualifier may be empty for some types, but the type and perms are always required. '-' can be used as placeholder 
+        when you do not care about permissions. This is now superseded by entity, type and permissions fields.
 
   recursive:
     version_added: "2.0"
@@ -88,12 +91,12 @@ options:
     description:
       - Recursively sets the specified ACL (added in Ansible 2.0). Incompatible with C(state=query).
    
-    no_mask:
-      version_added: "2.3.1.0"
-      required: false
-      default: null
-      description:
-        - Added feature to not recalculate the effective rights mask by default (setfacl -n, --no-mask).
+  no_mask:
+    version_added: "2.3.1.0"
+    required: false
+    default: null
+    description:
+      - Added feature to not recalculate the effective rights mask by default (setfacl -n, --no-mask).
 
 author:
     - "Brian Coca (@bcoca)"
@@ -179,7 +182,7 @@ def build_entry(etype, entity, permissions=None, use_nfsv4_acls=False):
 def build_command(module, mode, path, follow, default, recursive, no_mask, entry=''):
     '''Builds and returns a getfacl/setfacl command.'''
     if mode == 'set':
-        if no_mask == True:
+        if no_mask:
             cmd = [module.get_bin_path('setfacl', True)]
             cmd.append('-n -m "%s"' % entry)
         else:
@@ -322,7 +325,7 @@ def main():
             module.fail_json(msg="'entry' MUST NOT be set when 'state=query'.")
 
         default_flag, etype, entity, permissions = split_entry(entry)
-        if default_flag != None:
+        if default_flag is None:
             default = default_flag
 
     if get_platform().lower() == 'freebsd':

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-ANSIBLE_METADATA = {'metadata_version': '2.0',
+ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
 

--- a/lib/ansible/modules/files/acl.py
+++ b/lib/ansible/modules/files/acl.py
@@ -79,8 +79,8 @@ options:
     required: false
     default: null
     description:
-      - DEPRECATED. The acl to set or remove.  This must always be quoted in the form of '<etype>:<qualifier>:<perms>'.  
-        The qualifier may be empty for some types, but the type and perms are always required. '-' can be used as placeholder 
+      - DEPRECATED. The acl to set or remove.  This must always be quoted in the form of '<etype>:<qualifier>:<perms>'.
+        The qualifier may be empty for some types, but the type and perms are always required. '-' can be used as placeholder
         when you do not care about permissions. This is now superseded by entity, type and permissions fields.
 
   recursive:
@@ -90,7 +90,7 @@ options:
     choices: [ 'yes', 'no' ]
     description:
       - Recursively sets the specified ACL (added in Ansible 2.0). Incompatible with C(state=query).
-   
+
   no_mask:
     version_added: "2.3.1.0"
     required: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Added feature to not recalculate the effective rights mask by default (setfacl -n, --no-mask).
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Issue #26796. 
module always recalculated the effective rights mask, which force mask permission over all files when it's recursive, and it's reflected on default permissions.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
acl.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
[root@silvinux ansible]# ansible --version
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 12 2017, 17:58:54) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
[root@silvinux15 ansible]# 


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
