### PR TITLE
prompt for new pass on create/encrypt if none specified

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -234,7 +234,8 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         vault_ids = CLI.build_vault_ids(vault_ids,
                                         vault_password_files,
-                                        ask_vault_pass)
+                                        ask_vault_pass,
+                                        create_new_password)
 
         for vault_id_slug in vault_ids:
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
@@ -286,6 +287,8 @@ class CLI(with_metaclass(ABCMeta, object)):
 
             # update loader with as-yet-known vault secrets
             loader.set_vault_secrets(vault_secrets)
+
+
 
         return vault_secrets
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -288,8 +288,6 @@ class CLI(with_metaclass(ABCMeta, object)):
             # update loader with as-yet-known vault secrets
             loader.set_vault_secrets(vault_secrets)
 
-
-
         return vault_secrets
 
     def ask_passwords(self):

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -240,6 +240,11 @@ class CLI(with_metaclass(ABCMeta, object)):
         for vault_id_slug in vault_ids:
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
+
+                # prompts cant/shouldnt work without a tty, so dont add prompt secrets
+                if not sys.stdin.isatty():
+                    continue
+
                 # --vault-id some_name@prompt_ask_vault_pass --vault-id other_name@prompt_ask_vault_pass will be a little
                 # confusing since it will use the old format without the vault id in the prompt
                 built_vault_id = vault_id_name or C.DEFAULT_VAULT_IDENTITY

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -48,29 +48,24 @@ class TestCliVersion(unittest.TestCase):
 class TestCliBuildVaultIds(unittest.TestCase):
     def test(self):
         res = cli.CLI.build_vault_ids(['foo@bar'])
-        print('res: %s' % res)
         self.assertEqual(res, ['foo@bar'])
 
     def test_create_new_password_no_vault_id(self):
         res = cli.CLI.build_vault_ids([], create_new_password=True)
-        print('res: %s' % res)
         self.assertEqual(res, ['default@prompt_ask_vault_pass'])
 
     def test_create_new_password_no_vault_id_ask_vault_pass(self):
         res = cli.CLI.build_vault_ids([], ask_vault_pass=True,
                                       create_new_password=True)
-        print('res: %s' % res)
         self.assertEqual(res, ['default@prompt_ask_vault_pass'])
 
     def test_create_new_password_with_vault_ids(self):
         res = cli.CLI.build_vault_ids(['foo@bar'], create_new_password=True)
-        print('res: %s' % res)
         self.assertEqual(res, ['foo@bar'])
 
     def test_create_new_password_no_vault_ids_password_files(self):
         res = cli.CLI.build_vault_ids([], vault_password_files=['some-password-file'],
                                       create_new_password=True)
-        print('res: %s' % res)
         self.assertEqual(res, ['default@some-password-file'])
 
     def test_everything(self):
@@ -80,12 +75,12 @@ class TestCliBuildVaultIds(unittest.TestCase):
                                                             'one-more-password-file'],
                                       ask_vault_pass=True,
                                       create_new_password=True)
-        print('res: %s' % res)
         self.assertEqual(set(res), set(['blip@prompt', 'baz@prompt_ask_vault_pass',
                                         'default@prompt_ask_vault_pass',
                                         'some-password-file', 'qux@another-password-file',
                                         'default@yet-another-password-file',
                                         'default@one-more-password-file']))
+
 
 class TestCliSetupVaultSecrets(unittest.TestCase):
     def setUp(self):

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -45,6 +45,48 @@ class TestCliVersion(unittest.TestCase):
         self.assertIn('python version', version_info['string'])
 
 
+class TestCliBuildVaultIds(unittest.TestCase):
+    def test(self):
+        res = cli.CLI.build_vault_ids(['foo@bar'])
+        print('res: %s' % res)
+        self.assertEqual(res, ['foo@bar'])
+
+    def test_create_new_password_no_vault_id(self):
+        res = cli.CLI.build_vault_ids([], create_new_password=True)
+        print('res: %s' % res)
+        self.assertEqual(res, ['default@prompt_ask_vault_pass'])
+
+    def test_create_new_password_no_vault_id_ask_vault_pass(self):
+        res = cli.CLI.build_vault_ids([], ask_vault_pass=True,
+                                      create_new_password=True)
+        print('res: %s' % res)
+        self.assertEqual(res, ['default@prompt_ask_vault_pass'])
+
+    def test_create_new_password_with_vault_ids(self):
+        res = cli.CLI.build_vault_ids(['foo@bar'], create_new_password=True)
+        print('res: %s' % res)
+        self.assertEqual(res, ['foo@bar'])
+
+    def test_create_new_password_no_vault_ids_password_files(self):
+        res = cli.CLI.build_vault_ids([], vault_password_files=['some-password-file'],
+                                      create_new_password=True)
+        print('res: %s' % res)
+        self.assertEqual(res, ['default@some-password-file'])
+
+    def test_everything(self):
+        res = cli.CLI.build_vault_ids(['blip@prompt', 'baz@prompt_ask_vault_pass',
+                                       'some-password-file', 'qux@another-password-file'],
+                                      vault_password_files=['yet-another-password-file',
+                                                            'one-more-password-file'],
+                                      ask_vault_pass=True,
+                                      create_new_password=True)
+        print('res: %s' % res)
+        self.assertEqual(set(res), set(['blip@prompt', 'baz@prompt_ask_vault_pass',
+                                        'default@prompt_ask_vault_pass',
+                                        'some-password-file', 'qux@another-password-file',
+                                        'default@yet-another-password-file',
+                                        'default@one-more-password-file']))
+
 class TestCliSetupVaultSecrets(unittest.TestCase):
     def setUp(self):
         self.fake_loader = DictDataLoader({})


### PR DESCRIPTION

##### SUMMARY

Make 'ansible-vault' edit or encrypt prompt for a password
if none or provided elsewhere.

ie, 'ansible-vault create foo.yml' should prompt for a password
instead of requiring --ask-vault-pass like 'ansible-playbook'. This
makes the behavior match 2.3

Note: ansible-playbook does not prompt if not vault password
is provided

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_secrets_prompt_default 912e5b9f75) last updated 2017/08/14 15:45:52 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
