### PR TITLE
Fix package  actions if gather_facts: false

### DIFF
--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -53,7 +53,7 @@ class ActionModule(ActionBase):
             facts = self._execute_module(module_name='setup', module_args=dict(filter='ansible_pkg_mgr', gather_subset='!all'), task_vars=task_vars)
             display.debug("Facts %s" % facts)
             if 'ansible_facts' in facts and 'ansible_pkg_mgr' in facts['ansible_facts']:
-                module = getattr(facts['ansible_facts'], 'ansible_pkg_mgr', 'auto')
+                module = facts['ansible_facts']['ansible_pkg_mgr']
 
         if module != 'auto':
 


### PR DESCRIPTION
If called without any facts, so that 'pkg_mgr' or 'service_mgr'
facts are unknown, the package/service actions would also
throw:

   Could not detect which package manager to use.
   Try gathering facts or setting the "use" option.'

A getattr() on a dict was failing and always returning the
default 'auto', which then causes the above error.

update to just use a dict .get() instead of getattr()

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/action/package.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_package_service_action_no_facts fcf6d4e7fd) last updated 2017/07/19 19:24:15 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
