### PR TITLE
ec2_group: add integration test for port ranges

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -403,9 +403,9 @@ def ports_expand(ports):
         if not isinstance(port, str):
             ports_expanded.append((port,) * 2)
         elif '-' in port:
-            ports_expanded.append(tuple(p.strip() for p in port.split('-', 1)))
+            ports_expanded.append(tuple(int(p.strip()) for p in port.split('-', 1)))
         else:
-            ports_expanded.append((port.strip(),) * 2)
+            ports_expanded.append((int(port.strip()),) * 2)
 
     return ports_expanded
 

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -403,9 +403,9 @@ def ports_expand(ports):
         if not isinstance(port, str):
             ports_expanded.append((port,) * 2)
         elif '-' in port:
-            ports_expanded.append(tuple(int(p.strip()) for p in port.split('-', 1)))
+            ports_expanded.append(tuple(p.strip() for p in port.split('-', 1)))
         else:
-            ports_expanded.append((int(port.strip()),) * 2)
+            ports_expanded.append((port.strip(),) * 2)
 
     return ports_expanded
 

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -409,6 +409,33 @@
 
 
     # ============================================================
+
+    - name: test adding a range of ports and ports given as strings (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        # set purge_rules to false so we don't get a false positive from previously added rules
+        purge_rules: false
+        rules:
+        - proto: "tcp"
+          ports:
+            - 8183-8190
+            - '8192'
+          cidr_ip: 1.1.1.1/32
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+          - 'result.changed'
+          - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
     - name: test state=absent (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'


### PR DESCRIPTION
##### SUMMARY
Failing shippable because the fix is in #27145. This is a follow-up tests pull request.

The rules option 'ports' should work with ranges and ports provided as strings since bd05c65. It was broken, so I've ~fixed it and~ added a test. Edit: #27145 is a better fix, since from_ports and to_ports provided as strings is also fixed.

Traceback before:
```
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/by/k8_fbl593dlctgqmwq5wzl2c0000gn/T/ansible_k319ukpf/ansible_module_ec2_group.py", line 763, in <module>
    main()
  File "/var/folders/by/k8_fbl593dlctgqmwq5wzl2c0000gn/T/ansible_k319ukpf/ansible_module_ec2_group.py", line 644, in main
    module, rule, "ipv4")
  File "/var/folders/by/k8_fbl593dlctgqmwq5wzl2c0000gn/T/ansible_k319ukpf/ansible_module_ec2_group.py", line 417, in authorize_ip
    IpPermissions=[ip_permission])
  File "/Users/shertel/Workspace/ansible/venv/python3.5.2/lib/python3.5/site-packages/botocore/client.py", line 310, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/shertel/Workspace/ansible/venv/python3.5.2/lib/python3.5/site-packages/botocore/client.py", line 573, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/Users/shertel/Workspace/ansible/venv/python3.5.2/lib/python3.5/site-packages/botocore/client.py", line 628, in _convert_to_request_dict
    api_params, operation_model)
  File "/Users/shertel/Workspace/ansible/venv/python3.5.2/lib/python3.5/site-packages/botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter IpPermissions[0].FromPort, value: 10, type: <class 'str'>, valid types: <class 'int'>
Invalid type for parameter IpPermissions[0].ToPort, value: 10, type: <class 'str'>, valid types: <class 'int'>
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py
test/integration/targets/ec2_group/tasks/main.yml

##### ANSIBLE VERSION
```
2.4.0
```