### PR TITLE
Removes scary container-enabled warning

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -220,14 +220,9 @@ class GalaxyRole(object):
                 if not role_data:
                     raise AnsibleError("- sorry, %s was not found on %s." % (self.src, api.api_server))
 
-                if role_data.get('role_type') == 'CON' and not os.environ.get('ANSIBLE_CONTAINER'):
-                    # Container Enabled, running outside of a container
-                    display.warning("%s is a Container Enabled role and should only be installed using "
-                                    "Ansible Container" % self.name)
-
                 if role_data.get('role_type') == 'APP':
                     # Container Role
-                    display.warning("%s is a Container App role and should only be installed using Ansible "
+                    display.warning("%s is a Container App role, and should only be installed using Ansible "
                                     "Container" % self.name)
 
                 role_versions = api.fetch_role_related('versions', role_data['id'])


### PR DESCRIPTION
##### SUMMARY
Per #27537, remove the warning related to installing *container enabled* roles outside of an Ansible Container target.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/role.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 7592f9132a) last updated 2017/08/01 11:40:04 (GMT -400)
  config file = None
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/projects/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```