### PR TITLE
Make the 'not found' regex case sensitive

### DIFF
--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -41,7 +41,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"invalid input", re.I),
         re.compile(br"(?:incomplete|ambiguous) command", re.I),
         re.compile(br"connection timed out", re.I),
-        re.compile(br"[^\r\n]+ not found", re.I),
+        re.compile(br"[^\r\n]+ not found"),
         re.compile(br"'[^']' +returned error code: ?\d+"),
     ]
 


### PR DESCRIPTION
##### SUMMARY

Turns out in some commands, like 'sh bgp summary' a line containing
'Not found' can be shown as a column.
This causes those commands to error out with RC=1 .

Fixes #26577 
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/terminal/ios.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (not_found_regex_case_sensitive 1e0306b7a5) last updated 2017/07/20 11:17:45 (GMT +200)
```
