### PR TITLE
Clarified documentation for the unsafe_writes option

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -58,11 +58,11 @@ options:
   unsafe_writes:
     description:
       -  Normally this module uses atomic operations to prevent data corruption or inconsistent reads from the target files,
-         sometimes systems are configured or just broken in ways that prevent this. One example are docker mounted files,
-         they cannot be updated atomically (from inside the container) and can only be written in an unsafe manner.
-      -  This boolean option allows ansible to fall back to unsafe methods of updating files for those cases in which you do
-         not have any other choice (however, it doesn't actually force Ansible to do anything). Be aware that this is subject
-         to race conditions and can lead to data corruption.
+         but sometimes systems are configured or just broken in ways that prevent this. One example is docker mounted files,
+         which cannot be updated atomically from inside the container and can only be written in an unsafe manner.
+      -  This boolean option allows Ansible to fall back to unsafe methods of updating files for those cases where atomic
+         operations are not available (however, it doesn't actually force Ansible to do anything). IMPORTANT: note that this 
+         is subject to race conditions and can lead to data corruption.
     required: false
     default: false
     version_added: "2.2"

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -59,11 +59,12 @@ options:
     description:
       -  Normally this module uses atomic operations to prevent data corruption or inconsistent reads from the target files,
          sometimes systems are configured or just broken in ways that prevent this. One example are docker mounted files,
-         they cannot be updated atomically and can only be done in an unsafe manner.
+         they cannot be updated atomically (from inside the container) and can only be written in an unsafe manner.
       -  This boolean option allows ansible to fall back to unsafe methods of updating files for those cases in which you do
-         not have any other choice. Be aware that this is subject to race conditions and can lead to data corruption.
-    type: bool
-    default: 'no'
+         not have any other choice (however, it doesn't actually force Ansible to do anything). Be aware that this is subject
+         to race conditions and can lead to data corruption.
+    required: false
+    default: false
     version_added: "2.2"
   attributes:
     description:

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -57,14 +57,17 @@ options:
     default: "s0"
   unsafe_writes:
     description:
-      -  Normally this module uses atomic operations to prevent data corruption or inconsistent reads from the target files,
-         but sometimes systems are configured or just broken in ways that prevent this. One example is docker mounted files,
-         which cannot be updated atomically from inside the container and can only be written in an unsafe manner.
-      -  This boolean option allows Ansible to fall back to unsafe methods of updating files for those cases where atomic
-         operations are not available (however, it doesn't actually force Ansible to do anything). IMPORTANT: note that this 
-         is subject to race conditions and can lead to data corruption.
+      - By default this module uses atomic operations to prevent data corruption
+        or inconsistent reads from the target files,
+        but sometimes systems are configured or just broken in ways that prevent this. One example is docker mounted files,
+        which cannot be updated atomically from inside the container and can only be written in an unsafe manner.
+      - This option allows Ansible to fall back to unsafe methods of
+        updating files for those cases where atomic
+        operations are not available (however, it doesn't actually force Ansible to perform unsafe writes). IMPORTANT! Note that this
+        is subject to race conditions and can lead to data corruption.
     required: false
     default: false
+    type: boolean
     version_added: "2.2"
   attributes:
     description:

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -57,17 +57,14 @@ options:
     default: "s0"
   unsafe_writes:
     description:
-      - By default this module uses atomic operations to prevent data corruption
-        or inconsistent reads from the target files,
+      - By default this module uses atomic operations to prevent data
+        corruption or inconsistent reads from the target files,
         but sometimes systems are configured or just broken in ways that prevent this. One example is docker mounted files,
         which cannot be updated atomically from inside the container and can only be written in an unsafe manner.
       - This option allows Ansible to fall back to unsafe methods of
-        updating files for those cases where atomic
-        operations are not available (however, it doesn't actually force Ansible to perform unsafe writes). IMPORTANT! Note that this
-        is subject to race conditions and can lead to data corruption.
-    required: false
-    default: false
-    type: boolean
+        updating files when atomic operations fail (however, it doesn't force Ansible to perform unsafe writes). IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
+    type: bool
+    default: 'no'
     version_added: "2.2"
   attributes:
     description:

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -62,7 +62,8 @@ options:
         but sometimes systems are configured or just broken in ways that prevent this. One example is docker mounted files,
         which cannot be updated atomically from inside the container and can only be written in an unsafe manner.
       - This option allows Ansible to fall back to unsafe methods of
-        updating files when atomic operations fail (however, it doesn't force Ansible to perform unsafe writes). IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
+        updating files when atomic operations fail (however, it doesn't force Ansible to perform unsafe writes).
+        IMPORTANT! Unsafe writes are subject to race conditions and can lead to data corruption.
     type: bool
     default: 'no'
     version_added: "2.2"


### PR DESCRIPTION
Per #24449.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The documentation did not describe the behavior of the `unsafe_writes` option that becomes clear only from comments on the issue #24449.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
template and other 'files' modules.

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /Volumes/qwe/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:16:53) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```