### PR TITLE
Fix missing option in #27848

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -440,6 +440,7 @@ class Ec2Inventory(object):
             'group_by_ami_id',
             'group_by_instance_type',
             'group_by_instance_state',
+            'group_by_platform',
             'group_by_key_pair',
             'group_by_vpc_id',
             'group_by_security_group',


### PR DESCRIPTION
##### SUMMARY
Failed to add the new option to the array `group_by_options` in the initial PR #27848

By adding the new option it avoids the bug reported there.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`contrib/inventory/ec2.py`

##### ANSIBLE VERSION
```
2.3
```