### PR TITLE
Iosxr attribute error #27122

### DIFF
--- a/lib/ansible/modules/network/iosxr/iosxr_logging.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_logging.py
@@ -104,9 +104,6 @@ commands:
     - logging hostnameprefix 172.16.0.1
 """
 
-import q
-
-
 import re
 
 from ansible.module_utils.basic import AnsibleModule
@@ -125,8 +122,6 @@ def validate_size(value, module):
 def map_obj_to_commands(updates, module):
     commands = list()
     want, have = updates
-    q(want)
-    q(have)
     for w in want:
         dest = w['dest']
         name = w['name']
@@ -135,10 +130,6 @@ def map_obj_to_commands(updates, module):
         level = w['level']
         state = w['state']
         del w['state']
-
-        q(w)
-        q(w in have)
-
 
         if state == 'absent' and w in have:
             if dest == 'hostnameprefix':
@@ -150,7 +141,6 @@ def map_obj_to_commands(updates, module):
 
             if facility:
                 commands.append('no logging facility {}'.format(facility))
-            q(commands)
 
         if state == 'present' and w not in have:
             if facility:
@@ -171,8 +161,6 @@ def map_obj_to_commands(updates, module):
                     dest_cmd += ' {}'.format(level)
 
                 commands.append(dest_cmd)
-            q(commands)
-    q(commands)
     return commands
 
 
@@ -245,18 +233,11 @@ def map_config_to_obj(module):
     data = get_config(module, flags=['logging'])
     lines = data.split("\n")
 
-    q(lines)
-
-
     for line in lines:
         match = re.search(r'logging (\S+)', line, re.M)
         if match:
-            q(match.group(1))
-            q(line)
             if match.group(1) in dest_group:
                 dest = match.group(1)
-                q(dest)
-
                 obj.append({
                     'dest': dest,
                     'name': parse_name(line, dest),
@@ -333,7 +314,6 @@ def map_params_to_obj(module):
 def main():
     """ main entry point for module execution
     """
-    q("-------------------------------------------------------------------------------------------------------------------")
     argument_spec = dict(
         dest=dict(type='str', choices=['on', 'hostnameprefix', 'console', 'monitor', 'buffered']),
         name=dict(type='str'),

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -10,7 +10,7 @@
 
 - assert:
     that:
-      - 'result.chaned == true'
+      - 'result.changed == true'
       - '"logging host 172.16.0.1" in result.commands'
       - '"logging facility local7" in result.commands'
 

--- a/test/integration/targets/iosxr_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_logging/tests/cli/basic.yaml
@@ -1,4 +1,11 @@
 ---
+- name: Remove host logging (if it exists)
+  iosxr_logging:
+    dest: hostnameprefix
+    name: 172.16.0.1
+    state: absent
+    provider: "{{ cli }}"
+
 - name: Set up host logging
   iosxr_logging:
     dest: hostnameprefix
@@ -9,7 +16,7 @@
 
 - assert:
     that:
-      - 'result.chaned == true'
+      - 'result.changed == true'
       - '"logging hostnameprefix 172.16.0.1" in result.commands'
       - '"logging facility local7" in result.commands'
 
@@ -50,10 +57,10 @@
     that:
       - 'result.changed == false'
 
-- name: Console logging with level warnings
+- name: Console logging with level warning
   iosxr_logging:
     dest: console
-    level: warnings
+    level: warning
     state: present
     provider: "{{ cli }}"
   register: result
@@ -61,7 +68,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"logging console warnings" in result.commands'
+      - '"logging console warning" in result.commands'
 
 - name: Configure Buffer size
   iosxr_logging:
@@ -78,7 +85,7 @@
 - name: remove logging as collection tearDown
   iosxr_logging:
     aggregate:
-      - { dest: console, level: warnings, state: absent }
+      - { dest: console, level: warning, state: absent }
       - { dest: buffered, size: 4800000, state: absent }
     provider: "{{ cli }}"
   register: result

--- a/test/integration/targets/iosxr_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_logging/tests/cli/basic.yaml
@@ -1,11 +1,29 @@
 ---
-- name: Remove host logging (if it exists)
+# Remove old logging entries so that they don't conflict with tests
+- name: Remove host logging
   iosxr_logging:
     dest: hostnameprefix
     name: 172.16.0.1
     state: absent
     provider: "{{ cli }}"
 
+- name: Remove console logging
+  iosxr_logging:
+    dest: console
+    level: warning
+    state: absent
+    provider: "{{ cli }}"
+  register: result
+
+- name: Remove buffer
+  iosxr_logging:
+    dest: buffered
+    size: 4800000
+    state: absent
+    provider: "{{ cli }}"
+  register: result
+
+# Start tests
 - name: Set up host logging
   iosxr_logging:
     dest: hostnameprefix


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #27122

iosxr_logging was breaking in situations where no configs were present

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- iosxr_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```ansible 2.4.0 (iosxr-attribute-error-#27122 7cc1b754a4) last updated 2017/07/28 10:10:51 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
