### PR TITLE
New module: sleep the task execution (utilities/logic/sleep)

### DIFF
--- a/lib/ansible/modules/utilities/logic/sleep.py
+++ b/lib/ansible/modules/utilities/logic/sleep.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Dag Wieers <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['stableinterface'],
+                    'supported_by': 'core'}
+
+DOCUMENTATION = r'''
+---
+module: sleep
+short_description: Sleep the task execution for some time
+description:
+- Sleep the task execution for some time for a specific host.
+- This module is different from the M(pause) module in that it works at the task execution level.
+- 'This module is only useful for specific strategies (e.g. C(strategy: free) that allow a free flow of tasks per target.'
+- This module is also supported for Windows targets.
+version_added: '2.4'
+options:
+  minutes:
+    description:
+    - A positive number of minutes to sleep.
+    default: 0
+  seconds:
+    description:
+    - A positive number of seconds to sleep.
+    default: 0
+author:
+- Dag Wieers (@dagwieers)
+notes:
+- If you specify 0 or negative for minutes or seconds, it will wait for 1 second,
+- This module is also supported for Windows targets.
+'''
+
+EXAMPLES = r'''
+- name: Sleep for 5 seconds
+  sleep:
+    seconds: 5
+
+- name: Sleep a random number of seconds (between 0 and 60)
+  sleep:
+    seconds: '{{ 600|random }}'
+'''
+
+RETURN = r'''
+elapsed:
+  description: The number of seconds the action plugin was sleeping
+  returned: always
+  type: int
+  sample: 5
+'''

--- a/lib/ansible/plugins/action/sleep.py
+++ b/lib/ansible/plugins/action/sleep.py
@@ -1,0 +1,39 @@
+# Copyright: (c) 2017, Dag Wieers <dag@wieers.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from time import sleep
+
+from ansible.module_utils._text import to_text
+from ansible.plugins.action import ActionBase
+
+
+class ActionModule(ActionBase):
+    ''' Sleeps for some time '''
+
+    def run(self, tmp=None, task_vars=dict()):
+        ''' Run the sleep action module '''
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+        result['changed'] = False
+
+        try:
+            minutes = int(self._task.args.get('minutes', 0))
+            seconds = int(self._task.args.get('seconds', 0))
+        except ValueError as e:
+            result['elapsed'] = 0
+            result['failed'] = True
+            result['msg'] = u"non-integer value given for 'minutes' or 'seconds':\n%s" % to_text(e)
+            return result
+
+        duration = minutes * 60 + seconds
+        if duration <= 0:
+            duration = 1
+
+        sleep(duration)
+
+        result['elapsed'] = duration
+
+        return result

--- a/test/integration/targets/sleep/aliases
+++ b/test/integration/targets/sleep/aliases
@@ -1,0 +1,1 @@
+posix/ci/group1

--- a/test/integration/targets/sleep/tasks/main.yml
+++ b/test/integration/targets/sleep/tasks/main.yml
@@ -1,0 +1,43 @@
+- name: Sleep with no parameters
+  sleep:
+  register: sleep_empty
+
+- name: Test sleep_empty
+  assert:
+    that:
+    - not sleep_empty|failed
+    - sleep_empty.elapsed == 1
+
+- name: Sleep with negative time
+  sleep:
+    minutes: -1
+  register: sleep_negative
+
+- name: Test sleep_negative
+  assert:
+    that:
+    - not sleep_negative|failed
+    - sleep_negative.elapsed == 1
+
+- name: Sleep for 5 seconds
+  sleep:
+    seconds: 5
+  register: sleep_five
+
+- name: Test sleep_five
+  assert:
+    that:
+    - not sleep_five|failed
+    - sleep_five.elapsed == 5
+
+- name: Sleep with invalid time
+  sleep:
+    seconds: foobar
+  ignore_errors: yes
+  register: sleep_invalid
+
+- name: Test sleep_invalid
+  assert:
+    that:
+    - sleep_invalid|failed
+    - sleep_invalid.elapsed == 0


### PR DESCRIPTION
##### SUMMARY
So we have a need for delaying the task execution for a specific time
for various hosts (i.e. when cloning a massive amount of systems).

When using `strategy: free` this enables us to delay each task for the
specified time. (**pause** is not an option here !)

```yaml
- name: Clone hundreds of VM guests in specific order
  hosts: vmware
  gather_facts: no
  strategy: free
  tasks:

  - sleep:
      seconds: '{{ vmware_boot_delay|default(0) }}'

  - vmware_guest:
      <options>
```

This module is IMO the most elegant way to do this, but the need for this is a result of how strategies evolved, and design limitations of the past.

**Benefits**
- It is a simple building block, would be easy for users to find by name
- Works locally (action_plugin, not a module) so no target required, no connection being made
- Does not require `delegate_to: localhost` or `local_action:` (as sleeping remotely is never a use-case)
- Works for Windows equally well
- Could also be used as an alternative to **pause** wrt. pause not being reliable  (https://github.com/ansible/ansible/issues/19966)

**Drawbacks**
- Implement a specific function that one can already do using wait_for
- Confusing **sleep** vs **pause** (requires documentation to clarify difference !)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
sleep

##### ANSIBLE VERSION
v2.4