### PR TITLE
make _dump_results in debug.py accept all keyword arguments

### DIFF
--- a/lib/ansible/plugins/callback/debug.py
+++ b/lib/ansible/plugins/callback/debug.py
@@ -15,7 +15,7 @@ class CallbackModule(CallbackModule_default):  # pylint: disable=too-few-public-
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'debug'
 
-    def _dump_results(self, result):
+    def _dump_results(self, result, **kwargs):
         '''Return the text to output for a result.'''
 
         # Enable JSON identation


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

the default _dump_results accepts several keyword arguments. If these
are passed to _dump_results in plugins/callback/debug.py Ansible will
thrown an 'unexpected keyword argument' error. This commit modifies
_dump_results in plugins/callback/debug.py to accept all keyword
arguments.

Closes: #27151
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/callback/debug.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (bug/27151 f92d6ad6da) last updated 2017/07/20 23:53:41 (GMT -400)
  config file = None
  configured module search path = [u'/home/lars/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lars/src/ansible/lib/ansible
  executable location = /home/lars/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
