### PR TITLE
ovirt_templates: fixed typo in doc

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -40,7 +40,7 @@ options:
     state:
         description:
             - "Should the template be present/absent/exported/imported/registered.
-               When C(state) is R(registered) and the unregistered template's name
+               When C(state) is I(registered) and the unregistered template's name
                belongs to an already registered in engine template then we fail
                to register the unregistered template."
         choices: ['present', 'absent', 'exported', 'imported', 'registered']
@@ -75,7 +75,7 @@ options:
     storage_domain:
         description:
             - "When C(state) is I(imported) this parameter specifies the name of the destination data storage domain.
-               When C(state) is R(registered) this parameter specifies the name of the data storage domain of the unregistered template."
+               When C(state) is I(registered) this parameter specifies the name of the data storage domain of the unregistered template."
     clone_permissions:
         description:
             - "If I(True) then the permissions of the VM (only the direct ones, not the inherited ones)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch fixes documentation typo, where `R()` is used instead of `I()`, in order to make text in brackets italic.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_templates

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
