### PR TITLE
Typo in module example code

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -82,7 +82,7 @@ working on a whole new file. Here is an example:
                 - Control to demo if the result of this module is changed or not
             required: false
 
-    extends_documentation_fragment
+    extends_documentation_fragment:
         - azure
 
     author:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In the DOCUMENTATION constant there is a typo on line 85 of this rst file.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Docs
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 914ae2fb26) last updated 2017/08/10 22:47:34 (GMT +200)
  config file = None
  configured module search path = ['/home/stemid/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stemid/Utveckling/ansible/lib/ansible
  executable location = /home/stemid/Utveckling/ansible/bin/ansible
  python version = 3.6.2 (default, Jul 19 2017, 13:09:21) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
