### PR TITLE
EC2 ASG - Fix for desired, min and max size values not honored for values of 0

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -942,9 +942,9 @@ def create_autoscaling_group(connection, module):
                     attach_lb_target_groups(connection, group_name, tgs_to_attach)
 
         # check for attributes that aren't required for updating an existing ASG
-        desired_capacity = desired_capacity or as_group['DesiredCapacity']
-        min_size = min_size or as_group['MinSize']
-        max_size = max_size or as_group['MaxSize']
+        desired_capacity = desired_capacity if desired_capacity is not None else as_group['DesiredCapacity']
+        min_size = min_size if min_size is not None else as_group['MinSize']
+        max_size = max_size if max_size is not None else as_group['MaxSize']
         launch_config_name = launch_config_name or as_group['LaunchConfigurationName']
 
         launch_configs = describe_launch_configurations(connection, launch_config_name)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The current logic overwrites the user's request for a value of 0 for `desired_capacity`, `max_size` and `min_size`.  This fix allows values of 0 for these parameters and only uses the existing values when the parameter value is `None`.

This appears to have broken from 2.3 to 2.4.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/amazon/ec2_asg.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (ec2_asg_desired_count_fix bda10e7aea) last updated 2017/08/08 10:44:54 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/deployment/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/deployment/testing/ansible_latest/ansible/lib/ansible
  executable location = /home/deployment/testing/ansible_latest/ansible/bin/ansible
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]
You have new mail in /var/spool/mail/deployment
```
