### PR TITLE
Fix incorrect use of datetime in letsencrypt

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -159,7 +159,6 @@ import binascii
 import copy
 import hashlib
 import json
-import locale
 import os
 import re
 import shutil
@@ -215,12 +214,12 @@ def get_cert_days(module, cert_file):
     _, out, _ = module.run_command(openssl_cert_cmd, check_rc=True)
     try:
         not_after_str = re.search(r"\s+Not After\s*:\s+(.*)", out.decode('utf8')).group(1)
-        not_after = datetime.datetime.fromtimestamp(time.mktime(time.strptime(not_after_str, '%b %d %H:%M:%S %Y %Z')))
+        not_after = datetime.fromtimestamp(time.mktime(time.strptime(not_after_str, '%b %d %H:%M:%S %Y %Z')))
     except AttributeError:
         module.fail_json(msg="No 'Not after' date found in {0}".format(cert_file))
     except ValueError:
         module.fail_json(msg="Failed to parse 'Not after' date of {0}".format(cert_file))
-    now = datetime.datetime.utcnow()
+    now = datetime.utcnow()
     return (not_after - now).days
 
 
@@ -789,7 +788,7 @@ def main():
     )
 
     # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.
-    locale.setlocale(locale.LC_ALL, "C")
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
 
     cert_days = get_cert_days(module, module.params['dest'])
     if cert_days < module.params['remaining_days']:


### PR DESCRIPTION
Also correctly sets the locale for run_command executions using the module
provided method for setting the locale instead of the locale module in python.

##### SUMMARY
See above.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
module

##### ANSIBLE VERSION
```
ansible 2.4.0 (fix_letsencrypt_datetime 6b5291d68f) last updated 2017/08/02 16:13:52 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /data/devel/ansible/lib/ansible
  executable location = /data/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
