### PR TITLE
Fixes#27314 - Handled issue in parsing "exit" in dellos6 running config 

### DIFF
--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -162,7 +162,7 @@ def os6_parse(lines, indent=None, comment_tokens=None):
         re.compile(r'support-assist.*$'),
         re.compile(r'template.*$'),
         re.compile(r'address-family.*$'),
-        re.compile(r'spanning-tree mst.*$'),
+        re.compile(r'spanning-tree mst configuration.*$'),
         re.compile(r'logging.*$'),
         re.compile(r'(radius-server|tacacs-server) host.*$')]
 
@@ -208,7 +208,7 @@ def os6_parse(lines, indent=None, comment_tokens=None):
                     if parent:
                         cfg._parents.extend(parent)
                     parent = list()
-                    config.append(cfg)
+                config.append(cfg)
             # handle sublevel children
             elif parent_match is False and len(parent) > 0:
                 if not children:
@@ -234,7 +234,11 @@ class Dellos6NetworkConfig(NetworkConfig):
         for item in self.items:
             if str(item) == "exit":
                 for diff_item in diff:
-                    if item._parents == diff_item._parents:
+                    if diff_item._parents:
+                        if item._parents == diff_item._parents:
+                            diff.append(item)
+                            break
+                    else:
                         diff.append(item)
                         break
             elif item not in other:

--- a/lib/ansible/plugins/terminal/dellos6.py
+++ b/lib/ansible/plugins/terminal/dellos6.py
@@ -48,7 +48,7 @@ class TerminalModule(TerminalBase):
 
         cmd = {u'command': u'enable'}
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompt'] = to_text(r"[\r\n]?password:$", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
         try:
             self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))


### PR DESCRIPTION
##### SUMMARY

Included changes to handle "exit" in dellos6 running-config.
Fixes #27314

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

ansible.module_utils.dellos6

##### ANSIBLE VERSION

```
ansible 2.4.0  (devel b4b3ca9d64) 
config file = /etc/ansible/ansible.cfg 
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']

```


##### ADDITIONAL INFORMATION

Included change in plugin file of dellos6.py to support in devel.



