### PR TITLE
win_stat: Add stat.isreg support

### DIFF
--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -78,7 +78,13 @@ $checksum_algorithm = Get-AnsibleParam -obj $params -name "checksum_algorithm" -
 
 $result = @{
     changed = $false
-    stat = @{}
+    stat = @{
+        exists = $false
+        isdir = $false
+        islnk = $false
+        isreg = $false
+        isshared = $false
+    }
 }
 
 # Backward compatibility
@@ -89,11 +95,6 @@ if ($get_md5 -eq $true -and (Get-Member -inputobject $params -name "get_md5") ) 
 If (Test-Path -Path $path)
 {
     $result.stat.exists = $true
-
-    # Initial values
-    $result.stat.isdir = $false
-    $result.stat.islnk = $false
-    $result.stat.isshared = $false
 
     # Need to use -Force so it picks up hidden files
     $info = Get-Item -Force $path
@@ -160,8 +161,9 @@ If (Test-Path -Path $path)
     }
     Else
     {
-        $result.stat.size = $info.Length
         $result.stat.extension = $info.Extension
+        $result.stat.isreg = $true
+        $result.stat.size = $info.Length
 
         If ($get_md5) {
             $result.stat.md5 = Get-FileChecksum -path $path -algorithm "md5"
@@ -171,10 +173,6 @@ If (Test-Path -Path $path)
             $result.stat.checksum = Get-FileChecksum -path $path -algorithm $checksum_algorithm
         }
     }
-}
-Else
-{
-    $result.stat.exists = $false
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -80,10 +80,6 @@ $result = @{
     changed = $false
     stat = @{
         exists = $false
-        isdir = $false
-        islnk = $false
-        isreg = $false
-        isshared = $false
     }
 }
 
@@ -95,6 +91,12 @@ if ($get_md5 -eq $true -and (Get-Member -inputobject $params -name "get_md5") ) 
 If (Test-Path -Path $path)
 {
     $result.stat.exists = $true
+
+    # Initial values
+    $result.stat.isdir = $false
+    $result.stat.islnk = $false
+    $result.stat.isreg = $false
+    $result.stat.isshared = $false
 
     # Need to use -Force so it picks up hidden files
     $info = Get-Item -Force $path

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -155,7 +155,7 @@ stat:
             sample: True
         isdir:
             description: if the path is a directory or not
-            returned: always
+            returned: success, path exists
             type: boolean
             sample: True
         ishidden:
@@ -165,7 +165,7 @@ stat:
             sample: True
         islnk:
             description: if the path is a symbolic link or junction or not
-            returned: always
+            returned: success, path exists
             type: boolean
             sample: True
         isreadonly:
@@ -175,12 +175,12 @@ stat:
             sample: True
         isreg:
             description: if the path is a regular file
-            returned: always
+            returned: success, path exists
             type: boolean
             sample: True
         isshared:
             description: if the path is shared or not
-            returned: always
+            returned: success, path exists
             type: boolean
             sample: True
         lastaccesstime:

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -155,7 +155,7 @@ stat:
             sample: True
         isdir:
             description: if the path is a directory or not
-            returned: success, path exists
+            returned: always
             type: boolean
             sample: True
         ishidden:
@@ -165,7 +165,7 @@ stat:
             sample: True
         islnk:
             description: if the path is a symbolic link or junction or not
-            returned: success, path exists
+            returned: always
             type: boolean
             sample: True
         isreadonly:
@@ -173,9 +173,14 @@ stat:
             returned: success, path exists
             type: boolean
             sample: True
+        isreg:
+            description: if the path is a regular file
+            returned: always
+            type: boolean
+            sample: True
         isshared:
             description: if the path is shared or not
-            returned: success, path exists
+            returned: always
             type: boolean
             sample: True
         lastaccesstime:


### PR DESCRIPTION
##### SUMMARY
This PR includes the following changes:
- Adds stat.isreg support (cfr. the stat module)
- ~Always returns stat.isdir, stat.islnk, stat.isreg, stat.isshared~

This relates to #27723

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_stat

##### ANSIBLE VERSION
v2.4