### PR TITLE
fixed a syntax problem that was preventing a warning box from being displayed

### DIFF
--- a/docs/docsite/rst/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network_debug_troubleshooting.rst
@@ -36,7 +36,7 @@ Errors generally fall into one of the following categories:
   * Not using ``connection: local``
 
 
-.. warning: ``unable to open shell`
+.. warning:: ``unable to open shell``
 
   The ``unable to open shell`` message is new in Ansible 2.3, it means that the ``ansible-connection`` daemon has not been able to successfully
   talk to the remote network device. This generally means that there is an authentication issue. See the "Authentication and connection issues" section
@@ -508,39 +508,38 @@ Add `authorize: yes` to the task. For example:
 
 .. delete_to not honoured
    ----------------------
-   
+
    FIXME Do we get an error message
-   
+
    FIXME Link to howto
-   
-   
-   
-   
+
+
+
+
    fixmes
    ======
-   
+
    Error: "number of connection attempts exceeded, unable to connect to control socket"
    ------------------------------------------------------------------------------------
-   
+
    **Platforms:** Any
-   
+
    This occurs when Ansible wasn't able to connect to the remote device and obtain a shell with the timeout.
-   
-   
+
+
    This information is available when ``ANSIBLE_LOG_PATH`` is set see (FIXMELINKTOSECTION):
-   
+
    .. code-block:: yaml
-   
+
      less $ANSIBLE_LOG_PATH
      2017-03-10 15:32:06,173 p=19677 u=fred |  connect retry timeout expired, unable to connect to control socket
      2017-03-10 15:32:06,174 p=19677 u=fred |  persistent_connect_retry_timeout is 15 secs
      2017-03-10 15:32:06,222 p=19669 u=fred |  fatal: [veos01]: FAILED! => {
-   
+
    Suggestions to resolve:
-   
+
    Do stuff For example:
-   
+
    .. code-block:: yaml
-   
+
    	Example stuff
-   


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
http://docs.ansible.com/ansible/latest/network_debug_troubleshooting.html is supposed to have a warning box between the "How to Troubleshoot" and "Enabling Networking logging and how to read the logfile" sections as per this section of the code:

```How to troubleshoot
===================

This section covers troubleshooting issues with Network Modules.

Errors generally fall into one of the following categories:

:Authentication issues:
  * Not correctly specifying credentials
  * Remote device (network switch/router) not falling back to other other authentication methods
  * SSH key issues
:Timeout issues:
  * Can occur when trying to pull a large amount of data
  * May actually be masking a authentication issue
:Playbook issues:
  * Use of ``delegate_to``, instead of ``ProxyCommand``
  * Not using ``connection: local``


.. warning: ``unable to open shell`

  The ``unable to open shell`` message is new in Ansible 2.3, it means that the ``ansible-connection`` daemon has not been able to successfully
  talk to the remote network device. This generally means that there is an authentication issue. See the "Authentication and connection issues" section
  in this document for more information.

.. _enable_network_logging:

Enabling Networking logging and how to read the logfile
-------------------------------------------------------
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (docs-unable-to-open-shell-warning 2377a3a516) last updated 2017/08/07 15:50:53 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
