### PR TITLE
Additional fix for #27167: port-channel interface idempotence

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -207,7 +207,10 @@ def get_value(arg, config, module):
 def get_existing(module, args):
     existing = {}
     netcfg = CustomNetworkConfig(indent=2, contents=get_config(module))
-    parents = ['interface {0}'.format(module.params['interface'].capitalize())]
+    if module.params['interface'].startswith('loopback') or module.params['interface'].startswith('port-channel'):
+        parents = ['interface {0}'.format(module.params['interface'])]
+    else:
+        parents = ['interface {0}'.format(module.params['interface'].capitalize())]
     config = netcfg.get_section(parents)
     if 'ospf' in config:
         for arg in args:
@@ -390,7 +393,7 @@ def main():
                                                'message_digest_password']],
                            supports_check_mode=True)
 
-    if not module.params['interface'].startswith('loopback'):
+    if not module.params['interface'].startswith('loopback') and not module.params['interface'].startswith('port-channel'):
         module.params['interface'] = module.params['interface'].capitalize()
 
     warnings = list()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #27167 - an additional idempotence issue was found with port-channel interfaces

Unlike regular interfaces and SVIs, port-channels are not nvgened with capitalization. This PR takes care of that and hence restores idempotence for port-channel interfaces.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_interface_ospf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 9339b0f4a7) last updated 2017/08/09 14:42:04 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
pytest test_nxos_interface_ospf.py 
=================================================================== test session starts ===================================================================
platform linux2 -- Python 2.7.6, pytest-3.1.2, py-1.4.34, pluggy-0.4.0
rootdir: /root/agents-ci/ansible, inifile:
collected 1 items 

test_nxos_interface_ospf.py .

================================================================ 1 passed in 0.10 seconds =================================================================
```
