### PR TITLE
Handle win style CRLF newlines in vault text

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -159,7 +159,7 @@ def parse_vaulttext_envelope(b_vaulttext_envelope, default_vault_id=None):
     # used by decrypt
     default_vault_id = default_vault_id or C.DEFAULT_VAULT_IDENTITY
 
-    b_tmpdata = b_vaulttext_envelope.split(b'\n')
+    b_tmpdata = b_vaulttext_envelope.splitlines()
     b_tmpheader = b_tmpdata[0].strip().split(b';')
 
     b_version = b_tmpheader[1].strip()

--- a/test/units/parsing/vault/test_vault.py
+++ b/test/units/parsing/vault/test_vault.py
@@ -516,6 +516,14 @@ class TestVaultLib(unittest.TestCase):
         self.assertEqual(cipher_name, u'TEST', msg="cipher name was not properly set")
         self.assertEqual(b_version, b"9.9", msg="version was not properly set")
 
+    def test_parse_vaulttext_envelope_crlf(self):
+        b_vaulttext = b"$ANSIBLE_VAULT;9.9;TEST\r\nansible"
+        b_ciphertext, b_version, cipher_name, vault_id = vault.parse_vaulttext_envelope(b_vaulttext)
+        b_lines = b_ciphertext.split(b'\n')
+        self.assertEqual(b_lines[0], b"ansible", msg="Payload was not properly split from the header")
+        self.assertEqual(cipher_name, u'TEST', msg="cipher name was not properly set")
+        self.assertEqual(b_version, b"9.9", msg="version was not properly set")
+
     def test_encrypt_decrypt_aes(self):
         self.v.cipher_name = u'AES'
         vault_secrets = self._vault_secrets_from_password('default', 'ansible')


### PR DESCRIPTION
When parsing a vaulttext blob, use .splitlines()
instead of split(b'\n') to handle \n newlines and
windows style \r\n (CRLF) new lines.

The vaulttext enevelope at this point is just the header line
and a hexlify()'ed blob, so CRLF is a valid newline here.

Fixes #22914


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/parsinb/vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_text_crlf_22914 bfa209bb09) last updated 2017/08/01 13:10:20 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```
