### PR TITLE
Moving info from main community page

### DIFF
--- a/docs/docsite/rst/community/communication.rst
+++ b/docs/docsite/rst/community/communication.rst
@@ -1,3 +1,47 @@
 Communicating
 =============
 
+
+Mailing List Information
+------------------------
+
+Ansible has several mailing lists.  Your first post to the mailing list will be moderated (to reduce spam), so please allow a day or less for your first post.
+
+`Ansible Project List <https://groups.google.com/forum/#!forum/ansible-project>`_ is for sharing Ansible Tips, answering questions, and general user discussion.
+
+`Ansible Development List <https://groups.google.com/forum/#!forum/ansible-devel>`_ is for learning how to develop on Ansible, asking about prospective feature design, or discussions about extending ansible or features in progress.
+
+`Ansible Announce list <https://groups.google.com/forum/#!forum/ansible-announce>`_ is a read-only list that shares information about new releases of Ansible, and also rare infrequent event information, such as announcements about an AnsibleFest coming up, which is our official conference series.
+
+`Ansible Container List <https://groups.google.com/forum/#!forum/ansible-container>`_ is for users and developers of the Ansible Container project.
+
+`Ansible Lockdown List <https://groups.google.com/forum/#!forum/ansible-lockdown>`_ is for all things related to Ansible Lockdown projects, including DISA STIG automation and CIS Benchmarks.
+
+To subscribe to a group from a non-google account, you can send an email to the subscription address requesting the subscription. For example: ansible-devel+subscribe@googlegroups.com
+
+IRC Channel
+-----------
+
+Ansible has several IRC channels on Freenode (irc.freenode.net):
+
+- ``#ansible`` - For general use questions and support.
+- ``#ansible-devel`` - For discussions on developer topics and code related to features/bugs.
+- ``#ansible-aws`` - For discussions on Amazon Web Services.
+- ``#ansible-container`` - For discussions on Ansible Container.
+- ``#ansible-vmware`` - For discussions on Ansible & VMware.
+- ``#ansible-windows`` - For discussions on Ansible & Windows.
+- ``#ansible-meeting`` - For public community meetings. We will generally announce these on one or more of the above mailing lists. See the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_
+- ``#ansible-notices`` - Mostly bot output from things like Github, etc.
+
+IRC Meetings
+------------
+
+The Ansible community holds regular IRC meetings on various topics, and anyone who is interested is invited to 
+participate. For more information about Ansible meetings, consult the `meeting schedule and agenda page <https://github.com/ansible/community/blob/master/meetings/README.md>`_.
+
+Tower Support Questions
+-----------------------
+
+Ansible `Tower <https://ansible.com/tower>`_ is a UI, Server, and REST endpoint for Ansible, produced by Ansible, Inc.
+
+If you have a question about Tower, visit `Red Hat support <https://access.redhat.com/products/ansible-tower-red-hat/>`_ rather than using the IRC channel or the general project mailing list.


### PR DESCRIPTION
##### SUMMARY
Moving info from main community page, part of https://github.com/ansible/community/issues/169

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
n/a

##### ANSIBLE VERSION
n/a

##### ADDITIONAL INFORMATION
n/a