### PR TITLE
rabbitmq_user module can change password without 'force: yes'

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -198,7 +198,7 @@ class RabbitMqUser(object):
             self._exec(['add_user', self.username, self.password])
         else:
             self._exec(['add_user', self.username, ''])
-            self._exec(['clear_password', self.username])
+            self.clear_password()
 
     def delete(self):
         self._exec(['delete_user', self.username])
@@ -231,11 +231,18 @@ class RabbitMqUser(object):
 
     def has_password_modification(self):
         _, rc = self._exec(['authenticate_user', self.username, self.password], run_in_check_mode=True, check_rc=False)
-        # 'EX_NOUSER' (The user specified does not exist) from https://github.com/rabbitmq/rabbitmq-server/blob/master/include/rabbit_cli.hrl#L70
-        return rc == 67
+
+        # The old version of rabbitmqctl (before 3.7) returned 'EX_NOUSER' (67) exit code when 'authenticate_user' command could not authenticate user: https://github.com/rabbitmq/rabbitmq-server/blob/fdd9f295d8b33a0774b3fa1f9753ff044fcfee15/src/rabbit_cli.erl#L140
+        # The new one (>= 3.7) returns 'EX_DATAERR' (65) exit code: https://github.com/rabbitmq/rabbitmq-cli/blob/5fe70511a25e8221ad7fc7e7fb40b020dbebc0ac/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex#L41
+        # Old rabbitmqctl exit codes: https://github.com/rabbitmq/rabbitmq-server/blob/fdd9f295d8b33a0774b3fa1f9753ff044fcfee15/include/rabbit_cli.hrl#L70
+        # New rabbbitmqctl exit codes: https://github.com/rabbitmq/rabbitmq-cli/blob/2461c0494c7780622555f33d9e0b82d0e686a497/lib/rabbitmq/cli/core/exit_codes.ex#L19
+        return rc == 67 or rc == 65
 
     def set_password(self):
         self._exec(['change_password', self.username, self.password])
+
+    def clear_password(self):
+        self._exec(['clear_password', self.username])
 
 
 def main():
@@ -304,8 +311,12 @@ def main():
                 rabbitmq_user.set_permissions()
                 result['changed'] = True
 
-            if rabbitmq_user.has_password_modification():
-                rabbitmq_user.set_password()
+            if self.password is not None:
+                if rabbitmq_user.has_password_modification():
+                    rabbitmq_user.set_password()
+                    result['changed'] = True
+            else:
+                rabbitmq_user.clear_password()
                 result['changed'] = True
     elif state == 'present':
         rabbitmq_user.add()

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -230,12 +230,19 @@ class RabbitMqUser(object):
         return sorted(self._permissions) != sorted(self.permissions)
 
     def has_password_modification(self):
-        _, rc = self._exec(['authenticate_user', self.username, self.password], run_in_check_mode=True, check_rc=False)
+        auth_user_out, rc = self._exec(['authenticate_user', self.username, self.password], run_in_check_mode=True, check_rc=False)
 
-        # The old version of rabbitmqctl (before 3.7) returned 'EX_NOUSER' (67) exit code when 'authenticate_user' command could not authenticate user: https://github.com/rabbitmq/rabbitmq-server/blob/fdd9f295d8b33a0774b3fa1f9753ff044fcfee15/src/rabbit_cli.erl#L140
-        # The new one (>= 3.7) returns 'EX_DATAERR' (65) exit code: https://github.com/rabbitmq/rabbitmq-cli/blob/5fe70511a25e8221ad7fc7e7fb40b020dbebc0ac/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex#L41
-        # Old rabbitmqctl exit codes: https://github.com/rabbitmq/rabbitmq-server/blob/fdd9f295d8b33a0774b3fa1f9753ff044fcfee15/include/rabbit_cli.hrl#L70
-        # New rabbbitmqctl exit codes: https://github.com/rabbitmq/rabbitmq-cli/blob/2461c0494c7780622555f33d9e0b82d0e686a497/lib/rabbitmq/cli/core/exit_codes.ex#L19
+        # The old version of rabbitmqctl (before 3.7) returned 'EX_NOUSER' (67) exit code when 'authenticate_user' command could not authenticate user:
+        # https://github.com/rabbitmq/rabbitmq-server/blob/fdd9f295d8b33a0774b3fa1f9753ff044fcfee15/src/rabbit_cli.erl#L140
+        #
+        # The new one (>= 3.7) returns 'EX_DATAERR' (65) exit code:
+        # https://github.com/rabbitmq/rabbitmq-cli/blob/5fe70511a25e8221ad7fc7e7fb40b020dbebc0ac/lib/rabbitmq/cli/ctl/commands/authenticate_user_command.ex#L41
+        #
+        # Old rabbitmqctl exit codes:
+        # https://github.com/rabbitmq/rabbitmq-server/blob/fdd9f295d8b33a0774b3fa1f9753ff044fcfee15/include/rabbit_cli.hrl#L70
+        #
+        # New rabbbitmqctl exit codes:
+        # https://github.com/rabbitmq/rabbitmq-cli/blob/2461c0494c7780622555f33d9e0b82d0e686a497/lib/rabbitmq/cli/core/exit_codes.ex#L19
         return rc == 67 or rc == 65
 
     def set_password(self):
@@ -311,12 +318,8 @@ def main():
                 rabbitmq_user.set_permissions()
                 result['changed'] = True
 
-            if self.password is not None:
-                if rabbitmq_user.has_password_modification():
-                    rabbitmq_user.set_password()
-                    result['changed'] = True
-            else:
-                rabbitmq_user.clear_password()
+            if password is not None and rabbitmq_user.has_password_modification():
+                rabbitmq_user.set_password()
                 result['changed'] = True
     elif state == 'present':
         rabbitmq_user.add()

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -31,8 +31,8 @@ options:
   password:
     description:
       - Password of user to add.
-      - To change the password of an existing user for RabbitMQ < 3.6.5,
-        you must also specify C(force=yes).
+      - To change the password of an existing user, you must also specify C(force=yes).
+      - Since 2.4, C(force=yes) is optional with RabbitMQ 3.6.5 and later.
     required: false
     default: null
   tags:

--- a/lib/ansible/modules/messaging/rabbitmq_user.py
+++ b/lib/ansible/modules/messaging/rabbitmq_user.py
@@ -237,6 +237,7 @@ class RabbitMqUser(object):
     def set_password(self):
         self._exec(['change_password', self.username, self.password])
 
+
 def main():
     arg_spec = dict(
         user=dict(required=True, aliases=['username', 'name']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In this PR I fixed #3237.
Since RabbitMQ 3.6.5 ([release notes](https://rabbitmq.docs.pivotal.io/36/relnotes/release-notes-rabbitmq3.6.5.html)) `rabbitmqctl` contains `authenticate_user` option:
>rabbitmqctl authenticate_user is a new command that can be used to test user authentication.

I used this option to check user password.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
messaging/rabbitmq_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (3237-change-rabbitmq-user-password-without-force 335fa4965c) last updated 2017/08/04 15:09:26 (GMT +300)
  config file = /home/art/.ansible.cfg
  configured module search path = [u'/home/art/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/art/projects/github/ansible/lib/ansible
  executable location = /home/art/projects/github/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
