### PR TITLE
cloudstack: cs_facts: add option for custom meta data ip

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_facts.py
@@ -35,8 +35,6 @@ options:
   filter:
     description:
       - Filter for a specific fact.
-    required: false
-    default: null
     choices:
       - cloudstack_service_offering
       - cloudstack_availability_zone
@@ -46,6 +44,11 @@ options:
       - cloudstack_local_ipv4
       - cloudstack_instance_id
       - cloudstack_user_data
+  meta_data_host:
+    description:
+      - Host or IP of the meta data API service.
+      - If not set, determination by parsing the dhcp lease file.
+    version_added: "2.4"
 requirements: [ 'yaml' ]
 '''
 
@@ -57,6 +60,12 @@ EXAMPLES = '''
 # Gather specific fact on instances
 - name: Gather cloudstack facts
   cs_facts: filter=cloudstack_instance_id
+
+# Gather specific fact on instances with a given meta_data_host
+- name: Gather cloudstack facts
+  cs_facts:
+    filter: cloudstack_instance_id
+    meta_data_host: 169.254.169.254
 '''
 
 RETURN = '''
@@ -182,7 +191,9 @@ class CloudStackFacts(object):
 
     def _get_api_ip(self):
         """Return the IP of the DHCP server."""
-        if not self.api_ip:
+        if module.params.get('meta_data_host'):
+            return module.params.get('meta_data_host')
+        elif not self.api_ip:
             dhcp_lease_file = self._get_dhcp_lease_file()
             for line in open(dhcp_lease_file):
                 if 'dhcp-server-identifier' in line:
@@ -209,6 +220,7 @@ def main():
                 'cloudstack_instance_id',
                 'cloudstack_user_data',
             ]),
+            meta_data_host=dict(),
         ),
         supports_check_mode=False
     )


### PR DESCRIPTION
##### SUMMARY
new optional param for specifying the meta data host or IP.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cs_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
