### PR TITLE
+ Add DBName in RDS Facts if it's not null

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -586,10 +586,8 @@ class RDSDBInstance:
             d["endpoint"] = None
             d["port"] = None
             d["vpc_security_groups"] = None
-        
         if self.instance.DBName is not None:
             d['DBName'] = self.instance.DBName
-        
         # ReadReplicaSourceDBInstanceIdentifier may or may not exist
         try:
             d["replication_source"] = self.instance.ReadReplicaSourceDBInstanceIdentifier

--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -586,7 +586,10 @@ class RDSDBInstance:
             d["endpoint"] = None
             d["port"] = None
             d["vpc_security_groups"] = None
-
+        
+        if self.instance.DBName is not None:
+            d['DBName'] = self.instance.DBName
+        
         # ReadReplicaSourceDBInstanceIdentifier may or may not exist
         try:
             d["replication_source"] = self.instance.ReadReplicaSourceDBInstanceIdentifier
@@ -626,7 +629,8 @@ class RDS2DBInstance:
         else:
             d['endpoint'] = None
             d['port'] = None
-
+        if self.instance["DBName"] is not None:
+            d['DBName'] = self.instance['DBName']
         return d
 
 

--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -586,7 +586,7 @@ class RDSDBInstance:
             d["endpoint"] = None
             d["port"] = None
             d["vpc_security_groups"] = None
-        if self.instance.DBName is not None:
+        if self.instance.DBName:
             d['DBName'] = self.instance.DBName
         # ReadReplicaSourceDBInstanceIdentifier may or may not exist
         try:
@@ -627,7 +627,7 @@ class RDS2DBInstance:
         else:
             d['endpoint'] = None
             d['port'] = None
-        if self.instance["DBName"] is not None:
+        if self.instance["DBName"]:
             d['DBName'] = self.instance['DBName']
         return d
 


### PR DESCRIPTION
##### SUMMARY
DB Name from RDS should be visible when pulling facts. 

There is an old issue opened here:
https://github.com/ansible/ansible-modules-core/issues/1784
Since this issue is opened on a different repo, i will not include the number in the commit message.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
RDS module.

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 7b3df9e950) last updated 2017/07/20 18:40:14 (GMT +300)
  config file = None
  configured module search path = [u'/home/ansible-dev/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible-dev/ansible/lib/ansible
  executable location = /home/ansible-dev/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
