### PR TITLE
Fix --ask-vault-pass prompt to match old when poss

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -259,7 +259,7 @@ class PromptVaultSecret(VaultSecret):
         b_vault_passwords = []
 
         for prompt_format in self.prompt_formats:
-            prompt = prompt_format % self.vault_id
+            prompt = prompt_format % {'vault_id': self.vault_id}
             try:
                 vault_pass = display.prompt(prompt, private=True)
             except EOFError:


### PR DESCRIPTION
If we don't use more than one vault-id, and we use
--ask-vault-pass, instead of using the new vault prompt
format ('Vault password (my_vault_id): ') we use the old
one ('Vault password: ').

This avoids confusing Tower when it needs to detect an
interactive vault password prompt.

This also potentially could allow vault password prompts
to be customized per vault_id.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_secrets_default_prompt_tower c3b393de85) last updated 2017/08/01 15:16:26 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
