### PR TITLE
Add dnf group install/upgrade integration tests

### DIFF
--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -240,3 +240,53 @@
 - name: uninstall sos in /
   dnf: name=sos installroot='/'
   register: dnf_result
+
+# GROUP INSTALL
+- name: install RPM Development Tools group
+  dnf:
+    name: "@RPM Development Tools"
+    state: present
+  register: dnf_result
+
+- debug: var=dnf_result
+
+- name: verify installation of the group
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+
+- name: verify dnf module outputs
+  assert:
+    that:
+        - "'changed' in dnf_result"
+        - "'results' in dnf_result"
+
+# cleanup until https://github.com/ansible/ansible/issues/27377 is resolved
+- shell: dnf -y group install "RPM Development Tools" && dnf -y group remove "RPM Development Tools"
+
+# GROUP UPGRADE - this will go to the same method as group install
+# but through group_update - it is its invocation we're testing here
+# see commit 119c9e5d6eb572c4a4800fbe8136095f9063c37b
+- name: install latest RPM Development Tools
+  dnf:
+    name: "@RPM Development Tools"
+    state: latest
+  register: dnf_result
+
+- debug: var=dnf_result
+
+- name: verify installation of the group
+  assert:
+    that:
+        - "not dnf_result.failed | default(False)"
+        - "dnf_result.changed"
+
+- name: verify dnf module outputs
+  assert:
+    that:
+        - "'changed' in dnf_result"
+        - "'results' in dnf_result"
+
+# cleanup until https://github.com/ansible/ansible/issues/27377 is resolved
+- shell: dnf -y group install "RPM Development Tools" && dnf -y group remove "RPM Development Tools"


### PR DESCRIPTION
##### SUMMARY
This adds missing integration tests for dnf group commands.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/dnf/tasks/dnf.yml

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 9e03953fce) last updated 2017/07/31 12:22:30 (GMT +200)
  config file = /home/mkrizek/devel/ansible/ansible.cfg
  configured module search path = [u'/home/mkrizek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mkrizek/devel/ansible/lib/ansible
  executable location = /home/mkrizek/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

##### ADDITIONAL INFORMATION
None
