### PR TITLE
vmware_guest relative paths for folder

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -213,6 +213,24 @@ def find_host_portgroup_by_name(host, portgroup_name):
     return None
 
 
+def compile_folder_path_for_object(vobj):
+    """ make a /vm/foo/bar/baz like folder path for an object """
+
+    paths = []
+    if isinstance(vobj, vim.Folder):
+        paths.append(vobj.name)
+
+    thisobj = vobj
+    while hasattr(thisobj, 'parent'):
+        thisobj = thisobj.parent
+        if isinstance(thisobj, vim.Folder):
+            paths.append(thisobj.name)
+    paths.reverse()
+    if paths[0] == 'Datacenters':
+        paths.remove('Datacenters')
+    return '/' + '/'.join(paths)
+		
+		
 def _get_vm_prop(vm, attributes):
     """Safely get a property or return None"""
     result = vm

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -229,8 +229,8 @@ def compile_folder_path_for_object(vobj):
     if paths[0] == 'Datacenters':
         paths.remove('Datacenters')
     return '/' + '/'.join(paths)
-		
-		
+
+
 def _get_vm_prop(vm, attributes):
     """Safely get a property or return None"""
     result = vm

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1219,7 +1219,6 @@ class PyVmomiHelper(object):
         if datacenter is None:
             self.module.fail_json(msg='No datacenter named %(datacenter)s was found' % self.params)
 
-
         # Prepend / if it was missing from the folder path, also strip trailing slashes
         if not self.params['folder'].startswith('/'):
             self.params['folder'] = '/%(folder)s' % self.params

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1228,8 +1228,6 @@ class PyVmomiHelper(object):
         dcpath = compile_folder_path_for_object(datacenter)
 
         # Check for full path first in case it was already supplied
-        if (self.params['folder']  == dcpath + self.params['datacenter'] + self.params['folder']):
-            fullpath = self.params['folder']
         if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):
             fullpath = self.params['folder']
         elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -87,7 +87,7 @@ options:
     - '   folder: folder1/datacenter1/vm'
     - '   folder: /folder1/datacenter1/vm/folder2'
     - '   folder: vm/folder2'
-    - '   fodler: folder2'
+    - '   folder: folder2'
     default: /vm
   hardware:
     description:
@@ -316,7 +316,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
-from ansible.module_utils.vmware import connect_to_api, find_obj, gather_vm_facts, get_all_objs
+from ansible.module_utils.vmware import connect_to_api, find_obj, gather_vm_facts, get_all_objs, compile_folder_path_for_object
 from ansible.module_utils.vmware import serialize_spec
 
 try:
@@ -1211,7 +1211,6 @@ class PyVmomiHelper(object):
         # https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.RelocateSpec.html
 
         # FIXME:
-        #   - multiple datacenters
         #   - multiple templates by the same name
         #   - static IPs
 
@@ -1220,15 +1219,27 @@ class PyVmomiHelper(object):
         if datacenter is None:
             self.module.fail_json(msg='No datacenter named %(datacenter)s was found' % self.params)
 
-        destfolder = None
 
-        # make an attempt with findinventorybypath, although this works poorly
-        # when datacenters are nested under folders
-        f_obj = self.content.searchIndex.FindByInventoryPath('%(folder)s' % self.params)
+        # Prepend / if it was missing from the folder path, also strip trailing slashes
+        if not self.params['folder'].startswith('/'):
+            self.params['folder'] = '/%(folder)s' % self.params
+        self.params['folder'] = self.params['folder'].rstrip('/')
 
-        # retry by walking down the object tree
-        if f_obj is None:
-            f_obj = self.find_folder(self.params['folder'])
+        dcpath = compile_folder_path_for_object(datacenter)
+
+        # Check for full path first in case it was already supplied
+        if (self.params['folder']  == dcpath + self.params['datacenter'] + self.params['folder']):
+            fullpath = self.params['folder']
+        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):
+            fullpath = self.params['folder']
+        elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
+            fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+        elif (self.params['folder'].startswith('/')):
+            fullpath = "%s%s/vm%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+        else:
+            fullpath = "%s%s/vm/%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+
+        f_obj = self.content.searchIndex.FindByInventoryPath(fullpath)
 
         # abort if no strategy was successful
         if f_obj is None:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -80,7 +80,7 @@ import os
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.vmware import connect_to_api, gather_vm_facts, get_all_objs
+from ansible.module_utils.vmware import connect_to_api, gather_vm_facts, get_all_objs, compile_folder_path_for_object
 
 
 HAS_PYVMOMI = False
@@ -126,7 +126,7 @@ class PyVmomiHelper(object):
                 continue
             # Match by name or uuid
             if vobj.config.name == name or vobj.config.uuid == uuid:
-                folderpath = self.compile_folder_path_for_object(vobj)
+                folderpath = compile_folder_path_for_object(vobj)
                 results.append(folderpath)
 
         return results
@@ -199,24 +199,6 @@ class PyVmomiHelper(object):
             self.get_datacenter()
         self.folders = self._build_folder_tree(self.datacenter.vmFolder)
         self._build_folder_map(self.folders)
-
-    @staticmethod
-    def compile_folder_path_for_object(vobj):
-        """ make a /vm/foo/bar/baz like folder path for an object """
-
-        paths = []
-        if isinstance(vobj, vim.Folder):
-            paths.append(vobj.name)
-
-        thisobj = vobj
-        while hasattr(thisobj, 'parent'):
-            thisobj = thisobj.parent
-            if isinstance(thisobj, vim.Folder):
-                paths.append(thisobj.name)
-        paths.reverse()
-        if paths[0] == 'Datacenters':
-            paths.remove('Datacenters')
-        return '/' + '/'.join(paths)
 
     def get_datacenter(self):
         self.datacenter = get_obj(


### PR DESCRIPTION
Move compile_folder_path_for_object function from vmware_guest_find to
utilities
Allow full path or relative path to be specified for the folder
parameter.  We will build the full path to the new VM.

##### SUMMARY
The changes made in #26511 caused us to need to enter a full path for the folder parameter.  This has the undesirable affect of breaking current playbooks that utilize a relative path.  This PR allows you to specify either a relative or full path to the folder, and it will build out the full path from what it is given.

vmware_guest_find has a function for building out this path already, so I move it to the utilities folder so that other modules can take advantage of it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest
vmware_guest_find

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /root/playbooks/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
Required code before the change 
```
      vmware_guest:
        name: "{{ vmname }}"
        template: "{{ vmtemplate }}"
        state: poweredon
        datacenter: "{{ vmdatacenter }}"
        cluster: "{{ vmcluster }}"
        folder: /MyDCFolder/MyDC/vm/MyFolder
```
After the change (pay attention to the folder: parameter).  It will now accept either option though (full path or relative path)
```
      vmware_guest:
        name: "{{ vmname }}"
        template: "{{ vmtemplate }}"
        state: poweredon
        datacenter: "{{ vmdatacenter }}"
        cluster: "{{ vmcluster }}"
        folder: MyFolder
```
It will now accept the folder being in any of these formats
```
    - '   folder: /ha-datacenter/vm'
    - '   folder: ha-datacenter/vm'
    - '   folder: /datacenter1/vm'
    - '   folder: datacenter1/vm'
    - '   folder: /datacenter1/vm/folder1'
    - '   folder: datacenter1/vm/folder1'
    - '   folder: /folder1/datacenter1/vm'
    - '   folder: folder1/datacenter1/vm'
    - '   folder: /folder1/datacenter1/vm/folder2'
    - '   folder: vm/folder2'
    - '   folder: folder2'
    default: /vm
```