### PR TITLE
Fixes #26881: Added support for third-party modules.

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_checklist.rst
@@ -24,7 +24,7 @@ The following  checklist items are important guidelines for people who want to c
 * The shebang must always be ``#!/usr/bin/python``.  This allows ``ansible_python_interpreter`` to work
 * Modules must be written to support Python 2.6. If this is not possible, required minimum Python version and rationale should be explained in the requirements section in ``DOCUMENTATION``.  In Ansible-2.3 the minimum requirement for modules was Python-2.4.
 * Modules must be written to use proper Python-3 syntax.  At some point in the future we'll come up with rules for running on Python-3 but we're not there yet.  See :doc:`developing_python3` for help on how to do this.
-* Modules must have a metadata section.  For the vast majority of new modules,
+* Modules must have a metadata section.  For the vast majority of new built-in modules,
   the metadata should look exactly like this:
 
 .. code-block:: python

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -35,7 +35,7 @@ ANSIBLE_METADATA Block
 
 ``ANSIBLE_METADATA`` contains information about the module for use by other tools. At the moment, it informs other tools which type of maintainer the module has and to what degree users can rely on a module's behaviour remaining the same over time.
 
-For new modules, the following block can be simply added into your module
+For new built-in modules, the following block can be simply added into your module
 
 .. code-block:: python
 
@@ -47,6 +47,16 @@ For new modules, the following block can be simply added into your module
 
    * ``metadata_version`` is the version of the ``ANSIBLE_METADATA`` schema, *not* the version of the module.
    * Promoting a module's ``status`` or ``supported_by`` status should only be done by members of the Ansible Core Team.
+
+The following block indicates that the module is a third-party module and where its repository can be found:
+
+.. code-block:: python
+
+   ANSIBLE_METADATA = {'metadata_version': '1.1',
+                       'status': ['preview'],
+                       'supported_by': 'community',
+                       'shipped_by': 'other',
+                       'other_repo_url': 'http://github.com/great-ansible-modules/my-modules'}
 
 .. note:: Pre-released metdata version
 
@@ -79,6 +89,7 @@ Fields
    of the metadata. We’ll increment Y if we add fields or legal values
    to an existing field. We’ll increment X if we remove fields or values
    or change the type or meaning of a field.
+
 :supported_by: This field records who supports the module.
    Default value is ``community``. Values are:
 
@@ -105,6 +116,40 @@ Fields
    :removed: This module is not present in the release. A stub is
       kept so that documentation can be built. The documentation helps
       users port from the removed module to new modules.
+
+Version 1.1 of the metadata
++++++++++++++++++++++++++++
+
+Structure
+`````````
+
+.. code-block:: python
+
+  ANSIBLE_METADATA = {
+      'metadata_version': '1.1',
+      'supported_by': 'community',
+      'status': ['preview', 'deprecated'],
+      'shipped_by': 'other',
+      'other_repo_url': 'http://github.com/great-ansible-modules/my-modules'
+  }
+
+Fields
+``````
+
+The fields from version 1.0 of the metadata are also valid in version 1.1.
+The following fields have been added:
+
+:shipped_by: This string field records who ships the module.
+   It is optional, and its default value is ``ansible``.
+   The following strings are valid values and have the following meanings:
+
+   :ansible: The module is shipped with Ansible. These modules are termed
+     *built-in modules*.
+   :other: The module is not shipped with Ansible. These modules are termed
+     *third-party modules*.
+
+:other_repo_url: This field records the source code repository of a third-party
+   module. It is optional and has no default. It is ignored for built-in modules.
 
 DOCUMENTATION Block
 -------------------

--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -45,7 +45,7 @@ Environment setup
 New module development
 ======================
 
-If you are creating a new module that doesn't exist, you would start
+If you are creating a new built-in module that doesn't exist, you would start
 working on a whole new file. Here is an example:
 
 -  Navigate to the directory that you want to develop your new module

--- a/docs/docsite/rst/modules_support.rst
+++ b/docs/docsite/rst/modules_support.rst
@@ -3,26 +3,33 @@ Module Support
 
 .. toctree:: :maxdepth: 1
 
-Ansible has many modules, but not all of them are maintained by the core project committers. Each module should have associated metadata that indicates which of the following categories they fall into. This should be visible in each module's documentation.
+Ansible provides a rich set of modules (termed *built-in modules*) and in addition can use modules provided by others (termed *third party modules*).
 
-Documentation updates for each module can also be edited directly in the module and by submitting a pull request to the module source code; just look for the "DOCUMENTATION" block in the source tree.
+Not all of the built-in modules are maintained by the core project committers. Each built-in module should have associated metadata that indicates which of the following categories they fall into. This should be visible in each module's documentation.
 
-If you believe you have found a bug in a module and are already running the latest stable or development version of Ansible, first look in the `issue tracker at github.com/ansible/ansible <https://github.com/ansible/ansible/issues>`_ to see if a bug has already been filed.  If not, we would be grateful if you would file one.
+Documentation updates for each built-in module can also be edited directly in the module and by submitting a pull request to the module source code; just look for the "DOCUMENTATION" block in the source tree.
+
+If you believe you have found a bug in a built-in module and are already running the latest stable or development version of Ansible, first look in the `issue tracker at github.com/ansible/ansible <https://github.com/ansible/ansible/issues>`_ to see if a bug has already been filed.  If not, we would be grateful if you would file one.
 
 Should you have a question rather than a bug report, inquiries are welcome on the `ansible-project google group <https://groups.google.com/forum/#!forum/ansible-project>`_ or on Ansible's "#ansible" channel, located on irc.freenode.net.
 
 For development-oriented topics, use the `ansible-devel google group <https://groups.google.com/forum/#!forum/ansible-devel>`_  or Ansible's ``#ansible`` and ``#ansible-devel`` channels, located on irc.freenode.net.  You should also read :doc:`community`, :doc:`dev_guide/testing` and :doc:`dev_guide/developing_modules`.
 
