### PR TITLE
fix to_bytes in two more places

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_key.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_key.py
@@ -196,7 +196,7 @@ def main():
                     test = ec2.get_key_pair(tmpkeyname)
 
                 # create tmp key
-                tmpkey = ec2.import_key_pair(tmpkeyname, key_material)
+                tmpkey = ec2.import_key_pair(tmpkeyname, to_bytes(key_material))
                 # get tmp key fingerprint
                 tmpfingerprint = tmpkey.fingerprint
                 # delete tmp key
@@ -205,7 +205,7 @@ def main():
                 if key.fingerprint != tmpfingerprint:
                     if not module.check_mode:
                         key.delete()
-                        key = ec2.import_key_pair(name, key_material)
+                        key = ec2.import_key_pair(name, to_bytes(key_material))
 
                         if wait:
                             start = time.time()


### PR DESCRIPTION

##### SUMMARY
PR #23051 fixes the first failure of this, but it doesn't fix the successive calls.

cc @s-hertel @ryansb because you were on that PR.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_key.py


##### ANSIBLE VERSION
2.3.1

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
