### PR TITLE
Add bcrypt and SHA1 to password_hash, add tests, update docs

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -340,7 +340,7 @@ Get a string checksum::
 
 Other hashes (platform dependent)::
 
-    {{ 'test2'|hash('blowfish') }}
+    {{ 'test2'|hash('bcrypt') }}
 
 To get a sha512 password hash (random salt)::
 
@@ -348,11 +348,13 @@ To get a sha512 password hash (random salt)::
 
 To get a sha256 password hash with a specific salt::
 
-    {{ 'secretpassword'|password_hash('sha256', 'mysecretsalt') }}
+    {{ 'secretpassword'|password_hash('sha256', '16charsLongSaltX') }}
 
 
-Hash types available depend on the master system running ansible,
-'hash' depends on hashlib password_hash depends on crypt.
+There is a support for `md5`, `sha1`, `sha256`, `sha512` and `bcrypt`,
+but concrete hash types available depends on the master system running
+Ansible – `hash` depends on hashlib, while `password_hash` depends on
+crypt (or passlib + bcrypt) python modules.
 
 .. _combine_filter:
 

--- a/test/units/plugins/filter/test_password_hash.py
+++ b/test/units/plugins/filter/test_password_hash.py
@@ -1,0 +1,57 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+
+import pytest
+
+
+__metaclass__ = type
+
+from ansible.plugins.filter.core import get_encrypted_password
+from ansible import errors
+
+
+def test_md5():
+    expected_result = '$1$12345678$o2n/JiO/h5VviOInWJ4OQ/'
+    assert get_encrypted_password('password', 'md5', salt='12345678') == expected_result
+    assert get_encrypted_password('password', 'md5', salt='xxxxxxxx') != expected_result
+    assert get_encrypted_password('aaaaaaaa', 'md5', salt='12345678') != expected_result
+
+
+def test_sha1():
+    expected_result = '$sha1$480000$1234567890abcdef$0dqtrHQD1d054xh6KlthCRribz6D'
+    assert get_encrypted_password('password', 'sha1', salt='1234567890abcdef') == expected_result
+
+
+def test_sha256():
+    expected_result = '$5$rounds=535000$1234567890abcdef$.0h4aOwY/VLi7JZgHMpT4nnUnM9fblM0W76l0aOcc.7'
+    assert get_encrypted_password('password', 'sha256', salt='1234567890abcdef') == expected_result
+
+
+def test_sha512():
+    expected_result = '$6$rounds=656000$1234567890abcdef$zwZMM.vpCtgYA/7VF/gOjasxcF04UkjJBKv0/pcUHBSb0S8mb46dO71cu/YM9wFPqgRMW8B24JjedYk6hHlWs1'
+    assert get_encrypted_password('password', 'sha512', salt='1234567890abcdef') == expected_result
+
+
+def test_bcrypt():
+    expected_result = '$2b$12$12345678901234567890aOpVxCaEL7mB6vCKwsWEmst5i10B6c.z.'
+    assert get_encrypted_password('password', 'bcrypt', salt='12345678901234567890ab') == expected_result
+
+
+def test_unknown():
+    with pytest.raises(errors.AnsibleFilterError):
+        get_encrypted_password('password', 'unknown')


### PR DESCRIPTION
##### SUMMARY
- Fixes #26322. #25347
- Fixes bug, that "blowfish" hash cannot be computed because of wrong salt length. It is fixed by replacing it by "bcrypt" and setting a correct length.
- Changes a behaviour of `hash` and `password_hash` to follow fail-fast principe – to raise an exception instead of silently generating an empty hash, which is obviously invalid.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible/plugins/filter/core

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = None
  python version = 2.6.9 (unknown, Apr 24 2017, 09:36:04) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```
