### PR TITLE
Restore Digital Ocean module maintainer that was in maintainer.txt

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -160,8 +160,8 @@ files:
   $modules/cloud/centurylink/: clc-runner
   $modules/cloud/cloudscale/cloudscale_server.py: gaudenz
   $modules/cloud/cloudstack/: resmo
+  $modules/cloud/digital_ocean/: bondanthony
   $modules/cloud/digital_ocean/digital_ocean.py: alukovenko zbal
-  $modules/cloud/digital_ocean/digital_ocean_block_storage.py: bondanthony
   $modules/cloud/digital_ocean/digital_ocean_domain.py: alukovenko mgregson
   $modules/cloud/digital_ocean/digital_ocean_sshkey.py: alukovenko mgregson
   $modules/cloud/digital_ocean/digital_ocean_tag.py: kontrafiktion


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update module maintainer to match what was in the old maintainer.txt file. Current maintainers have been inactive for while. I would like to assist with moving the digital_ocean modules forward as the Digital Ocean API is rapidly changing.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
digital_ocean modules
