### PR TITLE
docs: fix community meetings link

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -9,7 +9,7 @@ The roadmap will be updated by version. Based on team and community feedback, an
 
 These roadmaps are the team's *best guess* roadmaps based on the Ansible team's experience and are also based on requests and feedback from the community.  There are things that may not make it on due to time constraints, lack of community maintainers, etc.  And there may be things that got missed, so each roadmap is published both as an idea of what is upcoming in Ansible, and as a medium for seeking further feedback from the community. Here are the good places for you to submit feedback:
 
-- Add to the agenda of a `Core IRC Meetings <https://github.com/ansible/community/blob/master/MEETINGS.md>`_ (preferred)
+- Add to the agenda of a `Core IRC Meetings <https://github.com/ansible/community/blob/master/meetings/README.md>`_ (preferred)
 - Ansible's google-group: ansible-devel
 - AnsibleFest conferences.
 - IRC freenode channel: #ansible-devel (this one may have things lost in lots of conversation, so a caution).

--- a/docs/docsite/rst/community.rst
+++ b/docs/docsite/rst/community.rst
@@ -229,7 +229,7 @@ IRC Meetings
 ------------
 
 The Ansible community holds regular IRC meetings on various topics, and anyone who is interested is invited to 
-participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/MEETINGS.md>`_.
+participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
 
 Release Numbering
 -----------------
@@ -263,7 +263,7 @@ Ansible has several IRC channels on Freenode (irc.freenode.net):
 - ``#ansible-container`` - For discussions on Ansible Container.
 - ``#ansible-vmware`` - For discussions on Ansible & VMware.
 - ``#ansible-windows`` - For discussions on Ansible & Windows.
-- ``#ansible-meeting`` - For public community meetings. We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/MEETINGS.md>`_
+- ``#ansible-meeting`` - For public community meetings. We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
 - ``#ansible-notices`` - Mostly bot output from things like Github, etc.
 
 Notes on Priority Flags

--- a/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_in_groups.rst
@@ -26,7 +26,7 @@ Although it's tempting to get straight into coding, there are a few things to be
 * Shared code can be placed into ``lib/ansible/module_utils/``
 * Shared documentation (for example describing common arguments) can be placed in ``lib/ansible/utils/module_docs_fragments/``.
 * With great power comes great responsibility: Ansible module maintainers have a duty to help keep modules up to date. As with all successful community projects, module maintainers should keep a watchful eye for reported issues and contributions.
-* Although not required, unit and/or integration tests are strongly recommended. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :doc:`testing` and the `Testing Working Group <https://github.com/ansible/community/blob/master/MEETINGS.md>`_.
+* Although not required, unit and/or integration tests are strongly recommended. Unit tests are especially valuable when external resources (such as cloud or network devices) are required. For more information see :doc:`testing` and the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
   * Starting with Ansible 2.4 all :doc:`../list_of_network_modules` MUST have unit tests.
 
 
@@ -65,7 +65,7 @@ On :doc:`../community` you can find how to:
 
 * Subscribe to the Mailing Lists - We suggest "Ansible Development List" (for codefreeze info) and "Ansible Announce list"
 * ``#ansible-devel`` - We have found that IRC ``#ansible-devel`` on FreeNodes IRC network works best for module developers so we can have an interactive dialogue.
-* IRC meetings - Join the various weekly IRC meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/MEETINGS.md>`_
+* IRC meetings - Join the various weekly IRC meetings `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
 
 
 Your First Pull Request

--- a/docs/docsite/rst/dev_guide/testing.rst
+++ b/docs/docsite/rst/dev_guide/testing.rst
@@ -191,5 +191,5 @@ If the PR does not resolve the issue, or if you see any failures from the unit/i
 Want to know more about testing?
 ================================
 
-If you'd like to know more about the plans for improving testing Ansible then why not join the `Testing Working Group <https://github.com/ansible/community/blob/master/MEETINGS.md>`_.
+If you'd like to know more about the plans for improving testing Ansible then why not join the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
 

--- a/docs/docsite/rst/dev_guide/testing_compile.rst
+++ b/docs/docsite/rst/dev_guide/testing_compile.rst
@@ -64,4 +64,4 @@ The full list of requirements can be found at `test/runner/requirements <https:/
 Extending compile tests
 =======================
 
-If you believe changes are needed to the Compile tests please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/MEETINGS.md>`_ so it can be discussed.
+If you believe changes are needed to the Compile tests please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/meetings/README.md>`_ so it can be discussed.

--- a/docs/docsite/rst/dev_guide/testing_httptester.rst
+++ b/docs/docsite/rst/dev_guide/testing_httptester.rst
@@ -69,4 +69,4 @@ Ansible
 Extending httptester
 ====================
 
-If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/MEETINGS.md>`_ to avoid duplicated effort.
+If you have sometime to improve ``httptester`` please add a comment on the `Testing Working Group Agenda <https://github.com/ansible/community/blob/master/meetings/README.md>`_ to avoid duplicated effort.

--- a/docs/docsite/rst/dev_guide/testing_integration.rst
+++ b/docs/docsite/rst/dev_guide/testing_integration.rst
@@ -267,4 +267,4 @@ A top level playbook is required such as ``ansible/test/integration/eos.yaml`` w
 Where to find out more
 ======================
 
-If you'd like to know more about the plans for improving testing Ansible then why not join the `Testing Working Group <https://github.com/ansible/community/blob/master/MEETINGS.md>`_.
+If you'd like to know more about the plans for improving testing Ansible then why not join the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.

--- a/docs/docsite/rst/dev_guide/testing_pep8.rst
+++ b/docs/docsite/rst/dev_guide/testing_pep8.rst
@@ -14,7 +14,7 @@ All `PEP 8`_ tests are executed, except those listed in the `current ignore list
 
 .. warning: Updating the Rule Set
 
-   Changes to the Rule Set need approval from the Core Team, and must be done via the `Testing Working Group <https://github.com/ansible/community/blob/master/MEETINGS.md>`_.
+   Changes to the Rule Set need approval from the Core Team, and must be done via the `Testing Working Group <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
 
 Legacy Rule Set
 ===============


### PR DESCRIPTION
##### SUMMARY
The meetings link changed in https://github.com/ansible/community/commit/0487040a83fcb4611f13a93568632c6c6202e25f

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
ansible 2.4.0 (docs-fix-meetings-link 767c37984c) last updated 2017/07/25 13:29:53 (GMT +200)
  config file = None
  configured module search path = [u'/home/mkrizek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mkrizek/devel/ansible/lib/ansible
  executable location = /home/mkrizek/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
None