### PR TITLE
[WIP] Fix lost connection_user in local connections.

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -452,8 +452,14 @@ class PlayContext(Base):
         # this ensures any become settings are obeyed correctly
         # we store original in 'connection_user' for use of network/other modules that fallback to it as login user
         if new_info.connection == 'local':
-            new_info.connection_user = new_info.remote_user
-            new_info.remote_user = pwd.getpwuid(os.getuid()).pw_name
+            # If the remote_user has already been set to the currently logged in user
+            # then we have already changed it.  Do not change it twice.
+            # Use the old value for remote_user for connection_user.
+            if new_info.remote_user == pwd.getpwuid(os.getuid()).pw_name:
+                new_info.connection_user = self.remote_user
+            else:
+                new_info.connection_user = new_info.remote_user
+                new_info.remote_user = pwd.getpwuid(os.getuid()).pw_name
 
         # set no_log to default if it was not previouslly set
         if new_info.no_log is None:

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -448,18 +448,9 @@ class PlayContext(Base):
                 elif getattr(new_info, 'connection', None) == 'local' and (not remote_addr_local or not inv_hostname_local):
                     setattr(new_info, 'connection', C.DEFAULT_TRANSPORT)
 
-        # if the final connection type is local, reset the remote_user value to that of the currently logged in user
-        # this ensures any become settings are obeyed correctly
-        # we store original in 'connection_user' for use of network/other modules that fallback to it as login user
+        # set connection_user from either the new_info for remote_user or the play if it is not set
         if new_info.connection == 'local':
-            # If the remote_user has already been set to the currently logged in user
-            # then we have already changed it.  Do not change it twice.
-            # Use the old value for remote_user for connection_user.
-            if new_info.remote_user == pwd.getpwuid(os.getuid()).pw_name:
-                new_info.connection_user = self.remote_user
-            else:
-                new_info.connection_user = new_info.remote_user
-                new_info.remote_user = pwd.getpwuid(os.getuid()).pw_name
+            new_info.connection_user = new_info.remote_user or self.remote_user
 
         # set no_log to default if it was not previouslly set
         if new_info.no_log is None:

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -32,6 +32,7 @@ __metaclass__ = type
 
 import os
 import subprocess
+import traceback
 from collections import Mapping
 
 from ansible.errors import AnsibleError, AnsibleParserError
@@ -106,11 +107,11 @@ class InventoryModule(BaseInventoryPlugin):
                     raise AnsibleError("Inventory {0} contained characters that cannot be interpreted as UTF-8: {1}".format(path, to_native(e)))
 
                 try:
-                    inventory.cache[cache_key] = self.loader.load(data, file_name=path)
+                    processed = self.loader.load(data, file_name=path)
+                    inventory.cache[cache_key] = processed
                 except Exception as e:
                     raise AnsibleError("failed to parse executable inventory script results from {0}: {1}\n{2}".format(path, to_native(e), err))
 
-            processed = inventory.cache[cache_key]
             if not isinstance(processed, Mapping):
                 raise AnsibleError("failed to parse executable inventory script results from {0}: needs to be a json dict\n{1}".format(path, err))
 
@@ -141,7 +142,7 @@ class InventoryModule(BaseInventoryPlugin):
                 self.populate_host_vars([host], got)
 
         except Exception as e:
-            raise AnsibleParserError(to_native(e))
+            raise AnsibleParserError("str(e): {0} to_native(e): {1} type(e): {2} traceback: {3}".format(str(e), to_native(e), type(e), traceback.format_exc(e)))
 
     def _parse_group(self, group, data):
 


### PR DESCRIPTION

##### SUMMARY

For local connections remote_user is changed to be the currently logged
in user.   The old value of remote_user is stored in connection_user so
the persistent connections can use the correct user name.   If this code
is run twice the currently logged in user will be set to remote_user and
to connection_user losing the original user for the persistent
connection.

This problem causes a play with two tasks to fail on the second task since the
user used to connect to the networking device is incorrect. 

