### PR TITLE
removed requirements on WANT_JSON and POWERSHELL_COMMON

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -636,18 +636,12 @@ class ModuleValidator(Validator):
                     )
 
     def _find_ps_replacers(self):
-        if 'WANT_JSON' not in self.text:
-            self.reporter.error(
-                path=self.object_path,
-                code=206,
-                msg='WANT_JSON not found in module'
-            )
-
-        if REPLACER_WINDOWS not in self.text:
+        ps_module_util_template = '#Requires -Module Ansible.ModuleUtils.'
+        if ps_module_util_template not in self.text and REPLACER_WINDOWS not in self.text:
             self.reporter.error(
                 path=self.object_path,
                 code=207,
-                msg='"%s" not found in module' % REPLACER_WINDOWS
+                msg='"%s" not found in module' % ps_module_util_template
             )
 
     def _find_ps_docs_py_file(self):


### PR DESCRIPTION
##### SUMMARY
New modules don't need `# WANT_JSON` or `# POWERSHELL_COMMON`, this removes the sanity check run on modules so that Shippable will pass with the new style

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-test validate-modules

##### ANSIBLE VERSION
```
2.4
```