### PR TITLE
Fix module failure with pacemaker_cluster: state=cleanup

### DIFF
--- a/lib/ansible/modules/clustering/pacemaker_cluster.py
+++ b/lib/ansible/modules/clustering/pacemaker_cluster.py
@@ -219,7 +219,7 @@ def main():
             module.fail_json(msg="Failed during the restart of the cluster, the cluster can't be stopped")
 
     if state in ['cleanup']:
-        set_cluster(module, state, timeout, force)
+        clean_cluster(module, timeout)
         module.exit_json(changed=True,
                  out=cluster_state)
 

--- a/lib/ansible/modules/clustering/pacemaker_cluster.py
+++ b/lib/ansible/modules/clustering/pacemaker_cluster.py
@@ -220,8 +220,9 @@ def main():
 
     if state in ['cleanup']:
         clean_cluster(module, timeout)
+        cluster_state = get_cluster_status(module)
         module.exit_json(changed=True,
-                 out=cluster_state)
+                         out=cluster_state)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

##### SUMMARY


If state=cleanup was used, set_cluster() was being called
with 'cleanup' state which it doesn't handle. Instead
use existing clean_cluster() method.

**NOTE: This is a completely untested fix**


Fixes #27799


<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cluster/pacemaker_cluster.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (pacemaker_27799 8fb5ce57c5) last updated 2017/08/07 11:48:57 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```
