### PR TITLE
ec2_ami_copy.py: Fix WaiterError handling.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -180,7 +180,7 @@ def copy_image(module, ec2):
 
         module.exit_json(changed=True, image_id=image_id)
     except WaiterError as we:
-        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' %  we.reason)
+        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' % str(we))
     except ClientError as ce:
         module.fail_json(msg=ce.message)
     except NoCredentialsError:

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -180,7 +180,7 @@ def copy_image(module, ec2):
 
         module.exit_json(changed=True, image_id=image_id)
     except WaiterError as we:
-        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' % str(we))
+        module.fail_json(msg='An error occurred waiting for the image to become available. (%s)' % str(we), exception=traceback.format_exc())
     except ClientError as ce:
         module.fail_json(msg=ce.message)
     except NoCredentialsError:

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -133,6 +133,8 @@ EXAMPLES = '''
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info)
 
+import traceback
+
 try:
     import boto
     import boto.ec2


### PR DESCRIPTION
##### SUMMARY
Fix for the unhandled 'An error occured waiting for the image to become available' in ansible_module_ec2_ami_copy.py reported in https://github.com/ansible/ansible/issues/26971

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami_copy.py

##### ANSIBLE VERSION
ansible==2.3.1.0 

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
