### PR TITLE
provide usable examples for sudo validation

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -143,14 +143,14 @@ EXAMPLES = r'''
 - copy:
     src: /mine/sudoers
     dest: /etc/sudoers
-    validate: visudo -cf %s
+    validate: /usr/sbin/visudo -cf %s
 
 # Copy a "sudoers" file on the remote machine for editing
 - copy:
     src: /etc/sudoers
     dest: /etc/sudoers.edit
     remote_src: yes
-    validate: visudo -cf %s
+    validate: /usr/sbin/visudo -cf %s
 
 # Create a CSV file from your complete inventory using an inline template
 - hosts: all

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -184,7 +184,7 @@ EXAMPLES = r"""
     state: present
     regexp: '^%ADMIN ALL='
     line: '%ADMIN ALL=(ALL) NOPASSWD: ALL'
-    validate: 'visudo -cf %s'
+    validate: '/usr/sbin/visudo -cf %s'
 """
 
 import re

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -137,7 +137,7 @@ EXAMPLES = r'''
 - template:
     src: /mine/sudoers
     dest: /etc/sudoers
-    validate: 'visudo -cf %s'
+    validate: '/usr/sbin/visudo -cf %s'
 
 # Update sshd configuration safely, avoid locking yourself out
 - template:


### PR DESCRIPTION
##### SUMMARY
quality of life update for documentation; visudo is not in PATH, so we must declare a path.


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- lineinfile
- copy
- template

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.3.1.0
  config file = /home/pete9168/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
Ansible version output provided as requested, but patches apply against devel HEAD.  https://github.com/ansible/ansible-modules-core/issues/5091 keeps getting traffic, that would probably stop if the example were more directly usable.