### PR TITLE
Include aliases in ansible-doc output

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -312,7 +312,8 @@ class DocCLI(CLI):
 
             aliases = ''
             if 'aliases' in opt:
-                choices = "(Aliases: " + ", ".join(str(i) for i in opt['aliases']) + ")"
+                if len(opt['aliases']) > 0:
+                    aliases = "(Aliases: " + ", ".join(str(i) for i in opt['aliases']) + ")"
                 del opt['aliases']
             choices = ''
             if 'choices' in opt:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -317,7 +317,8 @@ class DocCLI(CLI):
                 del opt['aliases']
             choices = ''
             if 'choices' in opt:
-                choices = "(Choices: " + ", ".join(str(i) for i in opt['choices']) + ")"
+                if len(opt['choices']) > 0:
+                    choices = "(Choices: " + ", ".join(str(i) for i in opt['choices']) + ")"
                 del opt['choices']
             default = ''
             if 'default' in opt or not required:


### PR DESCRIPTION
##### SUMMARY

Include aliases in `ansible-doc` output when they exist. Many modules define an empty list for both Aliases and Choices, so only print them out when there are items in the list rather than displaying 'Aliases': ' or 'Choices:' with no options.

Fixes #24498 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME

`doc.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION

Output prior to this fix. Missing Aliases and empty Choices are returned.

```
> ansible-doc pagerduty

...
- hours
        Length of maintenance window in hours.
        (Choices: )[Default: 1]
...
- service
        A comma separated list of PagerDuty service IDs.
        (Choices: )[Default: None]
...
```

Output with this fix. Empty lists are not output and Aliases are printed.

```
> ansible-doc pagerduty

...
- hours
        Length of maintenance window in hours.
        [Default: 1]
...
- service
        A comma separated list of PagerDuty service IDs.
        (Aliases: services)[Default: None]
...
```


Output with this fix when both Aliases and Choices exist:
```
> ansible-doc route53

...
= state
        Specifies the state of the resource record. As of Ansible 2.4, the `command' option has been changed to `state' as default and the choices 'present' and 'absent' have been added, but
        `command' still works as well.
        (Aliases: command)(Choices: present, absent, get, create, delete)
...
```