### PR TITLE
Add "clean" option support for pkgng module

### DIFF
--- a/lib/ansible/modules/packaging/os/pkgng.py
+++ b/lib/ansible/modules/packaging/os/pkgng.py
@@ -92,6 +92,15 @@ options:
         required: false
         choices: [ "yes", "no" ]
         default: no
+    clean:
+        version_added: "2.4"
+        description:
+            - Clean the local cache of fetched remote packages. Use
+              C(obsolete) to only remove obsolete package files (e.g.
+              old versions) or C(all) to remove all cached package files.
+        required: false
+        choices: [ "none", "obsolete", "all" ]
+        default: none
 author: "bleader (@bleader)"
 notes:
     - When using pkgsite, be careful that already in cache packages won't be downloaded again.
@@ -309,6 +318,22 @@ def autoremove_packages(module, pkgng_path, dir_arg):
 
     return True, "autoremoved %d package(s)" % (autoremove_c)
 
+def clean_packages(module, pkgng_path, mode, dir_arg):
+    all_arg = ''
+    if mode == 'all':
+        all_arg = '-a'
+
+    rc, out, err = module.run_command("%s %s clean %s -n" % (pkgng_path, dir_arg, all_arg))
+
+    will_clean = re.search('^The following package files will be deleted:', out, re.MULTILINE)
+    if not will_clean:
+        return False, "no package(s) to clean"
+
+    if not module.check_mode:
+        rc, out, err = module.run_command("%s %s clean %s" % (pkgng_path, dir_arg, all_arg))
+
+    return True, "cleaned package cache"
+
 def main():
     module = AnsibleModule(
         argument_spec       = dict(
@@ -320,7 +345,9 @@ def main():
             rootdir         = dict(default="", required=False, type='path'),
             chroot          = dict(default="", required=False, type='path'),
             jail            = dict(default="", required=False, type='str'),
-            autoremove      = dict(default=False, type='bool')),
+            autoremove      = dict(default=False, type='bool'),
+            clean           = dict(default='none', choices=['none', 'obsolete', 'all'], required=False),
+        ),
         supports_check_mode = True,
         mutually_exclusive  =[["rootdir", "chroot", "jail"]])
 
@@ -359,6 +386,11 @@ def main():
 
     if p["autoremove"]:
         _changed, _msg = autoremove_packages(module, pkgng_path, dir_arg)
+        changed = changed or _changed
+        msgs.append(_msg)
+
+    if p["clean"] != 'none':
+        _changed, _msg = clean_packages(module, pkgng_path, p["clean"], dir_arg)
         changed = changed or _changed
         msgs.append(_msg)
 


### PR DESCRIPTION
##### SUMMARY

Runs `pkg clean` which removes cached package files. Possible values:
- none (do not clean, default)
- obsolete (clean only obsolete package files (e.g. old versions))
- all (clean all package files)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
pkgng module

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/amdmi3/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jun 28 2017, 15:57:52) [GCC 4.2.1 Compatible FreeBSD Clang 3.8.0 (tags/RELEASE_380/final 262564)]
```

##### ADDITIONAL INFORMATION
This obsoletes stalled #20575, which was based on my original pull request ansible-modules-extras#2339. The issue mentioned in ansible-modules-extras#2339 was fixed, compared to #20575 this fixes incorrect default clean option value (should be `none`, not `no`)