### PR TITLE
Fixes #19666 Correct AMI information output by ec2_ami module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -401,7 +401,9 @@ def get_ami_info(image):
         root_device_name=image.root_device_name,
         root_device_type=image.root_device_type,
         tags=image.tags,
-        virtualization_type=image.virtualization_type
+        virtualization_type=image.virtualization_type,
+        name=image.name,
+        platform=image.platform
     )
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes the documented outputs from the ec2_ami module when creating AMIs

Fixes #19666

- Adds AMI name to outputs on AMI creation
- Adds AMI platform to outputs on AMI creation


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami module (cloud/amazon)

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /home/rwilliams/projects/work/deploy-pipeline-lib/ansible.cfg
  configured module search path = [u'./library']
  python version = 2.7.11 (default, Jun  6 2017, 11:14:21) [GCC 7.1.1 20170516]
```