### PR TITLE
Replace network-admin for network-operator on eos_user collections test

### DIFF
--- a/test/integration/targets/eos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_user/tests/cli/basic.yaml
@@ -21,14 +21,14 @@
       - username: test2
     authorize: yes
     state: present
-    role: network-admin
+    role: network-operator
     provider: "{{ cli }}"
   register: result
 
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["username test1 role network-admin", "username test2 role network-admin"]'
+      - 'result.commands == ["username test1 role network-operator", "username test2 role network-operator"]'
 
 - name: tearDown
   eos_user:


### PR DESCRIPTION
The 'admin' word was being masked by Ansible as potential cred.
Let's just use network-operator since we are just testing here
we can create users in aggregate.