### PR TITLE
Change play timeout for persistent connection command timeout

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -2,9 +2,11 @@
 # This file is used by `ansible-test network-integration`
 
 [defaults]
-timeout = 60
 host_key_checking = False
 log_path = /tmp/ansible-test.out
 
 [ssh_connection]
 ssh_args = '-o UserKnownHostsFile=/dev/null'
+
+[persistent_connection]
+command_timeout = 60


### PR DESCRIPTION
There's been a change in persistent connect framework that switches
playbook timeout (which corresponds to 'timeout' param) to command_timeout.
While we fix this and return the functionality, let's put the command_timeout
in place to avoid CI being red.