### PR TITLE
Fix undefined vars in network module_utils

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -28,7 +28,7 @@
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network_common import to_list, EntityCollection
-from ansible.module_utils.connection import Connection
+from ansible.module_utils.connection import Connection, exec_command
 
 _DEVICE_CONFIGS = {}
 _CONNECTION = None


### PR DESCRIPTION
Fixing undefined vars so we can have pylint catch them on every commit

References #27193 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

