### PR TITLE
helpers.py: Fixes #27334 include empty task file within a 'block' dis…

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -207,6 +207,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     try:
                         data = loader.load_from_file(include_file)
                         if data is None:
+                            display.warning('file %s is empty and had no tasks to include' % include_file)
                             continue
                         elif not isinstance(data, list):
                             raise AnsibleParserError("included task files must contain a list of tasks", obj=data)

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -207,7 +207,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     try:
                         data = loader.load_from_file(include_file)
                         if data is None:
-                            return []
+                            continue
                         elif not isinstance(data, list):
                             raise AnsibleParserError("included task files must contain a list of tasks", obj=data)
 


### PR DESCRIPTION
##### SUMMARY
Fix the issue #[27334](https://github.com/ansible/ansible/issues/27334). Before this pull request, when a block include a empty task file all the following tasks will be ignored and not included in the playbook.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/helpers.py

##### ANSIBLE VERSION
```
$ ./build/scripts-2.7/ansible --version
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/build/lib/ansible
  executable location = ./build/scripts-2.7/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
This [loop](https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/helpers.py#L95) analyzes all the tasks of a block. When the include of the empty file is analyzed the function [load_from_file](https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/helpers.py#L208) returns None and the function in helpers.py terminate [returning a empty list](https://github.com/ansible/ansible/blob/devel/lib/ansible/playbook/helpers.py#L210) without analyze the other task of the block. I have replaced "return []" with "continue" in order to allow the parsing and the execution of the following block's tasks.

BEFORE:
```
$ ./build/scripts-2.7/ansible-playbook /tmp/testblockwithempty.yml 

PLAY [localhost] *****************************************************************************

TASK [Gathering Facts] ***********************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
```
AFTER:
```
$ ./build/scripts-2.7/ansible-playbook /tmp/testblockwithempty.yml 
[DEPRECATION WARNING]: The use of 'include' for tasks has been deprecated. Use 'import_tasks'
 for static inclusions or 'include_tasks' for dynamic inclusions.
This feature will be 
removed in a future release. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.

PLAY [localhost] *****************************************************************************

TASK [Gathering Facts] ***********************************************************************
ok: [localhost]

TASK [command] *******************************************************************************
changed: [localhost]

TASK [debug] *********************************************************************************
ok: [localhost] => {
    "msg": "Hello World"
}

PLAY RECAP ***********************************************************************************
localhost                  : ok=3    changed=1    unreachable=0    failed=0 
```

