### PR TITLE
Comment the user/pass of Junos group_vars netconf provider

### DIFF
--- a/test/integration/group_vars/junos.yaml
+++ b/test/integration/group_vars/junos.yaml
@@ -1,8 +1,8 @@
 ---
 netconf:
   host: "{{ ansible_ssh_host }}"
-  username: "{{ junos_cli_user | default('ansible') }}"
-  password: "{{ junos_cli_pass | default('Ansible') }}"
+  #username: "{{ junos_cli_user | default('ansible') }}"
+  #password: "{{ junos_cli_pass | default('Ansible') }}"
   transport: netconf
 
 cli:


### PR DESCRIPTION
We set the ansible_ssh_user and ansible_ssh_pass on the Junos
group. However, that has lower precedence than group_vars.
Commenting the group_vars so we have the creds for all Nodepool nodes
within the inventory.