### PR TITLE
The choffman github nick is not the actual author of the rabbitmq module

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -384,7 +384,9 @@ files:
   $modules/messaging/rabbitmq_policy.py: retr0h
   $modules/messaging/rabbitmq_queue.py: $team_rabbitmq
   $modules/messaging/rabbitmq_user.py: $team_rabbitmq
-  $modules/messaging/rabbitmq_vhost.py: choffman
+  $modules/messaging/rabbitmq_vhost.py:
+    ignored: choffman
+    maintainers: $team_rabbitmq
   $modules/monitoring/airbrake_deployment.py: bpennypacker
   $modules/monitoring/bigpanda.py: hkariti
   $modules/monitoring/boundary_meter.py: ccollicutt


### PR DESCRIPTION
Put the nick in ignored so that they do not get CC'd on every ticket for
that module

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```