### PR TITLE
Fix ansible_virtualization_role fact on CloudLinux

### DIFF
--- a/lib/ansible/module_utils/facts/virtual/linux.py
+++ b/lib/ansible/module_utils/facts/virtual/linux.py
@@ -55,7 +55,7 @@ class LinuxVirtual(Virtual):
                     virtual_facts['virtualization_role'] = 'guest'
                     return virtual_facts
 
-        if os.path.exists('/proc/vz'):
+        if os.path.exists('/proc/vz') and not os.path.exists('/proc/lve'):
             virtual_facts['virtualization_type'] = 'openvz'
             if os.path.exists('/proc/bc'):
                 virtual_facts['virtualization_role'] = 'host'


### PR DESCRIPTION
##### SUMMARY
CloudLinux and OpenVZ have common roots, but CloudLinux does not really provide OS virtualization so it should not be regarded as a 'openvz' system. This change adds a check for the existance of the LVE kernel module which only exists on CloudLinux.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
facts

##### ANSIBLE VERSION
````
ansible 2.4.0 (cloudlinux-virtualization-type 297617fa80) last updated 2017/07/22 21:11:12 (GMT +200)
  config file = /Users/silverwind/git/ansible/ansible.cfg
  configured module search path = [u'/Users/silverwind/git/ansible-git/modules', u'/etc/ansible/modules', u'/usr/share/ansible']
  ansible python module location = /Users/silverwind/git/ansible-git/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
````

##### ADDITIONAL INFORMATION
Fixes: https://github.com/ansible/ansible/issues/26424
