### PR TITLE
command/shell: do not show passwords in logs

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -185,7 +185,7 @@ def main():
         err = b''
 
     result = dict(
-        cmd=args,
+        cmd=module.to_clean_args(args),
         stdout=out.rstrip(b"\r\n"),
         stderr=err.rstrip(b"\r\n"),
         rc=rc,

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -217,3 +217,23 @@
 
 - name: remove the previously created file
   file: path={{output_dir_test}}/afile.txt state=absent
+
+- name: execute a command with a password in the args
+  command: true --password=supersecret
+  register: command_result
+
+- name: check for password in the cmd
+  assert:
+    that:
+      - "'--password=supersecret' not in command_result.cmd"
+      - "'--password=********' in command_result.cmd"
+
+- name: execute a command via shell with a password in the args
+  shell: true --password=supersecret
+  register: shell_result
+
+- name: check for password in the cmd
+  assert:
+    that:
+      - "'--password=supersecret' not in shell_result.cmd"
+      - "'--password=********' in shell_result.cmd"


### PR DESCRIPTION
##### SUMMARY
When a command is executed with password argument via command/shell modules, this patch prevents the password being shown in the ansible output and in the logs.

This is a partial fix for https://github.com/ansible/ansible/issues/27941, only partial because you need to workaround the issue by using `--password` instead of `-p`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
command
shell

##### ANSIBLE VERSION
```
devel
```