### PR TITLE
ec2_lc_facts: get all matching launch configs - fixes #25498

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -317,7 +317,7 @@ def ec2_connect(module):
     return ec2
 
 
-def paging(pause=0, marker_property='marker'):
+def paging(pause=0, marker_property='marker', result_key=None):
     """ Adds paging to boto retrieval functions that support a 'marker'
         this is configurable as not all boto functions seem to use the
         same name.
@@ -328,8 +328,12 @@ def paging(pause=0, marker_property='marker'):
             marker = None
             while True:
                 try:
-                    new = f(*args, marker=marker, **kwargs)
-                    marker = getattr(new, marker_property)
+                    if marker:
+                        kwargs[marker_property] = marker
+                    new = f(*args, **kwargs)
+                    marker = new.get(marker_property)
+                    if result_key:
+                        new = new[result_key]
                     results.extend(new)
                     if not marker:
                         break

--- a/lib/ansible/modules/cloud/amazon/ec2_lc_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc_facts.py
@@ -170,6 +170,8 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+from ansible.module_utils.ec2 import paging
+
 
 def list_launch_configs(connection, module):
 
@@ -180,7 +182,8 @@ def list_launch_configs(connection, module):
     sort_end = module.params.get('sort_end')
 
     try:
-        launch_configs = connection.describe_launch_configurations(LaunchConfigurationNames=launch_config_name)
+        launch_configs = {'LaunchConfigurations': paging(pause=0, marker_property='NextToken', result_key='LaunchConfigurations')
+                                                        (connection.describe_launch_configurations)(LaunchConfigurationNames=launch_config_name)}
     except ClientError as e:
         module.fail_json(msg=e.message)
 


### PR DESCRIPTION
##### SUMMARY
Make module_utils.ec2 paging() more functional by fixing the parameter input to be configurable, not failing if the result doesn't have a marker attribute, and allowing optional control of what result key gets added. I can't find paging() used anywhere else (probably because it's sort of broken).

Utilize paging() in ec2_lc_facts. fixes #25498

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py
lib/ansible/modules/cloud/amazon/ec2_lc_facts.py

##### ANSIBLE VERSION
```
2.4.0
```
