### PR TITLE
Vault secrets empty password

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -180,7 +180,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         return ret
 
     @staticmethod
-    def build_vault_ids(vault_ids, vault_password_files=None, ask_vault_pass=None):
+    def build_vault_ids(vault_ids, vault_password_files=None,
+                        ask_vault_pass=None, create_new_password=None):
         vault_password_files = vault_password_files or []
         vault_ids = vault_ids or []
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -252,7 +252,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                     prompted_vault_secret.load()
                 except AnsibleError as exc:
                     display.warning('Error in vault password prompt (%s): %s' % (vault_id_name, exc))
-                    continue
+                    raise
 
                 vault_secrets.append((built_vault_id, prompted_vault_secret))
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -34,7 +34,7 @@ from abc import ABCMeta, abstractmethod
 
 import ansible
 from ansible import constants as C
-from ansible.errors import AnsibleOptionsError
+from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.inventory.manager import InventoryManager
 from ansible.module_utils.six import with_metaclass, string_types
 from ansible.module_utils._text import to_bytes, to_text
@@ -193,7 +193,9 @@ class CLI(with_metaclass(ABCMeta, object)):
             # used by --vault-id and --vault-password-file
             vault_ids.append(id_slug)
 
-        if ask_vault_pass:
+        # if an action needs an encrypt password (create_new_password=True) and we dont
+        # have other secrets setup, then automatically add a password prompt as well.
+        if ask_vault_pass or (create_new_password and not vault_ids):
             id_slug = u'%s@%s' % (C.DEFAULT_VAULT_IDENTITY, u'prompt_ask_vault_pass')
             vault_ids.append(id_slug)
 
@@ -233,21 +235,24 @@ class CLI(with_metaclass(ABCMeta, object)):
         for vault_id_slug in vault_ids:
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
-
                 # --vault-id some_name@prompt_ask_vault_pass --vault-id other_name@prompt_ask_vault_pass will be a little
                 # confusing since it will use the old format without the vault id in the prompt
-                if vault_id_name:
-                    prompted_vault_secret = PromptVaultSecret(prompt_formats=prompt_formats[vault_id_value],
-                                                              vault_id=vault_id_name)
+                built_vault_id = vault_id_name or C.DEFAULT_VAULT_IDENTITY
+
+                # choose the prompt based on --vault-id=prompt or --ask-vault-pass. --ask-vault-pass
+                # always gets the old format for Tower compatibility.
+                # ie, we used --ask-vault-pass, so we need to use the old vault password prompt
+                # format since Tower needs to match on that format.
+                prompted_vault_secret = PromptVaultSecret(prompt_formats=prompt_formats[vault_id_value],
+                                                          vault_id=built_vault_id)
+
+                try:
                     prompted_vault_secret.load()
-                    vault_secrets.append((vault_id_name, prompted_vault_secret))
-                else:
-                    # ie, we used --ask-vault-pass, so we need to use the old vault password prompt
-                    # format since Tower needs to match on that format.
-                    prompted_vault_secret = PromptVaultSecret(prompt_formats=prompt_formats[vault_id_value],
-                                                              vault_id=C.DEFAULT_VAULT_IDENTITY)
-                    prompted_vault_secret.load()
-                    vault_secrets.append((C.DEFAULT_VAULT_IDENTITY, prompted_vault_secret))
+                except AnsibleError as exc:
+                    display.warning('Error in vault password prompt (%s): %s' % (vault_id_name, exc))
+                    continue
+
+                vault_secrets.append((built_vault_id, prompted_vault_secret))
 
                 # update loader with new secrets incrementally, so we can load a vault password
                 # that is encrypted with a vault secret provided earlier

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -263,7 +263,8 @@ class PromptVaultSecret(VaultSecret):
             try:
                 vault_pass = display.prompt(prompt, private=True)
             except EOFError:
