### PR TITLE
Add missing provider on disable EAPI tasks

### DIFF
--- a/test/integration/targets/eos_banner/tasks/eapi.yaml
+++ b/test/integration/targets/eos_banner/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"

--- a/test/integration/targets/eos_command/tasks/eapi.yaml
+++ b/test/integration/targets/eos_command/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"

--- a/test/integration/targets/eos_config/tasks/eapi.yaml
+++ b/test/integration/targets/eos_config/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"

--- a/test/integration/targets/eos_facts/tasks/eapi.yaml
+++ b/test/integration/targets/eos_facts/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"

--- a/test/integration/targets/eos_system/tasks/eapi.yaml
+++ b/test/integration/targets/eos_system/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"

--- a/test/integration/targets/eos_template/tasks/eapi.yaml
+++ b/test/integration/targets/eos_template/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"

--- a/test/integration/targets/eos_user/tasks/eapi.yaml
+++ b/test/integration/targets/eos_user/tasks/eapi.yaml
@@ -25,3 +25,4 @@
 - name: disable eapi
   eos_eapi:
     state: stopped
+    provider: "{{ cli }}"


### PR DESCRIPTION
Enabling EAPI is not common on CLI *and* EAPI tests, therefore
enabling it should be put at the eapi.yaml task level.