### PR TITLE
no shut command need to be added

### DIFF
--- a/lib/ansible/module_utils/cnos.py
+++ b/lib/ansible/module_utils/cnos.py
@@ -960,6 +960,10 @@ def interfaceLevel2Config(
     elif (interfaceL2Arg1 == "shutdown"):
         # debugOutput("shutdown")
         command = interfaceL2Arg1
+    
+    elif (interfaceL2Arg1 == "no shutdown"):
+        # debugOutput("no shutdown")
+        command = interfaceL2Arg1
 
     elif (interfaceL2Arg1 == "snmp"):
         # debugOutput("snmp")


### PR DESCRIPTION
No shutdown command is required to enable the interface

##### SUMMARY
For the interface configuration to be concluded you need to issue a "no shutdown" command. The module was not supporting that, rather only shutdown command was there. This bug is getting fixed based on comments from field.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/cnos.py

##### ANSIBLE VERSION
ansible 2.4.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Now "no shutdown" command is also supported in module pertaining to interface configuration.

     elif (interfaceL2Arg1 == "shutdown"):
         # debugOutput("shutdown")
         command = interfaceL2Arg1
+    
+    elif (interfaceL2Arg1 == "no shutdown"):
+        # debugOutput("no shutdown")
+        command = interfaceL2Arg1
 
     elif (interfaceL2Arg1 == "snmp"):
         # debugOutput("snmp")