### PR TITLE
Add fail on invalid arguments logic

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -162,6 +162,7 @@ def main():
     argument_spec.update(eos_argument_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
+                           fail_on_invalid_arguments=False,
                            supports_check_mode=True)
 
     warnings = list()

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -162,7 +162,6 @@ def main():
     argument_spec.update(eos_argument_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
-                           fail_on_invalid_arguments=False,
                            supports_check_mode=True)
 
     warnings = list()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
By default, a module will fail if task contains an argument that is not
valid in the argspec.
This change adds a flag that controls whether a module wants to fail
the task if that event occurs.
This is useful in non-standalone modules like package or the vendor
neutral network modules, where some arguments may not be present in
some implementation module and we don't want to bail out but just warn
and move on the play on that host/device.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/basic

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (add_fail_on_missing_arguments_logic 60e9d9a069) last updated 2017/08/08 15:07:43 (GMT +200)
```