### PR TITLE
template: lookup: Restore actual old behavior when `allow_unsafe=True`

### DIFF
--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -595,19 +595,21 @@ class Templar:
                                        "original message: %s" % (name, type(e), e))
                 ran = None
 
-            if ran and not allow_unsafe:
+            if ran:
                 if wantlist:
                     ran = wrap_var(ran)
                 else:
                     try:
-                        ran = UnsafeProxy(",".join(ran))
+                        ran = ",".join(ran)
+                        if not allow_unsafe:
+                            ran = UnsafeProxy(ran)
                     except TypeError:
                         if isinstance(ran, list) and len(ran) == 1:
                             ran = wrap_var(ran[0])
                         else:
                             ran = wrap_var(ran)
 
-                if self.cur_context:
+                if self.cur_context and not allow_unsafe:
                     self.cur_context.unsafe = True
             return ran
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
`lookup` has been broken for certain files since upgrading from `2.3.0.0` to `2.3.1.0` as described in the release notes. But the old behavior of `lookup` is not restored when using `allow_unsafe=True`.

This fixes `lookup` to match the old behavior exactly when explicitly overridden.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
template lookup

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```

##### ADDITIONAL INFORMATION
Commit that broke `lookup`: a1886911fcf4b691130cfc70dfc5daa5e07c46a3