### PR TITLE
Get rid of more wildcard imports and add boilerplate to more modules

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
@@ -1,20 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -193,6 +186,7 @@ import traceback
 from distutils.version import LooseVersion
 
 try:
+    # Imported as a dependency for dopy
     import six
     HAS_SIX = True
 except ImportError:
@@ -478,6 +472,7 @@ def main():
         module.fail_json(msg=str(e), id=e.id)
     except (DoError, Exception) as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_block_storage.py
@@ -1,20 +1,12 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -118,9 +110,9 @@ id:
 import json
 import os
 import time
+import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.urls import fetch_url
 
 
@@ -338,12 +330,11 @@ def main():
     )
     try:
         handle_request(module)
-    except DOBlockStorageException:
-        e = get_exception()
-        module.fail_json(msg=e.message)
-    except KeyError:
-        e = get_exception()
-        module.fail_json(msg='Unable to load %s' % e.message)
+    except DOBlockStorageException as e:
+        module.fail_json(msg=e.message, exception=traceback.format_exc())
+    except KeyError as e:
+        module.fail_json(msg='Unable to load %s' % e.message, exception=traceback.format_exc())
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -1,20 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
                     'supported_by': 'community'}
@@ -96,6 +89,7 @@ except ImportError as e:
     HAS_DOPY = False
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 
 
 class JsonfyMixIn(object):
@@ -244,7 +238,8 @@ def main():
     try:
         core(module)
     except (DoError, Exception) as e:
-        module.fail_json(msg=str(e), exception=traceback.format_exc())
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -1,20 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -181,6 +174,7 @@ def main():
         core(module)
     except (DoError, Exception) as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
@@ -1,20 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -279,6 +272,7 @@ def main():
         core(module)
     except Exception as e:
         module.fail_json(msg=str(e))
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -4,22 +4,11 @@
 # (c) 2014, Joshua Conner <joshua.conner@gmail.com>
 # (c) 2014, Pavel Antonov <antonov@adwz.ru>
 #
-# This file is part of Ansible,
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-######################################################################
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['deprecated'],
@@ -524,11 +513,6 @@ EXAMPLES = '''
       syslog-tag: myservice
 '''
 
-HAS_DOCKER_PY = True
-DEFAULT_DOCKER_API_VERSION = None
-DEFAULT_TIMEOUT_SECONDS = 60
-
-import sys
 import json
 import os
 import shlex
@@ -543,9 +527,12 @@ try:
     import docker.utils
     import docker.errors
     from requests.exceptions import RequestException
+    HAS_DOCKER_PY = True
 except ImportError:
     HAS_DOCKER_PY = False
 
+DEFAULT_DOCKER_API_VERSION = None
+DEFAULT_TIMEOUT_SECONDS = 60
 if HAS_DOCKER_PY:
     try:
         from docker.errors import APIError as DockerAPIError
