### PR TITLE
Fixing Issue #27270 - EFS TypeError

### DIFF
--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -407,8 +407,8 @@ class EFSConnection(object):
             changed = filter(
                 lambda sid: not targets_equal(['SubnetId', 'IpAddress', 'NetworkInterfaceId'],
                                               current_targets[sid], targets[sid]), intersection)
-            targets_to_delete = list(targets_to_delete) + changed
-            targets_to_create = list(targets_to_create) + changed
+            targets_to_delete = list(targets_to_delete) + list(changed)
+            targets_to_create = list(targets_to_create) + list(changed)
 
             if targets_to_delete:
                 for sid in targets_to_delete:

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -403,12 +403,11 @@ class EFSConnection(object):
             targets_to_create, intersection, targets_to_delete = dict_diff(current_targets,
                                                                            targets, True)
 
-            """ To modify mount target it should be deleted and created again """
-            changed = filter(
-                lambda sid: not targets_equal(['SubnetId', 'IpAddress', 'NetworkInterfaceId'],
-                                              current_targets[sid], targets[sid]), intersection)
-            targets_to_delete = list(targets_to_delete) + list(changed)
-            targets_to_create = list(targets_to_create) + list(changed)
+            # To modify mount target it should be deleted and created again
+            changed = [sid for sid in intersection if not targets_equal(['SubnetId', 'IpAddress', 'NetworkInterfaceId'],
+                                                                        current_targets[sid], targets[sid])]
+            targets_to_delete = list(targets_to_delete) + changed
+            targets_to_create = list(targets_to_create) + changed
 
             if targets_to_delete:
                 for sid in targets_to_delete:
@@ -434,17 +433,16 @@ class EFSConnection(object):
                 )
                 result = True
 
-            security_groups_to_update = filter(
-                lambda sid: 'SecurityGroups' in targets[sid] and
-                            current_targets[sid]['SecurityGroups'] != targets[sid]['SecurityGroups'],
-                intersection
-            )
+            # If no security groups were passed into the module, then do not change it.
+            security_groups_to_update = [sid for sid in intersection if
+                                         'SecurityGroups' in targets[sid] and
+                                         current_targets[sid]['SecurityGroups'] != targets[sid]['SecurityGroups']]
 
             if security_groups_to_update:
                 for sid in security_groups_to_update:
                     self.connection.modify_mount_target_security_groups(
                         MountTargetId=current_targets[sid]['MountTargetId'],
-                        SecurityGroups=targets[sid]['SecurityGroups']
+                        SecurityGroups=targets[sid].get('SecurityGroups', None)
                     )
                 result = True
 


### PR DESCRIPTION
##### SUMMARY
Resolving a TypeError invoked by the AWS EFS module when it attempts to add a Filter type to a List type.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/cloud/amazon/efs.py`

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/patrick/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
See Issue #27270 