### PR TITLE
ec2_asg: LaunchConfigurationName may not exist for ASG instances - fixes #26864

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -423,7 +423,7 @@ def get_properties(autoscaling_group, module):
         for i in autoscaling_group_instances:
             instance_facts[i['InstanceId']] = {'health_status': i['HealthStatus'],
                                                'lifecycle_state': i['LifecycleState'],
-                                               'launch_config_name': i['LaunchConfigurationName']}
+                                               'launch_config_name': i.get('LaunchConfigurationName')}
             if i['HealthStatus'] == 'Healthy' and i['LifecycleState'] == 'InService':
                 properties['viable_instances'] += 1
             if i['HealthStatus'] == 'Healthy':


### PR DESCRIPTION
##### SUMMARY
when replacing launch configurations the previous launch config is removed from any instances.  The instance launch config data may be empty. Setting `replace_all_instances: True` is necessary for updating instances to use a new launch configuration. Fixes #26864 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_asg.py

##### ANSIBLE VERSION
```
2.4.0
```
