### PR TITLE
win_stat: add explicit error message when file is in use

### DIFF
--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -168,11 +168,19 @@ If (Test-Path -Path $path)
         $result.stat.size = $info.Length
 
         If ($get_md5) {
-            $result.stat.md5 = Get-FileChecksum -path $path -algorithm "md5"
+            try {
+                $result.stat.md5 = Get-FileChecksum -path $path -algorithm "md5"
+            } catch {
+                Fail-Json -obj $result -message "failed to get MD5 hash of file, set get_md5 to False to ignore this error: $($_.Exception.Message)"
+            }
         }
 
         If ($get_checksum) {
-            $result.stat.checksum = Get-FileChecksum -path $path -algorithm $checksum_algorithm
+            try {
+                $result.stat.checksum = Get-FileChecksum -path $path -algorithm $checksum_algorithm
+            } catch {
+                Fail-Json -obj $result -message "failed to get hash of file, set get_checksum to False to ignore this error: $($_.Exception.Message)"
+            }
         }
     }
 }

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -537,7 +537,29 @@
       - win_stat_no_args.msg
       - not win_stat_no_args|changed
 
+- name: ensure file that will be in use is deleted before test
+  win_file:
+    path: '{{win_stat_dir}}\in_use'
+    state: absent
+
+- name: lock file in the background for next task
+  win_command: powershell.exe "$data = 'abcdefghijklmnopqrstuvwxyz' * 1024; $file = [System.IO.File]::Open('{{win_stat_dir}}\in_use', 'OpenOrCreate', 'ReadWrite', 'None'); $writer = New-Object IO.StreamWriter($file); $start = Get-Date; while (((Get-Date) - $start).TotalSeconds -lt 10) { $writer.WriteLine($data) }; $writer.Close(); $file.Close()"
+  async: 15
+  poll: 0
+  register: a
+
+- name: fail to get stat of file in use
+  win_stat:
+    path: '{{win_stat_dir}}\in_use'
+    get_md5: False
+  register: fail_file_in_use
+  failed_when: "'failed to get hash of file' not in fail_file_in_use.msg"
+
 - name: remove testing folder
   win_file:
     path: "{{win_output_dir}}\\win_stat"
     state: absent
+  register: cleanup
+  retries: 3 # in case async task is still running, try 3 times
+  delay: 5
+  until: not cleanup|failed

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -543,8 +543,8 @@
     state: absent
 
 - name: lock file in the background for next task
-  win_command: powershell.exe "$data = 'abcdefghijklmnopqrstuvwxyz' * 1024; $file = [System.IO.File]::Open('{{win_stat_dir}}\in_use', 'OpenOrCreate', 'ReadWrite', 'None'); $writer = New-Object IO.StreamWriter($file); $start = Get-Date; while (((Get-Date) - $start).TotalSeconds -lt 10) { $writer.WriteLine($data) }; $writer.Close(); $file.Close()"
-  async: 15
+  win_command: powershell.exe "$data = 'abcdefghijklmnopqrstuvwxyz' * 1024; $file = [System.IO.File]::Open('{{win_stat_dir}}\in_use', 'OpenOrCreate', 'ReadWrite', 'None'); $writer = New-Object IO.StreamWriter($file); $start = Get-Date; while (((Get-Date) - $start).TotalSeconds -lt 15) { $writer.WriteLine($data) }; $writer.Close(); $file.Close()"
+  async: 20
   poll: 0
   register: a
 


### PR DESCRIPTION
##### SUMMARY
When a file is in use, win_stat will fail to get the checksum of a file. This will catch this error and put a more human friendly message so people can easily understand what is going on. See https://github.com/ansible/ansible/issues/26885

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_stat

##### ANSIBLE VERSION
```
ansible 2.4.0 (win_stat-file-in-use f8c98098a5) last updated 2017/08/07 10:38:54 (GMT +1000)
  config file = None
  configured module search path = ['/home/jborean/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jborean/dev/ansible/lib/ansible
  executable location = /home/jborean/dev/ansible/bin/ansible
  python version = 3.6.2 (default, Jul 20 2017, 18:18:25) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```