### PR TITLE
Replace opensuse42.1 with opensuse42.3 in CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -30,8 +30,8 @@ matrix:
     - env: TEST=linux/centos7/1
     - env: TEST=linux/fedora24/1
     - env: TEST=linux/fedora25/1
-    - env: TEST=linux/opensuse42.1/1
     - env: TEST=linux/opensuse42.2/1
+    - env: TEST=linux/opensuse42.3/1
     - env: TEST=linux/ubuntu1404/1
     - env: TEST=linux/ubuntu1604/1
     - env: TEST=linux/ubuntu1604py3/1
@@ -40,8 +40,8 @@ matrix:
     - env: TEST=linux/centos7/2
     - env: TEST=linux/fedora24/2
     - env: TEST=linux/fedora25/2
-    - env: TEST=linux/opensuse42.1/2
     - env: TEST=linux/opensuse42.2/2
+    - env: TEST=linux/opensuse42.3/2
     - env: TEST=linux/ubuntu1404/2
     - env: TEST=linux/ubuntu1604/2
     - env: TEST=linux/ubuntu1604py3/2
@@ -50,8 +50,8 @@ matrix:
     - env: TEST=linux/centos7/3
     - env: TEST=linux/fedora24/3
     - env: TEST=linux/fedora25/3
-    - env: TEST=linux/opensuse42.1/3
     - env: TEST=linux/opensuse42.2/3
+    - env: TEST=linux/opensuse42.3/3
     - env: TEST=linux/ubuntu1404/3
     - env: TEST=linux/ubuntu1604/3
     - env: TEST=linux/ubuntu1604py3/3

--- a/test/runner/completion/docker.txt
+++ b/test/runner/completion/docker.txt
@@ -2,9 +2,8 @@ centos6
 centos7
 fedora24
 fedora25
-opensuse42.1
 opensuse42.2
-ubuntu1204
+opensuse42.3
 ubuntu1404
 ubuntu1604
 ubuntu1604py3


### PR DESCRIPTION
##### SUMMARY

Replace opensuse42.1 with opensuse42.3 in CI.

Also remove ubuntu1204 completion entry which is no longer used.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.4.0 (opensuse-ci 85b33aaae8) last updated 2017/08/05 12:08:25 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
