### PR TITLE
Temp staging post 2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Ansible Changes By Release
   * Fix traceback when checking for passwords in logged strings when logging executed commands.
   * docker_login module
 * ios_config: Fix traceback when the efaults parameter is not set
+* iosxr_config: Fixed unicode error when UTF-8 characters are in configs
 
 ## 2.3.2 "Ramble On" - TBD
 

--- a/lib/ansible/module_utils/netcfg.py
+++ b/lib/ansible/module_utils/netcfg.py
@@ -164,6 +164,7 @@ class NetworkConfig(object):
     def parse(self, lines, comment_tokens=None):
         toplevel = re.compile(r'\S')
         childline = re.compile(r'^\s*(.+)$')
+        entry_reg = re.compile(r'([{};])')
 
         ancestors = list()
         config = list()
@@ -171,8 +172,8 @@ class NetworkConfig(object):
         curlevel = 0
         prevlevel = 0
 
-        for linenum, line in enumerate(str(lines).split('\n')):
-            text = str(re.sub(r'([{};])', '', line)).strip()
+        for linenum, line in enumerate(to_native(lines, errors='surrogate_or_strict').split('\n')):
+            text = entry_reg.sub('', line).strip()
 
             cfg = ConfigLine(line)
 

--- a/lib/ansible/plugins/action/iosxr_config.py
+++ b/lib/ansible/plugins/action/iosxr_config.py
@@ -25,7 +25,7 @@ import time
 import glob
 
 from ansible.plugins.action.iosxr import ActionModule as _ActionModule
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
 from ansible.utils.vars import merge_hash
 
@@ -74,7 +74,7 @@ class ActionModule(_ActionModule):
             os.remove(fn)
         tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
         filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
-        open(filename, 'w').write(contents)
+        open(filename, 'w').write(to_bytes(contents))
         return filename
 
     def _handle_template(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Cherry pick bug fix for unicode error in iosxr_config
Merged to devel and the temp-staging-post-2.3.2 branch for inclusion in 2.3.3

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- iosxr_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
