### PR TITLE
netapp/sf module using incorrect datatype for QoS

### DIFF
--- a/lib/ansible/modules/storage/netapp/sf_volume_manager.py
+++ b/lib/ansible/modules/storage/netapp/sf_volume_manager.py
@@ -156,7 +156,7 @@ class SolidFireVolume(object):
             account_id=dict(required=True, type='int'),
 
             enable512e=dict(type='bool', aliases=['512emulation']),
-            qos=dict(required=False, type='str', default=None),
+            qos=dict(required=False, type='dict', default=None),
             attributes=dict(required=False, type='dict', default=None),
 
             volume_id=dict(type='int', default=None),


### PR DESCRIPTION



##### SUMMARY
Fixes #27594 

The Netapp SolidFire storage module is specifying a type of
string for the QoS parameter, however this needs to be a dict
in order to be properly parsed by the Cluster API.  This PR
just sets that type correctly so it can be converted to JSON.
(ie: {minIOPS: 1000, maxIOPS: 500, burstIOPS 10000}).

This change simply changes the qos type entry from string to dict .


##### ISSUE TYPE
 - Bugfix Pull Request
 
##### COMPONENT NAME
lib/ansible/modules/storage/netapp/sf_volume_manager.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
```


##### ADDITIONAL INFORMATION
<!---
There are a number of other little issues similar to this that will be addressed shortly.
  -->


