### PR TITLE
Fix: modifying existing application lb using certificates now properl…

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -538,9 +538,13 @@ def compare_listener(current_listener, new_listener):
         if current_listener['SslPolicy'] != new_listener['SslPolicy']:
             modified_listener['SslPolicy'] = new_listener['SslPolicy']
         if current_listener['Certificates'][0]['CertificateArn'] != new_listener['Certificates'][0]['CertificateArn']:
+            modified_listener['Certificates'] = []
+            modified_listener['Certificates'].append({})
             modified_listener['Certificates'][0]['CertificateArn'] = new_listener['Certificates'][0]['CertificateArn']
     elif current_listener['Protocol'] != 'HTTPS' and new_listener['Protocol'] == 'HTTPS':
         modified_listener['SslPolicy'] = new_listener['SslPolicy']
+        modified_listener['Certificates'] = []
+        modified_listener['Certificates'].append({})
         modified_listener['Certificates'][0]['CertificateArn'] = new_listener['Certificates'][0]['CertificateArn']
 
     # Default action


### PR DESCRIPTION
…y sets certificates

##### SUMMARY
Fixed an issue where modifying an existing application load balancer fails because certificates are not copied to a new dictionary correctly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elb_application_lb.py

##### ANSIBLE VERSION
```
2.4.0
```

