### PR TITLE
conn,buildah: don't pass bytes to shlex.split

### DIFF
--- a/lib/ansible/plugins/connection/buildah.py
+++ b/lib/ansible/plugins/connection/buildah.py
@@ -49,7 +49,7 @@ import shutil
 import subprocess
 
 import ansible.constants as C
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase, ensure_connect
 
 
@@ -127,7 +127,8 @@ class Connection(ConnectionBase):
         """ run specified command in a running OCI container using buildah """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        cmd_args_list = shlex.split(cmd)
+        # shlex.split has a bug with text strings on Python-2.6 and can only handle text strings on Python-3
+        cmd_args_list = shlex.split(to_native(cmd, errors='surrogate_or_strict'))
 
         rc, stdout, stderr = self._buildah("run", cmd_args_list)
 

--- a/lib/ansible/plugins/connection/buildah.py
+++ b/lib/ansible/plugins/connection/buildah.py
@@ -127,8 +127,7 @@ class Connection(ConnectionBase):
         """ run specified command in a running OCI container using buildah """
         super(Connection, self).exec_command(cmd, in_data=in_data, sudoable=sudoable)
 
-        cmd_bytes = to_bytes(cmd, errors='surrogate_or_strict')
-        cmd_args_list = shlex.split(cmd_bytes)
+        cmd_args_list = shlex.split(cmd)
 
         rc, stdout, stderr = self._buildah("run", cmd_args_list)
 


### PR DESCRIPTION
##### SUMMARY

Getting this traceback using python 3:

```
Traceback (most recent call last):
  File "/root/.local/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 96, in run
    item_results = self._run_loop(items)
  File "/root/.local/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 291, in _run_loop
    res = self._execute(variables=task_vars)
  File "/root/.local/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 526, in _execute
    result = self._handler.run(task_vars=variables)
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/action/normal.py", line 45, in run
    results = merge_hash(results, self._execute_module(tmp=tmp, task_vars=task_vars, wrap_async=wrap_async))
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/action/__init__.py", line 638, in _execute_module
    tmp = self._make_tmp_path()
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/action/__init__.py", line 244, in _make_tmp_path
    tmpdir = self._remote_expand_user(self._play_context.remote_tmp_dir, sudoable=False)
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/action/__init__.py", line 548, in _remote_expand_user
    data = self._low_level_execute_command(cmd, sudoable=False)
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/action/__init__.py", line 895, in _low_level_execute_command
    rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/connection/__init__.py", line 52, in wrapped
    return func(self, *args, **kwargs)
  File "/root/.local/lib/python3.6/site-packages/ansible/plugins/connection/buildah.py", line 131, in exec_command
    cmd_args_list = shlex.split(cmd_bytes)
  File "/usr/lib64/python3.6/shlex.py", line 305, in split
    return list(lex)
  File "/usr/lib64/python3.6/shlex.py", line 295, in __next__
    token = self.get_token()
  File "/usr/lib64/python3.6/shlex.py", line 105, in get_token
    raw = self.read_token()
  File "/usr/lib64/python3.6/shlex.py", line 136, in read_token
    nextchar = self.instream.read(1)
AttributeError: 'bytes' object has no attribute 'read'
```

I locally tested all combinations (python2, python3, bytes, unicode) and indeed, the only combination, python 3 and bytes is raising traceback (`python3-3.6.2-4.fc27.x86_64`).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/buildah

##### ANSIBLE VERSION
2.4 (git HEAD)
