### PR TITLE
Expand the result from pwd to make the est more robust

### DIFF
--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -70,7 +70,7 @@
 - name: assert chdir works
   assert:
     that:
-    - "chdir_result.stdout == '{{output_dir | expanduser | realpath}}'"
+    - "'{{chdir_result.stdout |expanduser | realpath }}' == '{{output_dir | expanduser | realpath}}'"
 
 - name: test timeout option
   expect:


### PR DESCRIPTION
Sometimes MacOSX's pwd doesn't return an expanded path.  Not sure why
but this test is still valid if we expand it via a playbook filter so
go ahead and do that.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
test/integration/target/expect/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3.x
```


##### ADDITIONAL INFORMATION
Inspired by this shippable failure:
https://app.shippable.com/github/ansible/ansible/runs/29839/6/tests
