### PR TITLE
Update apt cache if cache_valid_time is set

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -49,6 +49,7 @@ options:
   cache_valid_time:
     description:
       - Update the apt cache if its older than the I(cache_valid_time). This option is set in seconds.
+        As of Ansible 2.4, this implicitly sets I(update_cache) if set.
     required: false
     default: 0
   purge:
@@ -926,7 +927,7 @@ def main():
         # Cache valid time is default 0, which will update the cache if
         #  needed and `update_cache` was set to true
         updated_cache = False
-        if p['update_cache']:
+        if p['update_cache'] or p['cache_valid_time']:
             now = datetime.datetime.now()
             tdelta = datetime.timedelta(seconds=p['cache_valid_time'])
             if not mtimestamp + tdelta >= now:


### PR DESCRIPTION
##### SUMMARY
It's not clear from the docs whether you need to set `update_cache`
when using `cache_valid_time`.

Setting `cache_valid_time` should imply `update_cache`. Update docs
to reflect this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apt

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 24e393aef1) last updated 2017/08/02 14:02:31 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```
