### PR TITLE
Remove wildcard imports and get_exception calls

### DIFF
--- a/lib/ansible/module_utils/aos.py
+++ b/lib/ansible/module_utils/aos.py
@@ -32,12 +32,12 @@ This module adds shared support for Apstra AOS modules
 
 In order to use this module, include it as part of your module
 
-from ansible.module_utils.aos import *
+from ansible.module_utils.aos import (check_aos_version, get_aos_session, find_collection_item,
+                                      content_to_dict, do_load_resource)
 
 """
 import json
 
-from ansible.module_utils.pycompat24 import get_exception
 from distutils.version import LooseVersion
 
 try:
@@ -52,6 +52,8 @@ try:
     HAS_AOS_PYEZ = True
 except ImportError:
     HAS_AOS_PYEZ = False
+
+from ansible.module_utils._text import to_native
 
 
 def check_aos_version(module, min=False):
@@ -172,8 +174,7 @@ def do_load_resource(module, collection, name):
         try:
             item.datum = module.params['content']
             item.write()
-        except:
-            e = get_exception()
-            module.fail_json(msg="Unable to write item content : %r" % e)
+        except Exception as e:
+            module.fail_json(msg="Unable to write item content : %r" % to_native(e))
 
     module.exit_json(changed=True, name=item.name, id=item.id, value=item.value)

--- a/lib/ansible/module_utils/ce.py
+++ b/lib/ansible/module_utils/ce.py
@@ -31,12 +31,13 @@
 import re
 import socket
 import sys
+import traceback
 
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.network_common import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import iteritems
+from ansible.module_utils._text import to_native
 
 
 try:
@@ -66,7 +67,6 @@ ce_argument_spec = {
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in ce_argument_spec:
         if key not in ['provider', 'transport'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
@@ -323,9 +323,9 @@ class Netconf(object):
                                       timeout=30)
         except AuthenticationError:
             self._module.fail_json(msg='Error: Authentication failed while connecting to device.')
-        except Exception:
-            err = get_exception()
-            self._module.fail_json(msg='Error: %s' % str(err).replace("\r\n", ""))
+        except Exception as err:
+            self._module.fail_json(msg='Error: %s' % to_native(err).replace("\r\n", ""),
+                                   exception=traceback.format_exc())
             raise
 
     def __del__(self):
@@ -339,9 +339,8 @@ class Netconf(object):
 
         try:
             con_obj = self.mc.edit_config(target='running', config=xml_str)
-        except RPCError:
-            err = get_exception()
-            self._module.fail_json(msg='Error: %s' % str(err).replace("\r\n", ""))
+        except RPCError as err:
+            self._module.fail_json(msg='Error: %s' % to_native(err).replace("\r\n", ""))
 
         return con_obj.xml
 
@@ -351,9 +350,8 @@ class Netconf(object):
         con_obj = None
         try:
             con_obj = self.mc.get(filter=xml_str)
-        except RPCError:
-            err = get_exception()
-            self._module.fail_json(msg='Error: %s' % str(err).replace("\r\n", ""))
+        except RPCError as err:
+            self._module.fail_json(msg='Error: %s' % to_native(err).replace("\r\n", ""))
 
         set_id = get_nc_set_id(con_obj.xml)
         if not set_id:
@@ -368,9 +366,8 @@ class Netconf(object):
             # get next data
             try:
                 con_obj_next = self.mc.dispatch(xsd_fetch)
-            except RPCError:
-                err = get_exception()
-                self._module.fail_json(msg='Error: %s' % str(err).replace("\r\n", ""))
+            except RPCError as err:
+                self._module.fail_json(msg='Error: %s' % to_native(err).replace("\r\n", ""))
 
             if "<data/>" in con_obj_next.xml:
                 break
@@ -388,9 +385,8 @@ class Netconf(object):
 
         try:
             con_obj = self.mc.action(action=xml_str)
-        except RPCError:
-            err = get_exception()
-            self._module.fail_json(msg='Error: %s' % str(err).replace("\r\n", ""))
+        except RPCError as err:
+            self._module.fail_json(msg='Error: %s' % to_native(err).replace("\r\n", ""))
         except TimeoutExpiredError:
             raise
 
@@ -403,9 +399,8 @@ class Netconf(object):
 
         try:
             con_obj = self.mc.cli(command=xml_str)
-        except RPCError:
-            err = get_exception()
-            self._module.fail_json(msg='Error: %s' % str(err).replace("\r\n", ""))
+        except RPCError as err:
+            self._module.fail_json(msg='Error: %s' % to_native(err).replace("\r\n", ""))
 
         return con_obj.xml
 

--- a/lib/ansible/module_utils/cloud.py
+++ b/lib/ansible/module_utils/cloud.py
@@ -22,7 +22,7 @@ This module adds shared support for generic cloud modules
 In order to use this module, include it as part of a custom
 module as shown below.
 
-from ansible.module_utils.cloud import *
+from ansible.module_utils.cloud import CloudRetry
 
 The 'cloud' module provides the following common classes:
 
@@ -43,8 +43,6 @@ import random
 from functools import wraps
 import syslog
 import time
-
-from ansible.module_utils.pycompat24 import get_exception
 
 
 def _exponential_backoff(retries=10, delay=2, backoff=2, max_delay=60):
@@ -140,8 +138,7 @@ class CloudRetry(object):
                 for delay in backoff_strategy():
                     try:
                         return f(*args, **kwargs)
-                    except Exception:
-                        e = get_exception()
+                    except Exception as e:
                         if isinstance(e, cls.base_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code):

--- a/lib/ansible/module_utils/exoscale.py
+++ b/lib/ansible/module_utils/exoscale.py
@@ -29,11 +29,9 @@
 
 import os
 
-# import module snippets
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils.six import integer_types, string_types
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import fetch_url
 
 EXO_DNS_BASEURL = "https://api.exoscale.ch/dns/v1"
@@ -66,9 +64,8 @@ class ExoDns(object):
                 config = self.read_config(ini_group=region)
                 self.api_key = config['key']
                 self.api_secret = config['secret']
-            except Exception:
-                e = get_exception()
-                self.module.fail_json(msg="Error while processing config: %s" % e)
+            except Exception as e:
+                self.module.fail_json(msg="Error while processing config: %s" % to_native(e))
 
         self.headers = {
             'X-DNS-Token': "%s:%s" % (self.api_key, self.api_secret),
@@ -133,9 +130,8 @@ class ExoDns(object):
         try:
             return self.module.from_json(to_text(response.read()))
 
-        except Exception:
-            e = get_exception()
-            self.module.fail_json(msg="Could not process response into json: %s" % e)
+        except Exception as e:
+            self.module.fail_json(msg="Could not process response into json: %s" % to_native(e))
 
     def has_changed(self, want_dict, current_dict, only_keys=None):
         changed = False

--- a/lib/ansible/module_utils/fortios.py
+++ b/lib/ansible/module_utils/fortios.py
@@ -28,15 +28,15 @@
 #
 import os
 import time
+import traceback
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
 
 
 # check for pyFG lib
 try:
     from pyFG import FortiOS, FortiConfig
-    from pyFG.exceptions import CommandExecutionException, FailedCommit
+    from pyFG.exceptions import FailedCommit
     HAS_PYFG = True
 except ImportError:
     HAS_PYFG = False
@@ -115,9 +115,9 @@ class AnsibleFortios(object):
 
             try:
                 self.forti_device.open()
-            except Exception:
-                e = get_exception()
-                self.module.fail_json(msg='Error connecting device. %s' % e)
+            except Exception as e:
+                self.module.fail_json(msg='Error connecting device. %s' % to_native(e),
+                                      exception=traceback.format_exc())
 
     def load_config(self, path):
         self.path = path
@@ -128,19 +128,19 @@ class AnsibleFortios(object):
                 f = open(self.module.params['config_file'], 'r')
                 running = f.read()
                 f.close()
-            except IOError:
-                e = get_exception()
-                self.module.fail_json(msg='Error reading configuration file. %s' % e)
+            except IOError as e:
+                self.module.fail_json(msg='Error reading configuration file. %s' % to_native(e),
+                                      exception=traceback.format_exc())
             self.forti_device.load_config(config_text=running, path=path)
 
         else:
             # get  config
             try:
                 self.forti_device.load_config(path=path)
-            except Exception:
+            except Exception as e:
                 self.forti_device.close()
-                e = get_exception()
-                self.module.fail_json(msg='Error reading running config. %s' % e)
+                self.module.fail_json(msg='Error reading running config. %s' % to_native(e),
+                                      exception=traceback.format_exc())
 
         # set configs in object
         self.result['running_config'] = self.forti_device.running_config.to_text()
@@ -163,16 +163,15 @@ class AnsibleFortios(object):
                     f = open(self.module.params['config_file'], 'w')
                     f.write(self.candidate_config.to_text())
                     f.close()
-                except IOError:
-                    e = get_exception()
-                    self.module.fail_json(msg='Error writing configuration file. %s' % e)
+                except IOError as e:
+                    self.module.fail_json(msg='Error writing configuration file. %s' %
+                                          to_native(e), exception=traceback.format_exc())
             else:
                 try:
                     self.forti_device.commit()
-                except FailedCommit:
+                except FailedCommit as e:
                     # Something's wrong (rollback is automatic)
                     self.forti_device.close()
-                    e = get_exception()
                     error_list = self.get_error_infos(e)
                     self.module.fail_json(msg_error_list=error_list, msg="Unable to commit change, check your args, the error was %s" % e.message)
 

--- a/lib/ansible/module_utils/ipa.py
+++ b/lib/ansible/module_utils/ipa.py
@@ -32,8 +32,7 @@ try:
 except ImportError:
     import simplejson as json
 
-from ansible.module_utils._text import to_bytes, to_text
-from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url
@@ -69,9 +68,8 @@ class IPAClient(object):
                             'Content-Type': 'application/json',
                             'Accept': 'application/json',
                             'Cookie': resp.info().get('Set-Cookie')}
-        except Exception:
-            e = get_exception()
-            self._fail('login', str(e))
+        except Exception as e:
+            self._fail('login', to_native(e))
 
     def _fail(self, msg, e):
         if 'message' in e:
@@ -90,9 +88,8 @@ class IPAClient(object):
             status_code = info['status']
             if status_code not in [200, 201, 204]:
                 self._fail(method, info['msg'])
-        except Exception:
-            e = get_exception()
-            self._fail('post %s' % method, str(e))
+        except Exception as e:
+            self._fail('post %s' % method, to_native(e))
 
         if PY3:
             charset = resp.headers.get_content_charset('latin-1')
@@ -105,7 +102,7 @@ class IPAClient(object):
         resp = json.loads(to_text(resp.read(), encoding=charset), encoding=charset)
         err = resp.get('error')
         if err is not None:
-            self._fail('repsonse %s' % method, err)
+            self._fail('response %s' % method, err)
 
         if 'result' in resp:
             result = resp.get('result')

--- a/lib/ansible/module_utils/network.py
+++ b/lib/ansible/module_utils/network.py
@@ -24,12 +24,15 @@
 # INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#
+
+import traceback
+
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.basic import env_fallback, get_exception
-from ansible.module_utils.netcli import Cli, Command
+from ansible.module_utils.basic import env_fallback
+from ansible.module_utils.netcli import Cli
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import iteritems
+
 
 NET_TRANSPORT_ARGS = dict(
     host=dict(required=True),
@@ -130,9 +133,8 @@ class NetworkModule(AnsibleModule):
             self.connection = cls()
         except KeyError:
             self.fail_json(msg='Unknown transport or no default transport specified')
-        except (TypeError, NetworkError):
-            exc = get_exception()
-            self.fail_json(msg=to_native(exc))
+        except (TypeError, NetworkError) as exc:
+            self.fail_json(msg=to_native(exc), exception=traceback.format_exc())
 
         if connect_on_load:
             self.connect()
@@ -176,18 +178,16 @@ class NetworkModule(AnsibleModule):
                     self.connection.authorize(self.params)
                 self.log('connected to %s:%s using %s' % (self.params['host'],
                          self.params['port'], self.params['transport']))
-        except NetworkError:
-            exc = get_exception()
-            self.fail_json(msg=to_native(exc))
+        except NetworkError as exc:
+            self.fail_json(msg=to_native(exc), exception=traceback.format_exc())
 
     def disconnect(self):
         try:
             if self.connected:
                 self.connection.disconnect()
             self.log('disconnected from %s' % self.params['host'])
-        except NetworkError:
-            exc = get_exception()
-            self.fail_json(msg=to_native(exc))
+        except NetworkError as exc:
+            self.fail_json(msg=to_native(exc), exception=traceback.format_exc())
 
 
 def register_transport(transport, default=False):

--- a/lib/ansible/module_utils/postgres.py
+++ b/lib/ansible/module_utils/postgres.py
@@ -34,9 +34,6 @@ try:
 except ImportError:
     HAS_PSYCOPG2 = False
 
-from ansible.module_utils.basic import get_exception
-from ansible.module_utils.six import iteritems
-
 
 class LibraryError(Exception):
     pass

--- a/lib/ansible/module_utils/shell.py
+++ b/lib/ansible/module_utils/shell.py
@@ -19,9 +19,7 @@
 import os
 import re
 import socket
-import time
 import signal
-import json
 
 try:
     import paramiko
@@ -30,7 +28,6 @@ try:
 except ImportError:
     HAS_PARAMIKO = False
 
-from ansible.module_utils.basic import get_exception
 from ansible.module_utils.network import NetworkError
 from ansible.module_utils.six import BytesIO
 from ansible.module_utils._text import to_native
@@ -105,8 +102,7 @@ class Shell(object):
             raise ShellError('Unable to authenticate to remote device')
         except socket.timeout:
             raise ShellError("timeout trying to connect to remote device")
-        except socket.error:
-            exc = get_exception()
+        except socket.error as exc:
             if exc.errno == 60:
                 raise ShellError('timeout trying to connect to host')
             raise
@@ -147,8 +143,7 @@ class Shell(object):
                     if cmd:
                         resp = self.sanitize(cmd, resp)
                     return resp
-            except ShellError:
-                exc = get_exception()
+            except ShellError as exc:
                 exc.command = cmd['command']
                 raise
 
@@ -167,8 +162,7 @@ class Shell(object):
             signal.alarm(0)
 
             return (0, out, '')
-        except ShellError:
-            exc = get_exception()
+        except ShellError as exc:
             return (1, '', to_native(exc))
 
     def close(self):
@@ -236,8 +230,7 @@ class CliBase(object):
             self.shell.open(host, port=port, username=username,
                             password=password, key_filename=key_file)
 
-        except ShellError:
-            exc = get_exception()
+        except ShellError as exc:
             raise NetworkError(msg='failed to connect to %s:%s' % (host, port),
                                exc=to_native(exc))
 
@@ -277,8 +270,7 @@ class CliBase(object):
                     raise ShellError(err)
                 responses.append(out)
             return responses
-        except ShellError:
-            exc = get_exception()
+        except ShellError as exc:
             raise NetworkError(to_native(exc))
 
     def run_commands(self, x):

--- a/test/sanity/code-smell/boilerplate.sh
+++ b/test/sanity/code-smell/boilerplate.sh
@@ -3,7 +3,7 @@
 metaclass1=$(find ./bin -type f -exec grep -HL '__metaclass__ = type' '{}' '+')
 future1=$(find ./bin -type f -exec grep -HL 'from __future__ import (absolute_import, division, print_function)' '{}' '+')
 
-# We eventually want to remove the module_utils and modules pruning from metaclass2 and future2
+# We eventually want to remove the module_utils pruning from metaclass2 and future2
 metaclass2=$(find ./lib/ansible -path ./lib/ansible/modules -prune \
         -o -path ./lib/ansible/module_utils -prune \
         -o -path ./lib/ansible/module_utils/six/_six.py -prune \

--- a/test/sanity/code-smell/no-wildcard-import.sh
+++ b/test/sanity/code-smell/no-wildcard-import.sh
@@ -17,9 +17,6 @@ wildcard_imports=$(find . -path ./test/runner/.tox -prune \
         -o -path ./test/units/plugins/action/test_action.py \
         -o -path ./lib/ansible/compat/tests/mock.py -prune \
         -o -path ./lib/ansible/compat/tests/unittest.py \
-        -o -path ./lib/ansible/module_utils/api.py -prune \
-        -o -path ./lib/ansible/module_utils/cloud.py -prune \
-        -o -path ./lib/ansible/module_utils/aos.py -prune \
         -o -path ./test/units/modules/network/cumulus/test_nclu.py -prune \
         -o -path ./lib/ansible/modules/cloud/amazon -prune \
         -o -path ./lib/ansible/modules/cloud/openstack -prune \


### PR DESCRIPTION
Fixed module_utils

##### SUMMARY
Getting rid of wildcard imports will let pylint with less false negatives.  get_exception is deprecated.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
varous changes in module_utils

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```