### PR TITLE
fix issue with trailing white space when logging into asa

### DIFF
--- a/lib/ansible/plugins/terminal/asa.py
+++ b/lib/ansible/plugins/terminal/asa.py
@@ -40,7 +40,7 @@ class TerminalModule(TerminalBase):
     ]
 
     def on_open_shell(self):
-        if self._get_prompt().endswith(b'#'):
+        if self._get_prompt().strip().endswith(b'#'):
             self.disable_pager()
 
     def disable_pager(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When using an ASA that defaults to enable mode, there is a trailing white space after the prompt. Added .strip() to remove the whitespace so module picked up on the `#`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugin/terminal/asa.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0, but really using @ogenstad asa branch that was just merged to fix other issues with ASA modules.
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
