### PR TITLE
Add missing copyright header in modules cleaned up yesterday

### DIFF
--- a/lib/ansible/modules/packaging/os/dpkg_selections.py
+++ b/lib/ansible/modules/packaging/os/dpkg_selections.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
+# Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2015, Ansible, inc
+# (c) 2015, Ansible Project
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 


### PR DESCRIPTION
##### SUMMARY
We should have a copyright header on all files.  Make sure the files that had boilerplate cleaned up yesterday have the headers.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
