### PR TITLE
Handle better the many ways information can be passed around

### DIFF
--- a/lib/ansible/plugins/callback/selective.py
+++ b/lib/ansible/plugins/callback/selective.py
@@ -182,8 +182,7 @@ class CallbackModule(CallbackBase):
             self._print_task()
             self.last_skipped = False
             msg = to_text(result._result.get('msg', '')) or\
-                to_text(result._result.get('reason', '')) or\
-                to_text(result._result.get('message', ''))
+                to_text(result._result.get('reason', ''))
 
             stderr = [result._result.get('exception', None),
                       result._result.get('module_stderr', None)]

--- a/lib/ansible/plugins/callback/selective.py
+++ b/lib/ansible/plugins/callback/selective.py
@@ -154,12 +154,12 @@ class CallbackModule(CallbackBase):
             print("{} {}".format(line, '-' * (line_length - len(line))))
             print(self._indent_text(msg, indent_level + 4))
 
-        if diff is not None:
+        if diff:
             self._print_diff(diff, indent_level)
-        if stdout is not None:
+        if stdout:
             stdout = colorize(stdout, 'failed')
             print(self._indent_text(stdout, indent_level + 4))
-        if stderr is not None:
+        if stderr:
             stderr = colorize(stderr, 'failed')
             print(self._indent_text(stderr, indent_level + 4))
 
@@ -174,15 +174,21 @@ class CallbackModule(CallbackBase):
 
     def v2_runner_on_ok(self, result, **kwargs):
         """Run when a task finishes correctly."""
-        failed = 'failed' in result._result
-        unreachable = 'unreachable' in result._result
+        failed = result._result.get("failed")
+        unreachable = result._result.get("unreachable")
 
         if 'print_action' in result._task.tags or failed or unreachable or \
-           self._display.verbosity > 1:
+            self._display.verbosity > 1:
             self._print_task()
             self.last_skipped = False
             msg = to_text(result._result.get('msg', '')) or\
-                to_text(result._result.get('reason', ''))
+                to_text(result._result.get('reason', '')) or\
+                to_text(result._result.get('message', ''))
+
+            stderr = [result._result.get('exception', None),
+                      result._result.get('module_stderr', None)]
+            stderr = "\n".join([e for e in stderr if e]).strip()
+
             self._print_host_or_item(result._host,
                                      result._result.get('changed', False),
                                      msg,
@@ -190,11 +196,16 @@ class CallbackModule(CallbackBase):
                                      is_host=True,
                                      error=failed or unreachable,
                                      stdout=result._result.get('module_stdout', None),
-                                     stderr=result._result.get('exception', None),
+                                     stderr=stderr.strip(),
                                      )
             if 'results' in result._result:
                 for r in result._result['results']:
                     failed = 'failed' in r
+
+                    stderr = [r.get('exception', None), r.get('module_stderr', None)]
+                    stderr = "\n".join([e for e in stderr if e]).strip()
+
+
                     self._print_host_or_item(r['item'],
                                              r.get('changed', False),
                                              to_text(r.get('msg', '')),
@@ -202,7 +213,7 @@ class CallbackModule(CallbackBase):
                                              is_host=False,
                                              error=failed,
                                              stdout=r.get('module_stdout', None),
-                                             stderr=r.get('exception', None),
+                                             stderr=stderr.strip(),
                                              )
         else:
             self.last_skipped = True

--- a/lib/ansible/plugins/callback/selective.py
+++ b/lib/ansible/plugins/callback/selective.py
@@ -178,7 +178,7 @@ class CallbackModule(CallbackBase):
         unreachable = result._result.get("unreachable")
 
         if 'print_action' in result._task.tags or failed or unreachable or \
-            self._display.verbosity > 1:
+                self._display.verbosity > 1:
             self._print_task()
             self.last_skipped = False
             msg = to_text(result._result.get('msg', '')) or\
@@ -204,7 +204,6 @@ class CallbackModule(CallbackBase):
 
                     stderr = [r.get('exception', None), r.get('module_stderr', None)]
                     stderr = "\n".join([e for e in stderr if e]).strip()
-
 
                     self._print_host_or_item(r['item'],
                                              r.get('changed', False),


### PR DESCRIPTION
##### SUMMARY

The selective callback was failing to properly detect if a task had failed or not and it was failing to report some useful messages.
 
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

sective callback

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /Users/dbarroso/workspace/ansibly/ansible.cfg
  configured module search path = ['plugins/library']
```


##### ADDITIONAL INFORMATION

No changes feature-wise other than avoid false errors like this:

```
# common : Verify no system alarms ********************************************
    lab-aaoc-mpls-pe01         - FAILED!!! -- All assertions passed
```