### PR TITLE
Match tabs before options

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -126,16 +126,16 @@ from ansible.module_utils.basic import AnsibleModule
 
 def match_opt(option, line):
     option = re.escape(option)
-    return re.match(' *%s( |\t)*=' % option, line) \
-      or re.match('# *%s( |\t)*=' % option, line) \
-      or re.match('; *%s( |\t)*=' % option, line)
+    return re.match('( |\t)*%s( |\t)*=' % option, line) \
+      or re.match('#( |\t)*%s( |\t)*=' % option, line) \
+      or re.match(';( |\t)*%s( |\t)*=' % option, line)
 
 # ==============================================================
 # match_active_opt
 
 def match_active_opt(option, line):
     option = re.escape(option)
-    return re.match(' *%s( |\t)*=' % option, line)
+    return re.match('( |\t)*%s( |\t)*=' % option, line)
 
 # ==============================================================
 # do_ini


### PR DESCRIPTION
##### SUMMARY
Fixes #28032 -- leading tabs before options are correctly matched.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ini_file

##### ANSIBLE VERSION
2.3 and devel

##### ADDITIONAL INFORMATION
Changed match_opt() and match_active_opt() match "( |\t)*" before the option string