### PR TITLE
Port cs_facts to the ansible 2.4 facts API

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_facts.py
@@ -123,9 +123,9 @@ class CloudStackFacts(object):
     def __init__(self):
         collector = ansible_collector.get_ansible_collector(all_collector_classes=default_collectors.collectors,
                                                             filter_spec='default_ipv4',
-                                                            gather_subset=['network'],
+                                                            gather_subset=['!all', 'network'],
                                                             gather_timeout=10)
-        self.facts = fact_collector.collect(module)
+        self.facts = collector.collect(module)
 
         self.api_ip = None
         self.fact_paths = {

--- a/lib/ansible/modules/cloud/cloudstack/cs_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_facts.py
@@ -106,7 +106,7 @@ cloudstack_user_data:
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
-from ansible.module_utils.facts import ansible_facts, module
+from ansible.module_utils.facts import ansible_collector, default_collectors
 
 try:
     import yaml
@@ -121,7 +121,12 @@ CS_USERDATA_BASE_URL = "http://%s/latest/user-data"
 class CloudStackFacts(object):
 
     def __init__(self):
-        self.facts = ansible_facts(module)
+        collector = ansible_collector.get_ansible_collector(all_collector_classes=default_collectors.collectors,
+                                                            filter_spec='default_ipv4',
+                                                            gather_subset=['network'],
+                                                            gather_timeout=10)
+        self.facts = fact_collector.collect(module)
+
         self.api_ip = None
         self.fact_paths = {
             'cloudstack_service_offering': 'service-offering',


### PR DESCRIPTION
Fixes #27256
References #27254

##### SUMMARY
The facts API has changed in 2.4.  Need to port cs_facts to the new API as it calls facts to figure out dhcp leases.

This is also needed for enabling pylint tests for undefined varialbes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/cloudstack/cs_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```