### PR TITLE
panos_dag_tags: create tags for dynamic address objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -516,6 +516,7 @@ Ansible Changes By Release
   * nuage_vpsk
 - panos
   * panos_sag
+  * panos_dag_tags
 - purestorage
   * purefa_hg
   * purefa_host

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -19,6 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
 DOCUMENTATION = '''
 ---
 module: panos_dag_tags
@@ -63,9 +67,6 @@ RETURN = '''
 # Default return values
 '''
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'metadata_version': '1.0'}
 
 from ansible.module_utils.basic import AnsibleModule, get_exception
 

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -1,0 +1,207 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Ansible module to manage PaloAltoNetworks Firewall
+# (c) 2016, techbizdev <techbizdev@paloaltonetworks.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: panos_dag_tags
+short_description: Create tags for DAG's
+description:
+    - Create the ip address to tag associations. Tags will in turn be used to create DAG's
+author: "Vinay Venkataraghavan @vinayvenkat"
+version_added: "2.4"
+requirements:
+    - pan-python
+    - pan-device
+options:
+    ip_address:
+        description:
+            - IP address (or hostname) of PAN-OS device
+        required: true
+        default: null
+    password:
+        description:
+            - password for authentication
+        required: true
+        default: null
+    username:
+        description:
+            - username for authentication
+        required: false
+        default: "admin"
+    description:
+        description:
+            - The purpose / objective of the static Address Group
+        required: false
+        default: null
+    commit:
+        description:
+            - commit if changed
+        required: false
+        default: true
+    
+'''
+
+RETURN = '''
+# Default return values
+'''
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.0'}
+
+from ansible.module_utils.basic import AnsibleModule, get_exception
+
+try:
+    from pandevice import base
+    from pandevice import firewall
+    from pandevice import panorama
+    from pandevice import objects
+
+    HAS_LIB = True
+except ImportError:
+    HAS_LIB = False
+
+def register_ip_to_tag_map(device, ip_addresses, tag):
+    """
+    
+    :param device: 
+    :param ip_addresses: 
+    :param tag: 
+    :return: 
+    """
+
+    exc = None
+    try:
+        device.userid.register(ip_addresses, tag)
+    except Exception, e:
+            exc = get_exception()
+
+    if exc:
+        return (False, exc)
+    else:
+        return (True, exc)
+
+def get_all_address_group_mapping(device):
+    """
+    Retrieve all the tag to IP address mappings
+    :param device: 
+    :return: 
+    """
+    exc = None
+    ret = None
+    try:
+        ret = device.userid.get_registered_ip()
+    except Exception, e:
+        exc = get_exception()
+
+    if exc:
+        return (False, exc)
+    else:
+        return (ret, exc)
+
+def delete_address_from_mapping(device, ip_address, tags):
+    """
+    Delete an IP address from a tag mapping. 
+    :param device: 
+    :param ip_address:
+    :param tags: 
+    :return: 
+    """
+
+    exc = None
+    try:
+        ret = device.userid.unregister(ip_address, tags)
+    except Exception, e:
+        exc = get_exception()
+
+    if exc:
+        return (False, exc)
+    else:
+        return (True, exc)
+
+def main():
+
+    argument_spec = dict(
+        ip_address=dict(required=True),
+        password=dict(required=True),
+        username=dict(default='admin'),
+        api_key=dict(no_log=True),
+        devicegroup=dict(default=None),
+        description=dict(default=None),
+        ip_to_register=dict(type='str', required=False),
+        tag_names=dict(type='list', required=True),
+        commit=dict(type='bool', default=True),
+        operation=dict(type='str', required=True)
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    if not HAS_LIB:
+        module.fail_json(msg='pan-python is required for this module')
+
+    ip_address = module.params["ip_address"]
+    password = module.params["password"]
+    username = module.params['username']
+    api_key = module.params['api_key']
+    commit = module.params['commit']
+    devicegroup = module.params['devicegroup']
+    operation = module.params['operation']
+
+    # Create the device with the appropriate pandevice type
+    device = base.PanDevice.create_from_device(ip_address, username, password, api_key=api_key)
+
+    # If Panorama, validate the devicegroup
+    dev_group = None
+    if devicegroup and isinstance(device, panorama.Panorama):
+        dev_group = get_devicegroup(device, devicegroup)
+        if dev_group:
+            device.add(dev_group)
+        else:
+            module.fail_json(msg='\'%s\' device group not found in Panorama. Is the name correct?' % devicegroup)
+
+    result = None
+    if operation == 'add':
+        result, exc = register_ip_to_tag_map(device,
+                               ip_addresses=module.params.get('ip_to_register', None),
+                               tag=module.params.get('tag_names', None)
+                      )
+    elif operation == 'list':
+        result, exc = get_all_address_group_mapping(device)
+    elif operation == 'delete':
+        result, exc = delete_address_from_mapping(device,
+                                                  ip_address=module.params.get('ip_to_register', None),
+                                                  tags=module.params.get('tag_names', [])
+                      )
+    else:
+        module.fail_json(msg="Unsupported option")
+
+    if not result:
+        module.fail_json(msg=exc)
+
+    if commit:
+        try:
+            device.commit(sync=True)
+        except Exception, e:
+            module.fail_json(get_exception())
+
+    module.exit_json(changed=True, msg=result)
+
+if __name__ == "__main__":
+    main()

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -101,8 +101,9 @@ def register_ip_to_tag_map(device, ip_addresses, tag):
     exc = None
     try:
         device.userid.register(ip_addresses, tag)
-    except Exception, e:
+    except Exception:
         exc = get_exception()
+        return False, exc
 
     if exc:
         return False, exc
@@ -120,7 +121,7 @@ def get_all_address_group_mapping(device):
     ret = None
     try:
         ret = device.userid.get_registered_ip()
-    except Exception, e:
+    except Exception:
         exc = get_exception()
 
     if exc:
@@ -141,7 +142,7 @@ def delete_address_from_mapping(device, ip_address, tags):
     exc = None
     try:
         ret = device.userid.unregister(ip_address, tags)
-    except Exception, e:
+    except Exception:
         exc = get_exception()
 
     if exc:
@@ -210,8 +211,9 @@ def main():
     if commit:
         try:
             device.commit(sync=True)
-        except Exception, e:
-            module.fail_json(get_exception())
+        except Exception:
+            exc = get_exception()
+            module.fail_json(msg=exc)
 
     module.exit_json(changed=True, msg=result)
 

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -80,6 +80,15 @@ except ImportError:
     HAS_LIB = False
 
 
+def get_devicegroup(device, devicegroup):
+    dg_list = device.refresh_devices()
+    for group in dg_list:
+        if isinstance(group, panorama.DeviceGroup):
+            if group.name == devicegroup:
+                return group
+    return False
+
+
 def register_ip_to_tag_map(device, ip_addresses, tag):
     """
     

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -63,6 +63,37 @@ options:
     
 '''
 
+EXAMPLES = '''
+- name: Create the tags to map IP addresses
+  panos_dag_tags:
+    ip_address: "{{ mgmt_ip }}"
+    password: "{{ admin_password }}"
+    ip_to_register: "{{ ip_to_register }}"
+    tag_names: "{{ tag_names }}"
+    description: "Tags to allow certain IP's to access various SaaS Applications"
+    operation: 'add'
+  tags: "add-dagip"
+
+- name: List the IP address to tag mapping
+  panos_dag_tags:
+    ip_address: "{{ mgmt_ip }}"
+    password: "{{ admin_password }}"
+    tag_names: "{{ tag_names }}"
+    description: "List the IP address to tag mapping"
+    operation: 'list'
+  tags: "list-dagip"
+
+- name: Unregister an IP address from a tag mapping
+  panos_dag_tags:
+    ip_address: "{{ mgmt_ip }}"
+    password: "{{ admin_password }}"
+    ip_to_register: "{{ ip_to_register }}"
+    tag_names: "{{ tag_names }}"
+    description: "Unregister IP address from tag mappings"
+    operation: 'delete'
+  tags: "delete-dagip"
+'''
+
 RETURN = '''
 # Default return values
 '''

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -79,6 +79,7 @@ try:
 except ImportError:
     HAS_LIB = False
 
+
 def register_ip_to_tag_map(device, ip_addresses, tag):
     """
     
@@ -92,12 +93,13 @@ def register_ip_to_tag_map(device, ip_addresses, tag):
     try:
         device.userid.register(ip_addresses, tag)
     except Exception, e:
-            exc = get_exception()
+        exc = get_exception()
 
     if exc:
-        return (False, exc)
+        return False, exc
     else:
-        return (True, exc)
+        return True, exc
+
 
 def get_all_address_group_mapping(device):
     """
@@ -113,9 +115,10 @@ def get_all_address_group_mapping(device):
         exc = get_exception()
 
     if exc:
-        return (False, exc)
+        return False, exc
     else:
-        return (ret, exc)
+        return ret, exc
+
 
 def delete_address_from_mapping(device, ip_address, tags):
     """
@@ -133,12 +136,12 @@ def delete_address_from_mapping(device, ip_address, tags):
         exc = get_exception()
 
     if exc:
-        return (False, exc)
+        return False, exc
     else:
-        return (True, exc)
+        return True, exc
+
 
 def main():
-
     argument_spec = dict(
         ip_address=dict(required=True),
         password=dict(required=True),
@@ -179,16 +182,16 @@ def main():
     result = None
     if operation == 'add':
         result, exc = register_ip_to_tag_map(device,
-                               ip_addresses=module.params.get('ip_to_register', None),
-                               tag=module.params.get('tag_names', None)
-                      )
+                                             ip_addresses=module.params.get('ip_to_register', None),
+                                             tag=module.params.get('tag_names', None)
+                                             )
     elif operation == 'list':
         result, exc = get_all_address_group_mapping(device)
     elif operation == 'delete':
         result, exc = delete_address_from_mapping(device,
                                                   ip_address=module.params.get('ip_to_register', None),
                                                   tags=module.params.get('tag_names', [])
-                      )
+                                                  )
     else:
         module.fail_json(msg="Unsupported option")
 
