### PR TITLE
pip: Use chdir directive in the venv path (fixes #25122)

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -380,6 +380,11 @@ def main():
     virtualenv_python = module.params['virtualenv_python']
     chdir = module.params['chdir']
     umask = module.params['umask']
+    env = module.params['virtualenv']
+
+    venv_created = False
+    if chdir:
+        env = os.path.join(chdir, env)
 
     if umask and not isinstance(umask, int):
         try:
@@ -402,8 +407,6 @@ def main():
         err = ''
         out = ''
 
-        env = module.params['virtualenv']
-        venv_created = False
         if env:
             if not os.path.exists(os.path.join(env, 'bin', 'activate')):
                 venv_created = True

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -183,3 +183,22 @@
   assert:
     that:
       - "pip_install_venv.changed"
+
+# https://github.com/ansible/ansible/issues/25122
+- name: ensure is a fresh virtualenv
+  file:
+    state: absent
+    name: "{{ output_dir }}/pipenv"
+
+- name: install requirements file into virtual + chdir
+  pip:
+   name: q
+   chdir: "{{ output_dir }}/"
+   virtualenv: "pipenv"
+   state: present
+  register: venv_chdir
+
+- name: make sure fresh virtualenv + chdir report changed
+  assert:
+    that:
+      - "venv_chdir.changed"


### PR DESCRIPTION
##### SUMMARY
- Now `virtualenv` path include `chdir` when the directive is set. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
# devel branch
ansible 2.4.0 (issue_25122 15c08749fa) last updated 2017/07/15 23:13:38 (GMT +200)
  config file = 
  configured module search path = [u'/home/julien/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/julien/works/repos/perso/ansible/ansible/lib/ansible
  executable location = /home/julien/works/repos/perso/ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Jan  4 2017, 22:30:16) [GCC 5.3.0]
```
