### PR TITLE
[Fixes #26690] Supports Python 3 handling of base64 encoding

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -143,6 +143,7 @@ login_results:
 
 import base64
 
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.docker_common import *
 
 
@@ -276,8 +277,12 @@ class LoginManager(DockerBaseClass):
             self.log("Adding registry_url %s to auths." % (self.registry_url))
             config['auths'][self.registry_url] = dict()
 
+        auth = base64.b64encode(
+            to_bytes(self.username) + b':' + to_bytes(self.password)
+        )
+
         encoded_credentials = dict(
-            auth=base64.b64encode(self.username + b':' + self.password),
+            auth=to_text(auth),
             email=self.email
         )
 

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -277,12 +277,13 @@ class LoginManager(DockerBaseClass):
             self.log("Adding registry_url %s to auths." % (self.registry_url))
             config['auths'][self.registry_url] = dict()
 
-        auth = base64.b64encode(
+        b64auth = base64.b64encode(
             to_bytes(self.username) + b':' + to_bytes(self.password)
         )
+        auth = to_text(b64auth)
 
         encoded_credentials = dict(
-            auth=to_text(auth),
+            auth=auth,
             email=self.email
         )
 


### PR DESCRIPTION
##### SUMMARY
This fixes the base64 encoding of Docker credentials to support Python 3, which both expects and returns a `bytes` object. Prior to this fix, this module would unsuccessfully attempt to concatenate strings and bytes objects before encoding.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`docker_login`

##### ANSIBLE VERSION
This is an editable install from the cloned repo.
```
ansible 2.4.0 (bugfix/docker_login_py3_support 02878aa794) last updated 2017/07/16 13:03:40 (GMT -500)
  config file = /Users/willmedlar/ansible-deployments/ansible.cfg
  configured module search path = ['/Users/willmedlar/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/willmedlar/ansible/lib/ansible
  executable location = /Users/willmedlar/.pyenv/versions/ansible/bin/ansible
  python version = 3.6.2rc2 (default, Jul 15 2017, 18:31:53) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```

##### ADDITIONAL INFORMATION
See #26690 for more information on the issue at hand.

I didn't see an integration test for `docker_login`, but I suggest the addition of one. Per the blame this module has been broken for Python 3 since its introduction.