### PR TITLE
 rhn_channel: fix broken import/Py3 compat and add unit tests

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -122,7 +122,7 @@ def main():
     password = module.params['password']
 
     # initialize connection
-    client = xmlrpc_client(saturl)
+    client = xmlrpc_client.Server(saturl)
     session = client.auth.login(user, password)
 
     # get systemid

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -131,22 +131,22 @@ def main():
     # get channels for system
     chans = base_channels(client, session, sys_id)
 
+    try:
+        if state == 'present':
+            if channelname in chans:
+                module.exit_json(changed=False, msg="Channel %s already exists" % channelname)
+            else:
+                subscribe_channels(channelname, client, session, systname, sys_id)
+                module.exit_json(changed=True, msg="Channel %s added" % channelname)
 
-    if state == 'present':
-        if channelname in chans:
-            module.exit_json(changed=False, msg="Channel %s already exists" % channelname)
-        else:
-            subscribe_channels(channelname, client, session, systname, sys_id)
-            module.exit_json(changed=True, msg="Channel %s added" % channelname)
-
-    if state == 'absent':
-        if not channelname in chans:
-            module.exit_json(changed=False, msg="Not subscribed to channel %s." % channelname)
-        else:
-            unsubscribe_channels(channelname, client, session, systname, sys_id)
-            module.exit_json(changed=True, msg="Channel %s removed" % channelname)
-
-    client.auth.logout(session)
+        if state == 'absent':
+            if not channelname in chans:
+                module.exit_json(changed=False, msg="Not subscribed to channel %s." % channelname)
+            else:
+                unsubscribe_channels(channelname, client, session, systname, sys_id)
+                module.exit_json(changed=True, msg="Channel %s removed" % channelname)
+    finally:
+        client.auth.logout(session)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -64,9 +64,8 @@ EXAMPLES = '''
     password: guessme
 '''
 
-import xmlrpclib
-from operator import itemgetter
-import re
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves import xmlrpc_client
 
 
 # ------------------------------------------------------- #
@@ -137,8 +136,8 @@ def main():
     user = module.params['user']
     password = module.params['password']
 
-    #initialize connection
-    client = xmlrpclib.Server(saturl, verbose=0)
+    # initialize connection
+    client = xmlrpc_client(saturl)
     session = client.auth.login(user, password)
 
     # get systemid
@@ -164,9 +163,6 @@ def main():
 
     client.auth.logout(session)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -22,36 +22,32 @@ description:
 version_added: "1.1"
 author: "Vincent Van der Kussen (@vincentvdk)"
 notes:
-    - this module fetches the system id from RHN.
-requirements:
-    - none
+    - This module fetches the system id from RHN.
+    - This module doesn't support I(check_mode).
 options:
     name:
         description:
-            - name of the software channel
+            - Name of the software channel.
         required: true
-        default: null
     sysname:
         description:
-            - name of the system as it is known in RHN/Satellite
+            - Name of the system as it is known in RHN/Satellite.
         required: true
-        default: null
     state:
         description:
-            - whether the channel should be present or not
-        required: false
+            - Whether the channel should be present or not, taking action if the state is different from what is stated.
         default: present
     url:
         description:
-            - The full url to the RHN/Satellite api
+            - The full URL to the RHN/Satellite API.
         required: true
     user:
         description:
-            - RHN/Satellite user
+            - RHN/Satellite login
         required: true
     password:
         description:
