### PR TITLE
hashi_vault: fix token logic again

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -68,10 +68,6 @@ class HashiVault:
 
         self.url = kwargs.get('url', ANSIBLE_HASHI_VAULT_ADDR)
 
-        self.token = kwargs.get('token')
-        if self.token is None:
-            raise AnsibleError("No Hashicorp Vault Token specified for hash_vault lookup")
-
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')
         if s is None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When #17824 was merged it restored an incorrect parameter check that was previously fixed in #21920. The lookup now supports alternative authentication methods so the token is not mandatory, and there are more ways of setting the token than passing it in as a module arg.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
hashi_vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (detached HEAD 5df4ff8983) last updated 2017/08/07 16:57:39 (GMT -400)
  config file = /home/ec2-user/ansible-aws-dev/ansible/ansible.cfg
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible-aws-dev/git/ansible.git/lib/ansible
  executable location = /home/ec2-user/ansible-aws-dev/git/ansible.git/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [certificate : mx-test.a.mail.umich.edu : Install private key] ************
fatal: [high-monika.mx-test.a.mail.umich.edu]: FAILED! => {"failed": true, "msg": "An unhandled exception occurred while running
 the lookup plugin 'hashi_vault'. Error was a <class 'ansible.errors.AnsibleError'>, original message: No Hashicorp Vault Token 
specified for hash_vault lookup"}
```

After:
```
TASK [certificate : mx-test.a.mail.umich.edu : Install private key] ************
ok: [high-monika.mx-test.a.mail.umich.edu]
```