### PR TITLE
leftover from porting become to v2 that's unused

### DIFF
--- a/lib/ansible/playbook/become.py
+++ b/lib/ansible/playbook/become.py
@@ -93,12 +93,3 @@ class Become:
             display.deprecated("Instead of su/su_user, use become/become_user and set become_method to 'su' (default is sudo)", '2.6')
 
         return ds
-
-    def set_become_defaults(self, become, become_method, become_user):
-        ''' if we are becoming someone else, but some fields are unset,
-            make sure they're initialized to the default config values  '''
-        if become:
-            if become_method is None:
-                become_method = C.DEFAULT_BECOME_METHOD
-            if become_user is None:
-                become_user = C.DEFAULT_BECOME_USER

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -455,9 +455,6 @@ class PlayContext(Base):
         if new_info.no_log is None:
             new_info.no_log = C.DEFAULT_NO_LOG
 
-        # set become defaults if not previouslly set
-        task.set_become_defaults(new_info.become, new_info.become_method, new_info.become_user)
-
         if task.always_run:
             display.deprecated("always_run is deprecated. Use check_mode = no instead.", version="2.4", removed=False)
             new_info.check_mode = False


### PR DESCRIPTION
The set_become_default() function is not needed.  All this time, if it
was called it would try to set a value on a passed by value variable
(meaning that it had no effect after returning to the caller).  Since
become has been working in v2, this code is not needed.  Removing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/become.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```