### PR TITLE
Fix for ios integration test failure

### DIFF
--- a/test/integration/targets/prepare_ios_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ios_tests/tasks/main.yml
@@ -3,6 +3,7 @@
 - name: Ensure we have loopback 888 for testing
   ios_config:
     src: config.j2
+    authorize: yes
     provider: "{{ cli }}"
 
 


### PR DESCRIPTION
Fixes #27116

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Ensure play context remain same while executing playbook to prepare environment
after first integration test suite is run.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
