### PR TITLE
user: Fix add for SuSE Linux Enterprise 11

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -381,6 +381,13 @@ class User(object):
                     cmd.append('-n')
                 else:
                     cmd.append('-N')
+            elif os.path.exists('/etc/SuSE-release'):
+                # -N did not exist in useradd before SLE 11 and did not
+                # automatically create a group
+                dist = platform.dist()
+                major_release = int(dist[1].split('.')[0])
+                if major_release >= 12:
+                    cmd.append('-N')
             else:
                 cmd.append('-N')
 


### PR DESCRIPTION
##### SUMMARY
SLE11's useradd does not contain "-N" (and does not create a group alongside the user).  This PR adds a special case similar to a fix for redhat releases before 6.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
system/user/add

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/rparks/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Mar  3 2017, 14:20:07) [GCC 4.3.4 [gcc-4_3-branch revision 152973]]

```


##### ADDITIONAL INFORMATION
Any user add

```
- name: Setup user
  user:
    name: bosun
```
