### PR TITLE
Update cnos.py to remove unused method checkServerForImage

### DIFF
--- a/lib/ansible/module_utils/cnos.py
+++ b/lib/ansible/module_utils/cnos.py
@@ -32,7 +32,6 @@
 # Lenovo Networking
 
 import time
-import ftplib
 import socket
 import re
 try:
@@ -3089,41 +3088,7 @@ def doSecureImageTransfer(
     return retVal
 # EOM
 
-# Method to find whether image is there in server or not
-# This is not complete. Need to figure out How to do for SCP and SFTP
-
-
-def checkServerForImage(protocol, ipaddress, folder, username, password):
-    # server = "10.241.105.214"
-    server = ipaddress
-    # username = "pbhosale"
-    username = username
-    # password = "Lab4man1"
-    password = password
-    imageDir = "cnos_images"
-    output = 0
-    try:
-        ftp = ftplib.FTP(server)
-        ftp.login(username, password)
-    except Exception:
-        # debugOutput e
-        return 1
-    else:
-        filelist = []  # to store all files
-        ftp.retrlines('NLST', filelist.append)  # append to list
-        num = 0
-        for f in filelist:
-            # debugOutput f
-            if(f == imageDir):
-                num = 1
-        if(num == 0):
-            resp = ftp.mkd(imageDir)
-        if(resp != imageDir):
-            return 1
-    return output
-# EOM
-
-# Method for device response than time delay
+# Method for enter enable mode
 #
 
 
@@ -3179,7 +3144,7 @@ def enterEnableModeForDevice(enablePassword, timeout, obj):
     return retVal
 # EOM
 
-# Method for device response than time delay
+# Method for device response for a  time delay
 #
 
 


### PR DESCRIPTION
##### SUMMARY
Removing an un used method in the utility module. Inside cnos.py, checkServerForImage method was never used. Removed its library dependency too

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib\ansible\module_utils\cnos.py

##### ANSIBLE VERSION
ansible 2.4.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
##### ADDITIONAL INFORMATION
There was an unsued utility method in cnos.py. This has to be removed as this stale method was catering only to FTP.
@@ -32,7 +32,6 @@
 # Lenovo Networking
 
 import time
-import ftplib
 import socket
 import re
 try:
@@ -3089,41 +3088,7 @@ def doSecureImageTransfer(
     return retVal
 # EOM
 
-# Method to find whether image is there in server or not
-# This is not complete. Need to figure out How to do for SCP and SFTP
-
-
-def checkServerForImage(protocol, ipaddress, folder, username, password):
-    # server = "10.241.105.214"
-    server = ipaddress
-    # username = "pbhosale"
-    username = username
-    # password = "Lab4man1"
-    password = password
-    imageDir = "cnos_images"
-    output = 0
-    try:
-        ftp = ftplib.FTP(server)
-        ftp.login(username, password)
-    except Exception:
-        # debugOutput e
-        return 1
-    else:
-        filelist = []  # to store all files
-        ftp.retrlines('NLST', filelist.append)  # append to list
-        num = 0
-        for f in filelist:
-            # debugOutput f
-            if(f == imageDir):
-                num = 1
-        if(num == 0):
-            resp = ftp.mkd(imageDir)
-        if(resp != imageDir):
-            return 1
-    return output
-# EOM
-
-# Method for device response than time delay
+# Method for enter enable mode
 #
 
 
@@ -3179,7 +3144,7 @@ def enterEnableModeForDevice(enablePassword, timeout, obj):
     return retVal
 # EOM
 
-# Method for device response than time delay
+# Method for device response for a  time delay
 #
 