### PR TITLE
Change network *_user modules to use configured_password to set a users password

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -49,7 +49,6 @@ options:
         exclusive with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
     version_added: "2.4"
-  password:
   configured_password:
     description:
       - The password to be configured on the remote Arista EOS device. The

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -340,12 +340,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password']:
+    if module.params['password'] and not module.params['configured_password']:
         warnings.append(
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-
+        
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -50,6 +50,7 @@ options:
         Please note that this option is not same as C(provider username).
     version_added: "2.4"
   password:
+  configured_password:
     description:
       - The password to be configured on the remote Arista EOS device. The
         password needs to be provided in clear and it will be encrypted
@@ -125,8 +126,8 @@ EXAMPLES = """
 
 - name: Change Password for User netop
   eos_user:
-    name: netop
-    password: "{{ new_password }}"
+    username: netop
+    configured_password: "{{ new_password }}"
     update_password: always
     state: present
 """
@@ -182,9 +183,9 @@ def map_obj_to_commands(updates, module):
         if needs_update('privilege'):
             add('privilege %s' % want['privilege'])
 
-        if needs_update('password'):
+        if needs_update('configured_password'):
             if update_password == 'always' or not have:
-                add('secret %s' % want['password'])
+                add('secret %s' % want['configured_password'])
 
         if needs_update('sshkey'):
             add('sshkey %s' % want['sshkey'])
@@ -233,7 +234,7 @@ def map_config_to_obj(module):
             'name': user,
             'state': 'present',
             'nopassword': 'nopassword' in cfg,
-            'password': None,
+            'configured_password': None,
             'sshkey': parse_sshkey(cfg),
             'privilege': parse_privilege(cfg),
             'role': parse_role(cfg)
@@ -286,7 +287,7 @@ def map_params_to_obj(module):
 
     for item in collection:
         get_value = partial(get_param_value, item=item, module=module)
-        item['password'] = get_value('password')
+        item['configured_password'] = get_value('configured_password')
         item['nopassword'] = get_value('nopassword')
         item['privilege'] = get_value('privilege')
         item['role'] = get_value('role')
@@ -318,7 +319,7 @@ def main():
         aggregate=dict(type='list', aliases=['collection', 'users']),
         name=dict(),
 
-        password=dict(no_log=True),
+        configured_password=dict(no_log=True),
         nopassword=dict(type='bool'),
         update_password=dict(default='always', choices=['on_create', 'always']),
 

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -340,6 +340,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
+    if module.params['password']:
+        warnings.append(
+            'The "password" argument is used to authenticate the current connection. ' +
+            'To set a user password use "configured_password" instead.'
+        )
+
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -56,6 +56,7 @@ options:
         password needs to be provided in clear and it will be encrypted
         on the device.
         Please note that this option is not same as C(provider password).
+    version_added: "2.4"
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this
@@ -345,7 +346,7 @@ def main():
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-        
+
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -365,12 +365,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password']:
+    if module.params['password'] and not module.params['configured_password']:
         warnings.append(
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-        
+
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -365,6 +365,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
+    if module.params['password']:
+        warnings.append(
+            'The "password" argument is used to authenticate the current connection. ' +
+            'To set a user password use "configured_password" instead.'
+        )
+        
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -198,12 +198,7 @@ def map_obj_to_commands(updates, module):
         want, have = update
 
         if want['state'] == 'absent':
-            cmd = json.dumps({
-                'command': 'no username %s' % want['name'],
-                'prompt': 'This operation will remove all username related configurations with same name',
-                'answer': 'y'
-            })
-            commands.append(cmd)
+            commands.append(user_del_cmd(want['name']))
             continue
 
         if needs_update(want, have, 'view'):

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -37,7 +37,7 @@ options:
         This argument accepts a string value and is mutually exclusive
         with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
-  password:
+  configured_password:
     description:
       - The password to be configured on the Cisco IOS XR device. The
         password needs to be provided in clear and it will be encrypted
@@ -81,7 +81,7 @@ EXAMPLES = """
 - name: create a new user
   iosxr_user:
     name: ansible
-    password: test
+    configured_password: test
     state: present
 - name: remove all users except admin
   iosxr_user:
@@ -96,7 +96,7 @@ EXAMPLES = """
 - name: Change Password for User netop
   iosxr_user:
     name: netop
-    password: "{{ new_password }}"
+    configured_password: "{{ new_password }}"
     update_password: always
     state: present
 """
@@ -142,16 +142,16 @@ def map_obj_to_commands(updates, module):
             user_cmd = 'username ' + name
             commands.append(user_cmd)
 
-            if w['password']:
-                commands.append(user_cmd + ' secret ' + w['password'])
+            if w['configured_password']:
+                commands.append(user_cmd + ' secret ' + w['configured_password'])
             if w['group']:
                 commands.append(user_cmd + ' group ' + w['group'])
 
         elif state == 'present' and obj_in_have:
             user_cmd = 'username ' + name
 
-            if module.params['update_password'] == 'always' and w['password']:
-                commands.append(user_cmd + ' secret ' + w['password'])
+            if module.params['update_password'] == 'always' and w['configured_password']:
+                commands.append(user_cmd + ' secret ' + w['configured_password'])
             if w['group'] and w['group'] != obj_in_have['group']:
                 commands.append(user_cmd + ' group ' + w['group'])
 
@@ -181,7 +181,7 @@ def map_config_to_obj(module):
         obj = {
             'name': name,
             'state': 'present',
-            'password': None,
+            'configured_password': None,
             'group': group
         }
         instances.append(obj)
@@ -232,7 +232,7 @@ def map_params_to_obj(module):
 
     for item in aggregate:
         get_value = partial(get_param_value, item=item, module=module)
-        item['password'] = get_value('password')
+        item['configured_password'] = get_value('configured_password')
         item['group'] = get_value('group')
         item['state'] = get_value('state')
         objects.append(item)
@@ -247,7 +247,7 @@ def main():
         aggregate=dict(type='list', aliases=['users', 'collection']),
         name=dict(),
 
-        password=dict(no_log=True),
+        configured_password=dict(no_log=True),
         update_password=dict(default='always', choices=['on_create', 'always']),
 
         group=dict(aliases=['role']),

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -264,6 +264,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
+    if module.params['password']:
+        warnings.append(
+            'The "password" argument is used to authenticate the current connection. ' +
+            'To set a user password use "configured_password" instead.'
+        )
+        
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -264,12 +264,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password']:
+    if module.params['password'] and not module.params['configured_password']:
         warnings.append(
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-        
+
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -51,6 +51,12 @@ options:
         exclusive with the C(aggregate) argument.
     required: false
     default: null
+  configured_password:
+    description:
+      - The password to be configured on the network device. The
+        password needs to be provided in cleartext and it will be encrypted
+        on the device.
+        Please note that this option is not same as C(provider password).
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this
@@ -178,9 +184,9 @@ def map_obj_to_commands(updates, module):
         if want['state'] == 'present' and not have:
             commands.append('username %s' % want['name'])
 
-        if needs_update('password'):
+        if needs_update('configured_password'):
             if update_password == 'always' or not have:
-                add('password %s' % want['password'])
+                add('password %s' % want['configured_password'])
 
         if needs_update('sshkey'):
             add('sshkey %s' % want['sshkey'])
@@ -221,7 +227,7 @@ def map_config_to_obj(module):
     for item in to_list(data['TABLE_template']['ROW_template']):
         objects.append({
             'name': item['usr_name'],
-            'password': parse_password(item),
+            'configured_password': parse_password(item),
             'sshkey': item.get('sshkey_info'),
             'roles': parse_roles(item),
             'state': 'present'
@@ -266,7 +272,7 @@ def map_params_to_obj(module):
     for item in collection:
         get_value = partial(get_param_value, item=item, module=module)
         item.update({
-            'password': get_value('password'),
+            'configured_password': get_value('configured_password'),
             'sshkey': get_value('sshkey'),
             'roles': get_value('roles'),
             'state': get_value('state')
@@ -302,7 +308,7 @@ def main():
         aggregate=dict(type='list', no_log=True, aliases=['collection', 'users']),
         name=dict(),
 
-        password=dict(no_log=True),
+        configured_password=dict(no_log=True),
         update_password=dict(default='always', choices=['on_create', 'always']),
 
         roles=dict(type='list', aliases=['role']),

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -57,6 +57,7 @@ options:
         password needs to be provided in cleartext and it will be encrypted
         on the device.
         Please note that this option is not same as C(provider password).
+    version_added: "2.4"
   update_password:
     description:
       - Since passwords are encrypted in the device running config, this

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -331,6 +331,12 @@ def main():
     result = {'changed': False}
 
     warnings = list()
+    if module.params['password']:
+        warnings.append(
+            'The "password" argument is used to authenticate the current connection. ' +
+            'To set a user password use "configured_password" instead.'
+        )
+        
     check_args(module, warnings)
     result['warnings'] = warnings
 

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -331,12 +331,12 @@ def main():
     result = {'changed': False}
 
     warnings = list()
-    if module.params['password']:
+    if module.params['password'] and not module.params['configured_password']:
         warnings.append(
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-        
+
     check_args(module, warnings)
     result['warnings'] = warnings
 

--- a/lib/ansible/modules/network/system/net_user.py
+++ b/lib/ansible/modules/network/system/net_user.py
@@ -37,7 +37,7 @@ options:
         This argument accepts a string value and is mutually exclusive
         with the C(aggregate) argument.
         Please note that this option is not same as C(provider username).
-  password:
+  configured_password:
     description:
       - The password to be configured on the remote network device. The
         password needs to be provided in clear and it will be encrypted

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -301,12 +301,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    if module.params['password']:
+    if module.params['password'] and not module.params['configured_password']:
         warnings.append(
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-        
+
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -231,18 +231,18 @@ def map_params_to_obj(module):
         if not module.params['name'] and module.params['purge']:
             return list()
         else:
-            aggregatelist = [{'name': module.params['name']}]
+            users = [{'name': module.params['name']}]
     else:
-        aggregatelist = list()
+        users = list()
         for item in aggregate:
             if not isinstance(item, dict):
-                aggregatelist.append({'name': item})
+                users.append({'name': item})
             else:
-                aggregatelist.append(item)
+                users.append(item)
 
     objects = list()
 
-    for item in aggregatelist:
+    for item in users:
         get_value = partial(get_param_value, item=item, module=module)
         item['configured_password'] = get_value('configured_password')
         item['full_name'] = get_value('full_name')

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -301,6 +301,12 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
+    if module.params['password']:
+        warnings.append(
+            'The "password" argument is used to authenticate the current connection. ' +
+            'To set a user password use "configured_password" instead.'
+        )
+        
     check_args(module, warnings)
 
     result = {'changed': False}

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -53,7 +53,7 @@ options:
       - The C(full_name) argument provides the full name of the user
         account to be created on the remote device. This argument accepts
         any text string value.
-  password:
+  configured_password:
     description:
       - The password to be configured on the VyOS device. The
         password needs to be provided in clear and it will be encrypted
@@ -95,7 +95,7 @@ EXAMPLES = """
 - name: create a new user
   vyos_user:
     name: ansible
-    password: password
+    configured_password: password
     state: present
 - name: remove all users except admin
   vyos_user:
@@ -110,7 +110,7 @@ EXAMPLES = """
 - name: Change Password for User netop
   vyos_user:
     name: netop
-    password: "{{ new_password }}"
+    configured_password: "{{ new_password }}"
     update_password: always
     state: present
 """
@@ -166,9 +166,9 @@ def spec_to_commands(updates, module):
         if needs_update(want, have, 'full_name'):
             add(commands, want, "full-name %s" % want['full_name'])
 
-        if needs_update(want, have, 'password'):
+        if needs_update(want, have, 'configured_password'):
             if update_password == 'always' or not have:
-                add(commands, want, 'authentication plaintext-password %s' % want['password'])
+                add(commands, want, 'authentication plaintext-password %s' % want['configured_password'])
 
     return commands
 
@@ -203,7 +203,7 @@ def config_to_dict(module):
         obj = {
             'name': user,
             'state': 'present',
-            'password': None,
+            'configured_password': None,
             'level': parse_level(cfg),
             'full_name': parse_full_name(cfg)
         }
@@ -244,7 +244,7 @@ def map_params_to_obj(module):
 
     for item in aggregatelist:
         get_value = partial(get_param_value, item=item, module=module)
-        item['password'] = get_value('password')
+        item['configured_password'] = get_value('configured_password')
         item['full_name'] = get_value('full_name')
         item['level'] = get_value('level')
         item['state'] = get_value('state')
@@ -275,7 +275,7 @@ def main():
         full_name=dict(),
         level=dict(aliases=['role']),
 
-        password=dict(no_log=True),
+        configured_password=dict(no_log=True),
         update_password=dict(default='always', choices=['on_create', 'always']),
 
         purge=dict(type='bool', default=False),

--- a/test/integration/targets/eos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/eos_user/tests/cli/auth.yaml
@@ -12,13 +12,13 @@
 
   - name: test login
     expect:
-      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "pass123"
 
   - name: test login with invalid password (shoul fail)
     expect:
-      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes

--- a/test/integration/targets/eos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/eos_user/tests/cli/auth.yaml
@@ -16,7 +16,7 @@
       responses:
         (?i)password: "pass123"
 
-  - name: test login with invalid password (shoul fail)
+  - name: test login with invalid password (should fail)
     expect:
       command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:

--- a/test/integration/targets/eos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/eos_user/tests/cli/auth.yaml
@@ -1,26 +1,39 @@
 ---
-- name: create user with password
-  eos_user:
-    name: netend
-    privilege: 15
-    role: network-operator
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-    configured_password: pass123
-  register: result
-
-- name: test auth with new user
-  eos_command:
-    commands: ['show version']
-    provider:
-      host: "{{ ansible_host }}"
-      transport: cli
+- block:
+  - name: Create user with password
+    eos_user:
+      name: auth_user
+      privilege: 15
+      role: network-operator
+      state: present
       authorize: yes
-      password: pass123
-      username: netend
+      provider: "{{ cli }}"
+      configured_password: pass123
 
-- name: delete user
-  eos_user:
-    name: netend
-    state: absent
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (shoul fail)
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    eos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+      authorize: yes
+    register: result

--- a/test/integration/targets/eos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/eos_user/tests/cli/auth.yaml
@@ -1,0 +1,26 @@
+---
+- name: create user with password
+  eos_user:
+    name: netend
+    privilege: 15
+    role: network-operator
+    state: present
+    authorize: yes
+    provider: "{{ cli }}"
+    configured_password: pass123
+  register: result
+
+- name: test auth with new user
+  eos_command:
+    commands: ['show version']
+    provider:
+      host: "{{ ansible_host }}"
+      transport: cli
+      authorize: yes
+      password: pass123
+      username: netend
+
+- name: delete user
+  eos_user:
+    name: netend
+    state: absent

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -12,13 +12,13 @@
 
   - name: test login
     expect:
-      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "pass123"
 
   - name: test login with invalid password (shoul fail)
     expect:
-      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -16,7 +16,7 @@
       responses:
         (?i)password: "pass123"
 
-  - name: test login with invalid password (shoul fail)
+  - name: test login with invalid password (should fail)
     expect:
       command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -1,0 +1,39 @@
+---
+- block:
+  - name: Create user with password
+    ios_user:
+      name: auth_user
+      privilege: 15
+      role: network-operator
+      state: present
+      authorize: yes
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (shoul fail)
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: Teardown old user
+    ios_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+      authorize: yes
+    register: result

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -30,7 +30,7 @@
         - results.failed
 
   always:
-  - name: Teardown old user
+  - name: delete user
     ios_user:
       name: auth_user
       state: absent

--- a/test/integration/targets/iosxr_user/tests/cli/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/auth.yaml
@@ -13,7 +13,7 @@
       responses:
         (?i)password: "pass123"
 
-  - name: test login with invalid password (shoul fail)
+  - name: test login with invalid password (should fail)
     expect:
       command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:

--- a/test/integration/targets/iosxr_user/tests/cli/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/auth.yaml
@@ -1,0 +1,35 @@
+---
+- block:
+  - name: Create user with password
+    iosxr_user:
+      name: auth_user
+      state: present
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (shoul fail)
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    iosxr_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+    register: result

--- a/test/integration/targets/iosxr_user/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/basic.yaml
@@ -10,7 +10,7 @@
 - name: Create user (SetUp)
   iosxr_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     state: present
     provider: "{{ cli }}"
   register: result
@@ -24,7 +24,7 @@
 - name: Create user with update_password always (not idempotent)
   iosxr_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     update_password: always
     state: present
     provider: "{{ cli }}"
@@ -39,7 +39,7 @@
 - name: Create user again with update_password on_create (idempotent)
   iosxr_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     update_password: on_create
     state: present
     provider: "{{ cli }}"
@@ -53,7 +53,7 @@
 - name: Modify user group
   iosxr_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     update_password: on_create
     group: sysadmin
     state: present
@@ -69,7 +69,7 @@
 - name: Modify user group again (idempotent)
   iosxr_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     update_password: on_create
     group: sysadmin
     state: present
@@ -86,7 +86,7 @@
     aggregate:
       - name: ansibletest2
       - name: ansibletest3
-    password: test
+    configured_password: test
     state: present
     group: sysadmin
     provider: "{{ cli }}"
@@ -107,7 +107,7 @@
     aggregate:
       - name: ansibletest2
       - name: ansibletest3
-    password: test
+    configured_password: test
     state: present
     group: sysadmin
     provider: "{{ cli }}"
@@ -126,7 +126,7 @@
     aggregate:
       - name: ansibletest2
       - name: ansibletest3
-    password: test
+    configured_password: test
     update_password: on_create
     state: present
     group: sysadmin

--- a/test/integration/targets/nxos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/cli/auth.yaml
@@ -1,0 +1,36 @@
+---
+- block:
+  - name: Create user with password
+    nxos_user:
+      name: auth_user
+      role: network-operator
+      state: present
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (shoul fail)
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    nxos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+    register: result

--- a/test/integration/targets/nxos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/cli/auth.yaml
@@ -14,7 +14,7 @@
       responses:
         (?i)password: "pass123"
 
-  - name: test login with invalid password (shoul fail)
+  - name: test login with invalid password (should fail)
     expect:
       command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:

--- a/test/integration/targets/nxos_user/tests/nxapi/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/nxapi/auth.yaml
@@ -1,0 +1,36 @@
+---
+- block:
+  - name: Create user with password
+    nxos_user:
+      name: auth_user
+      role: network-operator
+      state: present
+      provider: "{{ nxapi }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (shoul fail)
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    nxos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ nxapi }}"
+    register: result

