### PR TITLE
Azure  azure_rm_common update

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -696,8 +696,7 @@ class AzureRMModuleBase(object):
             self._dns_client = DnsManagementClient(
                 self.azure_credentials,
                 self.subscription_id,
-                base_url=self.base_url,
-                api_version='2016-04-01'
+                base_url=self.base_url
             )
             self._register('Microsoft.Dns')
         return self._dns_client

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -700,4 +700,3 @@ class AzureRMModuleBase(object):
             )
             self._register('Microsoft.Dns')
         return self._dns_client
-

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -94,10 +94,12 @@ try:
     from azure.mgmt.storage.version import VERSION as storage_client_version
     from azure.mgmt.compute.version import VERSION as compute_client_version
     from azure.mgmt.resource.version import VERSION as resource_client_version
+    from azure.mgmt.dns.version import VERSION as dns_client_version
     from azure.mgmt.network import NetworkManagementClient
     from azure.mgmt.resource.resources import ResourceManagementClient
     from azure.mgmt.storage import StorageManagementClient
     from azure.mgmt.compute import ComputeManagementClient
+    from azure.mgmt.dns import DnsManagementClient
     from azure.storage.cloudstorageaccount import CloudStorageAccount
 except ImportError as exc:
     HAS_AZURE_EXC = exc
@@ -126,7 +128,8 @@ AZURE_EXPECTED_VERSIONS = dict(
     storage_client_version="1.0.0",
     compute_client_version="1.0.0",
     network_client_version="1.0.0",
-    resource_client_version="1.1.0"
+    resource_client_version="1.1.0",
+    dns_client_version="1.0.1"
 )
 
 AZURE_MIN_RELEASE = '2.0.0'
@@ -174,6 +177,7 @@ class AzureRMModuleBase(object):
         self._storage_client = None
         self._resource_client = None
         self._compute_client = None
+        self._dns_client = None
         self.check_mode = self.module.check_mode
         self.facts_module = facts_module
         # self.debug = self.module.params.get('debug')
@@ -683,3 +687,18 @@ class AzureRMModuleBase(object):
             )
             self._register('Microsoft.Compute')
         return self._compute_client
+
+    @property
+    def dns_client(self):
+        self.log('Getting dns client')
+        if not self._dns_client:
+            self.check_client_version('dns', dns_client_version, AZURE_EXPECTED_VERSIONS['dns_client_version'])
+            self._dns_client = DnsManagementClient(
+                self.azure_credentials,
+                self.subscription_id,
+                base_url=self.base_url,
+                api_version='2016-04-01'
+            )
+            self._register('Microsoft.Dns')
+        return self._dns_client
+


### PR DESCRIPTION
##### SUMMARY
In order to support new Azure modules for DNS Zone and Record Set creation/manipulation, I needed to update the azure_rm_common.py module.

I added a few lines for importing the DNS client version and the DNS management client itself. Then, using the other clients that were already present (compute, resource, storage and network), I followed the same templates for getting the client and registering it. I didn't modify any of the code that was originally there and I only added my own lines to add support for the DNS client.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_common.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (azure2.0.0 3d55af2f58) last updated 2017/08/08 13:03:06 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /home/t-ozboms/ansible3/ansible/lib/ansible
  executable location = /home/t-ozboms/ansible3/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```