### PR TITLE
Gather facts

### DIFF
--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -1,5 +1,10 @@
 ---
 
+# network-integration test are ran with gather_facts: no
+# We need to explicitly call setup so ansible_distribution isnset
+
+- name: Gather Facts 
+  setup:
 - name: Install openvswitch-switch package if we are on Ubuntu
   apt:
     name: openvswitch-switch

--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 
 # network-integration test are ran with gather_facts: no
-# We need to explicitly call setup so ansible_distribution isnset
+# We need to explicitly call setup so ansible_distribution is set
 
 - name: Gather Facts 
   setup:
+
 - name: Install openvswitch-switch package if we are on Ubuntu
   apt:
     name: openvswitch-switch


### PR DESCRIPTION
##### SUMMARY

network-integration test are ran with gather_facts: no
We need to explicitly call setup so ansible_distribution is set

Previously this wasn't an issue as run_ovs_integration_tests gathered facts. No we are using ansible-test and DCI this isn't the case. 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
