### PR TITLE
Remove assert that junos command xml contains inventory_hostname_short

### DIFF
--- a/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
@@ -8,7 +8,6 @@
       - show interfaces lo0
     format: xml
     wait_for:
-      - "result[0].rpc-reply.software-information.host-name contains {{ inventory_hostname_short }}"
       - "result[1].rpc-reply.interface-information.physical-interface.name contains lo0"
     provider: "{{ netconf }}"
   register: result


### PR DESCRIPTION
The test assumes the node has the hostname set as the inventory_hostname_short.
That's not the case in our CI, we the inventory_hostname is a UUID, returned
by the openstack dynamic inventory.