### PR TITLE
junos_netconf integration test failure fix

### DIFF
--- a/lib/ansible/modules/network/junos/junos_netconf.py
+++ b/lib/ansible/modules/network/junos/junos_netconf.py
@@ -161,11 +161,12 @@ def load_config(module, config, commit=False):
     exec_command(module, 'top')
     rc, diff, err = exec_command(module, 'show | compare')
 
-    if commit:
-        exec_command(module, 'commit and-quit')
-    else:
-        for cmd in ['rollback 0', 'exit']:
-            exec_command(module, cmd)
+    if diff:
+        if commit:
+            exec_command(module, 'commit and-quit')
+        else:
+            for cmd in ['rollback 0', 'exit']:
+                exec_command(module, cmd)
 
     return str(diff).strip()
 
@@ -196,16 +197,11 @@ def main():
 
     if commands:
         commit = not module.check_mode
-        diff = load_config(module, commands)
+        diff = load_config(module, commands, commit=commit)
         if diff:
-            if commit:
-                commit_configuration(module)
-            else:
-                discard_changes(module)
-            result['changed'] = True
-
             if module._diff:
                 result['diff'] = {'prepared': diff}
+            result['changed'] = True
 
     module.exit_json(**result)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
junos_netconf fails when port is changed
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_netconf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
