### PR TITLE
openssl_*: Allow user to specify privatekey passphrase

### DIFF
--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -26,12 +26,14 @@ except ImportError:
 import hashlib
 
 
-def get_fingerprint(path):
+def get_fingerprint(path, passphrase):
     """Generate the fingerprint of the public key. """
 
     fingerprint = {}
 
-    privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM, open(path, 'r').read())
+    privatekey = crypto.load_privatekey(crypto.FILETYPE_PEM,
+                                        open(path, 'rb').read(),
+                                        passphrase)
 
     try:
         publickey = crypto.dump_publickey(crypto.FILETYPE_ASN1, privatekey)


### PR DESCRIPTION


##### SUMMARY

Allow a user to specify the privatekey passphrase when dealing with
openssl modules.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

- openssl_privatekey
- openssl_publickey
- openssl_csr

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

- N/A

Fixes #27043 