### PR TITLE
Fix structured output not supported in nxos_pim_interface

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -170,10 +170,17 @@ PARAM_TO_COMMAND_KEYMAP = {
 
 
 def execute_show_command(command, module, text=False):
-    if text is False:
-        command += ' | json'
+    if text:
+        cmds = [{
+            'command': command,
+            'output': 'text'
+        }]
+    else:
+        cmds = [{
+            'command': command,
+            'output': 'json'
+        }]
 
-    cmds = [command]
     return run_commands(module, cmds)
 
 

--- a/test/units/modules/network/nxos/test_nxos_pim_interface.py
+++ b/test/units/modules/network/nxos/test_nxos_pim_interface.py
@@ -47,6 +47,8 @@ class TestNxosIPInterfaceModule(TestNxosModule):
             output = list()
 
             for command in commands:
+                if type(command) == dict:
+                    command = command['command']
                 filename = str(command).split(' | ')[0].replace(' ', '_').replace('/', '_')
                 output.append(load_fixture(module_name, filename))
             return output


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: #27489

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_pim_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxapi-pim-interface 94e2d76706) last updated 2017/08/13 14:02:02 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
