### PR TITLE
filter ipaddr: add custom delimiter option to ip4_hex()

### DIFF
--- a/lib/ansible/plugins/filter/ipaddr.py
+++ b/lib/ansible/plugins/filter/ipaddr.py
@@ -982,10 +982,10 @@ def _need_netaddr(f_name, *args, **kwargs):
                                     'installed on the ansible controller' % f_name)
 
 
-def ip4_hex(arg):
+def ip4_hex(arg, delimiter=''):
     ''' Convert an IPv4 address to Hexadecimal notation '''
     numbers = list(map(int, arg.split('.')))
-    return '{:02x}{:02x}{:02x}{:02x}'.format(*numbers)
+    return '{0:02x}{sep}{1:02x}{sep}{2:02x}{sep}{3:02x}'.format(*numbers, sep=delimiter)
 
 
 # ---- Ansible filters ----


### PR DESCRIPTION
##### SUMMARY
This commit adds the possibility to insert a delimiter. The delimiter defaults to an empty string, so backward compatibility is given.

We use this e.g. to convert an IPv4 address to a mac-address compatible format.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugin/filter/ipaddr -> ip4_hex()

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tobias/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jul  2 2017, 22:24:59) [GCC 7.1.1 20170621]
```