### PR TITLE
Remove _diff default  from play_context

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -216,7 +216,7 @@ class PlayContext(Base):
     _force_handlers = FieldAttribute(isa='bool', default=False)
     _start_at_task = FieldAttribute(isa='string')
     _step = FieldAttribute(isa='bool', default=False)
-    _diff = FieldAttribute(isa='bool', default=C.DIFF_ALWAYS)
+    _diff = FieldAttribute(isa='bool')
 
     # Fact gathering settings
     _gather_subset = FieldAttribute(isa='string', default=C.DEFAULT_GATHER_SUBSET)


### PR DESCRIPTION
##### SUMMARY

Removing default for `_diff` from `play_context` since is set by options.

Follow up from PR #27746

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

`play_context.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```