### PR TITLE
assumption made that dopy only dep in digital_ocean inventory script

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -153,7 +153,7 @@ except ImportError:
 try:
     from dopy.manager import DoManager
 except ImportError as e:
-    sys.exit("failed=True msg='`dopy` library required for this script'")
+    sys.exit("failed=True msg={}".format(e.message))
 
 
 class DigitalOceanInventory(object):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows the error thrown by the import to be descriptive. Found an error that I was missing dopy, after I had installed it. Turns out my venv just needed six.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
digital_ocean.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
(ansible-dev) ✘-1 ~/code/ansible [devel|✔]
22:21 $ pip freeze
certifi==2017.7.27.1
chardet==3.0.4
chube==0.1.21
dopy==0.3.7
idna==2.5
linode-python==1.1.1
pycurl==7.43.0
PyYAML==3.12
requests==2.18.2
urllib3==1.22
(ansible-dev) ✔ ~/code/ansible [devel|✔]
22:22 $ ./contrib/inventory/digital_ocean.py
failed=True msg='`dopy` library required for this script'
```
After 
```
(ansible-dev) ✔ ~/code/ansible [:be8a080486|✔]
22:23 $ pip freeze
certifi==2017.7.27.1
chardet==3.0.4
chube==0.1.21
dopy==0.3.7
idna==2.5
linode-python==1.1.1
pycurl==7.43.0
PyYAML==3.12
requests==2.18.2
urllib3==1.22
(ansible-dev) ✔ ~/code/ansible [:be8a080486|✔]
22:23 $ ./contrib/inventory/digital_ocean.py
failed=True msg=No module named six
```
