### PR TITLE
openssl_csr: Fix typo in the documentation

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -89,11 +89,11 @@ options:
         aliases: [ 'O' ]
         description:
             - organizationName field of the certificate signing request subject
-    organizationUnitName:
+    organizationalUnitName:
         required: false
         aliases: [ 'OU' ]
         description:
-            - organizationUnitName field of the certificate signing request subject
+            - organizationalUnitName field of the certificate signing request subject
     commonName:
         required: false
         aliases: [ 'CN' ]


### PR DESCRIPTION


##### SUMMARY

Documentation state 'organizationUnitName' when the actual name of the
param is 'organizationalUnitName'

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

- crypto/openssl_csr.py

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

- N/A