### PR TITLE
ansible_dict_to_boto3_tag_list cast tag values to string

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -495,7 +495,7 @@ def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value
 
     tags_list = []
     for k, v in tags_dict.items():
-        tags_list.append({tag_name_key_name: k, tag_value_key_name: v})
+        tags_list.append({tag_name_key_name: k, tag_value_key_name: str(v)})
 
     return tags_list
 

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -30,6 +30,7 @@ import os
 import re
 from time import sleep
 
+from ansible.module_utils._text import to_native
 from ansible.module_utils.cloud import CloudRetry
 
 try:
@@ -495,7 +496,7 @@ def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value
 
     tags_list = []
     for k, v in tags_dict.items():
-        tags_list.append({tag_name_key_name: k, tag_value_key_name: str(v)})
+        tags_list.append({tag_name_key_name: k, tag_value_key_name: to_native(v)})
 
     return tags_list
 


### PR DESCRIPTION
##### SUMMARY
It is expected behavior for ansible modules to convert boolean-esque strings into bools as evidenced here: https://github.com/ansible/ansible/blob/81151ef02cd16f64eac02c077fc9c24f77ca4f6e/lib/ansible/plugins/action/set_fact.py#L48

This auto-coercing behavior makes it very difficult to pass any `"true" | "false"` value as a tag value via modules using boto3.

```yaml
# role/defaults/main.yml
---
my_tag_value: "False"

# role/tasks/main.yml
---
- name: deploy stack
  cloudformation:
    stack_name: "foo-stack"
    state: present
    template: "path/to/my/tpl.json"
    tags:
      # Our str("False") gets auto-coerced into bool(False) by
      # ansible and boto3 isn't happy about this :( 
      MyTagName: "{{my_tag_value}}"  
```

Will result in an error similar to:
```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Parameter validation failed:\nInvalid type for parameter Tags[5].Value, value: False, type: <type 'bool'>, valid types: <type 'basestring'> Parameter validation failed:\nInvalid type for parameter Tags[5].Value, value: False, type: <type 'bool'>, valid types: <type 'basestring'> - <class 'botocore.exceptions.ParamValidationError'>"}
```

Having the `ansible.module_utils.ec2.ansible_dict_to_boto3_tag_list` convenience method explicitly cast tag values to string will help overcome this issue. It's worth nothing that this shouldn't change behavior anywhere as tag values are expected to be strings.

Related issues:
https://github.com/ansible/ansible/issues/11905
https://github.com/ansible/ansible/pull/24182




##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ansible.module_utils.ec2.ansible_dict_to_boto3_tag_list`

##### ANSIBLE VERSION
```
2.4.0
```
