### PR TITLE
Revert "Enforce the _raw_params variable with include_role (#26430)"

### DIFF
--- a/test/integration/ovs.yaml
+++ b/test/integration/ovs.yaml
@@ -19,7 +19,6 @@
     - block:
       - include_role:
           name: openvswitch_db
-          _raw_params: openvswitch_db
         when: "limit_to in ['*', 'openvswitch_db']"
       rescue:
         - set_fact:


### PR DESCRIPTION
##### SUMMARY

Since https://github.com/ansible/ansible/issues/26525 has been fixed, we can revert this patch.

This reverts commit 05477412ba122fe3b3d52ddeb2c3ab813979a33c.

##### ISSUE TYPE

 - Bugfix Pull Request
 
##### COMPONENT NAME

- N/A

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

- N/A