### PR TITLE
Fix incorrect bool check in Pure Storage modules

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_pg.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_pg.py
@@ -162,7 +162,7 @@ def delete_pgroup(module, array):
     changed = True
     if not module.check_mode:
         array.destroy_pgroup(module.params['pgroup'])
-        if module.params['eradicate'] == 'true':
+        if module.params['eradicate']:
             array.eradicate_pgroup(module.params['pgroup'])
     module.exit_json(changed=changed)
 

--- a/lib/ansible/modules/storage/purestorage/purefa_volume.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_volume.py
@@ -141,7 +141,7 @@ def delete_volume(module, array):
     """ Delete Volume"""
     if not module.check_mode:
         array.destroy_volume(module.params['name'])
-        if module.params['eradicate'] == 'true':
+        if module.params['eradicate']:
             array.eradicate_volume(module.params['name'])
     module.exit_json(changed=True)
 


### PR DESCRIPTION
##### SUMMARY
Fix an incorrect interpretation of a bool variable. 
Wasn't taking notice of the eradicate requests

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/storage/purestorage

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 1fb1793c70) last updated 2017/08/08 08:07:53 (GMT -700)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
Type of bool was incorrectly being checked in if statement. 
Corrected to use appropriate syntax