### PR TITLE
fix seboolean python3 - Fixes #25651

### DIFF
--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -517,7 +517,6 @@ lib/ansible/modules/system/osx_defaults.py
 lib/ansible/modules/system/pam_limits.py
 lib/ansible/modules/system/puppet.py
 lib/ansible/modules/system/runit.py
-lib/ansible/modules/system/seboolean.py
 lib/ansible/modules/system/sefcontext.py
 lib/ansible/modules/system/seport.py
 lib/ansible/modules/system/service.py


### PR DESCRIPTION
    https://github.com/ansible/ansible/issues/25651

Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### SUMMARY

Fix https://github.com/ansible/ansible/issues/25651

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

seboolean module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix-seboolean-python3 409fa86e61) last updated 2017/07/20 22:44:24 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```


##### ADDITIONAL INFORMATION
Before patch

```
osbs-node02.stg.phx2.fedoraproject.org | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "SELinux boolean virt_use_nfs does not exist."
}
```

After patch
```
osbs-node02.stg.phx2.fedoraproject.org | SUCCESS => {
    "changed": true, 
    "failed": false, 
    "name": "virt_use_nfs"
}
```
