### PR TITLE
nxos_interface integration tests: ignore failures when trying to remove interfaces that are already mis…

### DIFF
--- a/test/integration/targets/nxos_interface/tests/cli/set_state_present.yaml
+++ b/test/integration/targets/nxos_interface/tests/cli/set_state_present.yaml
@@ -6,6 +6,7 @@
     lines:
       - no interface Loopback1
     provider: "{{ cli }}"
+  ignore_errors: yes # Fails if the interface is already absent
 
 - name: set state=present
   nxos_interface:

--- a/test/integration/targets/nxos_interface/tests/nxapi/set_state_present.yaml
+++ b/test/integration/targets/nxos_interface/tests/nxapi/set_state_present.yaml
@@ -6,6 +6,7 @@
     lines:
       - no interface Loopback1
     provider: "{{ nxapi }}"
+  ignore_errors: yes # Fails if the interface is already absent
 
 - name: set state=present
   nxos_interface:


### PR DESCRIPTION
…sing using nxos_config

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes: #27512

nxos_interface tests were failing because we were using nxos_config to try and remove loopback1 during setup, which fails if loopback1 is already absent.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxos-interface d40d360096) last updated 2017/08/10 09:12:02 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
