### PR TITLE
New content for bugs and features

### DIFF
--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -1,13 +1,32 @@
 Reporting Bugs And Requesting Features
 ======================================
 
-What is a bug
--------------
-Has it already been filed
-Is there a PR in flight
+I'd Like To Report A Bug
+------------------------
 
+Ansible practices responsible disclosure - if this is a security related bug, email `security@ansible.com <mailto:security@ansible.com>`_ instead of filing a ticket or posting to the Google Group and you will receive a prompt response.
 
-What's a feature
------------------
+Ansible bugs should be reported to `github.com/ansible/ansible <https://github.com/ansible/ansible>`_ after
+signing up for a free GitHub account.  Before reporting a bug, please use the bug/issue search
+to see if the issue has already been reported. This is listed on the bottom of the docs page for any module.
 
-Feature vs proposal LINK docs/community/proposal_process.rst
+Knowing your ansible version and the exact commands you are running, and what you expect, saves time and helps us help everyone with their issues more quickly.
+
+Do not use the issue tracker for "how do I do this" type questions.  These are great candidates for IRC or the mailing list instead where things are likely to be more of a discussion.
+
+To be respectful of reviewers' time and allow us to help everyone efficiently, please  provide minimal well-reduced and well-commented examples versus sharing your entire production playbook.  Include playbook snippets and output where possible.
+
+When sharing YAML in playbooks, formatting can be preserved by using `code blocks <https://help.github.com/articles/creating-and-highlighting-code-blocks/>`_.
+
+For multiple-file content, we encourage use of gist.github.com.  Online pastebin content can expire, so it's nice to have things around for a longer term if they are referenced in a ticket.
+
+If you are not sure if something is a bug yet, you are welcome to ask about something on the mailing list or IRC first.  
+
+As we are a very high volume project, if you determine that you do have a bug, please be sure to open the issue yourself to ensure we have a record of it. Don’t rely on someone else in the community to file the bug report for you.
+
+Requesting a feature
+--------------------
+
+The best way to get a feature into Ansible is to submit a pull request.
+
+The next best way of getting a feature into Ansible is to submit a proposal through the Ansible proposal process: https://github.com/ansible/proposals


### PR DESCRIPTION
##### SUMMARY

1. Copies over "bug" content from existing rst/community.rst page (which will be refactored once all these pages are in.)

2. For features, pointed to the Proposals section, which we should probably leave in ansible/proposals, where it is actively used.

One piece of the ongoing community docs shift (https://github.com/ansible/community/issues/169).

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
n/a

##### ANSIBLE VERSION
n/a

##### ADDITIONAL INFORMATION
n/a