### PR TITLE
Fix lookup into search paths when undefined.

### DIFF
--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -111,7 +111,7 @@ class LookupBase(with_metaclass(ABCMeta, object)):
         if 'ansible_search_path' in myvars:
             paths = myvars['ansible_search_path']
         else:
-            paths = self.get_basedir(myvars)
+            paths = [self.get_basedir(myvars)]
 
         result = None
         try:


### PR DESCRIPTION
##### SUMMARY
A fileglob may issue a warning `Unable to find xxxx in expected paths` when `ansible_search_path` is not defined, because it loops over the characters in the string instead of looping over a list of one element.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
library/plugin/lookup

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /home/eduardo/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Mar  6 2017, 16:32:24) [GCC 5.4.0]
```

##### ADDITIONAL INFORMATION
Create a role with a task like this:
```
- local_action:
    module: debug
    msg: "{{ item }}"
  with_fileglob: "test/*.txt"
```
and some files
```
# mkdir -p files/test
# touch files/test/{a,b,c}.txt
```
Run ansible.

