### PR TITLE
deprecate ec2_facts instead of making it an alias

### DIFF
--- a/lib/ansible/modules/cloud/amazon/_ec2_facts.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_facts.py
@@ -1,1 +1,43 @@
-ec2_metadata_facts.py
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['deprecated'],
+                    'supported_by': 'curated'}
+
+DOCUMENTATION = '''
+---
+module: ec2_facts
+deprecated: Use ec2_metadata_facts instead.
+short_description: Gathers facts (instance metadata) about remote hosts within ec2
+version_added: "1.0"
+author:
+    - Silviu Dicu (@silviud)
+    - Vinay Dandekar (@roadmapper)
+description:
+    - This module fetches data from the instance metadata endpoint in ec2 as per
+      http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html.
+      The module must be called from within the EC2 instance itself.
+notes:
+    - Parameters to filter on ec2_metadata_facts may be added later.
+'''
+
+from ec2_metadata_facts import *
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes: bug #27105
Introduced by https://github.com/ansible/ansible/commit/5b109506c4a4d1ecfdc9d77184ed1175f4275c95

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/amazon/_ec2_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/fred/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/fred/external/ansible/.tox/py27/lib/python2.7/site-packages/ansible
  executable location = /home/fred/external/ansible/.tox/py27/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
