### PR TITLE
Make newer stuff PEP8 compliant

### DIFF
--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -1,20 +1,5 @@
-# (c) 2017, Ansible by Red Hat, Inc.
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
-# ansible-vault is a script that encrypts/decrypts YAML files. See
-# http://docs.ansible.com/playbooks_vault.html for more details.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -44,7 +29,7 @@ except ImportError:
 class ConfigCLI(CLI):
     """ Config command line class """
 
-    VALID_ACTIONS = ("view", "dump", "list") # TODO: edit, update, search
+    VALID_ACTIONS = ("view", "dump", "list")  # TODO: edit, update, search
 
     def __init__(self, args, callback=None):
 
@@ -55,8 +40,8 @@ class ConfigCLI(CLI):
     def parse(self):
 
         self.parser = CLI.base_parser(
-            usage = "usage: %%prog [%s] [--help] [options] [ansible.cfg]" % "|".join(self.VALID_ACTIONS),
-            epilog = "\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0]),
+            usage="usage: %%prog [%s] [--help] [options] [ansible.cfg]" % "|".join(self.VALID_ACTIONS),
+            epilog="\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0]),
             desc="View, edit, and manage ansible configuration.",
         )
         self.parser.add_option('-c', '--config', dest='config_file', help="path to configuration file, defaults to first file found in precedence.")
@@ -121,10 +106,10 @@ class ConfigCLI(CLI):
             option = entry
         subprocess.call([
             'ansible',
-            '-m','ini_file',
+            '-m', 'ini_file',
             'localhost',
-            '-c','local',
-            '-a','"dest=%s section=%s option=%s value=%s backup=yes"' % (self.config_file, section, option, value)
+            '-c', 'local',
+            '-a', '"dest=%s section=%s option=%s value=%s backup=yes"' % (self.config_file, section, option, value)
         ])
 
     def execute_view(self):
@@ -145,7 +130,7 @@ class ConfigCLI(CLI):
 
         # pylint: disable=unreachable
         try:
-            editor = shlex.split(os.environ.get('EDITOR','vi'))
+            editor = shlex.split(os.environ.get('EDITOR', 'vi'))
             editor.append(self.config_file)
             subprocess.call(editor)
         except Exception as e:

--- a/lib/ansible/config/data.py
+++ b/lib/ansible/config/data.py
@@ -1,7 +1,6 @@
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -26,9 +25,9 @@ class ConfigData(object):
 
         settings = []
         if plugin is None:
-            settings = [ self._global_settings[k] for k in self._global_settings ]
+            settings = [self._global_settings[k] for k in self._global_settings]
         elif plugin.type in self._plugins and plugin.name in self._plugins[plugin.type]:
-            settings = [ self._plugins[plugin.type][plugin.name][k] for k in self._plugins[plugin.type][plugin.name] ]
+            settings = [self._plugins[plugin.type][plugin.name][k] for k in self._plugins[plugin.type][plugin.name]]
 
         return settings
 

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -1,7 +1,6 @@
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -215,9 +214,9 @@ class ConfigManager(object):
                 except configparser.Error as e:
                     raise AnsibleOptionsError("Error reading config file (%s): %s" % (cfile, to_native(e)))
             # FIXME: this should eventually handle yaml config files
-            #elif ftype == 'yaml':
-            #    with open(cfile, 'rb') as config_stream:
-            #        self._parser = yaml.safe_load(config_stream)
+            # elif ftype == 'yaml':
+            #     with open(cfile, 'rb') as config_stream:
+            #         self._parser = yaml.safe_load(config_stream)
             else:
                 raise AnsibleOptionsError("Unsupported configuration file type: %s" % to_native(ftype))
 

--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -1,8 +1,7 @@
-# Copyright (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -59,7 +58,7 @@ def set_constant(name, value, export=vars()):
     export[name] = value
 
 
