### PR TITLE
Don't include dependent roles in the dep chain for include_role

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -296,6 +296,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                                 (use_handlers and C.DEFAULT_HANDLER_INCLUDES_STATIC)  or \
                                 (not needs_templating and ir.all_parents_static() and not ir.loop)
                     display.debug('Determined that if include_role static is %s' % str(is_static))
+
                 if is_static:
                     # uses compiled list from object
                     t = task_list.extend(ir.get_block_list(variable_manager=variable_manager, loader=loader))

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -82,7 +82,6 @@ class IncludeRole(Task):
             dep_chain = []
         else:
             dep_chain = list(self._parent_role._parents)
-            dep_chain.extend(self._parent_role.get_all_dependencies())
             dep_chain.append(self._parent_role)
 
         blocks = actual_role.compile(play=myplay, dep_chain=dep_chain)
@@ -117,7 +116,7 @@ class IncludeRole(Task):
             if option in ir.args:
                 setattr(ir, option, ir.args.get(option))
 
-        return ir.load_data(data, variable_manager=variable_manager, loader=loader)
+        return ir
 
     def copy(self, exclude_parent=False, exclude_tasks=False):
 


### PR DESCRIPTION
The dependency chain should not include roles below the parent, as it
can introduce very weird things like conditionals from child deps impacting
non-related roles.

Fixes #25136

(cherry picked from commit 495a809f469dcb19f27d61993554b80c7bf79e9b)

##### SUMMARY
Fixes include_role when conditionals are used.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible==2.2.3.0
```


##### ADDITIONAL INFORMATION
Fixes include_role erroneous skipping/conditional handling shown in http://logs.openstack.org/89/483989/7/check/gate-openstack-ansible-openstack-ansible-ceph-centos-7-nv/0d9b2c0/console.html#_2017-07-17_09_37_53_887032

This was fixed in stable-2.3, but it was not picked to stable-2.2, which is also affected by the same bug.