### PR TITLE
[cloud] ovirt: add headers param to auth

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -143,6 +143,7 @@ def create_connection(auth):
         insecure=auth.get('insecure', False),
         token=auth.get('token', None),
         kerberos=auth.get('kerberos', None),
+        headers=dict(filter=auth.get('filter', False)),
     )
 
 

--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -143,7 +143,7 @@ def create_connection(auth):
         insecure=auth.get('insecure', False),
         token=auth.get('token', None),
         kerberos=auth.get('kerberos', None),
-        headers=dict(filter=auth.get('filter', False)),
+        headers=auth.get('headers', None),
     )
 
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -90,6 +90,7 @@ options:
         description:
             - "A boolean flag that indicates if a 'Filter: true' http header
                should be added to each API call."
+        version_added: "2.4"
 
 requirements:
   - python >= 2.7
@@ -176,7 +177,7 @@ ovirt_auth:
             type: bool
             sample: False
         filter:
-            description: Flag indicating if 'Filter: true' http header is added to each API call.
+            description: Flag indicating if a Filter http header should be added to each API call.
             returned: success
             type: bool
             sample: False

--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -85,11 +85,10 @@ options:
             - "A boolean flag indicating if Kerberos authentication
                should be used instead of the default basic authentication."
 
-    filter:
+    headers:
         required: False
         description:
-            - "A boolean flag that indicates if a 'Filter: true' http header
-               should be added to each API call."
+            - "A dictionary of HTTP headers to be added to each API call."
         version_added: "2.4"
 
 requirements:
@@ -176,11 +175,10 @@ ovirt_auth:
             returned: success
             type: bool
             sample: False
-        filter:
-            description: Flag indicating if a Filter http header should be added to each API call.
+        headers:
+            description: Dictionary of HTTP headers to be added to each API call.
             returned: success
-            type: bool
-            sample: False
+            type: dict
 '''
 
 import traceback
@@ -205,7 +203,7 @@ def main():
             timeout=dict(required=False, type='int', default=0),
             compress=dict(required=False, type='bool', default=True),
             kerberos=dict(required=False, type='bool', default=False),
-            filter=dict(required=False, type='bool', default=False),
+            headers=dict(required=False, type='dict'),
             state=dict(default='present', choices=['present', 'absent']),
             ovirt_auth=dict(required=None, type='dict'),
         ),
@@ -232,7 +230,7 @@ def main():
         timeout=params.get('timeout'),
         compress=params.get('compress'),
         kerberos=params.get('kerberos'),
-        filter=params.get('filter'),
+        headers=params.get('headers'),
         token=params.get('token'),
     )
     try:
@@ -248,7 +246,7 @@ def main():
                     timeout=params.get('timeout'),
                     compress=params.get('compress'),
                     kerberos=params.get('kerberos'),
-                    filter=params.get('filter'),
+                    headers=params.get('headers'),
                 ) if state == 'present' else dict()
             )
         )

--- a/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_auth.py
@@ -84,6 +84,13 @@ options:
         description:
             - "A boolean flag indicating if Kerberos authentication
                should be used instead of the default basic authentication."
+
+    filter:
+        required: False
+        description:
+            - "A boolean flag that indicates if a 'Filter: true' http header
+               should be added to each API call."
+
 requirements:
   - python >= 2.7
   - ovirt-engine-sdk-python >= 4.0.0
@@ -168,6 +175,11 @@ ovirt_auth:
             returned: success
             type: bool
             sample: False
+        filter:
+            description: Flag indicating if 'Filter: true' http header is added to each API call.
+            returned: success
+            type: bool
+            sample: False
 '''
 
 import traceback
@@ -192,6 +204,7 @@ def main():
             timeout=dict(required=False, type='int', default=0),
             compress=dict(required=False, type='bool', default=True),
             kerberos=dict(required=False, type='bool', default=False),
+            filter=dict(required=False, type='bool', default=False),
             state=dict(default='present', choices=['present', 'absent']),
             ovirt_auth=dict(required=None, type='dict'),
         ),
@@ -218,6 +231,7 @@ def main():
         timeout=params.get('timeout'),
         compress=params.get('compress'),
         kerberos=params.get('kerberos'),
+        filter=params.get('filter'),
         token=params.get('token'),
     )
     try:
@@ -233,6 +247,7 @@ def main():
                     timeout=params.get('timeout'),
                     compress=params.get('compress'),
                     kerberos=params.get('kerberos'),
+                    filter=params.get('filter'),
                 ) if state == 'present' else dict()
             )
         )

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -56,6 +56,8 @@ options:
             CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
             - "C(kerberos) - A boolean flag indicating if Kerberos authentication
             should be used instead of the default basic authentication."
+            - "C(filter) - A boolean flag that indicates if a 'Filter: true' http header
+            should be added to each API call."
     timeout:
         description:
             - "The amount of time in seconds the module should wait for the instance to

--- a/lib/ansible/utils/module_docs_fragments/ovirt.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt.py
@@ -56,8 +56,7 @@ options:
             CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
             - "C(kerberos) - A boolean flag indicating if Kerberos authentication
             should be used instead of the default basic authentication."
-            - "C(filter) - A boolean flag that indicates if a 'Filter: true' http header
-            should be added to each API call."
+            - "C(headers) - Dictionary of HTTP headers to be added to each API call."
     timeout:
         description:
             - "The amount of time in seconds the module should wait for the instance to

--- a/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
@@ -53,6 +53,8 @@ options:
             CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
             - "C(kerberos) - A boolean flag indicating if Kerberos authentication
             should be used instead of the default basic authentication."
+            - "C(filter) - A boolean flag that indicates if a 'Filter: true' http header
+            should be added to each API call."
 requirements:
   - python >= 2.7
   - ovirt-engine-sdk-python >= 4.0.0

--- a/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
+++ b/lib/ansible/utils/module_docs_fragments/ovirt_facts.py
@@ -53,8 +53,7 @@ options:
             CA certificate store is used. Default value is set by I(OVIRT_CAFILE) environment variable."
             - "C(kerberos) - A boolean flag indicating if Kerberos authentication
             should be used instead of the default basic authentication."
-            - "C(filter) - A boolean flag that indicates if a 'Filter: true' http header
-            should be added to each API call."
+            - "C(headers) - Dictionary of HTTP headers to be added to each API call."
 requirements:
   - python >= 2.7
   - ovirt-engine-sdk-python >= 4.0.0


### PR DESCRIPTION
##### SUMMARY
Adds a `headers` dict param to oVirt authentication.
This allows adding `Filter: true` http header to each API call (needed for non-admin users).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ovirt module

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
None
