### PR TITLE
Replace fxp0 for lo0 on junos_command equal and notequal tests

### DIFF
--- a/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
@@ -5,10 +5,9 @@
   junos_command:
     commands:
       - show version
-      - show interfaces fxp0
+      - show interfaces lo0
     wait_for:
-      - "result[0].rpc-reply.software-information.host-name == {{ inventory_hostname_short }}"
-      - "result[1].rpc-reply.interface-information.physical-interface.name == fxp0"
+      - "result[1].rpc-reply.interface-information.physical-interface.name == lo0"
     format: xml
     provider: "{{ netconf }}"
   register: result
@@ -23,10 +22,9 @@
   junos_command:
     commands:
       - show version
-      - show interfaces fxp0
+      - show interfaces lo0
     wait_for:
-      - "result[0].rpc-reply.software-information.host-name eq {{ inventory_hostname_short }}"
-      - "result[1].rpc-reply.interface-information.physical-interface.name eq fxp0"
+      - "result[1].rpc-reply.interface-information.physical-interface.name eq lo0"
     format: xml
     provider: "{{ netconf }}"
   register: result

--- a/test/integration/targets/junos_command/tests/netconf_xml/notequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/notequal.yaml
@@ -5,7 +5,7 @@
   junos_command:
     commands:
       - show version
-      - show interfaces fxp0
+      - show interfaces lo0
     format: xml
     wait_for:
       - "result[0].rpc-reply.software-information.host-name neq localhost"
@@ -22,7 +22,7 @@
   junos_command:
     commands:
       - show version
-      - show interfaces fxp0
+      - show interfaces lo0
     format: xml
     wait_for:
       - "result[0].rpc-reply.software-information.host-name != localhost"


### PR DESCRIPTION
The nodes in the CI do not use fxp nomenclature, but em.
Use lo0, as that's common for nodes in our CI and our test lab.