### PR TITLE
Avoid using deprecated group_install API

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -375,7 +375,7 @@ def ensure(module, base, state, names, autoremove):
             # Install groups.
             for group in groups:
                 try:
-                    base.group_install(group, dnf.const.GROUP_PACKAGE_TYPES)
+                    base.group_install(group.id, dnf.const.GROUP_PACKAGE_TYPES)
                 except dnf.exceptions.Error as e:
                     # In dnf 2.0 if all the mandatory packages in a group do
                     # not install, an error is raised.  We want to capture
@@ -402,7 +402,7 @@ def ensure(module, base, state, names, autoremove):
                         base.group_upgrade(group)
                     except dnf.exceptions.CompsError:
                         # If not already installed, try to install.
-                        base.group_install(group, dnf.const.GROUP_PACKAGE_TYPES)
+                        base.group_install(group.id, dnf.const.GROUP_PACKAGE_TYPES)
                 except dnf.exceptions.Error as e:
                     failures.append((group, e))
 


### PR DESCRIPTION
##### SUMMARY
DNF's base.group_install() function accepts a string as its first
argument.  Prior to DNF-2, compatibility code existed which allowed this
function to accept a base.comps.Group object instead.  That is no longer
possible.

Pass "group.id" to base.group_install() instead of "group" to work
around this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
packaging/os/dnf

##### ANSIBLE VERSION
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

##### ADDITIONAL INFORMATION
This fixes issue #26868 for me.  I tested against all non-EOL Fedora releases but don't have anything older around.  I verified the change with the DNF upstream.