### PR TITLE
Azure inventory returns private ip

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -20,3 +20,5 @@ group_by_resource_group=yes
 group_by_location=yes
 group_by_security_group=yes
 group_by_tag=yes
+
+# Return ansible_host with private ip address. Set ansible_host_private_ip=yes, otherwise ansible_host will be set as public_ip.

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -229,7 +229,8 @@ AZURE_CONFIG_SETTINGS = dict(
     group_by_resource_group='AZURE_GROUP_BY_RESOURCE_GROUP',
     group_by_location='AZURE_GROUP_BY_LOCATION',
     group_by_security_group='AZURE_GROUP_BY_SECURITY_GROUP',
-    group_by_tag='AZURE_GROUP_BY_TAG'
+    group_by_tag='AZURE_GROUP_BY_TAG',
+    ansible_host_private_ip='AZURE_HOST_PRIVATE_IP'
 )
 
 AZURE_MIN_VERSION = "0.30.0rc5"
@@ -417,6 +418,7 @@ class AzureInventory(object):
         self.group_by_security_group = True
         self.group_by_tag = True
         self.include_powerstate = True
+        self.ansible_host_private_ip = False
 
         self._inventory = dict(
             _meta=dict(
@@ -590,12 +592,17 @@ class AzureInventory(object):
                     for ip_config in network_interface.ip_configurations:
                         host_vars['private_ip'] = ip_config.private_ip_address
                         host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method
+
+                        if self.ansible_host_private_ip:
+                            host_vars['ansible_host'] = ip_config.private_ip_address
+
                         if ip_config.public_ip_address:
                             public_ip_reference = self._parse_ref_id(ip_config.public_ip_address.id)
                             public_ip_address = self._network_client.public_ip_addresses.get(
                                 public_ip_reference['resourceGroups'],
                                 public_ip_reference['publicIPAddresses'])
-                            host_vars['ansible_host'] = public_ip_address.ip_address
+                            if not self.ansible_host_private_ip:
+                                host_vars['ansible_host'] = public_ip_address.ip_address
                             host_vars['public_ip'] = public_ip_address.ip_address
                             host_vars['public_ip_name'] = public_ip_address.name
                             host_vars['public_ip_alloc_method'] = public_ip_address.public_ip_allocation_method


### PR DESCRIPTION
##### SUMMARY
Current version of azure_rm.py exports `ansible_host` as `public_ip` only. 
Suggested changes don't modify current script behavior, only add feature to manage public/private ip capturing with additional option in azure_rm.ini file

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/azure_rm.py
contrib/inventory/azure_rm.ini

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr 20 2017, 12:13:37) [GCC 6.3.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
PREVIOUSLY:
```
contrib/inventory/azure_rm.py --host azure-vm0001 --pretty
...
"_meta": {
    "hostvars": {
      "azure-vm0001": {
        "ansible_host": "40.69.XX.YY",
        "computer_name": "azure-vm0001",
...
```

WITH PROPOSED CHANGES:
```
contrib/inventory/azure_rm.py --host azure-vm0001 --pretty
...
"_meta": {
    "hostvars": {
      "azure-vm0001": {
        "ansible_host": "10.105.XY.YZ",
        "computer_name": "azure-vm0001",
...
```