@@ -560,6 +547,8 @@ if HAS_DOCKER_PY:
         # docker-py less than 1.2
         DEFAULT_DOCKER_API_VERSION = docker.client.DEFAULT_DOCKER_API_VERSION
         DEFAULT_TIMEOUT_SECONDS = docker.client.DEFAULT_TIMEOUT_SECONDS
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def _human_to_bytes(number):
@@ -1979,8 +1968,6 @@ def main():
     except RequestException as e:
         module.fail_json(changed=manager.has_changed(), msg=repr(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # Copyright 2016 Red Hat | Ansible
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # Copyright 2016 Red Hat | Ansible
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -250,11 +240,10 @@ image:
     type: dict
     sample: {}
 '''
-import re
 import os
+import re
 
-from ansible.module_utils.docker_common import (HAS_DOCKER_PY_2, AnsibleDockerClient,
-                                                DockerBaseClass)
+from ansible.module_utils.docker_common import HAS_DOCKER_PY_2, AnsibleDockerClient, DockerBaseClass
 from ansible.module_utils._text import to_native
 
 try:

--- a/lib/ansible/modules/cloud/docker/docker_image_facts.py
+++ b/lib/ansible/modules/cloud/docker/docker_image_facts.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # Copyright 2016 Red Hat | Ansible
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -161,14 +151,14 @@ images:
     ]
 '''
 
-from ansible.module_utils.docker_common import *
-
 try:
-    from docker import auth
     from docker import utils
 except ImportError:
     # missing docker-py handled in docker_common
     pass
+
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
+
 
 class ImageManager(DockerBaseClass):
 
@@ -241,9 +231,6 @@ def main():
     ImageManager(client, results)
     client.module.exit_json(**results)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -4,21 +4,10 @@
 #          Chris Houseknecht, <house@redhat.com>
 #          James Tanner, <jtanner@redhat.com>
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
@@ -142,9 +131,12 @@ login_results:
 '''
 
 import base64
+import json
+import os
+import re
 
 from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.docker_common import *
+from ansible.module_utils.docker_common import AnsibleDockerClient, DEFAULT_DOCKER_REGISTRY, DockerBaseClass, EMAIL_REGEX
 
 
 class LoginManager(DockerBaseClass):
@@ -333,8 +325,6 @@ def main():
         del results['actions']
     client.module.exit_json(**results)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # Copyright 2016 Red Hat | Ansible
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -161,14 +151,12 @@ facts:
     sample: {}
 '''
 
-from ansible.module_utils.docker_common import *
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass, HAS_DOCKER_PY_2
 
 try:
     from docker import utils
     if HAS_DOCKER_PY_2:
-        from docker.types import Ulimit, IPAMPool, IPAMConfig
-    else:
-        from docker.utils.types import Ulimit
+        from docker.types import IPAMPool, IPAMConfig
 except:
     # missing docker-py handled in ansible.module_utils.docker
     pass
@@ -390,8 +378,6 @@ def main():
     cm = DockerNetworkManager(client)
     client.module.exit_json(**cm.results)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/docker/docker_secret.py
+++ b/lib/ansible/modules/cloud/docker/docker_secret.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # Copyright 2016 Red Hat | Ansible
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -152,7 +142,6 @@ except ImportError:
     # missing docker-py handled in ansible.module_utils.docker
     pass
 
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
 from ansible.module_utils._text import to_native, to_bytes
 

--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # Copyright 2016 Red Hat | Ansible
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -449,38 +439,37 @@ actions:
                           type: string
 '''
 
-HAS_YAML = True
-HAS_YAML_EXC = None
-HAS_COMPOSE = True
-HAS_COMPOSE_EXC = None
-MINIMUM_COMPOSE_VERSION = '1.7.0'
-
-import sys
+import os
 import re
+import sys
+import tempfile
+from contextlib import contextmanager
+from distutils.version import LooseVersion
 
 try:
     import yaml
+    HAS_YAML = True
+    HAS_YAML_EXC = None
 except ImportError as exc:
     HAS_YAML = False
     HAS_YAML_EXC = str(exc)
 
-from distutils.version import LooseVersion
-from ansible.module_utils.basic import *
-
 try:
     from compose import __version__ as compose_version
-    from compose.project import ProjectError
     from compose.cli.command import project_from_options
-    from compose.service import ConvergenceStrategy, NoSuchImageError
+    from compose.service import NoSuchImageError
     from compose.cli.main import convergence_strategy_from_opts, build_action_from_opts, image_type_from_opt
     from compose.const import DEFAULT_TIMEOUT
+    HAS_COMPOSE = True
+    HAS_COMPOSE_EXC = None
+    MINIMUM_COMPOSE_VERSION = '1.7.0'
+
 except ImportError as exc:
     HAS_COMPOSE = False
     HAS_COMPOSE_EXC = str(exc)
     DEFAULT_TIMEOUT = 10
 
-from ansible.module_utils.docker_common import *
-from contextlib import contextmanager
+from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseClass
 
 
 AUTH_PARAM_MAPPING = {

--- a/lib/ansible/modules/cloud/docker/docker_volume.py
+++ b/lib/ansible/modules/cloud/docker/docker_volume.py
@@ -2,21 +2,12 @@
 # coding: utf-8
 #
 # Copyright 2017 Red Hat | Ansible, Alex Grönholm <alex.gronholm@nextday.fi>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -112,8 +103,8 @@ except ImportError:
     # missing docker-py handled in ansible.module_utils.docker
     pass
 
-from ansible.module_utils.six import iteritems, text_type
 from ansible.module_utils.docker_common import DockerBaseClass, AnsibleDockerClient
+from ansible.module_utils.six import iteritems, text_type
 
 
 class TaskParameters(DockerBaseClass):
@@ -257,6 +248,7 @@ def main():
 
     cm = DockerVolumeManager(client)
     client.module.exit_json(**cm.results)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/helm.py
+++ b/lib/ansible/modules/cloud/misc/helm.py
@@ -1,18 +1,11 @@
 #!/usr/bin/python
 # (c) 2016, Flavio Percoco <flavio@redhat.com>
 #
-# This module is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -102,9 +95,6 @@ EXAMPLES = '''
     name: my-memcached
 '''
 
-
-import os
-
 try:
     import grpc
     from pyhelm import tiller
@@ -112,7 +102,6 @@ try:
     HAS_PYHELM = True
 except ImportError as exc:
     HAS_PYHELM = False
-
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -127,9 +116,9 @@ def install(module, tserver):
 
     chartb = chartbuilder.ChartBuilder(chart)
     try:
-        result = tserver.install_release(chartb.get_helm_chart(), namespace,
-                                         dry_run=False, name=name,
-                                         values=values)
+        tserver.install_release(chartb.get_helm_chart(), namespace,
+                                dry_run=False, name=name,
+                                values=values)
         changed = True
     except grpc._channel._Rendezvous as exc:
         if "already exists" not in str(exc):
@@ -149,7 +138,7 @@ def delete(module, tserver, purge=False):
     disable_hooks = params['disable_hooks']
 
     try:
-        result = tserver.uninstall_release(name, disable_hooks, purge)
+        tserver.uninstall_release(name, disable_hooks, purge)
         changed = True
     except grpc._channel._Rendezvous as exc:
         if 'not found' not in str(exc):

--- a/lib/ansible/modules/cloud/misc/ovirt.py
+++ b/lib/ansible/modules/cloud/misc/ovirt.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 
 # (c) 2013, Vincent Van der Kussen <vincent at vanderkussen.org>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -268,6 +258,7 @@ ovirt:
     rootpw: bigsecret
 
 '''
+import time
 
 try:
     from ovirtsdk.api import API
@@ -275,6 +266,9 @@ try:
     HAS_OVIRTSDK = True
 except ImportError:
     HAS_OVIRTSDK = False
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 # ------------------------------------------------------------------- #
 # create connection with API
@@ -523,11 +517,6 @@ def main():
             vm_remove(c, vmname)
             module.exit_json(changed=True, msg="VM %s removed" % vmname)
 
-
-
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/proxmox.py
+++ b/lib/ansible/modules/cloud/misc/proxmox.py
@@ -1,18 +1,10 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -327,15 +319,17 @@ EXAMPLES = '''
 
 import os
 import time
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
+import traceback
 
 try:
     from proxmoxer import ProxmoxAPI
     HAS_PROXMOXER = True
 except ImportError:
     HAS_PROXMOXER = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
 
 VZ_TYPE = None
 
@@ -344,9 +338,9 @@ def get_nextvmid(module, proxmox):
     try:
         vmid = proxmox.cluster.nextid.get()
         return vmid
-    except Exception:
-        exc = get_exception()
-        module.fail_json(msg="Unable to get next vmid. Failed with exception: %s" % exc)
+    except Exception as e:
+        module.fail_json(msg="Unable to get next vmid. Failed with exception: %s" % to_native(e),
+                         exception=traceback.format_exc())
 
 
 def get_vmid(proxmox, hostname):
@@ -637,7 +631,7 @@ def main():
 
                 time.sleep(1)
         except Exception as e:
-            module.fail_json(msg="deletion of VM %s failed with exception: %s" % (vmid, e))
+            module.fail_json(msg="deletion of VM %s failed with exception: %s" % (vmid, to_native(e)))
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -2,20 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2016, Abdoul Bah (@helldorado) <bahabdoul at gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""
-Ansible module to manage Qemu(KVM) instance in Proxmox VE cluster.
-This module is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-This software is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with this software.  If not, see <http://www.gnu.org/licenses/>.
-"""
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -706,15 +697,17 @@ status:
 import os
 import re
 import time
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
+import traceback
 
 try:
     from proxmoxer import ProxmoxAPI
     HAS_PROXMOXER = True
 except ImportError:
     HAS_PROXMOXER = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
 
 VZ_TYPE = 'qemu'
 
@@ -723,9 +716,9 @@ def get_nextvmid(module, proxmox):
     try:
         vmid = proxmox.cluster.nextid.get()
         return vmid
-    except Exception:
-        exc = get_exception()
-        module.fail_json(msg="Unable to get next vmid. Failed with exception: %s" % exc)
+    except Exception as e:
+        module.fail_json(msg="Unable to get next vmid. Failed with exception: %s" % to_native(e),
+                         exception=traceback.format_exc())
 
 
 def get_vmid(proxmox, name):

--- a/lib/ansible/modules/cloud/misc/proxmox_template.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_template.py
@@ -1,18 +1,12 @@
 #!/usr/bin/python
-# This file is part of Ansible
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Copyright: Ansible Project
 #
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -138,14 +132,14 @@ EXAMPLES = '''
 
 import os
 import time
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
 
 try:
     from proxmoxer import ProxmoxAPI
     HAS_PROXMOXER = True
 except ImportError:
     HAS_PROXMOXER = False
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def get_template(proxmox, node, storage, content_type, template):

--- a/lib/ansible/modules/cloud/misc/rhevm.py
+++ b/lib/ansible/modules/cloud/misc/rhevm.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 
 # (c) 2016, Timothy Vandenbrande <timothy.vandenbrande@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -331,9 +321,6 @@ EXAMPLES = '''
 '''
 
 import time
-import sys
-import traceback
-import json
 
 try:
     from ovirtsdk.api import API
@@ -341,6 +328,9 @@ try:
     HAS_SDK = True
 except ImportError:
     HAS_SDK = False
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 RHEV_FAILED = 1
 RHEV_SUCCESS = 0
@@ -1024,13 +1014,13 @@ class RHEV(object):
             vminfo['cpu_cores']   = VM.cpu.topology.cores
             vminfo['cpu_sockets'] = VM.cpu.topology.sockets
             vminfo['cpu_shares']  = VM.cpu_shares
-            vminfo['memory']      = (int(VM.memory) / 1024 / 1024 / 1024)
-            vminfo['mem_pol']     = (int(VM.memory_policy.guaranteed) / 1024 / 1024 / 1024)
+            vminfo['memory']      = (int(VM.memory) // 1024 // 1024 // 1024)
+            vminfo['mem_pol']     = (int(VM.memory_policy.guaranteed) // 1024 // 1024 // 1024)
             vminfo['os']          = VM.get_os().type_
             vminfo['del_prot']    = VM.delete_protected
             try:
                 vminfo['host']    = str(self.conn.get_Host_byid(str(VM.host.id)).name)
-            except Exception as e:
+            except Exception:
                 vminfo['host']    = None
             vminfo['boot_order']  = []
             for boot_dev in VM.os.get_boot():
@@ -1039,7 +1029,7 @@ class RHEV(object):
             for DISK in VM.disks.list():
                 disk = dict()
                 disk['name'] = DISK.name
-                disk['size'] = (int(DISK.size) / 1024 / 1024 / 1024)
+                disk['size'] = (int(DISK.size) // 1024 // 1024 // 1024)
                 disk['domain'] = str((self.conn.get_domain_byid(DISK.get_storage_domains().get_storage_domain()[0].id)).name)
                 disk['interface'] = DISK.interface
                 vminfo['disks'].append(disk)
@@ -1522,9 +1512,6 @@ def main():
     else:
         module.exit_json(**result)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/serverless.py
+++ b/lib/ansible/modules/cloud/misc/serverless.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2016, Ryan Scott Brown <ryansb@redhat.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -125,10 +114,11 @@ command:
   sample: serverless deploy --stage production
 """
 
-
 import os
 import traceback
 import yaml
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def read_serverless_config(module):
@@ -208,8 +198,6 @@ def main():
     module.exit_json(changed=True, state='present', out=out, command=command,
             service_name=get_service_name(module, stage))
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -1,19 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""
-Virt management features
+# Copyright 2007, 2012 Red Hat, Inc
+# Michael DeHaan <michael.dehaan@gmail.com>
+# Seth Vidal <skvidal@fedoraproject.org>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-Copyright 2007, 2012 Red Hat, Inc
-Michael DeHaan <michael.dehaan@gmail.com>
-Seth Vidal <skvidal@fedoraproject.org>
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
-This software may be freely redistributed under the terms of the GNU
-general public license.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -119,11 +115,8 @@ status:
     sample: "success"
     returned: success
 '''
-VIRT_FAILED = 1
-VIRT_SUCCESS = 0
-VIRT_UNAVAILABLE=2
 
-import sys
+import traceback
 
 try:
     import libvirt
@@ -131,6 +124,14 @@ except ImportError:
     HAS_VIRT = False
 else:
     HAS_VIRT = True
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+
+VIRT_FAILED = 1
+VIRT_SUCCESS = 0
+VIRT_UNAVAILABLE=2
 
 ALL_COMMANDS = []
 VM_COMMANDS = ['create','status', 'start', 'stop', 'pause', 'unpause',
@@ -537,19 +538,14 @@ def main():
     rc = VIRT_SUCCESS
     try:
         rc, result = core(module)
-    except Exception:
-        e = get_exception()
-        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
 
     if rc != 0: # something went wrong emit the msg
         module.fail_json(rc=rc, msg=result)
     else:
         module.exit_json(**result)
 
-
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.pycompat24 import get_exception
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/misc/virt_net.py
+++ b/lib/ansible/modules/cloud/misc/virt_net.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Maciej Delmanowski <drybjed@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -141,11 +131,6 @@ EXAMPLES = '''
     name: br_nat
 '''
 
-VIRT_FAILED = 1
-VIRT_SUCCESS = 0
-VIRT_UNAVAILABLE=2
-
-
 try:
     import libvirt
 except ImportError:
@@ -163,6 +148,10 @@ else:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+
+VIRT_FAILED = 1
+VIRT_SUCCESS = 0
+VIRT_UNAVAILABLE=2
 
 ALL_COMMANDS = []
 ENTRY_COMMANDS = ['create', 'status', 'start', 'stop',

--- a/lib/ansible/modules/cloud/misc/virt_pool.py
+++ b/lib/ansible/modules/cloud/misc/virt_pool.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Maciej Delmanowski <drybjed@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -156,10 +146,6 @@ EXAMPLES = '''
     name: vms
 '''
 
-VIRT_FAILED = 1
-VIRT_SUCCESS = 0
-VIRT_UNAVAILABLE=2
-
 try:
     import libvirt
 except ImportError:
@@ -176,6 +162,10 @@ else:
 
 from ansible.module_utils.basic import AnsibleModule
 
+
+VIRT_FAILED = 1
+VIRT_SUCCESS = 0
+VIRT_UNAVAILABLE=2
 
 ALL_COMMANDS = []
 ENTRY_COMMANDS = ['create', 'status', 'start', 'stop', 'build', 'delete',

--- a/lib/ansible/modules/cloud/misc/xenserver_facts.py
+++ b/lib/ansible/modules/cloud/misc/xenserver_facts.py
@@ -1,18 +1,10 @@
 #!/usr/bin/python -tt
-# This file is part of Ansible
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
@@ -61,6 +53,8 @@ try:
     HAVE_XENAPI = True
 except ImportError:
     pass
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 class XenServerFacts:
@@ -209,7 +203,6 @@ def main():
 
     module.exit_json(ansible=data)
 
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/webfaction/webfaction_app.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_app.py
@@ -1,31 +1,19 @@
 #!/usr/bin/python
 #
-# Create a Webfaction application using Ansible and the Webfaction API
-#
-# Valid application types can be found by looking here:
-# http://docs.webfaction.com/xmlrpc-api/apps.html#application-types
-#
-# ------------------------------------------
-#
 # (c) Quentin Stafford-Fraser 2015, with contributions gratefully acknowledged from:
 #     * Andy Baker
 #     * Federico Tarantini
 #
-# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Create a Webfaction application using Ansible and the Webfaction API
 #
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Valid application types can be found by looking here:
+# http://docs.webfaction.com/xmlrpc-api/apps.html#application-types
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -113,7 +101,11 @@ EXAMPLES = '''
 
 import xmlrpclib
 
+from ansible.module_utils.basic import AnsibleModule
+
+
 webfaction = xmlrpclib.ServerProxy('https://api.webfaction.com/')
+
 
 def main():
 
@@ -202,7 +194,6 @@ def main():
         result = result
     )
 
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/webfaction/webfaction_db.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_db.py
@@ -1,28 +1,16 @@
 #!/usr/bin/python
 #
-# Create a webfaction database using Ansible and the Webfaction API
-#
-# ------------------------------------------
-#
 # (c) Quentin Stafford-Fraser 2015, with contributions gratefully acknowledged from:
 #     * Andy Baker
 #     * Federico Tarantini
 #
-# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Create a webfaction database using Ansible and the Webfaction API
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -103,10 +91,13 @@ EXAMPLES = '''
 
 '''
 
-import socket
 import xmlrpclib
 
+from ansible.module_utils.basic import AnsibleModule
+
+
 webfaction = xmlrpclib.ServerProxy('https://api.webfaction.com/')
+
 
 def main():
 
@@ -203,7 +194,6 @@ def main():
         result = result
     )
 
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/webfaction/webfaction_domain.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_domain.py
@@ -1,26 +1,13 @@
 #!/usr/bin/python
 #
-# Create Webfaction domains and subdomains using Ansible and the Webfaction API
-#
-# ------------------------------------------
-#
 # (c) Quentin Stafford-Fraser 2015
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Create Webfaction domains and subdomains using Ansible and the Webfaction API
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -95,10 +82,13 @@ EXAMPLES = '''
 
 '''
 
-import socket
 import xmlrpclib
 
+from ansible.module_utils.basic import AnsibleModule
+
+
 webfaction = xmlrpclib.ServerProxy('https://api.webfaction.com/')
+
 
 def main():
 
@@ -175,7 +165,6 @@ def main():
         result = result
     )
 
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
@@ -1,25 +1,13 @@
 #!/usr/bin/python
 #
-# Create webfaction mailbox using Ansible and the Webfaction API
-#
-# ------------------------------------------
 # (c) Quentin Stafford-Fraser and Andy Baker 2015
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Create webfaction mailbox using Ansible and the Webfaction API
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -81,10 +69,13 @@ EXAMPLES = '''
       login_password={{webfaction_passwd}}
 '''
 
-import socket
 import xmlrpclib
 
+from ansible.module_utils.basic import AnsibleModule
+
+
 webfaction = xmlrpclib.ServerProxy('https://api.webfaction.com/')
+
 
 def main():
 
@@ -141,8 +132,6 @@ def main():
 
     module.exit_json(changed=True, result=result)
 
-
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/webfaction/webfaction_site.py
+++ b/lib/ansible/modules/cloud/webfaction/webfaction_site.py
@@ -1,26 +1,12 @@
 #!/usr/bin/python
+# (c) Quentin Stafford-Fraser 2015
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
 # Create Webfaction website using Ansible and the Webfaction API
-#
-# ------------------------------------------
-#
-# (c) Quentin Stafford-Fraser 2015
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -113,7 +99,11 @@ EXAMPLES = '''
 import socket
 import xmlrpclib
 
+from ansible.module_utils.basic import AnsibleModule
+
+
 webfaction = xmlrpclib.ServerProxy('https://api.webfaction.com/')
+
 
 def main():
 
@@ -212,9 +202,6 @@ def main():
         result = result
     )
 
-
-
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -123,8 +113,6 @@ EXAMPLES = '''
         state: absent
 '''
 
-import sys
-
 try:
     import consul
     from requests.exceptions import ConnectionError
@@ -137,8 +125,6 @@ try:
     pyhcl_installed = True
 except ImportError:
     pyhcl_installed = False
-
-from requests.exceptions import ConnectionError
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
@@ -157,7 +143,6 @@ def execute(module):
 def update_acl(module):
 
     rules = module.params.get('rules')
-    state = module.params.get('state')
     token = module.params.get('token')
     token_type = module.params.get('token_type')
     mgmt = module.params.get('mgmt_token')
@@ -204,7 +189,6 @@ def update_acl(module):
 
 
 def remove_acl(module):
-    state = module.params.get('state')
     token = module.params.get('token')
     mgmt = module.params.get('mgmt_token')
 

--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -144,8 +134,6 @@ EXAMPLES = '''
       state: acquire
 '''
 
-import sys
-
 try:
     import consul
     from requests.exceptions import ConnectionError
@@ -153,7 +141,8 @@ try:
 except ImportError:
     python_consul_installed = False
 
-from requests.exceptions import ConnectionError
+from ansible.module_utils.basic import AnsibleModule
+
 
 def execute(module):
 
@@ -230,7 +219,6 @@ def remove_value(module):
     consul_api = get_consul_api(module)
 
     key = module.params.get('key')
-    value = module.params.get('value')
 
     index, existing = consul_api.kv.get(
         key, recurse=module.params.get('recurse'))
@@ -288,7 +276,5 @@ def main():
         module.fail_json(msg=str(e))
 
 
-# import module snippets
-from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/clustering/consul_session.py
+++ b/lib/ansible/modules/clustering/consul_session.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -144,6 +134,9 @@ try:
     python_consul_installed = True
 except ImportError:
     python_consul_installed = False
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 def execute(module):
 
@@ -281,7 +274,6 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e))
 
-# import module snippets
-from ansible.module_utils.basic import *
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # Copyright 2015 Google Inc. All Rights Reserved.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -156,12 +146,17 @@ api_response:
 '''
 
 import base64
+import json
 
 try:
     import yaml
     has_lib_yaml = True
 except ImportError:
     has_lib_yaml = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url
+
 
 ############################################################################
 ############################################################################
@@ -192,9 +187,9 @@ except ImportError:
 #     for a in apis.keys():
 #         results.append('"%s": "%s"' % (a[3:].lower(), apis[a]))
 #     results.sort()
-#     print "KIND_URL = {"
-#     print ",\n".join(results)
-#     print "}"
+#     print("KIND_URL = {")
+#     print(",\n".join(results))
+#     print("}")
 #
 # if __name__ == '__main__':
 #     print_kind_url_map()
@@ -401,11 +396,6 @@ def main():
         body.append(item_body)
 
     module.exit_json(changed=changed, api_response=body)
-
-
-# import module snippets
-from ansible.module_utils.basic import *    # NOQA
-from ansible.module_utils.urls import *     # NOQA
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/clustering/pacemaker_cluster.py
+++ b/lib/ansible/modules/clustering/pacemaker_cluster.py
@@ -2,19 +2,11 @@
 #coding: utf-8 -*-
 
 # (c) 2016, Mathieu Bultel <mbultel@redhat.com>
-#
-# This module is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This software is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -83,7 +75,9 @@ rc:
 '''
 
 import time
-from distutils.version import StrictVersion
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 _PCS_CLUSTER_DOWN="Error: cluster is not currently running on this node"
 
@@ -229,6 +223,6 @@ def main():
         module.exit_json(changed=True,
                  out=cluster_state)
 
-from ansible.module_utils.basic import AnsibleModule
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/clustering/znode.py
+++ b/lib/ansible/modules/clustering/znode.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # Copyright 2015 WP Engine, Inc. All rights reserved.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -111,13 +101,16 @@ EXAMPLES = """
   delegate_to: 127.0.0.1
 """
 
+import time
+
 try:
     from kazoo.client import KazooClient
-    from kazoo.exceptions import NoNodeError, ZookeeperError
     from kazoo.handlers.threading import KazooTimeoutError
     KAZOO_INSTALLED = True
 except ImportError:
     KAZOO_INSTALLED = False
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 def main():
@@ -261,7 +254,6 @@ class KazooCommandProxy():
         return False, {'msg': 'The node did not appear before the operation timed out.', 'timeout': timeout,
                        'znode': path}
 
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -4,20 +4,11 @@
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>, and others
 # (c) 2016, Toshio Kuratomi <tkuratomi@ansible.com>
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
@@ -92,11 +83,10 @@ EXAMPLES = '''
 
 import datetime
 import glob
-import shlex
 import os
+import shlex
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import b
 
 
 def check_command(module, commandline):
@@ -190,14 +180,14 @@ def main():
     delta = endd - startd
 
     if out is None:
-        out = b('')
+        out = b''
     if err is None:
-        err = b('')
+        err = b''
 
     result = dict(
         cmd      = args,
-        stdout   = out.rstrip(b("\r\n")),
-        stderr   = err.rstrip(b("\r\n")),
+        stdout   = out.rstrip(b"\r\n"),
+        stderr   = err.rstrip(b"\r\n"),
         rc       = rc,
         start    = str(startd),
         end      = str(endd),

--- a/lib/ansible/modules/commands/raw.py
+++ b/lib/ansible/modules/commands/raw.py
@@ -1,19 +1,10 @@
 # this is a virtual module that is entirely implemented server side
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],

--- a/lib/ansible/modules/commands/script.py
+++ b/lib/ansible/modules/commands/script.py
@@ -1,17 +1,9 @@
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],

--- a/lib/ansible/modules/commands/shell.py
+++ b/lib/ansible/modules/commands/shell.py
@@ -1,21 +1,13 @@
-# There is no actual shell module source, when you use 'shell' in ansible,
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# # There is no actual shell module source, when you use 'shell' in ansible,
 # it runs the 'command' module with special arguments and it behaves differently.
 # See the command source and the comment "#USE_SHELL".
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2017, Yanis Guenane <yanis+ansible@guenane.org>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],

--- a/lib/ansible/modules/crypto/openssl_privatekey.py
+++ b/lib/ansible/modules/crypto/openssl_privatekey.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2016, Yanis Guenane <yanis+ansible@guenane.org>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -134,17 +126,16 @@ fingerprint:
 
 import os
 
-from ansible.module_utils import crypto as crypto_utils
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
-
 try:
     from OpenSSL import crypto
 except ImportError:
     pyopenssl_found = False
 else:
     pyopenssl_found = True
+
+from ansible.module_utils import crypto as crypto_utils
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
 
 
 class PrivateKeyError(crypto_utils.OpenSSLObjectError):

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2016, Yanis Guenane <yanis+ansible@guenane.org>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -134,10 +126,6 @@ fingerprint:
 import hashlib
 import os
 
-from ansible.module_utils import crypto as crypto_utils
-from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
-
 try:
     from OpenSSL import crypto
     from cryptography.hazmat.backends import default_backend
@@ -146,6 +134,10 @@ except ImportError:
     pyopenssl_found = False
 else:
     pyopenssl_found = True
+
+from ansible.module_utils import crypto as crypto_utils
+from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import AnsibleModule
 
 
 class PublicKeyError(crypto_utils.OpenSSLObjectError):

--- a/lib/ansible/modules/inventory/add_host.py
+++ b/lib/ansible/modules/inventory/add_host.py
@@ -1,19 +1,11 @@
 # -*- mode: python -*-
+#
+# Copyright: Ansible Team
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],

--- a/lib/ansible/modules/inventory/group_by.py
+++ b/lib/ansible/modules/inventory/group_by.py
@@ -1,19 +1,11 @@
 # -*- mode: python -*-
+#
+# Copyright: Ansible Team
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],

--- a/lib/ansible/modules/messaging/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq_binding.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Manuel Sousa <manuel.sousa@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -113,9 +102,12 @@ EXAMPLES = '''
     routing_key: '*.info'
 '''
 
+import json
 import requests
 import urllib
-import json
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     module = AnsibleModule(
@@ -227,8 +219,6 @@ def main():
             name = module.params['name']
         )
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Manuel Sousa <manuel.sousa@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -115,9 +104,12 @@ EXAMPLES = '''
     vhost: myVhost
 '''
 
+import json
 import requests
 import urllib
-import json
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     module = AnsibleModule(
@@ -223,8 +215,6 @@ def main():
             name = module.params['name']
         )
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_parameter.py
+++ b/lib/ansible/modules/messaging/rabbitmq_parameter.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -74,6 +64,10 @@ EXAMPLES = """
     value: '"guest"'
     state: present
 """
+import json
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 class RabbitMqParameter(object):
     def __init__(self, module, component, name, value, vhost, node):
@@ -160,8 +154,6 @@ def main():
 
     module.exit_json(changed=changed, component=component, name=name, vhost=vhost, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_plugin.py
+++ b/lib/ansible/modules/messaging/rabbitmq_plugin.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -67,6 +57,9 @@ EXAMPLES = '''
 '''
 
 import os
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 class RabbitMqPlugins(object):
     def __init__(self, module):
@@ -152,8 +145,6 @@ def main():
     changed = len(enabled) > 0 or len(disabled) > 0
     module.exit_json(changed=changed, enabled=enabled, disabled=disabled)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_policy.py
+++ b/lib/ansible/modules/messaging/rabbitmq_policy.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, John Dewey <john@dewey.ws>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -93,6 +82,9 @@ EXAMPLES = '''
     tags:
       ha-mode: all
 '''
+from ansible.module_utils.basic import AnsibleModule
+
+
 class RabbitMqPolicy(object):
     def __init__(self, module, name):
         self._module = module
@@ -174,8 +166,6 @@ def main():
 
     module.exit_json(changed=changed, name=name, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Manuel Sousa <manuel.sousa@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -130,9 +119,12 @@ EXAMPLES = '''
     login_host: remote.example.org
 '''
 
+import json
 import requests
 import urllib
-import json
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     module = AnsibleModule(
@@ -271,8 +263,6 @@ def main():
             name = module.params['name']
         )
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -133,6 +123,9 @@ EXAMPLES = '''
         write_priv: .*
     state: present
 '''
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 class RabbitMqUser(object):
     def __init__(self, module, username, password, tags, permissions,
@@ -308,8 +301,6 @@ def main():
 
     module.exit_json(changed=changed, user=username, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/messaging/rabbitmq_vhost.py
+++ b/lib/ansible/modules/messaging/rabbitmq_vhost.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Chatham Financial <oss@chathamfinancial.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -64,6 +53,9 @@ EXAMPLES = '''
     name: /test
     state: present
 '''
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 class RabbitMqVhost(object):
     def __init__(self, module, name, tracing, node):
@@ -149,8 +141,6 @@ def main():
 
     module.exit_json(changed=changed, name=name, state=state)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Jan-Piet Mens <jpmens () gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 # see examples/playbooks/get_url.yml
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
@@ -299,9 +288,11 @@ import os
 import re
 import shutil
 import tempfile
+import traceback
 
-from ansible.module_utils.basic import AnsibleModule, get_exception
+from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
+from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 # ==============================================================
@@ -355,10 +346,10 @@ def url_get(module, url, dest, use_proxy, last_mod_time, force, timeout=10, head
     f = os.fdopen(fd, 'wb')
     try:
         shutil.copyfileobj(rsp, f)
-    except Exception:
-        e = get_exception()
+    except Exception as e:
         os.remove(tempname)
-        module.fail_json(msg="failed to create temporary content file: %s" % e)
+        module.fail_json(msg="failed to create temporary content file: %s" % to_native(e),
+                         exception=traceback.format_exc())
     f.close()
     rsp.close()
     return tempname, info
@@ -536,10 +527,10 @@ def main():
                 if os.path.exists(dest):
                     backup_file = module.backup_local(dest)
             shutil.copyfile(tmpsrc, dest)
-        except Exception:
-            e = get_exception()
+        except Exception as e:
             os.remove(tmpsrc)
-            module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, e))
+            module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)),
+                             exception=traceback.format_exc())
         changed = True
     else:
         changed = False

--- a/lib/ansible/modules/net_tools/basics/slurp.py
+++ b/lib/ansible/modules/net_tools/basics/slurp.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2012, Michael DeHaan <michael.dehaan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -2,23 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Romeo Theriault <romeot () hawaii.edu>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
-# see examples/playbooks/uri.yml
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['stableinterface'],
@@ -239,19 +227,16 @@ EXAMPLES = '''
 
 import cgi
 import datetime
+import json
 import os
 import shutil
 import tempfile
+import traceback
 
-try:
-    import json
-except ImportError:
-    import simplejson as json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 import ansible.module_utils.six as six
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
 
@@ -261,10 +246,10 @@ def write_file(module, url, dest, content):
     f = open(tmpsrc, 'wb')
     try:
         f.write(content)
-    except Exception:
-        err = get_exception()
+    except Exception as e:
         os.remove(tmpsrc)
-        module.fail_json(msg="failed to create temporary content file: %s" % str(err))
+        module.fail_json(msg="failed to create temporary content file: %s" % to_native(e),
+                         exception=traceback.format_exc())
     f.close()
 
     checksum_src   = None
@@ -297,10 +282,10 @@ def write_file(module, url, dest, content):
     if checksum_src != checksum_dest:
         try:
             shutil.copyfile(tmpsrc, dest)
-        except Exception:
-            err = get_exception()
+        except Exception as e:
             os.remove(tmpsrc)
-            module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, str(err)))
+            module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)),
+                             exception=traceback.format_exc())
 
     os.remove(tmpsrc)
 

--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2016 Michael Gruener <michael.gruener@chaosmoon.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -280,18 +270,11 @@ record:
             sample: sample.com
 '''
 
-try:
-    import json
-except ImportError:
-    try:
-        import simplejson as json
-    except ImportError:
-        # Let snippet from module_utils/basic.py return a proper error in this case
-        pass
+import json
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import fetch_url
 
 
@@ -342,9 +325,8 @@ class CloudflareAPI(object):
         if payload:
             try:
                 data = json.dumps(payload)
-            except Exception:
-                e = get_exception()
-                self.module.fail_json(msg="Failed to encode payload as JSON: %s " % str(e))
+            except Exception as e:
+                self.module.fail_json(msg="Failed to encode payload as JSON: %s " % to_native(e))
 
         resp, info = fetch_url(self.module,
                                self.cf_api_endpoint + api_call,

--- a/lib/ansible/modules/net_tools/dnsimple.py
+++ b/lib/ansible/modules/net_tools/dnsimple.py
@@ -1,18 +1,10 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -169,12 +161,16 @@ EXAMPLES = '''
 '''
 
 import os
+
 try:
     from dnsimple import DNSimple
     from dnsimple.dnsimple import DNSimpleException
     HAS_DNSIMPLE = True
 except ImportError:
     HAS_DNSIMPLE = False
+
+from ansible.module_utils.basic import AnsibleModule
+
 
 def main():
     module = AnsibleModule(
@@ -338,15 +334,11 @@ def main():
             else:
                 module.fail_json(msg="'%s' is an unknown value for the state argument" % state)
 
-    except DNSimpleException:
-        e = get_exception()
+    except DNSimpleException as e:
         module.fail_json(msg="Unable to contact DNSimple: %s" % e.message)
 
     module.fail_json(msg="Unknown what you wanted me to do")
 
-# import module snippets
-from ansible.module_utils.basic import *
-from ansible.module_utils.pycompat24 import get_exception
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -1,18 +1,10 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -717,7 +709,7 @@ def main():
             module.exit_json(changed=True)
 
         # record does not exist, return w/o change.
-        module.exit_json(changed=False)
+        module.exit_json(changed=changed)
 
     else:
         module.fail_json(

--- a/lib/ansible/modules/net_tools/exoscale/exo_dns_domain.py
+++ b/lib/ansible/modules/net_tools/exoscale/exo_dns_domain.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2016, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -186,11 +176,7 @@ exo_dns_domain:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.exoscale import (
-    ExoDns,
-    exo_dns_argument_spec,
-    exo_dns_required_together
-)
+from ansible.module_utils.exoscale import ExoDns, exo_dns_argument_spec, exo_dns_required_together
 
 
 class ExoDnsDomain(ExoDns):

--- a/lib/ansible/modules/net_tools/exoscale/exo_dns_record.py
+++ b/lib/ansible/modules/net_tools/exoscale/exo_dns_record.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2016, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -246,11 +236,8 @@ exo_dns_record:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.exoscale import (
-    ExoDns,
-    exo_dns_argument_spec,
-    exo_dns_required_together
-)
+from ansible.module_utils.exoscale import ExoDns, exo_dns_argument_spec, exo_dns_required_together
+
 
 EXO_RECORD_TYPES = [
     'A',

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2014, Ravi Bhure <ravibhure@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -184,10 +174,12 @@ EXAMPLES = '''
     backend: www
 '''
 
-import socket
 import csv
+import socket
 import time
 from string import Template
+
+from ansible.module_utils.basic import AnsibleModule
 
 
 DEFAULT_SOCKET_LOCATION = "/var/run/haproxy.sock"
@@ -429,8 +421,6 @@ def main():
     ansible_haproxy = HAProxy(module)
     ansible_haproxy.act()
 
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/ipify_facts.py
+++ b/lib/ansible/modules/net_tools/ipify_facts.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -75,14 +65,7 @@ ipify_public_ip:
   sample: 1.2.3.4
 '''
 
-try:
-    import json
-except ImportError:
-    try:
-        import simplejson as json
-    except ImportError:
-        # Let snippet from module_utils/basic.py return a proper error in this case
-        pass
+import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -123,6 +106,7 @@ def main():
     ipify_facts = IpifyFacts().run()
     ipify_facts_result = dict(changed=False, ansible_facts=ipify_facts)
     module.exit_json(**ipify_facts_result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/ipinfoio_facts.py
+++ b/lib/ansible/modules/net_tools/ipinfoio_facts.py
@@ -1,21 +1,11 @@
 #!/usr/bin/python
 #
 # (c) 2016, Aleksei Kostiuk <unitoff@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -90,6 +80,10 @@ ansible_facts:
       type: string
       sample: "94035"
 '''
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible.module_utils.urls import fetch_url
+
 
 USER_AGENT = 'ansible-ipinfoio-module/0.0.1'
 
@@ -135,8 +129,6 @@ def main():
         changed=False, ansible_facts=ipinfoio.get_geo_data())
     module.exit_json(**ipinfoio_result)
 
-from ansible.module_utils.basic import * # NOQA
-from ansible.module_utils.urls import * # NOQA
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -4,20 +4,11 @@
 # (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -193,8 +184,7 @@ modlist:
   sample: '[[2, "olcRootDN", ["cn=root,dc=example,dc=com"]]]'
 """
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
+import traceback
 
 try:
     import ldap
@@ -203,6 +193,9 @@ try:
     HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 
 
 class LdapAttr(object):
@@ -251,11 +244,10 @@ class LdapAttr(object):
         try:
             results = self.connection.search_s(
                 self.dn, ldap.SCOPE_BASE, attrlist=[self.name])
-        except ldap.LDAPError:
-            e = get_exception()
+        except ldap.LDAPError as e:
             self.module.fail_json(
                 msg="Cannot search for attribute %s" % self.name,
-                details=str(e))
+                details=to_native(e))
 
         current = results[0][1].get(self.name, [])
         modlist = []
@@ -293,19 +285,17 @@ class LdapAttr(object):
         if self.start_tls:
             try:
                 connection.start_tls_s()
-            except ldap.LDAPError:
-                e = get_exception()
-                self.module.fail_json(msg="Cannot start TLS.", details=str(e))
+            except ldap.LDAPError as e:
+                self.module.fail_json(msg="Cannot start TLS.", details=to_native(e))
 
         try:
             if self.bind_dn is not None:
                 connection.simple_bind_s(self.bind_dn, self.bind_pw)
             else:
                 connection.sasl_interactive_bind_s('', ldap.sasl.external())
-        except ldap.LDAPError:
-            e = get_exception()
+        except ldap.LDAPError as e:
             self.module.fail_json(
-                msg="Cannot bind to the server.", details=str(e))
+                msg="Cannot bind to the server.", details=to_native(e))
 
         return connection
 
