### PR TITLE
Issue 27345 include attribute error fix

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -103,13 +103,13 @@ class IncludedFile:
                                     parent_include = parent_include._parent
                                     continue
                                 if isinstance(parent_include, IncludeRole):
-                                    parent_include_dir = os.path.dirname(parent_include._role_path)
+                                    parent_include_dir = parent_include._role_path
                                 else:
                                     parent_include_dir = os.path.dirname(templar.template(parent_include.args.get('_raw_params')))
-                                if cumulative_path is None:
-                                    cumulative_path = parent_include_dir
-                                elif not os.path.isabs(cumulative_path):
+                                if cumulative_path is not None and not os.path.isabs(cumulative_path):
                                     cumulative_path = os.path.join(parent_include_dir, cumulative_path)
+                                else:
+                                    cumulative_path = parent_include_dir
                                 include_target = templar.template(include_result['include'])
                                 if original_task._role:
                                     new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -127,6 +127,7 @@ class IncludeRole(TaskInclude):
         new_me._from_files = self._from_files.copy()
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
+        new_me._role_path = self._role_path
 
         return new_me
 


### PR DESCRIPTION
##### SUMMARY
This fixes #27345, however it exposed some additional logic issues in IncludeFile. These are based on the fact that with include_role, the role paths in question for parents are almost always an absolute path unlike normally with task includes (which are usually relative).

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
playbook/role_include.py
playbook/included_file.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue_27345_include_attribute_error_fix 72c02715d7) last updated 2017/08/03 15:02:35 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /data/devel/ansible/lib/ansible
  executable location = /data/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```
