### PR TITLE
Strip all lines in responses from aireos

### DIFF
--- a/lib/ansible/module_utils/aireos.py
+++ b/lib/ansible/module_utils/aireos.py
@@ -47,8 +47,9 @@ ARGS_DEFAULT_VALUE = {}
 
 
 def sanitize(resp):
-    # Takes config from device and strips whitespace from all lines
+    # Takes response from device and strips whitespace from all lines
     # Aireos adds in extra preceding whitespace which netcfg parses as children/parents, which Aireos does not do
+    # Aireos also adds in trailing whitespace that is unused
     cleaned = []
     for line in resp.splitlines():
         cleaned.append(line.strip())
@@ -112,7 +113,7 @@ def run_commands(module, commands, check_rc=True):
         rc, out, err = exec_command(module, cmd)
         if check_rc and rc != 0:
             module.fail_json(msg=to_text(err, errors='surrogate_then_replace'), rc=rc)
-        responses.append(to_text(out, errors='surrogate_then_replace'))
+        responses.append(sanitize(to_text(out, errors='surrogate_then_replace')))
     return responses
 
 

--- a/lib/ansible/modules/network/aireos/aireos_config.py
+++ b/lib/ansible/modules/network/aireos/aireos_config.py
@@ -167,7 +167,7 @@ backup_path:
   type: string
   sample: /playbooks/ansible/backup/aireos_config.2016-07-16@22:28:34
 """
-from ansible.module_utils.aireos import run_commands, get_config, load_config, sanitize
+from ansible.module_utils.aireos import run_commands, get_config, load_config
 from ansible.module_utils.aireos import aireos_argument_spec
 from ansible.module_utils.aireos import check_args as aireos_check_args
 from ansible.module_utils.basic import AnsibleModule
@@ -281,7 +281,7 @@ def main():
 
     if module._diff:
         output = run_commands(module, 'show run-config commands')
-        contents = sanitize(output[0])
+        contents = output[0]
 
         # recreate the object in order to process diff_ignore_lines
         running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Removing all extra whitespace from lines returned from aireos devices. Aireos likes to prepend and append whitespace that isn't used for anything, this removes it.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aireos_config aireos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (sanitize_aireos_resp 02014cb5d9) last updated 2017/08/02 11:27:25 (GMT -700)
  config file = /Users/james/.ansible.cfg
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/work/git/ansible/lib/ansible
  executable location = /Users/james/Documents/work/git/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