@@ -360,10 +350,9 @@ def main():
         if not module.check_mode:
             try:
                 ldap.connection.modify_s(ldap.dn, modlist)
-            except Exception:
-                e = get_exception()
-                module.fail_json(
-                    msg="Attribute action failed.", details=str(e))
+            except Exception as e:
+                module.fail_json(msg="Attribute action failed.", details=to_native(e),
+                                 exception=traceback.format_exc())
 
     module.exit_json(changed=changed, modlist=modlist)
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -4,20 +4,11 @@
 # (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 #
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],

--- a/lib/ansible/modules/net_tools/lldp.py
+++ b/lib/ansible/modules/net_tools/lldp.py
@@ -1,18 +1,11 @@
 #!/usr/bin/python -tt
-# This file is part of Ansible
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -50,12 +43,15 @@ EXAMPLES = '''
 
 '''
 
+from ansible.module_utils.basic import AnsibleModule
+
 
 def gather_lldp(module):
     cmd = ['lldpctl', '-f', 'keyvalue']
     rc, output, err = module.run_command(cmd)
     if output:
         output_dict = {}
+        current_dict = {}
         lldp_entries = output.split("\n")
 
         for entry in lldp_entries:
@@ -84,8 +80,6 @@ def main():
     except TypeError:
         module.fail_json(msg="lldpctl command failed. is lldpd running?")
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -2,21 +2,10 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Chris Long <alcamie@gmail.com> <chlong@redhat.com>
-#
-# This file is a module for Ansible that interacts with Network Manager
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.    See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.    If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
@@ -491,9 +480,7 @@ EXAMPLES='''
 #     - 9 nmcli and NetworkManager versions mismatch
 #     - 10 Connection, device, or access point does not exist.
 '''
