### PR TITLE
Handle timezone updates on Ubuntu 16.04+ on containers

### DIFF
--- a/test/integration/targets/timezone/aliases
+++ b/test/integration/targets/timezone/aliases
@@ -1,0 +1,4 @@
+destructive
+posix/ci/group1
+skip/osx
+systemd

--- a/test/integration/targets/timezone/tasks/main.yml
+++ b/test/integration/targets/timezone/tasks/main.yml
@@ -1,0 +1,15 @@
+- name: set timezone to Etc/UTC
+  timezone:
+    name: Etc/UTC
+
+- name: set timezone to Australia/Brisbane
+  timezone:
+    name: Australia/Brisbane
+  register: timezone_set
+
+- name: ensure timezone changed
+  assert:
+    that:
+      - timezone_set.changed
+      - timezone_set.diff.after.name == 'Australia/Brisbane'
+      - timezone_set.diff.before.name == 'Etc/UTC'


### PR DESCRIPTION
##### SUMMARY

Although Ubuntu 16.04 will use timedatectl by default,
containers without a working timedatectl need to use the
old method.

A bug in Ubuntu for the old method means having to write
a nasty hack

https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
timezone

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 1517db06c5) last updated 2017/08/01 13:59:40 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
Tested against Ubuntu 14 and 16 containers. Added tests for further coverage