### PR TITLE
Fix running docker container with not readable logging driver

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1961,7 +1961,14 @@ class ContainerManager(DockerBaseClass):
 
             if not self.parameters.detach:
                 status = self.client.wait(container_id)
-                output = self.client.logs(container_id, stdout=True, stderr=True, stream=False, timestamps=False)
+                config = self.client.inspect_container(container_id)
+                logging_driver = config['HostConfig']['LogConfig']['Type']
+
+                if logging_driver == 'json-file' or logging_driver == 'journald':
+                    output = self.client.logs(container_id, stdout=True, stderr=True, stream=False, timestamps=False)
+                else:
+                    output = "Result logged using `%s` driver" % logging_driver
+
                 if status != 0:
                     self.fail(output, status=status)
                 if self.parameters.cleanup:


### PR DESCRIPTION
##### SUMMARY

Fixes #27278 

According to the [docker documentation](https://docs.docker.com/engine/api/v1.30/#operation/ContainerLogs) it possible to run `docker logs` command only if you're using either `json-file` or `journald` logging driver.

When you run attached container with another deriver (e.g. `none`, or `syslog`) ansible fails with error 

```
docker.errors.APIError: 500 Server Error: Internal Server Error (\"configured logging reader does not support reading\")
```

The error happens because we are trying to read logs after starting a container. To overcome this issue, I try to read logs only if logging driver supports reading.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

modules/cloud/docker/docker_container


##### ANSIBLE VERSION

```
ansible 2.3.1.0
  config file = /Users/bolshakov/Documents/Projects/amediateka/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```

Example yaml file:

```yaml
> cat run.yml

- name: Deploy
  hosts:
    - application
  tasks:
    - name: Pull image
      docker_container:
        name: test-syslog
        image: busybox:latest
        state: started
        detach: false
        pull: true
        command: echo hello
        log_driver: syslog
        log_options:
          syslog-facility: local4
          syslog-address: udp://127.0.0.1:514
```

I don't know how to provide tests for that change.