### PR TITLE
fix unicode errors in iosxr

### DIFF
--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -29,7 +29,7 @@ import re
 import hashlib
 
 from ansible.module_utils.six.moves import zip
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.network_common import to_list
 
 DEFAULT_COMMENT_TOKENS = ['#', '!', '/*', '*/', 'echo']
@@ -205,6 +205,7 @@ class NetworkConfig(object):
     def parse(self, lines, comment_tokens=None):
         toplevel = re.compile(r'\S')
         childline = re.compile(r'^\s*(.+)$')
+        entry_reg = re.compile(r'([{};])')
 
         ancestors = list()
         config = list()
@@ -212,8 +213,8 @@ class NetworkConfig(object):
         curlevel = 0
         prevlevel = 0
 
-        for linenum, line in enumerate(str(lines).split('\n')):
-            text = str(re.sub(r'([{};])', '', line)).strip()
+        for linenum, line in enumerate(to_native(lines, errors='surrogate_or_strict').split('\n')):
+            text = entry_reg.sub('', line).strip()
 
             cfg = ConfigLine(line)
 

--- a/lib/ansible/plugins/action/iosxr_config.py
+++ b/lib/ansible/plugins/action/iosxr_config.py
@@ -25,7 +25,7 @@ import time
 import glob
 
 from ansible.plugins.action.iosxr import ActionModule as _ActionModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.utils.vars import merge_hash
 
@@ -74,7 +74,7 @@ class ActionModule(_ActionModule):
             os.remove(fn)
         tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
         filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
-        open(filename, 'w').write(contents)
+        open(filename, 'w').write(to_bytes(contents))
         return filename
 
     def _handle_template(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: #26917

Need to use the ansible to_native, to_byte instead of str() to ensure that we get the correct character encoding for modules which handle unicode.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- iosxr

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (iosxr-#26917 ec28dd06ad) last updated 2017/07/19 12:37:20 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
