### PR TITLE
Fix symlink handling

### DIFF
--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -292,10 +292,16 @@ stat:
             type: boolean
             sample: False
         lnk_source:
-            description: Original path
+            description: Target of the symlink.  Changed in 2.4.  Previously, this was normalized for the remote filesystem
+            returned: success, path exists and user can read stats and the path is a symbolic link
+            type: string
+            sample: ../foobar/21102015-1445431274-908472971
+        abs_lnk_source:
+            description: Target of the symlink normalized for the remote filesystem
             returned: success, path exists and user can read stats and the path is a symbolic link
             type: string
             sample: /home/foobar/21102015-1445431274-908472971
+            version_added: 2.4
         md5:
             description: md5 hash of the path
             returned: success, path exists and user can read stats and path
@@ -480,7 +486,8 @@ def main():
 
     # symlink info
     if output.get('islnk'):
-        output['lnk_source'] = os.path.realpath(b_path)
+        output['lnk_source'] = os.readlink(b_path)
+        output['abs_lnk_source'] = os.path.realpath(b_path)
 
     try:  # user data
         pw = pwd.getpwuid(st.st_uid)

--- a/lib/ansible/modules/files/stat.py
+++ b/lib/ansible/modules/files/stat.py
@@ -292,15 +292,15 @@ stat:
             type: boolean
             sample: False
         lnk_source:
-            description: Target of the symlink.  Changed in 2.4.  Previously, this was normalized for the remote filesystem
-            returned: success, path exists and user can read stats and the path is a symbolic link
-            type: string
-            sample: ../foobar/21102015-1445431274-908472971
-        abs_lnk_source:
             description: Target of the symlink normalized for the remote filesystem
             returned: success, path exists and user can read stats and the path is a symbolic link
             type: string
             sample: /home/foobar/21102015-1445431274-908472971
+        lnk_target:
+            description: Target of the symlink.  Note that relative paths remain relative
+            returned: success, path exists and user can read stats and the path is a symbolic link
+            type: string
+            sample: ../foobar/21102015-1445431274-908472971
             version_added: 2.4
         md5:
             description: md5 hash of the path
@@ -486,8 +486,8 @@ def main():
 
     # symlink info
     if output.get('islnk'):
-        output['lnk_source'] = os.readlink(b_path)
-        output['abs_lnk_source'] = os.path.realpath(b_path)
+        output['lnk_source'] = os.path.realpath(b_path)
+        output['lnk_target'] = os.readlink(b_path)
 
     try:  # user data
         pw = pwd.getpwuid(st.st_uid)


### PR DESCRIPTION
On symlinks, make lnk_source return the actual target of the symlink.

Add a new return field abs_lnk_source that returns the normalized
(relative paths expanded) path to the target of the symlink.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/files/stat.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ln -s ../ /var/tmp/testabc
ansible localhost -c local -m stat -a 'path=/var/tmp/testabc' |grep lnk_source
```

Expected: 
```
        "lnk_source": "../", 
```

Actual:
```
        "lnk_source": "/var/tmp", 
```

With PR Applied:
```
        "lnk_source": "../", 
        "abs_lnk_source": "/var/tmp", 
```