### PR TITLE
Change the transmit delay on junos_lldp test

### DIFF
--- a/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
@@ -30,7 +30,7 @@
   junos_lldp:
     interval: 10
     hold_multiplier: 5
-    transmit_delay: 30
+    transmit_delay: 2
     state: present
     provider: "{{ netconf }}"
   register: result


### PR DESCRIPTION
We are getting this error message:
"Advertisement-interval should be greater than or equal to four times the tx-delay".
Changing transmit delay to 2 meets that constraint.