### PR TITLE
facts: fix arm64 ansible_processor_vcpus = 0

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -193,7 +193,7 @@ class LinuxHardware(Hardware):
 
             # model name is for Intel arch, Processor (mind the uppercase P)
             # works for some ARM devices, like the Sheevaplug.
-            if key in ['model name', 'Processor', 'vendor_id', 'cpu', 'Vendor']:
+            if key in ['model name', 'Processor', 'vendor_id', 'cpu', 'Vendor', 'processor']:
                 if 'processor' not in cpu_facts:
                     cpu_facts['processor'] = []
                 cpu_facts['processor'].append(data[1].strip())


### PR DESCRIPTION
On arm64, /proc/cpuinfo has no 'model name', 'Processor', 'vendor_id', 'cpu', 'Vendor',
as a resul "ansible_processor_count": 0 & "ansible_processor_vcpus": 0
Add checking element "processor" to fix the issue.

$ ansible -i ~/all-in-one  -m setup all | grep proc
	"ansible_processor": [],
	"ansible_processor_cores": 1,
	"ansible_processor_count": 0,
	"ansible_processor_threads_per_core": 1,
	"ansible_processor_vcpus": 0,

$ cat /proc/cpuinfo
processor	: 0
BogoMIPS	: 100.00
Features	: fp asimd evtstrm aes pmull sha1 sha2 crc32
CPU implementer	: 0x41
CPU architecture: 8
CPU variant	: 0x1
CPU part	: 0xd07
CPU revision	: 1

$ ansible --version
ansible 2.3.1.0
config file =
configured module search path = Default w/o overrides
python version = 2.7.9 (default, Aug 13 2016, 16:27:01) [GCC 4.9.2]

With fix, checking processor as well:
$ ansible -i ~/all-in-one  -m setup all | grep proc
	"ansible_processor": [
	"ansible_processor_cores": 1,
	"ansible_processor_count": 16,
	"ansible_processor_threads_per_core": 1,
	"ansible_processor_vcpus": 16,

Signed-off-by: Zhangfei Gao <zhangfei.gao@linaro.org>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
