### PR TITLE
Support tilde (~) paths for unarchive creates tests

### DIFF
--- a/lib/ansible/plugins/action/unarchive.py
+++ b/lib/ansible/plugins/action/unarchive.py
@@ -66,6 +66,7 @@ class ActionModule(ActionBase):
             # do not run the command if the line contains creates=filename
             # and the filename already exists. This allows idempotence
             # of command executions.
+            creates = self._remote_expand_user(creates)
             if self._remote_file_exists(creates):
                 result['skipped'] = True
                 result['msg'] = "skipped, since %s exists" % creates


### PR DESCRIPTION
##### SUMMARY
This expands the value of the creates parameter the same way which the
value of the dest parameter is already being expanded.

Fixes #26965

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 37e757286d) last updated 2017/07/19 02:43:04 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/workdir/ansible/lib/ansible
  executable location = /home/andreas/workdir/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
