### PR TITLE
win_update: added extra job parameters to run even if on battery

### DIFF
--- a/lib/ansible/modules/windows/win_updates.ps1
+++ b/lib/ansible/modules/windows/win_updates.ps1
@@ -303,7 +303,7 @@ Function RunAsScheduledJob {
     Name = $job_name
     ArgumentList = $job_arg_list
     ErrorAction = "Stop"
-    ScheduledJobOption = @{ RunElevated=$True }
+    ScheduledJobOption = @{ RunElevated=$True; StartIfOnBatteries=$True; StopIfGoingOnBatteries=$False }
   }
 
   if($job_init) { $rsj_args.InitializationScript = $job_init }

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -72,6 +72,9 @@ notes:
 - C(win_updates) does not manage reboots, but will signal when a reboot is required with the reboot_required return value.
 - C(win_updates) can take a significant amount of time to complete (hours, in some cases).
   Performance depends on many factors, including OS version, number of updates, system load, and update server load.
+- C(win_updates) runs the module as a scheduled task, this task is set to start and continue to run even if the Windows host
+  swaps to battery power. This behaviour was changed from Ansible 2.4, before this the scheduled task would fail to start on
+  battery power.
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### SUMMARY
When running win_update on a host running on battery power, the job will fail with a timeout message. This adds extra job parameters to allow the scheduled task that runs the updates to start and continue running when on battery power.

This shouldn't affect most people but I've come across the issue a few times when working on a dev boxes and using my laptop, virtualbox passes on the battery info to the Windows host which can be problematic with this module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_updates

##### ANSIBLE VERSION
```
ansible 2.4.0 (win_update-battery 03bcd13bcc) last updated 2017/08/15 18:31:46 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/jborean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jborean/dev/ansible/lib/ansible
  executable location = /Users/jborean/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Aug  4 2017, 13:45:28) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
Example Playbook
```
---
- name: adhoc stuff
  hosts: 2012R2
  gather_facts: no

  tasks:
  - win_updates:
      state: searched
      categories:
      - CriticalUpdates
```

Current Result when Windows host is running on battery power
```
PLAY [adhoc stuff] *********************************************************************************************************************************************

TASK [win_updates] *********************************************************************************************************************************************
Tuesday 15 August 2017  18:44:00 +1000 (0:00:00.076)       0:00:00.076 ******** 
fatal: [Server2012R2]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Timed out waiting for scheduled task to start\r\nAt line:334 char:9\r\n+         Throw \"Timed out waiting for scheduled task to start\"\r\n+         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n    + CategoryInfo          : OperationStopped: (Timed out waiti...d task to s \r\n   tart:String) [], RuntimeException\r\n    + FullyQualifiedErrorId : Timed out waiting for scheduled task to start\r\n \r\n\r\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}

PLAY RECAP *****************************************************************************************************************************************************
Server2012R2               : ok=0    changed=0    unreachable=0    failed=1   

Tuesday 15 August 2017  18:44:31 +1000 (0:00:31.174)       0:00:31.251 ******** 
=============================================================================== 
win_updates -------------------------------------------------------------------------------------------------------------------------------------------- 31.17s
Playbook run took 0 days, 0 hours, 0 minutes, 31 seconds
```

Fixed Result
```
PLAY [adhoc stuff] *********************************************************************************************************************************************

TASK [win_updates] *********************************************************************************************************************************************
Tuesday 15 August 2017  18:45:19 +1000 (0:00:00.074)       0:00:00.074 ******** 
changed: [Server2012R2]

PLAY RECAP *****************************************************************************************************************************************************
Server2012R2               : ok=1    changed=1    unreachable=0    failed=0   

Tuesday 15 August 2017  18:45:30 +1000 (0:00:11.715)       0:00:11.790 ******** 
=============================================================================== 
win_updates -------------------------------------------------------------------------------------------------------------------------------------------- 11.72s
Playbook run took 0 days, 0 hours, 0 minutes, 11 seconds
```