### PR TITLE
Fix documentation issue in jira module (#27820)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -31,7 +31,7 @@ options:
   operation:
     required: true
     aliases: [ command ]
-    choices: [ create, comment, edit, fetch, transition ]
+    choices: [ create, comment, edit, fetch, transition , link ]
     description:
       - The operation to perform.
 
@@ -201,13 +201,15 @@ EXAMPLES = """
     name: '{{ issue.meta.fields.creator.name }}'
     comment: '{{ issue.meta.fields.creator.displayName }}'
 
+# You can get list of valid linktypes at /rest/api/2/issueLinkType
+# url of your jira installation.
 - name: Create link from HSP-1 to MKY-1
   jira:
     uri: '{{ server }}'
     username: '{{ user }}'
     password: '{{ pass }}'
     operation: link
-    linktype: Relate
+    linktype: Relates
     inwardissue: HSP-1
     outwardissue: MKY-1
 


### PR DESCRIPTION
##### SUMMARY
Fixes documentation for jira module (#27820)
* For link action example change linktype from Relate to Relates
* Add url for reference available linktypes.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
jira

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/e.slezhuk/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```