### PR TITLE
Fix sending facts to Foreman

### DIFF
--- a/lib/ansible/plugins/callback/foreman.py
+++ b/lib/ansible/plugins/callback/foreman.py
@@ -197,7 +197,7 @@ class CallbackModule(CallbackBase):
         res = result._result
         module = result._task.action
 
-        if module == 'setup':
+        if module == 'setup' or 'ansible_facts' in res:
             host = result._host.get_name()
             self.send_facts(host, res)
         else:


### PR DESCRIPTION
##### SUMMARY
module setup is not always available, therefore the facts upload was never triggered, we can decide based on ansible_facts being present. If they are present, send them to Foreman.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Foreman callback script

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
1. setup Foreman and configure the callback
2. run ansible
3. there's no fact upload request in Foreman production.log
4. with this patch, ansible sends facts again