### PR TITLE
Fixes#27314 - Handled issue in parsing "exit" in dellos6 running config. 

### DIFF
--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -234,12 +234,12 @@ class Dellos6NetworkConfig(NetworkConfig):
             if str(item) == "exit":
                 for diff_item in diff:
                     if diff_item._parents:
-                       if item._parents == diff_item._parents:
-                          diff.append(item)
-                          break
+                        if item._parents == diff_item._parents:
+                            diff.append(item)
+                            break
                     else:
-                       diff.append(item)
-                       break
+                        diff.append(item)
+                        break
             elif item not in other:
                 diff.append(item)
         return diff

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -161,7 +161,7 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'support-assist.*$'),
         re.compile(r'template.*$'),
         re.compile(r'address-family.*$'),
-        re.compile(r'spanning-tree mst.*$'),
+        re.compile(r'spanning-tree mst configuration.*$'),
         re.compile(r'logging.*$'),
         re.compile(r'(radius-server|tacacs-server) host.*$')]
 
@@ -207,7 +207,7 @@ def os6_parse(lines, indent=None, comment_tokens=None):
                     if parent:
                         cfg._parents.extend(parent)
                     parent = list()
-                    config.append(cfg)
+                config.append(cfg)
             # handle sublevel children
             elif parent_match is False and len(parent) > 0:
                 if not children:
@@ -233,9 +233,14 @@ class Dellos6NetworkConfig(NetworkConfig):
         for item in self.items:
             if str(item) == "exit":
                 for diff_item in diff:
-                    if item._parents == diff_item._parents:
-                        diff.append(item)
-                        break
+                    if diff_item._parents:
+                       if item._parents == diff_item._parents:
+                          diff.append(item)
+                          break
+                    else:
+                       diff.append(item)
+                       break
             elif item not in other:
                 diff.append(item)
         return diff
+


### PR DESCRIPTION
##### SUMMARY
Included changes to handle "exit" in dellos6 running-config.
Fixes #27314 


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ansible.module_utils.dellos6

##### ANSIBLE VERSION
```
ansible 2.3.2.0 (stable-2.3 9d435fd47b) 
config file = /etc/ansible/ansible.cfg 
configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