--- a/test/integration/targets/vyos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/auth.yaml
@@ -1,0 +1,36 @@
+---
+- block:
+  - name: Create user with password
+    vyos_user:
+      name: auth_user
+      role: admin
+      state: present
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (should fail)
+    expect:
+      command: "ssh auth_user@{{ inventory_hostname }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    vyos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+    register: result

--- a/test/integration/targets/vyos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/basic.yaml
@@ -10,7 +10,7 @@
 - name: Create user
   vyos_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     state: present
     provider: "{{ cli }}"
   register: result
@@ -39,7 +39,7 @@
 - name: Add user again (Idempotent)
   vyos_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     state: present
     update_password: on_create
     provider: "{{ cli }}"

--- a/test/integration/targets/vyos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/basic.yaml
@@ -1,4 +1,5 @@
 ---
+<<<<<<< HEAD
 - name: Setup
   vyos_config:
     lines:
@@ -8,6 +9,19 @@
     provider: "{{ cli }}"
 
 - name: Create user
+=======
+- name: tearDown
+  vyos_user:
+    users:
+      - name: ansibletest1
+      - name: ansibletest2
+      - name: ansibletest3
+    state: absent
+    provider: "{{ cli }}"
+  register: result
+
+- name: Create user (SetUp)
+>>>>>>> [WIP] fix vyos_user password
   vyos_user:
     name: ansibletest1
     password: test

