### PR TITLE
Set default user-agent for module_utils.urls fetch_url

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1020,7 +1020,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
 
     username = module.params.get('url_username', '')
     password = module.params.get('url_password', '')
-    http_agent = module.params.get('http_agent', None)
+    http_agent = module.params.get('http_agent', 'ansible-httpget')
     force_basic_auth = module.params.get('force_basic_auth', '')
 
     follow_redirects = module.params.get('follow_redirects', 'urllib2')


### PR DESCRIPTION
##### SUMMARY
The HTTP User-Agent "ansible-httpget" is already kind of the default,
it being the default value provided by the `url_argument_spec` helper
method. Yet, it may not be practical for all modules to get their
argument_spec that way.

Without a default User-Agent we fall back on the library
User-Agent. That being something like "Python-urllib/2.7".

While I'm no big fan of web servers making decisions based on the
provided User-Agent I still think that part of being a well-behaved
HTTP client is to provide an informative User-Agent. Not to mention
that it's a good thing for Ansible to behave consistently.

Indirectly fixes #26239

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils.urls 

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 13e7e00706) last updated 2017/07/20 08:08:00 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/workdir/ansible/lib/ansible
  executable location = /home/andreas/workdir/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```