### PR TITLE
New community docs: Simple "good enough" index page

### DIFF
--- a/docs/docsite/rst/community/index.rst
+++ b/docs/docsite/rst/community/index.rst
@@ -7,8 +7,7 @@ Ansible Community Guide
 
 Welcome to the Ansible Community Guide!
 
-The purpose of this guide is to document how you can interact with and contribute to Ansible as a community member.
-[TODO: add something better here]
+The purpose of this guide is to teach you everything you need to know about being a contributing member of the Ansible community. 
 
 To get started, select one of the following topics.
 


### PR DESCRIPTION
These proposed changes will come a page at a time, so we don't block on a huge PR for review.

This one is simple. It's the index page. It'll say a lot more later, but for now it just has to say "this is the guide!" and point to all the other pages. Removing the FIXME so it reads like a "finished", if minimal, page.