### PR TITLE
Handle missing docker-py better

### DIFF
--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -371,13 +371,25 @@ HAS_DOCKER_PY = True
 HAS_DOCKER_ERROR = False
 
 try:
-    from docker import Client
     from docker.errors import APIError, TLSParameterError
     from docker.tls import TLSConfig
     from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
 except ImportError as exc:
     HAS_DOCKER_ERROR = str(exc)
     HAS_DOCKER_PY = False
+
+# Client has recently been split into DockerClient and APIClient
+try:
+    from docker import Client
+except ImportError as exc:
+    try:
+        from docker import APIClient as Client
+    except ImportError as exc:
+        HAS_DOCKER_ERROR = str(exc)
+        HAS_DOCKER_PY = False
+
+        class Client:
+            pass
 
 DEFAULT_DOCKER_HOST = 'unix://var/run/docker.sock'
 DEFAULT_TLS = False

--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -791,6 +791,10 @@ class DockerInventory(object):
         if config_path:
             try:
                 config_file = os.path.abspath(config_path)
+                # default config path is docker.yml in same directory as this script
+                # old behaviour is docker.yml in current directory. Handle both.
+                if not os.path.exists(config_file):
+                    config_file = os.path.abspath(os.path.basename(config_path))
             except:
                 config_file = None
 
@@ -825,7 +829,7 @@ class DockerInventory(object):
         # Parse command line arguments
 
         basename = os.path.splitext(os.path.basename(__file__))[0]
-        default_config = basename + '.yml'
+        default_config = os.path.join(os.path.dirname(__file__), basename + '.yml')
 
         parser = argparse.ArgumentParser(
             description='Return Ansible inventory for one or more Docker hosts.')


### PR DESCRIPTION
##### SUMMARY

To provide graceful failure, need to create a dummy `Client`
class so that the inventory script will get as far as displaying
a useful error message

Before

```
$ contrib/inventory/docker.py --pretty
Traceback (most recent call last):
  File "contrib/inventory/docker.py", line 418, in <module>
    class AnsibleDockerClient(Client):
NameError: name 'Client' is not defined
```

After

```
$ contrib/inventory/docker.py --pretty
Failed to import docker-py. Try `pip install docker-py` - cannot import name Client
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/docker.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 1517db06c5) last updated 2017/08/01 13:59:40 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