-# import ansible.module_utils.basic
-import os
-import sys
+
 HAVE_DBUS=False
 try:
     import dbus
@@ -607,7 +594,7 @@ class Nmcli(object):
             for setting in secrets:
                 for key in secrets[setting]:
                     config[setting_name][key]=secrets[setting][key]
-        except Exception as e:
+        except:
             pass
 
     def dict_to_string(self, d):
@@ -639,7 +626,7 @@ class Nmcli(object):
         for setting_name in config:
             setting_list.append(self.dict_to_string(config[setting_name]))
         return setting_list
-        # print ""
+        # print("")
 
     def bool_to_string(self, boolean):
         if boolean:
@@ -1197,6 +1184,7 @@ def main():
         result['stderr']=err
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/omapi_host.py
+++ b/lib/ansible/modules/net_tools/omapi_host.py
@@ -1,26 +1,15 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-"""
-Ansible module to configure DHCPd hosts using OMAPI protocol
-(c) 2016, Loic Blot <loic.blot@unix-experience.fr>
-Sponsored by Infopro Digital. http://www.infopro-digital.com/
-Sponsored by E.T.A.I. http://www.etai.fr/
+# (c) 2016, Loic Blot <loic.blot@unix-experience.fr>
+# Sponsored by Infopro Digital. http://www.infopro-digital.com/
+# Sponsored by E.T.A.I. http://www.etai.fr/
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-This file is part of Ansible
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
-Ansible is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-Ansible is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License
-along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-"""
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
                     'status': ['preview'],
