### PR TITLE
Fix #21112 : Adding support for configuring a CD-rom iso image

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -558,7 +558,7 @@ class PyVmomiHelper(PyVmomi):
         if vm_creation and self.params['guest_id'] is None:
             self.module.fail_json(msg="guest_id attribute is mandatory for VM creation")
 
-        if vm_obj is None or self.params['guest_id'] != vm_obj.summary.config.guestId:
+        if self.params['guest_id'] and (vm_obj is None or self.params['guest_id'] != vm_obj.summary.config.guestId):
             self.change_detected = True
             self.configspec.guestId = self.params['guest_id']
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -380,7 +380,7 @@ class PyVmomiDeviceHelper(object):
         cdrom_spec = vim.vm.device.VirtualDeviceSpec()
         cdrom_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         cdrom_spec.device = vim.vm.device.VirtualCdrom()
-        cdrom_spec.device.controllerKey = ide_ctl.key
+        cdrom_spec.device.controllerKey = ide_ctl.device.key
         cdrom_spec.device.key = -1
         cdrom_spec.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
         cdrom_spec.device.connectable.allowGuestControl = True

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -605,11 +605,11 @@ class PyVmomiHelper(PyVmomi):
                     self.module.fail_json(msg="hardware.cdrom specified for a VM or template which already has 4 IDE devices of which none are a cdrom")
 
                 cdrom_spec = self.device_helper.create_cdrom(ide_ctl=ide_device, iso_path=self.params['cdrom']['iso_path'])
-            elif not ( isinstance(cdrom_device.backing, vim.vm.device.VirtualCdrom.IsoBackingInfo) and \
-                    cdrom_device.backing.fileName == self.params['cdrom']['iso_path'] and \
-                    cdrom_device.connectable.allowGuestControl and \
-                    cdrom_device.connectable.startConnected and \
-                    (vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOn or cdrom_device.connectable.connected) ):
+            elif not (isinstance(cdrom_device.backing, vim.vm.device.VirtualCdrom.IsoBackingInfo) and
+                      cdrom_device.backing.fileName == self.params['cdrom']['iso_path'] and
+                      cdrom_device.connectable.allowGuestControl and
+                      cdrom_device.connectable.startConnected and
+                      (vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOn or cdrom_device.connectable.connected)):
 
                 # Updating an existing CD-ROM
                 cdrom_device.backing = vim.vm.device.VirtualCdrom.IsoBackingInfo(fileName=self.params['cdrom']['iso_path'])

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -107,7 +107,7 @@ options:
     - 'Valid attributes are:'
     - ' - C(type) (string): The type of CD-ROM, valid options are C(none), C(client) or C(iso). With C(none) the CD-ROM will be disconnected but present.'
     - ' - C(iso_path) (string): The datastore path to the ISO file to use, in the form of C([datastore1] path/to/file.iso). Required if type is iso.'
-    version_added: '2.4'
+    version_added: '2.5'
   resource_pool:
     description:
     - Affect machine to the given resource pool.

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -1,0 +1,81 @@
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim with no folders
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of Clusters from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
+  register: clusterlist
+
+- debug: var=vcsim_instance
+- debug: var=clusterlist
+
+- name: Create VM with CDROM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: CDROM-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+    cdrom:
+      iso_path: "[LocalDS_0] base.iso"
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was created
+  assert:
+    that:
+      - "cdrom_vm.failed == false"
+      - "cdrom_vm.changed == true"
+
+- name: Update CDROM settings for all VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: CDROM-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cdrom:
+      iso_path: "[LocalDS_0] base_new.iso"
+    state: present
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "cdrom_vm.failed == false"
+      - "cdrom_vm.changed == true"

--- a/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -47,6 +47,7 @@
       type: thin
       datastore: LocalDS_0
     cdrom:
+      type: iso
       iso_path: "[LocalDS_0] base.iso"
   register: cdrom_vm
 
@@ -58,7 +59,7 @@
       - "cdrom_vm.failed == false"
       - "cdrom_vm.changed == true"
 
-- name: Update CDROM settings for all VMs
+- name: Update CDROM to iso for the new VM
   vmware_guest:
     validate_certs: False
     hostname: "{{ vcsim }}"
@@ -68,7 +69,52 @@
     name: CDROM-Test
     datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
     cdrom:
+      type: iso
       iso_path: "[LocalDS_0] base_new.iso"
+    state: present
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "cdrom_vm.failed == false"
+      - "cdrom_vm.changed == true"
+
+- name: Update CDROM to client for the new VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: CDROM-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cdrom:
+      type: client
+    state: present
+  register: cdrom_vm
+
+- debug: var=cdrom_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "cdrom_vm.failed == false"
+      - "cdrom_vm.changed == true"
+
+- name: Update CDROM to none for the new VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: CDROM-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cdrom:
+      type: none
     state: present
   register: cdrom_vm
 

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -13,3 +13,4 @@
 - include: poweroff_d1_c1_f1.yml
 - include: clone_d1_c1_f0.yml
 - include: create_d1_c1_f0.yml
+- include: cdrom_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
Fix for #21112: It supports attaching an ISO image to a CD-rom. If a CD-rom does not exist on the VM, it will add it.

Also contains two small bug fixes:
- `size_mb` when adding a disk, was not supported because of a bad string match
- Even if `guest_id` was not configured, it still marked it as changed trying to update it

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (vmware_guest_cdrom 16fccea639) last updated 2017/08/14 14:14:58 (GMT +200)
  config file = None
  configured module search path = [u'/Users/philippe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/philippe/GitHub/pdellaert/ansible/lib/ansible
  executable location = /Users/philippe/GitHub/pdellaert/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
Example tasks to create a VM with a CD-Rom and then update it
```
- name: Create VM with CDROM
  vmware_guest:
    validate_certs: no
    hostname: "vcenter"
    username: "administrator@vsphere.local"
    password: "vmware"
    datacenter: "Datacenter"
    cluster: "Cluster"
    folder: "/Datacenter/vm"
    name: CDROM-Test
    resource_pool: Resources
    guest_id: centos64Guest
    hardware:
      memory_mb: 512
      num_cpus: 1
      scsi: paravirtual
    disk:
    - size_mb: 128
      type: thin
      datastore: datastore1
    cdrom:
      iso_path: "[datastore1] base.iso"

- name: Update CDROM settings for all VMs
  vmware_guest:
    validate_certs: no
    hostname: "vcenter"
    username: "administrator@vsphere.local"
    password: "vmware"
    datacenter: "Datacenter"
    cluster: "Cluster"
    folder: "/Datacenter/vm"
    name: CDROM-Test
    cdrom:
      iso_path: "[datastore1] base_new.iso"
    state: present
  register: cdrom_vm
```