@@ -202,6 +205,7 @@ def main():
             module.fail_json(get_exception())
 
     module.exit_json(changed=True, msg=result)
+
 
 if __name__ == "__main__":
     main()

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -60,7 +60,6 @@ options:
             - commit if changed
         required: false
         default: true
-    
 '''
 
 EXAMPLES = '''
@@ -123,11 +122,10 @@ def get_devicegroup(device, devicegroup):
 
 def register_ip_to_tag_map(device, ip_addresses, tag):
     """
-    
-    :param device: 
-    :param ip_addresses: 
-    :param tag: 
-    :return: 
+    :param device:
+    :param ip_addresses:
+    :param tag:
+    :return:
     """
 
     exc = None
@@ -146,9 +144,10 @@ def register_ip_to_tag_map(device, ip_addresses, tag):
 def get_all_address_group_mapping(device):
     """
     Retrieve all the tag to IP address mappings
-    :param device: 
-    :return: 
+    :param device:
+    :return:
     """
+
     exc = None
     ret = None
     try:
@@ -164,11 +163,11 @@ def get_all_address_group_mapping(device):
 
 def delete_address_from_mapping(device, ip_address, tags):
     """
-    Delete an IP address from a tag mapping. 
-    :param device: 
+    Delete an IP address from a tag mapping.
+    :param device:
     :param ip_address:
-    :param tags: 
-    :return: 
+    :param tags:
+    :return:
     """
 
     exc = None

