### PR TITLE
Fix typo in hashi_vault error message

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -70,7 +70,7 @@ class HashiVault:
 
         self.token = kwargs.get('token')
         if self.token is None:
-            raise AnsibleError("No Hashicorp Vault Token specified for hash_vault lookup")
+            raise AnsibleError("No Hashicorp Vault Token specified for hashi_vault lookup")
 
         # split secret arg, which has format 'secret/hello:value' into secret='secret/hello' and secret_field='value'
         s = kwargs.get('secret')


### PR DESCRIPTION
##### SUMMARY
Fix typo in hashi_vault lookup plugin error message

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hashi_vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0.0 (devel)
```
