### PR TITLE
Fixes #28080 : fix nxos_bgp_af idempotence when multiple networks are defined

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -460,13 +460,14 @@ def get_existing(module, args, warnings):
 
         if config:
             for arg in args:
-                if arg not in ['asn', 'afi', 'safi', 'vrf']:
+                if arg not in ['asn', 'afi', 'safi', 'vrf', 'networks']:
                     existing[arg] = get_value(arg, config, module)
 
             existing['asn'] = existing_asn
             existing['afi'] = module.params['afi']
             existing['safi'] = module.params['safi']
             existing['vrf'] = module.params['vrf']
+            existing['networks'] = module.params['networks']
     else:
         warnings.append("The BGP process {0} didn't exist but the task just created it.".format(module.params['asn']))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #28080 

The list of existing networks were being cropped and only the first one was retained. This caused idempotence issues.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_bgp_af

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel ebb1d75ee0) last updated 2017/08/10 15:40:07 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```