The fix checks to see if we already set the remote_user to the
currently logged in user and then uses the old value for
connection_user if so.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/play_context.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (local_connection_fix 25492bd918) last updated 2017/08/04
16:55:46 (GMT +000)
  config file = /home/ben/git/vyos-topology/ansible.cfg
  configured module search path =
[u'/home/ben/git/vyos-topology/library']
  ansible python module location = /home/ben/git/ansible/lib/ansible
  executable location = /home/ben/env/vyos-topology/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0
20160609]
```


##### ADDITIONAL INFORMATION

A playbook with a play with two tasks that runs on VyOS will fail if the
user is provided from an the ANSIBLE_REMOTE_USER environment variable

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

$ ansible-playbook -i hosts playbook/interfaces.yml

PLAY [Up all interfaces on switches]
************************************************************************************************************************************************

TASK [vyos_config]
******************************************************************************************************************************************************************
ok: [Spine2]
ok: [Leaf1]
ok: [Spine1]
ok: [Leaf2]
ok: [Leaf3]

TASK [vyos_config]
******************************************************************************************************************************************************************
ok: [Spine1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.6', u'local_port': 9102, u'remote_device_name': u'Leaf1',
u'remote_port': 9103, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.5', u'id': 1, u'network': 383})
ok: [Leaf3] => (item={u'remote_interface_name': u'eth3',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.13', u'local_port': 9107, u'remote_device_name': u'Spine1',
u'remote_port': 9106, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.14', u'id': 1, u'network': 385})
ok: [Spine2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.18', u'local_port': 9108, u'remote_device_name': u'Leaf1',
u'remote_port': 9109, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.17', u'id': 1, u'network': 386})
ok: [Leaf2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.9', u'local_port': 9105, u'remote_device_name': u'Spine1',
u'remote_port': 9104, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.10', u'id': 1, u'network': 384})
ok: [Leaf1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.5', u'local_port': 9103, u'remote_device_name': u'Spine1',
u'remote_port': 9102, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.6', u'id': 1, u'network': 383})
failed: [Spine1] (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.10', u'local_port': 9104, u'remote_device_name': u'Leaf2',
u'remote_port': 9105, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.9', u'id': 2, u'network': 384}) => {"changed": false,
"failed": true, "item": {"id": 2, "ip_address": "192.168.0.9",
"local_port": 9104, "name": "eth2", "netmask": "255.255.255.252",
"network": 384, "remote_device_name": "Leaf2", "remote_interface_name":
"eth1", "remote_ip_address": "192.168.0.10", "remote_port": 9105,
"subnet_prefixlen": 30}, "msg": "unable to open shell. Please see:
https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell"}
failed: [Leaf3] (item={u'remote_interface_name': u'eth3',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.25', u'local_port': 9113, u'remote_device_name': u'Spine2',
u'remote_port': 9112, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.26', u'id': 2, u'network': 388}) => {"changed": false,
"failed": true, "item": {"id": 2, "ip_address": "192.168.0.26",
"local_port": 9113, "name": "eth2", "netmask": "255.255.255.252",
"network": 388, "remote_device_name": "Spine2", "remote_interface_name":
"eth3", "remote_ip_address": "192.168.0.25", "remote_port": 9112,
"subnet_prefixlen": 30}, "msg": "unable to open shell. Please see:
https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell"}
failed: [Spine2] (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.22', u'local_port': 9110, u'remote_device_name': u'Leaf2',
u'remote_port': 9111, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.21', u'id': 2, u'network': 387}) => {"changed": false,
"failed": true, "item": {"id": 2, "ip_address": "192.168.0.21",
"local_port": 9110, "name": "eth2", "netmask": "255.255.255.252",
"network": 387, "remote_device_name": "Leaf2", "remote_interface_name":
"eth2", "remote_ip_address": "192.168.0.22", "remote_port": 9111,
"subnet_prefixlen": 30}, "msg": "unable to open shell. Please see:
https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell"}
failed: [Leaf1] (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.17', u'local_port': 9109, u'remote_device_name': u'Spine2',
u'remote_port': 9108, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.18', u'id': 2, u'network': 386}) => {"changed": false,
"failed": true, "item": {"id": 2, "ip_address": "192.168.0.18",
"local_port": 9109, "name": "eth2", "netmask": "255.255.255.252",
"network": 386, "remote_device_name": "Spine2", "remote_interface_name":
"eth1", "remote_ip_address": "192.168.0.17", "remote_port": 9108,
"subnet_prefixlen": 30}, "msg": "unable to open shell. Please see:
https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell"}
failed: [Leaf2] (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.21', u'local_port': 9111, u'remote_device_name': u'Spine2',
u'remote_port': 9110, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.22', u'id': 2, u'network': 387}) => {"changed": false,
"failed": true, "item": {"id": 2, "ip_address": "192.168.0.22",
"local_port": 9111, "name": "eth2", "netmask": "255.255.255.252",
"network": 387, "remote_device_name": "Spine2", "remote_interface_name":
"eth2", "remote_ip_address": "192.168.0.21", 
...

PLAY RECAP
**************************************************************************************************************************************************************************
Leaf1                      : ok=1    changed=0    unreachable=0
failed=1   
Leaf2                      : ok=1    changed=0    unreachable=0
failed=1   
Leaf3                      : ok=1    changed=0    unreachable=0
failed=1   
Spine1                     : ok=1    changed=0    unreachable=0
failed=1   
Spine2                     : ok=1    changed=0    unreachable=0
failed=1   


-----


$ ansible-playbook -i hosts playbook/interfaces.yml

PLAY [Up all interfaces on switches]
************************************************************************************************************************************************

TASK [vyos_config]
******************************************************************************************************************************************************************
ok: [Spine1]
ok: [Leaf1]
ok: [Leaf3]
ok: [Spine2]
ok: [Leaf2]

TASK [vyos_config]
******************************************************************************************************************************************************************
ok: [Leaf3] => (item={u'remote_interface_name': u'eth3',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.13', u'local_port': 9107, u'remote_device_name': u'Spine1',
u'remote_port': 9106, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.14', u'id': 1, u'network': 385})
ok: [Leaf1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.5', u'local_port': 9103, u'remote_device_name': u'Spine1',
u'remote_port': 9102, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.6', u'id': 1, u'network': 383})
ok: [Spine1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.6', u'local_port': 9102, u'remote_device_name': u'Leaf1',
u'remote_port': 9103, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.5', u'id': 1, u'network': 383})
ok: [Spine2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.18', u'local_port': 9108, u'remote_device_name': u'Leaf1',
u'remote_port': 9109, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.17', u'id': 1, u'network': 386})
ok: [Leaf2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth1', u'remote_ip_address':
u'192.168.0.9', u'local_port': 9105, u'remote_device_name': u'Spine1',
u'remote_port': 9104, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.10', u'id': 1, u'network': 384})
ok: [Leaf3] => (item={u'remote_interface_name': u'eth3',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.25', u'local_port': 9113, u'remote_device_name': u'Spine2',
u'remote_port': 9112, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.26', u'id': 2, u'network': 388})
ok: [Spine1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.10', u'local_port': 9104, u'remote_device_name': u'Leaf2',
u'remote_port': 9105, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.9', u'id': 2, u'network': 384})
ok: [Leaf1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.17', u'local_port': 9109, u'remote_device_name': u'Spine2',
u'remote_port': 9108, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.18', u'id': 2, u'network': 386})
ok: [Leaf2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.21', u'local_port': 9111, u'remote_device_name': u'Spine2',
u'remote_port': 9110, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.22', u'id': 2, u'network': 387})
ok: [Spine2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth2', u'remote_ip_address':
u'192.168.0.22', u'local_port': 9110, u'remote_device_name': u'Leaf2',
u'remote_port': 9111, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.21', u'id': 2, u'network': 387})
ok: [Spine1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth3', u'remote_ip_address':
u'192.168.0.14', u'local_port': 9106, u'remote_device_name': u'Leaf3',
u'remote_port': 9107, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.13', u'id': 3, u'network': 385})
ok: [Leaf1] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth3', u'remote_ip_address':
u'192.168.0.46', u'local_port': 9122, u'remote_device_name': u'Host1',
u'remote_port': 9123, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.45', u'id': 3, u'network': 390})
ok: [Leaf3] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth3', u'remote_ip_address':
u'192.168.0.38', u'local_port': 9118, u'remote_device_name': u'Host3',
u'remote_port': 9119, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.37', u'id': 3, u'network': 392})
ok: [Spine2] => (item={u'remote_interface_name': u'eth2',
u'subnet_prefixlen': 30, u'name': u'eth3', u'remote_ip_address':
u'192.168.0.26', u'local_port': 9112, u'remote_device_name': u'Leaf3',
u'remote_port': 9113, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.25', u'id': 3, u'network': 388})
ok: [Leaf2] => (item={u'remote_interface_name': u'eth1',
u'subnet_prefixlen': 30, u'name': u'eth3', u'remote_ip_address':
u'192.168.0.34', u'local_port': 9116, u'remote_device_name': u'Host2',
u'remote_port': 9117, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.33', u'id': 3, u'network': 391})
ok: [Spine1] => (item={u'remote_interface_name': u'eth4',
u'subnet_prefixlen': 30, u'name': u'eth4', u'remote_ip_address':
u'192.168.0.30', u'local_port': 9114, u'remote_device_name': u'Spine2',
u'remote_port': 9115, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.29', u'id': 4, u'network': 389})
ok: [Leaf1] => (item={u'remote_interface_name': u'eth5',
u'subnet_prefixlen': 30, u'name': u'eth4', u'remote_ip_address':
u'192.168.0.41', u'local_port': 9121, u'remote_device_name': u'Leaf1',
u'remote_port': 9120, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.42', u'id': 4, u'network': 393})
ok: [Spine2] => (item={u'remote_interface_name': u'eth4',
u'subnet_prefixlen': 30, u'name': u'eth4', u'remote_ip_address':
u'192.168.0.29', u'local_port': 9115, u'remote_device_name': u'Spine1',
u'remote_port': 9114, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.30', u'id': 4, u'network': 389})
ok: [Leaf2] => (item={u'remote_interface_name': u'eth5',
u'subnet_prefixlen': 30, u'name': u'eth4', u'remote_ip_address':
u'192.168.0.1', u'local_port': 9101, u'remote_device_name': u'Leaf2',
u'remote_port': 9100, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.2', u'id': 4, u'network': 394})
ok: [Leaf1] => (item={u'remote_interface_name': u'eth4',
u'subnet_prefixlen': 30, u'name': u'eth5', u'remote_ip_address':
u'192.168.0.42', u'local_port': 9120, u'remote_device_name': u'Leaf1',
u'remote_port': 9121, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.41', u'id': 5, u'network': 393})
ok: [Leaf2] => (item={u'remote_interface_name': u'eth4',
u'subnet_prefixlen': 30, u'name': u'eth5', u'remote_ip_address':
u'192.168.0.2', u'local_port': 9100, u'remote_device_name': u'Leaf2',
u'remote_port': 9101, u'netmask': u'255.255.255.252', u'ip_address':
u'192.168.0.1', u'id': 5, u'network': 394})

...

PLAY RECAP
**************************************************************************************************************************************************************************
Host1                      : ok=2    changed=1    unreachable=0
failed=0   
Host2                      : ok=2    changed=1    unreachable=0
failed=0   
Host3                      : ok=2    changed=1    unreachable=0
failed=0   
Leaf1                      : ok=3    changed=0    unreachable=0
failed=0   
Leaf2                      : ok=3    changed=0    unreachable=0
failed=0   
Leaf3                      : ok=3    changed=0    unreachable=0
failed=0   
Spine1                     : ok=3    changed=0    unreachable=0
failed=0   
Spine2                     : ok=3    changed=0    unreachable=0
failed=0   


```
