### PR TITLE
new module: Manage MCP interface policies [network/aci/aci_mcp]

### DIFF
--- a/lib/ansible/modules/network/aci/aci_mcp.py
+++ b/lib/ansible/modules/network/aci/aci_mcp.py
@@ -1,0 +1,121 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_mcp
+short_description: Manage MCP interface policies on Cisco ACI fabrics
+description:
+- Manage MCP interface policies on Cisco ACI fabrics.
+author:
+- Swetha Chunduri (@schunduri)
+- Dag Wieers (@dagwieers)
+- Jacob McGill (@jmcgill298)
+version_added: '2.4'
+requirements:
+- ACI Fabric 1.0(3f)+
+options:
+  mcp:
+    description:
+    - The name of the MCP interface.
+    required: yes
+    aliases: [ mcp_interface, name ]
+  description:
+    description:
+    - Description for the MCP interface.
+    aliases: [ descr ]
+  admin_state:
+    description:
+    - Enable or disable admin state.
+    choices: [ disable, enable ]
+    default: enable
+  state:
+    description:
+    - Use C(present) or C(absent) for adding or removing.
+    - Use C(query) for listing an object or multiple objects.
+    choices: [ absent, present, query ]
+    default: present
+extends_documentation_fragment: aci
+'''
+
+# FIXME: Add more, better examples
+EXAMPLES = r'''
+- aci_mcp:
+    hostname: '{{ hostname }}'
+    username: '{{ username }}'
+    password: '{{ password }}'
+    mcp: '{{ mcp }}'
+    description: '{{ descr }}'
+    admin_state: '{{ admin_state }}'
+'''
+
+RETURN = r'''
+#
+'''
+
+from ansible.module_utils.aci import ACIModule, aci_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    argument_spec = aci_argument_spec
+    argument_spec.update(
+        mcp=dict(type='str', required=False, aliases=['mcp_interface', 'name']),  # Not required for querying all objects
+        description=dict(type='str', aliases=['descr']),
+        admin_state=dict(type='str', choices=['disabled', 'enabled']),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+        method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    mcp = module.params['mcp']
+    description = module.params['description']
+    admin_state = module.params['admin_state']
+    state = module.params['state']
+
+    aci = ACIModule(module)
+
+    # TODO: This logic could be cleaner.
+    if mcp is not None:
+        path = 'api/mo/uni/infra/mcpIfP--%(mcp)s.json' % module.params
+    elif state == 'query':
+        # Query all objects
+        path = 'api/node/class/mcpIfPol.json'
+    else:
+        module.fail_json(msg="Parameter 'mcp' is required for state 'absent' or 'present'")
+
+    aci.result['url'] = '%(protocol)s://%(hostname)s/' % aci.params + path
+
+    aci.get_existing()
+
+    if state == 'present':
+        # Filter out module parameters with null values
+        aci.payload(aci_class='mcpIfPol', class_config=dict(name=mcp, descr=description, adminSt=admin_state))
+
+        # Generate config diff which will be used as POST request body
+        aci.get_diff(aci_class='mcpIfPol')
+
+        # Submit changes if module not in check_mode and the proposed is different than existing
+        aci.post_config()
+
+    elif state == 'absent':
+        aci.delete_config()
+
+    module.exit_json(**aci.result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
##### SUMMARY
Manage MCP interface policies on Cisco ACI fabrics.
This module is idempotent, and supports check-mode and has diff-support.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
aci_mcp

##### ANSIBLE VERSION
v2.4