### PR TITLE
Fix EntityCollection stacktrace

### DIFF
--- a/lib/ansible/module_utils/network_common.py
+++ b/lib/ansible/module_utils/network_common.py
@@ -173,7 +173,7 @@ class EntityCollection(Entity):
             iterable = [super(EntityCollection, self).__call__(self._module.params, strict)]
 
         if not isinstance(iterable, (list, tuple)):
-            module.fail_json(msg='value must be an iterable')
+            self._module.fail_json(msg='value must be an iterable')
 
         return [(super(EntityCollection, self).__call__(i, strict)) for i in iterable]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make EntityCollection fail gracefully instead of a stacktrace.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/network_common.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
