### PR TITLE
Enable log_path on network integration targets

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -4,3 +4,4 @@
 [defaults]
 timeout = 60
 host_key_checking = False
+log_path = /tmp/ansible-test.out


### PR DESCRIPTION
Logs it to /tmp/ansible-test.out