### PR TITLE
fix prompt error when deleting ios user

### DIFF
--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -154,6 +154,14 @@ def validate_privilege(value, module):
         module.fail_json(msg='privilege must be between 1 and 15, got %s' % value)
 
 
+def user_del_cmd(username):
+    return json.dumps({
+        'command': 'no username %s' % username,
+        'prompt': 'This operation will remove all username related configurations with same name',
+        'answer': 'y'
+    })
+
+
 def map_obj_to_commands(updates, module):
     commands = list()
     state = module.params['state']
@@ -169,12 +177,7 @@ def map_obj_to_commands(updates, module):
         want, have = update
 
         if want['state'] == 'absent':
-            cmd = json.dumps({
-                'command': 'no username %s' % want['name'],
-                'prompt': 'This operation will remove all username related configurations with same name',
-                'answer': 'y'
-            })
-            commands.append(cmd)
+            commands.append(user_del_cmd(want['name']))
             continue
 
         if needs_update(want, have, 'view'):
@@ -191,12 +194,7 @@ def map_obj_to_commands(updates, module):
             if want['nopassword']:
                 add(commands, want, 'nopassword')
             else:
-                cmd = json.dumps({
-                    'command': 'no username %s nopassword' % want['name'],
-                    'prompt': 'This operation will remove all username related configurations with same name',
-                    'answer': 'y'
-                })
-                add(commands, want, cmd)
+                add(commands, want, user_del_cmd(want['name']))
 
     return commands
 
@@ -347,12 +345,7 @@ def main():
         have_users = [x['name'] for x in have]
         for item in set(have_users).difference(want_users):
             if item != 'admin':
-                cmd = json.dumps({
-                    'command': 'no username %s' % item,
-                    'prompt': 'This operation will remove all username related configurations with same name',
-                    'answer': 'y'
-                })
-                commands.append(cmd)
+                commands.append(user_del_cmd(item))
 
     result['commands'] = commands
 

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -1,4 +1,15 @@
 ---
+- name: tear down old users if they exist (Setup)
+  ios_user:
+    aggregate:
+      - name: ansibletest1
+      - name: ansibletest2
+      - name: ansibletest3
+    state: absent
+    authorize: yes
+    provider: "{{ cli }}"
+  register: result
+
 - name: Create user (SetUp)
   ios_user:
     name: ansibletest1
@@ -75,4 +86,6 @@
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["no username ansibletest1", "no username ansibletest2", "no username ansibletest3"]'
+      - '"no username ansibletest1" in result.commands[0]'
+      - '"no username ansibletest2" in result.commands[1]'
+      - '"no username ansibletest3" in result.commands[2]'

--- a/test/units/modules/network/ios/test_ios_user.py
+++ b/test/units/modules/network/ios/test_ios_user.py
@@ -53,10 +53,17 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_delete(self):
         set_module_args(dict(name='ansible', state='absent'))
         result = self.execute_module(changed=True)
-        cmd = '{"answer": "y", ' +\
-              '"prompt": "This operation will remove all username related ' +\
-              'configurations with same name", "command": "no username ansible"}'
-        self.assertEqual(result['commands'], [cmd])
+        cmd = json.loads(
+            '{"answer": "y", ' +
+            '"prompt": "This operation will remove all username related ' +
+            'configurations with same name", "command": "no username ansible"}'
+        )
+
+        result_cmd = []
+        for i in result['commands']:
+            result_cmd.append(json.loads(i))
+
+        self.assertEqual(result_cmd, [cmd])
 
     def test_ios_user_password(self):
         set_module_args(dict(name='ansible', password='test'))
@@ -75,10 +82,17 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_purge(self):
         set_module_args(dict(purge=True))
         result = self.execute_module(changed=True)
-        cmd = '{"answer": "y", ' +\
-              '"prompt": "This operation will remove all username related ' +\
-              'configurations with same name", "command": "no username ansible"}'
-        self.assertEqual(result['commands'], [cmd])
+        cmd = json.loads(
+            '{"answer": "y", ' +
+            '"prompt": "This operation will remove all username related ' +
+            'configurations with same name", "command": "no username ansible"}'
+        )
+
+        result_cmd = []
+        for i in result['commands']:
+            result_cmd.append(json.loads(i))
+
+        self.assertEqual(result_cmd, [cmd])
 
     def test_ios_user_view(self):
         set_module_args(dict(name='ansible', view='test'))

--- a/test/units/modules/network/ios/test_ios_user.py
+++ b/test/units/modules/network/ios/test_ios_user.py
@@ -53,7 +53,10 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_delete(self):
         set_module_args(dict(name='ansible', state='absent'))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['{"answer": "y", "prompt": "This operation will remove all username related configurations with same name", "command": "no username ansible"}'])
+        cmd = '{"answer": "y", ' +\
+              '"prompt": "This operation will remove all username related ' +\
+              'configurations with same name", "command": "no username ansible"}'
+        self.assertEqual(result['commands'], [cmd])
 
     def test_ios_user_password(self):
         set_module_args(dict(name='ansible', password='test'))
@@ -72,7 +75,10 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_purge(self):
         set_module_args(dict(purge=True))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['{"answer": "y", "prompt": "This operation will remove all username related configurations with same name", "command": "no username ansible"}'])
+        cmd = '{"answer": "y", ' +\
+              '"prompt": "This operation will remove all username related ' +\
+              'configurations with same name", "command": "no username ansible"}'
+        self.assertEqual(result['commands'], [cmd])
 
     def test_ios_user_view(self):
         set_module_args(dict(name='ansible', view='test'))

--- a/test/units/modules/network/ios/test_ios_user.py
+++ b/test/units/modules/network/ios/test_ios_user.py
@@ -53,7 +53,7 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_delete(self):
         set_module_args(dict(name='ansible', state='absent'))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['no username ansible'])
+        self.assertEqual(result['commands'], ['{"answer": "y", "prompt": "This operation will remove all username related configurations with same name", "command": "no username ansible"}'])
 
     def test_ios_user_password(self):
         set_module_args(dict(name='ansible', password='test'))
@@ -72,7 +72,7 @@ class TestIosUserModule(TestIosModule):
     def test_ios_user_purge(self):
         set_module_args(dict(purge=True))
         result = self.execute_module(changed=True)
-        self.assertEqual(result['commands'], ['no username ansible'])
+        self.assertEqual(result['commands'], ['{"answer": "y", "prompt": "This operation will remove all username related configurations with same name", "command": "no username ansible"}'])
 
     def test_ios_user_view(self):
         set_module_args(dict(name='ansible', view='test'))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes:  #27115

Update ios_user to send a json command with the expected prompt/answer when issuing a `no username foo` command.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix-ios-user 27a4e9311b) last updated 2017/08/14 12:55:00 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
