### PR TITLE
fixed nontype error

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -232,17 +232,17 @@ def map_config_to_obj(module):
 
     for line in data.split('\n'):
         match = re.search(r'logging (\S+)', line, re.M)
+        if match:
+            if match.group(1) in dest_group:
+                dest = match.group(1)
 
-        if match.group(1) in dest_group:
-            dest = match.group(1)
-        else:
-            pass
-
-        obj.append({'dest': dest,
+                obj.append({
+                    'dest': dest,
                     'name': parse_name(line, dest),
                     'size': parse_size(line, dest),
                     'facility': parse_facility(line),
-                    'level': parse_level(line, dest)})
+                    'level': parse_level(line, dest)
+                })
 
     return obj
 

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -1,4 +1,30 @@
 ---
+# ensure logging configs are empty
+- name: Remove host logging
+  ios_logging:
+    dest: host
+    name: 172.16.0.1
+    state: absent
+    authorize: yes
+    provider: "{{ cli }}"
+
+- name: Remove console
+  ios_logging:
+    dest: console
+    level: warnings
+    state: absent
+    authorize: yes
+    provider: "{{ cli }}"
+
+- name: Remove buffer
+  ios_logging:
+    dest: buffered
+    size: 8000
+    authorize: yes
+    state: absent
+    provider: "{{ cli }}"
+
+# start tests
 - name: Set up host logging
   ios_logging:
     dest: host


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: #27110

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ios-nontype 3f136e553c) last updated 2017/07/28 10:54:52 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
