### PR TITLE
ec2_vpc_igw: fix check mode - fixes #27490

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -127,14 +127,26 @@ def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
         if cur_tags == tags:
             return {'changed': False, 'tags': cur_tags}
 
+        if check_mode:
+            latest_check_mode_tags = cur_tags
+
         to_delete = dict((k, cur_tags[k]) for k in cur_tags if k not in tags)
         if to_delete and not add_only:
-            vpc_conn.delete_tags(resource_id, to_delete, dry_run=check_mode)
+            if check_mode:
+                # just overwriting latest_check_mode_tags instead of deleting keys
+                latest_check_mode_tags = dict((k, cur_tags[k]) for k in cur_tags if k not in to_delete)
+            else:
+                vpc_conn.delete_tags(resource_id, to_delete)
 
         to_add = dict((k, tags[k]) for k in tags if k not in cur_tags or cur_tags[k] != tags[k])
         if to_add:
-            vpc_conn.create_tags(resource_id, to_add, dry_run=check_mode)
+            if check_mode:
+                latest_check_mode_tags.update(to_add)
+            else:
+                vpc_conn.create_tags(resource_id, to_add)
 
+        if check_mode:
+            return {'changed': True, 'tags': latest_check_mode_tags}
         latest_tags = get_resource_tags(vpc_conn, resource_id)
         return {'changed': True, 'tags': latest_tags}
     except EC2ResponseError as e:
@@ -187,6 +199,11 @@ def ensure_igw_present(vpc_conn, vpc_id, tags, check_mode):
     igw.vpc_id = vpc_id
 
     if tags != igw.tags:
+        if check_mode:
+            check_mode_tags = ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
+            igw_info = get_igw_info(igw)
+            igw_info['tags'] = check_mode_tags
+            return {'changed': True, 'gateway': igw_info}
         ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
         igw.tags = tags
         changed = True

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -202,7 +202,7 @@ def ensure_igw_present(vpc_conn, vpc_id, tags, check_mode):
         if check_mode:
             check_mode_tags = ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
             igw_info = get_igw_info(igw)
-            igw_info['tags'] = check_mode_tags
+            igw_info.get('tags', {}).update(check_mode_tags.get('tags', {}))
             return {'changed': True, 'gateway': igw_info}
         ensure_tags(vpc_conn, igw.id, tags, False, check_mode)
         igw.tags = tags


### PR DESCRIPTION
##### SUMMARY
Fix check_mode for adding/removing tags. Removes the use of boto's dry_run parameter because it is not equivalent to check mode.

Fixes #27490 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py

##### ANSIBLE VERSION
```
2.4.0
```
