### PR TITLE
Netscaler: Lowercase enabled, disabled option values

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
@@ -128,18 +128,18 @@ options:
 
     stateupdate:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Enable state updates for a specific content switching virtual server. By default, the Content
                 Switching virtual server is always UP, regardless of the state of the Load Balancing virtual servers
                 bound to it. This parameter interacts with the global setting as follows:
             - "Global Level | Vserver Level | Result"
-            - "ENABLED ENABLED ENABLED"
-            - "ENABLED DISABLED ENABLED"
-            - "DISABLED ENABLED ENABLED"
-            - "DISABLED DISABLED DISABLED"
+            - "enabled enabled enabled"
+            - "enabled disabled enabled"
+            - "disabled enabled enabled"
+            - "disabled disabled disabled"
             - >-
                 If you want to enable state updates for only some content switching virtual servers, be sure to
                 disable the state update parameter.
@@ -202,8 +202,8 @@ options:
 
     sopersistence:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Maintain source-IP based persistence on primary and backup virtual servers."
 
@@ -233,15 +233,15 @@ options:
 
     redirectportrewrite:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "State of port rewrite while performing HTTP redirect."
 
     downstateflush:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Flush all active transactions associated with a virtual server whose state transitions from UP to
@@ -259,8 +259,8 @@ options:
 
     disableprimaryondown:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Continue forwarding the traffic to backup virtual server even after the primary server comes UP from
@@ -326,8 +326,8 @@ options:
 
     push:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Process traffic with the push virtual server that is bound to this content switching virtual server
@@ -423,8 +423,8 @@ options:
 
     appflowlog:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Enable logging appflow flow information."
 
@@ -788,8 +788,8 @@ def main():
         stateupdate=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         cacheable=dict(type='bool'),
@@ -816,8 +816,8 @@ def main():
         sopersistence=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         sopersistencetimeout=dict(type='float'),
@@ -833,22 +833,22 @@ def main():
         redirectportrewrite=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         downstateflush=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         disableprimaryondown=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         insertvserveripport=dict(
@@ -869,8 +869,8 @@ def main():
         push=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         pushvserver=dict(type='str'),
@@ -908,8 +908,8 @@ def main():
         appflowlog=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         netprofile=dict(type='str'),
@@ -1087,6 +1087,13 @@ def main():
         'authentication': ['bool_on_off'],
         'l2conn': ['bool_on_off'],
         'pushmulticlients': ['bool_yes_no'],
+        'stateupdate': [lambda v: v.upper()],
+        'sopersistence': [lambda v: v.upper()],
+        'redirectportrewrite': [lambda v: v.upper()],
+        'downstateflush': [lambda v: v.upper()],
+        'disableprimaryondown': [lambda v: v.upper()],
+        'push': [lambda v: v.upper()],
+        'appflowlog': [lambda v: v.upper()],
     }
 
     # Instantiate config proxy

--- a/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_gslb_vserver.py
@@ -174,15 +174,15 @@ options:
 
     mir:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Include multiple IP addresses in the DNS responses sent to clients."
 
     disableprimaryondown:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Continue to direct traffic to the backup chain even after the primary GSLB virtual server returns to
@@ -246,8 +246,8 @@ options:
 
     sopersistence:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 If spillover occurs, maintain source IP address based persistence for both primary and backup GSLB
@@ -281,8 +281,8 @@ options:
 
     appflowlog:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Enable logging appflow flow information."
 
@@ -323,8 +323,8 @@ options:
 
     disabled:
         description:
-            - When set to C(yes) the GSLB Vserver state will be set to DISABLED.
-            - When set to C(no) the GSLB Vserver state will be set to ENABLED.
+            - When set to C(yes) the GSLB Vserver state will be set to C(disabled).
+            - When set to C(no) the GSLB Vserver state will be set to C(enabled).
             - >-
                 Note that due to limitations of the underlying NITRO API a C(disabled) state change alone
                 does not cause the module result to report a changed status.
@@ -680,15 +680,15 @@ def main():
         mir=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         disableprimaryondown=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         dynamicweight=dict(
@@ -720,8 +720,8 @@ def main():
         sopersistence=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         sopersistencetimeout=dict(type='float'),
@@ -737,8 +737,8 @@ def main():
         appflowlog=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         domainname=dict(type='str'),
@@ -844,6 +844,13 @@ def main():
         'servicetype',
     ]
 
