### PR TITLE
Fixes #27626: blockinfile returns backup file name with backup: yes

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -329,9 +329,10 @@ def main():
         msg = 'Block inserted'
         changed = True
 
+    backup_file = None
     if changed and not module.check_mode:
         if module.boolean(params['backup']) and path_exists:
-            module.backup_local(path)
+            backup_file = module.backup_local(path)
         # We should always follow symlinks so that we change the real file
         real_path = os.path.realpath(params['path'])
         write_changes(module, result, real_path)
@@ -346,7 +347,10 @@ def main():
     attr_diff['after_header'] = '%s (file attributes)' % path
 
     difflist = [diff, attr_diff]
-    module.exit_json(changed=changed, msg=msg, diff=difflist)
+    if module.boolean(params['backup']) and path_exists:
+        module.exit_json(changed=changed, msg=msg, diff=difflist, backup_file=backup_file)
+    else:
+        module.exit_json(changed=changed, msg=msg, diff=difflist)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
Fix #27626  
With this changes, blockinfile module returns backup filename when backup=yes
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
blockinfile

##### ANSIBLE VERSION
```
$ ./build/scripts-2.7/ansible --version
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/build/lib/ansible
  executable location = ./build/scripts-2.7/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION

**BEFORE**
```
$ ./build/scripts-2.7/ansible-playbook /tmp/local.yml 
 
PLAY [localhost] *****************************************************************************

TASK [file] **********************************************************************************
changed: [localhost]

TASK [update line] ***************************************************************************
changed: [localhost]

TASK [debug] *********************************************************************************
ok: [localhost] => {
    "msg": {
        "backup": "/tmp/test.15424.2017-08-07@21:00:57~", 
        "changed": true, 
        "diff": [
            {
                "after": "", 
                "after_header": "/tmp/test (content)", 
                "before": "", 
                "before_header": "/tmp/test (content)"
            }, 
            {
                "after_header": "/tmp/test (file attributes)", 
                "before_header": "/tmp/test (file attributes)"
            }
        ], 
        "failed": false, 
        "msg": "line added"
    }
}

TASK [update block] **************************************************************************
changed: [localhost]

TASK [debug] *********************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": true, 
        "failed": false, 
        "msg": "Block inserted"
    }
}

PLAY RECAP ***********************************************************************************
localhost                  : ok=5    changed=3    unreachable=0    failed=0   
```
**AFTER*
```
$ ./build/scripts-2.7/ansible-playbook /tmp/local.yml 
 
PLAY [localhost] *****************************************************************************

TASK [file] **********************************************************************************
changed: [localhost]

TASK [update line] ***************************************************************************
changed: [localhost]

TASK [debug] *********************************************************************************
ok: [localhost] => {
    "msg": {
        "backup": "/tmp/test.16935.2017-08-07@21:22:21~", 
        "changed": true, 
        "diff": [
            {
                "after": "", 
                "after_header": "/tmp/test (content)", 
                "before": "", 
                "before_header": "/tmp/test (content)"
            }, 
            {
                "after_header": "/tmp/test (file attributes)", 
                "before_header": "/tmp/test (file attributes)"
            }
        ], 
        "failed": false, 
        "msg": "line added"
    }
}

TASK [update block] **************************************************************************
ok: [localhost]

TASK [debug] *********************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": false, 
        "failed": false, 
        "msg": ""
    }
}

PLAY RECAP ***********************************************************************************
localhost                  : ok=5    changed=2    unreachable=0    failed=0   

```
