### PR TITLE
composer: docs: fix conflicting statement about defaults

### DIFF
--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -112,7 +112,7 @@ options:
         description:
             - Optimize autoloader during autoloader dump (see --optimize-autoloader).
             - Convert PSR-0/4 autoloading to classmap to get a faster autoloader.
-            - Recommended especially for production, but can take a bit of time to run so it is currently not done by default.
+            - Recommended especially for production, but can take a bit of time to run.
         required: false
         default: true
         choices: [ true, false]


### PR DESCRIPTION
##### SUMMARY
fix conflicting statement about defaults in docs

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
composer

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
fixes #27310 