### PR TITLE
New module: Add kinit (identity/kinit)

### DIFF
--- a/lib/ansible/modules/identity/kinit.py
+++ b/lib/ansible/modules/identity/kinit.py
@@ -27,27 +27,33 @@ DOCUMENTATION = '''
 module: kinit
 version_added: "2.4"
 author: "Ali (@bincyber)"
-short_description: Obtain a Kerberos ticket-granting ticket
+short_description: Obtain a Kerberos ticket-granting ticket.
 description:
-  - "This module is a wrapper around kinit to obtain a short-lived Kerberos ticket-granting ticket (TGT)."
+  - "This module is a wrapper around kinit to obtain a short-lived Kerberos ticket-granting ticket (TGT).
+  The M(expect) or M(shell) module could be used instead, however to ensure the principal's password is not logged,
+  the I(no_log: True) task attribute must be set resulting in hidden error messages and the loss of an audit trail.
+  By default, this module prevents the password for the authenticating principal from being shown or logged while
+  still displaying error messages and enabling the task to be logged for auditing purposes."
 options:
   principal:
     description:
-      - The principal to obtain a Kerberos ticket-granting ticket for. The principal can include the primary, instance, and realm. eg. primary/instance@REALM
+      - The principal to obtain a Kerberos ticket for. The principal can include the primary, instance, and realm. eg. primary/instance@REALM
     required: yes
     default: null
   password:
     description:
-      - The password used to authenticate to the KDC.
+      - The password used to authenticate to the Kerberos server.
     required: yes
     default: null
   lifetime:
     description:
-      - The lifetime of the Kerberos ticket-granting ticket.
+      - The lifetime of the Kerberos ticket.
     required: false
     default: 60
 requirements:
-   - kinit
+  - kinit
+notes:
+  - "This module requires I(kinit) which needs to be installed on all target systems."
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/identity/kinit.py
+++ b/lib/ansible/modules/identity/kinit.py
@@ -1,23 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 ANSIBLE_METADATA = {
-    'metadata_version': '1.0',
+    'metadata_version': '1.1',
     'supported_by': 'community',
     'status': ['preview']
 }
@@ -25,7 +15,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: kinit
-version_added: "2.4"
+version_added: "2.5"
 author: "Ali (@bincyber)"
 short_description: Obtain a Kerberos ticket-granting ticket.
 description:
@@ -84,7 +74,6 @@ rc:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from distutils.spawn import find_executable
 import shlex
 
 
@@ -106,9 +95,7 @@ def main():
     password = module.params['password']
     lifetime = module.params.get('lifetime', 60)
 
-    kinit = find_executable('kinit')
-    if kinit is None:
-        module.fail_json(msg="kinit is required")
+    kinit = module.get_bin_path("kinit", required=True)
 
     cmd = shlex.split('{0} {1} -l {2}'.format(kinit, principal, lifetime))
 

--- a/lib/ansible/modules/identity/kinit.py
+++ b/lib/ansible/modules/identity/kinit.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'supported_by': 'community',
+    'status': ['preview']
+}
+
+DOCUMENTATION = '''
+---
+module: kinit
+version_added: "2.4"
+author: "Ali (@bincyber)"
+short_description: Obtain a Kerberos ticket-granting ticket
+description:
+  - "This module is a wrapper around kinit to obtain a short-lived Kerberos ticket-granting ticket (TGT)."
+options:
+  principal:
+    description:
+      - The principal to obtain a Kerberos ticket-granting ticket for. The principal can include the primary, instance, and realm. eg. primary/instance@REALM
+    required: yes
+    default: null
+  password:
+    description:
+      - The password used to authenticate to the KDC.
+    required: yes
+    default: null
+  lifetime:
+    description:
+      - The lifetime of the Kerberos ticket-granting ticket.
+    required: false
+    default: 60
+requirements:
+   - kinit
+'''
+
+EXAMPLES = '''
+# obtain a Kerberos ticket with a lifetime of 30 seconds
+- kinit:
+    principal: johndoe
+    password: supersecretpassword
+    lifetime: 30
+
+# obtain a Kerberos ticket for a principal that includes the realm
+- kinit:
+    principal: johndoe@REALM.EXAMPLE.COM
+    password: supersecretpassword
+'''
+
+RETURN = '''
+msg:
+    description: the status message describing what occurred
+    returned: always
+    type: string
+    sample: "Successfully obtained Kerberos ticket"
+
+rc:
+    description: the return code after executing kinit
+    returned: always
+    type: int
+    sample: 0
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from distutils.spawn import find_executable
+import shlex
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            principal=dict(required=True, type='str'),
+            password=dict(required=True, type='str', no_log=True),
+            lifetime=dict(required=False, type='int', default=60)
+        ),
+        required_together=[
+            ['principal', 'password']
+        ],
+        supports_check_mode=False,
+    )
+
+    principal = module.params['principal']
+    password = module.params['password']
+    lifetime = module.params.get('lifetime', 60)
+
+    kinit = find_executable('kinit')
+    if kinit is None:
+        module.fail_json(msg="kinit is required")
+
+    cmd = shlex.split('{0} {1} -l {2}'.format(kinit, principal, lifetime))
+
+    (rc, out, err) = module.run_command(cmd, data=password, binary_data=False)
+    if rc:
+        module.fail_json(msg=err, rc=rc)
+    else:
+        module.exit_json(changed=True, msg='Successfully obtained Kerberos ticket', rc=rc)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/identity/kinit.py
+++ b/lib/ansible/modules/identity/kinit.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = '''
 ---
 module: kinit
-version_added: "2.6"
+version_added: "2.8"
 author: "Ali (@bincyber)"
 short_description: Obtain a Kerberos ticket-granting ticket.
 description:
@@ -56,19 +56,19 @@ notes:
 '''
 
 EXAMPLES = '''
-# obtain a Kerberos ticket with a lifetime of 30 seconds
-- kinit:
+- name: obtain a Kerberos ticket with a lifetime of 30 seconds
+  kinit:
     principal: johndoe
     password: 'supersecretpassword'
     lifetime: 30
 
-# obtain a Kerberos ticket for a principal that includes the realm
-- kinit:
+- name: obtain a Kerberos ticket for a principal that includes the realm
+  kinit:
     principal: johndoe@REALM.EXAMPLE.COM
     password: 'supersecretpassword'
 
-# destroy all existing Kerberos tickets for the principal
-- kinit:
+- name: destroy all existing Kerberos tickets for the principal
+  kinit:
     principal: johndoe
     state: absent
 '''


