### PR TITLE
Add 2 modules for managing volumes in the Packet host

### DIFF
--- a/lib/ansible/modules/cloud/packet/packet_volume.py
+++ b/lib/ansible/modules/cloud/packet/packet_volume.py
@@ -1,0 +1,301 @@
+#!/usr/bin/python
+# Copyright 2017 Tomas Karasek <tom.to.the.k@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: packet_volume
+short_description: Create/delete a volume in Packet host.
+description:
+     - Create/delete a volume in Packet host.
+     - API is documented at U(https://www.packet.net/developers/api/volumes).
+version_added: "2.4"
+author: "Tomas Karasek <tom.to.the.k@gmail.com>"
+options:
+  state:
+    description:
+     - Ddesired state of the volume.
+    default: present
+    choices: ['present', 'absent']
+  project_id:
+    description:
+      - ID of project of the device.
+    required: true
+  auth_token:
+    description:
+     - Packet api token. You can also supply it in env var C(PACKET_API_TOKEN).
+  name:
+    description:
+     - Selector for API-generated name of the volume
+  description:
+    description:
+     - User-defined description attribute for Packet volume.
+     - "It is used used as idempotent identifier - if volume with given
+       description exists, new one is not created."
+  id:
+    description:
+     - UUID of a volume.
+  plan:
+    description:
+     - storage_1 for standard tier, storage_2 for premium tier.
+     - Tiers are described at U(https://www.packet.net/bare-metal/services/storage/).
+    choices: [storage_1, storage_2]
+    default: storage_1
+  facility:
+    description:
+     - Location of the volume.
+     - Volumes can only be attached to device in the same location.
+    choices: [ewr1, ams1, sjc1]
+  size:
+    description:
+     - Size of the volume in gigabytes.
+  locked:
+    description:
+     - Create new volume locked.
+    type: bool
+    default: False
+  billing_cycle:
+    description:
+     - Billing cycle for new volume.
+    choices: [hourly, monthly]
+  snapshot_policy:
+    description:
+      - Snapshot policy for new volume.
+    suboptions:
+      snapshot_count:
+        description:
+          - How many snaphots to keep, a postivie integer.
+        required: True
+      snapshot_frequency:
+        description:
+          - Frequency of snapshots.
+        required: True
+        choices: ["15min", "1hour", "1day", "1week", "1month", "1year"]
+
+requirements:
+  - "python >= 2.6"
+  - "packet-python >= 1.35"
+
+'''
+
+EXAMPLES = '''
+# All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
+# You can also pass the api token in module param auth_token.
+
+- hosts: localhost
+  vars:
+    volname: testvol123
+    project_id: 53000fb2-ee46-4673-93a8-de2c2bdba33b
+
+  tasks:
+    - name: test create volume
+      packet_volume:
+        description: "{{ volname }}"
+        project_id: "{{ project_id }}"
+        facility: 'ewr1'
+        plan: 'storage_1'
+        state: present
+        size: 10
+        snapshot_policy:
+          snapshot_count: 10
+          snapshot_frequency: 1day
+      register: result_create
+
+    - name: test delete volume
+      packet_volume:
+        id: "{{ result_create.id }}"
+        project_id: "{{ project_id }}"
+        state: absent
+'''
+
+RETURN = '''
+changed:
+    description: True if a volume was created or removed.
+    type: bool
+    sample: True
+    returned: success
+id:
+    description: UUID of specified volume
+    type: string
+    returned: success
+    sample: 53000fb2-ee46-4673-93a8-de2c2bdba33c
+name:
+    description: The API-generated name of the volume resource.
+    type: string
+    returned: if volume is attached/detached to/from some device
+    sample: "volume-a91dc506"
+description:
+    description: The user-defined description of the volume resource.
+    type: string
+    returned: success
+    sample: "Just another volume"
+'''  # NOQA
+
+import os
+import uuid
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+from __future__ import (absolute_import, division, print_function)
+
+HAS_PACKET_SDK = True
+
+
+try:
+    import packet
+except ImportError:
+    HAS_PACKET_SDK = False
+
+
+PACKET_API_TOKEN_ENV_VAR = "PACKET_API_TOKEN"
+
+VOLUME_STATES = ["present", "absent"]
+STORAGE_PLANS = ["storage_1", "storage_2"]
+STORAGE_FACILITIES = ["ewr1", "ams1", "sjc1"]
+BILLING = ["hourly", "monthly"]
+
+
+def is_valid_uuid(myuuid):
+    try:
+        val = uuid.UUID(myuuid, version=4)
+    except ValueError:
+        return False
+    return str(val) == myuuid
+
+
+def get_volume_selector(module):
+    if module.params.get('id'):
+        i = module.params.get('id')
+        if not is_valid_uuid(i):
+            raise Exception("Volume ID '%s' is not a valid UUID" % i)
+        return lambda v: v['id'] == i
+    elif module.params.get('name'):
+        n = module.params.get('name')
+        return lambda v: v['name'] == n
+    elif module.params.get('description'):
+        d = module.params.get('description')
+        return lambda v: v['description'] == d
+
+
+def get_or_fail(params, key):
+    item = params.get(key)
+    if item is None:
+        raise Exception("%s must be specified for new volume" % key)
+    return item
+
+
+def act_on_volume(target_state, module, packet_conn):
+    return_dict = {'changed': False}
+    s = get_volume_selector(module)
+    project_id = module.params.get("project_id")
+    api_method = "projects/%s/storage" % project_id
+    all_volumes = packet_conn.call_api(api_method, "GET")['volumes']
+    matching_volumes = [v for v in all_volumes if s(v)]
+
+    if target_state == "present":
+        if len(matching_volumes) == 0:
+            params = {
+                "description": get_or_fail(module.params, "description"),
+                "size": get_or_fail(module.params, "size"),
+                "plan": get_or_fail(module.params, "plan"),
+                "facility": get_or_fail(module.params, "facility"),
+                "locked": get_or_fail(module.params, "locked"),
+                "billing_cycle": get_or_fail(module.params, "billing_cycle"),
+                "snapshot_policies": module.params.get("snapshot_policy"),
+            }
+
+            new_volume_data = packet_conn.call_api(api_method, "POST", params)
+            return_dict['changed'] = True
+            for k in ['id', 'name', 'description']:
+                return_dict[k] = new_volume_data[k]
+
+        else:
+            for k in ['id', 'name', 'description']:
+                return_dict[k] = matching_volumes[0][k]
+
+    else:
+        if len(matching_volumes) > 1:
+            _msg = ("More than one volume matches in module call for absent state: %s"
+                    % matching_volumes)
+            raise Exception(_msg)
+        if len(matching_volumes) == 1:
+            volume = matching_volumes[0]
+            packet_conn.call_api("storage/%s" % volume['id'], "DELETE")
+            return_dict['changed'] = True
+            return_dict.update({k: volume[k] for k in ['id', 'name', 'description']})
+    return return_dict
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            id=dict(type='str', default=None),
+            description=dict(type="str", default=None),
+            name=dict(type='str', default=None),
+            state=dict(choices=VOLUME_STATES, default="present"),
+            auth_token=dict(default=os.environ.get(PACKET_API_TOKEN_ENV_VAR),
+                            no_log=True),
+            project_id=dict(required=True),
+            plan=dict(type="str", choices=STORAGE_PLANS, default="storage_1"),
+            facility=dict(type="str", choices=STORAGE_FACILITIES),
+            size=dict(type="int"),
+            locked=dict(type="bool", default=False),
+            snapshot_policy=dict(type='dict', default=None),
+            billing_cycle=dict(type='str', choices=BILLING, default="hourly"),
+        ),
+        required_one_of=[("name", "id", "description")],
+        mutually_exclusive=[
+            ('name', 'id'),
+            ('id', 'description'),
+            ('name', 'description'),
+        ]
+    )
+
+    if not HAS_PACKET_SDK:
+        module.fail_json(msg='packet required for this module')
+
+    if not module.params.get('auth_token'):
+        _fail_msg = ("if Packet API token is not in environment variable %s, "
+                     "the auth_token parameter is required" %
+                     PACKET_API_TOKEN_ENV_VAR)
+        module.fail_json(msg=_fail_msg)
+
+    auth_token = module.params.get('auth_token')
+
+    packet_conn = packet.Manager(auth_token=auth_token)
+
+    state = module.params.get('state')
+
+    if state in VOLUME_STATES:
+        try:
+            module.exit_json(**act_on_volume(state, module, packet_conn))
+        except Exception as e:
+            module.fail_json(
+                msg='failed to set volume state %s: %s' %
+                (state, e))
+    else:
+        module.fail_json(msg='%s is not a valid state for this module' % state)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/packet/packet_volume_attachment.py
+++ b/lib/ansible/modules/cloud/packet/packet_volume_attachment.py
@@ -1,0 +1,295 @@
+#!/usr/bin/python
+# Copyright 2017 Tomas Karasek <tom.to.the.k@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: packet_volume_attachment
+short_description: Attach/detach a volume to a device in the Packet host.
+description:
+     - Attach/detach a volume to a device in the Packet host.
+     - API is documented at U(https://www.packet.net/developers/api/volumeattachments/).
+     - "This module creates the attachment route in the Packet API. In order to discover
+       the block devices on the server, you have to run the Attach Scripts,
+       as documented at U(https://help.packet.net/technical/storage/packet-block-storage-linux)."
+version_added: "2.4"
+author: "Tomas Karasek <tom.to.the.k@gmail.com>"
+options:
+  state:
+    description:
+     - Indicate desired state of the attachment.
+    default: present
+    choices: ['present', 'absent']
+  auth_token:
+    description:
+     - Packet api token. You can also supply it in env var C(PACKET_API_TOKEN).
+  project_id:
+    description:
+     - UUID of the project to which the device and volume belong.
+  volume:
+    description:
+     - Selector for the volume.
+     - It can be a UUID, an API-generated volume name, or user-defined description string.
+     - 'Example values: 4a347482-b546-4f67-8300-fb5018ef0c5, volume-4a347482, "my volume"'
+  device:
+    description:
+     - Selector for the device.
+     - It can be a UUID of the device, or a hostname.
+     - 'Example values: 98a14f7a-3d27-4478-b7cf-35b5670523f3, "my device"'
+
+requirements:
+  - "python >= 2.6"
+  - "packet-python >= 1.35"
+
+'''
+
+EXAMPLES = '''
+# All the examples assume that you have your Packet API token in env var PACKET_API_TOKEN.
+# You can also pass the api token in module param auth_token.
+
+- hosts: localhost
+
+  vars:
+    volname: testvol
+    devname: testdev
+    project_id: 52000fb2-ee46-4673-93a8-de2c2bdba33b
+
+  tasks:
+    - name: test create volume
+      packet_volume:
+        description: "{{ volname }}"
+        project_id: "{{ project_id }}"
+        facility: ewr1
+        plan: storage_1
+        state: present
+        size: 10
+        snapshot_policy:
+          snapshot_count: 10
+          snapshot_frequency: 1day
+
+    - packet_device:
+        project_id: "{{ project_id }}"
+        hostnames: "{{ devname }}"
+        operating_system: ubuntu_16_04
+        plan: baremetal_0
+        facility: ewr1
+        state: present
+
+    - name: Attach testvol to testdev
+      packet_volume_attachment:
+        project_id: "{{ project_id }}"
+        volume: "{{ volname }}"
+        device: "{{ devname }}"
+
+    - name: Detach testvol from testdev
+      packet_volume_attachment:
+        project_id: "{{ project_id }}"
+        volume: "{{ volname }}"
+        device: "{{ devname }}"
+        state: absent
+
+'''
+
+RETURN = '''
+changed:
+    description: True if a volume was attached or detached.
+    type: bool
+    sample: True
+    returned: success
+volume_id:
+    description: UUID of volume addressed by the module call.
+    type: string
+    returned: success
+device_id:
+    description: UUID of device addressed by the module call. 
+    type: string
+    returned: success
+'''  # NOQA
+
+import os
+import uuid
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+from __future__ import (absolute_import, division, print_function)
+
+HAS_PACKET_SDK = True
+
+
+try:
+    import packet
+except ImportError:
+    HAS_PACKET_SDK = False
+
+
+PACKET_API_TOKEN_ENV_VAR = "PACKET_API_TOKEN"
+
+STATES = ["present", "absent"]
+
+
+def is_valid_uuid(myuuid):
+    try:
+        val = uuid.UUID(myuuid, version=4)
+    except ValueError:
+        return False
+    return str(val) == myuuid
+
+
+def get_volume_selector(spec):
+    if is_valid_uuid(spec):
+        return lambda v: v['id'] == spec
+    else:
+        return lambda v: v['name'] == spec or v['description'] == spec
+
+
+def get_device_selector(spec):
+    if is_valid_uuid(spec):
+        return lambda v: v['id'] == spec
+    else:
+        return lambda v: v['hostname'] == spec
+
+
+def do_attach(packet_conn, vol_id, dev_id):
+    api_method = "storage/%s/attachments" % vol_id
+    packet_conn.call_api(
+        api_method,
+        params={"device_id": dev_id},
+        type="POST")
+
+
+def do_detach(packet_conn, vol, dev_id=None):
+    def dev_match(a):
+        return (dev_id is None) or (a['device']['id'] == dev_id)
+    for a in vol['attachments']:
+        if dev_match(a):
+            print(a['href'])
+            packet_conn.call_api(a['href'], type="DELETE")
+
+
+def validate_selected(l, resource_type, spec):
+    if len(l) > 1:
+        _msg = ("more than one %s matches specification %s: %s" %
+                (resource_type, spec, l))
+        raise Exception(_msg)
+    if len(l) == 0:
+        _msg = "no %s matches specification: %s" % (resource_type, spec)
+        raise Exception(_msg)
+
+
+def get_attached_dev_ids(volume_dict):
+    if len(volume_dict['attachments']) == 0:
+        return []
+    else:
+        return [a['device']['id'] for a in volume_dict['attachments']]
+
+
+def act_on_volume_attachment(target_state, module, packet_conn):
+    return_dict = {'changed': False}
+    volspec = module.params.get("volume")
+    devspec = module.params.get("device")
+    if devspec is None and target_state == 'present':
+        raise ("If you want to attach a volume, you must specify a device.")
+    project_id = module.params.get("project_id")
+    volumes_api_method = "projects/%s/storage" % project_id
+    volumes = packet_conn.call_api(volumes_api_method,
+                                   params={'include': 'facility,attachments.device'})['volumes']
+    v_match = get_volume_selector(volspec)
+    matching_volumes = [v for v in volumes if v_match(v)]
+    validate_selected(matching_volumes, "volume", volspec)
+    volume = matching_volumes[0]
+    return_dict['volume_id'] = volume['id']
+
+    device = None
+    if devspec is not None:
+        devices_api_method = "projects/%s/devices" % project_id
+        devices = packet_conn.call_api(devices_api_method)['devices']
+        d_match = get_device_selector(devspec)
+        matching_devices = [d for d in devices if d_match(d)]
+        validate_selected(matching_devices, "device", devspec)
+        device = matching_devices[0]
+        return_dict['device_id'] = device['id']
+
+    attached_device_ids = get_attached_dev_ids(volume)
+
+    if target_state == "present":
+        if len(attached_device_ids) == 0:
+            do_attach(packet_conn, volume['id'], device['id'])
+            return_dict['changed'] = True
+        elif device['id'] not in attached_device_ids:
+            # Don't reattach volume which is attached to a different device.
+            # Rather fail than force remove a device on state == 'present'.
+            raise Exception("volume %s is already attached to device %s" %
+                            (volume, attached_device_ids))
+    else:
+        if device is None:
+            if len(attached_device_ids) > 0:
+                do_detach(packet_conn, volume)
+                return_dict['changed'] = True
+        elif device['id'] in attached_device_ids:
+            do_detach(packet_conn, volume, device['id'])
+            return_dict['changed'] = True
+
+    return return_dict
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            state=dict(choices=STATES, default="present"),
+            auth_token=dict(default=os.environ.get(PACKET_API_TOKEN_ENV_VAR),
+                            no_log=True),
+            volume=dict(type="str", required=True),
+            project_id=dict(type="str", required=True),
+            device=dict(type="str"),
+        ),
+    )
+
+    if not HAS_PACKET_SDK:
+        module.fail_json(msg='packet required for this module')
+
+    if not module.params.get('auth_token'):
+        _fail_msg = ("if Packet API token is not in environment variable %s, "
+                     "the auth_token parameter is required" %
+                     PACKET_API_TOKEN_ENV_VAR)
+        module.fail_json(msg=_fail_msg)
+
+    auth_token = module.params.get('auth_token')
+
+    packet_conn = packet.Manager(auth_token=auth_token)
+
+    state = module.params.get('state')
+
+    if state in STATES:
+        try:
+            module.exit_json(
+                **act_on_volume_attachment(state, module, packet_conn))
+        except Exception as e:
+            module.fail_json(
+                msg='failed to set volume_attachment state %s: %s' %
+                (state, e))
+    else:
+        module.fail_json(msg='%s is not a valid state for this module' % state)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
This PR adds 2 modules
- packet_volume for creating/removing block storage in the Packet Host
- packet_volume_attachment for attaching/detaching volume to a device in the Packet Host

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
- modules/cloud/packet/packet_volume
- modules/cloud/packet/packet_volume_attachment

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (packet-volume 7d1c2ef550) last updated 2017/08/07 15:33:27 (GMT +300)
  config file = None
  configured module search path = [u'/home/tomk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tomk/ansible/lib/ansible
  executable location = /home/tomk/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```

##### ADDITIONAL INFORMATION

There are no tests here. We had a discussion about integration tests for Packet modules in #23127, in email, and also in the Test group meeting (https://meetbot-raw.fedoraproject.org/ansible-meeting/2017-08-03/testing_working_group.2017-08-03-17.03.log.html#l-60). The resolution was that there's no way to add Packet API credentials to Ansible Shippable config, and there's no Packet sandbox API to take advantage of. 

I maintain some tests in https://github.com/t0mk/packet-ansible-tests/.