### PR TITLE
OpenSSL modules uses file_common_args

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -31,7 +31,7 @@ description:
     - "This module allows one to (re)generates OpenSSL certificate signing requests.
        It uses the pyOpenSSL python library to interact with openssl. This module support
        the subjectAltName extension. Note: At least one of commonName or subjectAltName must
-       be specified."
+       be specified. This module uses file common arguments to specify generated file permissions."
 requirements:
     - "python-pyOpenSSL"
 options:

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -30,7 +30,8 @@ short_description: Generate OpenSSL private keys.
 description:
     - "This module allows one to (re)generate OpenSSL private keys. It uses
        the pyOpenSSL python library to interact with openssl. One can generate
-       either RSA or DSA private keys. Keys are generated in PEM format."
+       either RSA or DSA private keys. Keys are generated in PEM format.
+       This module uses file common arguments to specify generated file permissions."
 requirements:
     - "python-pyOpenSSL"
 options:

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -30,7 +30,8 @@ short_description: Generate an OpenSSL public key from its private key.
 description:
     - "This module allows one to (re)generate OpenSSL public keys from their private keys.
        It uses the pyOpenSSL python library to interact with openssl. Keys are generated
-       in PEM format. This module works only if the version of PyOpenSSL is recent enough (> 16.0.0)"
+       in PEM format. This module works only if the version of PyOpenSSL is recent enough (> 16.0.0).
+       This module uses file common arguments to specify generated file permissions."
 requirements:
     - "python-pyOpenSSL"
 options:
@@ -145,6 +146,10 @@ class PublicKey(object):
                 publickey_file = open(self.path, 'w')
                 publickey_file.write(publickey_content)
                 publickey_file.close()
+
+                file_args = module.load_file_common_arguments(module.params)
+                if module.set_fs_attributes_if_different(file_args, False):
+                    self.changed = True
             except (IOError, OSError) as exc:
                 raise PublicKeyError(exc)
             except AttributeError as exc:


### PR DESCRIPTION
##### SUMMARY

Ensure `openssl_publickey` uses `add_file_common_args` and make sure it is documented for all the `crypto/` namespace.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- `crypto/`

##### ANSIBLE VERSION

- devel


##### ADDITIONAL INFORMATION

```
[spredzy@bordeaux openssl]$ cat playbook.yml 
---
- hosts: localhost
  tasks:
    - name: PrivateKey
      openssl_privatekey:
        path: /tmp/openssl/test.key

    - name: PublicKey
      become: True
      openssl_publickey:
        path: /tmp/openssl/test.pub
        privatekey_path: /tmp/openssl/test.key
        owner: qemu
        group: qemu
        mode: '0777'
[spredzy@bordeaux openssl]$ ansible-playbook playbook.yml 
 [WARNING]: Could not match supplied host pattern, ignoring: all

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] ******************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************
ok: [localhost]

TASK [PrivateKey] *****************************************************************************************************************************************************************************
changed: [localhost]

TASK [PublicKey] ******************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************************************************************************************************
localhost                  : ok=3    changed=2    unreachable=0    failed=0   

[spredzy@bordeaux openssl]$ ls -l
total 16
-rw-rw-r--. 1 spredzy spredzy   10 Jul 19 10:48 playbook.retry
-rw-rw-r--. 1 spredzy spredzy  328 Jul 19 11:05 playbook.yml
-rw-------. 1 spredzy spredzy 3272 Jul 19 11:05 test.key
-rwxrwxrwx. 1 qemu    qemu     800 Jul 19 11:05 test.pub
[spredzy@bordeaux openssl]$
```

Fixes #23998