### PR TITLE
Adding Nuage module to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -242,6 +242,8 @@ Ansible Changes By Release
   * gcp_target_proxy
   * gcp_url_map
 - gunicorn
+- nuage
+  * nuage_vpsk
 - purestorage
   * purefa_hg
   * purefa_host


### PR DESCRIPTION
##### SUMMARY
Adding the newly added Nuage module (#24895) to the CHANGELOG
cc @gundalow 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
nuage_vspk

##### ANSIBLE VERSION
```
ansible 2.4.0 (vmware_guest_tools b1783f40c5) last updated 2017/07/26 18:32:38 (GMT +200)
  config file = None
  configured module search path = [u'/Users/pdellaer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pdellaer/GitHub/pdellaert/ansible/lib/ansible
  executable location = /Users/pdellaer/GitHub/pdellaert/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```