### PR TITLE
rm_azure_common.py update - add support for DNS Zone

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -91,6 +91,8 @@ try:
     from azure.mgmt.storage.version import VERSION as storage_client_version
     from azure.mgmt.compute.version import VERSION as compute_client_version
     from azure.mgmt.resource.version import VERSION as resource_client_version
+    from azure.mgmt.dns.version import VERSION as dns_client_version
+    from azure.mgmt.dns.dns_management_client import DnsManagementClient
     from azure.mgmt.network.network_management_client import NetworkManagementClient
     from azure.mgmt.resource.resources.resource_management_client import ResourceManagementClient
     from azure.mgmt.storage.storage_management_client import StorageManagementClient
@@ -115,7 +117,8 @@ AZURE_EXPECTED_VERSIONS = dict(
     storage_client_version="0.30.0rc5",
     compute_client_version="0.30.0rc5",
     network_client_version="0.30.0rc5",
-    resource_client_version="0.30.0rc5"
+    resource_client_version="0.30.0rc5",
+    dns_client_version="0.30.0rc5"
 )
 
 AZURE_MIN_RELEASE = '2.0.0rc5'
@@ -163,6 +166,7 @@ class AzureRMModuleBase(object):
         self._storage_client = None
         self._resource_client = None
         self._compute_client = None
+        self._dns_client = None
         self.check_mode = self.module.check_mode
         self.facts_module = facts_module
         # self.debug = self.module.params.get('debug')
@@ -620,3 +624,12 @@ class AzureRMModuleBase(object):
             self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Compute')
         return self._compute_client
+
+    @property
+    def dns_client(self):
+        self.log('Getting dns client. . .')
+        if not self._dns_client:
+            self.check_client_version('dns', dns_client_version, AZURE_EXPECTED_VERSIONS['dns_client_version'])
+            self._dns_client = DnsManagementClient(self.azure_credentials, self.subscription_id)
+            self._register('Microsoft.Dns')
+        return self._dns_client

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -633,4 +633,3 @@ class AzureRMModuleBase(object):
             self._dns_client = DnsManagementClient(self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Dns')
         return self._dns_client
-

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -633,3 +633,4 @@ class AzureRMModuleBase(object):
             self._dns_client = DnsManagementClient(self.azure_credentials, self.subscription_id)
             self._register('Microsoft.Dns')
         return self._dns_client
+


### PR DESCRIPTION
##### SUMMARY
In order to support new Azure modules for DNS Zone and Record Set creation/manipulation, I needed to update the azure_rm_common.py module.

I added a few lines for importing the DNS client version and the DNS management client itself. Then, using the other clients that were already present (compute, resource, storage and network), I followed the same templates for getting the client and registering it. I didn't modify any of the code that was originally there and I only added my own lines to add support for the DNS client. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_common.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 7bed60ba5f) last updated 2017/06/21 12:56:46 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /home/t-ozboms/ansible2/lib/ansible
  executable location = /home/t-ozboms/ansible2/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```
