### PR TITLE
add_hosts.py: Fix add_host does not recognise 'host' alias

### DIFF
--- a/lib/ansible/modules/inventory/add_host.py
+++ b/lib/ansible/modules/inventory/add_host.py
@@ -44,6 +44,7 @@ notes:
     - This module bypasses the play host loop and only runs once for all the hosts in the play, if you need it
       to iterate use a with\_ directive.
     - This module is also supported for Windows targets.
+    - The alias 'host' of the parameter 'name' is only available on >=2.4
 author:
     - "Ansible Core Team"
     - "Seth Vidal"

--- a/lib/ansible/plugins/action/add_host.py
+++ b/lib/ansible/plugins/action/add_host.py
@@ -46,7 +46,7 @@ class ActionModule(ActionBase):
         result = super(ActionModule, self).run(tmp, task_vars)
 
         # Parse out any hostname:port patterns
-        new_name = self._task.args.get('name', self._task.args.get('hostname', None))
+        new_name = self._task.args.get('name', self._task.args.get('hostname', self._task.args.get('host', None)))
         display.vv("creating host via 'add_host': hostname=%s" % new_name)
 
         try:


### PR DESCRIPTION
##### SUMMARY

Now the module add_host accept the aliases "host" and "hostname" for the parameter name as reported in the [documentation](http://docs.ansible.com/ansible/latest/add_host_module.html)

Fixes  #27368 

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
add_hosts.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/build/lib/ansible
  executable location = ./ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
This fix use the same approach used for parameter groups and its aliases "groupname" and "group" of the same module [add_host.py](https://github.com/ansible/ansible/blob/d17321783307010e1a6c83fec105380d67612cd8/lib/ansible/plugins/action/add_host.py#L62)