+    transforms = {
+        'mir': [lambda v: v.upper()],
+        'disableprimaryondown': [lambda v: v.upper()],
+        'sopersistence': [lambda v: v.upper()],
+        'appflowlog': [lambda v: v.upper()],
+    }
+
     # Instantiate config proxy
     gslb_vserver_proxy = ConfigProxy(
         actual=gslbvserver(),
@@ -852,6 +859,7 @@ def main():
         readwrite_attrs=readwrite_attrs,
         readonly_attrs=readonly_attrs,
         immutable_attrs=immutable_attrs,
+        transforms=transforms,
     )
 
     try:

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_monitor.py
@@ -284,8 +284,8 @@ options:
 
     lrtm:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Calculate the least response times for bound services. If this parameter is not enabled, the
@@ -419,12 +419,12 @@ options:
 
     state:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
-                State of the monitor. The C(DISABLED) setting disables not only the monitor being configured, but all
-                monitors of the same type, until the parameter is set to C(ENABLED). If the monitor is bound to a
+                State of the monitor. The C(disabled) setting disables not only the monitor being configured, but all
+                monitors of the same type, until the parameter is set to C(enabled). If the monitor is bound to a
                 service, the state of the monitor is not taken into account when the state of the service is
                 determined.
 
@@ -757,8 +757,8 @@ options:
 
     storedb:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Store the database list populated with the responses to monitor probes. Used in database specific
@@ -997,8 +997,8 @@ def main():
         lrtm=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         deviation=dict(type='float'),
@@ -1114,8 +1114,8 @@ def main():
         storedb=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         storefrontcheckbackendservices=dict(type='bool'),
@@ -1292,6 +1292,8 @@ def main():
         'iptunnel': ['bool_yes_no'],
         'transparent': ['bool_yes_no'],
         'reverse': ['bool_yes_no'],
