### PR TITLE
fetch: fail if flat=yes and dest=existing-dir w/o trailing slash

### DIFF
--- a/lib/ansible/plugins/action/fetch.py
+++ b/lib/ansible/plugins/action/fetch.py
@@ -120,6 +120,11 @@ class ActionModule(ActionBase):
 
         dest = os.path.expanduser(dest)
         if flat:
+            if os.path.isdir(to_bytes(dest, errors='surrogate_or_strict')) and not dest.endswith(os.sep):
+                result['msg'] = "dest is an existing directory, use a trailing slash if you want to fetch src into that directory"
+                result['file'] = dest
+                result['failed'] = True
+                return result
             if dest.endswith(os.sep):
                 # if the path ends with "/", we'll use the source filename as the
                 # destination filename

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -122,3 +122,17 @@
   assert:
     that:
       'diff.stdout == ""'
+
+- name: dest is an existing directory name without trailing slash and flat=yes, should fail
+  fetch:
+    src: "{{ output_dir }}/orig"
+    dest: "{{ output_dir }}"
+    flat: yes
+  register: failed_fetch_dest_dir
+  ignore_errors: true
+
+- name: check that it indeed failed
+  assert:
+    that:
+      - "failed_fetch_dest_dir|failed"
+      - "failed_fetch_dest_dir.msg"


### PR DESCRIPTION
##### SUMMARY
Fix for https://github.com/ansible/ansible/issues/27312

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
fetch

##### ANSIBLE VERSION
ansible 2.4.0 (devel a49c419651) last updated 2017/07/28 09:23:22 (GMT +200)
  config file = /home/mkrizek/devel/ansible/ansible.cfg
  configured module search path = [u'/home/mkrizek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mkrizek/devel/ansible/lib/ansible
  executable location = /home/mkrizek/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

##### ADDITIONAL INFORMATION