### PR TITLE
foreman inventory: don't fail on disappearing hosts

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -197,11 +197,11 @@ class ForemanInventory(object):
 
     def _get_host_data_by_id(self, hid):
         url = "%s/api/v2/hosts/%s" % (self.foreman_url, hid)
-        return self._get_json(url)
+        return self._get_json(url, [404]) or {}
 
     def _get_facts_by_id(self, hid):
         url = "%s/api/v2/hosts/%s/facts" % (self.foreman_url, hid)
-        return self._get_json(url)
+        return self._get_json(url, [404]) or {}
 
     def _resolve_params(self, host_params):
         """Convert host params to dict"""
@@ -212,10 +212,6 @@ class ForemanInventory(object):
             params[name] = param['value']
 
         return params
-
-    def _get_facts_by_id(self, hid):
-        url = "%s/api/v2/hosts/%s/facts" % (self.foreman_url, hid)
-        return self._get_json(url)
 
     def _get_facts(self, host):
         """Fetch all host facts of the host"""


### PR DESCRIPTION
##### SUMMARY
Since we first have to fetch the list of hosts and later on query the
details of these hosts we must not fail when a host got deleted in the
meantime. Otherwise it's impossible to run ansible in dynamic
environments that create and delete hosts frequently.

This was already present on the external version of this inventory but
got somehow lost during the upstreaming.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (foreman-inventory-404 fff23de6cc) last updated 2017/07/19 19:07:08 (GMT +200)
```