-                break
+                raise AnsibleVaultError('EOFError (ctrl-d) on prompt for (%s)' % self.vault_id)
+
             b_vault_pass = to_bytes(vault_pass, errors='strict', nonstring='simplerepr').strip()
             b_vault_passwords.append(b_vault_pass)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -222,15 +222,16 @@ def format_vaulttext_envelope(b_ciphertext, cipher_name, version=None, vault_id=
     return b_vaulttext
 
 
-def verify_secret_is_not_empty(secret):
+def verify_secret_is_not_empty(secret, msg=None):
     '''Check the secret against minimal requirements.
 
     Raises: AnsibleVaultPasswordError if the password does not meet requirements.
 
     Currently, only requirement is that the password is not None or an empty string.
     '''
+    msg = msg or 'Invalid vault password was provided'
     if not secret:
-        raise AnsibleVaultPasswordError('Invalid vault password was provided')
+        raise AnsibleVaultPasswordError(msg)
 
 
 class VaultSecret:
@@ -353,7 +354,8 @@ class FileVaultSecret(VaultSecret):
         except (OSError, IOError) as e:
             raise AnsibleError("Could not read vault password file %s: %s" % (filename, e))
 
-        verify_secret_is_not_empty(vault_pass)
+        verify_secret_is_not_empty(vault_pass,
+                                   msg='Invalid vault password was provided from file (%s)' % filename)
 
         return vault_pass
 
@@ -384,7 +386,8 @@ class ScriptVaultSecret(FileVaultSecret):
             raise AnsibleError("Vault password script %s returned non-zero (%s): %s" % (filename, p.returncode, stderr))
 
         vault_pass = stdout.strip(b'\r\n')
-        verify_secret_is_not_empty(vault_pass)
+        verify_secret_is_not_empty(vault_pass,
+                                   msg='Invalid vault password was provided from script (%s)' % filename)
         return vault_pass
 
 

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -14,6 +14,7 @@ echo "This is a test file for format 1.2" > "${TEST_FILE_1_2}"
 
 TEST_FILE_OUTPUT="${MYTMPDIR}/test_file_output"
 
+
 # old format
 ansible-vault view "$@" --vault-password-file vault-password-ansible format_1_0_AES.yml
 
@@ -37,6 +38,7 @@ echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
 set -eux
+
 
 # new format, view
 ansible-vault view "$@" --vault-password-file vault-password format_1_1_AES256.yml
@@ -184,6 +186,24 @@ ansible-vault encrypt "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --outpu
 ansible-vault view "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" - < "${TEST_FILE_OUTPUT}"
 ansible-vault decrypt "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --output=- < "${TEST_FILE_OUTPUT}"
 
+# test using an empty vault password file
+ansible-vault view "$@" --vault-password-file empty-password format_1_1_AES256.yml && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
+ansible-vault view "$@" --vault-id=empty@empty-password --vault-password-file empty-password format_1_1_AES256.yml && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
+echo 'foo' > some_file.txt
+ansible-vault encrypt "$@" --vault-password-file empty-password some_file.txt && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
+
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" "a test string"
 
 ansible-vault encrypt_string "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" --name "blippy" "a test string names blippy"
@@ -276,6 +296,12 @@ echo "rc was $WRONG_RC (1 is expected)"
 
 # with multiple wrong passwords with --vault-id
 ansible-playbook test_vault.yml          -i ../../inventory -v "$@" --vault-id wrong1@vault-password-wrong --vault-id wrong2@vault-password-wrong && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
+# with empty password file
+ansible-playbook test_vault.yml           -i ../../inventory -v "$@" --vault-id empty@empty-password && :
 WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Match the 2.3 behavior when an empty '' password is used.

ie, exit with an error immediately.

Do this as soon as any password/secret source provides an empty password. even in the
cases where there are multiple vault ids. 

This applies for empty passwords from a prompt, a file, or a script. It also applies for
ending a prompt via ctrl-D/EOFError.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/parsing/vault/
lib/ansible/cli/vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_secrets_prompt_default 912e5b9f75) last updated 2017/08/14 15:45:52 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Example output for the cases where this errors/exits.


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
[newswoop:F25:ansible (vault_secrets_empty_password %)]$ cat empty-password 
[newswoop:F25:ansible (vault_secrets_empty_password %)]$ ansible-playbook --vault-id=foo@empty-password --vault-id=bar@empty-password -i hosts_vault ping_ssh.yml
 [WARNING]: Error in vault password file loading (foo): Invalid vault password was provided from file (/home/adrian/src/ansible/empty-password)

ERROR! Invalid vault password was provided from file (/home/adrian/src/ansible/empty-password)


[newswoop:F25:ansible (vault_secrets_empty_password %)]$ ansible-vault view --vault-id=foo@empty_password --vault-id=bar@empty_password --vault-id=blip@prompt foo3.yml 
ERROR! The vault password file /home/adrian/src/ansible/empty_password was not found
[newswoop:F25:ansible (vault_secrets_empty_password %)]$ ansible-vault view --vault-id=foo@empty-password --vault-id=bar@empty-password foo3.yml 
 [WARNING]: Error in vault password file loading (foo): Invalid vault password was provided from file (/home/adrian/src/ansible/empty-password)

ERROR! Invalid vault password was provided from file (/home/adrian/src/ansible/empty-password)
[newswoop:F25:ansible (vault_secrets_empty_password %)]$ ansible-vault view --vault-password-file=empty-password foo3.yml 
 [WARNING]: Error in vault password file loading (default): Invalid vault password was provided from file (/home/adrian/src/ansible/empty-password)

ERROR! Invalid vault password was provided from file (/home/adrian/src/ansible/empty-password)
[newswoop:F25:ansible (vault_secrets_empty_password %)]$ ansible-vault view --vault-id=empty@prompt foo3.yml 
Vault password (empty): 
 [WARNING]: Error in vault password prompt (empty): Invalid vault password was provided

ERROR! Invalid vault password was provided

```
