### PR TITLE
fix enabling nxapi for nxos integration testsuite

### DIFF
--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -2,9 +2,9 @@
 # NXAPI is enabled differently on NX-OS platforms.
 # Try both commands to enable NXAPI and ignore any errors.
 - name: enable nxapi on remote device
-  nxos_config:
-    lines:
-      - feature nxapi
+  nxos_feature:
+    feature: nxapi
+    state: enabled
     provider: "{{ cli }}"
   ignore_errors: yes
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Use `nxos_feature` for prepare_nxos_tests since `nxos_config` module fails with timeout.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/prepare_nxos_tests/tasks/main.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
`nxos_config` fails with the following issue.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
"msg": "timeout trying to send command: show running-config all"
```
