### PR TITLE
Add ipa host_otp option to ipa_host module to allow one time passwords for provisioning

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -25,7 +25,6 @@ version_added: '2.2'
 author:
 - James Tanner (@jctanner) <tanner.jc@gmail.com>
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
-- Steve Jacobs (@stevejacobs) <sjacobs@brokencrew.com>
 notes:
 - Tested on vSphere 5.5 and 6.0
 requirements:
@@ -100,7 +99,7 @@ options:
     - A list of disks to add.
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
-    - ' - C(type) (string): Valid value is C(thin) or C(eagerzeroedthick) (default: None).'
+    - ' - C(type) (string): Valid value is C(thin) (default: None).'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   resource_pool:
@@ -972,8 +971,6 @@ class PyVmomiHelper(object):
             if 'type' in expected_disk_spec:
                 if expected_disk_spec.get('type', '').lower() == 'thin':
                     diskspec.device.backing.thinProvisioned = True
-                if expected_disk_spec.get('type', '').lower() == 'eagerzeroedthick':
-                    diskspec.device.backing.eagerlyScrub = True
 
             # which datastore?
             if expected_disk_spec.get('datastore'):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -25,6 +25,7 @@ version_added: '2.2'
 author:
 - James Tanner (@jctanner) <tanner.jc@gmail.com>
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
+- Steve Jacobs (@stevejacobs) <sjacobs@brokencrew.com>
 notes:
 - Tested on vSphere 5.5 and 6.0
 requirements:
@@ -99,7 +100,7 @@ options:
     - A list of disks to add.
     - 'Valid attributes are:'
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
-    - ' - C(type) (string): Valid value is C(thin) (default: None).'
+    - ' - C(type) (string): Valid value is C(thin) or C(eagerzeroedthick) (default: None).'
     - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   resource_pool:
@@ -971,6 +972,8 @@ class PyVmomiHelper(object):
             if 'type' in expected_disk_spec:
                 if expected_disk_spec.get('type', '').lower() == 'thin':
                     diskspec.device.backing.thinProvisioned = True
+                if expected_disk_spec.get('type', '').lower() == 'eagerzeroedthick':
+                    diskspec.device.backing.eagerlyScrub = True
 
             # which datastore?
             if expected_disk_spec.get('datastore'):

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -44,6 +44,7 @@ options:
     - OTP Password to add this host to IPA
     required: false
     version_added: "2.4"
+    aliases: ["userpassword"]
   mac_address:
     description:
     - List of Hardware MAC address(es) off this host.

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -43,6 +43,7 @@ options:
     description:
     - OTP Password to add this host to IPA
     required: false
+    version_added: "2.4"
   mac_address:
     description:
     - List of Hardware MAC address(es) off this host.

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -14,7 +14,9 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: ipa_host
-author: Thomas Krahn (@Nosmoht)
+author: 
+    - Thomas Krahn (@Nosmoht)
+    - Steve Jacobs (@stevejacobs) <sjacobs@brokencrew.com>
 short_description: Manage FreeIPA host
 description:
 - Add, modify and delete an IPA host using IPA API
@@ -36,6 +38,10 @@ options:
   ip_address:
     description:
     - Add the host to DNS with this IP address.
+    required: false
+  host_otp:
+    description:
+    - OTP Password to add this host to IPA
     required: false
   mac_address:
     description:
@@ -184,7 +190,7 @@ class HostIPAClient(IPAClient):
 
 
 def get_host_dict(description=None, force=None, ip_address=None, ns_host_location=None, ns_hardware_platform=None,
-                  ns_os_version=None, user_certificate=None, mac_address=None):
+                  ns_os_version=None, user_certificate=None, mac_address=None, userpassword=None):
     data = {}
     if description is not None:
         data['description'] = description
@@ -202,6 +208,8 @@ def get_host_dict(description=None, force=None, ip_address=None, ns_host_locatio
         data['usercertificate'] = [{"__base64__": item} for item in user_certificate]
     if mac_address is not None:
         data['macaddress'] = mac_address
+    if userpassword is not None:
+        data['userpassword'] = userpassword
     return data
 
 
@@ -225,7 +233,8 @@ def ensure(module, client):
                                 ns_hardware_platform=module.params['ns_hardware_platform'],
                                 ns_os_version=module.params['ns_os_version'],
                                 user_certificate=module.params['user_certificate'],
-                                mac_address=module.params['mac_address'])
+                                mac_address=module.params['mac_address'],
+                                userpassword=module.params['userpassword'])
     changed = False
     if state in ['present', 'enabled', 'disabled']:
         if not ipa_host:
@@ -271,6 +280,7 @@ def main():
             ipa_user=dict(type='str', required=False, default='admin'),
             ipa_pass=dict(type='str', required=True, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
+            userpassword=dict(type='str', required=False,no_log=True, aliases=['host_otp']),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -14,12 +14,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.0',
 DOCUMENTATION = '''
 ---
 module: ipa_host
-author: 
+author:
     - Thomas Krahn (@Nosmoht)
     - Steve Jacobs (@stevejacobs) <sjacobs@brokencrew.com>
 short_description: Manage FreeIPA host
 description:
 - Add, modify and delete an IPA host using IPA API
+version_added: '2.3'
 options:
   fqdn:
     description:
@@ -280,7 +281,7 @@ def main():
             ipa_user=dict(type='str', required=False, default='admin'),
             ipa_pass=dict(type='str', required=True, no_log=True),
             validate_certs=dict(type='bool', required=False, default=True),
-            userpassword=dict(type='str', required=False,no_log=True, aliases=['host_otp']),
+            userpassword=dict(type='str', required=False, no_log=True, aliases=['host_otp']),
         ),
         supports_check_mode=True,
     )

--- a/lib/ansible/modules/identity/ipa/ipa_host.py
+++ b/lib/ansible/modules/identity/ipa/ipa_host.py
@@ -20,7 +20,6 @@ author:
 short_description: Manage FreeIPA host
 description:
 - Add, modify and delete an IPA host using IPA API
-version_added: '2.3'
 options:
   fqdn:
     description:


### PR DESCRIPTION
##### SUMMARY
This PR adds a host_otp option to the ipa_host module. 

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
ipa_host module

##### ANSIBLE VERSION
```
2.4.0 0.0.devel
```


##### ADDITIONAL INFORMATION
```
One Time Passwords are useful for host provisioning in IPA. They allow a host to be added to ipa using the one time password, instead of an admin username/password for IPA. 
```
