### PR TITLE
fix NameError eos_config

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -222,7 +222,7 @@ class Cli:
             pass
 
         if not all((bool(use_session), self.supports_sessions)):
-            return configure(self, commands)
+            return self.configure(self, commands)
 
         conn = get_connection(self)
         session = 'ansible_%s' % int(time.time())
@@ -395,7 +395,7 @@ class Eapi:
         there will be no returned diff or session values
         """
         if not self.supports_sessions:
-            return configure(self, commands)
+            return self.configure(self, commands)
 
         session = 'ansible_%s' % int(time.time())
         result = {'session': session}


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix NameError `global name configure` not define.
related issue https://github.com/ansible/ansible/issues/27630#issuecomment-319634757
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/eos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
stable-2.3
```