### PR TITLE
ansible-test: Fix environments with LD_LIBRARY_PATH

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -202,7 +202,8 @@ def common_environment():
 
     optional = (
         'HTTPTESTER',
-        'SSH_AUTH_SOCK'
+        'LD_LIBRARY_PATH',
+        'SSH_AUTH_SOCK',
     )
 
     env.update(pass_vars(required=required, optional=optional))


### PR DESCRIPTION
##### SUMMARY
This was needed in order to run ansible-test on RHEL7 using RHSCL python 3.5 !

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
v2.4