### PR TITLE
WIP conditional: allow a var defined as dict with invalid key to be skipped - fixes #27268

### DIFF
--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -217,10 +217,13 @@ class Conditional:
                 if not found:
                     var_name = None
                 else:
-                    var_name = var_name.groups()[0]
+                    var_name = found.groups()[0]
 
                 # next we extract all defined/undefined tests from the conditional string
                 def_undef = self.extract_defined_undefined(conditional)
+                # undefined var_name found, but conditional had no matches; likely a complex var
+                if not def_undef and var_name and ('is defined' in conditional or 'is not undefined' in conditional):
+                    return False
                 # then we loop through these, comparing the error variable name against
                 # each def/undef test we found above. If there is a match, we determine
                 # whether the logic/state mean the variable should exist or not and return

--- a/test/integration/targets/conditionals/tasks/main.yml
+++ b/test/integration/targets/conditionals/tasks/main.yml
@@ -336,6 +336,21 @@
     that:
     - "result.skipped == true"
 
+- name: test vars using invalid key does not run with conditional is defined
+  vars:
+    mydict:
+      a: foo
+      b: bar
+    var_needed_to_run: "{{ mydict['c'] }}"
+  debug: var=var_needed_to_run
+  when: var_needed_to_run is defined
+  register: result
+
+- name: assert the task was skipped
+  assert:
+    that:
+    - "result.skipped == true"
+
 - name: test list with invalid element does not run with conditional is defined
   vars:
     mylist: []

--- a/test/integration/targets/conditionals/tasks/main.yml
+++ b/test/integration/targets/conditionals/tasks/main.yml
@@ -351,6 +351,26 @@
     that:
     - "result.skipped == true"
 
+- name: test conditional (is defined) with an undefined dict with an undefined key
+  debug: msg=foo
+  when: foo['bar'] is defined
+  register: result
+
+- name: assert the task was skipped
+  assert:
+    that:
+    - "result.skipped == true"
+
+- name: test conditional (is not undefined) with an undefined dict with an undefined key
+  debug: msg=foo
+  when: foo['bar'] is not undefined
+  register: result
+
+- name: assert the task was skipped
+  assert:
+    that:
+    - "result.skipped == true"
+
 - name: test list with invalid element does not run with conditional is defined
   vars:
     mylist: []


### PR DESCRIPTION
##### SUMMARY
Fixes #27268 - see the issue for reproducers.
Added tests so it doesn't get broken again. This is different than the use case already tested [here](https://github.com/ansible/ansible/blob/devel/test/integration/targets/conditionals/tasks/main.yml#L325-L337).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/conditional.py

##### ANSIBLE VERSION
```
2.4.0
```
