### PR TITLE
Remove eos group_vars creds and increase eapi timeout

### DIFF
--- a/test/integration/group_vars/eos.yaml
+++ b/test/integration/group_vars/eos.yaml
@@ -1,16 +1,13 @@
 ---
 cli:
   host: "{{ ansible_host }}"
-  username: "{{ eos_cli_user | default('admin') }}"
-  password: "{{ eos_cli_pass | default('admin') }}"
   transport: cli
   authorize: yes
 
 eapi:
   host: "{{ ansible_host }}"
-  username: "{{ eos_eapi_user | default('admin') }}"
-  password: "{{ eos_eapi_pass | default('admin') }}"
   transport: eapi
+  timeout: 60
   use_ssl: no
   port: 80
   authorize: yes


### PR DESCRIPTION
We don't need provider creds as we set those at inventory group vars,
increasing eapi timeout as some eapi tests are flip flopping with
timeouts.