### PR TITLE
ansible-test: allow ansible.cfg overrides

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -1,0 +1,5 @@
+# NOTE: This file is used by ansible-test to override specific Ansible constants
+# This file is used by `ansible-test network-integration`
+
+[defaults]
+timeout = 60

--- a/test/runner/lib/ansible_util.py
+++ b/test/runner/lib/ansible_util.py
@@ -21,10 +21,14 @@ def ansible_environment(args, color=True):
     if not path.startswith(ansible_path + os.pathsep):
         path = ansible_path + os.pathsep + path
 
+    ansible_config = '/dev/null'
+    if os.path.isfile('test/integration/%s.cfg' % args.command):
+        ansible_config = os.path.abspath('test/integration/%s.cfg' % args.command)
+
     ansible = dict(
         ANSIBLE_FORCE_COLOR='%s' % 'true' if args.color and color else 'false',
         ANSIBLE_DEPRECATION_WARNINGS='false',
-        ANSIBLE_CONFIG='/dev/null',
+        ANSIBLE_CONFIG=ansible_config,
         ANSIBLE_HOST_KEY_CHECKING='false',
         PYTHONPATH=os.path.abspath('lib'),
         PAGER='/bin/cat',


### PR DESCRIPTION
##### SUMMARY
If a cfg file exists for this this command then use it.
This allows versioned test configuration to override the built in
Ansible constants.



##### ISSUE TYPE
 - Feature Pull Request

```
ansible-test network-integration -vvve junos_command
>>> Environment Description
{}
Running junos_command integration test role
>>> Playbook: junos_command-MdVcIS.yml
- hosts: junos
  gather_facts: False
  roles:
    - { role: junos_command }
Run command: ansible-playbook junos_command-MdVcIS.yml -i inventory.networking -e @integration_config.yml -vvv
Working directory: test/integration
Program found: /home/johnb/git/ansible-inc/ansible-workspace-4/bin/ansible-playbook
ANSIBLE_CALLBACK_WHITELIST=junit
ANSIBLE_CONFIG=test/integration/network-integration.cfg
ANSIBLE_DEPRECATION_WARNINGS=false
ANSIBLE_FORCE_COLOR=true
ANSIBLE_HOST_KEY_CHECKING=false

# HERE vvvvvvv
ANSIBLE_ROLES_PATH=/home/johnb/git/ansible-inc/ansible-workspace-4/test/integration/targets
# ^^^^^^^^


ANSIBLE_TEST_CI=
ANSIBLE_TEST_PYTHON_INTERPRETER=/usr/bin/python2.7
ANSIBLE_TEST_PYTHON_VERSION=2.7
HOME=/home/johnb
JUNIT_OUTPUT_DIR=/home/johnb/git/ansible-inc/ansible-workspace-4/test/results/junit
LC_ALL=en_US.UTF-8
PAGER=/bin/cat
PATH=/tmp/ansible-test-coverage-tmp/coverage:/home/johnb/git/ansible-inc/ansible-workspace-4/bin:/home/johnb/git/ansible-inc/ansible-workspace-4/test/runner:/home/johnb/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/home/johnb/go/bin:/home/johnb/gocode/bin
PYTHONPATH=/home/johnb/git/ansible-inc/ansible-workspace-4/lib
SSH_AUTH_SOCK=/run/user/1000/keyring/ssh

```
