### PR TITLE
fix for nxos_vxlan_vtep_vni remove idempotent issue

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -330,7 +330,7 @@ def main():
     candidate = CustomNetworkConfig(indent=3)
     if state == 'present':
         state_present(module, existing, proposed, candidate)
-    elif state == 'absent':
+    elif existing and state == 'absent':
         state_absent(module, existing, proposed, candidate)
 
     if candidate:


### PR DESCRIPTION
##### SUMMARY
Fixes:
#27926 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_vxlan_vtep_vni

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 54cd641df4) last updated 2017/07/19 18:06:44 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/p2/Projects/nxos_ansible/p1_ansible/lib/ansible
  executable location = /root/p2/Projects/nxos_ansible/p1_ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
```

```
