### PR TITLE
win_stat: Add missing return info for older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Ansible Changes By Release
 * Fix check mode in archive module
 * Fix UnboundLocalError in check mode in cs_role module
 * Fix to always use lowercase hostnames for host keys in known_hosts module
+* Added missing return results for win_stat
 
 <a id="2.3.2"></a>
 

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -112,7 +112,7 @@ changed:
 stat:
     description: dictionary containing all the stat data
     returned: success
-    type: dictionary
+    type: complex
     contains:
         attributes:
             description: attributes of the file at path in raw form
@@ -130,11 +130,21 @@ stat:
             returned: success, path exists
             type: float
             sample: 1477984205.15
+        exists:
+            description: if the path exists or not
+            returned: success
+            type: boolean
+            sample: True
         extension:
             description: the extension of the file at path
             returned: success, path exists, path is a file
             type: string
             sample: ".ps1"
+        filename:
+            description: the name of the file (without path)
+            returned: success, path exists, path is a file
+            type: string
+            sammple: foo.ini
         isarchive:
             description: if the path is ready for archiving or not
             returned: success, path exists
@@ -192,9 +202,9 @@ stat:
             sample: BUILTIN\Administrators
         path:
             description: the full absolute path to the file
-            returned: success, path exists
+            returned: success, path exists, file exists
             type: string
-            sample: BUILTIN\Administrators
+            sample: C:\foo.ini
         sharename:
             description: the name of share if folder is shared
             returned: success, path exists, file is a directory and isshared == True


### PR DESCRIPTION
##### SUMMARY
win_stat return info was missing return values, this was added to devel but wasn't done to stable-2.3 at the same time. See https://github.com/ansible/ansible/issues/27723

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_stat

##### ANSIBLE VERSION
```
2.3
```