### PR TITLE
Add a (disabled) code-smell test for detecting _ variables

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/no-underscore-variable.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/no-underscore-variable.rst
@@ -1,0 +1,28 @@
+Sanity Tests » no-underscore-variable
+=====================================
+
+In the future, Ansible may use the identifier ``_`` to internationalize its
+message strings.  To be ready for that, we need to make sure that there are
+no conflicting identifiers defined in the code base.
+
+In common practice, ``_`` is frequently used as a dummy variable (a variable
+to receive a value from a function where the value is useless and never used).
+In Ansible, we're using the identifier ``dummy`` for this purpose instead.
+
+Example of unfixed code:
+
+.. code-block:: python
+
+    for _ in range(0, retries):
+        success = retry_thing()
+        if success:
+            break
+
+Example of fixed code:
+
+.. code-block:: python
+
+    for dummy in range(0, retries):
+        success = retry_thing()
+        if success:
+            break

--- a/test/sanity/code-smell/no-underscore-variable.sh
+++ b/test/sanity/code-smell/no-underscore-variable.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Only needed until we can enable a pylint test for this.  We may have to write
+# one or add it to another existing test (like the one to warn on inappropriate
+# variable names).  Adding to an existing test may be hard as we may have many
+# other things that are not compliant with that test.
+
+
+# Need to fix everything in the whitelist in order to enable a pylint test.
+# We've settled on "dummy" as the variable to replace dummy variables with
+# (vast majority of these cases)
+#
+# before enabling *this* test, we need to create a full list of files which we need to fix
+# Can use the base find command to help generate that list
+#   find . -name '*.py' -type f -exec egrep -H '( |[^C]\()_( |,|\))' \{\} \+
+#
+underscore_as_variable=$(find . -path ./test/runner/.tox -prune \
+        -path ./contrib/inventory/gce.py \
+        -o -name '*.py' -type f -exec egrep -H '( |[^C]\()_( |,|\))' \{\} \+ )
+
+
+if test -n "$underscore_as_variable" ; then
+  printf "\n== Underscore used as a variable ==\n"
+  printf "%s" "$underscore_as_variable"
+  failures=$(printf "%s" "$underscore_as_variable"| wc -l)
+  failures=$((failures + 2))
+  exit "$failures"
+fi
+
+exit 0

--- a/test/sanity/code-smell/skip.txt
+++ b/test/sanity/code-smell/skip.txt
@@ -1,1 +1,2 @@
 inappropriately-private.sh
+no-underscore-variable.sh


### PR DESCRIPTION
We are reserving the _ identifier for i18n work.  Code should use the
identifier dummy for dummy variables instead.

This test is currently skipped as someone needs to generate the list of
files which are currently out of compliance before this can be turned
on.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
New code-smell test

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