### PR DESCRIPTION
##### SUMMARY

Added a new module for obtaining a short-lived Kerberos ticket-granting ticket (TGT).

Some cli tools such as `ipa` use Kerberos for authentication thus they require obtaining a valid Kerberos ticket before they are executed.

Currently, this can be accomplished using the expect module:
```
- name: expect | acquire a short-lived Kerberos ticket
  expect:
    command: "/usr/bin/kinit {{ kerberos_principal }} -l 60"
    responses:
      "Password for.*": "{{ password }}"
  no_log: true

- name: shell | register an HTTP service in FreeIPA for this node
  shell: "/usr/bin/ipa service-add HTTP/{{ ansible_fqdn }} > /etc/ipa/service-add-http.log"
  args:
    creates: "/etc/ipa/service-add-http.log"
```
or the shell module:
```
- name: shell | acquire a short-lived Kerberos ticket
  shell: "echo {{ password }} | /usr/bin/kinit {{ kerberos_principal }} -l 60"
  no_log: true
```

However, the expect module requires a newer version of pexpect installed on the host (which is only available via pip on RHEL/CentOS machines and not yum). Also, since `no_log` is used, it hides error messages if the task fails and does not log. It is possible to use environment variables with the shell module to avoid the need to use `no_log`:
```
- name: shell | acquire a short-lived Kerberos ticket
  shell: "echo $KERBEROS_PASSWORD | /usr/bin/kinit {{ kerberos_principal }} -l 60"
  environment:
    KERBEROS_PASSWORD: "{{ password }}"
```
But I'd prefer a native module.

##### ISSUE TYPE
 - New Module Pull Request


##### COMPONENT NAME

kinit

##### ANSIBLE VERSION

```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'modules/']
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
