### PR TITLE
win_file: Remove 'Create a file' example

### DIFF
--- a/lib/ansible/modules/windows/win_file.py
+++ b/lib/ansible/modules/windows/win_file.py
@@ -59,11 +59,6 @@ options:
 '''
 
 EXAMPLES = r'''
-- name: Create a file
-  win_file:
-    path: C:\Temp\foo.conf
-    state: file
-
 - name: Touch a file (creates if not present, updates modification time if present)
   win_file:
     path: C:\Temp\foo.conf


### PR DESCRIPTION
Fixes #28005

##### SUMMARY

Removes the misleading example in the win_file documentation.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

win_file