### PR TITLE
Fixes #26411 with always changed due to comparing an int to a str

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -416,12 +416,12 @@ def compare_rules(r, rule):
         if rule['protocol'] != r['protocol']:
             changed = True
             r['protocol'] = rule['protocol']
-        if rule['source_port_range'] != r['source_port_range']:
+        if str(rule['source_port_range']) != str(r['source_port_range']):
             changed = True
-            r['source_port_range'] = rule['source_port_range']
-        if rule['destination_port_range'] != r['destination_port_range']:
+            r['source_port_range'] = str(rule['source_port_range'])
+        if str(rule['destination_port_range']) != str(r['destination_port_range']):
             changed = True
-            r['destination_port_range'] = rule['destination_port_range']
+            r['destination_port_range'] = str(rule['destination_port_range'])
         if rule['access'] != r['access']:
             changed = True
             r['access'] = rule['access']


### PR DESCRIPTION
##### SUMMARY

This fixes #26411 which was a problem due to the fact that Ansible was passing in the `destination_port_range` as an `int` if was only numeric characters, and the [Azure SDK uses `str` for port range values](http://azure-sdk-for-python.readthedocs.io/en/latest/ref/azure.mgmt.network.v2017_03_01.models.html#azure.mgmt.network.v2017_03_01.models.SecurityRule). This caused Ansible to report that `changed: true` even if nothing changed.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

azure_rm_securitygroup module (cloud/azure)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```