-The modules are hosted on GitHub in a subdirectory of the `ansible <https://github.com/ansible/ansible/tree/devel/lib/ansible/modules>`_ repo.
+The built-in modules are hosted on GitHub in a subdirectory of the `ansible <https://github.com/ansible/ansible/tree/devel/lib/ansible/modules>`_ repo.
+
+The third party modules are not hosted in the Ansible repo and are not shipped with Ansible itself.
 
 Core
 ````
 
-These are modules that the core ansible team maintains and will always ship with ansible itself.
+These are built-in modules that the core Ansible team maintains and will always ship with Ansible itself.
+
 They will also receive slightly higher priority for all requests. Non-core modules are still fully usable.
 
 Curated
 ```````
+
+These are built-in modules that are maintained outside of the core Ansible team, but reviewed by the core Ansible team.
 
 Some examples of Curated modules are submitted by other companies or maintained by the community. Maintainers of these types of modules must watch for any issues reported or pull requests raised against the module.
 
@@ -33,11 +40,12 @@ These modules are currently shipped with Ansible, but might be shipped separatel
 
 Community
 `````````
-These modules **are not** supported by Core Committers or by companies/partners associated to the module. They are maintained by the community.
+
+These are built-in or third-party modules that **are not** supported by Core Committers or by companies/partners associated to the module. They are maintained by the community.
 
 They are still fully usable, but the response rate to issues is purely up to the community.  Best effort support will be provided but is not covered under any support contracts.
 
-These modules are currently shipped with Ansible, but will most likely be shipped separately in the future.
+The built-in modules within this category are currently shipped with Ansible, but will most likely be shipped separately in the future. The third-party modules within this category are shipped separately.
 
 
 .. seealso::

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -207,7 +207,8 @@ Notes
 {% endif %}
 
 {% if not deprecated %}
-{% set support = { 'core': 'This module is maintained by those with core commit privileges', 'curated': 'This module is supported mainly by the community and is curated by core committers.', 'community': 'This module is community maintained without core committer oversight.'} %}
+{% set support = { 'core': 'This module is maintained by those with core commit privileges.', 'curated': 'This module is supported mainly by the community and is curated by core committers.', 'community': 'This module is community maintained without core committer oversight.'} %}
+{% set shipped = { 'ansible': 'This module is is a built-in module and is shipped with Ansible.', 'other': 'This module is a third-party module and is not shipped with Ansible. See the module\'s `source repository`_ for details.'} %}
 {% set module_states = { 'preview': 'it is not guaranteed to have a backwards compatible interface', 'stableinterface': 'the maintainers for this module guarantee that no backward incompatible interface changes will be made'} %}
 
 {% if metadata %}
@@ -220,7 +221,6 @@ Status
 This module is flagged as **@{cur_state}@** which means that @{module_states[cur_state]}@.
 {% endfor %}
 {% endif %}
-
 {% if metadata.supported_by %}
 
 Support
@@ -228,11 +228,33 @@ Support
 
 @{ support[metadata.supported_by] }@
 
