### PR TITLE
Fix cloudformation module for import of non-module_utils file

### DIFF
--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -3,7 +3,6 @@ lib/ansible/module_utils/avi.py
 lib/ansible/module_utils/azure_rm_common.py
 lib/ansible/module_utils/ovirt.py
 lib/ansible/module_utils/six/__init__.py
-lib/ansible/modules/cloud/amazon/cloudformation.py
 lib/ansible/modules/cloud/amazon/cloudtrail.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_dhcp_options.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py


### PR DESCRIPTION
##### SUMMARY

cloudformation module was trying to import a module from an install of ansible.  That would mean that ansible would have to be installed on the remote machine.  Fix that by using hashlib directly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/amazon/cloudformation.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
This code is not in the stable-2.3 branch so does not need to be backported
```

```