--- a/lib/ansible/modules/network/panos/panos_dag_tags.py
+++ b/lib/ansible/modules/network/panos/panos_dag_tags.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'status': ['preview'],
 DOCUMENTATION = '''
 ---
 module: panos_dag_tags
-short_description: Create tags for DAG's
+short_description: Create tags for DAG's on PAN-OS devices.
 description:
     - Create the ip address to tag associations. Tags will in turn be used to create DAG's
 author: "Vinay Venkataraghavan @vinayvenkat"
@@ -45,6 +45,9 @@ options:
             - password for authentication
         required: true
         default: null
+    api_key:
+        description:
+            - API key that can be used instead of I(username)/I(password) credentials.
     username:
         description:
             - username for authentication
@@ -185,7 +188,7 @@ def delete_address_from_mapping(device, ip_address, tags):
 def main():
     argument_spec = dict(
         ip_address=dict(required=True),
-        password=dict(required=True),
+        password=dict(required=True, no_log=True),
         username=dict(default='admin'),
         api_key=dict(no_log=True),
         devicegroup=dict(default=None),
@@ -196,7 +199,8 @@ def main():
         operation=dict(type='str', required=True)
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,
+                           required_one_of=[['api_key', 'password']])
     if not HAS_LIB:
         module.fail_json(msg='pan-python is required for this module')
 
@@ -218,7 +222,7 @@ def main():
         if dev_group:
             device.add(dev_group)
         else:
-            module.fail_json(msg='\'%s\' device group not found in Panorama. Is the name correct?' % devicegroup)
+            module.fail_json(msg="'%s' device group not found in Panorama. Is the name correct?" % devicegroup)
 
     result = None
     if operation == 'add':


### PR DESCRIPTION
##### SUMMARY
Security policies allow you to enforce rules and take action, and can be as
general or specific as needed. The policy rules are compared against the
incoming traffic in sequence, and because the first rule that matches the
traffic is applied, the more specific rules must precede the more general ones.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
panos_dag_tags

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Feb  6 2017, 11:22:10) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
N/A
