### PR TITLE
Fixes #23895 firewalld handle port arg whitespace

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -527,7 +527,7 @@ def main():
     source = module.params['source']
 
     if module.params['port'] is not None:
-        port, protocol = module.params['port'].split('/')
+        port, protocol = module.params['port'].strip().split('/')
         if protocol is None:
             module.fail_json(msg='improper port format (missing protocol?)')
     else:


### PR DESCRIPTION
Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### SUMMARY
Fixes #23895 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
firewalld module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix-firewalld-port-whitespace d9f5649545) last updated 2017/08/01 10:44:15 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```

