### PR TITLE
Fixes #27340 - make indent consistent for nxos_config

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -283,7 +283,7 @@ def get_running_config(module, config=None):
         else:
             flags = ['all']
             contents = get_config(module, flags=flags)
-    return NetworkConfig(indent=3, contents=contents)
+    return NetworkConfig(indent=2, contents=contents)
 
 
 def get_candidate(module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #27340
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixed inconsistent `indent` in this module which caused the gathered diff and the config to be applied mismatch. This caused the commands to be applied everytime and hence the idempotency issue.
 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxos_config 611cdd2c21) last updated 2017/08/02 11:16:01 (GMT -400)
  config file = None
  configured module search path = [u'/Users/rahushen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rahushen/cisco/ansible/lib/ansible
  executable location = /Users/rahushen/cisco/ansible/bin/ansible
  python version = 2.7.12 (v2.7.12:d33e0cf91556, Jun 26 2016, 12:10:39) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Unit test:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# pytest test_nxos_config.py 
=================================================================== test session starts ===================================================================
platform linux2 -- Python 2.7.6, pytest-3.1.2, py-1.4.34, pluggy-0.4.0
rootdir: /root/agents-ci/ansible, inifile:
collected 12 items 

test_nxos_config.py ............

================================================================ 12 passed in 0.15 seconds ================================================================
```
