### PR TITLE
Netscaler: Various small bug fixes

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_cs_action.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_action.py
@@ -204,8 +204,6 @@ def main():
     transforms = {
     }
 
-    json_encodes = ['targetvserverexpr']
-
     # Instantiate config proxy
     csaction_proxy = ConfigProxy(
         actual=csaction(),
@@ -215,7 +213,6 @@ def main():
         readonly_attrs=readonly_attrs,
         immutable_attrs=immutable_attrs,
         transforms=transforms,
-        json_encodes=json_encodes,
     )
 
     try:

--- a/lib/ansible/modules/network/netscaler/netscaler_service.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_service.py
@@ -180,11 +180,6 @@ options:
                 setting, the client-side connection port is used as the source port for the server-side connection.
             - "Note: This parameter is available only when the Use Source IP (USIP) parameter is set to YES."
 
-    sc:
-        description:
-            - "State of SureConnect for the service."
-        default: off
-
     sp:
         description:
             - "Enable surge protection for the service."
@@ -621,10 +616,6 @@ def main():
         cipheader=dict(type='str'),
         usip=dict(type='bool'),
         useproxyport=dict(type='bool'),
-        sc=dict(
-            type='bool',
-            default=False,
-        ),
         sp=dict(type='bool'),
         rtspsessionidremap=dict(
             type='bool',
@@ -742,7 +733,6 @@ def main():
         'cipheader',
         'usip',
         'useproxyport',
-        'sc',
         'sp',
         'rtspsessionidremap',
         'clttimeout',
@@ -828,7 +818,6 @@ def main():
         'healthmonitor': ['bool_yes_no'],
         'useproxyport': ['bool_yes_no'],
         'rtspsessionidremap': ['bool_on_off'],
-        'sc': ['bool_on_off'],
         'accessdown': ['bool_yes_no'],
         'cmp': ['bool_yes_no'],
     }

--- a/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
@@ -151,11 +151,6 @@ options:
                 the service as UP at all times.
         type: bool
 
-    sc:
-        description:
-            - "State of the SureConnect feature for the service group."
-        type: bool
-
     sp:
         description:
             - "Enable surge protection for the service group."
@@ -693,7 +688,6 @@ def main():
         pathmonitorindv=dict(type='bool'),
         useproxyport=dict(type='bool'),
         healthmonitor=dict(type='bool'),
-        sc=dict(type='bool'),
         sp=dict(type='bool'),
         rtspsessionidremap=dict(type='bool'),
         clttimeout=dict(type='float'),
@@ -789,7 +783,6 @@ def main():
         'pathmonitorindv',
         'useproxyport',
         'healthmonitor',
-        'sc',
         'sp',
         'rtspsessionidremap',
         'clttimeout',
@@ -862,7 +855,6 @@ def main():
         'healthmonitor': ['bool_yes_no'],
         'useproxyport': ['bool_yes_no'],
         'rtspsessionidremap': ['bool_on_off'],
-        'sc': ['bool_on_off'],
         'graceful': ['bool_yes_no'],
         'cmp': ['bool_yes_no'],
     }
@@ -926,7 +918,11 @@ def main():
                 if not servicegroup_exists(client, module):
                     module.fail_json(msg='Service group is not present', **module_result)
                 if not servicegroup_identical(client, module, servicegroup_proxy):
-                    module.fail_json(msg='Service group is not identical to configuration', **module_result)
+                    module.fail_json(
+                        msg='Service group is not identical to configuration',
+                        diff=diff(client, module, servicegroup_proxy),
+                        **module_result
+                    )
                 if not servicemembers_identical(client, module):
                     module.fail_json(msg='Service group members differ from configuration', **module_result)
                 if not monitor_bindings_identical(client, module):

--- a/test/units/modules/network/netscaler/test_netscaler_lb_vserver.py
+++ b/test/units/modules/network/netscaler/test_netscaler_lb_vserver.py
@@ -796,6 +796,7 @@ class TestNetscalerLBVServerModule(TestModule):
             ConfigProxy=Mock(return_value=lb_vserver_proxy_mock),
             ensure_feature_is_enabled=Mock(return_value=True),
             lb_vserver_exists=Mock(side_effect=[True, True]),
+            nitro_exception=self.MockException,
             do_state_change=do_state_change_mock,
         ):
             self.module = netscaler_lb_vserver


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR introduces the following minor bug fixes for Netscaler modules
* netscaler_cs_action: Remove json_encodes
* netscaler_service: Remove deprecated "sc" option
* netscaler_servicegroup: Remove deprecated "sc" option
* netscaler_servicegroup: Fix error message for non identical servicegroup failure
* netscaler_lb_vserver: Fix a unit test testcase

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

* lib/ansible/modules/network/netscaler/netscaler_cs_action.py
* lib/ansible/modules/network/netscaler/netscaler_service.py
* lib/ansible/modules/network/netscaler/netscaler_servicegroup.py
* test/units/modules/network/netscaler/test_netscaler_lb_vserver.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fixes c919a6f262) last updated 2017/08/04 17:06:26 (GMT +300)
  config file = /home/georgen/.ansible.cfg
  configured module search path = [u'/home/georgen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/georgen/repos/ansible_fork/lib/ansible
  executable location = /home/georgen/repos/ansible_fork/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```
