### PR TITLE
Removing openssl_publickey from pep8 legacy file

### DIFF
--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -236,9 +236,6 @@ class PublicKey(crypto_utils.OpenSSLObject):
 
         return _check_privatekey()
 
-
-
-
     def dump(self):
         """Serialize the object into a dictionary."""
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -202,7 +202,6 @@ lib/ansible/modules/clustering/consul_session.py
 lib/ansible/modules/clustering/kubernetes.py
 lib/ansible/modules/clustering/pacemaker_cluster.py
 lib/ansible/modules/commands/command.py
-lib/ansible/modules/crypto/openssl_publickey.py
 lib/ansible/modules/database/misc/elasticsearch_plugin.py
 lib/ansible/modules/database/misc/kibana_plugin.py
 lib/ansible/modules/database/misc/redis.py


### PR DESCRIPTION
##### SUMMARY

Removing openssl_publickey from pep8 legacy file

##### ISSUE TYPE

 - Bugfix Pull Request
 
##### COMPONENT NAME

- openssl_publickey

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

- N/A