### PR TITLE
Fix bugs in softlayer dynamic inventory

### DIFF
--- a/contrib/inventory/softlayer.py
+++ b/contrib/inventory/softlayer.py
@@ -52,7 +52,7 @@ class SoftLayerInventory(object):
         'primaryBackendIpAddress',
         'primaryIpAddress',
         'datacenter',
-        'tagReferences.tag.name',
+        'tagReferences',
         'userData.value',
     ]
 
@@ -85,7 +85,7 @@ class SoftLayerInventory(object):
             self.get_all_servers()
             print(self.json_format_dict(self.inventory, True))
         elif self.args.host:
-            self.get_virtual_servers()
+            self.get_all_servers()
             print(self.json_format_dict(self.inventory["_meta"]["hostvars"][self.args.host], True))
 
     def to_safe(self, word):
@@ -142,6 +142,12 @@ class SoftLayerInventory(object):
 
         dest = instance['primaryIpAddress']
 
+        instance['tags'] = list()
+        for tag in instance['tagReferences']:
+            instance['tags'].append(tag['tag']['name'])
+
+        del instance['tagReferences']
+
         self.inventory["_meta"]["hostvars"][dest] = instance
 
         # Inventory: group by memory
@@ -171,9 +177,8 @@ class SoftLayerInventory(object):
         # Inventory: group by type (hardware/virtual)
         self.push(self.inventory, instance_type, dest)
 
-        # Inventory: group by tag
-        for tag in instance['tagReferences']:
-            self.push(self.inventory, tag['tag']['name'], dest)
+        for tag in instance['tags']:
+            self.push(self.inventory, tag, dest)
 
     def get_virtual_servers(self):
         '''Get all the CCI instances'''


### PR DESCRIPTION
##### SUMMARY

* --host hostname did not work due to calling wrong function

* softlayer api returns a bunch of extra stuff in the tagReference dict that
  makes --list output crazy long, like over a terminal buffer for just one server
  this culls out the extranneous information and only inserts the actual user
  provided tags to each server.

##### ISSUE TYPE
 - Bugfix Pull Request

