### PR TITLE
extend plugin loader skip list to blacklist_exts

### DIFF
--- a/lib/ansible/plugins/__init__.py
+++ b/lib/ansible/plugins/__init__.py
@@ -274,7 +274,7 @@ class PluginLoader:
                 # FIXME: I believe this is only correct for modules and
                 # module_utils.  For all other plugins we want .pyc and .pyo should
                 # bew valid
-                if full_path.endswith(('.pyc', '.pyo')):
+                if full_path.endswith(C.BLACKLIST_EXTS):
                     continue
 
                 splitname = os.path.splitext(full_name)


### PR DESCRIPTION
##### SUMMARY

fixes #22268
<!--- Describe the change, including rationale and design decisions -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugin loader

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```