### PR TITLE
Add delay and check configuration when interfaces is set on eos_vrf

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -76,6 +76,7 @@ from ansible.module_utils.eos import eos_argument_spec, check_args
 from ansible.module_utils.six import iteritems
 
 import re
+import time
 
 
 def map_obj_to_commands(updates, module):
@@ -157,6 +158,7 @@ def main():
         vlan_id=dict(required=True, type='int'),
         name=dict(),
         interfaces=dict(),
+        delay=(default=30, type=int)
         aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present',
@@ -189,6 +191,13 @@ def main():
             result['diff'] = {'prepared': response.get('diff')}
         result['session_name'] = response.get('session')
         result['changed'] = True
+
+    if interfaces:
+        time.sleep(module.params['delay'])
+
+        if False:
+            module.fail_json("Interface foo does not have VLAN configured")
+
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -76,7 +76,6 @@ from ansible.module_utils.eos import eos_argument_spec, check_args
 from ansible.module_utils.six import iteritems
 
 import re
-import time
 
 
 def map_obj_to_commands(updates, module):
@@ -158,7 +157,6 @@ def main():
         vlan_id=dict(required=True, type='int'),
         name=dict(),
         interfaces=dict(),
-        delay=(default=30, type=int)
         aggregate=dict(),
         purge=dict(default=False, type='bool'),
         state=dict(default='present',
@@ -191,13 +189,6 @@ def main():
             result['diff'] = {'prepared': response.get('diff')}
         result['session_name'] = response.get('session')
         result['changed'] = True
-
-    if interfaces:
-        time.sleep(module.params['delay'])
-
-        if False:
-            module.fail_json("Interface foo does not have VLAN configured")
-
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -199,7 +199,8 @@ def main():
         result['session_name'] = response.get('session')
         result['changed'] = True
 
-    check_declarative_intent_params(module)
+    if result['changed'] == True:
+        check_declarative_intent_params(module)
 
     module.exit_json(**result)
 

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -199,7 +199,7 @@ def main():
         result['session_name'] = response.get('session')
         result['changed'] = True
 
-    if result['changed'] == True:
+    if result['changed']:
         check_declarative_intent_params(module)
 
     module.exit_json(**result)

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -165,7 +165,7 @@ def main():
     argument_spec = dict(
         name=dict(required=True),
         interfaces=dict(type='list'),
-        delay=dict(default=30, type='int'),
+        delay=dict(default=10, type='int'),
         rd=dict(),
         aggregate=dict(),
         purge=dict(default=False, type='bool'),

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -78,6 +78,7 @@ from ansible.module_utils.eos import eos_argument_spec, check_args
 from ansible.module_utils.six import iteritems
 
 import re
+import time
 
 
 def map_obj_to_commands(updates, module):
@@ -147,12 +148,24 @@ def map_params_to_obj(module):
     }
 
 
+def check_declarative_intent_params(module):
+    if module.params['interfaces']:
+        time.sleep(module.params['delay'])
+        have = map_config_to_obj(module)
+        vrf = module.params['name']
+
+        for i in module.params['interfaces']:
+            if i not in have['interfaces']:
+                module.fail_json(msg="Interface %s not configured on vrf %s" % (i, vrf))
+
+
 def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
         name=dict(required=True),
         interfaces=dict(type='list'),
+        delay=dict(default=30, type='int'),
         rd=dict(),
         aggregate=dict(),
         purge=dict(default=False, type='bool'),
@@ -185,6 +198,8 @@ def main():
             result['diff'] = {'prepared': response.get('diff')}
         result['session_name'] = response.get('session')
         result['changed'] = True
+
+    check_declarative_intent_params(module)
 
     module.exit_json(**result)
 


### PR DESCRIPTION
Per the spec we put up for declarative intent modules, we need to check declarative
intent params (in the case of eos_vrf it's 'interfaces') after a delay and non-declarative
params have been set.
If that doesn't meet desired state after delay, we fail the task.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_vrf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (add_declarative_intent_delay_eos_vrf db6114a3de) last updated 2017/08/08 13:18:02 (GMT +200)

```