### PR TITLE
Allow user to set rabbitmqctl path

### DIFF
--- a/lib/ansible/module_utils/rabbitmq.py
+++ b/lib/ansible/module_utils/rabbitmq.py
@@ -1,0 +1,31 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c) 2017 Ansible Project
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+rabbitmq_argument_spec_extra_ctl_paths = {
+    'extra_ctl_paths': dict(default=list(), type='list')
+}

--- a/lib/ansible/modules/messaging/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost.py
@@ -17,6 +17,8 @@ DOCUMENTATION = '''
 ---
 module: rabbitmq_vhost
 short_description: Manage the state of a virtual host in RabbitMQ
+extends_documentation_fragment:
+    - rabbitmq.extra_ctl_paths
 description:
   - Manage the state of a virtual host in RabbitMQ
 version_added: "1.1"
@@ -52,20 +54,34 @@ EXAMPLES = '''
 - rabbitmq_vhost:
     name: /test
     state: present
+
+# Ensure that the vhost /test exists using rabbitmqctl from
+# /usr/lib/rabbitmq/lib/rabbitmq_server-3.6.2/sbin/rabbitmqctl
+- rabbitmq_vhost:
+    name: /test
+    extra_ctl_paths:
+      - '/usr/lib/rabbitmq/lib/rabbitmq_server-3.6.2/sbin'
+    state: present
 '''
+
+from ansible.module_utils.rabbitmq import rabbitmq_argument_spec_extra_ctl_paths
+from ansible.module_utils.basic import AnsibleModule
+
 
 from ansible.module_utils.basic import AnsibleModule
 
 
 class RabbitMqVhost(object):
-    def __init__(self, module, name, tracing, node):
+    def __init__(self, module, name, tracing, node, extra_ctl_paths):
         self.module = module
         self.name = name
         self.tracing = tracing
         self.node = node
+        self.extra_ctl_paths = extra_ctl_paths
 
         self._tracing = False
-        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
+        self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True,
+                                                self.extra_ctl_paths)
 
     def _exec(self, args, run_in_check_mode=False):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
@@ -111,8 +127,10 @@ def main():
         name=dict(required=True, aliases=['vhost']),
         tracing=dict(default='off', aliases=['trace'], type='bool'),
         state=dict(default='present', choices=['present', 'absent']),
-        node=dict(default='rabbit'),
+        node=dict(default='rabbit')
     )
+
+    arg_spec.update(rabbitmq_argument_spec_extra_ctl_paths)
 
     module = AnsibleModule(
         argument_spec=arg_spec,
@@ -123,8 +141,9 @@ def main():
     tracing = module.params['tracing']
     state = module.params['state']
     node = module.params['node']
+    extra_ctl_paths = module.params['extra_ctl_paths']
     result = dict(changed=False, name=name, state=state)
-    rabbitmq_vhost = RabbitMqVhost(module, name, tracing, node)
+    rabbitmq_vhost = RabbitMqVhost(module, name, tracing, node, extra_ctl_paths)
 
     if rabbitmq_vhost.get():
         if state == 'absent':

--- a/lib/ansible/utils/module_docs_fragments/rabbitmq.py
+++ b/lib/ansible/utils/module_docs_fragments/rabbitmq.py
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2017 Ansible Project
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Documentation fragment for EXTRA CTL PATHS
+    EXTRA_CTL_PATHS = """
+options:
+  extra_ctl_paths:
+      description:
+        - List of alternative paths to look for rabbitmqctl in
+        - Only needed when running RabbitMQ as user other than root / rabbitmq
+      required: false
+      default: ()
+      version_added: "2.4"
+"""

--- a/lib/ansible/utils/module_docs_fragments/rabbitmq.py
+++ b/lib/ansible/utils/module_docs_fragments/rabbitmq.py
@@ -1,6 +1,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 # Copyright: (c) 2017, Ansible Project
 
+
 class ModuleDocFragment(object):
 
     # Documentation fragment for EXTRA CTL PATHS

--- a/lib/ansible/utils/module_docs_fragments/rabbitmq.py
+++ b/lib/ansible/utils/module_docs_fragments/rabbitmq.py
@@ -1,21 +1,5 @@
-#
-# Copyright (c) 2017 Ansible Project
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Copyright: (c) 2017, Ansible Project
 
 class ModuleDocFragment(object):
 
@@ -28,5 +12,5 @@ options:
         - Only needed when running RabbitMQ as user other than root / rabbitmq
       required: false
       default: ()
-      version_added: "2.4"
+      version_added: "2.5"
 """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #22945

This replaces https://github.com/ansible/ansible/pull/25601 which I damaged
through a rebase.

Added extra_ctl_paths as an optional setting to allow users who need to run
rabbitmqctl commands as a non-root user to set the path to this binary.

This is only needed by users in non-standard RabbitMQ environments as the
rabbitmqctl script includes checks on which user is running it and fails if
being run by a user other than root or rabbitmqctl.

As an example, on RHEL 6 with RabbitMQ 3.6.2,
/usr/lib/rabbitmq/lib/rabbitmq_server-3.6.2/sbin/rabbitmqctl can be run as a
user other than root or rabbitmq.

This solves the issue for some organisations who do not allow generic service
account names in different environments, or where Rabbit must be run as a
specific user for any other reason

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
messaging module (rabbitmq components)

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issues_22945_rabbitctl_path_config_test 1c40631382) last updated 2017/07/24 13:03:40 (GMT +100)
  config file = None
  configured module search path = [u'/Users/wpascoe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/wpascoe/development/ansible_upstream/lib/ansible
  executable location = /Users/wpascoe/development/ansible_upstream/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```

##### ADDITIONAL INFORMATION
Before the change, attempting to create a rabbit user when rabbitmq is not running as root or rabbitmq would result in the following:

```
TASK [rabbit : add rabbitmq user] ********************************************************************************************************************
fatal: [el6bt]: FAILED! => {"changed": false, "cmd": "/usr/sbin/rabbitmqctl -q list_users", "failed": true, "msg": "Error: could not recognise command", "rc": 1, "stderr": "Error: could not recognise command\n", "stderr_lines": ["Error: could not recognise command"], "stdout": "Usage:\nrabbitmqctl [-n <node>] [-t <timeout>] [-q] <command> [<command options>] \n\nOptions:\n    -n node\n    -q\n    -t timeout\n\nDefault node is \"rabbit@server\", where server is the local host. On a host \nnamed \"server.example.com\", the node name of the RabbitMQ Erlang node will \nusually be rabbit@server (unless RABBITMQ_NODENAME has been set to some \nnon-default value at broker startup time). The output of hostname -s is usually \nthe correct suffix to use after the \"@\" sign. See rabbitmq-server(1) for \ndetails of configuring the RabbitMQ broker.\n\nQuiet output mode is selected with the \"-q\" flag. Informational messages are \nsuppressed when quiet mode is in effect.\n\nOperation timeout in seconds. Only applicable to \"list\" commands. Default is \n\"infinity\".\n\nCommands:\n    stop [<pid_file>]\n    stop_app\n    start_app\n    wait <pid_file>\n    reset\n    force_reset\n    rotate_logs <suffix>\n\n    join_cluster <clusternode> [--ram]\n    cluster_status\n    change_cluster_node_type disc | ram\n    forget_cluster_node [--offline]\n    rename_cluster_node oldnode1 newnode1 [oldnode2] [newnode2 ...]\n    update_cluster_nodes clusternode\n    force_boot\n    sync_queue [-p <vhost>] queue\n    cancel_sync_queue [-p <vhost>] queue\n    purge_queue [-p <vhost>] queue\n    set_cluster_name name\n\n    add_user <username> <password>\n    delete_user <username>\n    change_password <username> <newpassword>\n    clear_password <username>\n    \n            authenticate_user <username> <password>\n          \n    set_user_tags <username> <tag> ...\n    list_users\n\n    add_vhost <vhost>\n    delete_vhost <vhost>\n    list_vhosts [<vhostinfoitem> ...]\n    set_permissions [-p <vhost>] <user> <conf> <write> <read>\n    clear_permissions [-p <vhost>] <username>\n    list_permissions [-p <vhost>]\n    list_user_permissions <username>\n\n    set_parameter [-p <vhost>] <component_name> <name> <value>\n    clear_parameter [-p <vhost>] <component_name> <key>\n    list_parameters [-p <vhost>]\n\n    set_policy [-p <vhost>] [--priority <priority>] [--apply-to <apply-to>] \n<name> <pattern>  <definition>\n    clear_policy [-p <vhost>] <name>\n    list_policies [-p <vhost>]\n\n    list_queues [-p <vhost>] [<queueinfoitem> ...]\n    list_exchanges [-p <vhost>] [<exchangeinfoitem> ...]\n    list_bindings [-p <vhost>] [<bindinginfoitem> ...]\n    list_connections [<connectioninfoitem> ...]\n    list_channels [<channelinfoitem> ...]\n    list_consumers [-p <vhost>]\n    status\n    node_health_check\n    environment\n    report\n    eval <expr>\n\n    close_connection <connectionpid> <explanation>\n    trace_on [-p <vhost>]\n    trace_off [-p <vhost>]\n    set_vm_memory_high_watermark <fraction>\n    set_vm_memory_high_watermark absolute <memory_limit>\n    set_disk_free_limit <disk_limit>\n    set_disk_free_limit mem_relative <fraction>\n\n<vhostinfoitem> must be a member of the list [name, tracing].\n\nThe list_queues, list_exchanges and list_bindings commands accept an optional \nvirtual host parameter for which to display results. The default value is \"/\".\n\n<queueinfoitem> must be a member of the list [name, durable, auto_delete, \narguments, policy, pid, owner_pid, exclusive, exclusive_consumer_pid, \nexclusive_consumer_tag, messages_ready, messages_unacknowledged, messages, \nmessages_ready_ram, messages_unacknowledged_ram, messages_ram, \nmessages_persistent, message_bytes, message_bytes_ready, \nmessage_bytes_unacknowledged, message_bytes_ram, message_bytes_persistent, \nhead_message_timestamp, disk_reads, disk_writes, consumers, \nconsumer_utilisation, memory, slave_pids, synchronised_slave_pids, state].\n\n<exchangeinfoitem> must be a member of the list [name, type, durable, \nauto_delete, internal, arguments, policy].\n\n<bindinginfoitem> must be a member of the list [source_name, source_kind, \ndestination_name, destination_kind, routing_key, arguments].\n\n<connectioninfoitem> must be a member of the list [pid, name, port, host, \npeer_port, peer_host, ssl, ssl_protocol, ssl_key_exchange, ssl_cipher, \nssl_hash, peer_cert_subject, peer_cert_issuer, peer_cert_validity, state, \nchannels, protocol, auth_mechanism, user, vhost, timeout, frame_max, \nchannel_max, client_properties, recv_oct, recv_cnt, send_oct, send_cnt, \nsend_pend, connected_at].\n\n<channelinfoitem> must be a member of the list [pid, connection, name, number, \nuser, vhost, transactional, confirm, consumer_count, messages_unacknowledged, \nmessages_uncommitted, acks_uncommitted, messages_unconfirmed, prefetch_count, \nglobal_prefetch_count].\n\n\n\nOnly root or rabbitmq should run rabbitmqctl\n\n", "stdout_lines": ["Usage:", "rabbitmqctl [-n <node>] [-t <timeout>] [-q] <command> [<command options>] ", "", "Options:", "    -n node", "    -q", "    -t timeout", "", "Default node is \"rabbit@server\", where server is the local host. On a host ", "named \"server.example.com\", the node name of the RabbitMQ Erlang node will ", "usually be rabbit@server (unless RABBITMQ_NODENAME has been set to some ", "non-default value at broker startup time). The output of hostname -s is usually ", "the correct suffix to use after the \"@\" sign. See rabbitmq-server(1) for ", "details of configuring the RabbitMQ broker.", "", "Quiet output mode is selected with the \"-q\" flag. Informational messages are ", "suppressed when quiet mode is in effect.", "", "Operation timeout in seconds. Only applicable to \"list\" commands. Default is ", "\"infinity\".", "", "Commands:", "    stop [<pid_file>]", "    stop_app", "    start_app", "    wait <pid_file>", "    reset", "    force_reset", "    rotate_logs <suffix>", "", "    join_cluster <clusternode> [--ram]", "    cluster_status", "    change_cluster_node_type disc | ram", "    forget_cluster_node [--offline]", "    rename_cluster_node oldnode1 newnode1 [oldnode2] [newnode2 ...]", "    update_cluster_nodes clusternode", "    force_boot", "    sync_queue [-p <vhost>] queue", "    cancel_sync_queue [-p <vhost>] queue", "    purge_queue [-p <vhost>] queue", "    set_cluster_name name", "", "    add_user <username> <password>", "    delete_user <username>", "    change_password <username> <newpassword>", "    clear_password <username>", "    ", "            authenticate_user <username> <password>", "          ", "    set_user_tags <username> <tag> ...", "    list_users", "", "    add_vhost <vhost>", "    delete_vhost <vhost>", "    list_vhosts [<vhostinfoitem> ...]", "    set_permissions [-p <vhost>] <user> <conf> <write> <read>", "    clear_permissions [-p <vhost>] <username>", "    list_permissions [-p <vhost>]", "    list_user_permissions <username>", "", "    set_parameter [-p <vhost>] <component_name> <name> <value>", "    clear_parameter [-p <vhost>] <component_name> <key>", "    list_parameters [-p <vhost>]", "", "    set_policy [-p <vhost>] [--priority <priority>] [--apply-to <apply-to>] ", "<name> <pattern>  <definition>", "    clear_policy [-p <vhost>] <name>", "    list_policies [-p <vhost>]", "", "    list_queues [-p <vhost>] [<queueinfoitem> ...]", "    list_exchanges [-p <vhost>] [<exchangeinfoitem> ...]", "    list_bindings [-p <vhost>] [<bindinginfoitem> ...]", "    list_connections [<connectioninfoitem> ...]", "    list_channels [<channelinfoitem> ...]", "    list_consumers [-p <vhost>]", "    status", "    node_health_check", "    environment", "    report", "    eval <expr>", "", "    close_connection <connectionpid> <explanation>", "    trace_on [-p <vhost>]", "    trace_off [-p <vhost>]", "    set_vm_memory_high_watermark <fraction>", "    set_vm_memory_high_watermark absolute <memory_limit>", "    set_disk_free_limit <disk_limit>", "    set_disk_free_limit mem_relative <fraction>", "", "<vhostinfoitem> must be a member of the list [name, tracing].", "", "The list_queues, list_exchanges and list_bindings commands accept an optional ", "virtual host parameter for which to display results. The default value is \"/\".", "", "<queueinfoitem> must be a member of the list [name, durable, auto_delete, ", "arguments, policy, pid, owner_pid, exclusive, exclusive_consumer_pid, ", "exclusive_consumer_tag, messages_ready, messages_unacknowledged, messages, ", "messages_ready_ram, messages_unacknowledged_ram, messages_ram, ", "messages_persistent, message_bytes, message_bytes_ready, ", "message_bytes_unacknowledged, message_bytes_ram, message_bytes_persistent, ", "head_message_timestamp, disk_reads, disk_writes, consumers, ", "consumer_utilisation, memory, slave_pids, synchronised_slave_pids, state].", "", "<exchangeinfoitem> must be a member of the list [name, type, durable, ", "auto_delete, internal, arguments, policy].", "", "<bindinginfoitem> must be a member of the list [source_name, source_kind, ", "destination_name, destination_kind, routing_key, arguments].", "", "<connectioninfoitem> must be a member of the list [pid, name, port, host, ", "peer_port, peer_host, ssl, ssl_protocol, ssl_key_exchange, ssl_cipher, ", "ssl_hash, peer_cert_subject, peer_cert_issuer, peer_cert_validity, state, ", "channels, protocol, auth_mechanism, user, vhost, timeout, frame_max, ", "channel_max, client_properties, recv_oct, recv_cnt, send_oct, send_cnt, ", "send_pend, connected_at].", "", "<channelinfoitem> must be a member of the list [pid, connection, name, number, ", "user, vhost, transactional, confirm, consumer_count, messages_unacknowledged, ", "messages_uncommitted, acks_uncommitted, messages_unconfirmed, prefetch_count, ", "global_prefetch_count].", "", "", "", "Only root or rabbitmq should run rabbitmqctl", ""]}
```

After the change, this succeeds:

```
TASK [rabbit : add rabbitmq user] ********************************************************************************************************************
ok: [host]
```
