### PR TITLE
added lines to mode: strict

### DIFF
--- a/test/integration/targets/iosxr_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/iosxr_config/tests/cli/toplevel_nonidempotent.yaml
@@ -8,7 +8,7 @@
 
 - name: configure top level command
   iosxr_config:
-    commands: ['hostname foo']
+    commands: ['banner motd "hello world"', 'hostname foo']
     match: strict
   register: result
 
@@ -16,10 +16,11 @@
     that:
       - "result.changed == true"
       - "'hostname foo' in result.commands"
+      - "'banner motd \"hello world\"' in result.commands"
 
 - name: configure top level command idempotent check
   iosxr_config:
-    commands: ['hostname foo']
+    commands: ['banner motd "hello world"', 'hostname foo']
     match: strict
   register: result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes:  #27120

`match: strict` in iosxr_config compares corresponding lines in the new config with the target config and applies any lines that don't match, so if target_config[0] != running_config[0], apply target_config[0].

In this case 
```
- name: configure top level command idempotent check
  iosxr_config:
    commands: ['hostname foo']
    match: strict
  register: result

- assert:
    that:
      - "result.changed == true"
```
was failing because since exact lines are compared, adding `hostname foo` a second time with `match: strict` should have triggered a change, but it wasn't because 'hostname foo' happened to be at the top of the running config. 

To solve this, I just added another line to the list of commands so that `hostname foo' is index 1 in the new config and index 0 in the running config. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
iosxr_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (iosxr-config 587fc154bf) last updated 2017/07/28 16:07:05 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
