### PR TITLE
win_dns_client failing on 2008R2 SP1 (Fixes #25216)

### DIFF
--- a/lib/ansible/modules/windows/win_dns_client.ps1
+++ b/lib/ansible/modules/windows/win_dns_client.ps1
@@ -135,7 +135,13 @@ Function Get-DnsClientMatch {
 
     $current_dns_v4 = ($current_dns_all | Where-Object AddressFamily -eq 2 <# IPv4 #>).ServerAddresses
 
-    $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses).Count -eq 0
+    If ($current_dns_v4 -eq $null) {
+        $v4_match = $False
+    }
+
+    Else {
+        $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses).Count -eq 0
+    }
 
     # TODO: implement IPv6
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix for Issue 25216
 [https://github.com/ansible/ansible/issues/25216](url)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_dns_client
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.6.6 (r266:84292, Aug  9 2016, 06:11:56) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
win_dns_client fails on 2008R2 SP1 server when no DNS servers are configured on the server.

<!--- Paste verbatim command output below, e.g. before and after your change -->

```diff
    $current_dns_v4 = ($current_dns_all | Where-Object AddressFamily -eq 2 <# IPv4 #>).ServerAddresses
-    $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses).Count -eq 0

+    If ($current_dns_v4 -eq $null) {
+        $v4_match = $False
+    }
+
+    Else {
+        $v4_match = @(Compare-Object $current_dns_v4 $ipv4_addresses).Count -eq 0
+    }

    # TODO: implement IPv6

```