### PR TITLE
nxos_smu: fix Structured output unsupported error in nxapi

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_smu.py
+++ b/lib/ansible/modules/network/nxos/nxos_smu.py
@@ -96,7 +96,8 @@ def execute_show_command(command, module, command_type='cli_show'):
             'command': command,
             'output': 'text',
         }]
-    else: cmds = [command]
+    else:
+        cmds = [command]
 
     return run_commands(module, cmds)
 

--- a/lib/ansible/modules/network/nxos/nxos_smu.py
+++ b/lib/ansible/modules/network/nxos/nxos_smu.py
@@ -89,17 +89,16 @@ import time
 import collections
 
 import re
-import re
 
 def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
-        cmds = [command]
-        body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
-        cmds = [command]
-        body = run_commands(module, cmds)
+    if command_type == 'cli_show_ascii':
+        cmds = [{
+            'command': command,
+            'output': 'text',
+        }]
+    else: cmds = [command]
 
-    return body
+    return run_commands(module, cmds)
 
 
 def remote_file_exists(module, dst, file_system='bootflash:'):
@@ -122,11 +121,18 @@ def get_commands(module, pkg, file_system):
     fixed_pkg = '.'.join(splitted_pkg[0:-1])
 
     command = 'show install inactive'
-    inactive_body = execute_show_command(command, module,
-                                                command_type='cli_show_ascii')
+    inactive_body = execute_show_command(
+        command,
+        module,
+        command_type='cli_show_ascii'
+    )
+
     command = 'show install active'
-    active_body = execute_show_command(command, module,
-                                                command_type='cli_show_ascii')
+    active_body = execute_show_command(
+        command,
+        module,
+        command_type='cli_show_ascii'
+    )
 
     if fixed_pkg not in inactive_body[0] and fixed_pkg not in active_body[0]:
         commands.append('install add {0}{1}'.format(file_system, pkg))
@@ -167,8 +173,9 @@ def main():
     remote_exists = remote_file_exists(module, pkg, file_system=file_system)
 
     if not remote_exists:
-        module.fail_json(msg="The requested package doesn't exist "
-                             "on the device")
+        module.fail_json(
+            msg="The requested package doesn't exist on the device"
+        )
 
     commands = get_commands(module, pkg, file_system)
     if not module.check_mode and commands:
@@ -178,12 +185,13 @@ def main():
     if 'configure' in commands:
         commands.pop(0)
 
-    module.exit_json(changed=changed,
-                     pkg=pkg,
-                     file_system=file_system,
-                     updates=commands)
+    module.exit_json(
+        changed=changed,
+        pkg=pkg,
+        file_system=file_system,
+        updates=commands
+    )
 
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #27561

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_smu

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxapi-transport-smu d9267aca00) last updated 2017/08/09 15:10:47 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
