### PR TITLE
playbooks_delegation: Minor fix in doc

### DIFF
--- a/docs/docsite/rst/playbooks_delegation.rst
+++ b/docs/docsite/rst/playbooks_delegation.rst
@@ -16,6 +16,7 @@ You should also consult the :doc:`modules` section, various modules like 'ec2_el
 You'll also want to read up on :doc:`playbooks_reuse_roles`, as the 'pre_task' and 'post_task' concepts are the places where you would typically call these modules.
 
 Be aware that certain tasks are impossible to delegate, i.e. `include`, `add_host`, `debug`, etc as they always execute on the controller.
+
 .. _rolling_update_batch_size:
 
 Rolling Update Batch Size


### PR DESCRIPTION
##### SUMMARY
This fixes a documentation typo by adding a new blank line before .. _rolling_update_batch_size:

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
playbooks_delegation

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

```
