### PR TITLE
Corrects default arg format used by datetime filter to match datetime.datetime

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -609,8 +609,8 @@ To make use of one attribute from each item in a list of complex variables, use 
 
 To get date object from string use the `to_datetime` filter, (new in version in 2.2)::
 
-    # get amount of seconds between two dates, default date format is %Y-%d-%m %H:%M:%S but you can pass your own one
-    {{ (("2016-08-04 20:00:12"|to_datetime) - ("2015-10-06"|to_datetime('%Y-%d-%m'))).seconds  }}
+    # get amount of seconds between two dates, default date format is %Y-%m-%d %H:%M:%S but you can pass your own one
+    {{ (("2016-08-14 20:00:12"|to_datetime) - ("2015-12-25"|to_datetime('%Y-%m-%d'))).seconds  }}
 
 
 Combination Filters

--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -125,7 +125,7 @@ def to_bool(a):
     return False
 
 
-def to_datetime(string, format="%Y-%d-%m %H:%M:%S"):
+def to_datetime(string, format="%Y-%m-%d %H:%M:%S"):
     return datetime.strptime(string, format)
 
 


### PR DESCRIPTION
##### SUMMARY
This ensures the default datetime format matches that of
datetime.datetime. Docs updated to match as well and to use 
unambiguous dates in examples.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
Datetime Filter Plugin

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /Users/arthur/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
For reference: https://docs.python.org/2/library/datetime.html#datetime.datetime (and strptime()) use the ISO8601 format `%Y-%m-%d %H:%M:%S`, not `%Y-%d-%m ...` as exists in the current Ansible filter.
