### PR TITLE
ovirt_templates: added option to name imported disk as a template

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -72,9 +72,11 @@ options:
         description:
             - "When C(state) is I(imported) and C(image_provider) is used this parameter specifies the name of disk
                to be imported as template."
+        aliases: ['glance_image_disk_name']
     template_image_disk_name:
         description:
-            - "When C(state) is I(imported) and C(image_provider) is used this parameter specifies the new name for imported disk.
+            - "When C(state) is I(imported) and C(image_provider) is used this parameter specifies the new name for imported disk,
+               if omitted then I(image_disk) name is used by default.
                This parameter is used only in case of importing disk image from Glance domain."
         version_added: "2.4"
     storage_domain:
@@ -121,6 +123,16 @@ EXAMPLES = '''
   name: mytemplate
   storage_domain: mystorage
   cluster: mycluster
+
+# Import image from Glance s a template
+- ovirt_templates:
+    state: imported
+    name: mytemplate
+    image_disk: "centos7"
+    template_image_disk_name: centos7_from_glance
+    image_provider: "glance_domain"
+    storage_domain: mystorage
+    cluster: mycluster
 '''
 
 RETURN = '''
@@ -233,7 +245,7 @@ def main():
         storage_domain=dict(default=None),
         exclusive=dict(type='bool'),
         image_provider=dict(default=None),
-        image_disk=dict(default=None),
+        image_disk=dict(default=None, aliases=['glance_image_disk_name']),
         template_image_disk_name=dict(default=None),
     )
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -76,6 +76,7 @@ options:
         description:
             - "When C(state) is I(imported) and C(image_provider) is used this parameter specifies the new name for imported disk.
                This parameter is used only in case of importing disk image from Glance domain."
+        version_added: "2.4"
     storage_domain:
         description:
             - "When C(state) is I(imported) this parameter specifies the name of the destination data storage domain.

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -72,6 +72,10 @@ options:
         description:
             - "When C(state) is I(imported) and C(image_provider) is used this parameter specifies the name of disk
                to be imported as template."
+    template_image_disk_name:
+        description:
+            - "When C(state) is I(imported) and C(image_provider) is used this parameter specifies the new name for imported disk.
+               This parameter is used only in case of importing disk image from Glance domain."
     storage_domain:
         description:
             - "When C(state) is I(imported) this parameter specifies the name of the destination data storage domain.
@@ -229,6 +233,7 @@ def main():
         exclusive=dict(type='bool'),
         image_provider=dict(default=None),
         image_disk=dict(default=None),
+        template_image_disk_name=dict(default=None),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -279,7 +284,7 @@ def main():
                 if module.params['image_provider']:
                     kwargs.update(
                         disk=otypes.Disk(
-                            name=module.params['image_disk']
+                            name=module.params['template_image_disk_name'] or module.params['image_disk']
                         ),
                         template=otypes.Template(
                             name=module.params['name'],


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When importing image from Glance as a template, it is handy feature that we can give different name to imported disk.

Partially Fixes: #27187 

Other part of that issue is not supported by oVirt Engine, so can not be covered as part of this PR.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_templates

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/lbednar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lbednar/ansible-sandbox/test-ansible/E/lib/python2.7/site-packages/ansible
  executable location = /home/lbednar/ansible-sandbox/test-ansible/E/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
    - ovirt_templates:
        auth: "{{ ovirt_auth }}"
        state: imported
        name: new-template
        image_provider: glance-domain
        image_disk: centos7
        template_image_disk_name: centos7_from_glance
        storage_domain: nfs_0
        cluster: Default
        wait: true
```
