### PR TITLE
Fix junos_logging integration test failure

### DIFF
--- a/lib/ansible/modules/network/junos/junos_logging.py
+++ b/lib/ansible/modules/network/junos/junos_logging.py
@@ -217,11 +217,13 @@ def main():
     param_to_xpath_map.update([
         ('name', {'xpath': 'name', 'is_key': True, 'top': dest}),
         ('facility', {'xpath': 'name', 'is_key': is_facility_key, 'top': field_top}),
-        ('level', {'xpath': module.params.get('level'), 'tag_only': True, 'top': field_top}),
         ('size', {'xpath': 'size', 'leaf_only': True, 'is_key': True, 'top': 'archive'}),
         ('files', {'xpath': 'files', 'leaf_only': True, 'is_key': True, 'top': 'archive'}),
         ('rotate_frequency', {'xpath': 'log-rotate-frequency', 'leaf_only': True}),
     ])
+
+    if module.params.get('level'):
+        param_to_xpath_map['level'] = {'xpath': module.params.get('level'), 'tag_only': True, 'top': field_top}
 
     validate_param_values(module, param_to_xpath_map)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add `level` in param_to_xpath_map dictionary only when value of `level` argument is given in tasks
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
