### PR TITLE
timezone: Assuming UTC when no /etc/localtime exists

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -521,7 +521,8 @@ class BSDTimezone(Timezone):
                 tz = os.readlink('/etc/localtime')
                 return tz.replace('/usr/share/zoneinfo/', '')
             except:
-                self.module.fail_json(msg='Could not read /etc/localtime')
+                self.module.warn('Could not read /etc/localtime. Assuming UTC')
+                return 'UTC'
         else:
             self.module.fail_json(msg='{0} is not a supported option on target platform'.
                                   format(key))


### PR DESCRIPTION
##### SUMMARY
On FreeBSD, when no /etc/localtime exists, the timezone module fails with:

```FAILED! => {"changed": false, "failed": true, "msg": "Could not read /etc/localtime"}```

Instead, we could assume UTC is used.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
timezone

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/andrea/projects/playbooks/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul  2 2017, 22:24:59) [GCC 7.1.1 20170621]
```