### PR TITLE
AWSRetry: accept a list of extra exceptions to extend retry_on

### DIFF
--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -59,7 +59,7 @@ class CloudRetry(object):
         pass
 
     @staticmethod
-    def found(response_code):
+    def found(response_code, added_exceptions):
         """ Return True if the Response Code to retry on was found.
         Args:
             response_code (str): This is the Response Code that is being matched against.
@@ -67,7 +67,7 @@ class CloudRetry(object):
         pass
 
     @classmethod
-    def backoff(cls, tries=10, delay=3, backoff=1.1):
+    def backoff(cls, tries=10, delay=3, backoff=1.1, added_exceptions=[]):
         """ Retry calling the Cloud decorated function using an exponential backoff.
         Kwargs:
             tries (int): Number of times to try (not retry) before giving up
@@ -76,6 +76,7 @@ class CloudRetry(object):
                 default=3
             backoff (int): backoff multiplier e.g. value of 2 will double the delay each retry
                 default=2
+            added_exceptions: A list of Exceptions codes (strings) to add to retry_on
 
         """
         def deco(f):
@@ -89,7 +90,7 @@ class CloudRetry(object):
                         e = get_exception()
                         if isinstance(e, cls.base_class):
                             response_code = cls.status_code_from_exception(e)
-                            if cls.found(response_code):
+                            if cls.found(response_code, added_exceptions):
                                 msg = "{0}: Retrying in {1} seconds...".format(str(e), max_delay)
                                 syslog.syslog(syslog.LOG_INFO, msg)
                                 time.sleep(max_delay)

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -77,7 +77,7 @@ class AWSRetry(CloudRetry):
         return error.response['Error']['Code']
 
     @staticmethod
-    def found(response_code):
+    def found(response_code, added_exceptions):
         # This list of failures is based on this API Reference
         # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/errors-overview.html
         #
@@ -92,12 +92,10 @@ class AWSRetry(CloudRetry):
             'RequestLimitExceeded', 'Unavailable', 'ServiceUnavailable',
             'InternalFailure', 'InternalError', 'TooManyRequestsException'
         ]
+        retry_on.extend(added_exceptions)
 
         not_found = re.compile(r'^\w+.NotFound')
-        if response_code in retry_on or not_found.search(response_code):
-            return True
-        else:
-            return False
+        return response_code in retry_on or not_found.search(response_code)
 
 
 def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None, **params):


### PR DESCRIPTION
##### SUMMARY
Some exceptions will be very module specific, such as DirectConnectClientException. Being able to pass special ClientError exceptions to AWSRetry makes more sense to me than padding retry_on with a lot of random exception codes that most things won't use.
Example: 
`@AWSRetry.backoff(tries=5, delay=5, backoff=2.0, added_exceptions=['DirectConnectClientException'])`

Also simplified logic in module_utils/ec2.py found()

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/cloud.py
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
