### PR TITLE
Add support for Python3 in vmware_guest_find

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -234,11 +234,11 @@ def compile_folder_path_for_object(vobj):
     thisobj = vobj
     while hasattr(thisobj, 'parent'):
         thisobj = thisobj.parent
+        if thisobj.name == 'Datacenters':
+            break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)
     paths.reverse()
-    if paths[0] == 'Datacenters':
-        paths.remove('Datacenters')
     return '/' + '/'.join(paths)
 
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -38,7 +38,7 @@ options:
             - This is required if name is not supplied.
    datacenter:
         description:
-            - Destination datacenter for the deploy operation.
+            - Destination datacenter for the find operation.
         required: True
 extends_documentation_fragment: vmware.documentation
 '''
@@ -78,14 +78,13 @@ from ansible.module_utils.vmware import (
     find_datacenter_by_name
 )
 
-HAS_PYVMOMI = False
 try:
     import pyVmomi
     from pyVmomi import vim
 
     HAS_PYVMOMI = True
 except ImportError:
-    pass
+    HAS_PYVMOMI = False
 
 
 class PyVmomiHelper(object):
@@ -198,24 +197,6 @@ class PyVmomiHelper(object):
 
         self.folders = self._build_folder_tree(self.datacenter.vmFolder)
         self._build_folder_map(self.folders)
-
-    @staticmethod
-    def compile_folder_path_for_object(vobj):
-        """ make a /vm/foo/bar/baz like folder path for an object """
-
-        paths = []
-        if isinstance(vobj, vim.Folder):
-            paths.append(vobj.name)
-
-        thisobj = vobj
-        while hasattr(thisobj, 'parent'):
-            thisobj = thisobj.parent
-            if isinstance(thisobj, vim.Folder):
-                paths.append(thisobj.name)
-        paths.reverse()
-        if paths[0] == 'Datacenters':
-            paths.remove('Datacenters')
-        return '/' + '/'.join(paths)
 
 
 def main():

--- a/test/integration/targets/vmware_guest_find/aliases
+++ b/test/integration/targets/vmware_guest_find/aliases
@@ -1,4 +1,3 @@
 posix/ci/cloud/vcenter
 cloud/vcenter
-skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_find/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_find/tasks/main.yml
@@ -1,3 +1,7 @@
+# Test code for the vmware_guest_find module.
+# (c) 2017, James Tanner <tanner.jc@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 - name: make sure pyvmomi is installed
   pip:
     name: pyvmomi


### PR DESCRIPTION
##### SUMMARY
* Remove redundant get_obj method
* Fix testcase
* Correct logic for compile_folder_path_for_object

Fixes: #25984

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest_find.py
test/integration/targets/vmware_guest_find/aliases
test/integration/targets/vmware_guest_find/tasks/main.yml

##### ANSIBLE VERSION
```
2.4devel
```