### PR TITLE
Fix undefined variable C in conf2yaml

### DIFF
--- a/hacking/conf2yaml.py
+++ b/hacking/conf2yaml.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 
 import ast
-import yaml
 import os
 import sys
+
+import yaml
+
+from ansible import constants as C
 from ansible.parsing.yaml.dumper import AnsibleDumper
 
 things = {}


### PR DESCRIPTION
##### SUMMARY

conf2yaml uses and undefined variable C in two places.  Fix that by importing ansible.constants as C.

References #27193

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hacking/conf2yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```