### PR TITLE
#27045 fix installation guide via apt (ubuntu)

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -141,6 +141,7 @@ To configure the PPA on your machine and install ansible run these commands:
     $ sudo apt-get update
     $ sudo apt-get install software-properties-common
     $ sudo apt-add-repository ppa:ansible/ansible
+    $ sudo apt-get update
     $ sudo apt-get install ansible
 
 .. note:: For the older version 1.9 we use this ppa:ansible/ansible-1.9

--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -138,9 +138,9 @@ To configure the PPA on your machine and install ansible run these commands:
 
 .. code-block:: bash
 
+    $ sudo apt-get update
     $ sudo apt-get install software-properties-common
     $ sudo apt-add-repository ppa:ansible/ansible
-    $ sudo apt-get update
     $ sudo apt-get install ansible
 
 .. note:: For the older version 1.9 we use this ppa:ansible/ansible-1.9


### PR DESCRIPTION
##### SUMMARY
Fix #27045
Executing `sudo apt-get update` befor `sudo apt-get install software-properties-common ` prevent from getting `Unable to locate package software-properties-common` error

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Installation guide

##### ANSIBLE VERSION
ansible 2.3.1.0

##### ADDITIONAL INFORMATION
Have changed the sequence of the execution command to
```
$ sudo apt-get update
$ sudo apt-get install software-properties-common
$ sudo apt-add-repository ppa:ansible/ansible
$ sudo apt-get install ansible
``` 
