### PR TITLE
new module: manage span destination groups [network/aci/aci_span_dst_group]

### DIFF
--- a/lib/ansible/modules/network/aci/aci_span_dst_group.py
+++ b/lib/ansible/modules/network/aci/aci_span_dst_group.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_span_dst_group
+short_description: Manage span destination groups on Cisco ACI fabrics
+description:
+- Manage span destination groups on Cisco ACI fabrics.
+author:
+- Swetha Chunduri (@schunduri)
+- Dag Wieers (@dagwieers)
+- Jacob McGill (@jmcgill298)
+version_added: '2.4'
+requirements:
+- ACI Fabric 1.0(3f)+
+notes:
+- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+options:
+  dst_group:
+    description:
+    - The name of the span destination group.
+    required: yes
+    aliases: [ name ]
+  description:
+    description:
+    - Description of the span destination group.
+    aliases: [ descr ]
+  tenant:
+    description:
+    - The name of the tenant.
+    required: yes
+    aliases: [ tenant_name ]
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment: aci
+'''
+
+# FIXME: Add more, better examples
+EXAMPLES = r'''
+- aci_span_dst_group:
+    hostname: '{{ inventory_hostname }}'
+    username: '{{ username }}'
+    password: '{{ password }}'
+    dst_group: '{{ dst_group }}'
+    description: '{{ descr }}'
+    tenant: '{{ tenant }}'
+'''
+
+RETURN = r'''
+#
+'''
+
+from ansible.module_utils.aci import ACIModule, aci_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    argument_spec = aci_argument_spec
+    argument_spec.update(
+        dst_group=dict(type='str', required=False, aliases=['name']),  # Not required for querying all objects
+        tenant=dict(type='str', required=True, aliases=['tenant_name']),  # Not required for querying all objects
+        description=dict(type='str', aliases=['descr']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+        method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    dst_group = module.params['dst_group']
+    # tenant = module.params['tenant']
+    description = module.params['description']
+    state = module.params['state']
+
+    aci = ACIModule(module)
+
+    # TODO: This logic could be cleaner.
+    if dst_group is not None:
+        path = 'api/mo/uni/tn-%(tenant)s/destgrp-%(dst_group)s.json' % module.params
+    elif state == 'query':
+        # Query all contracts
+        path = 'api/node/class/spanDestGrp.json'
+    else:
+        module.fail_json(msg="Parameter 'dst_group' is required for state 'absent' or 'present'")
+
+    aci.result['url'] = '%(protocol)s://%(hostname)s/' % aci.params + path
+
+    aci.get_existing()
+
+    if state == 'present':
+        # Filter out module parameters with null values
+        aci.payload(aci_class='spanDestGrp', class_config=dict(name=dst_group, descr=description))
+
+        # Generate config diff which will be used as POST request body
+        aci.get_diff(aci_class='spanDestGrp')
+
+        # Submit changes if module not in check_mode and the proposed is different than existing
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    module.exit_json(**aci.result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
##### SUMMARY
Manage span destination groups on Cisco ACI fabrics.
This module is idempotent, and supports check-mode and has diff-support.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
aci_span_dst_group

##### ANSIBLE VERSION
v2.4