### PR TITLE
ovirt_disks: added option to export disk to glance

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -138,6 +138,15 @@ options:
             - "Name of the openstack volume type. This is valid when working
                with cinder."
         version_added: "2.4"
+    image_provider:
+        description:
+            - "When C(state) is I(exported) disk is exported to given Glance image provider."
+            - "C(**IMPORTANT**)"
+            - "There is no reliable way to achieve idempotency, so every time
+               you specify this parameter the disk is exported, so please handle
+               your playbook accordingly to not export the disk all the time.
+               This option is valid only for template disks."
+        version_added: "2.4"
 extends_documentation_fragment: ovirt
 '''
 
@@ -188,6 +197,13 @@ EXAMPLES = '''
 - ovirt_disk:
     id: 7de90f31-222c-436c-a1ca-7e655bd5b60c
     download_image_path: /home/user/mydisk.qcow2
+
+# Export disk as image to Glance domain
+# Since Ansible 2.4
+- ovirt_disks:
+    id: 7de90f31-222c-436c-a1ca-7e655bd5b60c
+    image_provider: myglance
+    state: exported
 '''
 
 
@@ -515,7 +531,7 @@ class DiskAttachmentsModule(DisksModule):
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
-            choices=['present', 'absent', 'attached', 'detached'],
+            choices=['present', 'absent', 'attached', 'detached', 'exported'],
             default='present'
         ),
         id=dict(default=None),
@@ -536,6 +552,7 @@ def main():
         force=dict(default=False, type='bool'),
         sparsify=dict(default=None, type='bool'),
         openstack_volume_type=dict(default=None),
+        image_provider=dict(default=None),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -566,7 +583,7 @@ def main():
 
         ret = None
         # First take care of creating the VM, if needed:
-        if state == 'present' or state == 'detached' or state == 'attached':
+        if state in ('present', 'detached', 'attached', 'exported'):
             ret = disks_module.create(
                 entity=disk,
                 result_state=otypes.DiskStatus.OK if lun is None else None,
@@ -595,6 +612,13 @@ def main():
                     action='sparsify',
                     action_condition=lambda d: module.params['sparsify'],
                     wait_condition=lambda d: d.status == otypes.DiskStatus.OK,
+                )
+                # Export disk as image to glance domain
+                ret = disks_module.action(
+                    action='export',
+                    action_condition=lambda d: module.params['image_provider'],
+                    wait_condition=lambda d: d.status == otypes.DiskStatus.OK,
+                    storage_domain=otypes.StorageDomain(name=module.params['image_provider']),
                 )
         elif state == 'absent':
             ret = disks_module.remove()

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -622,7 +622,6 @@ def main():
                     msg="Can not export given disk '%s', it doesn't exist" %
                         module.params.get('name') or module.params.get('id')
                 )
-            disk = disks_service.disk_service(disk.id).get()
             if disk.storage_type == otypes.DiskStorageType.IMAGE:
                 ret = disks_module.action(
                     action='export',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
oVirt (4.1+) supports exporting disks of templates separately into OpenStack Glance storage.
Adding this feature there.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes: #26129

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_disks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/lbednar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lbednar/ansible-sandbox/test-ansible/E/lib/python2.7/site-packages/ansible
  executable location = /home/lbednar/ansible-sandbox/test-ansible/E/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
    - ovirt_disks:
        state: exported
        name: mytemplate-disk
        image_provider: myglance
        wait: true
```