### PR TITLE
[WIP] fix templating on jinja 2.9 

### DIFF
--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -154,7 +154,6 @@ class ActionModule(ActionBase):
             resultant = self._templar.do_template(template_data, preserve_trailing_newlines=True, escape_backslashes=False)
             self._templar.set_available_variables(old_vars)
         except Exception as e:
-            raise
             result['failed'] = True
             result['msg'] = "%s: %s" % (type(e).__name__, to_text(e))
             return result

--- a/lib/ansible/plugins/action/template.py
+++ b/lib/ansible/plugins/action/template.py
@@ -154,6 +154,7 @@ class ActionModule(ActionBase):
             resultant = self._templar.do_template(template_data, preserve_trailing_newlines=True, escape_backslashes=False)
             self._templar.set_available_variables(old_vars)
         except Exception as e:
+            raise
             result['failed'] = True
             result['msg'] = "%s: %s" % (type(e).__name__, to_text(e))
             return result

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -647,7 +647,7 @@ class Templar:
                 data = _escape_backslashes(data, myenv)
 
             try:
-                t = myenv.from_string(data)
+                t = myenv.from_string(data, template_class=AnsibleJ2Template)
             except TemplateSyntaxError as e:
                 raise AnsibleError("template error while templating string: %s. String: %s" % (to_native(e), to_native(data)))
             except Exception as e:

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -212,7 +212,7 @@ class AnsibleEnvironment(Environment):
     values for the Template and Context classes used by jinja2 internally.
     '''
     context_class = AnsibleContext
-    template_class = AnsibleJ2Template
+    # template_class = AnsibleJ2Template
 
 
 class Templar:

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -57,6 +57,22 @@ class AnsibleJ2Vars:
                     elif key not in ('context', 'environment', 'template'):
                         self._locals[key] = val
 
+    def __iter__(self):
+        for k in self._templar._available_variables:
+            yield k, self._templar._available_variables
+
+        for k in self._locals:
+            yield k, self._locals[k]
+
+        for k in self._extras:
+            print('k: %s' % k)
+            for j in k:
+                print('j: %s' % j)
+                yield j
+
+        for k in self._globals:
+            yield k, self._globals[k]
+
     def __contains__(self, k):
         if k in self._templar._available_variables:
             return True
@@ -76,10 +92,7 @@ class AnsibleJ2Vars:
             for i in self._extras:
                 if varname in i:
                     return i[varname]
-            if varname in self._globals:
-                return self._globals[varname]
-            else:
-                raise KeyError("undefined variable: %s" % varname)
+            return self._globals[varname]
 
         variable = self._templar._available_variables[varname]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Make ansible.vars.AnsibleJ2Vars more dict like, so it doesnt cause jinja runtime to fail
trying to use an instance of it as an arg to dict()

Fixes #20494

Only like tested, but pr for CI 

TODO: add test cases and reproducers to git

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/template

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

ansible 2.4.0 (jinja_29_20494 ae15bf932d) last updated 2017/08/08 19:58:13 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
