### PR TITLE
Maintain symlinks in setup.py sdist, build, and install commands

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 prune ticket_stubs
 prune hacking
 include README.md COPYING
+include SYMLINK_CACHE.json
 include requirements.txt
 include .coveragerc
 include .yamllint

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,107 @@
+
+import json
 import os
 import os.path
 import sys
+from collections import defaultdict
+from distutils.command.build_scripts import build_scripts as BuildScripts
+from distutils.command.sdist import sdist as SDist
 
-sys.path.insert(0, os.path.abspath('lib'))
-from ansible.release import __version__, __author__
 try:
     from setuptools import setup, find_packages
+    from setuptools.command.build_py import build_py as BuildPy
+    from setuptools.command.install_lib import install_lib as InstallLib
+    from setuptools.command.install_scripts import install_scripts as InstallScripts
 except ImportError:
     print("Ansible now needs setuptools in order to build. Install it using"
           " your package manager (usually python-setuptools) or via pip (pip"
           " install setuptools).")
     sys.exit(1)
+
+sys.path.insert(0, os.path.abspath('lib'))
+from ansible.release import __version__, __author__
+
+
+SYMLINK_CACHE = 'SYMLINK_CACHE.json'
+
+
+def _find_symlinks(topdir, extension=''):
+    """Find symlinks that should be maintained
+
+    Maintained symlinks exist in the bin dir or are modules which have
+    aliases.  Our heuristic is that they are a link in a certain path which
+    point to a file in the same directory.
+    """
+    symlinks = defaultdict(list)
+    for base_path, dirs, files in os.walk(topdir):
+        for filename in files:
+            filepath = os.path.join(base_path, filename)
+            if os.path.islink(filepath) and filename.endswith(extension):
+                target = os.readlink(filepath)
+                if os.path.dirname(target) == '':
+                    link = filepath[len(topdir):]
+                    if link.startswith('/'):
+                        link = link[1:]
+                    symlinks[os.path.basename(target)].append(link)
+    return symlinks
+
+
+def _maintain_symlinks(symlink_type, base_path):
+    """Switch a real file into a symlink"""
+    with open(SYMLINK_CACHE, 'r') as f:
+        symlink_data = json.loads(f.read())
+    symlinks = symlink_data[symlink_type]
+
+    for source in symlinks:
+        for dest in symlinks[source]:
+            dest_path = os.path.join(base_path, dest)
+            if not os.path.islink(dest_path):
+                try:
+                    os.unlink(dest_path)
+                except OSError as e:
+                    if e.errno == 2:
+                        # File does not exist which is all we wanted
+                        pass
+                os.symlink(source, dest_path)
+
+
+class BuildPyCommand(BuildPy):
+    def run(self):
+        BuildPy.run(self)
+        _maintain_symlinks('library', self.build_lib)
+
+
+class BuildScriptsCommand(BuildScripts):
+    def run(self):
+        BuildScripts.run(self)
+        _maintain_symlinks('script', self.build_dir)
+
+
+class InstallLibCommand(InstallLib):
+    def run(self):
+        InstallLib.run(self)
+        _maintain_symlinks('library', self.install_dir)
+
+
+class InstallScriptsCommand(InstallScripts):
+    def run(self):
+        InstallScripts.run(self)
+        _maintain_symlinks('script', self.install_dir)
+
+
+class SDistCommand(SDist):
+    def run(self):
+        # have to generate the cache of symlinks for release as sdist is the
+        # only command that has access to symlinks from the git repo
+        symlinks = {'script': _find_symlinks('bin'),
+                    'library': _find_symlinks('lib', '.py'),
+                    }
+
+        with open(SYMLINK_CACHE, 'w') as f:
+            f.write(json.dumps(symlinks))
+
+        SDist.run(self)
+
 
 with open('requirements.txt') as requirements_file:
     install_requirements = requirements_file.read().splitlines()
@@ -33,26 +124,16 @@ if crypto_backend:
     install_requirements.append(crypto_backend)
 
 
-SYMLINKS = {'ansible': frozenset(('ansible-console',
-                                  'ansible-doc',
-                                  'ansible-galaxy',
-                                  'ansible-playbook',
-                                  'ansible-pull',
-                                  'ansible-vault'))}
-
-for source in SYMLINKS:
-    for dest in SYMLINKS[source]:
-        dest_path = os.path.join('bin', dest)
-        if not os.path.islink(dest_path):
-            try:
-                os.unlink(dest_path)
-            except OSError as e:
-                if e.errno == 2:
-                    # File does not exist which is all we wanted
-                    pass
-            os.symlink(source, dest_path)
-
 setup(
+    # Use the distutils SDist so that symlinks are not expanded
+    # Use a custom Build for the same reason
+    cmdclass={
+        'build_py': BuildPyCommand,
+        'build_scripts': BuildScriptsCommand,
+        'install_lib': InstallLibCommand,
+        'install_scripts': InstallScriptsCommand,
+        'sdist': SDistCommand,
+    },
     name='ansible',
     version=__version__,
     description='Radically simple IT automation',


### PR DESCRIPTION
Symlinks are meaningful for ansible modules.  They differentiate between
aliases and deprecated modules.  They're also useful for saving space
and where downstream patches should be applied to the bin scripts.

Fixes #27105


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
