### PR TITLE
Allow for generating kubernetes YAML files from modules 

### DIFF
--- a/lib/ansible/module_utils/k8s_common.py
+++ b/lib/ansible/module_utils/k8s_common.py
@@ -129,7 +129,9 @@ class KubernetesAnsibleModule(AnsibleModule):
         namespace = self.params.get('namespace', None)
         existing = None
 
-        return_attributes = dict(changed=False, api_version=self.api_version)
+        return_attributes = dict(changed=False,
+                                 api_version=self.api_version,
+                                 request=self.helper.request_body_from_params(self.params))
         return_attributes[self.helper.base_model_name_snake] = {}
 
         try:

--- a/lib/ansible/module_utils/k8s_common.py
+++ b/lib/ansible/module_utils/k8s_common.py
@@ -85,7 +85,17 @@ class KubernetesAnsibleModule(AnsibleModule):
         :return: dict: a valid Ansible argument spec
         """
         if not self.argspec_cache:
-            spec = {}
+            spec = {
+                'dry_run': {
+                    'type': 'bool',
+                    'default': False,
+                    'description': [
+                        "If set to C(True) the module will exit without executing any action."
+                        "Useful to only generate YAML file definitions for the resources in the tasks."
+                    ]
+                }
+            }
+
             for arg_name, arg_properties in self.helper.argspec.items():
                 spec[arg_name] = {}
                 for option, option_value in arg_properties.items():
@@ -125,6 +135,7 @@ class KubernetesAnsibleModule(AnsibleModule):
 
         state = self.params.get('state', None)
         force = self.params.get('force', False)
+        dry_run = self.params.pop('dry_run', False)
         name = self.params.get('name')
         namespace = self.params.get('namespace', None)
         existing = None
@@ -133,6 +144,9 @@ class KubernetesAnsibleModule(AnsibleModule):
                                  api_version=self.api_version,
                                  request=self.helper.request_body_from_params(self.params))
         return_attributes[self.helper.base_model_name_snake] = {}
+
+        if dry_run:
+            self.exit_json(**return_attributes)
 
         try:
             auth_options = {}


### PR DESCRIPTION
##### SUMMARY
This PR adds the ability to generate kubernetes YAML files from modules.

By adding the request's dictionary to the returned ansible results and the ability to have dry_run executions, we'll allow consumers of this module for registering the result variable and dumping the requests onto a YAML file for later use with other k8s specific CLI tools.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
k8s_common

##### ANSIBLE VERSION
```
ansible 2.4.0 (k8s_common c07a362ebc)
```
