### PR TITLE
get_url, uri: urls docs fragments

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -971,16 +971,14 @@ def url_argument_spec():
     that will be requesting content via urllib/urllib2
     '''
     return dict(
-        url=dict(),
-        force=dict(default='no', aliases=['thirsty'], type='bool'),
-        http_agent=dict(default='ansible-httpget'),
-        use_proxy=dict(default='yes', type='bool'),
-        validate_certs=dict(default='yes', type='bool'),
-        url_username=dict(required=False),
-        url_password=dict(required=False, no_log=True),
-        force_basic_auth=dict(required=False, type='bool', default='no'),
-        client_cert=dict(required=False, type='path', default=None),
-        client_key=dict(required=False, type='path', default=None),
+        http_agent=dict(type='str', default='ansible-httpget'),
+        use_proxy=dict(type='bool', default=True),
+        validate_certs=dict(type='bool', default=True),
+        url_username=dict(type='str'),
+        url_password=dict(type='str', no_log=True),
+        force_basic_auth=dict(type='bool', default=False),
+        client_cert=dict(type='path'),
+        client_key=dict(type='path'),
     )
 
 

--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -20,14 +20,6 @@ short_description: Downloads files from HTTP, HTTPS, or FTP to node
 description:
      - Downloads files from HTTP, HTTPS, or FTP to the remote server. The remote
        server I(must) have direct access to the remote resource.
-     - By default, if an environment variable C(<protocol>_proxy) is set on
-       the target host, requests will be sent through that proxy. This
-       behaviour can be overridden by setting a variable for this task
-       (see `setting the environment
-       <http://docs.ansible.com/playbooks_environment.html>`_),
-       or by using the use_proxy option.
-     - HTTP redirects can redirect from HTTP to HTTPS so you should be sure that
-       your proxy environment for both protocols is correct.
      - From Ansible 2.4 when run with C(--check), it will do a HEAD request to validate the URL but
        will not download the entire file or verify it against hashes.
      - For Windows targets, use the M(win_get_url) module instead.
@@ -55,14 +47,15 @@ options:
   force:
     description:
       - If C(yes) and C(dest) is not a directory, will download the file every
-        time and replace the file if the contents change. If C(no), the file
-        will only be downloaded if the destination does not exist. Generally
-        should be C(yes) only for small local files.
+        time and replace the file if the contents change.
+      - If C(no), the file will only be downloaded if the destination does not
+        exist.
+      - Generally should be C(yes) only for small local files.
       - Prior to 0.6, this module behaved as if C(yes) was the default.
-    version_added: '0.7'
-    default: 'no'
     type: bool
+    default: 'no'
     aliases: [ thirsty ]
+    version_added: '0.7'
   backup:
     description:
       - Create a backup file including the timestamp information so you can get
@@ -94,18 +87,6 @@ options:
         (unless C(force) is true).
     default: ''
     version_added: "2.0"
-  use_proxy:
-    description:
-      - if C(no), it will not use a proxy, even if one is defined in
-        an environment variable on the target hosts.
-    default: 'yes'
-    type: bool
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites using self-signed certificates.
-    default: 'yes'
-    type: bool
   timeout:
     description:
       - Timeout in seconds for URL request.
@@ -115,45 +96,15 @@ options:
     description:
         - Add custom HTTP headers to a request in the format "key:value,key:value".
     version_added: '2.0'
-  url_username:
-    description:
-      - The username for use in HTTP basic authentication.
-      - This parameter can be used without C(url_password) for sites that allow empty passwords.
-    version_added: '1.6'
-  url_password:
-    description:
-        - The password for use in HTTP basic authentication.
-        - If the C(url_username) parameter is not specified, the C(url_password) parameter will not be used.
-    version_added: '1.6'
-  force_basic_auth:
-    version_added: '2.0'
-    description:
-      - httplib2, the library used by the uri module only sends authentication information when a webservice
-        responds to an initial request with a 401 status. Since some basic auth services do not properly
-        send a 401, logins will fail. This option forces the sending of the Basic authentication header
-        upon initial request.
-    default: 'no'
-    type: bool
-  client_cert:
-    description:
-      - PEM formatted certificate chain file to be used for SSL client
-        authentication. This file can also include the key as well, and if
-        the key is included, C(client_key) is not required.
-    version_added: '2.4'
-  client_key:
-    description:
-      - PEM formatted file that contains your private key to be used for SSL
-        client authentication. If C(client_cert) contains both the certificate
-        and key, this option is not required.
-    version_added: '2.4'
   others:
     description:
       - all arguments accepted by the M(file) module also work here
 # informational: requirements for nodes
 extends_documentation_fragment:
-    - files
+- files
+- urls
 notes:
-     - For Windows targets, use the M(win_get_url) module instead.
+- For Windows targets, use the M(win_get_url) module instead.
 author:
 - Jan-Piet Mens (@jpmens)
 '''
