### PR TITLE
Typo on path return Value : "authorzied"

### DIFF
--- a/lib/ansible/modules/system/authorized_key.py
+++ b/lib/ansible/modules/system/authorized_key.py
@@ -172,7 +172,7 @@ key_option:
   type: string
   sameple: null
 keyfile:
-  description: Path for authorzied key file.
+  description: Path for authorized key file.
   returned: success
   type: string
   sameple: /home/user/.ssh/authorized_keys


### PR DESCRIPTION
Seen on official documentation: http://docs.ansible.com/ansible/latest/authorized_key_module.html

##### SUMMARY
Minor aesthetic fix.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
authorized_key_module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.2.0-0.4.rc4
```


##### ADDITIONAL INFORMATION
