### PR TITLE
Fix vyos intergration test issue

### DIFF
--- a/test/integration/targets/vyos_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/basic.yaml
@@ -20,7 +20,7 @@
     speed: 100
     duplex: half
     mtu: 256
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
   register: result
 
@@ -31,7 +31,7 @@
       - '"set interfaces ethernet eth1 speed 100" in result.commands'
       - '"set interfaces ethernet eth1 duplex half" in result.commands'
       - '"set interfaces ethernet eth1 mtu 256" in result.commands'
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - name: Configure interface params (idempotent)
   vyos_interface:
@@ -42,12 +42,12 @@
     duplex: half
     mtu: 256
   register: result
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - assert:
     that:
       - 'result.changed == false'
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - name: Change interface params
   vyos_interface:
@@ -58,7 +58,7 @@
     duplex: full
     mtu: 512
   register: result
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - assert:
     that:
@@ -67,7 +67,7 @@
       - '"set interfaces ethernet eth1 speed 1000" in result.commands'
       - '"set interfaces ethernet eth1 duplex full" in result.commands'
       - '"set interfaces ethernet eth1 mtu 512" in result.commands'
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - name: Disable interface
   vyos_interface:
@@ -124,7 +124,7 @@
       - { name: eth1, description: test-interface-1,  speed: 100, duplex: half, mtu: 512}
       - { name: eth2, description: test-interface-2,  speed: 1000, duplex: full, mtu: 256}
   register: result
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - assert:
     that:
@@ -137,7 +137,7 @@
       - '"set interfaces ethernet eth2 speed 1000" in result.commands'
       - '"set interfaces ethernet eth2 duplex full" in result.commands'
       - '"set interfaces ethernet eth2 mtu 256" in result.commands'
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - name: Set interface on aggregate (idempotent)
   vyos_interface:
@@ -145,12 +145,12 @@
       - { name: eth1, description: test-interface-1,  speed: 100, duplex: half, mtu: 512}
       - { name: eth2, description: test-interface-2,  speed: 1000, duplex: full, mtu: 256}
   register: result
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - assert:
     that:
       - 'result.changed == false'
-  when: "'virtio' not in lsmod_out"
+  when: "'virtio' not in lsmod_out.stdout"
 
 - name: Disable interface on aggregate
   vyos_interface:

--- a/test/integration/targets/vyos_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/basic.yaml
@@ -1,6 +1,12 @@
 ---
 - debug: msg="START vyos_interface cli/basic.yaml"
 
+- name: Run vyos lsmod command
+  vyos_command:
+    commands:
+      - lsmod | grep virtio
+  register: lsmod_out
+
 - name: Set up - delete interface
   vyos_interface:
     name: eth1
@@ -14,6 +20,8 @@
     speed: 100
     duplex: half
     mtu: 256
+  when: "'virtio' not in lsmod_out"
+
   register: result
 
 - assert:
@@ -23,6 +31,7 @@
       - '"set interfaces ethernet eth1 speed 100" in result.commands'
       - '"set interfaces ethernet eth1 duplex half" in result.commands'
       - '"set interfaces ethernet eth1 mtu 256" in result.commands'
+  when: "'virtio' not in lsmod_out"
 
 - name: Configure interface params (idempotent)
   vyos_interface:
@@ -33,10 +42,12 @@
     duplex: half
     mtu: 256
   register: result
+  when: "'virtio' not in lsmod_out"
 
 - assert:
     that:
       - 'result.changed == false'
+  when: "'virtio' not in lsmod_out"
 
 - name: Change interface params
   vyos_interface:
@@ -47,6 +58,7 @@
     duplex: full
     mtu: 512
   register: result
+  when: "'virtio' not in lsmod_out"
 
 - assert:
     that:
@@ -55,6 +67,7 @@
       - '"set interfaces ethernet eth1 speed 1000" in result.commands'
       - '"set interfaces ethernet eth1 duplex full" in result.commands'
       - '"set interfaces ethernet eth1 mtu 512" in result.commands'
+  when: "'virtio' not in lsmod_out"
 
 - name: Disable interface
   vyos_interface:
@@ -111,6 +124,7 @@
       - { name: eth1, description: test-interface-1,  speed: 100, duplex: half, mtu: 512}
       - { name: eth2, description: test-interface-2,  speed: 1000, duplex: full, mtu: 256}
   register: result
+  when: "'virtio' not in lsmod_out"
 
 - assert:
     that:
@@ -123,6 +137,7 @@
       - '"set interfaces ethernet eth2 speed 1000" in result.commands'
       - '"set interfaces ethernet eth2 duplex full" in result.commands'
       - '"set interfaces ethernet eth2 mtu 256" in result.commands'
+  when: "'virtio' not in lsmod_out"
 
 - name: Set interface on aggregate (idempotent)
   vyos_interface:
@@ -130,16 +145,18 @@
       - { name: eth1, description: test-interface-1,  speed: 100, duplex: half, mtu: 512}
       - { name: eth2, description: test-interface-2,  speed: 1000, duplex: full, mtu: 256}
   register: result
+  when: "'virtio' not in lsmod_out"
 
 - assert:
     that:
       - 'result.changed == false'
+  when: "'virtio' not in lsmod_out"
 
 - name: Disable interface on aggregate
   vyos_interface:
     aggregate:
-      - { name: eth1, description: test-interface-1,  speed: 100, duplex: half, mtu: 512, state: down}
-      - { name: eth2, description: test-interface-2,  speed: 1000, duplex: full, mtu: 256, state: down}
+      - { name: eth1, description: test-interface-1, state: down}
+      - { name: eth2, description: test-interface-2, state: down}
   register: result
 
 - assert:
@@ -151,8 +168,8 @@
 - name: Enable interface on aggregate
   vyos_interface:
     aggregate:
-      - { name: eth1, description: test-interface-1,  speed: 100, duplex: half, mtu: 512, state: present}
-      - { name: eth2, description: test-interface-2,  speed: 1000, duplex: full, mtu: 256, state: present}
+      - { name: eth1, description: test-interface-1, state: present}
+      - { name: eth2, description: test-interface-2, state: present}
   register: result
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Disable testcase configuring interface `speed` parameters it runs on virtio network updater
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vyos_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
