### PR TITLE
os_image: Add checksum based glance image manipulation

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -45,7 +45,7 @@ options:
      required: false
      default: None
    checksum:
-     version_added: "2.4"
+     version_added: "2.5"
      description:
         - The checksum of the image
      required: false

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -168,8 +168,7 @@ def main():
 
         changed = False
         if module.params['checksum']:
-            #image = cloud.get_image(name_or_id=None,filters={'checksum': module.params['checksum']})
-            image = cloud.get_image(name_or_id=module.params['name'])
+            image = cloud.get_image(name_or_id=None,filters={'checksum': module.params['checksum']})
         else:
             image = cloud.get_image(name_or_id=module.params['name'])
 

--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -44,6 +44,12 @@ options:
         - The Id of the image
      required: false
      default: None
+   checksum:
+     version_added: "2.4"
+     description:
+        - The checksum of the image
+     required: false
+     default: None
    disk_format:
      description:
         - The format of the disk that is getting uploaded
@@ -138,6 +144,7 @@ def main():
     argument_spec = openstack_full_argument_spec(
         name              = dict(required=True),
         id                = dict(default=None),
+        checksum          = dict(default=None),
         disk_format       = dict(default='qcow2', choices=['ami', 'ari', 'aki', 'vhd', 'vmdk', 'raw', 'qcow2', 'vdi', 'iso', 'vhdx', 'ploop']),
         container_format  = dict(default='bare', choices=['ami', 'aki', 'ari', 'bare', 'ovf', 'ova', 'docker']),
         owner             = dict(default=None),
@@ -160,7 +167,11 @@ def main():
         cloud = shade.openstack_cloud(**module.params)
 
         changed = False
-        image = cloud.get_image(name_or_id=module.params['name'])
+        if module.params['checksum']:
+            #image = cloud.get_image(name_or_id=None,filters={'checksum': module.params['checksum']})
+            image = cloud.get_image(name_or_id=module.params['name'])
+        else:
+            image = cloud.get_image(name_or_id=module.params['name'])
 
         if module.params['state'] == 'present':
             if not image:


### PR DESCRIPTION
##### SUMMARY
Select OpenStack image based on checksum

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module: os_image

##### ADDITIONAL INFORMATION
When handling OpenStack images it is convenient to be able to select them by checksum rather than by name or ID. The same image could have different names or IDs based on the environment using the checksum is a reliable way to identify a specific image based on its content.
Selecting on checksum allows to rename images rather than to re-upload if the name needs to be changed.