--- a/test/integration/targets/vyos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/basic.yaml
@@ -24,7 +24,7 @@
 >>>>>>> [WIP] fix vyos_user password
   vyos_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     state: present
     provider: "{{ cli }}"
   register: result
@@ -53,7 +53,7 @@
 - name: Add user again (Idempotent)
   vyos_user:
     name: ansibletest1
-    password: test
+    configured_password: test
     state: present
     update_password: on_create
     provider: "{{ cli }}"

--- a/test/integration/targets/vyos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/basic.yaml
@@ -1,5 +1,4 @@
 ---
-<<<<<<< HEAD
 - name: Setup
   vyos_config:
     lines:
@@ -9,22 +8,9 @@
     provider: "{{ cli }}"
 
 - name: Create user
-=======
-- name: tearDown
-  vyos_user:
-    users:
-      - name: ansibletest1
-      - name: ansibletest2
-      - name: ansibletest3
-    state: absent
-    provider: "{{ cli }}"
-  register: result
-
-- name: Create user (SetUp)
->>>>>>> [WIP] fix vyos_user password
   vyos_user:
     name: ansibletest1
-    configured_password: test
+    password: test
     state: present
     provider: "{{ cli }}"
   register: result
@@ -53,7 +39,7 @@
 - name: Add user again (Idempotent)
   vyos_user:
     name: ansibletest1
