### PR TITLE
Pass server_hostname from task to subscription-manager

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -344,7 +344,7 @@ class Rhsm(RegistrationBase):
 
     def register(self, username, password, autosubscribe, activationkey, org_id,
                  consumer_type, consumer_name, consumer_id, force_register, environment,
-                 rhsm_baseurl, server_insecure):
+                 rhsm_baseurl, server_insecure, server_hostname):
         '''
             Register the current system to the provided RHSM or Sat6 server
             Raises:
@@ -361,6 +361,9 @@ class Rhsm(RegistrationBase):
 
         if server_insecure:
             args.extend(['--insecure'])
+
+        if server_hostname:
+            args.extend(['--serverurl', server_hostname])
 
         if activationkey:
             args.extend(['--activationkey', activationkey])
@@ -725,7 +728,7 @@ def main():
                 rhsm.configure(**module.params)
                 rhsm.register(username, password, autosubscribe, activationkey, org_id,
                               consumer_type, consumer_name, consumer_id, force_register,
-                              environment, rhsm_baseurl, server_insecure)
+                              environment, rhsm_baseurl, server_insecure, server_hostname)
                 if pool_ids:
                     subscribed_pool_ids = rhsm.subscribe_by_pool_ids(pool_ids)
                 else:


### PR DESCRIPTION
##### SUMMARY
Fix for https://github.com/ansible/ansible/issues/27364.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
redhat_subscription

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel f3bc8b84b6) last updated 2017/07/28 14:17:45 (GMT +200)
  config file = /home/mkrizek/devel/ansible/ansible.cfg
  configured module search path = [u'/home/mkrizek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mkrizek/devel/ansible/lib/ansible
  executable location = /home/mkrizek/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
None