### PR TITLE
Restore f5 unit test requirements.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -6,3 +6,4 @@ yamllint != 1.8.0 ; python_version < '2.7' # yamllint 1.8.0 requires python 2.7+
 isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previously passing pylint tests
 pycrypto >= 2.6 # Need features found in 2.6 and greater
 ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
+idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -1,6 +1,5 @@
 boto
 boto3
-idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 placebo
 cryptography
 pycrypto

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -1,5 +1,6 @@
 boto
 boto3
+idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 placebo
 cryptography
 pycrypto
@@ -18,6 +19,11 @@ setuptools > 0.6 # pytest-xdist installed via requirements does not work with ve
 unittest2 ; python_version < '2.7'
 netaddr
 ipaddress
+
+# requirements for F5 specific modules
+f5-sdk ; python_version >= '2.7'
+f5-icontrol-rest ; python_version >= '2.7'
+deepdiff
 
 # requirement for modules using Netconf protocol
 ncclient


### PR DESCRIPTION
##### SUMMARY

Restore f5 unit test requirements.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/runner/requirements/units.txt

##### ANSIBLE VERSION

```
ansible 2.4.0 (f5-tests d79dbb4963) last updated 2017/08/09 20:54:36 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
