### PR TITLE
Account for additional error codes for users and roles

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_user.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_user.py
@@ -204,6 +204,9 @@ class NetAppCDOTUser(object):
             # Error 16034 denotes a user not being found.
             if str(e.code) == "16034":
                 return False
+            # Error 16043 denotes the user existing, but the application missing
+            elif str(e.code) == "16043":
+                return False
             else:
                 self.module.fail_json(msg='Error getting user %s' % self.name, exception=str(e))
 

--- a/lib/ansible/modules/storage/netapp/na_cdot_user_role.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_user_role.py
@@ -158,6 +158,9 @@ class NetAppCDOTUserRole(object):
             # Error 16031 denotes a role not being found.
             if str(e.code) == "16031":
                 return False
+            # Error 16039 denotes a role existing but missing the command
+            elif str(e.code) == "16039":
+                return False
             else:
                 self.module.fail_json(msg='Error getting role %s' % self.name, exception=str(e))
 


### PR DESCRIPTION
##### SUMMARY
Added additional error handling for both na_cdot_user_role and na_cdot_user. 
Role error was for when role exists, but the command does not. 
User error was for when user exists but application does not. 



##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
/module/storage/netapp/na_cdot_user_role
/module/storage/netapp/na_cdot_user


##### ANSIBLE VERSION
```
ansible 2.4.0 (bugfix/missing-error-codes 69d508c800) last updated 2017/07/18 14:40:51 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/tec/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/tec/Desktop/work/ansible/lib/ansible
  executable location = /Users/tec/Desktop/ansible/netapp_python/bin/ansible
  python version = 2.7.10 (default, Feb  6 2017, 23:53:20) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
When attempting to add additional Applications to an existing user, I would receive the error message "NetApp API failed. Reason - 16043:Application not found". This error is the result of the module checking for said user. Since this error means the user exists, but the sub item (application) does not, it's valid to mark in the check as False and allow the module to create the sub item for the existing user. 

Similar issue for the user_role module. Received the error 16039, which meant the role exists, but the command did not. Valid to mark check as False and allow the module to create the command for the existing user. 

```
NetApp API failed. Reason - 16043:Application not found
 [WARNING]: Module did not set no_log for set_password

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "application": "http",
            "authentication_method": "password",
            "hostname": "na-cc-diamond.nam3.msu.edu",
            "name": "test",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "role_name": "admin",
            "set_password": null,
            "state": "present",
            "username": "admin",
            "vserver": "na-cc-diamond"
        }
    },
    "msg": "Error getting user test"
}
ok: [localhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "application": "http",
            "authentication_method": "password",
            "hostname": "na-cc-diamond.nam3.msu.edu",
            "name": "test",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "role_name": "admin",
            "set_password": null,
            "state": "present",
            "username": "admin",
            "vserver": "na-cc-diamond"
        }
    }
}
```
