### PR TITLE
add support for mariadb replication

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -257,6 +257,7 @@ def main():
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
     master_auto_position = module.params["master_auto_position"]
+    master_use_gtid = module.params["master_use_gtid"]
     ssl_cert = module.params["ssl_cert"]
     ssl_key = module.params["ssl_key"]
     ssl_ca = module.params["ssl_ca"]

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -217,7 +217,7 @@ def main():
             login_unix_socket=dict(default=None),
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave", "resetslave", "resetslaveall"]),
             master_auto_position=dict(default=False, type='bool'),
-            master_use_gtid=dict(default=False, choices=["slave_pos", "current_pos"),
+            master_use_gtid=dict(default=False, choices=["slave_pos", "current_pos"]),
             master_host=dict(default=None),
             master_user=dict(default=None),
             master_password=dict(default=None, no_log=True),

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -99,10 +99,18 @@ options:
             - same as mysql variable
     master_auto_position:
         description:
-            - does the host uses GTID based replication or not
+            - does the host uses GTID based replication or not (MySQL/Percona)
         required: false
         default: null
         version_added: "2.0"
+    master_use_gtid
+        description:
+            - which position to use use with GTID based replication (MariaDB)
+        required: false
+        default: null
+        choices: [ "slave_pos", "current_pos" ]
+        version_added: "2.3"
+
 
 extends_documentation_fragment: mysql
 '''
@@ -209,6 +217,7 @@ def main():
             login_unix_socket=dict(default=None),
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave", "resetslave", "resetslaveall"]),
             master_auto_position=dict(default=False, type='bool'),
+            master_use_gtid=dict(default=False, choices=["slave_pos", "current_pos"),
             master_host=dict(default=None),
             master_user=dict(default=None),
             master_password=dict(default=None, no_log=True),
@@ -339,6 +348,9 @@ def main():
             chm_params['master_ssl_cipher'] = master_ssl_cipher
         if master_auto_position:
             chm.append("MASTER_AUTO_POSITION = 1")
+        if master_use_gtid:
+            chm.append("MASTER_USE_GTID=%(master_use_gtid)s")
+            chm_params['master_use_gtid'] = master_use_gtid
         try:
             changemaster(cursor, chm, chm_params)
         except MySQLdb.Warning:

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -103,7 +103,7 @@ options:
         required: false
         default: null
         version_added: "2.0"
-    master_use_gtid
+    master_use_gtid:
         description:
             - which position to use use with GTID based replication (MariaDB)
         required: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
MariaDB uses a different syntax for GTID replication. Not tested yet more of a request, not very good with python

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
mysql/mysql-replication

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
