### PR TITLE
rhn_register: call logout

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -163,6 +163,12 @@ class Rhn(redhat.RegistrationBase):
     def __init__(self, module=None, username=None, password=None):
         redhat.RegistrationBase.__init__(self, module, username, password)
         self.config = self.load_config()
+        self.server = None
+        self.session = None
+
+    def logout(self):
+        if self.session is not None:
+            self.server.auth.logout(self.session)
 
     def load_config(self):
         '''
@@ -281,7 +287,7 @@ class Rhn(redhat.RegistrationBase):
         '''
             Convenience RPC wrapper
         '''
-        if not hasattr(self, 'server') or self.server is None:
+        if self.server is None:
             if self.hostname != 'rhn.redhat.com':
                 url = "https://%s/rpc/api" % self.hostname
             else:
@@ -405,6 +411,8 @@ def main():
         except Exception:
             e = get_exception()
             module.fail_json(msg="Failed to register with '%s': %s" % (rhn.hostname, e))
+        finally:
+            rhn.logout()
 
         module.exit_json(changed=True, msg="System successfully registered to '%s'." % rhn.hostname)
 
@@ -418,6 +426,8 @@ def main():
         except Exception:
             e = get_exception()
             module.fail_json(msg="Failed to unregister: %s" % e)
+        finally:
+            rhn.logout()
 
         module.exit_json(changed=True, msg="System successfully unregistered from %s." % rhn.hostname)
 

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -220,7 +220,7 @@ class Rhn(redhat.RegistrationBase):
                     root = etree.fromstring(xml_data)
                     systemid = root.xpath(xpath_str)[0].text
                 except ImportError:
-                    pass
+                    raise Exception('"libxml2" or "lxml" is required for this module.')
 
             # Strip the 'ID-' prefix
             if systemid is not None and systemid.startswith('ID-'):

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -341,10 +341,7 @@ class Rhn(redhat.RegistrationBase):
             Return True if we are running against Hosted (rhn.redhat.com) or
             False otherwise (when running against Satellite or Spacewalk)
         '''
-        if 'rhn.redhat.com' in self.hostname:
-            return True
-        else:
-            return False
+        return 'rhn.redhat.com' in self.hostname
 
 
 def main():
@@ -402,7 +399,7 @@ def main():
 
         # Register system
         if rhn.is_registered:
-            return module.exit_json(changed=False, msg="System already registered.")
+            module.exit_json(changed=False, msg="System already registered.")
 
         try:
             rhn.enable()
@@ -419,7 +416,7 @@ def main():
     # Ensure system is *not* registered
     if state == 'absent':
         if not rhn.is_registered:
-            return module.exit_json(changed=False, msg="System already unregistered.")
+            module.exit_json(changed=False, msg="System already unregistered.")
 
         try:
             rhn.unregister()


### PR DESCRIPTION
##### SUMMARY
Minor fixes:
- `rhn.logout()` wasn't called (added because I saw there was an attempt to call `logout` in [rhn_channel](https://github.com/pilou-/ansible/blob/4538411af6229fa1c409f9283ce2a4b632b4a4b8/lib/ansible/modules/packaging/os/rhn_channel.py#L174)).
- improve error message when XML related dependencies are missing
- remove useless `return` statements

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
packaging/os/rhn_register.py

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 7cf4416c9c) last updated 2017/07/31 23:15:21 (GMT +200)
```


##### ADDITIONAL INFORMATION
Commits were initially included in #26878, I split them in order to facilitate reviews.