### PR TITLE
Add support for `non_local` alias in ansible-test.

### DIFF
--- a/test/integration/targets/connection_buildah/aliases
+++ b/test/integration/targets/connection_buildah/aliases
@@ -1,1 +1,2 @@
 needs/root
+non_local

--- a/test/integration/targets/connection_buildah/runme.sh
+++ b/test/integration/targets/connection_buildah/runme.sh
@@ -2,6 +2,6 @@
 
 set -eux
 
-ANSIBLE_TEST_REMOTE_INTERPRETER='' ./posix.sh "$@"
+./posix.sh "$@"
 
-ANSIBLE_TEST_REMOTE_INTERPRETER='' ANSIBLE_REMOTE_USER="1000" ./posix.sh "$@"
+ANSIBLE_REMOTE_USER="1000" ./posix.sh "$@"

--- a/test/integration/targets/connection_buildah/test_connection.inventory
+++ b/test/integration/targets/connection_buildah/test_connection.inventory
@@ -5,7 +5,7 @@ buildah-container    ansible_ssh_pipelining=true
 # 2. create container:
 # $ sudo buildah from --name=buildah-container python:2
 # 3. run test:
-# $ ANSIBLE_TEST_REMOTE_INTERPRETER= ansible-test integration --local connection_buildah
+# $ ansible-test integration connection_buildah
 # 6. remove container
 # $ sudo buildah rm buildah-container
 ansible_host=buildah-container

--- a/test/integration/targets/connection_docker/aliases
+++ b/test/integration/targets/connection_docker/aliases
@@ -1,0 +1,1 @@
+non_local

--- a/test/integration/targets/connection_lxd/aliases
+++ b/test/integration/targets/connection_lxd/aliases
@@ -1,0 +1,1 @@
+non_local

--- a/test/integration/targets/openvswitch_db/aliases
+++ b/test/integration/targets/openvswitch_db/aliases
@@ -1,0 +1,1 @@
+non_local

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -629,6 +629,12 @@ def integration_environment(args, target, cmd):
     if args.debug_strategy:
         env.update(dict(ANSIBLE_STRATEGY='debug'))
 
+    if 'non_local/' in target.aliases:
+        if args.coverage:
+            display.warning('Skipping coverage reporting for non-local test: %s' % target.name)
+
+        env.update(dict(ANSIBLE_TEST_REMOTE_INTERPRETER=''))
+
     env.update(integration)
 
     cloud_environment = get_cloud_environment(args, target)


### PR DESCRIPTION
##### SUMMARY

Add support for `non_local` alias in ansible-test.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-non-local 45e3d7aa73) last updated 2017/07/28 10:58:05 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