+        'lrtm': [lambda v: v.upper()],
+        'storedb': [lambda v: v.upper()],
     }
 
     lbmonitor_proxy = ConfigProxy(

--- a/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py
@@ -382,8 +382,8 @@ options:
 
     sessionless:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Perform load balancing on a per-packet basis, without establishing sessions. Recommended for load
@@ -458,8 +458,8 @@ options:
 
     sopersistence:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 If spillover occurs, maintain source IP address based persistence for both primary and backup virtual
@@ -500,15 +500,15 @@ options:
 
     redirectportrewrite:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Rewrite the port and change the protocol to ensure successful HTTP redirects from services."
 
     downstateflush:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Flush all active transactions associated with a virtual server whose state transitions from UP to
@@ -516,8 +516,8 @@ options:
 
     disableprimaryondown:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 If the primary virtual server goes down, do not allow it to return to primary status until manually
@@ -554,7 +554,7 @@ options:
         description:
             - >-
                 Fully qualified domain name (FQDN) of the authentication virtual server to which the user must be
-                redirected for authentication. Make sure that the Authentication parameter is set to ENABLED.
+                redirected for authentication. Make sure that the Authentication parameter is set to C(yes).
             - "Minimum length = 3"
             - "Maximum length = 252"
 
@@ -576,8 +576,8 @@ options:
 
     push:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Process traffic with the push virtual server that is bound to this load balancing virtual server."
 
@@ -675,8 +675,8 @@ options:
 
     appflowlog:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Apply AppFlow logging to the virtual server."
 
@@ -802,22 +802,22 @@ options:
 
     macmoderetainvlan:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "This option is used to retain vlan information of incoming packet when macmode is enabled."
 
     dbslb:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Enable database specific load balancing for MySQL and MSSQL service types."
 
     dns64:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "This argument is for enabling/disabling the C(dns64) on lbvserver."
 
@@ -838,8 +838,8 @@ options:
 
     processlocal:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 By turning on this option packets destined to a vserver in a cluster will not under go any steering.
@@ -1421,8 +1421,8 @@ def main():
         sessionless=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         connfailover=dict(
@@ -1449,8 +1449,8 @@ def main():
         sopersistence=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         sopersistencetimeout=dict(type='float'),
@@ -1467,22 +1467,22 @@ def main():
         redirectportrewrite=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         downstateflush=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         disableprimaryondown=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         insertvserveripport=dict(
@@ -1501,8 +1501,8 @@ def main():
         push=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         pushvserver=dict(type='str'),
@@ -1540,8 +1540,8 @@ def main():
         appflowlog=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         netprofile=dict(type='str'),
@@ -1582,22 +1582,22 @@ def main():
         macmoderetainvlan=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         dbslb=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         dns64=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         bypassaaaa=dict(type='bool'),
@@ -1605,8 +1605,8 @@ def main():
         processlocal=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         dnsprofilename=dict(type='str'),
@@ -1805,6 +1805,17 @@ def main():
         'l2conn': ['bool_on_off'],
         'pushmulticlients': ['bool_yes_no'],
         'recursionavailable': ['bool_yes_no'],
+        'sessionless': [lambda v: v.upper()],
+        'sopersistence': [lambda v: v.upper()],
+        'redirectportrewrite': [lambda v: v.upper()],
+        'downstateflush': [lambda v: v.upper()],
+        'disableprimaryondown': [lambda v: v.upper()],
+        'push': [lambda v: v.upper()],
+        'appflowlog': [lambda v: v.upper()],
+        'macmoderetainvlan': [lambda v: v.upper()],
+        'dbslb': [lambda v: v.upper()],
+        'dns64': [lambda v: v.upper()],
+        'processlocal': [lambda v: v.upper()],
     }
 
     lbvserver_proxy = ConfigProxy(

--- a/lib/ansible/modules/network/netscaler/netscaler_server.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_server.py
@@ -89,8 +89,8 @@ options:
 
     disabled:
         description:
-            - When set to C(true) the server state will be set to DISABLED.
-            - When set to C(false) the server state will be set to ENABLED.
+            - When set to C(true) the server state will be set to C(disabled).
+            - When set to C(false) the server state will be set to C(enabled).
             - >-
                 Note that due to limitations of the underlying NITRO API a C(disabled) state change alone
                 does not cause the module result to report a changed status.

--- a/lib/ansible/modules/network/netscaler/netscaler_service.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_service.py
@@ -136,8 +136,8 @@ options:
 
     cip:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Before forwarding a request to the service, insert an HTTP header with the client's IPv4 or IPv6
@@ -252,13 +252,12 @@ options:
 
     downstateflush:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Flush all active transactions associated with a service whose state transitions from UP to DOWN. Do
                 not enable this option for applications that must complete their transactions.
-        default: ENABLED
 
     tcpprofilename:
         description:
@@ -285,11 +284,10 @@ options:
 
     appflowlog:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Enable logging of AppFlow information."
-        default: ENABLED
 
     netprofile:
         description:
@@ -308,14 +306,13 @@ options:
 
     processlocal:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 By turning on this option packets destined to a service in a cluster will not under go any steering.
                 Turn this option for single packet request response mode or when the upstream device is performing a
                 proper RSS for connection based distribution.
-        default: DISABLED
 
     dnsprofilename:
         description:
@@ -350,8 +347,8 @@ options:
                     - Weight to assign to the binding between the monitor and service.
             dup_state:
                 choices:
-                    - 'ENABLED'
-                    - 'DISABLED'
+                    - 'enabled'
+                    - 'disabled'
                 description:
                     - State of the monitor.
                     - The state setting for a monitor of a given type affects all monitors of that type.
@@ -614,8 +611,8 @@ def main():
         cip=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         cipheader=dict(type='str'),
@@ -648,10 +645,9 @@ def main():
         downstateflush=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ],
-            default='ENABLED',
         ),
         tcpprofilename=dict(type='str'),
         httpprofilename=dict(type='str'),
@@ -660,19 +656,17 @@ def main():
         appflowlog=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ],
-            default='ENABLED',
         ),
         netprofile=dict(type='str'),
         processlocal=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ],
-            default='DISABLED',
         ),
         dnsprofilename=dict(type='str'),
         ipaddress=dict(type='str'),
@@ -831,6 +825,10 @@ def main():
         'sc': ['bool_on_off'],
         'accessdown': ['bool_yes_no'],
         'cmp': ['bool_yes_no'],