-    configured_password: test
+    password: test
     state: present
     update_password: on_create
     provider: "{{ cli }}"

--- a/test/units/modules/network/eos/test_eos_user.py
+++ b/test/units/modules/network/eos/test_eos_user.py
@@ -54,7 +54,7 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_password(self):
-        set_module_args(dict(name='ansible', password='test'))
+        set_module_args(dict(username='ansible', configured_password='test'))
         commands = ['username ansible secret test']
         self.execute_module(changed=True, commands=commands)
 
@@ -83,15 +83,15 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_update_password_changed(self):
-        set_module_args(dict(name='test', password='test', update_password='on_create'))
+        set_module_args(dict(username='test', configured_password='test', update_password='on_create'))
         commands = ['username test secret test']
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_update_password_on_create_ok(self):
-        set_module_args(dict(name='ansible', password='test', update_password='on_create'))
+        set_module_args(dict(username='ansible', configured_password='test', update_password='on_create'))
         self.execute_module()
 
     def test_eos_user_update_password_always(self):
-        set_module_args(dict(name='ansible', password='test', update_password='always'))
+        set_module_args(dict(username='ansible', configured_password='test', update_password='always'))
         commands = ['username ansible secret test']
         self.execute_module(changed=True, commands=commands)

--- a/test/units/modules/network/eos/test_eos_user.py
+++ b/test/units/modules/network/eos/test_eos_user.py
@@ -54,7 +54,7 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_password(self):
-        set_module_args(dict(username='ansible', configured_password='test'))
+        set_module_args(dict(name='ansible', configured_password='test'))
         commands = ['username ansible secret test']
         self.execute_module(changed=True, commands=commands)
 
