### PR TITLE
get_url: get_url check if destination directory exists

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -502,7 +502,7 @@ def main():
         module.fail_json(msg="Request failed", status_code=info['status'], response=info['msg'])
     if not os.access(tmpsrc, os.R_OK):
         os.remove(tmpsrc)
-        module.fail_json(msg="Source %s not readable" % (tmpsrc))
+        module.fail_json(msg="Source %s is not readable" % (tmpsrc))
     checksum_src = module.sha1(tmpsrc)
 
     # check if there is no dest file
@@ -510,15 +510,18 @@ def main():
         # raise an error if copy has no permission on dest
         if not os.access(dest, os.W_OK):
             os.remove(tmpsrc)
-            module.fail_json(msg="Destination %s not writable" % (dest))
+            module.fail_json(msg="Destination %s is not writable" % (dest))
         if not os.access(dest, os.R_OK):
             os.remove(tmpsrc)
-            module.fail_json(msg="Destination %s not readable" % (dest))
+            module.fail_json(msg="Destination %s is not readable" % (dest))
         checksum_dest = module.sha1(dest)
     else:
+        if not os.path.exists(os.path.dirname(dest)):
+            os.remove(tmpsrc)
+            module.fail_json(msg="Destination %s does not exist" % (os.path.dirname(dest)))
         if not os.access(os.path.dirname(dest), os.W_OK):
             os.remove(tmpsrc)
-            module.fail_json(msg="Destination %s not writable" % (os.path.dirname(dest)))
+            module.fail_json(msg="Destination %s is not writable" % (os.path.dirname(dest)))
 
     backup_file = None
     if checksum_src != checksum_dest:


### PR DESCRIPTION
##### SUMMARY
Fix #27836 
With this fix ansible check if the dest directory exists before to check if it writable
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
get_url module

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/build/lib/ansible
  executable location = ./build/scripts-2.7/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION

BEFORE
```
$ ./build/scripts-2.7/ansible localhost -m get_url -a "url=http://www.google.it dest=/tmp/tmp/tmp1"
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Destination /tmp/tmp not writable"
}
```
AFTER
```
$ ./build/scripts-2.7/ansible localhost -m get_url -a "url=http://www.google.it dest=/tmp/tmp/tmp1"
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Destination /tmp/tmp not exist"
}
```