### PR TITLE
Optimize running of CI cloud integration tests.

### DIFF
--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -10,3 +10,4 @@ target="posix/ci/cloud/"
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    --changed-all-target 'posix/ci/cloud/vcenter/'


### PR DESCRIPTION
##### SUMMARY

Optimize running of CI cloud integration tests:

- Any `posix/ci/cloud/` targets affected by changes will run.
- Changes triggering all tests to run will instead target `posix/ci/cloud/vcenter/` targets.
- Nightly code coverage runs will run all `posix/ci/cloud/` targets.

This will reduce overhead for testing cloud modules.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.4.0 (cloud-tests da9faee9b7) last updated 2017/07/14 21:24:04 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
