### PR TITLE
Add missing import for basic_auth_argument_spec

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -26,6 +26,7 @@ from ansible.module_utils.six.moves.urllib.error import HTTPError
 
 from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.urls import open_url
+from ansible.module_utils.api import basic_auth_argument_spec
 
 HAS_NETAPP_LIB = False
 try:


### PR DESCRIPTION
##### SUMMARY
Fix adds a missing import for basic_auth_argument_spec in
netapp module_utils.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/netapp.py

##### ANSIBLE VERSION
```
2.4devel
```