### PR TITLE
Fixes for broken asa_config module

### DIFF
--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -103,8 +103,9 @@ def to_commands(module, commands):
 
 
 def run_commands(module, commands, check_rc=True):
-    commands = to_commands(module, to_list(commands))
     connection = get_connection(module)
+
+    commands = to_commands(module, to_list(commands))
 
     responses = list()
 
@@ -116,9 +117,13 @@ def run_commands(module, commands, check_rc=True):
 
 
 def get_config(module, flags=[]):
-    cmd = 'show running-config '
-    cmd += ' '.join(flags)
-    cmd = cmd.strip()
+    passwords = module.params['passwords']
+    if passwords:
+        cmd = 'more system:running-config'
+    else:
+        cmd = 'show running-config '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
 
     try:
         return _DEVICE_CONFIGS[cmd]

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -77,11 +77,6 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
 
-        # take the shell out of enable mode
-        if pc.become:
-            req = json.dumps(request_builder('get', 'disable'))
-            out = connection.exec_command(req)
-
         return result
 
     def load_provider(self):

--- a/lib/ansible/plugins/action/asa_config.py
+++ b/lib/ansible/plugins/action/asa_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2015 Peter Sprygada <psprygada@ansible.com>
+# (c) 2017, Red Hat, Inc.
 #
 # This file is part of Ansible
 #
@@ -19,9 +19,94 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible.plugins.action import ActionBase
-from ansible.plugins.action.net_config import ActionModule as NetActionModule
+import os
+import re
+import time
+import glob
+
+from ansible.plugins.action.asa import ActionModule as _ActionModule
+from ansible.module_utils._text import to_text
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.utils.vars import merge_hash
+
+PRIVATE_KEYS_RE = re.compile('__.+__')
 
 
-class ActionModule(NetActionModule, ActionBase):
-    pass
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._task.args.get('src'):
+            try:
+                self._handle_template()
+            except ValueError as exc:
+                return dict(failed=True, msg=exc.message)
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        if self._task.args.get('backup') and result.get('__backup__'):
+            # User requested backup and no error occurred in module.
+            # NOTE: If there is a parameter error, _backup key may not be in results.
+            filepath = self._write_backup(task_vars['inventory_hostname'],
+                                          result['__backup__'])
+
+            result['backup_path'] = filepath
+
+        # strip out any keys that have two leading and two trailing
+        # underscore characters
+        for key in result.keys():
+            if PRIVATE_KEYS_RE.match(key):
+                del result[key]
+
+        return result
+
+    def _get_working_path(self):
+        cwd = self._loader.get_basedir()
+        if self._task._role is not None:
+            cwd = self._task._role._role_path
+        return cwd
+
+    def _write_backup(self, host, contents):
+        backup_path = self._get_working_path() + '/backup'
+        if not os.path.exists(backup_path):
+            os.mkdir(backup_path)
+        for fn in glob.glob('%s/%s*' % (backup_path, host)):
+            os.remove(fn)
+        tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
+        filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
+        open(filename, 'w').write(contents)
+        return filename
+
+    def _handle_template(self):
+        src = self._task.args.get('src')
+        working_path = self._get_working_path()
+
+        if os.path.isabs(src) or urlsplit('src').scheme:
+            source = src
+        else:
+            source = self._loader.path_dwim_relative(working_path, 'templates', src)
+            if not source:
+                source = self._loader.path_dwim_relative(working_path, src)
+
+        if not os.path.exists(source):
+            raise ValueError('path specified in src not found')
+
+        try:
+            with open(source, 'r') as f:
+                template_data = to_text(f.read())
+        except IOError:
+            return dict(failed=True, msg='unable to load src file')
+
+        # Create a template search path in the following order:
+        # [working_path, self_role_path, dependent_role_paths, dirname(source)]
+        searchpath = [working_path]
+        if self._task._role is not None:
+            searchpath.append(self._task._role._role_path)
+            if hasattr(self._task, "_block:"):
+                dep_chain = self._task._block.get_dep_chain()
+                if dep_chain is not None:
+                    for role in dep_chain:
+                        searchpath.append(role._role_path)
+        searchpath.append(os.path.dirname(source))
+        self._templar.environment.loader.searchpath = searchpath
+        self._task.args['src'] = self._templar.template(template_data)

--- a/lib/ansible/plugins/terminal/asa.py
+++ b/lib/ansible/plugins/terminal/asa.py
@@ -51,7 +51,7 @@ class TerminalModule(TerminalBase):
             raise AnsibleConnectionFailure('unable to disable terminal pager')
 
     def on_authorize(self, passwd=None):
-        if self._get_prompt().endswith(b'#'):
+        if self._get_prompt().strip().endswith(b'#'):
             return
 
         cmd = {u'command': u'enable'}


### PR DESCRIPTION
##### SUMMARY
The ASA modules (networking) stopped working in Ansible 2.3. This PR will fix the asa_config module, however it doesn't yet address all of the functionality. The action plugin asa_config was removed (and will have to be re-added) so the template / backup feature hasn't been implemented yet.

Also the [enable mode decorator](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/cliconf/__init__.py#L44-L51) seems unreliable for this code. So it doesn't always work when a isn't logged into enabled mode from the start. It looks like the authorize function doesn't always trigger upon connecting. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - asa_config

##### ANSIBLE VERSION
```
ansible 2.4.0 (asa_config_migration cf6de2c281) last updated 2017/07/24 08:57:33 (GMT +200)
  config file = None
  configured module search path = [u'/Users/patrick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/patrick/src/forks/ansible/lib/ansible
  executable location = /Users/patrick/src/forks/ansible/bin/ansible
  python version = 2.7.10 (default, Sep 11 2015, 19:53:23) [GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
