### PR TITLE
Fix using DNF group upgrade/remove api

### DIFF
--- a/lib/ansible/modules/packaging/os/dnf.py
+++ b/lib/ansible/modules/packaging/os/dnf.py
@@ -399,7 +399,7 @@ def ensure(module, base, state, names, autoremove):
             for group in groups:
                 try:
                     try:
-                        base.group_upgrade(group)
+                        base.group_upgrade(group.id)
                     except dnf.exceptions.CompsError:
                         # If not already installed, try to install.
                         base.group_install(group.id, dnf.const.GROUP_PACKAGE_TYPES)
@@ -433,7 +433,7 @@ def ensure(module, base, state, names, autoremove):
 
             for group in groups:
                 try:
-                    base.group_remove(group)
+                    base.group_remove(group.id)
                 except dnf.exceptions.CompsError:
                     # Group is already uninstalled.
                     pass


### PR DESCRIPTION
##### SUMMARY
This is additional fix to https://github.com/ansible/ansible/pull/27302 for  https://github.com/ansible/ansible/issues/26868


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
dnf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 8643e9cb34) last updated 2017/07/26 16:14:01 (GMT +200)
  config file = /home/mkrizek/devel/ansible/ansible.cfg
  configured module search path = [u'/home/mkrizek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mkrizek/devel/ansible/lib/ansible
  executable location = /home/mkrizek/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
Tested on Fedora 25 and 26.

ad-hoc commands:

`-m dnf -a 'name="@virtualization" state=latest'` -> worked for me

`-m dnf -a 'name="@virtualization" state=absent'` -> this gave me 'nothing to do' but that seems unrelated and I will look into it separately
