### PR TITLE
use of multiple chocolatey package names

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -37,7 +37,8 @@ description:
 options:
   name:
     description:
-      - Name of the package to be installed. This must be a signle package name if state: absent is specified.
+      - Name of the package to be installed.
+      - This must be a signle package name.
     required: yes
   state:
     description:
@@ -150,18 +151,17 @@ EXAMPLES = r'''
 
 - name: install multiple packages
   win_chocolatey:
-    name: >-
-      pscx
-      windirstat
-    state: latest
-
-- win_chocolatey:
     name: "{{ item }}"
     state: absent
   with_items:
     - pscx
     - windirstat
-  
 
-
+- name: uninstall multiple packages
+  win_chocolatey:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - pscx
+    - windirstat
 '''

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -38,7 +38,7 @@ options:
   name:
     description:
       - Name of the package to be installed.
-      - This must be a signle package name.
+      - This must be a single package name.
     required: yes
   state:
     description:

--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -37,7 +37,7 @@ description:
 options:
   name:
     description:
-      - Name of the package to be installed.
+      - Name of the package to be installed. This must be a signle package name if state: absent is specified.
     required: yes
   state:
     description:
@@ -147,4 +147,21 @@ EXAMPLES = r'''
   win_chocolatey:
     name: git
     state: absent
+
+- name: install multiple packages
+  win_chocolatey:
+    name: >-
+      pscx
+      windirstat
+    state: latest
+
+- win_chocolatey:
+    name: "{{ item }}"
+    state: absent
+  with_items:
+    - pscx
+    - windirstat
+  
+
+
 '''


### PR DESCRIPTION
It might be helpful to users, to clarify whether/when <name:> must specify a single package.

Users who are familiar with chocolatey may be accustomed to installing multiple packages in a single invocation of 'choco install'.

I believe win_chocolatey currently accepts multiple package names when state: is latest or present.
For instance, this appears to work currently:

  - win_chocolatey:
      name: >-
        pscx
        windirstat
      state: latest

However, when state: is absent, uninstall is not performed if multiple package are specified.
The chocolate.log output suggests that chocolatey is treating the multiple packages as an 'exact' name of a single package name:
2017-08-10 19:04:04,087 2424 [DEBUG] - Command line: "C:\ProgramData\chocolatey\choco.exe" list --local-only --exact pscx windirstat
2017-08-10 19:04:04,087 2424 [DEBUG] - Received arguments: list --local-only --exact pscx windirstat

I find the current behavior helpful in terms of accepting multiple package names, even if uninstall must be treated differently.
It might be helpful to show an example of how multiple uninstalls can be handled by looping over them. 

  - win_chocolatey:
      name: "{{ item }}"
      state: absent
    with_items:
      - pscx
      - windirstat

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
