### PR TITLE
prepare_ovs call gather facts

### DIFF
--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -3,8 +3,8 @@
 # network-integration test are ran with gather_facts: no
 # We need to explicitly call setup so ansible_distribution is set
 
--name: Gather facts
- setup:
+- name: Gather facts
+  setup:
 
 - name: Install openvswitch-switch package if we are on Ubuntu
   apt:

--- a/test/integration/targets/prepare_ovs_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ovs_tests/tasks/main.yml
@@ -1,5 +1,11 @@
 ---
 
+# network-integration test are ran with gather_facts: no
+# We need to explicitly call setup so ansible_distribution is set
+
+-name: Gather facts
+ setup:
+
 - name: Install openvswitch-switch package if we are on Ubuntu
   apt:
     name: openvswitch-switch


### PR DESCRIPTION
##### SUMMARY

As we are no longer using run_ovs_integration_tests.yml we need to
explicitly gather facts so we can call the correct package manager.



##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
