### PR TITLE
Fix yum module with rpm file or url

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -948,6 +948,35 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
                 pkgs['update'].append(spec)
                 will_update.add(spec)
                 continue
+
+            # check if pkgspec is installed (if possible for idempotence)
+            # localpkg
+            elif spec.endswith('.rpm') and '://' not in spec:
+                if not os.path.exists(spec):
+                    res['msg'] += "No RPM file matching '%s' found on system" % spec
+                    res['results'].append("No RPM file matching '%s' found on system" % spec)
+                    res['rc'] = 127 # Ensure the task fails in with-loop
+                    module.fail_json(**res)
+
+                # get the pkg name-v-r.arch
+                nvra = local_nvra(module, spec)
+
+                # local rpm files can't be updated
+                if not is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
+                    pkgs['install'].append(spec)
+                continue
+
+            # URL
+            elif '://' in spec:
+                # download package so that we can check if it's already installed
+                package = fetch_rpm_from_url(spec, module=module)
+                nvra = local_nvra(module, package)
+
+                # local rpm files can't be updated
+                if not is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
+                    pkgs['install'].append(package)
+                continue
+
             # dep/pkgname  - find it
             else:
                 if is_installed(module, repoq, spec, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):


### PR DESCRIPTION
##### SUMMARY

This will fix the yum module when using state=latest with an rpm file or url. Basically, we will check which package the rpm file provides and only install it if this is not present. Updating from an rpm file is not supported yet so it will only install it and not update it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yum module

##### ANSIBLE VERSION
```
ansible 2.4.0 (check_rpm_file d81557fb72) last updated 2017/08/04 18:46:58 (GMT +200)
  config file = /tmp/ansible/ansible.cfg
  configured module search path = [u'/home/nporcel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/nporcel/tools/ansible/lib/ansible
  executable location = /home/nporcel/.virtualenvs/perf-ansible-local/bin/ansible
  python version = 2.7.12 (default, Jul 18 2016, 15:02:52) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION

I am using the following playbook for my tests, where centos is a centos 7 server. I replaced the actual rpm URL by `http://example.com/example.rpm`, but this should be reproduced with an actual rpm file.

```
- hosts: centos
  gather_facts: False
  tasks:
    - name: Add Couchbase repository
      yum:
        name: http://example.com/example.rpm
        state: latest
```

Before the fix, I have the following error:

```
fatal: [centos]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        (...)
    },
    "msg": "No package matching 'http://example.com/example.rpm' found available, installed or updated",
    "rc": 126,
    "results": [
        "No package matching 'http://example.com/example.rpm' found available, installed or updated"
    ]
}
```

After the fix, I have this output:

```
ok: [centos] => {
    "changed": false,
    "failed": false,
    "invocation": {
        (...)
    },
    "msg": "",
    "rc": 0,
    "results": [
        ""
    ]
}
```

I also tested with an rpm file instead of an URL and I have the same result before and after.