### PR TITLE
Iosxr diff in check mode

### DIFF
--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -139,7 +139,6 @@ def load_config(module, commands, warnings, commit=False, replace=False, comment
             cmd += ' comment {0}'.format(comment)
     else:
         cmd = 'abort'
-        diff = None
 
     rc, out, err = exec_command(module, cmd)
     if rc != 0:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If you run iosxr_config in check mode you cannot tell if a change is needed or if there's a diff, so you'd have to actually run it (not using check mode) to tell.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.4.0 (iosxr_checkmode_diff 498acbbef0) last updated 2017/08/03 11:45:01 (GMT -700)
  config file = /Users/james/.ansible.cfg
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/work/git/ansible/lib/ansible
  executable location = /Users/james/Documents/work/git/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Sample task : 
```
- name: Check if change is needed
  iosxr_config:
    provider: "{{ cli }}"
    lines: "{{ acl_lines }}"
    match: exact
    parents: "{{ acl_parents | default(omit) }}"
  check_mode: yes
  register: result
  when: acl_lines is defined
```

acl_lines with acl_parents together : 
```
ipv4 access-list test
10 permit ipv4 172.10.198.0 0.0.1.255 any
20 permit ipv4 10.20.192.0 0.0.31.255 any
30 permit ipv4 10.151.192.0 0.0.31.255 any
40 permit ipv4 10.220.240.0 0.0.1.255 any
```

On the device : 
```
ipv4 access-list test
10 permit ipv4 172.10.198.0 0.0.1.255 any
20 permit ipv4 10.20.192.0 0.0.31.255 any
```

Expected result : 
```
"changed": true,
"commands": [
        "ipv4 access-list test",
        "10 permit ipv4 172.10.198.0 0.0.1.255 any",
        "20 permit ipv4 10.20.192.0 0.0.31.255 any",
        "30 permit ipv4 10.151.192.0 0.0.31.255 any",
        "40 permit ipv4 10.220.240.0 0.0.1.255 any"
    ],
    "diff": {
        "prepared": "Building configuration...\n!! IOS XR Configuration 5.1.3\nipv4 access-list test\n 10 permit ipv4 172.10.198.0 0.0.1.255 any\n 20 permit ipv4 10.20.192.0 0.0.31.255 any\n 30 permit ipv4 10.151.192.0 0.0.31.255 any\n 40 permit ipv4 10.220.240.0 0.0.1.255 any\n!\nend"
    },
...
```
