### PR TITLE
template, copy: support for archive, atime, mtime parameters

### DIFF
--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -275,6 +275,9 @@ def main():
             directory_mode=dict(type='raw'),
             remote_src=dict(type='bool'),
             local_follow=dict(type='bool'),
+            atime=dict(type='raw'),
+            mtime=dict(type='raw'),
+            archive=dict(type='bool')  # Dissolved into other parameters before delegation to remote host
         ),
         add_file_common_args=True,
         supports_check_mode=True,

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -181,6 +181,9 @@ def main():
             state=dict(choices=['file', 'directory', 'link', 'hard', 'touch', 'absent'], default=None),
             path=dict(aliases=['dest', 'name'], required=True, type='path'),
             original_basename=dict(required=False),  # Internal use only, for recursive ops
+            archive=dict(type='bool', required=False),  # Internal use only, delegated here (see template)
+            atime=dict(required=False),
+            mtime=dict(required=False),
             recurse=dict(default=False, type='bool'),
             force=dict(required=False, default=False, type='bool'),
             diff_peek=dict(default=None),  # Internal use only, for internal checks in the action plugins

--- a/lib/ansible/modules/files/template.py
+++ b/lib/ansible/modules/files/template.py
@@ -88,6 +88,12 @@ options:
     type: bool
     default: 'no'
     version_added: "2.4"
+  archive:
+    description:
+      - When set to true, the created file retains permissions and ownership of the source template file.
+    required: false
+    default: 'no'
+    version_added: "2.4"
 notes:
   - For Windows you can use M(win_template) which uses '\r\n' as C(newline_sequence).
   - Including a string that uses a date in the template will result in the template being marked 'changed' each time

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -712,6 +712,8 @@ class TestModuleUtilsBasic(ModuleTestCase):
         with patch('os.path.islink', return_value=True):
             with patch('os.path.realpath', return_value='/path/to/real_file'):
                 res = am.load_file_common_arguments(params=extended_params)
+                res.pop('mtime')  # just fail on non-existent mtime/atime as we can hardly test exact values
+                res.pop('atime')
                 self.assertEqual(res, final_params)
 
     def test_module_utils_basic_ansible_module_selinux_mls_enabled(self):


### PR DESCRIPTION
##### SUMMARY
template, copy: added support for new parameter 'archive' to allow retaining ownership and timestamps of the source(s) to allow creation of (templated) file with exact permissions on destination.

template, copy, file: added support for new parameters mtime, atime to allow setting access/mod datetime in unix touch format HHMMDDhhmi[.ss]. This is a feature required by the aforementioned template, copy 'archive' feature and cannot be split in separate pull request.

This is a third port of original pull request(s) not integrated in time:
for Ansible <1.7: https://github.com/ansible/ansible/pull/9143
for Ansible 1.7+ (multi-module): https://github.com/ansible/ansible/pull/9233, https://github.com/ansible/ansible-modules-core/pull/102

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
file, copy, template

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION
Commands template, copy support new parameter archive=True/False (default). When set to true, the created file retains permissions and ownership of the source template file. This allows seamless creation of templated scripts on the remote host.

Commands template, copy support new parameters atime=, mtime= allowing for creation of exactly-dated files on the destination host. This is useful for environments sensitive to file datetime changes.

```
Part of normal template, copy command operation, no special output. Remote permission checking part of implementation, difference yields a change indication in ansible console.
```
