### PR TITLE
allow use of jinja2 variables for ec2_group from_port/to_port params

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -500,6 +500,9 @@ def serialize_group_grant(group_id, rule):
                   'FromPort': rule['from_port'],
                   'ToPort': rule['to_port'],
                   'UserIdGroupPairs': [{'GroupId': group_id}]}
+
+    convert_ports_to_int(permission)
+
     return permission
 
 
@@ -539,7 +542,16 @@ def serialize_ip_grant(rule, thisip, ethertype):
         permission.update({'IpRanges': [{'CidrIp': thisip}]})
     elif ethertype == "ipv6":
         permission.update({'Ipv6Ranges': [{'CidrIpv6': thisip}]})
+
+    convert_ports_to_int(permission)
+
     return permission
+
+
+def convert_ports_to_int(permission):
+    for key in ['FromPort', 'ToPort']:
+        if permission[key] is not None:
+            permission[key] = int(permission[key])
 
 
 def main():

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -351,6 +351,64 @@
             result.ip_permissions[1].user_id_group_pairs
 
     # ============================================================
+    - name: test ip rules convert port numbers from string to int (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: "8183"
+          to_port: "8183"
+          cidr_ipv6: "64:ff9b::/96"
+        rules_egress:
+        - proto: "tcp"
+          from_port: "8184"
+          to_port: "8184"
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test group rules convert port numbers from string to int (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: "8185"
+          to_port: "8185"
+          group_id: "{{result.group_id}}"
+        rules_egress:
+        - proto: "tcp"
+          from_port: "8186"
+          to_port: "8186"
+          cidr_ipv6: "64:ff9b::/96"
+          group_id: "{{result.group_id}}"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+
+    # ============================================================
     - name: test state=absent (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'


### PR DESCRIPTION
##### SUMMARY

This commit fixes a regression introduced in commit b980a5c02 in which the ec2_group module was updated to use boto3.

Previously, we were able to use jinja2 variables to dynamically set the from_port/to_port parameters as in the following example:

```
  - name: Update target security group to add source ingress rule
    ec2_group:
       name: "{{db_group_name}}"
       vpc_id: "{{vpc_id}}"
       description: "{{db_group_desc}}"
       rules:
         - proto: tcp
           from_port: "{{db_port}}"
           to_port: "{{db_port}}"
           group_id: "{{web_group_id}}"
```

But now now this fails because boto3 is validating that from_port/to_port parameters are integers. Unfortunately, due to restrictions in YAML syntax, it is not possible to force these to be integers when using jinja2 variables.

```
TASK [security-ingress-rule : Update target security group to add source ingress rule] **************************************************************************************************
task path: /projects/aluben/roles/security-ingress-rule/tasks/main.yml:26
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_ACagkT/ansible_module_ec2_group.py", line 763, in <module>
    main()
  File "/tmp/ansible_ACagkT/ansible_module_ec2_group.py", line 631, in main
    client.authorize_security_group_ingress(GroupId=group.group_id, IpPermissions=[ips])
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py", line 253, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py", line 531, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py", line 586, in _convert_to_request_dict
    api_params, operation_model)
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter IpPermissions[0].ToPort, value: 3306, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
Invalid type for parameter IpPermissions[0].FromPort, value: 3306, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_group module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 5617d68c3e) last updated 2017/07/20 16:28:00 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/aptdevadm/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/lib/ansible
  executable location = /opt/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

__Task Output Before Fix__
```
TASK [security-ingress-rule : Update target security group to add source ingress rule] **************************************************************************************************
task path: /projects/aluben/roles/security-ingress-rule/tasks/main.yml:26
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_ACagkT/ansible_module_ec2_group.py", line 763, in <module>
    main()
  File "/tmp/ansible_ACagkT/ansible_module_ec2_group.py", line 631, in main
    client.authorize_security_group_ingress(GroupId=group.group_id, IpPermissions=[ips])
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py", line 253, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py", line 531, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py", line 586, in _convert_to_request_dict
    api_params, operation_model)
  File "/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter IpPermissions[0].ToPort, value: 3306, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
Invalid type for parameter IpPermissions[0].FromPort, value: 3306, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_ACagkT/ansible_module_ec2_group.py\", line 763, in <module>\n    main()\n  File \"/tmp/ansible_ACagkT/ansible_module_ec2_group.py\", line 631, in main\n    client.authorize_security_group_ingress(GroupId=group.group_id, IpPermissions=[ips])\n  File \"/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py\", line 253, in _api_call\n    return self._make_api_call(operation_name, kwargs)\n  File \"/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py\", line 531, in _make_api_call\n    api_params, operation_model, context=request_context)\n  File \"/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/client.py\", line 586, in _convert_to_request_dict\n    api_params, operation_model)\n  File \"/home/aptdevadm/.local/lib/python2.7/site-packages/botocore/validate.py\", line 291, in serialize_to_request\n    raise ParamValidationError(report=report.generate_report())\nbotocore.exceptions.ParamValidationError: Parameter validation failed:\nInvalid type for parameter IpPermissions[0].ToPort, value: 3306, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>\nInvalid type for parameter IpPermissions[0].FromPort, value: 3306, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
```

__Task Output After Fix__
```
TASK [security-ingress-rule : Print the source Security Group Info] *********************************************************************************************************************
task path: /projects/aluben/roles/security-ingress-rule/tasks/main.yml:23
ok: [localhost] => {
    "the_source_security_group.security_groups[0]": {
        "description": "bitbucket", 
        "group_id": "sg-1a4b3f6b", 
        "group_name": "chambers-security-BitbucketSecurityGroup-RTMWCR5HP53B", 
        "ip_permissions": [
            {
                "from_port": 7999, 
                "ip_protocol": "tcp", 
                "ip_ranges": [], 
                "ipv6_ranges": [], 
                "prefix_list_ids": [], 
                "to_port": 7999, 
                "user_id_group_pairs": [
                    {
                        "group_id": "sg-22483c53", 
                        "user_id": "XXXXXXXXXXX"
                    }
                ]
            }, 
            {
                "from_port": 7995, 
                "ip_protocol": "tcp", 
                "ip_ranges": [], 
                "ipv6_ranges": [], 
                "prefix_list_ids": [], 
                "to_port": 7995, 
                "user_id_group_pairs": [
                    {
                        "group_id": "sg-22483c53", 
                        "user_id": "XXXXXXXXXXX"
                    }
                ]
            }
        ], 
        "ip_permissions_egress": [
            {
                "ip_protocol": "-1", 
                "ip_ranges": [
                    {
                        "cidr_ip": "0.0.0.0/0"
                    }
                ], 
                "ipv6_ranges": [], 
                "prefix_list_ids": [], 
                "user_id_group_pairs": []
            }
        ], 
        "owner_id": "XXXXXXXXXXX", 
        "tags": {
            "Name": "chambers-bitbucket", 
            "Stack": "chambers-security", 
            "aws:cloudformation:logical-id": "BitbucketSecurityGroup", 
            "aws:cloudformation:stack-id": "arn:aws:cloudformation:us-east-1:XXXXXXXXXXX:stack/chambers-security/6d6235f0-664c-11e7-8d33-500c28b236fd", 
            "aws:cloudformation:stack-name": "chambers-security", 
            "environment": "chambers"
        }, 
        "vpc_id": "vpc-91e475e8"
    }
}
```