### PR TITLE
EOS EAPI autocomplete params update

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -306,10 +306,9 @@ class Eapi:
             self.check_autocomplete()
         if self._autoc:
             params = dict(version=1, cmds=commands, format=output, autoComplete=True)
-            return dict(jsonrpc='2.0', id=reqid, method='runCmds', params=params)
         else:
             params = dict(version=1, cmds=commands, format=output)
-            return dict(jsonrpc='2.0', id=reqid, method='runCmds', params=params)
+        return dict(jsonrpc='2.0', id=reqid, method='runCmds', params=params)
 
     def send_request(self, commands, output='text'):
         commands = to_list(commands)

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -296,7 +296,7 @@ class Eapi:
         return self._session_support
 
     def _request_builder(self, commands, output, reqid=None):
-        params = dict(version=1, cmds=commands, format=output)
+        params = dict(version=1, cmds=commands, format=output, autoComplete=True)
         return dict(jsonrpc='2.0', id=reqid, method='runCmds', params=params)
 
     def send_request(self, commands, output='text'):

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -302,7 +302,7 @@ class Eapi:
             self._autoc = 'error' not in response
 
     def _request_builder(self, commands, output, reqid=None):
-        if self._autoc is None: 
+        if self._autoc is None:
             self.check_autocomplete()
         if self._autoc:
             params = dict(version=1, cmds=commands, format=output, autoComplete=True)


### PR DESCRIPTION
On EOS EAPI params, we need to set and pass "autoComplete: true" to be able to use command auto complete during execution which is the standard for CLI transport in Ansible.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is to make sure identical behavior for both CLI and EAPI transport methods for Arista switches. 
Need to add additional parameter "autoComplete: true" passed to EAPI . 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/eos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vinp/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vinp/.local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This is to make sure identical behavior for both CLI and EAPI transport methods for Arista switches. 
Need to add additional parameter "autoComplete: true" passed to EAPI . 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before this change: 
---------------------
fatal: [lab-arista-swi-4.us.com]: FAILED! => {
    "changed": false, 
    "code": 1002, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "commands": [
                {
                    "answer": null, 
                    "command": "show ver", 
                    "output": "text", 
                    "prompt": null
                }
            ], 
            "host": "lab-arista-swi-4.us.com", 
            "interval": 1, 
            "match": "all", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "provider": {
                "auth_pass": null, 
                "authorize": false, 
                "connection": "local", 
                "host": "lab-arista-swi-4.us.com", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 90, 
                "transport": "eapi", 
                "use_ssl": true, 
                "username": "vinpk", 
                "validate_certs": false
            }, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": 90, 
            "transport": "cli", 
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "url_username": "vinpk", 
            "use_ssl": true, 
            "username": "vinpk", 
            "validate_certs": false, 
            "wait_for": null
        }
    }, 
    "msg": "CLI command 2 of 2 'show ver' failed: invalid command"
}
	

After change: 
---------------
ok: [lab-arista-swi-4.us.com] => {
    "changed": false, 
    "failed": false, 
    "invocation": {
        "module_args": {
            "auth_pass": null, 
            "authorize": false, 
            "commands": [
                {
                    "answer": null, 
                    "command": "show ver", 
                    "output": "text", 
                    "prompt": null
                }
            ], 
            "host": "lab-arista-swi-4.us.com", 
            "interval": 1, 
            "match": "all", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "provider": {
                "auth_pass": null, 
                "authorize": false, 
                "connection": "local", 
                "host": "lab-arista-swi-4.us.com", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 90, 
                "transport": "eapi", 
                "use_ssl": true, 
                "username": "vinpk", 
                "validate_certs": false
            }, 
            "retries": 10, 
            "ssh_keyfile": null, 
            "timeout": 90, 
            "transport": "cli", 
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "url_username": "vinpk", 
            "use_ssl": true, 
            "username": "vinpk", 
            "validate_certs": false, 
            "wait_for": null
        }
    }, 
    "stdout": [
        "Arista DCS-7050TX-64-R\nHardware version:    01.10\nSerial number:       XXXXXXX\nSystem MAC address:  xx.xx.xx\n\nSoftware image version: 4.18.1.1F\nArchitecture:           i386\nInternal build version: 4.18.1.1F-5127975.41811F\nInternal build ID:      xxxxxx-id\n\nUptime:                 5 days, 14 hours and 16 minutes\nTotal memory:           3838080 kB\nFree memory:            2086868 kB"
    ], 
    "stdout_lines": [
        [
            "Arista DCS-7050TX-64-R", 
            "Hardware version:    01.10", 
            "Serial number:       XXXXXXX", 
            "System MAC address:  xx.xx.xx", 
            "", 
            "Software image version: 4.18.1.1F", 
            "Architecture:           i386", 
            "Internal build version: 4.18.1.1F-5127975.41811F", 
            "Internal build ID:      xxxxxx-id", 
            "", 
            "Uptime:                 5 days, 14 hours and 16 minutes", 
            "Total memory:           3838080 kB", 
            "Free memory:            2086868 kB"
        ]
    ]
}

```
