### PR TITLE
ios_facts: Add try/except to catch ipv6 interfaces that didn't appear on 'show i…

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -299,7 +299,11 @@ class Interfaces(FactsBase):
 
     def populate_ipv6_interfaces(self, data):
         for key, value in iteritems(data):
-            self.facts['interfaces'][key]['ipv6'] = list()
+            try:
+                self.facts['interfaces'][key]['ipv6'] = list()
+            except KeyError:
+                self.facts['interfaces'][key] = dict()
+                self.facts['interfaces'][key]['ipv6'] = list()
             addresses = re.findall(r'\s+(.+), subnet', value, re.M)
             subnets = re.findall(r', subnet is (.+)$', value, re.M)
             for addr, subnet in zip(addresses, subnets):


### PR DESCRIPTION
…nterfaces' output

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This adds a try/except function for when Cisco IOS presents different interfaces between the `show interface` and `show ipv6 interface` commands. If an interface is present in the IPv6 output, but not the standard interface output, it will cause a KeyError and ansible fails.

Now, if a KeyError is encountered, it creates the entry for the interface and adds the IPv6 list and the playbook can continue.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #27242 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /opt/isv/netflow/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 24 2016, 13:29:06) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```
##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
TASK [Get Cisco Facts] ***************************************************************************************************************************
task path: /opt/ansible/cisco-router.yaml:20
<cisco_rtr1> using connection plugin network_cli
<cisco_rtr1> socket_path: /home/usertest/.ansible/pc/23176f0a55
open_shell() returned 0 ok 
Using module file /opt/virtualenvs/ansiblerun/lib/python2.7/site-packages/ansible/modules/network/ios/ios_facts.py
<cisco_rtr1> ESTABLISH LOCAL CONNECTION FOR USER: usertest
<cisco_rtr1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<cisco_rtr1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600 `" && echo ansible-tmp-1500908715.18-68393613750600="` echo /home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600 `" ) && sleep 0'
<cisco_rtr1> PUT /tmp/tmpRQRKJf TO /home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600/ios_facts.py
<cisco_rtr1> EXEC /bin/sh -c 'chmod u+x /home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600/ /home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600/ios_facts.py && sleep 0'
<cisco_rtr1> EXEC /bin/sh -c '/usr/bin/python /home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600/ios_facts.py; rm -rf "/home/usertest/.ansible/tmp/ansible-tmp-1500908715.18-68393613750600/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_POLuRN/ansible_module_ios_facts.py", line 489, in <module>
    main()
  File "/tmp/ansible_POLuRN/ansible_module_ios_facts.py", line 474, in main
    inst.populate()
  File "/tmp/ansible_POLuRN/ansible_module_ios_facts.py", line 269, in populate
    self.populate_ipv6_interfaces(data)
  File "/tmp/ansible_POLuRN/ansible_module_ios_facts.py", line 302, in populate_ipv6_interfaces
    self.facts['interfaces'][key]['ipv6'] = list()
KeyError: 'VoIP-Null0'

fatal: [cisco_rtr1]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_POLuRN/ansible_module_ios_facts.py\", line 489, in <module>\n    main()\n  File \"/tmp/ansible_POLuRN/ansible_module_ios_facts.py\", line 474, in main\n    inst.populate()\n  File \"/tmp/ansible_POLuRN/ansible_module_ios_facts.py\", line 269, in populate\n    self.populate_ipv6_interfaces(data)\n  File \"/tmp/ansible_POLuRN/ansible_module_ios_facts.py\", line 302, in populate_ipv6_interfaces\n    self.facts['interfaces'][key]['ipv6'] = list()\nKeyError: 'VoIP-Null0'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
        to retry, use: --limit @/opt/ansible/cisco-router.retry
```

and after:
```
TASK [debug] *******************************************************************************************************************************************************************
ok: [cisco_rtr] => {
    "rtrinfo": {
        "ansible_facts": {
            "ansible_net_all_ipv4_addresses": [
                "redacted", 
                "redacted", 
            ], 
            "ansible_net_all_ipv6_addresses": [], 
            "ansible_net_gather_subset": [
                "default", 
                "interfaces"
            ], 
            "ansible_net_hostname": "cisco_rtr", 
            "ansible_net_image": "flash:c2951-universalk9-mz.SPA.154-3.M3.bin", 
            "ansible_net_interfaces": {
                "EDSP0": {
                    "ipv6": []
                }, 
                "EDSP0.1": {
                    "ipv6": []
                }, 
                "EDSP0.2": {
                    "ipv6": []
                }, 
                "EDSP0.3": {
                    "ipv6": []
                }, 
                "EDSP0.4": {
                    "ipv6": []
                }, 
                "EDSP0.5": {
                    "ipv6": []
                }, 
                "Embedded-Service-Engine0/0": {
                    "bandwidth": 10000, 
                    "description": null, 
                    "duplex": null, 
                    "ipv4": null, 
                    "lineprotocol": "down ", 
                    "macaddress": "0000.0000.0000", 
                    "mediatype": null, 
                    "mtu": 1500, 
                    "operstatus": "administratively down", 
                    "type": "Embedded Service Engine"
                }, 
                "GigabitEthernet0/0": {
                    "bandwidth": 1000000, 
                    "description": "REDACTED", 
                    "duplex": "Full", 
                    "ipv4": null, 
                    "lineprotocol": "up ", 
                    "macaddress": "6c20.565d.cde0", 
                    "mediatype": "RJ45", 
                    "mtu": 1500, 
                    "operstatus": "up", 
                    "type": "PQ3_TSEC"
                }, 
                "GigabitEthernet0/1": {
                    "bandwidth": 1000000, 
                    "description": "REDACTED", 
                    "duplex": "Full", 
                    "ipv4": null, 
                    "lineprotocol": "up ", 
                    "macaddress": "6c20.565d.cde0", 
                    "mediatype": "RJ45", 
                    "mtu": 1500, 
                    "operstatus": "up", 
                    "type": "PQ3_TSEC"
                }, 
                "VoIP-Null0": {
                    "ipv6": []
                }, 
                "VoipNull0.1": {
                    "ipv6": []
                }, 
            }, 
            "ansible_net_model": "CISCO2951/K9", 
            "ansible_net_neighbors": {
                "null": [
                    {
                        "host": null, 
                        "port": null
                    }
                ]
            }, 
            "ansible_net_serialnum": "REDACTED", 
            "ansible_net_version": "15.4(3)M3"
        }, 
        "changed": false
    }
}

PLAY RECAP *********************************************************************************************************************************************************************
cisco_rtr : ok=4    changed=0    unreachable=0    failed=0  
```
