### PR TITLE
Fixes doc string in docker_volume

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -44,9 +44,8 @@ options:
 
   driver_options:
     description:
-      - >
-        Dictionary of volume settings. Consult docker docs for valid options and values:
-        U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)
+      - "Dictionary of volume settings. Consult docker docs for valid options and values:
+        U(https://docs.docker.com/engine/reference/commandline/volume_create/#driver-specific-options)"
 
   labels:
     description:
@@ -55,8 +54,8 @@ options:
   force:
     description:
       - With state C(present) causes the volume to be deleted and recreated if the volume already
-        exist and the driver, driver options or labels differ.
-        This will cause any data in the existing volume to be lost.
+        exist and the driver, driver options or labels differ. This will cause any data in the existing
+        volume to be lost.
     type: bool
     default: 'no'
 
@@ -108,7 +107,13 @@ facts:
 '''
 
 from ansible.module_utils.six import iteritems, text_type
-from ansible.module_utils.docker_common import DockerBaseClass, AnsibleDockerClient, APIError
+from ansible.module_utils.docker_common import DockerBaseClass, AnsibleDockerClient
+
+try:
+    from docker.errors import APIError
+except:
+    # missing docker-py handled in ansible.module_utils.docker
+    pass
 
 
 class TaskParameters(DockerBaseClass):


### PR DESCRIPTION
##### SUMMARY
Fixing CI issues with doc string

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/docker/docker_volume.py 

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel ca4dc058c4) last updated 2017/07/19 13:56:01 (GMT -400)
  config file = /Users/chouseknecht/.ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```
##### ADDITIONAL INFORMATION
