### PR TITLE
Add IPv6 support to module_utils.urls TLS validation

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -720,11 +720,10 @@ class SSLValidationHandler(urllib_request.BaseHandler):
             return req
 
         try:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             if https_proxy:
                 proxy_parts = generic_urlparse(urlparse(https_proxy))
                 port = proxy_parts.get('port') or 443
-                s.connect((proxy_parts.get('hostname'), port))
+                s = socket.create_connection((proxy_parts.get('hostname'), port))
                 if proxy_parts.get('scheme') == 'http':
                     s.sendall(self.CONNECT_COMMAND % (self.hostname, self.port))
                     if proxy_parts.get('username'):
@@ -748,7 +747,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                 else:
                     raise ProxyError('Unsupported proxy scheme: %s. Currently ansible only supports HTTP proxies.' % proxy_parts.get('scheme'))
             else:
-                s.connect((self.hostname, self.port))
+                s = socket.create_connection((self.hostname, self.port))
                 if context:
                     ssl_s = context.wrap_socket(s, server_hostname=self.hostname)
                 elif HAS_URLLIB3_SSL_WRAP_SOCKET:


### PR DESCRIPTION
##### SUMMARY
socket.create_connection is a higher-level function, which tries to
establish a socket connection using both AF_INET and AF_INET6. It got
introduced in Python 2.6, which ought to be fine with Ansible 2.4.

Fixes #26740

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils.urls

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 613690bd46) last updated 2017/07/15 14:10:48 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/workdir/ansible/lib/ansible
  executable location = /home/andreas/workdir/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```