-            - "the user's password"
+            - RHN/Satellite password
         required: true
 '''
 

--- a/lib/ansible/modules/packaging/os/rhn_channel.py
+++ b/lib/ansible/modules/packaging/os/rhn_channel.py
@@ -80,16 +80,6 @@ def get_systemid(client, session, sysname):
 
 # ------------------------------------------------------- #
 
-# unused:
-#
-#def get_localsystemid():
-#    f = open("/etc/sysconfig/rhn/systemid", "r")
-#    content = f.read()
-#    loc_id = re.search(r'\b(ID-)(\d{10})' ,content)
-#    return loc_id.group(2)
-
-# ------------------------------------------------------- #
-
 def subscribe_channels(channelname, client, session, sysname, sys_id):
     channels = base_channels(client, session, sys_id)
     channels.append(channelname)
@@ -126,7 +116,6 @@ def main():
             user = dict(required=True),
             password = dict(required=True, aliases=['pwd'], no_log=True),
         )
-        #        supports_check_mode=True
     )
 
     state = module.params['state']

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -98,7 +98,6 @@ lib/ansible/modules/network/lenovo/cnos_vlag.py
 lib/ansible/modules/network/lenovo/cnos_vlan.py
 lib/ansible/modules/network/nxos/nxos_file_copy.py
 lib/ansible/modules/packaging/language/maven_artifact.py
-lib/ansible/modules/packaging/os/rhn_channel.py
 lib/ansible/modules/storage/infinidat/infini_export.py
 lib/ansible/modules/storage/infinidat/infini_export_client.py
 lib/ansible/modules/storage/infinidat/infini_fs.py

--- a/test/units/modules/packaging/os/rhn_utils.py
+++ b/test/units/modules/packaging/os/rhn_utils.py
@@ -1,0 +1,51 @@
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils.six.moves import xmlrpc_client
+from ansible.module_utils._text import to_bytes
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def get_method_name(request_body):
+    return xmlrpc_client.loads(request_body)[1]
+
+
+def mock_request(responses, module_name):
+    def transport_request(host, handler, request_body, verbose=0):
+        """Fake request"""
+        method_name = get_method_name(request_body)
+        excepted_name, response = responses.pop(0)
+        if method_name == excepted_name:
+            if isinstance(response, Exception):
+                raise response
+            else:
+                return response
+        else:
+            raise Exception('Expected call: %r, called with: %r' % (excepted_name, method_name))
+
+    target = '{0}.xmlrpc_client.Transport.request'.format(module_name)
+    return patch(target, side_effect=transport_request)

--- a/test/units/modules/packaging/os/test_rhn_channel.py
+++ b/test/units/modules/packaging/os/test_rhn_channel.py
@@ -1,0 +1,143 @@
+import json
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils.six.moves import xmlrpc_client
+from ansible.module_utils._text import to_bytes
+from ansible.modules.packaging.os import rhn_channel
+
+from .rhn_utils import (set_module_args, AnsibleExitJson, AnsibleFailJson,
+                        exit_json, fail_json, get_method_name, mock_request)
+
+
+class TestRhnChannel(unittest.TestCase):
+
+    def setUp(self):
+        self.module = rhn_channel
+        self.module.HAS_UP2DATE_CLIENT = True
+
+        self.mock_exit_fail = patch.multiple(basic.AnsibleModule, exit_json=exit_json, fail_json=fail_json)
+        self.mock_exit_fail.start()
+        self.addCleanup(self.mock_exit_fail.stop)
+
+    def tearDown(self):
+        pass
+
+    def test_without_required_parameters(self):
+        """Failure must occurs when all parameters are missing"""
+        with self.assertRaises(AnsibleFailJson):
+            set_module_args({})
+            self.module.main()
+
+    def test_channel_already_here(self):
+        """Check that result isn't changed"""
+        set_module_args({
+            'name': 'rhel-x86_64-server-6',
+            'sysname': 'server01',
+            'url': 'https://rhn.redhat.com/rpc/api',
+            'user': 'user',
+            'password': 'pass',
+        })
+
+        responses = [
+            ('auth.login', ['X' * 43]),
+            ('system.listUserSystems',
+             [[{'last_checkin': '2017-08-06 19:49:52.0', 'id': '0123456789', 'name': 'server01'}]]),
+            ('channel.software.listSystemChannels',
+             [[{'channel_name': 'Red Hat Enterprise Linux Server (v. 6 for 64-bit x86_64)', 'channel_label': 'rhel-x86_64-server-6'}]]),
+            ('auth.logout', [1]),
+        ]
+
+        with mock_request(responses, self.module.__name__):
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+        self.assertFalse(responses)  # all responses should have been consumed
+
+    def test_add_channel(self):
+        """Add another channel: check that result is changed"""
+        set_module_args({
+            'name': 'rhel-x86_64-server-6-debuginfo',
+            'sysname': 'server01',
+            'url': 'https://rhn.redhat.com/rpc/api',
+            'user': 'user',
+            'password': 'pass',
+        })
+
+        responses = [
+            ('auth.login', ['X' * 43]),
+            ('system.listUserSystems',
+             [[{'last_checkin': '2017-08-06 19:49:52.0', 'id': '0123456789', 'name': 'server01'}]]),
+            ('channel.software.listSystemChannels',
+             [[{'channel_name': 'Red Hat Enterprise Linux Server (v. 6 for 64-bit x86_64)', 'channel_label': 'rhel-x86_64-server-6'}]]),
+            ('channel.software.listSystemChannels',
+             [[{'channel_name': 'Red Hat Enterprise Linux Server (v. 6 for 64-bit x86_64)', 'channel_label': 'rhel-x86_64-server-6'}]]),
+            ('system.setChildChannels', [1]),
+            ('auth.logout', [1]),
+        ]
+
+        with mock_request(responses, self.module.__name__):
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+        self.assertFalse(responses)  # all responses should have been consumed
+
+    def test_remove_inexistent_channel(self):
+        """Check that result isn't changed"""
+        set_module_args({
+            'name': 'rhel-x86_64-server-6-debuginfo',
+            'state': 'absent',
+            'sysname': 'server01',
+            'url': 'https://rhn.redhat.com/rpc/api',
+            'user': 'user',
+            'password': 'pass',
+        })
+
+        responses = [
+            ('auth.login', ['X' * 43]),
+            ('system.listUserSystems',
+             [[{'last_checkin': '2017-08-06 19:49:52.0', 'id': '0123456789', 'name': 'server01'}]]),
+            ('channel.software.listSystemChannels',
+             [[{'channel_name': 'Red Hat Enterprise Linux Server (v. 6 for 64-bit x86_64)', 'channel_label': 'rhel-x86_64-server-6'}]]),
+            ('auth.logout', [1]),
+        ]
+
+        with mock_request(responses, self.module.__name__):
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+        self.assertFalse(responses)  # all responses should have been consumed
+
+    def test_remove_channel(self):
+        """Check that result isn't changed"""
+        set_module_args({
+            'name': 'rhel-x86_64-server-6-debuginfo',
+            'state': 'absent',
+            'sysname': 'server01',
+            'url': 'https://rhn.redhat.com/rpc/api',
+            'user': 'user',
+            'password': 'pass',
+        })
+
+        responses = [
+            ('auth.login', ['X' * 43]),
+            ('system.listUserSystems',
+             [[{'last_checkin': '2017-08-06 19:49:52.0', 'id': '0123456789', 'name': 'server01'}]]),
+            ('channel.software.listSystemChannels', [[
+                {'channel_name': 'RHEL Server Debuginfo (v.6 for x86_64)', 'channel_label': 'rhel-x86_64-server-6-debuginfo'},
+                {'channel_name': 'Red Hat Enterprise Linux Server (v. 6 for 64-bit x86_64)', 'channel_label': 'rhel-x86_64-server-6'}
+            ]]),
+            ('channel.software.listSystemChannels', [[
+                {'channel_name': 'RHEL Server Debuginfo (v.6 for x86_64)', 'channel_label': 'rhel-x86_64-server-6-debuginfo'},
+                {'channel_name': 'Red Hat Enterprise Linux Server (v. 6 for 64-bit x86_64)', 'channel_label': 'rhel-x86_64-server-6'}
+            ]]),
+            ('system.setChildChannels', [1]),
+            ('auth.logout', [1]),
+        ]
+
+        with mock_request(responses, self.module.__name__):
+            with self.assertRaises(AnsibleExitJson) as result:
+                self.module.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+        self.assertFalse(responses)  # all responses should have been consumed


### PR DESCRIPTION
##### SUMMARY
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `rhn_channel` module.

Other updates included:
- update `DOCUMENTATION` metadata
- remove commented statements
- fix `exit_json` usage

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
packaging/os/rhn_channel.py

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 7bc85f9b44) last updated 2017/07/14 11:19:12 (GMT +200)
```