### PR TITLE
xml: Add example with namespaces and clarify note

### DIFF
--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -109,7 +109,8 @@ requirements:
 - lxml >= 2.3.0
 notes:
 - This module does not handle complicated xpath expressions, so limit xpath selectors to simple expressions.
-- Beware that in case your XML elements are namespaced, you need to use the C(namespaces) parameter on all children of an element where namespace is defined, unless another namespace is defined.
+- Beware that in case your XML elements are namespaced, you need to use the C(namespaces) parameter.
+- Namespaces prefix should be used for all children of an element where namespace is defined, unless another namespace is defined for them.
 author:
 - Tim Bielawa (@tbielawa)
 - Magnus Hedemark (@magnus919)

--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -109,7 +109,7 @@ requirements:
 - lxml >= 2.3.0
 notes:
 - This module does not handle complicated xpath expressions, so limit xpath selectors to simple expressions.
-- Beware that in case your XML elements are namespaced, you need to use the C(namespaces) parameter.
+- Beware that in case your XML elements are namespaced, you need to use the C(namespaces) parameter on all children of an element where namespace is defined, unless another namespace is defined.
 author:
 - Tim Bielawa (@tbielawa)
 - Magnus Hedemark (@magnus919)
@@ -177,6 +177,26 @@ EXAMPLES = r'''
     path: /foo/bar.xml
     xpath: /business/website
     children: []
+
+# In case of namespaces, like in below XML, they have to be explicitely stated
+# Note: there's the prefix "x" in front of the "bar", too
+#<?xml version='1.0' encoding='UTF-8'?>
+#<foo xmlns="http://x.test" xmlns:attr="http://z.test">
+#  <bar>
+#    <baz xmlns="http://y.test" attr:my_namespaced_attribute="true" />
+#  </bar>
+#</foo>
+
+- name: Set namespaced '/x:foo/x:bar/y:baz/@z:my_namespaced_attribute' to 'false'
+  xml:
+    path: foo.xml
+    xpath: /x:foo/x:bar/y:baz
+    namespaces:
+      x: http://x.test
+      y: http://y.test
+      z: http://z.test
+    attribute: z:my_namespaced_attribute
+    value: "false"
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
As @dagwieers proposed here [cmprescott/ansible-xml#118](https://github.com/cmprescott/ansible-xml/issues/118), I'm adding an example that uses namespaces. Feel free to improve the PR.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
xml

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 2aee9fb28a) last updated 2017/08/13 01:47:49 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/sm4rk0/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/sm4rk0/ansible/lib/ansible
  executable location = /home/sm4rk0/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
