### PR TITLE
Add default_extra_vars to ansible.cfg and environment. Fixes #26858

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -411,8 +411,8 @@ class CLI(with_metaclass(ABCMeta, object)):
                               help="prepend path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
                               action="callback", callback=CLI.unfrack_path, type='str')
         if runtask_opts:
-            parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
-                              help="set additional variables as key=value or YAML/JSON, if filename prepend with @", default=[])
+            parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append", default=C.DEFAULT_EXTRA_VARS,
+                              help="set additional variables as key=value or YAML/JSON, if filename prepend with @")
 
         if fork_opts:
             parser.add_option('-f', '--forks', dest='forks', default=C.DEFAULT_FORKS, type='int',

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1075,6 +1075,15 @@ DEFAULT_VAULT_PASSWORD_FILE:
   - {key: vault_password_file, section: defaults}
   type: path
   yaml: {key: defaults.vault_password_file}
+DEFAULT_EXTRA_VARS:
+  default: []
+  description: 'Add extra_vars via environment or ansible.cfg'
+  env: [{name: ANSIBLE_EXTRA_VARS}]
+  ini:
+  - {key: default_extra_vars, section: defaults}
+  type: list
+  vars: []
+  yaml: {key: defaults.default_extra_vars}
 DEFAULT_VERBOSITY:
   default: 0
   description: 'TODO: write it'


### PR DESCRIPTION
##### SUMMARY
Set extra_vars in ansible.cfg or via environment

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
cli

##### ANSIBLE VERSION
```
ansible 2.4.0 (26858-add-extra_vars-in-ansible.cfg 7eecdf5568) last updated 2017/07/15 18:09:38 (GMT +200)
  config file = /home/rpolli/workspace-ansible/ansible/ansible.cfg
  configured module search path = [u'/home/rpolli/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rpolli/workspace-ansible/ansible/lib/ansible
  executable location = /home/rpolli/workspace-ansible/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:36) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```
##### STEPS TO REPRODUCE
```
# ansible.cfg
[defaults]
extra_vars = @file.yml
```

```yaml
ansible -m debug -a msg="I'm using variable {{ mytoken }} from file.yml" '
```

And I'll never have to type `-e@file.yml` anymore :D

```yaml
ansible -e@file.yml -m debug -a msg="I'm using variable {{ mytoken }} from file.yml" '
```

