### PR TITLE
Replace username for name in eos_user integration tests

### DIFF
--- a/test/integration/targets/eos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_user/tests/cli/basic.yaml
@@ -1,7 +1,7 @@
 ---
 - name: Create user
   eos_user:
-    username: netend
+    name: netend
     privilege: 15
     role: network-operator
     state: present
@@ -17,8 +17,8 @@
 - name: Collection of users
   eos_user:
     aggregate:
-      - username: test1
-      - username: test2
+      - name: test1
+      - name: test2
     authorize: yes
     state: present
     role: network-operator


### PR DESCRIPTION
username param is read by eos action plugion load_provider, if present
it is set as the play context remote user.
That means if you have a play remote_user: admin it won't be used, but instead
whatever is put in the task argument username.
Changing the tests to use name fixes the issue, we may want to remove username
as valid module argument in other change.