### PR TITLE
Fixes to pip with git install instructions

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -262,7 +262,7 @@ Then install Ansible with [1]_::
 
 Or if you are looking for the latest development version::
 
-    pip install git+git://github.com/ansible/ansible.git@devel
+    pip install git+https://github.com/ansible/ansible.git@devel
 
 If you are installing on OS X Mavericks, you may encounter some noise from your compiler.  A workaround is to do the following::
 
@@ -276,8 +276,6 @@ Tarballs of Tagged Releases
 +++++++++++++++++++++++++++
 
 Packaging Ansible or wanting to build a local package yourself, but don't want to do a git checkout?  Tarballs of releases are available on the `Ansible downloads <http://releases.ansible.com/ansible>`_ page.
-
-These releases are also tagged in the `git repository <https://github.com/ansible/ansible/releases>`_ with the release version.
 
 .. _from_source:
 


### PR DESCRIPTION
* use git+https:// in the example url because not everyone will have ssh
  keys registered on github
* Remove the link to the github tarballs as they do not work.  users can
  use releases.ansible.com instead.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docsite/rst/intro_installation.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


##### ADDITIONAL INFORMATION
For the github removal, we have been telling people not to use those for years (the github release page even has a big banner now that says to use releases.ansible.com tarballs instead) but the doc was still pointing people to it.