### PR TITLE
Add fix to read correct socket path from ansible-connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -249,7 +249,7 @@ class Server():
                 break
             time.sleep(1)
             timeout -= 1
-        return (0, self.socket_path, '')
+        return 0, b'\n#SOCKET_PATH#: %s\n' % self.socket_path, ''
 
 
 def communicate(sock, data):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, socket path is sent from `ansible-connection` (running as background
process) over stdout. This can conflict with debug logs that are also sent on
stdout resulting in incorrect socket path received by the main process.

To avoid this add a socket path delimiter string which is received by
main process and socket path is retrieved based on delimiter string.

This implementation will change in future when ansible-connection
framework is made more robust.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
connection/persistent.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
