### PR TITLE
change netconf test port from 8080 to 22

### DIFF
--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -13,7 +13,7 @@
 - name: Change port
   junos_netconf:
     state: present
-    netconf_port: 8080
+    netconf_port: 22
     provider: "{{ cli }}"
   register: result
 
@@ -24,7 +24,7 @@
 - name: idempotent tests
   junos_netconf:
     state: present
-    netconf_port: 8080
+    netconf_port: 22
     provider: "{{ cli }}"
   register: result
 
@@ -32,11 +32,11 @@
     that:
       - "result.changed == false"
 
-- name: Ensure we can communicate over 8080
+- name: Ensure we can communicate over 22
   junos_command:
     rpcs: get-software-information
     provider: "{{ netconf }}"
-    port: 8080
+    port: 22
 
 # This protects against the port override above not being honoured and a bug setting the port
 - name: Ensure we can NOT communicate over default port


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
change netconf test port from 8080 to 22
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
