### PR TITLE
Set startup type to automatic before attempting to start WinRM

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -171,12 +171,12 @@ If (!(Get-Service "WinRM"))
 }
 ElseIf ((Get-Service "WinRM").Status -ne "Running")
 {
-    Write-Verbose "Starting WinRM service."
-    Start-Service -Name "WinRM" -ErrorAction Stop
-    Write-Log "Started WinRM service."
     Write-Verbose "Setting WinRM service to start automatically on boot."
     Set-Service -Name "WinRM" -StartupType Automatic
     Write-Log "Set WinRM service to start automatically on boot."
+    Write-Verbose "Starting WinRM service."
+    Start-Service -Name "WinRM" -ErrorAction Stop
+    Write-Log "Started WinRM service."
 
 }
 


### PR DESCRIPTION
##### SUMMARY
If the WinRM service is disabled the script will fail. By relocating the setting of the startup type to automatic before starting the service, it is no longer disabled and will start.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Examples / Scripts / ConfigureRemotingForAnsible.ps1

##### ADDITIONAL INFORMATION
To reproduce:

Stop and disable WinRM service.
Run ConfigureRemotingForAnsible.ps1

Script will fail as service is unable to start.
