### PR TITLE
Fix undefined variable in libcloud dyn inv script

### DIFF
--- a/contrib/inventory/apache-libcloud.py
+++ b/contrib/inventory/apache-libcloud.py
@@ -248,8 +248,7 @@ class LibcloudInventory(object):
 
         node = self.get_node(node_id)
         instance_vars = {}
-        for key in vars(instance):
-            value = getattr(instance, key)
+        for key, value in vars(node).items():
             key = self.to_safe('ec2_' + key)
 
             # Handle complex types


### PR DESCRIPTION
##### SUMMARY
Working on fixing all undefined variables so we can turn on checking for those on every commit.  This fixes the libcloud dynamic inventory script.

Would like someone who uses the script or someone who knows the libcloud API to approve this PR as it's not entirely obvious this is the correct fix.

References #27193

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/apache-libcloud.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

##### ADDITIONAL INFORMATION
This bug will break anyone using apache-libcloud inventory with --hosts

/cc @sebgoa if you're still around, this is a small change.  Any chance you could review and approve it?