### PR TITLE
Test iso_extract on OS X.

### DIFF
--- a/test/integration/targets/iso_extract/aliases
+++ b/test/integration/targets/iso_extract/aliases
@@ -1,2 +1,1 @@
 posix/ci/group1
-skip/osx

--- a/test/integration/targets/iso_extract/tasks/7zip.yml
+++ b/test/integration/targets/iso_extract/tasks/7zip.yml
@@ -53,17 +53,24 @@
   become: yes
   when: ansible_distribution in ['Ubuntu']
 
-# FIXME: The homebrew module no longer seems to work
-#        "Error: Running Homebrew as root is extremely dangerous."
+- name: Find brew binary
+  command: which brew
+  register: brew_which
+  when: ansible_distribution in ['MacOSX']
+
+- name: Get owner of brew binary
+  stat:
+    path: "{{ brew_which.stdout }}"
+  register: brew_stat
+  when: ansible_distribution in ['MacOSX']
+
 - name: Install 7zip package if we are on MacOSX
-#  macports:
-#    name: p7zip
-#    state: installed
-#    update_cache: yes
   homebrew:
     name: p7zip
     state: present
-    update_homebrew: yes
+    update_homebrew: no
+  become: yes
+  become_user: "{{ brew_stat.stat.pw_name }}"
   when: ansible_distribution in ['MacOSX']
 
 - name: Install 7zip package if we are on FreeBSD


### PR DESCRIPTION
##### SUMMARY

Test iso_extract on OS X.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

iso_extract integration test

##### ANSIBLE VERSION

```
ansible 2.4.0 (iso_extract-osx 1ad05a9fec) last updated 2017/08/04 12:48:13 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
