### PR TITLE
Add vyos_interface default description

### DIFF
--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -123,6 +123,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vyos import load_config, get_config
 from ansible.module_utils.vyos import vyos_argument_spec, check_args
 
+DEFAULT_DESCRIPTION = 'configured by vyos_interface'
+
 
 def search_obj_in_list(name, lst):
     for o in lst:
@@ -269,7 +271,7 @@ def main():
     """
     argument_spec = dict(
         name=dict(),
-        description=dict(),
+        description=dict(default=DEFAULT_DESCRIPTION),
         speed=dict(),
         mtu=dict(type='int'),
         duplex=dict(choices=['full', 'half', 'auto']),

--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -234,6 +234,7 @@ def map_params_to_obj(module):
                 if item not in d:
                     d[item] = None
 
+            d['description'] = DEFAULT_DESCRIPTION
             if not d.get('state'):
                 d['state'] = module.params['state']
 

--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -123,7 +123,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vyos import load_config, get_config
 from ansible.module_utils.vyos import vyos_argument_spec, check_args
 
-DEFAULT_DESCRIPTION = 'configured by vyos_interface'
+DEFAULT_DESCRIPTION = "'configured by vyos_interface'"
 
 
 def search_obj_in_list(name, lst):

--- a/test/integration/targets/vyos_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/basic.yaml
@@ -49,7 +49,7 @@
   vyos_interface:
     name: eth1
     state: present
-    description: test-interface
+    description: test-interface-1
     speed: 100
     duplex: half
     mtu: 256
@@ -65,7 +65,7 @@
   vyos_interface:
     name: eth1
     state: present
-    description: test-interface-1
+    description: test-interface-2
     speed: 1000
     duplex: full
     mtu: 512
@@ -75,7 +75,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"set interfaces ethernet eth1 description test-interface-1" in result.commands'
+      - '"set interfaces ethernet eth1 description test-interface-2" in result.commands'
       - '"set interfaces ethernet eth1 speed 1000" in result.commands'
       - '"set interfaces ethernet eth1 duplex full" in result.commands'
       - '"set interfaces ethernet eth1 mtu 512" in result.commands'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* If `state=up` it should remove the `disable` configuration
  for the interface. However, if no other interface parameter is configured, it ends up deleting the interface itself which is not the desired behaviour. Hence adding a default description field to avoid such scenario's.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vyos_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
