### PR TITLE
Use ChocolateyInstall env variable after installation

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -77,7 +77,14 @@ Function Chocolatey-Install-Upgrade
             Fail-Json $result "Chocolatey bootstrap installation failed."
         }
         $result.changed = $true
-        $script:executable = "C:\ProgramData\chocolatey\bin\choco.exe"
+        if (Test-Path "Env:\ChocolateyInstall")
+        {
+            $script:executable = "{0}\bin\choco.exe" -f (Get-ChildItem "Env:\ChocolateyInstall").Value
+        }
+        else
+        {
+            $script:executable = "C:\ProgramData\chocolatey\bin\choco.exe"
+        }
         Add-Warning $result 'Chocolatey was missing from this system, so it was installed during this task run.'
 
     }

--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -77,16 +77,32 @@ Function Chocolatey-Install-Upgrade
             Fail-Json $result "Chocolatey bootstrap installation failed."
         }
         $result.changed = $true
-        if (Test-Path "Env:\ChocolateyInstall")
+        Add-Warning $result 'Chocolatey was missing from this system, so it was installed during this task run.'
+
+        # locate the newly installed choco.exe
+        $command = Get-Command -Name "choco.exe"
+        if ($command)
         {
-            $script:executable = "{0}\bin\choco.exe" -f (Get-ChildItem "Env:\ChocolateyInstall").Value
+            $path = $command.Path
         }
         else
         {
-            $script:executable = "C:\ProgramData\chocolatey\bin\choco.exe"
+            $env_value = $env:ChocolateyInstall
+            if ($env_value)
+            {
+                $path = "$env_value\bin\choco.exe"
+            }
+            else
+            {
+                $path = "$env:SYSTEMDRIVE\ProgramData\Chocolatey\bin\choco.exe"
+            }
         }
-        Add-Warning $result 'Chocolatey was missing from this system, so it was installed during this task run.'
+        if (-not (Test-Path -Path $path))
+        {
+            Fail-Json -obj $result -message "failed to find choco.exe, make sure it is added to the PATH or the env var ChocolateyInstall is set"
+        }
 
+        $script:executable = $path
     }
     else
     {


### PR DESCRIPTION
Fixes #19725 Custom install locations specified by the ChocolateyInstall
env variable in win_chocolatey

After an initial install of chocolatey, use the ChocolateyInstall
environment variable when assigning $script:executable .

##### SUMMARY

When installing the Chocolatey package manager, if the ChocolateyInstall environment variable is set, chocolatey will be installed to that pre-existing path. If this variable was set to a custom location the first win_chocolatey task will fail to find the choco.exe executable.

This change uses the env variable if it is available when setting the initial, first run path to choco.exe.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/windows/win_chocolatey.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (feature/custom-chocolateyinstall-location-gh#19725 2c98ce7cd4) last updated 2017/08/05 17:42:43 (GMT -700)
  config file = /Users/nhyde/Documents/shared/workspace/vagrant/win81-ansible/ansible.cfg
  configured module search path = [u'/Users/nhyde/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/nhyde/Documents/shared/workspace/vagrant/win81-ansible/ansible/lib/ansible
  executable location = /Users/nhyde/Documents/shared/workspace/vagrant/win81-ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible-playbook choco_with_env.yml

PLAY [windows] *****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Delete any existing machine 'ChocolateyInstall' var] *********************
ok: [127.0.0.1]

TASK [Delete any existing user 'ChocolateyInstall' var] ************************
ok: [127.0.0.1]

TASK [Remove our custom install directory] *************************************
ok: [127.0.0.1]

TASK [Remove default install directory] ****************************************
ok: [127.0.0.1]

TASK [Create custom install directory] *****************************************
changed: [127.0.0.1]

TASK [Set ChocolateyInstall ENV variable] **************************************
changed: [127.0.0.1]

TASK [Choco Update All] ********************************************************
 [WARNING]: Chocolatey was missing from this system, so it was installed during
this task run.

fatal: [127.0.0.1]: FAILED! => {"changed": true, "failed": true, "msg": "The term 'C:\\ProgramData\\chocolatey\\bin\\choco.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again."}
	to retry, use: --limit @/Users/nhyde/Documents/shared/workspace/vagrant/win81-ansible/choco_with_env.retry

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=7    changed=2    unreachable=0    failed=1   

```

After:
```
$ ansible-playbook choco_with_env.yml

PLAY [windows] *****************************************************************

TASK [Gathering Facts] *********************************************************
ok: [127.0.0.1]

TASK [Delete any existing machine 'ChocolateyInstall' var] *********************
ok: [127.0.0.1]

TASK [Delete any existing user 'ChocolateyInstall' var] ************************
ok: [127.0.0.1]

TASK [Remove our custom install directory] *************************************
ok: [127.0.0.1]

TASK [Remove default install directory] ****************************************
ok: [127.0.0.1]

TASK [Create custom install directory] *****************************************
changed: [127.0.0.1]

TASK [Set ChocolateyInstall ENV variable] **************************************
changed: [127.0.0.1]

TASK [Choco Update All] ********************************************************
 [WARNING]: Chocolatey was missing from this system, so it was installed during
this task run.

changed: [127.0.0.1]

TASK [Chocolatey is now present] ***********************************************
ok: [127.0.0.1]

TASK [Debug exe info only when unexpected] *************************************
skipping: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=9    changed=3    unreachable=0    failed=0   

```
```
# file: tasks/remove_env_var.yml
---
  - name: "Delete any existing machine '{{ env_var_name }}' var"
    win_environment:
      name: "{{ env_var_name }}"
      state: absent
      level: machine

  - name: "Delete any existing user '{{ env_var_name }}' var"
    win_environment:
      name: "{{ env_var_name }}"
      state: absent
      level: user
```

```
# file: choco_with_env.yml
- hosts: windows
  vars:
    choco_env_var: ChocolateyInstall
    choco_install_dir: C:\mydir

  tasks:
    - import_tasks: tasks/remove_env_var.yml
      vars:
        env_var_name: "{{ choco_env_var }}"

    - name: Remove our custom install directory
      win_file:
        path: "{{ choco_install_dir }}"
        state: absent

    - name: Remove default install directory
      win_file:
        path: C:\ProgramData\chocolatey
        state: absent

    - name: Create custom install directory
      win_file:
        path: "{{ choco_install_dir }}"
        state: directory

    - name: Set ChocolateyInstall ENV variable
      win_environment:
        name: "{{ choco_env_var }}"
        value: "{{ choco_install_dir }}"
        level: machine

    - name: Choco Update All
      win_chocolatey:
        name: all
        state: latest
    
    - name: Chocolatey is now present
      win_stat:
        path: "{{ choco_install_dir }}\\bin\\choco.exe"
      register: choco_exe

    - name: "Debug exe info only when unexpected"
      debug:
        var: choco_exe
      when: not choco_exe.stat.exists
```