### PR TITLE
Add ability to trust CA certs for java_cert module

### DIFF
--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -44,6 +44,13 @@ options:
   cert_alias:
     description:
       - Imported certificate alias.
+  trusted_ca:
+    description:
+      - Set to yes if you want the cert to be a trusted CA.
+    default: no
+    required: no
+    choices: [ 'yes', 'no' ]
+    version_added: '2.4'
   keystore_path:
     description:
       - Path to keystore.
@@ -130,12 +137,14 @@ def check_cert_present(module, executable, keystore_path, keystore_pass, alias):
         return True
     return False
 
-def import_cert_url(module, executable, url, port, keystore_path, keystore_pass, alias):
+def import_cert_url(module, executable, url, port, keystore_path, keystore_pass, alias, trusted_ca):
     ''' Import certificate from URL into keystore located at keystore_path '''
     fetch_cmd = ("%s -printcert -rfc -sslserver %s:%d")%(executable, url, port)
     import_cmd = ("%s -importcert -noprompt -keystore '%s' "
                   "-storepass '%s' -alias '%s'")%(executable, keystore_path,
                                                   keystore_pass, alias)
+    if trusted_ca:
+        import_cmd = " ".join([import_cmd, "-trustcacerts"])
 
     if module.check_mode:
         module.exit_json(changed=True)
@@ -156,7 +165,7 @@ def import_cert_url(module, executable, url, port, keystore_path, keystore_pass,
         return module.fail_json(msg=import_out, rc=import_rc, cmd=import_cmd,
                                 error=import_err)
 
-def import_cert_path(module, executable, path, keystore_path, keystore_pass, alias):
+def import_cert_path(module, executable, path, keystore_path, keystore_pass, alias, trusted_ca):
     ''' Import certificate from path into keystore located on
         keystore_path as alias '''
     import_cmd = ("%s -importcert -noprompt -keystore '%s' "
@@ -164,6 +173,8 @@ def import_cert_path(module, executable, path, keystore_path, keystore_pass, ali
                                                              keystore_path,
                                                              keystore_pass,
                                                              path, alias)
+    if trusted_ca:
+        import_cmd = " ".join([import_cmd, "-trustcacerts"])
 
     if module.check_mode:
         module.exit_json(changed=True)
@@ -220,6 +231,7 @@ def main():
         cert_path=dict(type='str'),
         cert_alias=dict(type='str'),
         cert_port=dict(default='443', type='int'),
+        trusted_ca=dict(default=False, type='bool'),
         keystore_path=dict(type='str'),
         keystore_pass=dict(required=True, type='str', no_log=True),
         keystore_create=dict(default=False, type='bool'),
@@ -242,6 +254,7 @@ def main():
     path = module.params.get('cert_path')
     port = module.params.get('cert_port')
     cert_alias = module.params.get('cert_alias') or url
+    trusted_ca = module.params.get('trusted_ca')
 
     keystore_path = module.params.get('keystore_path')
     keystore_pass = module.params.get('keystore_pass')
@@ -270,11 +283,11 @@ def main():
         if not cert_present:
             if path:
                 import_cert_path(module, executable, path, keystore_path,
-                                 keystore_pass, cert_alias)
+                                 keystore_pass, cert_alias, trusted_ca)
 
             if url:
                 import_cert_url(module, executable, url, port, keystore_path,
-                                keystore_pass, cert_alias)
+                                keystore_pass, cert_alias, trusted_ca)
 
     module.exit_json(changed=False)
 


### PR DESCRIPTION
##### SUMMARY
This will tell the java keytool command to import the cert as a trusted CA.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
java_cert module

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
Useful for:
- adding an internal CA for your organization.
- adding new vendor CA certs

