### PR TITLE
Remove the error checking from apply_patch()

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_smu.py
+++ b/lib/ansible/modules/network/nxos/nxos_smu.py
@@ -114,8 +114,6 @@ def apply_patch(module, commands):
     for command in commands:
         load_config(module, [command])
         time.sleep(5)
-        if 'failed' in response:
-            module.fail_json(msg="Operation failed!", response=response)
 
 
 def get_commands(module, pkg, file_system):


### PR DESCRIPTION
The error checking would itself cause a traceback.  The load_config()
function that we'd need to check for errors from only returns None so
there's no way to check for errors via the return value.  In the future
someone could rewrite the load_config function to return useful
information and restore the error checking but for now this is better as
it won't traceback on success and it will let us turn on static analysis
of undefined variables

Fixes #27255
References #27254

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/network/nxos/nxos_smu.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```
