### PR TITLE
Use apt-get instead of aptitude

### DIFF
--- a/test/integration/targets/apt/tasks/main.yml
+++ b/test/integration/targets/apt/tasks/main.yml
@@ -24,20 +24,13 @@
  - include: 'apt-builddep.yml'
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
- - name: Check if aptitude is installed
-   command: dpkg-query -l aptitude
-   register: deb_check
-   when: ansible_distribution in ('Ubuntu', 'Debian')
-
  - include: upgrade.yml upgrade_type=dist
    when: ansible_distribution in ('Ubuntu', 'Debian')
 
  - include: upgrade.yml upgrade_type=safe
    when:
      - ansible_distribution in ('Ubuntu', 'Debian')
-     - deb_check.stdout.find('no packages found') != -1
 
  - include: upgrade.yml upgrade_type=full
    when:
      - ansible_distribution in ('Ubuntu', 'Debian')
-     - deb_check.stdout.find('no packages found') != -1


### PR DESCRIPTION
##### SUMMARY

In answer to #2540, `aptitude` was introduced as tool of choice for running
upgrades in the apt module and installing new packages that arise as
dependencies during upgrades.

This recently lead to problems, as for example Ubuntu Xenial (16.04) ships
without aptitude (installed).

Studying the man pages of both apt-get and aptitude, it appears that we can
achieve the effects of `aptitude safe-upgrade` using

```
apt-get upgrade --with-new-pkgs --autoremove
```

while `aptitude full-upgrade` seems to be identical to `apt-get dist-upgrade`.

An argument in favor of apt-get over aptitude is that the former is more
back-end, while the latter is more user-friendly - I suppose (peronsal humble
opinion) that in ansible core, we should try to use the potentially more stable
and backwards compatible back-end tools.

Fixes #18987


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
core/apt

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```