-For more information on what this means please read :doc:`modules_support`
+{% if metadata.shipped_by and metadata.shipped_by == 'other' %}
+For more information on what this means please read `Module Support`_.
 
-{% endif %}
-{% endif %}
-{% endif %}
+For help in developing on modules, should you be so inclined, please read the contribution guidelines in the module's `source repository`_, `Testing Ansible`_ and `Developing Modules`_.
+
+.. _`Module Support`: http://docs.ansible.com/ansible/modules_support.html
+
+.. _`Testing Ansible`: http://docs.ansible.com/ansible/dev_guide/testing.html
+
+.. _`Developing Modules`: http://docs.ansible.com/ansible/dev_guide/developing_modules.html
+{% else %}
+For more information on what this means please read :doc:`modules_support`.
 
 For help in developing on modules, should you be so inclined, please read :doc:`community`, :doc:`dev_guide/testing` and :doc:`dev_guide/developing_modules`.
+{% endif %}
 
+{% endif %}
+{% if metadata.shipped_by %}
+
+Shipment
+~~~~~~~~
+
+@{ shipped[metadata.shipped_by] }@
+
+.. _`source repository`: @{ metadata.other_repo_url }@
+
+{% endif %}
+
+{% endif %}
+{% endif %}

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -233,11 +233,11 @@ For more information on what this means please read `Module Support`_.
 
 For help in developing on modules, should you be so inclined, please read the contribution guidelines in the module's `source repository`_, `Testing Ansible`_ and `Developing Modules`_.
 
-.. _`Module Support`: http://docs.ansible.com/ansible/modules_support.html
+.. _`Module Support`: http://docs.ansible.com/ansible/latest/modules_support.html
 
-.. _`Testing Ansible`: http://docs.ansible.com/ansible/dev_guide/testing.html
+.. _`Testing Ansible`: http://docs.ansible.com/ansible/latest/dev_guide/testing.html
 
-.. _`Developing Modules`: http://docs.ansible.com/ansible/dev_guide/developing_modules.html
+.. _`Developing Modules`: http://docs.ansible.com/ansible/latest/dev_guide/developing_modules.html
 {% else %}
 For more information on what this means please read :doc:`modules_support`.
 

--- a/test/sanity/validate-modules/schema.py
+++ b/test/sanity/validate-modules/schema.py
@@ -109,11 +109,14 @@ def metadata_schema(deprecated):
     if deprecated:
         valid_status = Any('deprecated')
 
+    # TODO: Check fields specific to a metadata version
     return Schema(
         {
             Required('status'): [valid_status],
-            Required('metadata_version'): '1.0',
-            Required('supported_by'): Any('core', 'community', 'curated')
+            Required('metadata_version'): Any('1.0', '1.1'),
+            Required('supported_by'): Any('core', 'community', 'curated'),
+            'shipped_by': Any('ansible', 'other'),
+            'other_repo_url': Any(*string_types)
         }
     )
 


### PR DESCRIPTION
##### SUMMARY

This change is a proposal (!!) on how to address issue #26881.

This change introduces new attributes in the `ANSIBLE_METADATA` and thus increases the metadata version to 1.1. It adjusts the metadata schema accordingly so that the `validate-modules` script runs fine, but it does not adjust the `metadata-tool` or any test cases. That would still need to be done, once the general approach of this PR has been reviewed and confirmed.

The new attributes are:

- `'shipped_by'`: `'ansible'` | `'other'` - to indicate how the module is shipped. Modules shipped with Ansible are termed 'built-in' modules, and modules not shipped with Ansible are termed 'third-party' modules.

- `'other_repo_url'`: `<url>` - to specify the source code repository for third-party modules.

The rationale for doing it this way is that this approach not only allows specifying third-party modules, but in addition provides a way how community modules can be moved out of the Ansible package over time.

The change also accomodates for these new metadata attributes in the development documentation:

- Updated the documentation of the ANSIBLE_METADATA format accordingly.
- Updated the documentation about developing Ansible modules to distinguish between built-in and third-party modules, as needed.
- Updated the "Support" section in the generated module documentation to distinguish between built-in and third-party modules, and that refers to the source repository for third-party modules.
- Added a section "Shipment" to the generated module documentation that shows the shipment specified in the metadata.

In addition, the change fixes some minor things:

- Minor editorial fixes in the text of the generated module documentation (plugin.rst.j2).
- Fixed that the explanation for the supported_by value was shown even when supported_by was not specified, by moving the location of some endif-statements in plugin.rst.j2.

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
`plugin.rst.j2` template
`validate-modules` script

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
N/A