### PR TITLE
Use atomic_move with get_url rather then shutil.copyfile

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -526,9 +526,10 @@ def main():
             if backup:
                 if os.path.exists(dest):
                     backup_file = module.backup_local(dest)
-            shutil.copyfile(tmpsrc, dest)
+            module.atomic_move(tmpsrc, dest)
         except Exception as e:
-            os.remove(tmpsrc)
+            if os.path.exists(tmpsrc):
+                os.remove(tmpsrc)
             module.fail_json(msg="failed to copy %s to %s: %s" % (tmpsrc, dest, to_native(e)),
                              exception=traceback.format_exc())
         changed = True
@@ -541,8 +542,6 @@ def main():
         if checksum != destination_checksum:
             os.remove(dest)
             module.fail_json(msg="The checksum for %s did not match %s; it was %s." % (dest, checksum, destination_checksum))
-
-    os.remove(tmpsrc)
 
     # allow file attribute changes
     module.params['path'] = dest


### PR DESCRIPTION
##### SUMMARY
This brings get_url inline with the other internal file handling modules, and allows replacement of in-use files.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel b629e36d3b) last updated 2017/07/20 15:14:54 (GMT +1100)
  config file = None
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible-work/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION
This addresses #24119 in the most direct way - the use of shutil.copyfile is replaced with the ansible.module.atomicmove command, which accomplishes the same effect and allows replacing in-use files similar to how the built-in copy module does.