### PR TITLE
Switch from "zabbix-api" to "pyzabbix"

### DIFF
--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -38,7 +38,7 @@ import argparse
 import ConfigParser
 
 try:
-    from zabbix_api import ZabbixAPI
+    from pyzabbix import ZabbixAPI
 except:
     print("Error: Zabbix API library must be installed: pip install zabbix-api.",
           file=sys.stderr)
@@ -84,12 +84,12 @@ class ZabbixInventory(object):
         return data
 
     def get_list(self, api):
-        hostsData = api.host.get({'output': 'extend', 'selectGroups': 'extend'})
+        hostsData = api.do_request('host.get', {'output': ['name'], 'selectGroups': ['name']})
 
         data = {}
         data[self.defaultgroup] = self.hoststub()
 
-        for host in hostsData:
+        for host in hostsData['result']:
             hostname = host['name']
             data[self.defaultgroup]['hosts'].append(hostname)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Change "zabbix.py" to use "pyzabbix" instead of "zabbix-api" and optimize the hosts query.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
zabbix.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The switch from "zabbix-api" to "pyzabbix" was made because "pyzabbix" is available on EPEL ("python-pyzabbix" package), while "zabbix-api" is not. That makes "pyzabbix" much more accessible than "zabbix-api" on Red Hat (and family) based systems.

Also, since only the host name and group names are used, those are now the only properties returned from Zabbix.