### PR TITLE
Update docs to reflect new MAINTAINERS location

### DIFF
--- a/MODULE_GUIDELINES.md
+++ b/MODULE_GUIDELINES.md
@@ -49,7 +49,7 @@ A detailed explanation of the PR workflow can be seen here: https://github.com/a
 
 # Extras maintainers list
 
-The full list of maintainers for modules is located here: https://github.com/ansible/ansibullbot/blob/master/MAINTAINERS.txt
+The full list of maintainers for modules is located here: https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml
 
 ## Changing Maintainership
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -41,8 +41,8 @@ more likely it will be that a PR that reaches “shipit” will be
 mergeable.
 
 .. _Ansibull PR Triage Bot: https://github.com/ansible/ansibullbot/blob/master/triage.py
-.. _Core: https://github.com/ansible/ansibullbot/blob/master/MAINTAINERS-CORE.txt
-.. _Extras: https://github.com/ansible/ansibullbot/blob/master/MAINTAINERS-CORE.txt
+.. _Core: https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml
+.. _Extras: https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml
 
 Some modules have no community maintainers assigned. In this case, the
 maintainer is listed as “ansible”. Ultimately, it’s our goal to have at


### PR DESCRIPTION
##### SUMMARY
MAINTAINERS.txt no longer exists, updating references to the new location

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs only

##### ANSIBLE VERSION
```
ansible 2.4.0 (update_maintainers_doc c49aa859df) last updated 2017/08/08 10:34:54 (GMT -500)
  config file = /home/patrick/.ansible.cfg
  configured module search path = [u'/home/patrick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/patrick/git/ansible/lib/ansible
  executable location = /home/patrick/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

