### PR TITLE
add support for sesu become method

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -42,7 +42,7 @@ def mk_boolean(value):
 # ### CONSTANTS ### yes, actual ones
 
 BLACKLIST_EXTS = ('.pyc', '.pyo', '.swp', '.bak', '~', '.rpm', '.md', '.txt')
-BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun']
+BECOME_METHODS = ['sudo', 'su', 'pbrun', 'pfexec', 'doas', 'dzdo', 'ksu', 'runas', 'pmrun', 'sesu']
 BECOME_ERROR_STRINGS = {
     'sudo': 'Sorry, try again.',
     'su': 'Authentication failure',
@@ -51,7 +51,8 @@ BECOME_ERROR_STRINGS = {
     'doas': 'Permission denied',
     'dzdo': '',
     'ksu': 'Password incorrect',
-    'pmrun': 'You are not permitted to run this command'
+    'pmrun': 'You are not permitted to run this command',
+    'sesu': ''
 }  # FIXME: deal with i18n
 BECOME_MISSING_STRINGS = {
     'sudo': 'sorry, a password is required to run sudo',
@@ -61,7 +62,8 @@ BECOME_MISSING_STRINGS = {
     'doas': 'Authorization required',
     'dzdo': '',
     'ksu': 'No password given',
-    'pmrun': ''
+    'pmrun': '',
+    'sesu': ''
 }  # FIXME: deal with i18n
 BOOL_TRUE = BOOLEANS_TRUE
 DEFAULT_BECOME_PASS = None

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -108,7 +108,7 @@ def check_command(module, commandline):
                   'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
                   'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'template or lineinfile',
                   'dnf': 'dnf', 'zypper': 'zypper' }
-    become   = [ 'sudo', 'su', 'pbrun', 'pfexec', 'runas', 'pmrun' ]
+    become   = [ 'sudo', 'su', 'pbrun', 'pfexec', 'runas', 'pmrun', 'sesu' ]
     command = os.path.basename(commandline.split()[0])
     if command in arguments:
         module.warn("Consider using file module with %s rather than running %s" % (arguments[command], command))

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -123,9 +123,9 @@ options:
       default: null
     become_method:
       description:
-        - Become method to Use for privledge escalation.
+        - Become method to Use for privilege escalation.
       required: False
-      choices: ["None", "sudo", "su", "pbrun", "pfexec", "pmrun"]
+      choices: ["None", "sudo", "su", "pbrun", "pfexec", "pmrun", "sesu"]
       default: "None"
     become_username:
       description:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -599,6 +599,13 @@ class PlayContext(Base):
                 prompt = 'Enter UPM user password:'
                 becomecmd = '%s %s %s' % (exe, flags, shlex_quote(command))
 
+            elif self.become_method == 'sesu':
+
+                exe = self.become_exe or 'sesu'
+
+                prompt = 'Please enter your password:'
+                becomecmd = '%s %s %s -c %s' % (exe, flags, self.become_user, shlex_quote(command))
+
             else:
                 raise AnsibleError("Privilege escalation method not found: %s" % self.become_method)
 


### PR DESCRIPTION
##### SUMMARY

This is a simple new addition to the supported list of become methods, which is `sesu`, a tool provided by CA Privileged Access Manager for privilege control. The tool has a similar behavior to the `su` command, although it has no i18n.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

Privilege Escalation system.

##### ANSIBLE VERSION
```
2.4.0.0 (based on devel branch)
```


##### ADDITIONAL INFORMATION

None, summary is self-explanatory.
