### PR TITLE
Fix zip filter plugin for Python3

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -26,6 +26,7 @@ import math
 
 from ansible import errors
 from ansible.module_utils import basic
+from ansible.module_utils.six.moves import zip, zip_longest
 
 
 def unique(a):
@@ -153,17 +154,10 @@ class FilterModule(object):
             'human_readable': human_readable,
             'human_to_bytes': human_to_bytes,
 
-        }
+            # zip
+            'zip': zip,
+            'zip_longest': zip_longest,
 
-        # py2 vs py3, reverse when py3 is predominant version
-        try:
-            filters['zip'] = itertools.izip
-            filters['zip_longest'] = itertools.izip_longest
-        except AttributeError:
-            try:
-                filters['zip'] = itertools.zip
-                filters['zip_longest'] = itertools.zip_longest
-            except:
-                pass
+        }
 
         return filters


### PR DESCRIPTION
##### SUMMARY
In Python3 the zip iterator is a builtin, while the zip_longest
iterator still requires the itertools module.

Fixes #28117

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zip filter plugin

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 000df2709d) last updated 2017/08/14 14:32:37 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/lab/ansible/devel/lib/ansible
  executable location = /home/andreas/lab/ansible/devel/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION
Fully diagnosed by @laevilgenius in #28117.
