### PR TITLE
Allow miq_token as an argument passed into the ManageIQ API Client

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -84,6 +84,18 @@ EXAMPLES = '''
       password: 'smartvm'
       verify_ssl: False
 
+- name: Create a new user in ManageIQ using a token
+  manageiq_user:
+    userid: 'jdoe'
+    name: 'Jane Doe'
+    password: 'VerySecret'
+    group: 'EvmGroup-user'
+    email: 'jdoe@example.com'
+    manageiq_connection:
+      url: 'http://127.0.0.1:3000'
+      token: 'sometoken'
+      verify_ssl: False
+
 - name: Delete a user in ManageIQ
   manageiq_user:
     state: 'absent'
@@ -94,6 +106,15 @@ EXAMPLES = '''
       password: 'smartvm'
       verify_ssl: False
 
+- name: Delete a user in ManageIQ using a token
+  manageiq_user:
+    state: 'absent'
+    userid: 'jdoe'
+    manageiq_connection:
+      url: 'http://127.0.0.1:3000'
+      token: 'sometoken'
+      verify_ssl: False
+
 - name: Update email of user in ManageIQ
   manageiq_user:
     userid: 'jdoe'
@@ -102,6 +123,15 @@ EXAMPLES = '''
       url: 'http://127.0.0.1:3000'
       username: 'admin'
       password: 'smartvm'
+      verify_ssl: False
+
+- name: Update email of user in ManageIQ using a token
+  manageiq_user:
+    userid: 'jdoe'
+    email: 'jaustine@example.com'
+    manageiq_connection:
+      url: 'http://127.0.0.1:3000'
+      token: 'sometoken'
       verify_ssl: False
 '''
 

--- a/lib/ansible/utils/module_docs_fragments/manageiq.py
+++ b/lib/ansible/utils/module_docs_fragments/manageiq.py
@@ -32,13 +32,17 @@ options:
         description:
           - ManageIQ environment url. C(MIQ_URL) env var if set. otherwise, it is required to pass it.
       username:
-        required: true
+        required: false
         description:
-          - ManageIQ username. C(MIQ_USERNAME) env var if set. otherwise, it is required to pass it.
+          - ManageIQ username. C(MIQ_USERNAME) env var if set. otherwise, required if no token is passed in.
       password:
-        required: true
+        required: false
         description:
-          - ManageIQ password. C(MIQ_PASSWORD) env var if set. otherwise, it is required to pass it.
+          - ManageIQ password. C(MIQ_PASSWORD) env var if set. otherwise, required if no token is passed in.
+      token:
+        required: false
+        description:
+          - ManageIQ token. C(MIQ_TOKEN) env var if set. otherwise, required if no username or password is passed in.
       verify_ssl:
         required: false
         default: true


### PR DESCRIPTION
##### SUMMARY
ManageIQ is an open source management platform for Hybrid IT.

This change is modifying:
```
manageiq.py to allow passing in a manageiq api token for use 
in authenticating with the manageiq-api-client-python
```


##### ISSUE TYPE
```
 Feature Pull Request
```

##### COMPONENT NAME
manageiq.py (module utils and doc_fragement)

##### ANSIBLE VERSION
```
ansible 2.3.0.0
```

