### PR TITLE
Update ansible-test completions to match CI.

### DIFF
--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,4 @@
 freebsd/10.3-STABLE
-freebsd/11.0-STABLE
+freebsd/11.1-STABLE
 osx/10.11
-rhel/7.3
+rhel/7.4


### PR DESCRIPTION
##### SUMMARY

Update ansible-test completions to match CI.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (devel a1abe7d941) last updated 2017/08/02 13:43:27 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
