### PR TITLE
Mark $team_openstack as owning openstack things

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -910,7 +910,7 @@ files:
   $module_utils/nxos.py:
     maintainers: $team_networking
     labels: networking
-  $module_utils/openstack.py
+  $module_utils/openstack.py:
     maintainers: $team_openstack
     labels:
     - cloud

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -220,49 +220,9 @@ files:
   $modules/cloud/misc/virt_net.py: drybjed
   $modules/cloud/misc/virt_pool.py: drybjed
   $modules/cloud/misc/xenserver_facts.py: andyhky
-  $modules/cloud/openstack/os_auth.py: $team_openstack
-  $modules/cloud/openstack/os_client_config.py: $team_openstack
-  $modules/cloud/openstack/os_flavor_facts.py: $team_openstack
-  $modules/cloud/openstack/os_floating_ip.py: $team_openstack
-  $modules/cloud/openstack/os_group.py: $team_openstack
-  $modules/cloud/openstack/os_image.py: $team_openstack
-  $modules/cloud/openstack/os_image_facts.py: dagnello
-  $modules/cloud/openstack/os_ironic.py: $team_openstack
-  $modules/cloud/openstack/os_ironic_inspect.py: $team_openstack
-  $modules/cloud/openstack/os_ironic_node.py: $team_openstack
-  $modules/cloud/openstack/os_keypair.py: $team_openstack
-  $modules/cloud/openstack/os_keystone_domain.py: $team_openstack
-  $modules/cloud/openstack/os_keystone_domain_facts.py: $team_openstack
-  $modules/cloud/openstack/os_keystone_role.py: $team_openstack
-  $modules/cloud/openstack/os_keystone_service.py: SamYaple
-  $modules/cloud/openstack/os_network.py: $team_openstack
-  $modules/cloud/openstack/os_networks_facts.py: dagnello
-  $modules/cloud/openstack/os_nova_flavor.py: $team_openstack
-  $modules/cloud/openstack/os_nova_host_aggregate.py: $team_openstack
-  $modules/cloud/openstack/os_object.py: $team_openstack
-  $modules/cloud/openstack/os_port.py: dagnello
-  $modules/cloud/openstack/os_port_facts.py: $team_openstack
-  $modules/cloud/openstack/os_project.py: agireud
-  $modules/cloud/openstack/os_project_facts.py: $team_openstack
-  $modules/cloud/openstack/os_quota.py: $team_openstack
-  $modules/cloud/openstack/os_recordset.py: $team_openstack
-  $modules/cloud/openstack/os_router.py: $team_openstack
-  $modules/cloud/openstack/os_security_group.py: $team_openstack
-  $modules/cloud/openstack/os_security_group_rule.py: $team_openstack
-  $modules/cloud/openstack/os_server.py: $team_openstack
-  $modules/cloud/openstack/os_server_actions.py: $team_openstack
-  $modules/cloud/openstack/os_server_facts.py: $team_openstack
-  $modules/cloud/openstack/os_server_group.py: kong
-  $modules/cloud/openstack/os_server_volume.py: $team_openstack
-  $modules/cloud/openstack/os_stack.py: $team_openstack
-  $modules/cloud/openstack/os_subnet.py: $team_openstack
-  $modules/cloud/openstack/os_subnets_facts.py: dagnello
-  $modules/cloud/openstack/os_user.py: $team_openstack
-  $modules/cloud/openstack/os_user_facts.py: $team_openstack
-  $modules/cloud/openstack/os_user_group.py: $team_openstack
-  $modules/cloud/openstack/os_user_role.py: $team_openstack
-  $modules/cloud/openstack/os_volume.py: $team_openstack
-  $modules/cloud/openstack/os_zone.py: $team_openstack
+  $modules/cloud/openstack/: $team_openstack
+  $modules/cloud/openstack/os_keystone_service.py: $team_openstack SamYaple
+  $modules/cloud/openstack/os_project.py: $team_openstack agireud
   $modules/cloud/ovh/ovh_ip_loadbalancing_backend.py: pascalheraud
   $modules/cloud/ovirt/: machacekondra
   $modules/cloud/packet/:
@@ -845,14 +805,18 @@ files:
     - dynamic inventory script
     - dynamic inventory
     - inventory script
-  contrib/inventory/openstack.py:
-    keywords:
-    - openstack dynamic inventory script
   contrib/inventory/linode.py:
     keywords:
     - linode dynamic inventory script
     maintainers:
     - intheclouddan rwaweber zbal
+  contrib/inventory/openstack.py:
+    keywords:
+    - openstack dynamic inventory script
+    maintainers: $team_openstack
+    labels:
+    - cloud
+    - openstack
   contrib/inventory/azure_rm.py:
     keywords:
     - azure inventory
@@ -946,6 +910,11 @@ files:
   $module_utils/nxos.py:
     maintainers: $team_networking
     labels: networking
+  $module_utils/openstack.py
+    maintainers: $team_openstack
+    labels:
+    - cloud
+    - openstack
   $module_utils/ordnance.py:
     maintainers: alexanderturner djh00t
     labels: networking
@@ -1075,7 +1044,8 @@ macros:
   team_netvisor: Qalthos amitsi gundalow privateip
   team_networking: Qalthos ganeshrn gundalow privateip rcarrillocruz trishnaguha
   team_nxos: GGabriele jedelman8 mikewiebe privateip rahushen rcarrillocruz trishnaguha
-  team_openstack: emonty j2sol juliakreger rcarrillocruz shrews thingee
+  team_openstack: emonty j2sol juliakreger rcarrillocruz shrews thingee dagnello
+  team_openswitch: Qalthos gundalow privateip
   team_rabbitmq: chrishoffman manuel-sousa romanek-adam
   team_rhn: alikins barnabycourt flossware vritant
   team_tower: ghjm jlaska matburt wwitzel3


### PR DESCRIPTION
##### SUMMARY
Rather than listing ownership of each module individually, mark the modules/cloud/openstack/ dir as team owned. Also add the openstack module utils and openstack inventory script.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yaml