### PR TITLE
Fix #26918: IOS TypeError

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -80,7 +80,6 @@ def get_defaults_flag(module):
         return ['full']
 
 
-
 def get_config(module, flags=[]):
     cmd = 'show running-config '
     cmd += ' '.join(flags)

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -71,13 +71,14 @@ def get_defaults_flag(module):
 
     commands = set()
     for line in out.splitlines():
-        if line:
+        if line.strip():
             commands.add(line.strip().split()[0])
 
     if 'all' in commands:
-        return 'all'
+        return ['all']
     else:
-        return 'full'
+        return ['full']
+
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -343,7 +343,7 @@ def get_running_config(module, current_config=None):
         if not module.params['defaults'] and current_config:
             contents, banners = extract_banners(current_config.config_text)
         else:
-            flags = get_defaults_flag(module) if module.params['defaults'] else None
+            flags = get_defaults_flag(module) if module.params['defaults'] else []
             contents = get_config(module, flags=flags)
     contents, banners = extract_banners(contents)
     return NetworkConfig(indent=1, contents=contents), banners


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #26918

Fixed ios.get_default_args so that it ignores empty lines in the config and it returns the correct type (a list of args).

Fixed ios_config.get_running_config so that it passes an empty list rather than None if no extra flags are being passed.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ios-type-error d094918205) last updated 2017/07/18 11:21:59 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
