### PR TITLE
junos_netconf integration test failure fix

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -292,7 +292,7 @@ def main():
         sys.exit("FAIL: %s" % e)
 
     ssh = connection_loader.get('ssh', class_only=True)
-    cp = ssh._create_control_path(pc.remote_addr, pc.connection, pc.remote_user)
+    cp = ssh._create_control_path(pc.remote_addr, pc.port, pc.remote_user)
 
     # create the persistent connection dir if need be and create the paths
     # which we will be using later

--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -49,7 +49,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "'unable to connect to' in result.msg"
+      - "'unable to open shell' in result.msg"
 
 - name: Set back netconf to default port
   junos_netconf:

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -61,7 +61,7 @@
 - assert:
     that:
       - "result.failed == true"
-      - "'unable to connect to' in result.msg"
+      - "'unable to open shell' in result.msg"
 
 - name: re-enable netconf
   junos_netconf:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Create socket using port value and not connection type
*  Correct error message in integration test task
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
