### PR TITLE
Use atomic_move rather than writing in place in redhat_subscription

### DIFF
--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -28,9 +28,9 @@
 
 import os
 import re
-import types
 import shutil
 import tempfile
+import types
 
 from ansible.module_utils.six.moves import configparser
 

--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -29,6 +29,8 @@
 import os
 import re
 import types
+import shutil
+import tempfile
 
 from ansible.module_utils.six.moves import configparser
 
@@ -59,16 +61,22 @@ class RegistrationBase(object):
 
     def update_plugin_conf(self, plugin, enabled=True):
         plugin_conf = '/etc/yum/pluginconf.d/%s.conf' % plugin
+
         if os.path.isfile(plugin_conf):
+            tmpfd, tmpfile = tempfile.mkstemp()
+            shutil.copy2(plugin_conf, tmpfile)
             cfg = configparser.ConfigParser()
-            cfg.read([plugin_conf])
+            cfg.read([tmpfile])
+
             if enabled:
                 cfg.set('main', 'enabled', 1)
             else:
                 cfg.set('main', 'enabled', 0)
-            fd = open(plugin_conf, 'w+')
+
+            fd = open(tmpfile, 'w+')
             cfg.write(fd)
             fd.close()
+            self.module.atomic_move(tmpfile, plugin_conf)
 
     def subscribe(self, **kwargs):
         raise NotImplementedError("Must be implemented by a sub-class")

--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -198,6 +198,8 @@ class Rhsm(RegistrationBase):
         '''
         args = ['subscription-manager', 'unregister']
         rc, stderr, stdout = self.module.run_command(args, check_rc=True)
+        self.update_plugin_conf('rhnplugin', False)
+        self.update_plugin_conf('subscription-manager', False)
 
     def subscribe(self, regexp):
         '''

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -17,7 +17,7 @@
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
-    'status': ['preview'],
+    'status': ['curated'],
     'supported_by': 'community'
 }
 

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -18,7 +18,7 @@
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
     'status': ['preview'],
-    'supported_by': 'curated'
+    'supported_by': 'community'
 }
 
 

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -17,8 +17,8 @@
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
-    'status': ['curated'],
-    'supported_by': 'community'
+    'status': ['preview'],
+    'supported_by': 'curated'
 }
 
 

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -210,9 +210,9 @@ subscribed_pool_ids:
 
 import os
 import re
-import types
 import shutil
 import tempfile
+import types
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -198,6 +198,16 @@ EXAMPLES = '''
     autosubscribe: yes
 '''
 
+RETURN = '''
+subscribed_pool_ids:
+    description: List of pool IDs to which system is now subscribed
+    returned: success
+    type: complex
+    contains: {
+        "8a85f9815ab905d3015ab928c7005de4": "1"
+    }
+'''
+
 import os
 import re
 import types

--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -412,6 +412,8 @@ class Rhsm(RegistrationBase):
         '''
         args = [SUBMAN_CMD, 'unregister']
         rc, stderr, stdout = self.module.run_command(args, check_rc=True)
+        self.update_plugin_conf('rhnplugin', False)
+        self.update_plugin_conf('subscription-manager', False)
 
     def subscribe(self, regexp):
         '''

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -19,8 +19,8 @@
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
-    'status': ['curated'],
-    'supported_by': 'core'
+    'status': ['preview'],
+    'supported_by': 'curated'
 }
 
 

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -20,7 +20,7 @@
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
     'status': ['preview'],
-    'supported_by': 'curated'
+    'supported_by': 'community'
 }
 
 

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -19,7 +19,7 @@
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
-    'status': ['preview'],
+    'status': ['curated'],
     'supported_by': 'core'
 }
 

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -17,9 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
-                    'status': ['preview'],
-                    'supported_by': 'core'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'core'
+}
 
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -141,8 +141,8 @@ RETURN = '''
 
 import os
 import sys
-import xmlrpclib
 import urlparse
+import xmlrpclib
 
 # Attempt to import rhn client tools
 sys.path.insert(0, '/usr/share/rhn')

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -135,6 +135,10 @@ EXAMPLES = '''
     channels: rhel-x86_64-server-6-foo-1,rhel-x86_64-server-6-bar-1
 '''
 
+RETURN = '''
+# Default return values
+'''
+
 import os
 import sys
 import xmlrpclib


### PR DESCRIPTION
##### SUMMARY

Use `atomic_move` when updating config file to avoid corruption.

Fixes #26811

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
`redhat_subscription`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

