### PR TITLE
Added proxy environment variables to default sudo flags

### DIFF
--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -963,7 +963,7 @@ DEFAULT_SUDO_EXE:
   vars: []
   yaml: {key: defaults.sudo_exe}
 DEFAULT_SUDO_FLAGS:
-  default: -H -S -n
+  default: -H -S -n http_proxy=$http_proxy https_proxy=$https_proxy no_proxy=$no_proxy ftp_proxy=$ftp_proxy
   desc: 'TODO: write it'
   env: [{name: ANSIBLE_SUDO_FLAGS}]
   ini:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I'd tried to use `apt_key` module behind the proxy server:
```yml
- name: Add InfluxDB public GPG key
  apt_key:
    url: https://repos.influxdata.com/influxdb.key
    state: present
```

And got the error:
```text
TASK [influx-db : Add InfluxDB public GPG key] **************************************************************************************************************
fatal: [server]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to connect to repos.influxdata.com at port 443: [Errno 111] Connection refused"}
```

`apt_key` module [delegates](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/packaging/os/apt_key.py#L223) all HTTP-related work to `fetch_url` function from [urls.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/urls.py):
```python
rsp, info = fetch_url(module, url)
```
which calls `open_url` function:
```python
r = open_url(url, data=data, headers=headers, method=method,
             use_proxy=use_proxy, force=force, last_mod_time=last_mod_time, timeout=timeout,
             validate_certs=validate_certs, url_username=username,
             url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
             follow_redirects=follow_redirects, client_cert=client_cert,
             client_key=client_key, cookies=cookies)
```

[open_url](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/urls.py#L813) uses `urllib_request.build_opener`:
```python
opener = urllib_request.build_opener(*handlers)
```
which [according to documentation](https://docs.python.org/3.0/library/urllib.request.html#urllib.request.build_opener) contains `urllib.request.ProxyHandler`:
>Return an OpenerDirector instance, which chains the handlers in the order given. handlers can be either instances of BaseHandler, or subclasses of BaseHandler (in which case it must be possible to call the constructor without any parameters). Instances of the following classes will be in front of the handlers, unless the handlers contain them, instances of them or subclasses of them: ProxyHandler, UnknownHandler, HTTPHandler, HTTPDefaultErrorHandler, HTTPRedirectHandler, FTPHandler, FileHandler, HTTPErrorProcessor.

`ProxyHandler` [should read](https://docs.python.org/3.1/library/urllib.request.html#urllib.request.ProxyHandler) proxies from the environment variables:
>The default is to read the list of proxies from the environment variables.

My `/etc/environment` contains proxy variables:
```
http_proxy=http://proxy:8080
https_proxy=http://proxy:8080
```
And I expect the `apt-key` command to succeed but it doesn't. :-(

The error was in the relationship between `sudo` command (I used `--become` option with default become method to run playbook) and environment variables. `sudo` drops environment variables by default (from `/etc/sudoers`):
```
Defaults        env_reset
```
thats why all proxy settings from `/etc/environment` are ignored.

I usually do not face this problem because I use `-E` flag for `sudo`.

There are two workarounds for this problem (all menthioned in #7322):
1. Explicitly add proxy settings to each command:
    ```yml
    - name: Add InfluxDB public GPG key
      apt_key:
        url: https://repos.influxdata.com/influxdb.key
        state: present
      environment:
        http_proxy: 'http://proxy:8080'
        https_proxy: 'http://proxy:8080'
   ```
2. Add `env_keep` to `/etc/sudoers`:
    ```text
    Defaults       env_keep += "http_proxy"
    Defaults       env_keep += "https_proxy"
    ```

And each of them requires a lot of "googling": it is not very obvious that the problem is not in the apt_key module but in the sudo settings.

In this PR I changed DEFAULT_SUDO_FLAGS: explicitly asked sudo to keep all proxy-related variables.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
core

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (sudo-does-not-drop-environment-proxy-variables b9b0d0ea5f) last updated 2017/08/02 18:41:38 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = [u'/home/art/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/art/projects/github/ansible/lib/ansible
  executable location = /home/art/projects/github/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
