### PR TITLE
alternatives: link is required when alternative is unknown

### DIFF
--- a/lib/ansible/modules/system/alternatives.py
+++ b/lib/ansible/modules/system/alternatives.py
@@ -37,7 +37,8 @@ options:
   link:
     description:
       - The path to the symbolic link that should point to the real executable.
-      - This option is required on RHEL-based distributions
+      - This option is always required on RHEL-based distributions. On Debian-based distributions this option is
+        required when the alternative I(name) is unknown to the system.
     required: false
   priority:
     description:


### PR DESCRIPTION
##### SUMMARY
Doc implied that `link` parameter was never required on Debian-based distribution. `link` is required when the alternative is unknown from the system.

Fixes #25598

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
alternatives

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.4.0 (devel 3ceeb5124e) last updated 2017/08/07 03:34:38 (GMT +200)
```