### PR TITLE
ansible-pull: add support to check mode

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -107,6 +107,8 @@ class PullCLI(CLI):
                                help='modified files in the working repository will be discarded')
         self.parser.add_option('--track-subs', dest='tracksubs', default=False, action='store_true',
                                help='submodules will track the latest changes. This is equivalent to specifying the --remote flag to git submodule update')
+        self.parser.add_option("--check", default=False, dest='check', action='store_true',
+                               help="don't make any changes; instead, try to predict some of the changes that may occur")
 
         # for pull we don't want a default
         self.parser.set_defaults(inventory=None)
@@ -243,6 +245,8 @@ class PullCLI(CLI):
             cmd += ' -l "%s"' % self.options.subset
         else:
             cmd += ' -l "%s"' % limit_opts
+        if self.options.check:
+            cmd += ' -C'
 
         os.chdir(self.options.dest)
 


### PR DESCRIPTION
##### SUMMARY

Add check mode support in ansible-pull command

Fixes #27989 

I have used as argument only --check avoing any short argument format as for instance '-C" because it has been already assigned to "-C CHECKOUT" in ansible-pull

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-pull

##### ANSIBLE VERSION
```
$ ./build/scripts-2.7/ansible-pull --version
ansible-pull 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gluster volume heal /.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /PycharmProjects/ansible/build/lib/ansible
  executable location = ./build/scripts-2.7/ansible-pull
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
BEFORE
```
$ ansible-pull -U /tmp/gitrepo -d /tmp/gitlocalrepo -C master --check
Usage: ansible-pull -U <repository> [options] [<playbook.yml>]

ansible-pull: error: --checkout option requires an argument
```
AFTER
```
$ ansible-pull -U /tmp/gitrepo -d /tmp/gitlocalrepo -C master --check
Starting Ansible Pull at 2017-08-10 19:44:34
/usr/bin/ansible-pull -U /tmp/gitrepo -d /tmp/gitlocalrepo -C master --check
 [WARNING]: Could not match supplied host pattern, ignoring: gsciorti
gsciorti.localdomain | SUCCESS => {
    "after": "2b3ff3a5f278f7ab35ab53f75d3b803c2e2b1aac", 
    "before": "2b3ff3a5f278f7ab35ab53f75d3b803c2e2b1aac", 
    "changed": false, 
    "failed": false, 
    "remote_url_changed": false
}

PLAY [all] ***********************************************************************************

TASK [command] *******************************************************************************
skipping: [g.localdomain]

PLAY RECAP ***********************************************************************************
gsciorti.localdomain       : ok=0    changed=0    unreachable=0    failed=0   
```