### PR TITLE
Fix style for maven_artifact documentation

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -31,7 +31,7 @@ short_description: Downloads an Artifact from a Maven Repository
 version_added: "2.0"
 description:
     - Downloads an artifact from a maven repository given the maven coordinates provided to the module.
-      Can retrieve snapshots or release versions of the artifact and will resolve the latest available 
+    - Can retrieve snapshots or release versions of the artifact and will resolve the latest available 
       version if one is not available.
 author: "Chris Schmidt (@chrisisbeef)"
 requirements:

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -30,9 +30,9 @@ module: maven_artifact
 short_description: Downloads an Artifact from a Maven Repository
 version_added: "2.0"
 description:
-    - Downloads an artifact from a maven repository given the maven coordinates provided to the module. Can retrieve
-    - snapshots or release versions of the artifact and will resolve the latest available version if one is not
-    - available.
+    - Downloads an artifact from a maven repository given the maven coordinates provided to the module.
+      Can retrieve snapshots or release versions of the artifact and will resolve the latest available 
+      version if one is not available.
 author: "Chris Schmidt (@chrisisbeef)"
 requirements:
     - "python >= 2.6"


### PR DESCRIPTION
##### SUMMARY
Removed unnecessary bullets from the synopsis under DOCUMENTATION. 
Previously there were bullets beginning each line with no respect to the start or end of sentences.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
N/A this is just a Docs change.
