### PR TITLE
Allow wait_for_ip_address when starting a vm without creating a new vm and to mark a template as a VM

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -551,6 +551,8 @@ class PyVmomiHelper(object):
 
                 elif expected_state == 'poweredon':
                     task = vm.PowerOn()
+                    if self.params['wait_for_ip_address']:
+                        self.wait_for_vm_ip(vm)
 
                 elif expected_state == 'restarted':
                     if current_state in ('poweredon', 'poweringon', 'resetting', 'poweredoff'):
@@ -1355,8 +1357,12 @@ class PyVmomiHelper(object):
         change_applied = False
 
         relospec = vim.vm.RelocateSpec()
-        if self.params['resource_pool']:
-            relospec.pool = self.select_resource_pool_by_name(self.params['resource_pool'])
+        if self.params['resource_pool'] or self.params['template']:
+            if self.params['esxi_hostname']:
+                host = self.select_host()
+                relospec.pool = self.select_resource_pool_by_host(host)
+            else:
+                relospec.pool = self.select_resource_pool_by_name(self.params['resource_pool'])
 
             if relospec.pool is None:
                 self.module.fail_json(msg='Unable to find resource pool "%(resource_pool)s"' % self.params)
@@ -1390,6 +1396,12 @@ class PyVmomiHelper(object):
         if self.params['is_template']:
             self.current_vm_obj.MarkAsTemplate()
             change_applied = True
+        elif self.params['name'] == self.params['template']:
+            try:
+                self.current_vm_obj.MarkAsVirtualMachine(relospec.pool, self.select_host())
+                change_applied = True
+            except pyVmomi.vmodl.fault.NotSupported:
+                change_applied = False
 
         vm_facts = self.gather_facts(self.current_vm_obj)
         return {'changed': change_applied, 'failed': False, 'instance': vm_facts}
@@ -1481,6 +1493,9 @@ def main():
                 result["changed"] = True
             if not tmp_result["failed"]:
                 result["failed"] = False
+            # If wait_for_ip_address is yes than return all information
+            if module.params['wait_for_ip_address']:
+                result = tmp_result
         else:
             # This should not happen
             assert False


### PR DESCRIPTION
Allow wait_for_ip_address when starting a vm without creating a new vm.
Add option to mark template as a VM.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The wait_for_ip_address option currently only works when creating a new vm,
this should also work when starting a VM that has been off for a long time.
This is done by adding the wait_for_vm_ip function call to the poweredon state and
returning the full tmp_result instead of failed and changed.

Secondly the option is added to mark a template as a virtual machine.
This is done when name and template are the same and is_template is no.
When a it's already a vm it will return NotSupported and mark it as not changed.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/modules']
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
