### PR TITLE
Update vcenter-simulator base to fedora:26 image.

### DIFF
--- a/test/utils/docker/vcenter-simulator/Dockerfile
+++ b/test/utils/docker/vcenter-simulator/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:25
+FROM fedora:26
 
 RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*; \


### PR DESCRIPTION
##### SUMMARY

Update vcenter-simulator base to fedora:26 image.

This is required because govmomi now requires go 1.8+ to be installed.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

vcenter-simulator

##### ANSIBLE VERSION

```
ansible 2.4.0 (vcenter-sim-update 76b39a2072) last updated 2017/08/04 10:51:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
