### PR TITLE
rm unused test template in template intg tests

### DIFF
--- a/test/integration/targets/template/templates/import_as_with_context.js
+++ b/test/integration/targets/template/templates/import_as_with_context.js
@@ -1,3 +1,0 @@
-{% import 'qux' as qux with context %}
-hello world as qux with context
-{{ qux.wibble }}


### PR DESCRIPTION
introduced in 501fc7a248c4ad09c2593a200b3fbbdff0e48c70
based on my patch.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/template/templates/
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (rm_unused_template 3ef7720131) last updated 2017/08/11 11:49:07 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