@@ -83,15 +83,15 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_update_password_changed(self):
-        set_module_args(dict(username='test', configured_password='test', update_password='on_create'))
+        set_module_args(dict(name='test', configured_password='test', update_password='on_create'))
         commands = ['username test secret test']
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_update_password_on_create_ok(self):
-        set_module_args(dict(username='ansible', configured_password='test', update_password='on_create'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='on_create'))
         self.execute_module()
 
     def test_eos_user_update_password_always(self):
-        set_module_args(dict(username='ansible', configured_password='test', update_password='always'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='always'))
         commands = ['username ansible secret test']
         self.execute_module(changed=True, commands=commands)

--- a/test/units/modules/network/ios/test_ios_user.py
+++ b/test/units/modules/network/ios/test_ios_user.py
@@ -66,7 +66,7 @@ class TestIosUserModule(TestIosModule):
         self.assertEqual(result_cmd, [cmd])
 
     def test_ios_user_password(self):
-        set_module_args(dict(name='ansible', password='test'))
+        set_module_args(dict(name='ansible', configured_password='test'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['username ansible secret test'])
 
@@ -100,15 +100,15 @@ class TestIosUserModule(TestIosModule):
         self.assertEqual(result['commands'], ['username ansible view test'])
 
     def test_ios_user_update_password_changed(self):
-        set_module_args(dict(name='test', password='test', update_password='on_create'))
+        set_module_args(dict(name='test', configured_password='test', update_password='on_create'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['username test secret test'])
 
     def test_ios_user_update_password_on_create_ok(self):
-        set_module_args(dict(name='ansible', password='test', update_password='on_create'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='on_create'))
         self.execute_module()
 
     def test_ios_user_update_password_always(self):
-        set_module_args(dict(name='ansible', password='test', update_password='always'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='always'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['username ansible secret test'])

--- a/test/units/modules/network/iosxr/test_iosxr_user.py
+++ b/test/units/modules/network/iosxr/test_iosxr_user.py
@@ -51,7 +51,7 @@ class TestIosxrUserModule(TestIosxrModule):
         self.assertEqual(result['commands'], ['no username ansible'])
 
     def test_iosxr_user_password(self):
-        set_module_args(dict(name='ansible', password='test'))
+        set_module_args(dict(name='ansible', configured_password='test'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['username ansible secret test'])
 
@@ -66,16 +66,16 @@ class TestIosxrUserModule(TestIosxrModule):
         self.assertEqual(result['commands'], ['username ansible group sysadmin'])
 
     def test_iosxr_user_update_password_changed(self):
-        set_module_args(dict(name='test', password='test', update_password='on_create'))
+        set_module_args(dict(name='test', configured_password='test', update_password='on_create'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'],
                          ['username test', 'username test secret test'])
 
     def test_iosxr_user_update_password_on_create_ok(self):
-        set_module_args(dict(name='ansible', password='test', update_password='on_create'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='on_create'))
         self.execute_module()
 
     def test_iosxr_user_update_password_always(self):
-        set_module_args(dict(name='ansible', password='test', update_password='always'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='always'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['username ansible secret test'])

--- a/test/units/modules/network/vyos/test_vyos_user.py
+++ b/test/units/modules/network/vyos/test_vyos_user.py
@@ -46,7 +46,7 @@ class TestVyosUserModule(TestVyosModule):
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_vyos_user_password(self):
-        set_module_args(dict(name='ansible', password='test'))
+        set_module_args(dict(name='ansible', configured_password='test'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['set system login user ansible authentication plaintext-password test'])
 
@@ -71,15 +71,15 @@ class TestVyosUserModule(TestVyosModule):
                                                              'delete system login user admin']))
 
     def test_vyos_user_update_password_changed(self):
-        set_module_args(dict(name='test', password='test', update_password='on_create'))
+        set_module_args(dict(name='test', configured_password='test', update_password='on_create'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['set system login user test authentication plaintext-password test'])
 
     def test_vyos_user_update_password_on_create_ok(self):
-        set_module_args(dict(name='ansible', password='test', update_password='on_create'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='on_create'))
         self.execute_module()
 
     def test_vyos_user_update_password_always(self):
-        set_module_args(dict(name='ansible', password='test', update_password='always'))
+        set_module_args(dict(name='ansible', configured_password='test', update_password='always'))
         result = self.execute_module(changed=True)
         self.assertEqual(result['commands'], ['set system login user ansible authentication plaintext-password test'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Change password to configured_password
- Add tests to check that authentication works on new users

Fixes: #28086
Fixes: #27181

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- eos_user
- ios_user
- iosxr_user
- nxos_user
- vyos_user
- net_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (refactor-user-args 71d39d0a8b) last updated 2017/08/14 17:47:55 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
