### PR TITLE
Fix: always use lower() when storing and retrieving host keys via ssh…

### DIFF
--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -37,7 +37,7 @@ options:
   name:
     aliases: [ 'host' ]
     description:
-      - The host to add or remove (must match a host specified in key)
+      - The host to add or remove (must match a host specified in key). It will be converted to lowercase so that ssh-keygen can find it.
     required: true
     default: null
   key:
@@ -101,7 +101,7 @@ def enforce_state(module, params):
     Add or remove key.
     """
 
-    host = params["name"]
+    host = params["name"].lower()
     key = params.get("key", None)
     port = params.get("port", None)
     path = params.get("path")


### PR DESCRIPTION
…-keygen #3089

##### SUMMARY

Ansible known_hosts relies on ssh-keygen to put/get keys from known_hosts.

ssh-keygen:

  -  always *stores*  hostnames in lowercase
  - retrieves hostnames in case-sensitive


The hostname is then always lowered.

https://github.com/ansible/ansible-modules-extras/issues/3089


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/known_hosts.py

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:36) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


