### PR TITLE
foreman inventory: allow '-' in group names

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -252,7 +252,7 @@ class ForemanInventory(object):
         >>> ForemanInventory.to_safe("foo-bar baz")
         'foo_barbaz'
         '''
-        regex = "[^A-Za-z0-9\_]"
+        regex = "[^A-Za-z0-9\_-]"
         return re.sub(regex, "_", word.replace(" ", ""))
 
     def update_cache(self):


### PR DESCRIPTION

##### SUMMARY
Don't replace '-' by '_' in the generated groups to stay compatible with
https://github.com/theforeman/foreman_ansible_inventory from where this
script was derived from. Otherwise it will break people migrating.

If this shouldn't be changed generally I can add an option for it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (foreman-allow-minus e202c10c92) last updated 2017/07/25 19:13:07 (GMT +200)
  config file = /var/scratch/src/ansible/ansible/ansible.cfg
  configured module search path = [u'/home/agx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/scratch/src/ansible/ansible/lib/ansible
  executable location = /var/scratch/src/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
Thanks for including the inventory upstream!
