### PR TITLE
Added eagerzeroedthick disk option to disk spec for vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -26,7 +26,6 @@ author:
 - James Tanner (@jctanner) <tanner.jc@gmail.com>
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
-- Steve Jacobs (@stevejacobs) <sjacobs@brokencrew.com>
 notes:
 - Tested on vSphere 5.5 and 6.0
 requirements:
@@ -102,7 +101,7 @@ options:
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
     - ' - C(type) (string): Valid values are:'
-    - '   C(thin) thin disk, C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.4, Default: C(None) thick disk, no eagerzero.'
+    - '   C(thin) thin disk, C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.5, Default: C(None) thick disk, no eagerzero.'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   cdrom:
@@ -1021,12 +1020,10 @@ class PyVmomiHelper(PyVmomi):
             # is it thin?
             if 'type' in expected_disk_spec:
                 disk_type = expected_disk_spec.get('type', '').lower()
-
                 if disk_type == 'thin':
                     diskspec.device.backing.thinProvisioned = True
                 elif disk_type == 'eagerzeroedthick':
                     diskspec.device.backing.eagerlyScrub = True
-                
 
             # which datastore?
             if expected_disk_spec.get('datastore'):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -26,6 +26,7 @@ author:
 - James Tanner (@jctanner) <tanner.jc@gmail.com>
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
+- Steve Jacobs (@stevejacobs) <sjacobs@brokencrew.com>
 notes:
 - Tested on vSphere 5.5 and 6.0
 requirements:
@@ -100,7 +101,7 @@ options:
     - A list of disks to add.
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
-    - ' - C(type) (string): Valid value is C(thin) (default: None).'
+    - ' - C(type) (string): Valid value is C(thin) or C(eagerzeroedthick) (default: None).'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   cdrom:
@@ -1018,8 +1019,13 @@ class PyVmomiHelper(PyVmomi):
 
             # is it thin?
             if 'type' in expected_disk_spec:
-                if expected_disk_spec.get('type', '').lower() == 'thin':
+                disk_type = expected_disk_spec.get('type', '').lower()
+
+                if disk_type == 'thin':
                     diskspec.device.backing.thinProvisioned = True
+                elif disk_type == 'eagerzeroedthick':
+                    diskspec.device.backing.eagerlyScrub = True
+                
 
             # which datastore?
             if expected_disk_spec.get('datastore'):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -101,7 +101,10 @@ options:
     - A list of disks to add.
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
-    - ' - C(type) (string): Valid value is C(thin) or C(eagerzeroedthick) (default: None).'
+    - ' - C(type) (string): Valid values are:
+    - '   C(thin) thin disk'
+    - '   C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.4'
+    - '   Default: C(None) thick disk, no eagerzero.
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   cdrom:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -101,10 +101,10 @@ options:
     - A list of disks to add.
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
-    - ' - C(type) (string): Valid values are:
+    - ' - C(type) (string): Valid values are:'
     - '   C(thin) thin disk'
     - '   C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.4'
-    - '   Default: C(None) thick disk, no eagerzero.
+    - '   Default: C(None) thick disk, no eagerzero.'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   cdrom:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -102,9 +102,7 @@ options:
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
     - ' - C(type) (string): Valid values are:'
-    - '   C(thin) thin disk'
-    - '   C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.4'
-    - '   Default: C(None) thick disk, no eagerzero.'
+    - '   C(thin) thin disk, C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.4, Default: C(None) thick disk, no eagerzero.'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   cdrom:

--- a/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/disk_type_d1_c1_f0.yml
@@ -1,0 +1,62 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: create new VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: eagerzeroedthick
+          autoselect_datastore: True
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'] }}"
+  register: disk_type_d1_c1_f0
+
+- debug: var=disk_type_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "disk_type_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"


### PR DESCRIPTION
##### SUMMARY
Add eagerzeroed disk option to disk spec. This PR adds the option to use an eagerzeroed thick disk for vmware guests. This is different than the 'default' thick spec, and can have performance implications in certain environments. Vmware's API doesn't call this option eagerzeroedthick, but all of their UI interfaces and marketing literature does.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_guest module

##### ANSIBLE VERSION
```
2.4.0 0.0.devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Tested agains vcenter 6.0u3 and 6.5.
```
