### PR TITLE
documented conflict with ec2 native module

### DIFF
--- a/docs/docsite/rst/intro_dynamic_inventory.rst
+++ b/docs/docsite/rst/intro_dynamic_inventory.rst
@@ -104,6 +104,8 @@ Example: AWS EC2 External Inventory Script
 
 If you use Amazon Web Services EC2, maintaining an inventory file might not be the best approach, because hosts may come and go over time, be managed by external applications, or you might even be using AWS autoscaling. For this reason, you can use the `EC2 external inventory  <https://raw.github.com/ansible/ansible/devel/contrib/inventory/ec2.py>`_ script.
 
+**Warning:** Installing this script into the project's ``./library`` directory will create a conflict with the `native ec2 module <http://docs.ansible.com/ansible/latest/ec2_module.html>`_.  The error will look sommething like ``ec2: error: unrecognized arguments``.  Typically, best practice is to keep the ec2.py inventory script in the project's root directory.
+
 You can use this script in one of two ways. The easiest is to use Ansible's ``-i`` command line option and specify the path to the script after
 marking it executable::
 


### PR DESCRIPTION
ec2.py overloads native ec2 module when placed in ./library

##### SUMMARY
<!--- Documented a simple fix for a conflict between the ec2 dynamic inventory and the native ec2 module -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
ec2.py dynamic inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]
```


##### ADDITIONAL INFORMATION
<!---
storing ec2.py in the library creates a conflict with the native ansible ec2 module
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
BEFORE:
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "usage: ec2.py [-h] [--list] [--host HOST] [--refresh-cache]\n              [--profile BOTO_PROFILE]\nec2.py: error: unrecognized arguments: /home/ec2-user/.ansible/tmp/ansible-tmp-1501193154.88-167766728329091/args\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
AFTER:
runs normally
```
