### PR TITLE
Fix setup_iam to use policy_name, not PolicyName

### DIFF
--- a/hacking/aws_config/setup-iam.yml
+++ b/hacking/aws_config/setup-iam.yml
@@ -43,9 +43,12 @@
       with_fileglob: "testing_policies/*"
       register: iam_managed_policies
 
+    - debug:
+        msg: "{{ iam_managed_policies | json_query('results[].policy.policy_name') }}"
+
     - name: Ensure IAM group exists and attach managed policies
       iam_group:
         name: "{{ iam_group }}"
         state: present
-        managed_policy: "{{ iam_managed_policies | json_query('results[].policy.PolicyName') }}"
+        managed_policy: "{{ iam_managed_policies | json_query('results[].policy.policy_name') }}"
         profile: "{{ profile|default(omit) }}"


### PR DESCRIPTION
##### SUMMARY
Update setup_iam.yml to work with latest iam_managed_policies
module, which correctly snakifies the results


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hacking/aws_config/setup_iam.yml

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 30ad30c470) last updated 2017/07/17 12:50:35 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
