### PR TITLE
docs: add fact caching directives to intro_configuration

### DIFF
--- a/docs/docsite/rst/intro_configuration.rst
+++ b/docs/docsite/rst/intro_configuration.rst
@@ -402,6 +402,42 @@ is very very conservative::
 
     forks = 5
 
+.. _fact_caching:
+
+fact_caching
+============
+
+This option allows you to configure fact caching.  When a fact cache
+is enabled and there is valid data for a host, Ansible will use that rather than running an implicit ``setup`` job on a remote host.
+
+The value of this option should be the name of a cache plugin.
+Current versions of Ansible include ``redis`` and ``jsonfile``::
+
+    fact_caching = jsonfile
+
+.. _fact_caching_connection:
+
+fact_caching_connection
+=======================
+
+This option tells Ansible where to cache facts.  The value is plugin
+dependent.  For the ``jsonfile`` plugin, it should be a path to a
+local directory.  For the ``redis`` plugin, the value is a
+``host:port:database`` triplet::
+
+    fact_caching_connection = localhost:6379:0
+
+.. _fact_caching_timeout:
+
+fact_caching_timeout
+====================
+
+This option tells Ansible when to expire values from the cache.
+Setting this value to 0 effectively disables expiry, and a positive
+value is a TTL in seconds::
+
+    fact_caching_timeout = 86400
+
 .. _fact_path:
 
 fact_path


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

the fact_caching* configuration directives were not listed in
intro_configuration.rst.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
fact caching

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
based on commit 317ad54599c8fa2cb82cdc47345204824a9c0f35
```


