### PR TITLE
Docs gluster_volume: arbiter => arbiters

### DIFF
--- a/lib/ansible/modules/system/gluster_volume.py
+++ b/lib/ansible/modules/system/gluster_volume.py
@@ -56,7 +56,7 @@ options:
     default: null
     description:
       - Replica count for volume
-  arbiter:
+  arbiters:
     required: false
     default: null
     description:


### PR DESCRIPTION
Change docs for gluster_volume to be artibters

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Documentation correction. Docs for gluterfs_volume display aribiter. The correct parameter is arbiters.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Docs Pull Request
##### COMPONENT NAME

docs

##### ANSIBLE VERSION

`2.3`

##### ADDITIONAL INFORMATION

n/a