### PR TITLE
Fix legacy su handling (bad conditional would not fire at the right time)

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -418,7 +418,7 @@ class PlayContext(Base):
                     if sudo_pass_name in variables:
                         setattr(new_info, 'become_pass', variables[sudo_pass_name])
                         break
-            if new_info.become_method == 'sudo':
+            elif new_info.become_method == 'su':
                 for su_pass_name in MAGIC_VARIABLE_MAPPING.get('su_pass'):
                     if su_pass_name in variables:
                         setattr(new_info, 'become_pass', variables[su_pass_name])


### PR DESCRIPTION

##### SUMMARY
The conditional was probably copied from earlier and was looking for sudo.  Since this is registering legacy su variables, it should be looking for su.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/playbook/play_context.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```
