### PR TITLE
Add potential work-around for expect on macOS.

### DIFF
--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -61,7 +61,7 @@
 
 - name: test chdir
   expect:
-    command: "pwd"
+    command: "/bin/sh -c 'pwd && sleep 1'"
     chdir: "{{output_dir}}"
     responses:
       foo: bar


### PR DESCRIPTION

##### SUMMARY

Add potential work-around for expect on macOS.

See http://pexpect.readthedocs.io/en/stable/commonissues.html#truncated-output-just-before-child-exits for additional details on the issue.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

expect integration tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (expect-test-fix 6f4ca9c7d5) last updated 2017/07/31 13:10:25 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
