### PR TITLE
Fix rabbitmq modules for python3 import

### DIFF
--- a/lib/ansible/modules/messaging/rabbitmq_binding.py
+++ b/lib/ansible/modules/messaging/rabbitmq_binding.py
@@ -103,15 +103,15 @@ EXAMPLES = '''
 '''
 
 import json
-import urllib
 
 try:
     import requests
     HAS_REQUESTS = True
-except ImportError as e:
+except ImportError:
     HAS_REQUESTS = False
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib import parse as urllib_parse
 
 
 def main():
@@ -143,15 +143,15 @@ def main():
     if module.params['routing_key'] == "":
         props = "~"
     else:
-        props = urllib.quote(module.params['routing_key'],'')
+        props = urllib_parse.quote(module.params['routing_key'],'')
 
     url = "http://%s:%s/api/bindings/%s/e/%s/%s/%s/%s" % (
         module.params['login_host'],
         module.params['login_port'],
-        urllib.quote(module.params['vhost'],''),
-        urllib.quote(module.params['name'],''),
+        urllib_parse.quote(module.params['vhost'],''),
+        urllib_parse.quote(module.params['name'],''),
         dest_type,
-        urllib.quote(module.params['destination'],''),
+        urllib_parse.quote(module.params['destination'],''),
         props
     )
 
@@ -190,10 +190,10 @@ def main():
             url = "http://%s:%s/api/bindings/%s/e/%s/%s/%s" % (
                 module.params['login_host'],
                 module.params['login_port'],
-                urllib.quote(module.params['vhost'],''),
-                urllib.quote(module.params['name'],''),
+                urllib_parse.quote(module.params['vhost'],''),
+                urllib_parse.quote(module.params['name'],''),
                 dest_type,
-                urllib.quote(module.params['destination'],'')
+                urllib_parse.quote(module.params['destination'],'')
             )
 
             r = requests.post(

--- a/lib/ansible/modules/messaging/rabbitmq_exchange.py
+++ b/lib/ansible/modules/messaging/rabbitmq_exchange.py
@@ -105,14 +105,15 @@ EXAMPLES = '''
 '''
 
 import json
+
 try:
     import requests
     HAS_REQUESTS = True
-except ImportError as e:
+except ImportError:
     HAS_REQUESTS = False
-import urllib
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib import parse as urllib_parse
 
 
 def main():
@@ -137,8 +138,8 @@ def main():
     url = "http://%s:%s/api/exchanges/%s/%s" % (
         module.params['login_host'],
         module.params['login_port'],
-        urllib.quote(module.params['vhost'],''),
-        urllib.quote(module.params['name'],'')
+        urllib_parse.quote(module.params['vhost'],''),
+        urllib_parse.quote(module.params['name'],'')
     )
 
     if not HAS_REQUESTS:

--- a/lib/ansible/modules/messaging/rabbitmq_queue.py
+++ b/lib/ansible/modules/messaging/rabbitmq_queue.py
@@ -120,14 +120,15 @@ EXAMPLES = '''
 '''
 
 import json
+
 try:
     import requests
     HAS_REQUESTS = True
-except ImportError as e:
+except ImportError:
     HAS_REQUESTS = False
-import urllib
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib import parse as urllib_parse
 
 
 def main():
@@ -155,7 +156,7 @@ def main():
     url = "http://%s:%s/api/queues/%s/%s" % (
         module.params['login_host'],
         module.params['login_port'],
-        urllib.quote(module.params['vhost'],''),
+        urllib_parse.quote(module.params['vhost'],''),
         module.params['name']
     )
 


### PR DESCRIPTION
Also get rid of unnecessary capture of exception into a variable for
python-2.4 compat.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rabbitmq_binding.py
rabbitmq_exchange.py
rabbitmq_queue.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.3
```


