### PR TITLE
cloud: cs_user: add feature keys handling

### DIFF
--- a/test/integration/targets/cs_user/tasks/main.yml
+++ b/test/integration/targets/cs_user/tasks/main.yml
@@ -66,6 +66,7 @@
     - user.account == "admin"
     - user.state == "enabled"
     - user.domain == "ROOT"
+    - user.user_api_key is not defined
 
 - name: test create user idempotence
   cs_user:
@@ -89,6 +90,96 @@
     - user.account == "admin"
     - user.state == "enabled"
     - user.domain == "ROOT"
+    - user.user_api_key is not defined
+
+- name: test create account
+  cs_account:
+    name: "{{ cs_resource_prefix }}_acc"
+    username: "{{ cs_resource_prefix }}_acc_username"
+    password: "{{ cs_resource_prefix }}_acc_password"
+    last_name: "{{ cs_resource_prefix }}_acc_last_name"
+    first_name: "{{ cs_resource_prefix }}_acc_first_name"
+    email: "{{ cs_resource_prefix }}@example.com"
+    network_domain: "example.com"
+  register: acc
+- name: verify results of create account
+  assert:
+    that:
+    - acc|success
+    - acc|changed
+    - acc.name == "{{ cs_resource_prefix }}_acc"
+    - acc.network_domain == "example.com"
+    - acc.account_type == "user"
+    - acc.state == "enabled"
+    - acc.domain == "ROOT"
+    - acc|changed
+
+- name: test create user2 in check mode
+  cs_user:
+    username: "{{ cs_resource_prefix }}_user2"
+    password: "{{ cs_resource_prefix }}_password2"
+    last_name: "{{ cs_resource_prefix }}_last_name2"
+    first_name: "{{ cs_resource_prefix }}_first_name2"
+    email: "{{ cs_resource_prefix }}@example2.com"
+    account: "{{ cs_resource_prefix }}_acc"
+    keys_registered: true
+  check_mode: true
+  register: user
+- name: verify results of create user idempotence
+  assert:
+    that:
+    - user|success
+    - user|changed
+
+- name: test create user2
+  cs_user:
+    username: "{{ cs_resource_prefix }}_user2"
+    password: "{{ cs_resource_prefix }}_password2"
+    last_name: "{{ cs_resource_prefix }}_last_name2"
+    first_name: "{{ cs_resource_prefix }}_first_name2"
+    email: "{{ cs_resource_prefix }}@example2.com"
+    account: "{{ cs_resource_prefix }}_acc"
+    keys_registered: true
+  register: user
+- name: verify results of create user idempotence
+  assert:
+    that:
+    - user|success
+    - user|changed
+    - user.username == "{{ cs_resource_prefix }}_user2"
+    - user.first_name == "{{ cs_resource_prefix }}_first_name2"
+    - user.last_name == "{{ cs_resource_prefix }}_last_name2"
+    - user.email == "{{ cs_resource_prefix }}@example2.com"
+    - user.account_type == "user"
+    - user.account == "{{ cs_resource_prefix }}_acc"
+    - user.state == "enabled"
+    - user.domain == "ROOT"
+    - user.user_api_key is defined
+
+- name: test create user2 idempotence
+  cs_user:
+    username: "{{ cs_resource_prefix }}_user2"
+    password: "{{ cs_resource_prefix }}_password2"
+    last_name: "{{ cs_resource_prefix }}_last_name2"
+    first_name: "{{ cs_resource_prefix }}_first_name2"
+    email: "{{ cs_resource_prefix }}@example2.com"
+    account: "{{ cs_resource_prefix }}_acc"
+    keys_registered: true
+  register: user
+- name: verify results of create user idempotence
+  assert:
+    that:
+    - user|success
+    - not user|changed
+    - user.username == "{{ cs_resource_prefix }}_user2"
+    - user.first_name == "{{ cs_resource_prefix }}_first_name2"
+    - user.last_name == "{{ cs_resource_prefix }}_last_name2"
+    - user.email == "{{ cs_resource_prefix }}@example2.com"
+    - user.account_type == "user"
+    - user.account == "{{ cs_resource_prefix }}_acc"
+    - user.state == "enabled"
+    - user.domain == "ROOT"
+    - user.user_api_key is defined
 
 - name: test update user in check mode
   cs_user:
@@ -98,6 +189,7 @@
     first_name: "{{ cs_resource_prefix }}_first_name1"
     email: "{{ cs_resource_prefix }}@example.com1"
     account: "admin"
+    keys_registered: true
   register: user
   check_mode: true
 - name: verify results of update user in check mode
@@ -113,6 +205,7 @@
     - user.account == "admin"
     - user.state == "enabled"
     - user.domain == "ROOT"
+    - user.user_api_key is not defined
 
 - name: test update user
   cs_user:
@@ -122,6 +215,7 @@
     first_name: "{{ cs_resource_prefix }}_first_name1"
     email: "{{ cs_resource_prefix }}@example.com1"
     account: "admin"
+    keys_registered: true
   register: user
 - name: verify results of update user
   assert:
@@ -136,6 +230,7 @@
     - user.account == "admin"
     - user.state == "enabled"
     - user.domain == "ROOT"
+    - user.user_api_key is defined
 
 - name: test update user idempotence
   cs_user:
@@ -145,6 +240,7 @@
     first_name: "{{ cs_resource_prefix }}_first_name1"
     email: "{{ cs_resource_prefix }}@example.com1"
     account: "admin"
+    keys_registered: true
   register: user
 - name: verify results of update user idempotence
   assert:
@@ -159,6 +255,7 @@
     - user.account == "admin"
     - user.state == "enabled"
     - user.domain == "ROOT"
+    - user.user_api_key is defined
 
 - name: test lock user in check mode
   cs_user:


### PR DESCRIPTION
##### SUMMARY
introduce a new param to specify if keys should be registered, also fixes a name collision with `api_key`, which is now used for showing the key used with the api, not the user key (introduced in 2.4). the user keys are now prefixed with `user_`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cs_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
