### PR TITLE
timer callback plugin: handle timezone changes better

### DIFF
--- a/lib/ansible/plugins/callback/timer.py
+++ b/lib/ansible/plugins/callback/timer.py
@@ -20,17 +20,17 @@ class CallbackModule(CallbackBase):
 
         super(CallbackModule, self).__init__()
 
-        self.start_time = datetime.now()
+        self.start_time = datetime.utcnow()
 
     def days_hours_minutes_seconds(self, runtime):
         minutes = (runtime.seconds // 60) % 60
-        r_seconds = runtime.seconds - (minutes * 60)
+        r_seconds = runtime.seconds % 60
         return runtime.days, runtime.seconds // 3600, minutes, r_seconds
 
     def playbook_on_stats(self, stats):
         self.v2_playbook_on_stats(stats)
 
     def v2_playbook_on_stats(self, stats):
-        end_time = datetime.now()
+        end_time = datetime.utcnow()
         runtime = end_time - self.start_time
         self._display.display("Playbook run took %s days, %s hours, %s minutes, %s seconds" % (self.days_hours_minutes_seconds(runtime)))


### PR DESCRIPTION
##### SUMMARY

A playbook that does `timezone name=Australia/Brisbane` on
a host previously in UTC will appear to take 10 hours.

Improve the seconds handling for playbooks that take longer
than one hour.

TZ change before:
```
Playbook run took 0 days, 10 hours, 0 minutes, 36055 seconds
```
After:
```
Playbook run took 0 days, 0 hours, 0 minutes, 55 seconds
```

Sleep for 100s more than one hour before:
```
Playbook run took 0 days, 1 hours, 1 minutes, 3641 seconds
```

After:
```
Playbook run took 0 days, 1 hours, 1 minutes, 41 seconds
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/callback/timer

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 66c35f60d2) last updated 2017/08/03 14:46:12 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

##### ADDITIONAL INFORMATION