+        'cip': [lambda v: v.upper()],
+        'downstateflush': [lambda v: v.upper()],
+        'appflowlog': [lambda v: v.upper()],
+        'processlocal': [lambda v: v.upper()],
     }
 
     monitor_bindings_rw_attrs = [

--- a/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
@@ -105,8 +105,8 @@ options:
 
     cip:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Insert the Client IP header in requests forwarded to the service."
 
@@ -209,8 +209,8 @@ options:
 
     downstateflush:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - >-
                 Flush all active transactions associated with all the services in the service group whose state
@@ -235,8 +235,8 @@ options:
 
     appflowlog:
         choices:
-            - 'ENABLED'
-            - 'DISABLED'
+            - 'enabled'
+            - 'disabled'
         description:
             - "Enable logging of AppFlow information for the specified service group."
 
@@ -683,8 +683,8 @@ def main():
         cip=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         cipheader=dict(type='str'),
@@ -706,8 +706,8 @@ def main():
         downstateflush=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         tcpprofilename=dict(type='str'),
@@ -716,8 +716,8 @@ def main():
         appflowlog=dict(
             type='str',
             choices=[
-                'ENABLED',
-                'DISABLED',
+                'enabled',
+                'disabled',
             ]
         ),
         netprofile=dict(type='str'),
@@ -865,6 +865,9 @@ def main():
         'sc': ['bool_on_off'],
         'graceful': ['bool_yes_no'],
         'cmp': ['bool_yes_no'],
+        'cip': [lambda v: v.upper()],
+        'downstateflush': [lambda v: v.upper()],
+        'appflowlog': [lambda v: v.upper()],
     }
 
     # Instantiate config proxy

--- a/test/integration/netscaler.yaml
+++ b/test/integration/netscaler.yaml
@@ -10,5 +10,16 @@
     debug: false
 
   roles:
-    - { role: netscaler_service, when: "limit_to in ['*', 'netscaler_service']" }
+    - { role: netscaler_cs_action, when: "limit_to in ['*', 'netscaler_cs_action']" }
+    - { role: netscaler_cs_policy, when: "limit_to in ['*', 'netscaler_cs_policy']" }
+    - { role: netscaler_cs_vserver, when: "limit_to in ['*', 'netscaler_cs_vserver']" }
     - { role: netscaler_server, when: "limit_to in ['*', 'netscaler_server']" }
+    - { role: netscaler_lb_vserver, when: "limit_to in ['*', 'netscaler_lb_vserver']" }
+    - { role: netscaler_lb_monitor, when: "limit_to in ['*', 'netscaler_lb_monitor']" }
+    - { role: netscaler_save_config, when: "limit_to in ['*', 'netscaler_save_config']" }
+    - { role: netscaler_service, when: "limit_to in ['*', 'netscaler_service']" }
+    - { role: netscaler_servicegroup, when: "limit_to in ['*', 'netscaler_servicegroup']" }
+    - { role: netscaler_gslb_service, when: "limit_to in ['*', 'netscaler_gslb_service']" }
+    - { role: netscaler_gslb_site, when: "limit_to in ['*', 'netscaler_gslb_site']" }
+    - { role: netscaler_gslb_vserver, when: "limit_to in ['*', 'netscaler_gslb_vserver']" }
+    - { role: netscaler_ssl_certkey, when: "limit_to in ['*', 'netscaler_ssl_certkey']" }

--- a/test/integration/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_http/setup.yaml
+++ b/test/integration/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_http/setup.yaml
@@ -18,20 +18,20 @@
     port: 80
     dnsrecordtype: A
     range: 2
-    stateupdate: DISABLED
+    stateupdate: disabled
     cacheable: no
     redirecturl: http://newurl.com
     clttimeout: 200
     precedence: RULE
     casesensitive: on
     somethod: CONNECTION
-    sopersistence: ENABLED
+    sopersistence: enabled
     sopersistencetimeout: 50
     sothreshold: 200
     sobackupaction: DROP
-    redirectportrewrite: DISABLED
-    downstateflush: DISABLED
-    disableprimaryondown: DISABLED
+    redirectportrewrite: disabled
+    downstateflush: disabled
+    disableprimaryondown: disabled
     insertvserveripport: VIPADDR
     vipheader: someheader
     rtspnat: off
@@ -40,12 +40,12 @@
     listenpolicy: "NONE"
     authn401: off
     authnvsname: someserver
-    push: DISABLED
+    push: disabled
     pushvserver: push_lb_vserver
     pushlabel: none
     pushmulticlients: no
     comment: some comment
     l2conn: off
