### PR TITLE
fix to alllow the winrm plugin to send input with Python 3

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -416,11 +416,11 @@ class Connection(ConnectionBase):
         in_size = os.path.getsize(to_bytes(in_path, errors='surrogate_or_strict'))
         offset = 0
         with open(to_bytes(in_path, errors='surrogate_or_strict'), 'rb') as in_file:
-            for out_data in iter((lambda: in_file.read(buffer_size)), ''):
+            for out_data in iter((lambda: in_file.read(buffer_size)), b''):
                 offset += len(out_data)
                 self._display.vvvvv('WINRM PUT "%s" to "%s" (offset=%d size=%d)' % (in_path, out_path, offset, len(out_data)), host=self._winrm_host)
                 # yes, we're double-encoding over the wire in this case- we want to ensure that the data shipped to the end PS pipeline is still b64-encoded
-                b64_data = base64.b64encode(out_data) + '\r\n'
+                b64_data = base64.b64encode(out_data) + b'\r\n'
                 # cough up the data, as well as an indicator if this is the last chunk so winrm_send knows to set the End signal
                 yield b64_data, (in_file.tell() == in_size)
 

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1379,8 +1379,8 @@ class ShellModule(object):
 
         # non-pipelining
 
-        cmd_parts = shlex.split(to_bytes(cmd), posix=False)
-        cmd_parts = map(to_text, cmd_parts)
+        cmd_parts = shlex.split(cmd, posix=False)
+        cmd_parts = list(map(to_text, cmd_parts))
         if shebang and shebang.lower() == '#!powershell':
             if not self._unquote(cmd_parts[0]).lower().endswith('.ps1'):
                 cmd_parts[0] = '"%s.ps1"' % self._unquote(cmd_parts[0])
@@ -1480,7 +1480,7 @@ class ShellModule(object):
                 script = u'%s\r\nIf (-not $?) { If (Get-Variable LASTEXITCODE -ErrorAction SilentlyContinue) { exit $LASTEXITCODE } Else { exit 1 } }\r\n'\
                     % script
             script = '\n'.join([x.strip() for x in script.splitlines() if x.strip()])
-            encoded_script = base64.b64encode(script.encode('utf-16-le'))
+            encoded_script = to_text(base64.b64encode(script.encode('utf-16-le')), 'utf-8')
             cmd_parts = _common_args + ['-EncodedCommand', encoded_script]
 
         if as_list:


### PR DESCRIPTION
##### SUMMARY
When using Python 3, the winrm and powershell plugins fail to send input to the client. Some minor changes need to occur to allow this

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
powershell

##### ANSIBLE VERSION
```
ansible 2.4.0 (fix/py3-winrm-send 332ca62cac) last updated 2017/07/31 14:05:00 (GMT +1000)
  config file = None
  configured module search path = ['/home/jborean/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jborean/dev/ansible/lib/ansible
  executable location = /home/jborean/dev/ansible/bin/ansible
  python version = 3.6.2 (default, Jul 20 2017, 18:18:25) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
