### PR TITLE
Fixes #23558 rpm key ids

### DIFF
--- a/lib/ansible/modules/packaging/os/rpm_key.py
+++ b/lib/ansible/modules/packaging/os/rpm_key.py
@@ -93,7 +93,7 @@ class RpmKey(object):
         self.gpg = self.module.get_bin_path('gpg')
         if not self.gpg:
             self.gpg = self.module.get_bin_path('gpg2',required=True)
-        
+
         if '://' in key:
             keyfile = self.fetch_key(key)
             keyid = self.getkeyid(keyfile)

--- a/lib/ansible/modules/packaging/os/rpm_key.py
+++ b/lib/ansible/modules/packaging/os/rpm_key.py
@@ -92,10 +92,8 @@ class RpmKey(object):
 
         self.gpg = self.module.get_bin_path('gpg')
         if not self.gpg:
-            self.gpg = self.module.get_bin_path('gpg2')
-        if not self.gpg:
-            self.module.fail_json(msg="rpm_key requires a command line gpg or gpg2, none found")
-
+            self.gpg = self.module.get_bin_path('gpg2',required=True)
+        
         if '://' in key:
             keyfile = self.fetch_key(key)
             keyid = self.getkeyid(keyfile)

--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -9,6 +9,11 @@
     url: https://download.fedoraproject.org/pub/epel/7/x86_64/s/sl-5.02-1.el7.x86_64.rpm
     dest: /tmp/sl.rpm
 
+- name: download Mono key
+  get_url:
+    url: http://keyserver.ubuntu.com/pks/lookup?op=get&search=0x3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
+    dest: /tmp/mono.gpg
+
 - name: remove EPEL GPG key from keyring
   rpm_key:
     state: absent
@@ -25,25 +30,40 @@
       - "'MISSING KEYS' in sl_check.stdout"
       - "sl_check.failed"
 
-- name: remove EPEL GPG key from keyring (Idempotant)
+- name: remove EPEL GPG key from keyring (idempotent)
   rpm_key:
     state: absent
     key: /tmp/RPM-GPG-KEY-EPEL-7
-  register: idempotant_test
+  register: idempotent_test
 
-- name: check Idempotant
+- name: check idempontence
   assert:
-    that: "not idempotant_test.changed"
+    that: "not idempotent_test.changed"
 
 - name: add EPEL GPG key to key ring
   rpm_key:
     state: present
     key: /tmp/RPM-GPG-KEY-EPEL-7
 
-- name: add EPEL GPG key to key ring (Idempotant)
+- name: add EPEL GPG key to key ring (idempotent)
   rpm_key:
     state: present
     key: /tmp/RPM-GPG-KEY-EPEL-7
+
+- name: add Mono gpg key
+  rpm_key:
+      state: present
+      key: /tmp/mono.gpg
+
+- name: add Mono gpg key
+  rpm_key:
+      state: present
+      key: /tmp/mono.gpg
+  register: mono_indempotence
+
+- name: verify idempotence
+  assert:
+    that: "not mono_indempotence.changed"
 
 - name: check GPG signature of sl. Should return okay
   shell: "rpm --checksig /tmp/sl.rpm"


### PR DESCRIPTION
##### SUMMARY
- fixup of bungled PR #23691 
- Changed rpm-keyid extraction method from extracting the first gpg-signature key-id of the key
to extraction the public keyid of the key
- Changed the rpm key verification method,
from comparing the short-gpgkeyid of the requested key with part of the installed  rpm-key packagenames
to
comparing the full gpg-keyid of the requested key to the keyids of all installed rpm-key-packages

Originally the keyid was extracted by calling:
```gpg --no-tty --batch --fixed-list-mode --with-colons --list-packet /tmp/key.1``` and grepping the first "signature packet", which in most cases is identical to the gpg-key-id of the key.
But it does not have to be the public-keyid. This can easily be extracted by calling 
`gpg --no-tty --batch --fixed-list-mode --with-colons /tmp/key.1` and grepping the pup-key part of the output.
 
Secondly the short gpgkey (last 8 Characters of the 16 character key) was extracted from the key found with the above method, and was compared to the package names of installed gpg-pupkey rpms: `rpm -qa gpg-pubkey`
This was changed to `rpm -qa gpg-pubkey --qf "%{description}"` which gets us the whole public key blocks of the packages, these are piped to `gpg --no-tty --batch --with-colons --fixed-list-mode -` and the full keyid is extracted from the package. These can now be compared to the keyid from the requested key, and a much more reliable comparision is archived

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/rpm_key.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (issue_23558_rpm_key_ids 8ce1ca82e0) last updated 2017/04/18 12:05:02 (GMT +200)
  config file = <redacted>/ansible/ansible.cfg
  configured module search path = [u'library']
  ansible python module location = <redacted>/ansible/lib/ansible
  executable location = <redacted>/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


