### PR TITLE
Minor fix for typo - ismount to is_mount

### DIFF
--- a/docs/docsite/rst/playbooks_tests.rst
+++ b/docs/docsite/rst/playbooks_tests.rst
@@ -127,7 +127,7 @@ The following tests can provide information about a path on the controller::
       when: mypath|samefile(path2)
 
     - debug: msg="path is a mount"
-      when: mypath|ismount
+      when: mypath|is_mount
 
 
 .. _test_task_results:


### PR DESCRIPTION
##### SUMMARY
Fix adds correction from ismount to is_mount filter in
playbooks_tests documentation.

Fixes: #27128

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docsite/rst/playbooks_tests.rst

##### ANSIBLE VERSION
```
2.4devel
```