### PR TITLE
Fix bug that diff.always = yes in ansible.cfg won't be respected

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -488,7 +488,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                               help="don't make any changes; instead, try to predict some of the changes that may occur")
             parser.add_option('--syntax-check', dest='syntax', action='store_true',
                               help="perform a syntax check on the playbook, but do not execute it")
-            parser.add_option("-D", "--diff", default=False, dest='diff', action='store_true',
+            parser.add_option("-D", "--diff", default=C.DIFF_ALWAYS, dest='diff', action='store_true',
                               help="when changing (small) files and templates, show the differences in those files; works great with --check")
 
         if meta_opts:


### PR DESCRIPTION
##### SUMMARY

Currently the change diff won't be printed without `--diff` option, even when following section is added to `ansible.cfg`.

```ini
[diff]
always=1
```

This change fixes this issue.

Related: #18501


##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`cli/__init__.py`

##### ANSIBLE VERSION

```
ansible 2.4.0 (fixdiffalways 910c2bf670) last updated 2017/08/04 17:16:25 (GMT +900)
  config file = /Users/10sr/my/j/ansible/ansible.cfg
  configured module search path = [u'/Users/10sr/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/10sr/my/ansible/lib/ansible
  executable location = /Users/10sr/my/ansible/bin/ansible
  python version = 2.7.13 (default, Mar 17 2017, 18:06:24) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
