### PR TITLE
Changing "device names" with _cnos to "device name" alone

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/cnos.py
+++ b/lib/ansible/utils/module_docs_fragments/cnos.py
@@ -82,7 +82,7 @@ options:
              NE2572_cnos are added since version 2.4
         required: Yes
         default: null
-        choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T_cnos,NE1032_cnos,
-         NE1032T_cnos,NE10032_cnos,NE2572_cnos]
+        choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T,NE1032,
+         NE1032T,NE10032,NE2572]
         version_added: 2.3
 '''


### PR DESCRIPTION
##### SUMMARY
All the new range of cnos switches from lenovo bears a unique name. So there is no need for suffixing them with _cnos. This decision has been taken by PLM, so its abided here.

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
lib\ansible\utils\module_docs_fragments\cnos.py

##### ANSIBLE VERSION
ansible 2.4.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
##### ADDITIONAL INFORMATION
Adding support to new devices from Lenovo which are supported from Ansible 2.4.0 onwards. Changing device name from <Device Name>_cnos to <Device Name>

        default: null
-        choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T_cnos,NE1032_cnos,
-         NE1032T_cnos,NE10032_cnos,NE2572_cnos]
+        choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T,NE1032,
+         NE1032T,NE10032,NE2572]
         version_added: 2.3

```