@@ -383,6 +334,7 @@ def main():
     argument_spec.update(
         url=dict(type='str', required=True),
         dest=dict(type='path', required=True),
+        force=dict(type='bool', default=False, aliases=['thirsty']),
         backup=dict(type='bool'),
         sha256sum=dict(type='str', default=''),
         checksum=dict(type='str', default=''),

--- a/lib/ansible/utils/module_docs_fragments/urls.py
+++ b/lib/ansible/utils/module_docs_fragments/urls.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*
+
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+    # Standard files documentation fragment
+    DOCUMENTATION = r'''
+options:
+  http_agent:
+    description:
+    - Set http user agent.
+    default: ansible-httpget
+  use_proxy:
+    description:
+    - if C(no), it will not use a proxy, even if one is defined in
+      an environment variable on the target hosts.
+    type: bool
+    default: 'yes'
+  validate_certs:
+    description:
+    - If C(no), SSL certificates will not be validated. This should only be used
+      on personally controlled sites using self-signed certificates.
+    - Prior to 1.9.2 the code defaulted to C(no).
+    type: bool
+    default: 'yes'
+    version_added: '1.9.2'
+  url_username:
+    description:
+    - The username for use in HTTP basic authentication.
+    - This parameter can be used without C(url_password) for sites that allow empty passwords.
+    version_added: '1.6'
+  url_password:
+    description:
+    - The password for use in HTTP basic authentication.
+    - If the C(url_username) parameter is not specified, the C(url_password) parameter will not be used.
+    version_added: '1.6'
+  force_basic_auth:
+    description:
+      - The library used by this module only sends authentication information when a webservice
+        responds to an initial request with a 401 status. Since some basic auth services do not properly
+        send a 401, logins will fail. This option forces the sending of the Basic authentication header
+        upon initial request.
+    type: bool
+    default: "no"
+    version_added: '2.0'
+  client_cert:
+    description:
+    - PEM formatted certificate chain file to be used for SSL client
+      authentication. This file can also include the key as well, and if
+      the key is included, C(client_key) is not required.
+    version_added: '2.4'
+  client_key:
+    description:
+    - PEM formatted file that contains your private key to be used for SSL
+      client authentication. If C(client_cert) contains both the certificate
+      and key, this option is not required.
+    version_added: '2.4'
+notes:
+- By default, if an environment variable C(<protocol>_proxy) is set on
+  the target host, requests will be sent through that proxy. This
+  behaviour can be overridden by setting a variable for this task
+  (see `setting the environment
+  <http://docs.ansible.com/playbooks_environment.html>`_),
+  or by using the C(use_proxy) option.
+- HTTP redirects can redirect from HTTP to HTTPS so you should be sure that
+  your proxy environment for both protocols is correct.
+'''


### PR DESCRIPTION
##### SUMMARY
This PR includes:
- Module docs fragments for the urls module_utils library
- Modifications to get_url and uri to reuse these docs fragments

I opted to remove `url` and `force` from the docs fragments and
`url_argument_spec` simply because they are not used by fetch_url or
open_url, or because they depend on a `dest` parameter that is uncommon
for other modules.

Some of the following modules could document some of these options as well:

- lib/ansible/modules/cloud/amazon/ec2_metadata_facts.py
- lib/ansible/modules/network/a10/a10_server.py
- lib/ansible/modules/network/a10/a10_server_axapi3.py
- lib/ansible/modules/network/a10/a10_service_group.py
- lib/ansible/modules/network/a10/a10_virtual_server.py
- lib/ansible/modules/notification/nexmo.py
- lib/ansible/modules/packaging/os/pulp_repo.py
- lib/ansible/modules/web_infrastructure/jenkins_plugin.py

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
get_url
uri

##### ANSIBLE VERSION
v2.4