### PR TITLE
Fix for IPv6 parsing issue (#18719)

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -197,7 +197,11 @@ class Connection(ConnectionBase):
         '''
         display.vvv("ESTABLISH WINRM CONNECTION FOR USER: %s on PORT %s TO %s" %
                     (self._winrm_user, self._winrm_port, self._winrm_host), host=self._winrm_host)
-        netloc = '%s:%d' % (self._winrm_host, self._winrm_port)
+        try:
+            socket.inet_aton(self._winrm_host)
+            netloc = '%s:%d' % (self._winrm_host, self._winrm_port)
+        except:
+            netloc = '[%s]:%d' % (self._winrm_host, self._winrm_port)
         endpoint = urlunsplit((self._winrm_scheme, netloc, self._winrm_path, '', ''))
         errors = []
         for transport in self._winrm_transport:


### PR DESCRIPTION
##### SUMMARY
Inserted a try except statement to check for an ipv4 address. If it's not ipv4, run the except code to format the ip:port for IPv6 using [RFC 3986](https://www.ietf.org/rfc/rfc3986.txt), section 3.2.2: Host.

Fixes issue #18719

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
winrm

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 3.6.1 (default, Apr  4 2017, 09:40:21) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

##### ADDITIONAL INFORMATION