### PR TITLE
nxos_interface fix tests by adding register: result 

### DIFF
--- a/test/integration/targets/nxos_interface/tests/cli/set_state_absent.yaml
+++ b/test/integration/targets/nxos_interface/tests/cli/set_state_absent.yaml
@@ -12,6 +12,7 @@
     interface: Loopback1
     state: absent
     provider: "{{ cli }}"
+  register: result
 
 - assert:
     that:
@@ -22,6 +23,7 @@
     interface: Loopback1
     state: absent
     provider: "{{ cli }}"
+  register: result
 
 - assert:
     that:

--- a/test/integration/targets/nxos_interface/tests/cli/set_state_present.yaml
+++ b/test/integration/targets/nxos_interface/tests/cli/set_state_present.yaml
@@ -12,6 +12,7 @@
     interface: Loopback1
     state: present
     provider: "{{ cli }}"
+  register: result
 
 - assert:
     that:
@@ -22,6 +23,7 @@
     interface: Loopback1
     state: present
     provider: "{{ cli }}"
+  register: result
 
 - assert:
     that:

--- a/test/integration/targets/nxos_interface/tests/nxapi/set_state_absent.yaml
+++ b/test/integration/targets/nxos_interface/tests/nxapi/set_state_absent.yaml
@@ -12,6 +12,7 @@
     interface: Loopback1
     state: absent
     provider: "{{ nxapi }}"
+  register: result
 
 - assert:
     that:
@@ -22,6 +23,7 @@
     interface: Loopback1
     state: absent
     provider: "{{ nxapi }}"
+  register: result
 
 - assert:
     that:

--- a/test/integration/targets/nxos_interface/tests/nxapi/set_state_present.yaml
+++ b/test/integration/targets/nxos_interface/tests/nxapi/set_state_present.yaml
@@ -12,6 +12,7 @@
     interface: Loopback1
     state: present
     provider: "{{ nxapi }}"
+  register: result
 
 - assert:
     that:
@@ -22,6 +23,7 @@
     interface: Loopback1
     state: present
     provider: "{{ nxapi }}"
+  register: result
 
 - assert:
     that:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

nxos_interface asserts were checking a variable called result that hadn't been registered.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxos-interface-add-results 50e6ef66c2) last updated 2017/07/31 13:05:59 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
