### PR TITLE
Don't compare group_vars paths with bytestrings

### DIFF
--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -122,7 +122,7 @@ class VarsModule(BaseVarsPlugin):
 
         found = []
         for spath in os.listdir(path):
-            if not spath.startswith('.') and not spath.endswith('~'):  # skip hidden and backups
+            if not spath.startswith(u'.') and not spath.endswith(u'~'):  # skip hidden and backups
 
                 ext = os.path.splitext(spath)[-1]
                 full_spath = os.path.join(path, spath)

--- a/lib/ansible/plugins/vars/host_group_vars.py
+++ b/lib/ansible/plugins/vars/host_group_vars.py
@@ -122,7 +122,7 @@ class VarsModule(BaseVarsPlugin):
 
         found = []
         for spath in os.listdir(path):
-            if not spath.startswith(b'.') and not spath.endswith(b'~'):  # skip hidden and backups
+            if not spath.startswith('.') and not spath.endswith('~'):  # skip hidden and backups
 
                 ext = os.path.splitext(spath)[-1]
                 full_spath = os.path.join(path, spath)


### PR DESCRIPTION
##### SUMMARY
Because the path variable which os.list_dir is given as an argument is converted to text with https://github.com/ansible/ansible/blob/3f12fccd02c1a6481ff61740071e67c82562e469/lib/ansible/plugins/vars/host_group_vars.py#L102, the results are provided as text, not binary strings, and must be compared to the same. 

##### ISSUE TYPE

 - Bugfix Pull Request
 
##### COMPONENT NAME
lib/ansible/plugins/vars/host_group_vars.py

##### ANSIBLE VERSION
I'm using the devel branch head with python 3.6 installed with pyenv.
```
ansible-playbook 2.4.0
  config file = None
  configured module search path = ['/Users/bschlueter/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/bschlueter/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/ansible
  executable location = /Users/bschlueter/.pyenv/versions/3.6.0/bin/ansible-playbook
  python version = 3.6.0 (default, Mar 30 2017, 19:42:07) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
No config file found; using defaults
setting up inventory plugins
Parsed /Users/bschlueter/workspace/personal/yas/.vagrant/provisioners/ansible/inventory/vagrant_ansible_inventory inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /Users/bschlueter/.pyenv/versions/3.6.0/Python.framework/Versions/3.6/lib/python3.6/site-packages/ansible/plugins/callback/__init__.py
```


##### ADDITIONAL INFORMATION
The original manifestation of the bug which this fixes was discussed in https://github.com/ansible/ansible/issues/25856.

This fixes 
```
ERROR! startswith first arg must be str or a tuple of str, not bytes
Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```
Which results when group_vars directories are present.