-    appflowlog: ENABLED
+    appflowlog: enabled
     icmpvsrresponse: PASSIVE
     rhistate: PASSIVE

--- a/test/integration/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_http/update.yaml
+++ b/test/integration/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_http/update.yaml
@@ -18,20 +18,20 @@
     port: 80
     dnsrecordtype: A
     range: 2
-    stateupdate: DISABLED
+    stateupdate: disabled
     cacheable: no
     redirecturl: http://url.com
     clttimeout: 200
     precedence: RULE
     casesensitive: on
     somethod: CONNECTION
-    sopersistence: ENABLED
+    sopersistence: enabled
     sopersistencetimeout: 50
     sothreshold: 200
     sobackupaction: DROP
-    redirectportrewrite: DISABLED
-    downstateflush: DISABLED
-    disableprimaryondown: DISABLED
+    redirectportrewrite: disabled
+    downstateflush: disabled
+    disableprimaryondown: disabled
     insertvserveripport: VIPADDR
     vipheader: someheader
     rtspnat: off
@@ -40,12 +40,12 @@
     listenpolicy: "NONE"
     authn401: off
     authnvsname: someserver
-    push: DISABLED
+    push: disabled
     pushvserver: push_lb_vserver
     pushlabel: none
     pushmulticlients: no
     comment: some comment
     l2conn: off
-    appflowlog: ENABLED
+    appflowlog: enabled
     icmpvsrresponse: PASSIVE
     rhistate: PASSIVE

--- a/test/integration/roles/netscaler_gslb_vserver/tasks/testbed.yaml
+++ b/test/integration/roles/netscaler_gslb_vserver/tasks/testbed.yaml
@@ -12,9 +12,9 @@
     siteipaddress: 192.168.1.1
     sitetype: LOCAL
     publicip: 192.168.1.1
-    metricexchange: ENABLED
-    nwmetricexchange: ENABLED
-    sessionexchange: ENABLED
+    metricexchange: enabled
+    nwmetricexchange: enabled
+    sessionexchange: enabled
     triggermonitor: ALWAYS
 
 

--- a/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/setup.yaml
+++ b/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/setup.yaml
@@ -22,17 +22,17 @@
     persistmask: 255.255.255.0
     v6persistmasklen: 128
     timeout: 1000
-    mir: DISABLED
-    disableprimaryondown: DISABLED
+    mir: disabled
+    disableprimaryondown: disabled
     dynamicweight: DISABLED
     considereffectivestate: NONE
     comment: some comment
     somethod: CONNECTION
-    sopersistence: DISABLED
+    sopersistence: disabled
     sopersistencetimeout: 100
     sothreshold: 5000
     sobackupaction: DROP
-    appflowlog: DISABLED
+    appflowlog: disabled
 
     domain_bindings:
       - domainname: example.com

--- a/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/update.yaml
+++ b/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/update.yaml
@@ -22,17 +22,17 @@
     persistmask: 255.255.255.0
     v6persistmasklen: 128
     timeout: 500
-    mir: DISABLED
-    disableprimaryondown: DISABLED
+    mir: disabled
+    disableprimaryondown: disabled
     dynamicweight: DISABLED
     considereffectivestate: NONE
     comment: some comment
     somethod: CONNECTION
-    sopersistence: DISABLED
+    sopersistence: disabled
     sopersistencetimeout: 100
     sothreshold: 5000
     sobackupaction: DROP
-    appflowlog: DISABLED
+    appflowlog: disabled
 
     domain_bindings:
       - domainname: example.com

--- a/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/update_domainbinding.yaml
+++ b/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/update_domainbinding.yaml
@@ -22,17 +22,17 @@
     persistmask: 255.255.255.0
     v6persistmasklen: 128
     timeout: 500
-    mir: DISABLED
-    disableprimaryondown: DISABLED
+    mir: disabled
+    disableprimaryondown: disabled
     dynamicweight: DISABLED
     considereffectivestate: NONE
     comment: some comment
     somethod: CONNECTION
-    sopersistence: DISABLED
+    sopersistence: disabled
     sopersistencetimeout: 100
     sothreshold: 5000
     sobackupaction: DROP
-    appflowlog: DISABLED
+    appflowlog: disabled
 
     domain_bindings:
       - domainname: anotherexample.com

