### PR TITLE
Fix ansible-test type hints.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -841,7 +841,7 @@ def compile_version(args, python_version, include, exclude):
     :type args: CompileConfig
     :type python_version: str
     :type include: tuple[CompletionTarget]
-    :param exclude: tuple[CompletionTarget]
+    :type exclude: tuple[CompletionTarget]
     :rtype: TestResult
     """
     command = 'compile'

--- a/test/runner/lib/git.py
+++ b/test/runner/lib/git.py
@@ -79,8 +79,8 @@ class Git(object):
     def run_git_split(self, cmd, separator=None, str_errors='strict'):
         """
         :type cmd: list[str]
-        :param separator: str | None
-        :type str_errors: 'strict' | 'replace'
+        :type separator: str | None
+        :type str_errors: str
         :rtype: list[str]
         """
         output = self.run_git(cmd, str_errors=str_errors).strip(separator)
@@ -93,7 +93,7 @@ class Git(object):
     def run_git(self, cmd, str_errors='strict'):
         """
         :type cmd: list[str]
-        :type str_errors: 'strict' | 'replace'
+        :type str_errors: str
         :rtype: str
         """
         return run_command(self.args, [self.git] + cmd, capture=True, always=True, str_errors=str_errors)[0]

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -312,7 +312,7 @@ def walk_test_targets(path=None, module_path=None, extensions=None, prefix=None)
 
 def analyze_integration_target_dependencies(integration_targets):
     """
-    :type: list[IntegrationTarget]
+    :type integration_targets: list[IntegrationTarget]
     :rtype: dict[str,set[str]]
     """
     hidden_role_target_names = set(t.name for t in integration_targets if t.type == 'role' and 'hidden/' in t.aliases)

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -93,7 +93,7 @@ def run_command(args, cmd, capture=False, env=None, data=None, cwd=None, always=
     :type stdin: file | None
     :type stdout: file | None
     :type cmd_verbosity: int
-    :type str_errors: 'strict' | 'replace'
+    :type str_errors: str
     :rtype: str | None, str | None
     """
     explain = args.explain and not always
@@ -113,7 +113,7 @@ def raw_command(cmd, capture=False, env=None, data=None, cwd=None, explain=False
     :type stdin: file | None
     :type stdout: file | None
     :type cmd_verbosity: int
-    :type str_errors: 'strict' | 'replace'
+    :type str_errors: str
     :rtype: str | None, str | None
     """
     if not cwd:


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test type hints.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (type-hints d2872d299f) last updated 2017/07/28 16:17:59 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
