### PR TITLE
crypto/openssl_*: Standardize implementaton and add support keyUsage, extenededKeyUsage

### DIFF
--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -95,6 +95,28 @@ def load_certificate_request(path):
         raise OpenSSLObjectError(exc)
 
 
+keyUsageLong = {
+    "digitalSignature": "Digital Signature",
+    "nonRepudiation": "Non Repudiation",
+    "keyEncipherment": "Key Encipherment",
+    "dataEncipherment": "Data Encipherment",
+    "keyAgreement": "Key Agreement",
+    "keyCertSign": "Certificate Sign",
+    "cRLSign": "CRL Sign",
+    "encipherOnly": "Encipher Only",
+    "decipherOnly": "Decipher Only",
+}
+
+extendedKeyUsageLong = {
+    "serverAuth": "TLS Web Server Authentication",
+    "clientAuth": "TLS Web Client Authentication",
+    "codeSigning": "Code Signing",
+    "emailProtection": "E-mail Protection",
+    "timeStamping": "Time Stamping",
+    "OCSPSigning": "OCSP Signing",
+}
+
+
 @six.add_metaclass(abc.ABCMeta)
 class OpenSSLObject(object):
 

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -84,6 +84,17 @@ def load_certificate(path):
         raise OpenSSLObjectError(exc)
 
 
+def load_certificate_request(path):
+    """Load the specified certificate signing request."""
+
+    try:
+        csr_content = open(path, 'rb').read()
+        csr = crypto.load_certificate_request(crypto.FILETYPE_PEM, csr_content)
+        return csr
+    except (IOError, OSError) as exc:
+        raise OpenSSLObjectError(exc)
+
+
 @six.add_metaclass(abc.ABCMeta)
 class OpenSSLObject(object):
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -332,26 +332,15 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             return True
 
         def _check_keyUsage_(extensions, extName, expected, long):
-            usages_ext = next((ext.__str__() for ext in extensions if ext.get_short_name() == extName), '')
-            usages = [usage.strip() for usage in usages_ext.split(',')]
-
-            for usage in expected:
-                if usage in usages:
-                    usages.remove(usage)
-                    continue
-                try:
-                    if long[usage] in usages:
-                        usages.remove(long[usage])
-                        continue
-                except KeyError:
-                    pass
-
+            usages_ext = [str(ext) for ext in extensions if ext.get_short_name() == extName]
+            if (not usages_ext and expected) or (usages_ext and not expected):
                 return False
-
-            if len(usages) > 0:
-                return False
-
-            return True
+            elif not usages_ext and not expected:
+                return True
+            else:
+                current = [usage.strip() for usage in usages_ext[0].split(',')]
+                expected = [long[usage] if usage in long else usage for usage in expected]
+                return current == expected
 
         def _check_keyUsage(extensions):
             return _check_keyUsage_(extensions, b'keyUsage', self.keyUsage, crypto_utils.keyUsageLong)

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -29,9 +29,10 @@ version_added: "2.4"
 short_description: Generate OpenSSL Certificate Signing Request (CSR)
 description:
     - "This module allows one to (re)generates OpenSSL certificate signing requests.
-       It uses the pyOpenSSL python library to interact with openssl. This module support
-       the subjectAltName extension. Note: At least one of commonName or subjectAltName must
-       be specified. This module uses file common arguments to specify generated file permissions."
+       It uses the pyOpenSSL python library to interact with openssl. This module supports
+       the subjectAltName as well as the keyUsage and extendedKeyUsage extensions.
+       Note: At least one of commonName or subjectAltName must be specified.
+       This module uses file common arguments to specify generated file permissions."
 requirements:
     - "python-pyOpenSSL"
 options:
@@ -182,7 +183,12 @@ EXAMPLES = '''
 
 
 RETURN = '''
-csr:
+privatekey:
+    description: Path to the TLS/SSL private key the CSR was generated for
+    returned: changed or success
+    type: string
+    sample: /etc/ssl/private/ansible.com.pem
+filename:
     description: Path to the generated Certificate Signing Request
     returned: changed or success
     type: string
@@ -398,7 +404,7 @@ def main():
             organizationalUnitName=dict(aliases=['OU'], type='str'),
             commonName=dict(aliases=['CN'], type='str'),
             emailAddress=dict(aliases=['E'], type='str'),
-            subjectAltName=dict(aliases=['subjectAltName'], type='list'),
+            subjectAltName=dict(type='list'),
             keyUsage=dict(type='list'),
             extendedKeyUsage=dict(aliases=['extKeyUsage'], type='list'),
         ),

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -352,9 +352,9 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             extensions = csr.get_extensions()
             return _check_subjectAltName(extensions) and _check_keyUsage(extensions) and _check_extenededKeyUsage(extensions)
 
-        def _check_signature(csr, privatekey):
+        def _check_signature(csr):
             try:
-                return csr.verify(privatekey)
+                return csr.verify(self.privatekey)
             except crypto.Error:
                 return False
 
@@ -363,7 +363,7 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
 
         csr = crypto_utils.load_certificate_request(self.path)
 
-        return _check_subject(csr) and _check_extensions(csr) and _check_signature(csr, self.privatekey)
+        return _check_subject(csr) and _check_extensions(csr) and _check_signature(csr)
 
     def dump(self):
         '''Serialize the object into a dictionary.'''

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -126,7 +126,8 @@ options:
 
 notes:
     - "If the certificate signing request already exists it will be checked whether subjectAltName,
-       keyUsage and extendedKeyUsage only contain the requested values"
+       keyUsage and extendedKeyUsage only contain the requested values and if the request was signed
+       by the given private key"
 '''
 
 
@@ -242,7 +243,6 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
         self.subjectAltName = module.params['subjectAltName']
         self.keyUsage = module.params['keyUsage']
         self.extendedKeyUsage = module.params['extendedKeyUsage']
-        self.changed = True
         self.request = None
         self.privatekey = None
 
@@ -295,8 +295,8 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
                 csr_file.close()
             except (IOError, OSError) as exc:
                 raise CertificateSigningRequestError(exc)
-        else:
-            self.changed = False
+
+            self.changed = True
 
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):
@@ -380,7 +380,8 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
         '''Serialize the object into a dictionary.'''
 
         result = {
-            'csr': self.path,
+            'privatekey': self.privatekey_path,
+            'filename': self.path,
             'subject': self.subject,
             'subjectAltName': self.subjectAltName,
             'keyUsage': self.keyUsage,


### PR DESCRIPTION
##### SUMMARY

The OpenSSLObject class has been merged[1]. This commit makes the
openssl_csr module rely on this class and standardize the way openssl
module should be written.
This also adds checks for subject alt names as well as support for keyUsage
and extendedKeyUsage certificate extensions.

This is based on the work of @psykotox and obsoletes #25215.

[1] #26945

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

  - openssl_csr

##### ANSIBLE VERSION
```
devel
```

##### ADDITIONAL INFORMATION
```
N/A
```
