### PR TITLE
Fix undefined vars on python3 and a whole bunch of other cleanup.

### DIFF
--- a/lib/ansible/module_utils/netscaler.py
+++ b/lib/ansible/module_utils/netscaler.py
@@ -32,6 +32,7 @@ import json
 import re
 
 from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.six import binary_type, text_type
 
 
 class ConfigProxy(object):
@@ -260,65 +261,43 @@ def monkey_patch_nitro_api():
     from nssrc.com.citrix.netscaler.nitro.resource.base.Json import Json
 
     def new_resource_to_string_convert(self, resrc):
-        try:
-            # Line below is the actual patch
-            dict_valid_values = dict((k.replace('_', '', 1), v) for k, v in resrc.__dict__.items() if v)
-            return json.dumps(dict_valid_values)
-        except Exception as e:
-            raise e
+        # Line below is the actual patch
+        dict_valid_values = dict((k.replace('_', '', 1), v) for k, v in resrc.__dict__.items() if v)
+        return json.dumps(dict_valid_values)
     Json.resource_to_string_convert = new_resource_to_string_convert
 
     from nssrc.com.citrix.netscaler.nitro.util.nitro_util import nitro_util
 
     @classmethod
     def object_to_string_new(cls, obj):
-        try:
-            str_ = ""
-            flds = obj.__dict__
-            # Line below is the actual patch
-            flds = dict((k.replace('_', '', 1), v) for k, v in flds.items() if v)
-            if (flds):
-                for k, v in flds.items():
-                    str_ = str_ + "\"" + k + "\":"
-                    if type(v) is unicode:
-                        v = v.encode('utf8')
-                    if type(v) is bool:
-                        str_ = str_ + v
-                    elif type(v) is str:
-                        str_ = str_ + "\"" + v + "\""
-                    elif type(v) is int:
-                        str_ = str_ + "\"" + str(v) + "\""
-                    if str_:
-                        str_ = str_ + ","
-            return str_
-        except Exception as e:
-            raise e
+        output = []
+        flds = obj.__dict__
+        for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
+            output.append('"%s":' % k)
+            if isinstance(v, bool):
+                output.append(str(v))
+            elif isinstance(v, (binary_type, text_type)):
+                v = to_native(v, errors='surrogate_or_strict')
+                output.append('"%s"' % v)
+            elif isinstance(v, int):
+                output.append('"%s"' % v)
+            output.append(",")
+        return ''.join(output)
 
     @classmethod
     def object_to_string_withoutquotes_new(cls, obj):
-        try:
-            str_ = ""
-            flds = obj.__dict__
-            # Line below is the actual patch
-            flds = dict((k.replace('_', '', 1), v) for k, v in flds.items() if v)
-            i = 0
-            if (flds):
-                for k, v in flds.items():
-                    str_ = str_ + k + ":"
-                    if type(v) is unicode:
-                        v = v.encode('utf8')
-                    if type(v) is bool:
-                        str_ = str_ + v
-                    elif type(v) is str:
-                        str_ = str_ + cls.encode(v)
-                    elif type(v) is int:
-                        str_ = str_ + str(v)
-                    i = i + 1
-                    if i != (len(flds.items())) and str_:
-                        str_ = str_ + ","
-            return str_
-        except Exception as e:
-            raise e
+        output = []
+        flds = obj.__dict__
+        for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
+            output.append('%s:' % k)
+            if isinstance(v, bool):
+                output.append(str(v))
+            elif isinstance(v, (binary_type, text_type)):
+                v = to_native(v, errors='surrogate_or_strict')
+                output.append(cls.encode(v))
+            elif isinstance(v, int):
+                output.append(str(v))
+        return ','.join(output)
 
     nitro_util.object_to_string = object_to_string_new
     nitro_util.object_to_string_withoutquotes = object_to_string_withoutquotes_new

--- a/lib/ansible/module_utils/netscaler.py
+++ b/lib/ansible/module_utils/netscaler.py
@@ -33,6 +33,7 @@ import re
 
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.six import binary_type, text_type
+from ansible.module_utils._text import to_native
 
 
 class ConfigProxy(object):
@@ -273,30 +274,27 @@ def monkey_patch_nitro_api():
         output = []
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
-            output.append('"%s":' % k)
             if isinstance(v, bool):
-                output.append(str(v))
+                output.append('"%s": %s' % (k, str(v)))
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
-                output.append('"%s"' % v)
+                output.append('"%s": "%s"' % (k, v))
             elif isinstance(v, int):
-                output.append('"%s"' % v)
-            output.append(",")
-        return ''.join(output)
+                output.append('"%s": "%s"' % (k, v))
+        return ','.join(output)
 
     @classmethod
     def object_to_string_withoutquotes_new(cls, obj):
         output = []
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
-            output.append('%s:' % k)
             if isinstance(v, bool):
