### PR TITLE
Add option to group ec2 instances by platform.

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -135,6 +135,7 @@ group_by_aws_account = False
 group_by_ami_id = True
 group_by_instance_type = True
 group_by_instance_state = False
+group_by_platform = True
 group_by_key_pair = True
 group_by_vpc_id = True
 group_by_security_group = True

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -930,6 +930,16 @@ class Ec2Inventory(object):
             if self.nested_groups:
                 self.push_group(self.inventory, 'instance_states', state_name)
 
+        # Inventory: Group by platform
+        if self.group_by_platform:
+            if instance.platform:
+                platform = self.to_safe('platform_' + instance.platform)
+            else:
+                platform = self.to_safe('platform_undefined')
+            self.push(self.inventory, platform, hostname)
+            if self.nested_groups:
+                self.push_group(self.inventory, 'platforms', platform)
+
         # Inventory: Group by key pair
         if self.group_by_key_pair and instance.key_name:
             key_name = self.to_safe('key_' + instance.key_name)


### PR DESCRIPTION
This is a reimplementation of [PR 14246](https://github.com/ansible/ansible/pull/14246) by @felipecvo. All credits to him.

I just changed the `dest` to `hostname` as requested previously by @s-hertel 

The below information copied from original PR.

##### SUMMARY
We have instances windows and linux in our environment, and for easy configuration for access, we need to group all windows instance together.

This PR allows me to:

*inventory/base.ini*

```
[platform_windows]

[windows:children]
platform_windows
```

And *inventory/group_vars/windows.yml*

```yaml
ansible_user: Administrator
ansible_password: SecretPasswordGoesHere
ansible_port: 5986
ansible_connection: winrm
ansible_winrm_server_cert_validation: ignore
```

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
contrib/inventory/ec2.py

##### ANSIBLE VERSION
```
2.3
```