### PR TITLE
Fix typo in Pure Storage Volume module

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_volume.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_volume.py
@@ -157,7 +157,7 @@ def main():
         )
     )
 
-    required_if = [('state', 'present', ('size'))]
+    required_if = [('state', 'present', ['size'])]
 
     module = AnsibleModule(argument_spec,
                            required_if=required_if,


### PR DESCRIPTION
##### SUMMARY
Fix typo in required_if definition in Pure Storage Volume module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/storage/purestorage/purefa_vol

##### ANSIBLE VERSION
  ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/pureuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

##### ADDITIONAL INFORMATION
Round parenthesis used instead of square causing required_if statement to send wrong values.
This will always cause any purefa_volume create call to fail
```

```
