### PR TITLE
Skip CI for default GitHub patch/revert branches.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -58,6 +58,12 @@ matrix:
 
     - env: TEST=cloud/ubuntu1604
     - env: TEST=cloud/ubuntu1604py3
+
+branches:
+  except:
+    - "*-patch-*"
+    - "revert-*-*"
+
 build:
   pre_ci:
     - docker images drydock/u16pytall


### PR DESCRIPTION
##### SUMMARY

The default naming convention for patch branches created in the GitHub UI when editing files is: `{username}-patch-{number}`

The default naming convention for revert branches created in the GitHub UI when reverting a PR is: `revert-{pr_number}-{pr_branch_name}`

This exclusion will prevent Shippable from running on these branches until a PR is created.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.4.0 (ci-patch f9cfc92975) last updated 2017/08/13 22:33:20 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
