### PR TITLE
Vault secrets default vault ids list

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -216,9 +216,6 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # If there are configured default vault identities, they are considered 'first'
         # so we prepend them to vault_ids (from cli) here
-        if C.DEFAULT_VAULT_IDENTITY_LIST:
-            default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
-            vault_ids = default_vault_ids + vault_ids
 
         vault_password_files = vault_password_files or []
         if C.DEFAULT_VAULT_PASSWORD_FILE:

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -214,6 +214,12 @@ class CLI(with_metaclass(ABCMeta, object)):
         # certain vault password prompt format, so 'promp_ask_vault_pass' vault_id gets the old format.
         prompt_formats = {}
 
+        # If there are configured default vault identities, they are considered 'first'
+        # so we prepend them to vault_ids (from cli) here
+        if C.DEFAULT_VAULT_IDENTITY_LIST:
+            default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
+            vault_ids = default_vault_ids + vault_ids
+
         vault_password_files = vault_password_files or []
         if C.DEFAULT_VAULT_PASSWORD_FILE:
             vault_password_files.append(C.DEFAULT_VAULT_PASSWORD_FILE)

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -415,8 +415,11 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
         self.loader, self.inventory, self.variable_manager = self._play_prereqs(self.options)
 
+        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
+        vault_ids = self.options.vault_ids
+        vault_ids = default_vault_ids + vault_ids
         vault_secrets = self.setup_vault_secrets(self.loader,
-                                                 vault_id=self.options.vault_ids,
+                                                 vault_ids=vault_ids,
                                                  vault_password_files=self.options.vault_password_files,
                                                  ask_vault_pass=self.options.ask_vault_pass)
         self.loader.set_vault_secrets(vault_secrets)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -23,6 +23,7 @@ import os
 import sys
 
 from ansible.cli import CLI
+from ansible import constants as C
 from ansible.errors import AnsibleOptionsError
 from ansible.module_utils._text import to_text, to_bytes
 from ansible.parsing.dataloader import DataLoader
@@ -156,6 +157,9 @@ class VaultCLI(CLI):
         # ask for a new password and confirm it, and 'read/write (rekey) that asks for the
         # old password, then asks for a new one and confirms it.
 
+        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
+        vault_ids = default_vault_ids + vault_ids
+
         # TODO: instead of prompting for these before, we could let VaultEditor
         #       call a callback when it needs it.
         if self.action in ['decrypt', 'view', 'rekey']:
@@ -163,7 +167,6 @@ class VaultCLI(CLI):
                                                      vault_ids=vault_ids,
                                                      vault_password_files=self.options.vault_password_files,
                                                      ask_vault_pass=self.options.ask_vault_pass)
-
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
@@ -178,7 +181,6 @@ class VaultCLI(CLI):
                                          vault_password_files=self.options.vault_password_files,
                                          ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
-
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 

--- a/lib/ansible/config/data/config.yml
+++ b/lib/ansible/config/data/config.yml
@@ -1088,6 +1088,15 @@ DEFAULT_VAULT_IDENTITY:
   - {key: vault_identity, section: defaults}
   vars: []
   yaml: {key: defaults.vault_identity}
+DEFAULT_VAULT_IDENTITY_LIST:
+  default: []
+  desc: 'A list of vault-ids to use by default. Equivalent to multiple --vault-id args. Vault-ids are tried in order.'
+  env: [{name: ANSIBLE_VAULT_IDENTITY_LIST}]
+  ini:
+  - {key: vault_identity_list, section: defaults}
+  value_type: list
+  vars: []
+  yaml: {key: defaults.vault_identity_list}
 DEFAULT_VAULT_PASSWORD_FILE:
   default:
   desc: 'TODO: write it'

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -98,6 +98,15 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
+# test with a default vault-id list set via config/env, right password
+ANSIBLE_VAULT_PASSWORD_FILE=wrong@vault-password-wrong,correct@vault-password ansible-vault view "$@" format_1_1_AES.yml && :
+
+# test with a default vault-id list set via config/env,wrong passwords
+ANSIBLE_VAULT_PASSWORD_FILE=wrong@vault-password-wrong,alsowrong@vault-password-wrong ansible-vault view "$@" format_1_1_AES.yml && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
 # encrypt it
 ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -141,8 +141,6 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
 
         self.assertIsInstance(res, list)
         matches = vault.match_secrets(res, ['default'])
-        print('res: %s' % res)
-        print('matches1: %s' % matches)
         # --vault-password-file/DEFAULT_VAULT_PASSWORD_FILE is higher precendce than prompts
         # if the same vault-id ('default') regardless of cli order since it didn't matter in 2.3
         self.assertEqual(matches[0][1].bytes, b'file1_password')

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -141,10 +141,46 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
 
         self.assertIsInstance(res, list)
         matches = vault.match_secrets(res, ['default'])
+        print('res: %s' % res)
+        print('matches1: %s' % matches)
         # --vault-password-file/DEFAULT_VAULT_PASSWORD_FILE is higher precendce than prompts
         # if the same vault-id ('default') regardless of cli order since it didn't matter in 2.3
         self.assertEqual(matches[0][1].bytes, b'file1_password')
         self.assertEqual(matches[1][1].bytes, b'prompt1_password')
+
+    @patch('ansible.cli.C', name='MockConfig')
+    @patch('ansible.cli.get_file_vault_secret')
+    @patch('ansible.cli.PromptVaultSecret')
+    def test_default_file_vault_identity_list(self, mock_prompt_secret,
+                                              mock_file_secret,
+                                              mock_config):
+        mock_config.DEFAULT_VAULT_PASSWORD_FILE = '/dev/null/secret'
+        mock_config.DEFAULT_VAULT_IDENTITY_LIST = ['some_prompt@prompt',
+                                                   'some_file@/dev/null/secret']
+
+        mock_prompt_secret.return_value = MagicMock(bytes=b'some_prompt_password',
+                                                    vault_id='some_prompt')
+
+        filename = '/dev/null/secret'
+        mock_file_secret.return_value = MagicMock(bytes=b'some_file_password',
+                                                  vault_id='some_file',
+                                                  filename=filename)
+
+        res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
+                                          vault_ids=[],
+                                          create_new_password=False,
+                                          ask_vault_pass=True)
+
+        self.assertIsInstance(res, list)
+        matches = vault.match_secrets(res, ['some_file'])
+        # --vault-password-file/DEFAULT_VAULT_PASSWORD_FILE is higher precendce than prompts
+        # if the same vault-id ('default') regardless of cli order since it didn't matter in 2.3
+        print('res: %s' % res)
+        print('matches1: %s' % matches)
+        self.assertEqual(matches[0][1].bytes, b'some_file_password')
+        matches = vault.match_secrets(res, ['some_prompt'])
+        self.assertEqual(matches[0][1].bytes, b'some_prompt_password')
+
 
     @patch('ansible.cli.PromptVaultSecret')
     def test_prompt_just_ask_vault_pass(self, mock_prompt_secret):


### PR DESCRIPTION
##### SUMMARY
add a default_vault_identity_list 

more or less the 'multiple vault-id' equilivent of 'default_vault_password_file', except 
is a ordered list and can include prompts

based on user feedback from ansible-project list

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_secrets_default_vault_ids_list a795661b51) last updated 2017/08/14 18:12:21 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