@@ -141,12 +130,10 @@ lease:
             sample: 'mydesktop'
 '''
 
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule, get_exception, to_bytes
-from ansible.module_utils.six import iteritems
+import binascii
 import socket
 import struct
-import binascii
+import traceback
 
 try:
     from pypureomapi import Omapi, OmapiMessage, OmapiError, OmapiErrorNotFound
@@ -155,6 +142,9 @@ try:
     pureomapi_found = True
 except ImportError:
     pureomapi_found = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native
 
 
 class OmapiHostManager:
@@ -169,13 +159,11 @@ class OmapiHostManager:
                                self.module.params['key'])
         except binascii.Error:
             self.module.fail_json(msg="Unable to open OMAPI connection. 'key' is not a valid base64 key.")
-        except OmapiError:
-            e = get_exception()
+        except OmapiError as e:
             self.module.fail_json(msg="Unable to open OMAPI connection. Ensure 'host', 'port', 'key' and 'key_name' "
-                                      "are valid. Exception was: %s" % e)
-        except socket.error:
-            e = get_exception()
-            self.module.fail_json(msg="Unable to connect to OMAPI server: %s" % e)
+                                      "are valid. Exception was: %s" % to_native(e))
+        except socket.error as e:
+            self.module.fail_json(msg="Unable to connect to OMAPI server: %s" % to_native(e))
 
     def get_host(self, macaddr):
         msg = OmapiMessage.open(to_bytes("host", errors='surrogate_or_strict'))
@@ -225,9 +213,9 @@ class OmapiHostManager:
                 if len(self.module.params['statements']) > 0:
                     stmt_join += "; ".join(self.module.params['statements'])
                     stmt_join += "; "
-            except TypeError:
-                e = get_exception()
-                self.module.fail_json(msg="Invalid statements found: %s" % e)
+            except TypeError as e:
+                self.module.fail_json(msg="Invalid statements found: %s" % to_native(e),
+                                      exception=traceback.format_exc())
 
             if len(stmt_join) > 0:
                 msg.obj.append(('statements', stmt_join))
@@ -238,9 +226,8 @@ class OmapiHostManager:
                     self.module.fail_json(msg="Failed to add host, ensure authentication and host parameters "
                                               "are valid.")
                 self.module.exit_json(changed=True, lease=self.unpack_facts(response.obj))
-            except OmapiError:
-                e = get_exception()
-                self.module.fail_json(msg="OMAPI error: %s" % e)
+            except OmapiError as e:
+                self.module.fail_json(msg="OMAPI error: %s" % to_native(e), exception=traceback.format_exc())
         # Forge update message
         else:
             response_obj = self.unpack_facts(host_response.obj)
@@ -276,9 +263,8 @@ class OmapiHostManager:
                     self.module.fail_json(msg="Failed to modify host, ensure authentication and host parameters "
                                               "are valid.")
                 self.module.exit_json(changed=True)
-            except OmapiError:
-                e = get_exception()
-                self.module.fail_json(msg="OMAPI error: %s" % e)
+            except OmapiError as e:
+                self.module.fail_json(msg="OMAPI error: %s" % to_native(e), exception=traceback.format_exc())
 
     def remove_host(self):
         try:
@@ -286,9 +272,8 @@ class OmapiHostManager:
             self.module.exit_json(changed=True)
         except OmapiErrorNotFound:
             self.module.exit_json()
-        except OmapiError:
-            e = get_exception()
-            self.module.fail_json(msg="OMAPI error: %s" % e)
+        except OmapiError as e:
+            self.module.fail_json(msg="OMAPI error: %s" % to_native(e), exception=traceback.format_exc())
 
 
 def main():
@@ -323,9 +308,9 @@ def main():
             host_manager.setup_host()
         elif module.params['state'] == 'absent':
             host_manager.remove_host()
-    except ValueError:
-        e = get_exception()
-        module.fail_json(msg="OMAPI input value error: %s" % e)
+    except ValueError as e:
+        module.fail_json(msg="OMAPI input value error: %s" % to_native(e), exception=traceback.format_exc())
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/snmp_facts.py
+++ b/lib/ansible/modules/net_tools/snmp_facts.py
@@ -1,19 +1,10 @@
 #!/usr/bin/python
 
 # This file is part of Networklore's snmp library for Ansible
-#
-# The module is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# The module is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.0',
@@ -97,10 +88,6 @@ EXAMPLES = '''
 '''
 
 import binascii
-
-from ansible.module_utils.basic import *
-from ansible.module_utils._text import to_text
-
 from collections import defaultdict
 
 try:
@@ -108,6 +95,10 @@ try:
     has_pysnmp = True
 except:
     has_pysnmp = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+
 
 class DefineOid(object):
 

--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -23,7 +23,6 @@ metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -pru
         -o -path ./lib/ansible/modules/packaging -prune \
         -o -path ./lib/ansible/modules/notification -prune \
         -o -path ./lib/ansible/modules/network -prune \
-        -o -path ./lib/ansible/modules/net_tools -prune \
         -o -path ./lib/ansible/modules/monitoring -prune \
         -o -path ./lib/ansible/modules/identity -prune \
         -o -path ./lib/ansible/modules/files -prune \
@@ -32,7 +31,6 @@ metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -pru
         -o -path ./lib/ansible/modules/cloud/rackspace -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \
-        -o -path ./lib/ansible/modules/cloud/misc -prune \
         -o -path ./lib/ansible/modules/cloud/google -prune \
         -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
         -o -path ./lib/ansible/modules/cloud/centurylink -prune \
@@ -44,7 +42,6 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
         -o -path ./lib/ansible/modules/packaging -prune \
         -o -path ./lib/ansible/modules/notification -prune \
         -o -path ./lib/ansible/modules/network -prune \
-        -o -path ./lib/ansible/modules/net_tools -prune \
         -o -path ./lib/ansible/modules/monitoring -prune \
         -o -path ./lib/ansible/modules/identity -prune \
         -o -path ./lib/ansible/modules/files -prune \
@@ -53,7 +50,6 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
         -o -path ./lib/ansible/modules/cloud/rackspace -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \
-        -o -path ./lib/ansible/modules/cloud/misc -prune \
         -o -path ./lib/ansible/modules/cloud/google -prune \
         -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
         -o -path ./lib/ansible/modules/cloud/centurylink -prune \
@@ -61,24 +57,23 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
         -o -name '*.py' -type f -size +0c -exec egrep -HL 'from __future__ import (?absolute_import, division, print_function)?' '{}' '+')
 
 # Ordered by approximate work, lowest to highest
-# cloud/misc
-# cloud/google
-# identity
-# cloud/source_control
-# cloud/centurylink
-# database ;; break up
-# net-tools
-# cloud/rackspace
-# cloud/vmware
-# files
-# cloud/openstack
-# monitoring
-# cloud/notification
-# cloud/cloudstack
+# cloud/google *
+# identity !
+# source_control *i
+# cloud/centurylink *
+# database ;; break up *!
+# cloud/rackspace *
+# cloud/vmware *i
+# files !
+# cloud/openstack *
+# monitoring *!
+# notification *!
+# cloud/cloudstack *
 # cloud/ovirt
-# cloud/packaging ;; breakup
-# cloud/amazon
-# network ;; break up
+# packaging ;; breakup *!
+# cloud/amazon *i
+# network ;; break up *!
+# ( * == import* fixes, ! == many get_exception fixes, i == a few get_exception fixes)
 ### TODO:
 ### - module_utils
 ### - contrib/

--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -57,21 +57,21 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
         -o -name '*.py' -type f -size +0c -exec egrep -HL 'from __future__ import (?absolute_import, division, print_function)?' '{}' '+')
 
 # Ordered by approximate work, lowest to highest
-# cloud/google *
 # identity !
-# source_control *i
 # cloud/centurylink *
+# source_control *i
+# files !
+# cloud/google *
+# notification *!
 # database ;; break up *!
+# packaging ;; breakup *!
 # cloud/rackspace *
 # cloud/vmware *i
-# files !
-# cloud/openstack *
 # monitoring *!
-# notification *!
 # cloud/cloudstack *
+# cloud/openstack *
 # cloud/ovirt
-# packaging ;; breakup *!
-# cloud/amazon *i
+# cloud/amazon *
 # network ;; break up *!
 # ( * == import* fixes, ! == many get_exception fixes, i == a few get_exception fixes)
 ### TODO:

--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -25,23 +25,15 @@ metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -pru
         -o -path ./lib/ansible/modules/network -prune \
         -o -path ./lib/ansible/modules/net_tools -prune \
         -o -path ./lib/ansible/modules/monitoring -prune \
-        -o -path ./lib/ansible/modules/messaging -prune \
-        -o -path ./lib/ansible/modules/inventory -prune \
         -o -path ./lib/ansible/modules/identity -prune \
         -o -path ./lib/ansible/modules/files -prune \
         -o -path ./lib/ansible/modules/database -prune \
-        -o -path ./lib/ansible/modules/crypto -prune \
-        -o -path ./lib/ansible/modules/commands -prune \
-        -o -path ./lib/ansible/modules/clustering -prune \
-        -o -path ./lib/ansible/modules/cloud/webfaction -prune \
         -o -path ./lib/ansible/modules/cloud/vmware -prune \
         -o -path ./lib/ansible/modules/cloud/rackspace -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \
         -o -path ./lib/ansible/modules/cloud/misc -prune \
         -o -path ./lib/ansible/modules/cloud/google -prune \
-        -o -path ./lib/ansible/modules/cloud/docker -prune \
-        -o -path ./lib/ansible/modules/cloud/digital_ocean -prune \
         -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
         -o -path ./lib/ansible/modules/cloud/centurylink -prune \
         -o -path ./lib/ansible/modules/cloud/amazon -prune \
@@ -54,31 +46,42 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
         -o -path ./lib/ansible/modules/network -prune \
         -o -path ./lib/ansible/modules/net_tools -prune \
         -o -path ./lib/ansible/modules/monitoring -prune \
-        -o -path ./lib/ansible/modules/messaging -prune \
-        -o -path ./lib/ansible/modules/inventory -prune \
         -o -path ./lib/ansible/modules/identity -prune \
         -o -path ./lib/ansible/modules/files -prune \
         -o -path ./lib/ansible/modules/database -prune \
-        -o -path ./lib/ansible/modules/crypto -prune \
-        -o -path ./lib/ansible/modules/commands -prune \
-        -o -path ./lib/ansible/modules/clustering -prune \
-        -o -path ./lib/ansible/modules/cloud/webfaction -prune \
         -o -path ./lib/ansible/modules/cloud/vmware -prune \
         -o -path ./lib/ansible/modules/cloud/rackspace -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \
         -o -path ./lib/ansible/modules/cloud/misc -prune \
         -o -path ./lib/ansible/modules/cloud/google -prune \
-        -o -path ./lib/ansible/modules/cloud/docker -prune \
-        -o -path ./lib/ansible/modules/cloud/digital_ocean -prune \
         -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
         -o -path ./lib/ansible/modules/cloud/centurylink -prune \
         -o -path ./lib/ansible/modules/cloud/amazon -prune \
         -o -name '*.py' -type f -size +0c -exec egrep -HL 'from __future__ import (?absolute_import, division, print_function)?' '{}' '+')
 
+# Ordered by approximate work, lowest to highest
+# cloud/misc
+# cloud/google
+# identity
+# cloud/source_control
+# cloud/centurylink
+# database ;; break up
+# net-tools
+# cloud/rackspace
+# cloud/vmware
+# files
+# cloud/openstack
+# monitoring
+# cloud/notification
+# cloud/cloudstack
+# cloud/ovirt
+# cloud/packaging ;; breakup
+# cloud/amazon
+# network ;; break up
 ### TODO:
-### - contrib/
 ### - module_utils
+### - contrib/
 
 
 if test -n "$metaclass1" -o -n "$metaclass2" -o -n "$metaclass3" ; then

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -194,7 +194,6 @@ lib/ansible/modules/cloud/vmware/vsphere_guest.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py
 lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py
-lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
 lib/ansible/modules/clustering/consul_acl.py
 lib/ansible/modules/clustering/consul_kv.py
@@ -233,10 +232,8 @@ lib/ansible/modules/messaging/rabbitmq_binding.py
 lib/ansible/modules/messaging/rabbitmq_exchange.py
 lib/ansible/modules/messaging/rabbitmq_parameter.py
 lib/ansible/modules/messaging/rabbitmq_plugin.py
-lib/ansible/modules/messaging/rabbitmq_policy.py
 lib/ansible/modules/messaging/rabbitmq_queue.py
 lib/ansible/modules/messaging/rabbitmq_user.py
-lib/ansible/modules/messaging/rabbitmq_vhost.py
 lib/ansible/modules/monitoring/airbrake_deployment.py
 lib/ansible/modules/monitoring/bigpanda.py
 lib/ansible/modules/monitoring/boundary_meter.py


### PR DESCRIPTION
This commit cleans up the following module categories:
* messaging
* inventory
* crypto
* commands
* clustering
* cloud/webfaction
* cloud/docker
* cloud/digital_ocean

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```