### PR TITLE
Adding aruba_config module

### DIFF
--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -1,0 +1,402 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: aruba_config
+version_added: "2.4"
+author: "James Mighion (@jmighion)"
+short_description: Manage Aruba configuration sections
+description:
+  - Aruba configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with Aruba configuration sections in
+    a deterministic way.
+extends_documentation_fragment: aruba
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is mutually
+        exclusive with I(lines).
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    type: bool
+  running_config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(running_config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+    aliases: ['config']
+  save_when:
+    description:
+      - When changes are made to the device running-configuration, the
+        changes are not copied to non-volatile storage by default.  Using
+        this argument will change that before.  If the argument is set to
+        I(always), then the running-config will always be copied to the
+        startup-config and the I(modified) flag will always be set to
+        True.  If the argument is set to I(modified), then the running-config
+        will only be copied to the startup-config if it has changed since
+        the last save to startup-config.  If the argument is set to
+        I(never), the running-config will never be copied to the the
+        startup-config
+    required: false
+    default: never
+    choices: ['always', 'never', 'modified']
+  diff_against:
+    description:
+      - When using the C(ansible-playbook --diff) command line argument
+        the module can generate diffs against different sources.
+      - When this option is configure as I(startup), the module will return
+        the diff of the running-config against the startup-config.
+      - When this option is configured as I(intended), the module will
+        return the diff of the running-config against the configuration
+        provided in the C(intended_config) argument.
+      - When this option is configured as I(running), the module will
+        return the before and after diff of the running-config with respect
+        to any changes made to the device configuration.
+    required: false
+    default: startup
+    choices: ['startup', 'intended', 'running']
+  diff_ignore_lines:
+    description:
+      - Use this argument to specify one or more lines that should be
+        ignored during the diff.  This is used for lines in the configuration
+        that are automatically updated by the system.  This argument takes
+        a list of regular expressions or exact line matches.
+    required: false
+  intended_config:
+    description:
+      - The C(intended_config) provides the master configuration that
+        the node should conform to and is used to check the final
+        running-config against.   This argument will not modify any settings
+        on the remote device and is strictly used to check the compliance
+        of the current device's configuration against.  When specifying this
+        argument, the task should also modify the C(diff_against) value and
+        set it to I(intended).
+    required: false
+"""
+
+EXAMPLES = """
+- name: configure top level configuration
+  aruba_config:
+    lines: hostname {{ inventory_hostname }}
+
+- name: diff the running-config against a provided config
+  aruba_config:
+    diff_against: intended
+    intended: "{{ lookup('file', 'master.cfg') }}"
+
+- name: configure interface settings
+  aruba_config:
+    lines:
+      - description test interface
+      - ip access-group 1 in
+    parents: interface gigabitethernet 0/0/0
+
+- name: load new acl into device
+  aruba_config:
+    lines:
+      - permit host 10.10.10.10
+      - ipv6 permit host fda9:97d6:32a3:3e59::3333
+    parents: ip access-list standard 1
+    before: no ip access-list standard 1
+    match: exact
+"""
+
+RETURN = """
+commands:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['hostname foo', 'vlan 1', 'name default']
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['hostname foo', 'vlan 1', 'name default']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: string
+  sample: /playbooks/ansible/backup/aruba_config.2016-07-16@22:28:34
+"""
+
+
+import re
+import time
+
+from ansible.module_utils.aruba import run_commands, get_config, load_config
+from ansible.module_utils.aruba import aruba_argument_spec
+from ansible.module_utils.aruba import check_args as aruba_check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.netcli import Conditional
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.six import iteritems
+
+
+def get_running_config(module, config=None):
+    contents = module.params['running_config']
+    if not contents:
+        if config:
+            contents = config
+        else:
+            contents = get_config(module)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def get_candidate(module):
+    candidate = NetworkConfig(indent=1)
+
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def save_config(module, result):
+    result['changed'] = True
+    if not module.check_mode:
+        run_commands(module, 'copy running-config startup-config')
+    else:
+        module.warn('Skipping command `copy running-config startup-config` '
+                    'due to check_mode.  Configuration not copied to '
+                    'non-volatile storage')
+
+
+def main():
+    """ main entry point for module execution
+    """
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+
+        running_config=dict(aliases=['config']),
+        intended_config=dict(),
+
+        backup=dict(type='bool', default=False),
+
+        save_when=dict(choices=['always', 'never', 'modified'], default='never'),
+
+        diff_against=dict(choices=['running', 'startup', 'intended']),
+        diff_ignore_lines=dict(type='list'),
+    )
+
+    argument_spec.update(aruba_argument_spec)
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('diff_against', 'intended', ['intended_config'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    warnings = list()
+    aruba_check_args(module, warnings)
+    result = {'changed': False, 'warnings': warnings}
+
+    config = None
+
+    if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
+        contents = get_config(module)
+        config = NetworkConfig(indent=1, contents=contents)
+        if module.params['backup']:
+            result['__backup__'] = contents
+
+    if any((module.params['src'], module.params['lines'])):
+        match = module.params['match']
+        replace = module.params['replace']
+
+        candidate = get_candidate(module)
+
+        if match != 'none':
+            config = get_running_config(module, config)
+            path = module.params['parents']
+            configobjs = candidate.difference(config, match=match, replace=replace, path=path)
+        else:
+            configobjs = candidate.items
+
+        if configobjs:
+            commands = dumps(configobjs, 'commands').split('\n')
+
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+            result['updates'] = commands
+
+            if not module.check_mode:
+                load_config(module, commands)
+
+            result['changed'] = True
+
+    running_config = None
+    startup_config = None
+
+    diff_ignore_lines = module.params['diff_ignore_lines']
+
+    if module.params['save_when'] == 'always':
+        save_config(module, result)
+    elif module.params['save_when'] == 'modified':
+        output = run_commands(module, ['show running-config', 'show startup-config'])
+
+        running_config = NetworkConfig(indent=1, contents=output[0], ignore_lines=diff_ignore_lines)
+        startup_config = NetworkConfig(indent=1, contents=output[1], ignore_lines=diff_ignore_lines)
+
+        if running_config.sha1 != startup_config.sha1:
+            save_config(module, result)
+
+    if module._diff:
+        if not running_config:
+            output = run_commands(module, 'show running-config')
+            contents = output[0]
+        else:
+            contents = running_config.config_text
+
+        # recreate the object in order to process diff_ignore_lines
+        running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+        if module.params['diff_against'] == 'running':
+            if module.check_mode:
+                module.warn("unable to perform diff against running-config due to check mode")
+                contents = None
+            else:
+                contents = config.config_text
+
+        elif module.params['diff_against'] == 'startup':
+            if not startup_config:
+                output = run_commands(module, 'show startup-config')
+                contents = output[0]
+            else:
+                contents = startup_config.config_text
+
+        elif module.params['diff_against'] == 'intended':
+            contents = module.params['intended_config']
+
+        if contents is not None:
+            base_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+
+            if running_config.sha1 != base_config.sha1:
+                result.update({
+                    'changed': True,
+                    'diff': {'before': str(base_config), 'after': str(running_config)}
+                })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -151,7 +151,6 @@ options:
         return the before and after diff of the running-config with respect
         to any changes made to the device configuration.
     required: false
-    default: startup
     choices: ['startup', 'intended', 'running']
   diff_ignore_lines:
     description:

--- a/lib/ansible/plugins/action/aruba_config.py
+++ b/lib/ansible/plugins/action/aruba_config.py
@@ -1,0 +1,112 @@
+#
+# (c) 2017, Red Hat, Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import os
+import re
+import time
+import glob
+
+from ansible.plugins.action.aruba import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=exc.message)
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in result.keys():
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/test/units/modules/network/aruba/fixtures/aruba_config_config.cfg
+++ b/test/units/modules/network/aruba/fixtures/aruba_config_config.cfg
@@ -1,0 +1,12 @@
+!
+hostname router
+!
+interface GigabitEthernet0/0
+ ip address 1.2.3.4 255.255.255.0
+ description test string
+!
+interface GigabitEthernet0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!

--- a/test/units/modules/network/aruba/fixtures/aruba_config_defaults.cfg
+++ b/test/units/modules/network/aruba/fixtures/aruba_config_defaults.cfg
@@ -1,0 +1,13 @@
+!
+hostname router
+!
+interface GigabitEthernet0/0
+ ip address 1.2.3.4 255.255.255.0
+ description test string
+ no shutdown
+!
+interface GigabitEthernet0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!

--- a/test/units/modules/network/aruba/fixtures/aruba_config_src.cfg
+++ b/test/units/modules/network/aruba/fixtures/aruba_config_src.cfg
@@ -1,0 +1,11 @@
+!
+hostname foo
+!
+interface GigabitEthernet0/0
+ no ip address
+!
+interface GigabitEthernet0/1
+ ip address 6.7.8.9 255.255.255.0
+ description test string
+ shutdown
+!

--- a/test/units/modules/network/aruba/test_aruba_config.py
+++ b/test/units/modules/network/aruba/test_aruba_config.py
@@ -1,0 +1,146 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.aruba import aruba_config
+from .aruba_module import TestArubaModule, load_fixture, set_module_args
+
+
+class TestArubaConfigModule(TestArubaModule):
+
+    module = aruba_config
+
+    def setUp(self):
+        self.mock_get_config = patch('ansible.modules.network.aruba.aruba_config.get_config')
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch('ansible.modules.network.aruba.aruba_config.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_run_commands = patch('ansible.modules.network.aruba.aruba_config.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        config_file = 'aruba_config_config.cfg'
+        self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_aruba_config_unchanged(self):
+        src = load_fixture('aruba_config_config.cfg')
+        set_module_args(dict(src=src))
+        self.execute_module()
+
+    def test_aruba_config_src(self):
+        src = load_fixture('aruba_config_src.cfg')
+        set_module_args(dict(src=src))
+        commands = ['hostname foo', 'interface GigabitEthernet0/0',
+                    'no ip address']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_aruba_config_backup(self):
+        set_module_args(dict(backup=True))
+        result = self.execute_module()
+        self.assertIn('__backup__', result)
+
+    def test_aruba_config_save(self):
+        self.run_commands.return_value = "Hostname foo"
+        set_module_args(dict(save_when='always'))
+        self.execute_module(changed=True)
+        self.assertEqual(self.run_commands.call_count, 1)
+        self.assertEqual(self.get_config.call_count, 0)
+        self.assertEqual(self.load_config.call_count, 0)
+        args = self.run_commands.call_args[0][1]
+        self.assertIn('copy running-config startup-config', args)
+
+    def test_aruba_config_lines_wo_parents(self):
+        set_module_args(dict(lines=['hostname foo']))
+        commands = ['hostname foo']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_aruba_config_lines_w_parents(self):
+        set_module_args(dict(lines=['shutdown'], parents=['interface GigabitEthernet0/0']))
+        commands = ['interface GigabitEthernet0/0', 'shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_aruba_config_before(self):
+        set_module_args(dict(lines=['hostname foo'], before=['test1', 'test2']))
+        commands = ['test1', 'test2', 'hostname foo']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_aruba_config_after(self):
+        set_module_args(dict(lines=['hostname foo'], after=['test1', 'test2']))
+        commands = ['hostname foo', 'test1', 'test2']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_aruba_config_before_after_no_change(self):
+        set_module_args(dict(lines=['hostname router'],
+                             before=['test1', 'test2'],
+                             after=['test3', 'test4']))
+        self.execute_module()
+
+    def test_aruba_config_config(self):
+        config = 'hostname localhost'
+        set_module_args(dict(lines=['hostname router'], config=config))
+        commands = ['hostname router']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_aruba_config_replace_block(self):
+        lines = ['description test string', 'test string']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, replace='block', parents=parents))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands)
+
+    def test_aruba_config_force(self):
+        lines = ['hostname router']
+        set_module_args(dict(lines=lines, match='none'))
+        self.execute_module(changed=True, commands=lines)
+
+    def test_aruba_config_match_none(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='none'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_aruba_config_match_strict(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='strict'))
+        commands = parents + ['shutdown']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_aruba_config_match_exact(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface GigabitEthernet0/0']
+        set_module_args(dict(lines=lines, parents=parents, match='exact'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New module `aruba_config`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aruba_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (aruba_config 4792b1f615) last updated 2017/07/20 11:27:57 (GMT -700)
  config file = /Users/james/.ansible.cfg
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/work/git/ansible/lib/ansible
  executable location = /Users/james/Documents/work/git/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


