### PR TITLE
Fix for subspec options validation issue #27715

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1960,9 +1960,9 @@ class AnsibleModule(object):
                         self._check_argument_types(spec, param)
                         self._check_argument_values(spec, param)
 
-                        self._check_required_together(self.required_together, param)
-                        self._check_required_one_of(self.required_one_of, param)
-                        self._check_required_if(self.required_if, param)
+                        self._check_required_together(v.get('required_together', None), param)
+                        self._check_required_one_of(v.get('required_one_of', None), param)
+                        self._check_required_if(v.get('required_if', None), param)
 
                     self._set_defaults(pre=False, spec=spec, param=param)
 

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1951,7 +1951,7 @@ class AnsibleModule(object):
 
                     # check exclusive early
                     if not self.bypass_checks:
-                        self._check_mutually_exclusive(self.mutually_exclusive, param)
+                        self._check_mutually_exclusive(v.get('mutually_exclusive', None), param)
 
                     self._set_defaults(pre=True, spec=spec, param=param)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #27715

This change actually looks at the `required_together`, `required_on_of` and `required_if` fields on the subspec itself when validating the subspec. Where the original code looked at the global values, which caused an issue.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
basic.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (fix_subspec_issue_27715 792bccf1d2) last updated 2017/08/04 00:53:29 (GMT +200)
  config file = None
  configured module search path = [u'/Users/pdellaer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pdellaer/GitHub/pdellaert/ansible/lib/ansible
  executable location = /Users/pdellaer/GitHub/pdellaert/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
Below is an example on how to configure the subspec values for `required_together`, `required_on_of` and `required_if` (based on the `nuage_vspk` module)
```python
    module = AnsibleModule(
        argument_spec=dict(
            auth=dict(
                required=True,
                type='dict',
                options=dict(
                    api_username=dict(required=True, type='str'),
                    api_enterprise=dict(required=True, type='str'),
                    api_url=dict(required=True, type='str'),
                    api_version=dict(required=True, type='str'),
                    api_password=dict(default=None, required=False, type='str', no_log=True),
                    api_certificate=dict(default=None, required=False, type='str', no_log=True),
                    api_key=dict(default=None, required=False, type='str', no_log=True)
                ),
                required_one_of=[
                    ['api_password', 'api_certificate']
                ],
                required_together=[
                    ['api_certificate', 'api_key']
                ]
            ),
            type=dict(required=True, type='str'),
            id=dict(default=None, required=False, type='str'),
            parent_id=dict(default=None, required=False, type='str'),
            parent_type=dict(default=None, required=False, type='str'),
            state=dict(default=None, choices=['present', 'absent'], type='str'),
            command=dict(default=None, choices=SUPPORTED_COMMANDS, type='str'),
            match_filter=dict(default=None, required=False, type='str'),
            properties=dict(default=None, required=False, type='dict'),
            children=dict(default=None, required=False, type='list')
        ),
        mutually_exclusive=[
            ['command', 'state']
        ],
        required_together=[
            ['parent_id', 'parent_type']
        ],
        required_one_of=[
            ['command', 'state']
        ],
        required_if=[
            ['state', 'present', ['id', 'properties', 'match_filter'], True],
            ['state', 'absent', ['id', 'properties', 'match_filter'], True],
            ['command', 'change_password', ['id', 'properties']],
            ['command', 'wait_for_job', ['id']]
        ],
        supports_check_mode=True
    )
```
