### PR TITLE
Fix a typo in deprecated message (playbook/helpers.py)

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -139,7 +139,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     is_static = True
                 elif t.static is not None:
                     display.deprecated("The use of 'static' has been deprecated. "
-                                       "Use 'import_role' for static inclusion, or 'include_role' for dynamic inclusion")
+                                       "Use 'import_tasks' for static inclusion, or 'include_tasks' for dynamic inclusion")
                     is_static = t.static
                 else:
                     is_static = C.DEFAULT_TASK_INCLUDES_STATIC or \


### PR DESCRIPTION
##### SUMMARY
Message refer to `import_role` and `include_role` instead of `import_tasks` and `include_tasks`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/helpers.py

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 4532c791fd) last updated 2017/07/18 01:15:07 (GMT +200)
```
