### PR TITLE
powershell setup fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,7 @@ include .coveragerc
 include .yamllint
 include examples/hosts
 include examples/ansible.cfg
-include lib/ansible/module_utils/powershell/*.psm1
+recursive-include lib/ansible/module_utils/powershell *
 recursive-include lib/ansible/modules *
 recursive-include lib/ansible/galaxy/data *
 recursive-include docs *

--- a/setup.py
+++ b/setup.py
@@ -172,9 +172,10 @@ setup(
     packages=find_packages('lib'),
     package_data={
         '': [
-            'module_utils/*.ps1',
+            'module_utils/powershell/*.psm1',
+            'module_utils/powershell/*/*.psm1',
             'modules/windows/*.ps1',
-            'modules/windows/*.ps1',
+            'modules/windows/*/*.ps1',
             'galaxy/data/*/*.*',
             'galaxy/data/*/*/.*',
             'galaxy/data/*/*/*.*',


### PR DESCRIPTION
##### SUMMARY
* fixes #27374
* recursively include top 2 levels of .psm1's under module_utils/powershell
* recursively include top 2 levels of .ps1's under modules/windows (for future restructuring)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
setup.py

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
