### PR TITLE
Comment cli provider creds on junos group_vars

### DIFF
--- a/test/integration/group_vars/junos.yaml
+++ b/test/integration/group_vars/junos.yaml
@@ -7,6 +7,6 @@ netconf:
 
 cli:
   host: "{{ ansible_ssh_host }}"
-  username: "{{ junos_cli_user | default('ansible') }}"
-  password: "{{ junos_cli_pass | default('Ansible') }}"
+  #username: "{{ junos_cli_user | default('ansible') }}"
+  #password: "{{ junos_cli_pass | default('Ansible') }}"
   transport: cli


### PR DESCRIPTION
We set the ansible_ssh_user and ansible_ssh_pass at the inventory level,
commenting these out to avoid precedence issue.