### PR TITLE
ec2_customer_gateway: add routing option to allow bgp_asn to be optional - fixes #27157

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
@@ -52,6 +52,7 @@ options:
       - The type of routing.
     choices: ['static', 'dynamic']
     default: dynamic
+    version_added: '2.4'
   state:
     description:
       - Create or terminate the Customer Gateway.

--- a/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
@@ -47,6 +47,11 @@ options:
     description:
       - Name of the customer gateway.
     required: true
+  routing:
+    description:
+      - The type of routing.
+    choices: ['static', 'dynamic']
+    default: dynamic
   state:
     description:
       - Create or terminate the Customer Gateway.
@@ -129,7 +134,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (boto3_conn, camel_dict_to_snake_dict,
-        ec2_argument_spec, get_aws_connection_info)
+                                      ec2_argument_spec, get_aws_connection_info)
 
 
 class Ec2CustomerGatewayManager:
@@ -153,6 +158,8 @@ class Ec2CustomerGatewayManager:
         return response
 
     def ensure_cgw_present(self, bgp_asn, ip_address):
+        if not bgp_asn:
+            bgp_asn = 65000
         response = self.ec2.create_customer_gateway(
             DryRun=False,
             Type='ipsec.1',
@@ -204,6 +211,7 @@ def main():
             bgp_asn=dict(required=False, type='int'),
             ip_address=dict(required=True),
             name=dict(required=True),
+            routing=dict(default='dynamic', choices=['dynamic', 'static']),
             state=dict(default='present', choices=['present', 'absent']),
         )
     )
@@ -211,7 +219,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            required_if=[
-                               ('state', 'present', ['bgp_asn'])
+                               ('routing', 'dynamic', ['bgp_asn'])
                            ]
                            )
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -17,7 +17,6 @@ lib/ansible/modules/cloud/amazon/dynamodb_table.py
 lib/ansible/modules/cloud/amazon/ec2_ami.py
 lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
 lib/ansible/modules/cloud/amazon/ec2_ami_find.py
-lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py
 lib/ansible/modules/cloud/amazon/ec2_eip.py
 lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
 lib/ansible/modules/cloud/amazon/ec2_key.py


### PR DESCRIPTION
##### SUMMARY
Fixes #27157 + pep8

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_customer_gateway.py

##### ANSIBLE VERSION
```
2.4.0
```
