### PR TITLE
pam_limits: fix add comment

### DIFF
--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -215,9 +215,6 @@ def main():
         if not new_comment:
             new_comment = old_comment
 
-        if new_comment:
-            new_comment = "\t#"+new_comment
-
         line_fields = newline.split(' ')
 
         if len(line_fields) != 4:
@@ -262,6 +259,8 @@ def main():
             # Change line only if value has changed
             if new_value != actual_value:
                 changed = True
+                if new_comment:
+                    new_comment = "\t#" + new_comment
                 new_limit = domain + "\t" + limit_type + "\t" + limit_item + "\t" + new_value + new_comment + "\n"
                 message = new_limit
                 nf.write(new_limit)
@@ -273,6 +272,8 @@ def main():
 
     if not found:
         changed = True
+        if new_comment:
+            new_comment = "\t#"+new_comment
         new_limit = domain + "\t" + limit_type + "\t" + limit_item + "\t" + new_value + new_comment + "\n"
         message = new_limit
         nf.write(new_limit)


### PR DESCRIPTION
##### SUMMARY
Fixes #27635 

Before this change the pam_limits module was broken when used with the parameter comment as reported in #27635 because it didn't add the hash character before the comment in limits.conf file
With this change, the problem has been solved.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pam_limits.py

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/g/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/g/PycharmProjects/ansible/build/lib/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Before the change the new_comment was formatted(to be wrote to the limits.conf file) in a loop each time that a string not starting with hash character was found in limits.conf (line 218-219 removed)
After the change the new_comment will be formatted only one time just before to be write in limits.conf (added line 262-263 275-276)

**Playbook used as test already included in #27635** 
```
$ cat /tmp/pam_limits.yml 
- name: Deploy
  hosts: localhost
  become: true
  become_user: root
  vars:
    user1_limits:
       - { domain: user1, type: soft, name: nofile, value: 1024, comment: User1 }
       - { domain: user1, type: hard, name: nofile, value: 65536, comment: User1 }
       - { domain: user1, type: soft, name: nproc, value: 2047, comment: User1 }
       - { domain: user1, type: hard, name: nproc, value: 16384, comment: User1 }
       - { domain: user1, type: soft, name: stack, value: 10240, comment: User1 }
       - { domain: user1, type: hard, name: stack, value: 32768, comment: User1 }
  tasks:
   - name: set user limits
     pam_limits:
       limit_item: "{{ item.name }}"
       limit_type: "{{ item.type }}"
       value: "{{ item.value }}"
       domain: "{{ item.domain }}"
       comment: "{{ item.comment }}"
     with_items: "{{ user1_limits }}"
```

**BEFORE:**
```
$ ./build/scripts-2.7/ansible-playbook /tmp/pam_limits.yml 

PLAY [Deploy] ********************************************************************************

TASK [Gathering Facts] ***********************************************************************
ok: [localhost]

TASK [set user limits] ***********************************************************************
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'soft', u'name': u'nofile', u'value': 1024})
failed: [localhost] (item={u'comment': u'User1', u'domain': u'user1', u'type': u'hard', u'name': u'nofile', u'value': 65536}) => {"changed": false, "failed": true, "item": {"comment": "User1", "domain": "user1", "name": "nofile", "type": "hard", "value": 65536}, "msg": "Invalid configuration of '/etc/security/limits.conf'. Current value of nofile is unsupported."}
failed: [localhost] (item={u'comment': u'User1', u'domain': u'user1', u'type': u'soft', u'name': u'nproc', u'value': 2047}) => {"changed": false, "failed": true, "item": {"comment": "User1", "domain": "user1", "name": "nproc", "type": "soft", "value": 2047}, "msg": "Invalid configuration of '/etc/security/limits.conf'. Current value of nofile is unsupported."}
failed: [localhost] (item={u'comment': u'User1', u'domain': u'user1', u'type': u'hard', u'name': u'nproc', u'value': 16384}) => {"changed": false, "failed": true, "item": {"comment": "User1", "domain": "user1", "name": "nproc", "type": "hard", "value": 16384}, "msg": "Invalid configuration of '/etc/security/limits.conf'. Current value of nofile is unsupported."}
failed: [localhost] (item={u'comment': u'User1', u'domain': u'user1', u'type': u'soft', u'name': u'stack', u'value': 10240}) => {"changed": false, "failed": true, "item": {"comment": "User1", "domain": "user1", "name": "stack", "type": "soft", "value": 10240}, "msg": "Invalid configuration of '/etc/security/limits.conf'. Current value of nofile is unsupported."}
failed: [localhost] (item={u'comment': u'User1', u'domain': u'user1', u'type': u'hard', u'name': u'stack', u'value': 32768}) => {"changed": false, "failed": true, "item": {"comment": "User1", "domain": "user1", "name": "stack", "type": "hard", "value": 32768}, "msg": "Invalid configuration of '/etc/security/limits.conf'. Current value of nofile is unsupported."}
	to retry, use: --limit @/tmp/pam_limits.retry

PLAY RECAP ***********************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   

$ tail /etc/security/limits.conf 
# ...
user1	soft	nofile	1024User1
```

**AFTER:**
```
$ ./build/scripts-2.7/ansible-playbook /tmp/pam_limits.yml 

PLAY [Deploy] ********************************************************************************

TASK [Gathering Facts] ***********************************************************************
ok: [localhost]

TASK [set user limits] ***********************************************************************
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'soft', u'name': u'nofile', u'value': 1024})
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'hard', u'name': u'nofile', u'value': 65536})
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'soft', u'name': u'nproc', u'value': 2047})
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'hard', u'name': u'nproc', u'value': 16384})
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'soft', u'name': u'stack', u'value': 10240})
changed: [localhost] => (item={u'comment': u'User1', u'domain': u'user1', u'type': u'hard', u'name': u'stack', u'value': 32768})

PLAY RECAP ***********************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0   

$ tail /etc/security/limits.conf 
# ...
user1	soft	nofile	1024	#User1
user1	hard	nofile	65536	#User1
user1	soft	nproc	2047	#User1
user1	hard	nproc	16384	#User1
user1	soft	stack	10240	#User1
user1	hard	stack	32768	#User1
```
