### PR TITLE
Fix for missing import and boilerplate

### DIFF
--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -186,8 +176,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -495,10 +485,9 @@ def main():
                                login_password,
                                config_file,
                                cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     proxysql_server = ProxySQLServer(module)
@@ -525,10 +514,9 @@ def main():
                                  " and doesn't need to be updated.")
                 result['server'] = \
                     proxysql_server.get_server_config(cursor)
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to modify server.. %s" % e
+                msg="unable to modify server.. %s" % to_native(e)
             )
 
     elif proxysql_server.state == "absent":
@@ -541,10 +529,9 @@ def main():
                 result['changed'] = False
                 result['msg'] = ("The server is already absent from the" +
                                  " mysql_hosts memory configuration")
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to remove server.. %s" % e
+                msg="unable to remove server.. %s" % to_native(e)
             )
 
     module.exit_json(**result)

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -111,7 +101,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -249,10 +239,9 @@ def main():
                                login_password,
                                config_file,
                                cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     result = {}
@@ -269,10 +258,9 @@ def main():
                     msg="The variable \"%s\" was not found" % variable
                 )
 
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to get config.. %s" % e
+                msg="unable to get config.. %s" % to_native(e)
             )
     else:
         try:
@@ -303,10 +291,9 @@ def main():
                     msg="The variable \"%s\" was not found" % variable
                 )
 
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to set config.. %s" % e
+                msg="unable to set config.. %s" % to_native(e)
             )
 
     module.exit_json(**result)

--- a/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -126,7 +116,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -230,10 +220,9 @@ def main():
                                login_user,
                                login_password,
                                config_file)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     result = {}
@@ -244,10 +233,9 @@ def main():
     try:
         result['changed'] = manage_config(manage_config_settings,
                                           cursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to manage config.. %s" % e
+            msg="unable to manage config.. %s" % to_native(e)
         )
 
     module.exit_json(**result)

--- a/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -175,8 +165,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -462,10 +452,9 @@ def main():
                                login_password,
                                config_file,
                                cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     proxysql_user = ProxySQLUser(module)
@@ -492,10 +481,9 @@ def main():
                                  " and doesn't need to be updated.")
                 result['user'] = \
                     proxysql_user.get_user_config(cursor)
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to modify user.. %s" % e
+                msg="unable to modify user.. %s" % to_native(e)
             )
 
     elif proxysql_user.state == "absent":
@@ -508,10 +496,9 @@ def main():
                 result['changed'] = False
                 result['msg'] = ("The user is already absent from the" +
                                  " mysql_users memory configuration")
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to remove user.. %s" % e
+                msg="unable to remove user.. %s" % to_native(e)
             )
 
     module.exit_json(**result)

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -258,8 +248,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -589,10 +579,9 @@ def main():
                                login_password,
                                config_file,
                                cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     proxysql_query_rule = ProxyQueryRule(module)
@@ -620,10 +609,9 @@ def main():
                 result['rules'] = \
                     proxysql_query_rule.get_rule_config(cursor)
 
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to modify rule.. %s" % e
+                msg="unable to modify rule.. %s" % to_native(e)
             )
 
     elif proxysql_query_rule.state == "absent":
@@ -644,10 +632,9 @@ def main():
                 result['changed'] = False
                 result['msg'] = ("The rule is already absent from the" +
                                  " mysql_query_rules memory configuration")
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to remove rule.. %s" % e
+                msg="unable to remove rule.. %s" % to_native(e)
             )
 
     module.exit_json(**result)

--- a/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -133,7 +123,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -366,10 +356,9 @@ def main():
                                login_password,
                                config_file,
                                cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     proxysql_repl_group = ProxySQLReplicationHostgroup(module)
@@ -398,10 +387,9 @@ def main():
                     result['repl_group'] = \
                         proxysql_repl_group.get_repl_group_config(cursor)
 
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to modify replication hostgroup.. %s" % e
+                msg="unable to modify replication hostgroup.. %s" % to_native(e)
             )
 
     elif proxysql_repl_group.state == "absent":
@@ -417,10 +405,9 @@ def main():
                                  " mysql_replication_hostgroups memory" +
                                  " configuration")
 
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to delete replication hostgroup.. %s" % e
+                msg="unable to delete replication hostgroup.. %s" % to_native(e)
             )
 
     module.exit_json(**result)

--- a/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 DOCUMENTATION = '''
 ---
@@ -163,8 +153,8 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.mysql import mysql_connect
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 
 try:
     import MySQLdb
@@ -404,10 +394,9 @@ def main():
                                login_password,
                                config_file,
                                cursor_class=MySQLdb.cursors.DictCursor)
-    except MySQLdb.Error:
-        e = get_exception()
+    except MySQLdb.Error as e:
         module.fail_json(
-            msg="unable to connect to ProxySQL Admin Module.. %s" % e
+            msg="unable to connect to ProxySQL Admin Module.. %s" % to_native(e)
         )
 
     proxysql_schedule = ProxySQLSchedule(module)
@@ -428,10 +417,9 @@ def main():
                                  " need to be updated.")
                 result['schedules'] = \
                     proxysql_schedule.get_schedule_config(cursor)
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to modify schedule.. %s" % e
+                msg="unable to modify schedule.. %s" % to_native(e)
             )
 
     elif proxysql_schedule.state == "absent":
@@ -452,10 +440,9 @@ def main():
                 result['changed'] = False
                 result['msg'] = ("The schedule is already absent from the" +
                                  " memory configuration")
-        except MySQLdb.Error:
-            e = get_exception()
+        except MySQLdb.Error as e:
             module.fail_json(
-                msg="unable to remove schedule.. %s" % e
+                msg="unable to remove schedule.. %s" % to_native(e)
             )
 
     module.exit_json(**result)

--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -20,7 +20,6 @@ future2=$(find ./lib/ansible -path ./lib/ansible/modules -prune \
 # Eventually we want metaclass3 and future3 to get down to 0
 metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune \
         -o -path ./lib/ansible/modules/files -prune \
-        -o -path ./lib/ansible/modules/database/proxysql -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \
         -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
@@ -42,7 +41,6 @@ metaclass3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -pru
 
 future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune \
         -o -path ./lib/ansible/modules/files -prune \
-        -o -path ./lib/ansible/modules/database/proxysql -prune \
         -o -path ./lib/ansible/modules/cloud/ovirt -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \
         -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
@@ -70,7 +68,6 @@ future3=$(find ./lib/ansible/modules -path ./lib/ansible/modules/windows -prune 
 # (everything below needs boilerplate added)
 # Priorities: import*, get_exception, then boilerplate-only
 #
-# database/proxysql [!]
 # network/ios
 # network/eos [i]
 # network/netvisor


### PR DESCRIPTION
##### SUMMARY
Fix adds missing imports and boilerplate for proxysql.
It also remove get_exception calls in-favor of native exception.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
lib/ansible/modules/database/proxysql/proxysql_global_variables.py
lib/ansible/modules/database/proxysql/proxysql_manage_config.py
lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
lib/ansible/modules/database/proxysql/proxysql_query_rules.py
lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
lib/ansible/modules/database/proxysql/proxysql_scheduler.py
test/sanity/code-smell/boilerplate.sh

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```