-### CONSTANTS ### yes, actual ones
+# CONSTANTS ### yes, actual ones
 BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun']
 BECOME_ERROR_STRINGS = {
     'sudo': 'Sorry, try again.',
@@ -100,7 +99,7 @@ TREE_DIR = None
 VAULT_VERSION_MIN = 1.0
 VAULT_VERSION_MAX = 1.0
 
-### POPULATE SETTINGS FROM CONFIG ###
+# POPULATE SETTINGS FROM CONFIG ###
 config = ConfigManager()
 
 # Generate constants from config
@@ -118,7 +117,7 @@ for setting in config.data.get_settings():
             except ValueError:
                 pass  # not a python data structure
         except:
-            pass # not templatable
+            pass  # not templatable
         value = ensure_type(value, setting.name)
 
     set_constant(setting.name, value)

--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -1,21 +1,7 @@
-# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -150,22 +136,22 @@ class BaseMeta(type):
 class Base(with_metaclass(BaseMeta, object)):
 
     # connection/transport
-    _connection  = FieldAttribute(isa='string')
-    _port        = FieldAttribute(isa='int')
+    _connection = FieldAttribute(isa='string')
+    _port = FieldAttribute(isa='int')
     _remote_user = FieldAttribute(isa='string')
 
     # variables
     _vars = FieldAttribute(isa='dict', priority=100, inherit=False)
 
     # flags and misc. settings
-    _environment         = FieldAttribute(isa='list')
-    _no_log              = FieldAttribute(isa='bool')
-    _always_run          = FieldAttribute(isa='bool')
-    _run_once            = FieldAttribute(isa='bool')
-    _ignore_errors       = FieldAttribute(isa='bool')
-    _check_mode          = FieldAttribute(isa='bool')
-    _diff                = FieldAttribute(isa='bool')
-    _any_errors_fatal    = FieldAttribute(isa='bool')
+    _environment = FieldAttribute(isa='list')
+    _no_log = FieldAttribute(isa='bool')
+    _always_run = FieldAttribute(isa='bool')
+    _run_once = FieldAttribute(isa='bool')
+    _ignore_errors = FieldAttribute(isa='bool')
+    _check_mode = FieldAttribute(isa='bool')
+    _diff = FieldAttribute(isa='bool')
+    _any_errors_fatal = FieldAttribute(isa='bool')
 
     # param names which have been deprecated/removed
     DEPRECATED_ATTRIBUTES = [
@@ -448,9 +434,9 @@ class Base(with_metaclass(BaseMeta, object)):
             except (AnsibleUndefinedVariable, UndefinedError) as e:
                 if templar._fail_on_undefined_errors and name != 'name':
                     if name == 'args':
-                        msg= "The task includes an option with an undefined variable. The error was: %s" % (to_native(e))
+                        msg = "The task includes an option with an undefined variable. The error was: %s" % (to_native(e))
                     else:
-                        msg= "The field '%s' has an invalid value, which includes an undefined variable. The error was: %s" % (name, to_native(e))
+                        msg = "The field '%s' has an invalid value, which includes an undefined variable. The error was: %s" % (name, to_native(e))
                     raise AnsibleParserError(msg, obj=self.get_ds(), orig_exc=e)
 
         self._finalized = True

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -1,7 +1,3 @@
-lib/ansible/cli/config.py
-lib/ansible/config/data.py
-lib/ansible/config/manager.py
-lib/ansible/constants.py
 lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
 lib/ansible/modules/cloud/amazon/_ec2_remote_facts.py
 lib/ansible/modules/cloud/amazon/_ec2_vpc.py
@@ -361,4 +357,3 @@ lib/ansible/modules/system/solaris_zone.py
 lib/ansible/modules/system/svc.py
 lib/ansible/modules/system/timezone.py
 lib/ansible/modules/system/ufw.py
-lib/ansible/playbook/base.py


### PR DESCRIPTION
##### SUMMARY
So we fixed everything that was not a module to be PEP8 compliant, and
in the meantime these 5 new files were additionally disabled from PEP8
testing.

This fixes it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
various files

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.4