### PR TITLE
strategy: lost list order using with_items during displaying results

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -327,7 +327,7 @@ class StrategyBase:
         while True:
             try:
                 self._results_lock.acquire()
-                task_result = self._results.pop()
+                task_result = self._results.popleft()
             except IndexError:
                 break
             finally:


### PR DESCRIPTION
##### SUMMARY
Fixes #21008

Before this change, with_items list order is lost during displaying results of ansible-playbook.

This problem occurs often during an high utilization of the server running ansible-playbook.

In order to simulate the server utilization I have used the command "cat /dev/urandom | pigz > /dev/null" (the same described in the issue) running in backgroung during the playbook executions.

Note: I tried to debug this bug using Pycharm but this bug doesn't occurs when ansible-playbook is running using Pycharm debug, it occurs running ansible-playbook from terminal

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
strategy

##### ANSIBLE VERSION
```
$ build/scripts-2.7/ansible --version
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
The items of the debug task are write in a deque using [append](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/strategy/__init__.py#L89)(from the right side of the queue)
The items of the debug task are read from the deque using [pop](https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/strategy/__init__.py#L330)(from the right side of the queue)

Before the changes contained in this PR:

- The bug occurs if the process writes to the deque structure two or more times and then it reads from it
- The bug doesn't occurs if the process sequentially write and read to the deque 

The solution is to write the queue from right(as before) and to read the queue from left(using leftpop instead of pop)

**Playbook used for the test** 
```
# cat /tmp/debug.yml 
- hosts: localhost
  connection: local
  gather_facts: off
  tasks:
    - debug: msg="{{item}}"
      with_items:
        - "HERE one"
        - "HERE two"
        - "HERE three"
        - "HERE four"
        - "HERE five"
        - "HERE six"
```

**BEFORE PR**
```
$ ./bin/ansible-playbook /tmp/debug.yml  

PLAY [localhost] *****************************************************************************

TASK [debug] *********************************************************************************
ok: [localhost] => (item=HERE four) => {
    "item": "HERE four", 
    "msg": "HERE four"
}
ok: [localhost] => (item=HERE three) => {
    "item": "HERE three", 
    "msg": "HERE three"
}
ok: [localhost] => (item=HERE two) => {
    "item": "HERE two", 
    "msg": "HERE two"
}
ok: [localhost] => (item=HERE one) => {
    "item": "HERE one", 
    "msg": "HERE one"
}
ok: [localhost] => (item=HERE six) => {
    "item": "HERE six", 
    "msg": "HERE six"
}
ok: [localhost] => (item=HERE five) => {
    "item": "HERE five", 
    "msg": "HERE five"
}

PLAY RECAP ***********************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0  

```

**AFTER PR**
```
$ ./bin/ansible-playbook /tmp/debug.yml  

PLAY [localhost] *****************************************************************************

TASK [debug] *********************************************************************************
ok: [localhost] => (item=HERE one) => {
    "item": "HERE one", 
    "msg": "HERE one"
}
ok: [localhost] => (item=HERE two) => {
    "item": "HERE two", 
    "msg": "HERE two"
}
ok: [localhost] => (item=HERE three) => {
    "item": "HERE three", 
    "msg": "HERE three"
}
ok: [localhost] => (item=HERE four) => {
    "item": "HERE four", 
    "msg": "HERE four"
}
ok: [localhost] => (item=HERE five) => {
    "item": "HERE five", 
    "msg": "HERE five"
}
ok: [localhost] => (item=HERE six) => {
    "item": "HERE six", 
    "msg": "HERE six"
}

PLAY RECAP ***********************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   

```
