### PR TITLE
Remove inventory_hostname assert on junos_command netconf_text contains

### DIFF
--- a/test/integration/targets/junos_command/tests/netconf_text/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/contains.yaml
@@ -8,7 +8,6 @@
       - show interfaces lo0
     display: text
     wait_for:
-      - "result[0] contains {{ inventory_hostname_short }}"
       - "result[1] contains lo0"
     provider: "{{ netconf }}"
   register: result


### PR DESCRIPTION
CI nodes have UUIDs as hostnames, not Ansible inventory hostnames.