-                output.append(str(v))
+                output.append('%s: %s' % (k, str(v))
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
-                output.append(cls.encode(v))
+                output.append('%s: %s' % (k, cls.encode(v)))
             elif isinstance(v, int):
-                output.append(str(v))
+            output.append('%s: %s' % (k, str(v)))
         return ','.join(output)
 
     nitro_util.object_to_string = object_to_string_new

--- a/lib/ansible/module_utils/netscaler.py
+++ b/lib/ansible/module_utils/netscaler.py
@@ -275,12 +275,12 @@ def monkey_patch_nitro_api():
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
             if isinstance(v, bool):
-                output.append('"%s": %s' % (k, v))
+                output.append('"%s":%s' % (k, v))
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
-                output.append('"%s": "%s"' % (k, v))
+                output.append('"%s":"%s"' % (k, v))
             elif isinstance(v, int):
-                output.append('"%s": "%s"' % (k, v))
+                output.append('"%s":"%s"' % (k, v))
         return ','.join(output)
 
     @classmethod
@@ -289,10 +289,10 @@ def monkey_patch_nitro_api():
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
             if isinstance(v, (int, bool)):
-                output.append('%s: %s' % (k, v)
+                output.append('%s:%s' % (k, v)
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
-                output.append('%s: %s' % (k, cls.encode(v)))
+                output.append('%s:%s' % (k, cls.encode(v)))
         return ','.join(output)
 
     nitro_util.object_to_string = object_to_string_new

--- a/lib/ansible/module_utils/netscaler.py
+++ b/lib/ansible/module_utils/netscaler.py
@@ -289,7 +289,7 @@ def monkey_patch_nitro_api():
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
             if isinstance(v, (int, bool)):
-                output.append('%s:%s' % (k, v)
+                output.append('%s:%s' % (k, v))
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
                 output.append('%s:%s' % (k, cls.encode(v)))

--- a/lib/ansible/module_utils/netscaler.py
+++ b/lib/ansible/module_utils/netscaler.py
@@ -275,7 +275,7 @@ def monkey_patch_nitro_api():
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
             if isinstance(v, bool):
-                output.append('"%s": %s' % (k, str(v)))
+                output.append('"%s": %s' % (k, v))
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
                 output.append('"%s": "%s"' % (k, v))
@@ -288,13 +288,11 @@ def monkey_patch_nitro_api():
         output = []
         flds = obj.__dict__
         for k, v in ((k.replace('_', '', 1), v) for k, v in flds.items() if v):
-            if isinstance(v, bool):
-                output.append('%s: %s' % (k, str(v))
+            if isinstance(v, (int, bool)):
+                output.append('%s: %s' % (k, v)
             elif isinstance(v, (binary_type, text_type)):
                 v = to_native(v, errors='surrogate_or_strict')
                 output.append('%s: %s' % (k, cls.encode(v)))
-            elif isinstance(v, int):
-            output.append('%s: %s' % (k, str(v)))
         return ','.join(output)
 
     nitro_util.object_to_string = object_to_string_new


### PR DESCRIPTION
Please review, especially the potential logic errors as I don't know what the
correct code should do there.

References #27193

* refactored new_resource_to_string_convert:
  * No need to catch any exception and then reraise it. Just let it continue to
    bubble up until caught.  Catching it and reraising it just serves to
    obfusscate the traceback which will make any problems much harder to debug

* refactored object_to_string_new:
  * No need to catch exception and reraise.  This just obfuscates the traceback
  * Build up a list and then join at the end instead of building up a string.
    list.append() is faster than string concatenation
  * No need to extract k, v pairs from one dict to make a second dict and then
    extract k, v pairs from the second dict.  Iterate over the k, v pairs
    extracted from the first dict directly instead of building the second dict.
  * No need to check if the dict is empty before iterating on it.  Iterating on
    an empty dict will automatically go to the end of the loop
  * Use isinstance instead of type(obj) is class, handles inheritance and is better style
  * use to_native instead of v.encode().  We can use the surrogate_or_strict
    error handler to deal with more potential tracebacks.  Does the right
    conversion on both Py2 and Py3.
  * Convert bool to string before combining it with the string we're building.
    This would have raised an exception as you can't add a bool to a string
  * Don't reference unicode directly as unicode does not exist in Python3
  * Convert int into a string before combining with a string we're building.
    This would have raised an exception as you can't add a bool to a string
  * Possible logical errors that I didn't change:
    * bools are not surrounded by quotes but ints are.
    * strings are not passed through cls.encode() while they are in
      object_to_string_withoutquotes_new()
    * The string resulting from this function will have a trailing comma
      whereas object_to_string_withoutquotes_new() will not have a trailing
      comma

* refactored object_to_string_withoutquotes_new:
  * No need to catch exception and reraise.  This just obfuscates the traceback
  * Build up a list and then join at the end instead of building up a string.
    list.append() is faster than string concatenation
  * No need to extract k, v pairs from one dict to make a second dict and then
    extract k, v pairs from the second dict.  Iterate over the k, v pairs
    extracted from the first dict directly instead of building the second dict.
  * No need to check if the dict is empty before iterating on it.  Iterating on
    an empty dict will automatically go to the end of the loop
  * Use isinstance instead of type(obj) is class, handles inheritance and is better style
  * use to_native instead of v.encode().  We can use the surrogate_or_strict
    error handler to deal with more potential tracebacks.  Does the right
    conversion on both Py2 and Py3.
  * Convert bool to string before combining it with the string we're building.
    This would have raised an exception as you can't add a bool to a string
  * Don't reference unicode directly as unicode does not exist in Python3
  * Possible logical errors that I didn't change:
    * strings are passed through cls.encode() while they are not passed through
      that function in object_to_string_new()
    * The string resulting from this function will not have a trailing comma
      whereas object_to_string_new() will have a trailing comma

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/netscaler.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```