### PR TITLE
Fix rstcheck: remove non breaking space

### DIFF
--- a/docs/docsite/rst/roadmap/ROADMAP_2_2.rst
+++ b/docs/docsite/rst/roadmap/ROADMAP_2_2.rst
@@ -117,7 +117,7 @@ Lead by Nate C, Peter S
 
 Role revamp
 -----------
-- **Implement ‘role revamp’ proposal to give users more control on role/task execution (Brian) **
+- **Implement ‘role revamp’ proposal to give users more control on role/task execution (Brian)**
 
   - **https://github.com/ansible/proposals/blob/master/roles_revamp.md**
 


### PR DESCRIPTION
error was: Inline strong start-string without end-string.

##### SUMMARY
Fix an `rstcheck` error which appeared [there](https://github.com/ansible/ansible/pull/26878#issuecomment-319970061).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
 docs/docsite/rst/roadmap/ROADMAP_2_2.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.4.0 (devel 1e42e1e04c) last updated 2017/08/03 16:00:37 (GMT +200)
```