### PR TITLE
Add Plugin data class, improve Setting to provide access to attributes

### DIFF
--- a/lib/ansible/config/data.py
+++ b/lib/ansible/config/data.py
@@ -17,11 +17,45 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+from ansible.module_utils._text import to_text
+from ansible.errors import AnsibleOptionsError
 __metaclass__ = type
 
-from collections import namedtuple
 
-Setting = namedtuple('Setting','name value origin')
+class Setting(object):
+    def __init__(self, **kwargs):
+        self._attributes = [
+            'default',
+            'desc',
+            'env',
+            'ini',
+            'value_type',
+            'vars',
+            'yaml',
+        ]
+        self._values = [
+            'name',
+            'value',
+            'origin'
+        ]
+
+        for attribute in self._attributes + self._values:
+            setattr(self, attribute, kwargs.get(attribute, None))
+
+    def __repr__(self):
+        return to_text("%s: %s" % (self.name, self.value))
+
+
+class Plugin(object):
+    def __init__(self, name=None, type=None):
+        if not name or not type:
+            raise AnsibleOptionsError("Plugins must be instanciated with a name and a type attribute")
+        self.name = name
+        self.type = type
+
+    def __repr__(self):
+        return to_text("%s plugin: %s" % (self.type, self.name))
+
 
 class ConfigData(object):
 

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -108,7 +108,9 @@ class ConfigManager(object):
     def update_config(self, configfile, defs, parser, ftype):
 
         # update the constant for config file
-        self.data.update_setting(Setting('CONFIG_FILE', configfile, ''))
+        self.data.update_setting(Setting(name='CONFIG_FILE',
+                                         value=configfile,
+                                         origin=''))
 
         origin = None
         # env and config defs can have several entries, ordered in list from lowest to highest precedence
@@ -153,8 +155,11 @@ class ConfigManager(object):
                 sys.stderr.write("Unable to set correct type for %s, skipping" %  config)
                 continue
 
-            # set the constant
-            self.data.update_setting(Setting(config, value, origin))
+            # Configure the setting
+            self.data.update_setting(Setting(name=config,
+                                             value=value,
+                                             origin=origin,
+                                             **defs[config]))
 
 
     def find_ini_config_file(self):


### PR DESCRIPTION
##### SUMMARY
This replaces the Setting namedtuple by a simple class which allows
to easily write and read to supported attributes.
Data parsed from any keys (such as desc, or default) in config.yml are
now available to get and update dynamically.

With this and the new Plugin data type, it essentially allows a plugin
to programmatically and dynamically configure itself.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible/config/manager

##### ANSIBLE VERSION
```
ansible 2.4.0
```

##### ADDITIONAL INFORMATION
This is just a quick thing of something I've been thinking about after looking at the new configuration manager for a bit.
ARA has been using (<2.4's) constants.get_config to configure itself in the [same way](http://ara.readthedocs.io/en/latest/configuration.html#ara) as Ansible.

This makes configuring ARA simple to configure and use for end users because it respects the same hierarchy of precedence (~/.ansible.cfg, /etc/ansible/ansible.cfg, env vars, etc.).
I realize users could eventually configure their config.yml to contain the plugin configuration but this PR allows plugins to do things like set their own defaults and configuration dynamically.

For example:
```
from ansible.config.manager import ConfigManager
from ansible.config.data import Setting, Plugin

config = ConfigManager()
plugin = Plugin(name='ara',
                type='callbacks')
database = Setting(
    name='ARA_DATABASE',
    desc='Path to the ARA database',
    env=[ {'name': 'ARA_DATABASE'} ],
    ini=[ {'key': 'database', 'section': 'ara'} ],
    value_type='list',
    vars=[],
    yaml={ 'key': 'plugins.callbacks.ara.database' },
    value='sqlite://',
    origin='default'
)
config.data.update_setting(database, plugin=plugin)
```

Happy to discuss if this makes sense.