### PR TITLE
Made at_revision part within hg source control module working properly, no matter in what form revision parameters gets passed

### DIFF
--- a/lib/ansible/modules/source_control/hg.py
+++ b/lib/ansible/modules/source_control/hg.py
@@ -231,13 +231,16 @@ class Hg(object):
         There is no point in pulling from a potentially down/slow remote site
         if the desired changeset is already the current changeset.
         """
-        if self.revision is None or len(self.revision) < 7:
-            # Assume it's a rev number, tag, or branch
+        if self.revision is None:
             return False
+        # transform whatever was passed as revision into changeset ID
+        (rc, currentRevisionOut, err) = self._command(['--debug', 'id', '-i', '-r', self.revision, '-R', self.dest])
+        if rc != 0:
+            self.module.fail_json(msg=err)
         (rc, out, err) = self._command(['--debug', 'id', '-i', '-R', self.dest])
         if rc != 0:
             self.module.fail_json(msg=err)
-        if out.startswith(self.revision):
+        if out.startswith(currentRevisionOut):
             return True
         return False
 


### PR DESCRIPTION
##### SUMMARY
This small fix will make detection of revision at which repository is at - working in all cases, no matter in what form **revision** param was passed.

Currently if you pass branch name or tag name, you are out of luck. **at_revision** will always think that we are not on revision we ask for, in effect performing redundant work afterwards.

Only if you pass **commit/revision ID** as **revision** parameter and it will be longer then 7 characters - you will get proper behavior. All other cases are broken in scope of **at_revision**.

For project I work on this is important as redundant *hg* calls adds up to our build time running even 3 to 5 minutes longer (yes - our repository is that big).

Please note that I am not a Python developer so my changes might actually not work but still, this is the best way to show where and what problem I believe I found.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
source_control (hg)

##### ANSIBLE VERSION
```
devel/all
```