--- a/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/update_gslbservice_binding.yaml
+++ b/test/integration/roles/netscaler_gslb_vserver/tests/nitro/http/update_gslbservice_binding.yaml
@@ -22,17 +22,17 @@
     persistmask: 255.255.255.0
     v6persistmasklen: 128
     timeout: 500
-    mir: DISABLED
-    disableprimaryondown: DISABLED
+    mir: disabled
+    disableprimaryondown: disabled
     dynamicweight: DISABLED
     considereffectivestate: NONE
     comment: some comment
     somethod: CONNECTION
-    sopersistence: DISABLED
+    sopersistence: disabled
     sopersistencetimeout: 100
     sothreshold: 5000
     sobackupaction: DROP
-    appflowlog: DISABLED
+    appflowlog: disabled
 
     domain_bindings:
       - domainname: example.com

--- a/test/integration/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_sip/setup.yaml
+++ b/test/integration/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_sip/setup.yaml
@@ -19,4 +19,4 @@
     sipuri: sip:sip.test
     sipreguri: sip:sip.register
 
-    lrtm: DISABLED
+    lrtm: disabled

--- a/test/integration/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_http/setup.yaml
+++ b/test/integration/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_http/setup.yaml
@@ -27,30 +27,30 @@
     v6persistmasklen: 64
     m: IP
     tosid: 6
-    sessionless: DISABLED
+    sessionless: disabled
     redirurl: http://somewhere.com
     cacheable: no
     clttimeout: 111
     somethod: CONNECTION
-    sopersistence: DISABLED
+    sopersistence: disabled
     sopersistencetimeout: 222
     sothreshold: 4096
     healththreshold: 55
     sobackupaction: DROP
-    redirectportrewrite: DISABLED
-    downstateflush: DISABLED
-    disableprimaryondown: DISABLED
+    redirectportrewrite: disabled
+    downstateflush: disabled
+    disableprimaryondown: disabled
     insertvserveripport: VIPADDR
     vipheader: vip
     authenticationhost: authenticate.me
     authentication: off
     authn401: off
     authnvsname: somename
-    push: DISABLED
+    push: disabled
     pushmulticlients: no
     comment: Vserver comment
     l2conn: "OFF"
-    appflowlog: DISABLED
+    appflowlog: disabled
     icmpvsrresponse: PASSIVE
     rhistate: PASSIVE
     newservicerequest: 11
@@ -58,10 +58,10 @@
     newservicerequestincrementinterval: 5
     minautoscalemembers: 8
     maxautoscalemembers: 10
-    macmoderetainvlan: DISABLED
-    dns64: DISABLED
+    macmoderetainvlan: disabled
+    dns64: disabled
     bypassaaaa: no
-    processlocal: DISABLED
+    processlocal: disabled
     backuplbmethod: LEASTCONNECTION
     hashlength: 100
     servicebindings:

--- a/test/integration/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_http/update.yaml
+++ b/test/integration/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_http/update.yaml
@@ -27,30 +27,30 @@
     v6persistmasklen: 64
     m: IP
     tosid: 6
-    sessionless: DISABLED
+    sessionless: disabled
     redirurl: http://somewhere.com
     cacheable: no
     clttimeout: 222
     somethod: CONNECTION
-    sopersistence: DISABLED
+    sopersistence: disabled
     sopersistencetimeout: 222
     sothreshold: 4096
     healththreshold: 55
     sobackupaction: DROP
-    redirectportrewrite: DISABLED
-    downstateflush: DISABLED
-    disableprimaryondown: DISABLED
+    redirectportrewrite: disabled
+    downstateflush: disabled
+    disableprimaryondown: disabled
     insertvserveripport: VIPADDR
     vipheader: vip
     authenticationhost: authenticate.me
     authentication: off
     authn401: off
     authnvsname: somename
-    push: DISABLED
+    push: disabled
     pushmulticlients: no
     comment: Vserver comment
     l2conn: "OFF"
-    appflowlog: DISABLED
+    appflowlog: disabled
     icmpvsrresponse: PASSIVE
     rhistate: PASSIVE
     newservicerequest: 11
@@ -58,10 +58,10 @@
     newservicerequestincrementinterval: 5
     minautoscalemembers: 8
     maxautoscalemembers: 10
-    macmoderetainvlan: DISABLED
-    dns64: DISABLED
+    macmoderetainvlan: disabled
+    dns64: disabled
     bypassaaaa: no
