### PR TITLE
Fix fallback and boolean check in argspec

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -115,9 +115,9 @@ NoneType = type(None)
 # this matters, make sure to check for strings before checking for sequencetype
 try:
     from collections.abc import KeysView
-    SEQUENCETYPE = (Sequence, KeysView)
+    SEQUENCETYPE = (Sequence, frozenset, KeysView)
 except:
-    SEQUENCETYPE = Sequence
+    SEQUENCETYPE = (Sequence, frozenset)
 
 try:
     import json
@@ -2044,7 +2044,7 @@ class AnsibleModule(object):
                     else:
                         fallback_args = item
                 try:
-                    param = fallback_strategy(*fallback_args, **fallback_kwargs)
+                    param[k] = fallback_strategy(*fallback_args, **fallback_kwargs)
                 except AnsibleFallbackNotFound:
                     continue
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #27978

*  Add missing assignment for param key in fallback handling
*  Add check for frozenset type
*  Unit test case
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
