### PR TITLE
Fix for ansiballz filenames conflicting with python stdlib modules

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -121,11 +121,11 @@ import __main__
 # stdlib module
 scriptdir = None
 try:
-    scriptdir = os.path.dirname(os.path.abspath(__main__.__file__))
+    scriptdir = os.path.dirname(os.path.realpath(__main__.__file__))
 except (AttributeError, OSError):
     # Some platforms don't set __file__ when reading from stdin
     # OSX raises OSError if using abspath() in a directory we don't have
-    # permission to read.
+    # permission to read (realpath calls abspath)
     pass
 if scriptdir is not None:
     sys.path = [p for p in sys.path if p != scriptdir]


### PR DESCRIPTION
The AnsiBallZ wrapper is transferred to the remote machine with
a filename similar to the Ansible-module it runs.  For modules like copy
and tempfile, this can end up conflicting with stdlib modules on the
remote machine depending on how python is setup there.  We have a little
bit of code in the wrapper to deal with this by removing the path that
the ansible module resides in from sys.path.

On MacOSX, that code was having a problem.  The path the module ends up
in included a symlinked directory so we were looking for a path in
sys.path but we had to look for the unsymlinked path instead.

Fix that by using os.path.realpath() instead of os.path.abspath()


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/executor/module_common.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel, 2.3
```