-    processlocal: DISABLED
+    processlocal: disabled
     backuplbmethod: LEASTCONNECTION
     hashlength: 100
     servicebindings:

--- a/test/integration/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_mysql/setup.yaml
+++ b/test/integration/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_mysql/setup.yaml
@@ -19,4 +19,4 @@
     mysqlcharacterset: 8
     mysqlservercapabilities: 244
 
-    dbslb: DISABLED
+    dbslb: disabled

--- a/test/integration/roles/netscaler_service/tests/nitro/http_service/setup.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/http_service/setup.yaml
@@ -19,7 +19,7 @@
     healthmonitor: no
     maxreq: 200
     cacheable: no
-    cip: ENABLED
+    cip: enabled
     cipheader: client-ip
     usip: yes
     useproxyport: yes
@@ -34,11 +34,11 @@
     maxbandwidth: 10000
     accessdown: "NO"
     monthreshold: 100
-    downstateflush: ENABLED
+    downstateflush: enabled
     hashid: 10
     comment: some comment
-    appflowlog: ENABLED
-    processlocal: ENABLED
+    appflowlog: enabled
+    processlocal: enabled
     graceful: no
 
     monitor_bindings:

--- a/test/integration/roles/netscaler_service/tests/nitro/http_service/update.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/http_service/update.yaml
@@ -19,7 +19,7 @@
     healthmonitor: no
     maxreq: 200
     cacheable: no
-    cip: ENABLED
+    cip: enabled
     cipheader: client-ip
     usip: yes
     useproxyport: yes
@@ -34,11 +34,11 @@
     maxbandwidth: 20000
     accessdown: "NO"
     monthreshold: 100
-    downstateflush: ENABLED
+    downstateflush: enabled
     hashid: 10
     comment: some comment
-    appflowlog: ENABLED
-    processlocal: ENABLED
+    appflowlog: enabled
+    processlocal: enabled
 
     monitor_bindings:
       - monitorname: http

--- a/test/integration/roles/netscaler_servicegroup/tests/nitro/servicegroup/setup.yaml
+++ b/test/integration/roles/netscaler_servicegroup/tests/nitro/servicegroup/setup.yaml
@@ -17,14 +17,13 @@
     maxclient: 100
     maxreq: 100
     cacheable: no
-    cip: ENABLED
+    cip: enabled
     cipheader: cip-header
     usip: no
     pathmonitor: no
     pathmonitorindv: no
     useproxyport: no
     healthmonitor: no
-    sc: off
     sp: off
     rtspsessionidremap: off
     clttimeout: 2000
@@ -34,9 +33,9 @@
     cmp: no
     maxbandwidth: 5000
     monthreshold: 100
-    downstateflush: DISABLED
+    downstateflush: disabled
     comment: some comment
-    appflowlog: ENABLED
+    appflowlog: enabled
     autoscale: POLICY
     memberport: 80
     graceful: no

--- a/test/integration/roles/netscaler_servicegroup/tests/nitro/servicegroup/update.yaml
+++ b/test/integration/roles/netscaler_servicegroup/tests/nitro/servicegroup/update.yaml
@@ -17,14 +17,13 @@
     maxclient: 100
     maxreq: 100
     cacheable: no
-    cip: ENABLED
+    cip: enabled
     cipheader: cip-header
     usip: no
     pathmonitor: no
     pathmonitorindv: no
     useproxyport: no
     healthmonitor: no
-    sc: off
     sp: off
     rtspsessionidremap: off
     clttimeout: 1000
@@ -34,9 +33,9 @@
     cmp: no
     maxbandwidth: 5000
     monthreshold: 100
-    downstateflush: DISABLED
+    downstateflush: disabled
     comment: some comment
-    appflowlog: ENABLED
+    appflowlog: enabled
     autoscale: POLICY
     memberport: 80
     graceful: no


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR lowercases enabled, disabled option values in all netscaler modules and associated integration tests.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

lib/ansible/modules/network/netscaler

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fixes c919a6f262) last updated 2017/08/04 17:06:26 (GMT +300)
  config file = /home/georgen/.ansible.cfg
  configured module search path = [u'/home/georgen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/georgen/repos/ansible_fork/lib/ansible
  executable location = /home/georgen/repos/ansible_fork/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This is a follow up to #27640