### PR TITLE
Fix double-quote chars in passwordstore examples

### DIFF
--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -109,40 +109,42 @@ The Passwordstore Lookup
 .. versionadded:: 2.3
 
 The ``passwordstore`` lookup enables Ansible to retrieve, create or update passwords from
-the passwordstore.org ``pass`` utility. It also retrieves YAML style keys stored as multilines
+the passwordstore.org_ ``pass`` utility. It also retrieves YAML style keys stored as multilines
 in the passwordfile.
+
+.. _passwordstore.org: https://www.passwordstore.org
 
 Examples
 --------
 Basic lookup. Fails if example/test doesn't exist::
 
-    password="{{ lookup('passwordstore', 'example/test')}}`
+    password="{{ lookup('passwordstore', 'example/test')}}"
 
 Create pass with random 16 character password. If password exists just give the password::
 
-    password="{{ lookup('passwordstore', 'example/test create=true')}}`
+    password="{{ lookup('passwordstore', 'example/test create=true')}}"
 
 Different size password::
 
-    password="{{ lookup('passwordstore', 'example/test create=true length=42')}}`
+    password="{{ lookup('passwordstore', 'example/test create=true length=42')}}"
 
 Create password and overwrite the password if it exists. As a bonus, this module includes the old password inside the pass file::
 
-    password="{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}`
+    password="{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"
 
 Return the value for user in the KV pair user: username::
 
-    password="{{ lookup('passwordstore', 'example/test subkey=user')}}`
+    password="{{ lookup('passwordstore', 'example/test subkey=user')}}"
 
 Return the entire password file content::
 
-    password="{{ lookup('passwordstore', 'example/test returnall=true')}}`
+    password="{{ lookup('passwordstore', 'example/test returnall=true')}}"
 
 The location of the password-store directory can be specified in the following ways:
   - Default is ~/.password-store
   - Can be overruled by PASSWORD_STORE_DIR environment variable
   - Can be overruled by 'passwordstore: path/to/.password-store' ansible setting
-  - Can be overrules by 'directory=path' argument in the lookup call
+  - Can be overruled by 'directory=path' argument in the lookup call
 
 .. _csvfile_lookup:
 


### PR DESCRIPTION
Also add link to passwordstore.org and correct a typo.

##### SUMMARY
The documentation and examples for the passwordstore.org lookup contain mis-matched quotes and a typo.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr 25 2017, 10:53:57) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```


##### ADDITIONAL INFORMATION
None.