### PR TITLE
Improve error messages when MySQLdb is not installed

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -276,7 +276,7 @@ def main():
     )
 
     if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+        module.fail_json(msg="The MySQL-python module is required.")
 
     db = module.params["name"]
     encoding = module.params["encoding"]

--- a/lib/ansible/modules/database/mysql/mysql_replication.py
+++ b/lib/ansible/modules/database/mysql/mysql_replication.py
@@ -243,7 +243,7 @@ def main():
     config_file = module.params['config_file']
 
     if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+        module.fail_json(msg="The MySQL-python module is required.")
     else:
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 

--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -591,7 +591,7 @@ def main():
     sql_log_bin = module.params["sql_log_bin"]
 
     if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+        module.fail_json(msg="The MySQL-python module is required.")
 
     cursor = None
     try:

--- a/lib/ansible/modules/database/mysql/mysql_variables.py
+++ b/lib/ansible/modules/database/mysql/mysql_variables.py
@@ -149,7 +149,7 @@ def main():
     if match('^[0-9a-z_]+$', mysqlvar) is None:
         module.fail_json(msg="invalid variable name \"%s\"" % mysqlvar)
     if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+        module.fail_json(msg="The MySQL-python module is required.")
     else:
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 


### PR DESCRIPTION
##### SUMMARY

The python package is called MySQL-python in pypi, and
reporting this rather than mysqldb makes resolving the
problem far easier.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mysql modules

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 5df4ff8983) last updated 2017/08/08 10:28:32 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
