### PR TITLE
Timezone modeule: Better env choice for Linux

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -385,7 +385,7 @@ class NosystemdTimezone(Timezone):
             if self._allow_ioerror(err, key):
                 lines = []
             else:
-                self.abort('cannot read configuration file "%s" for %s' % (filename, key))
+                self.abort('tried to configure %s using a file "%s", but could not read it' % (key, filename))
         else:
             lines = file.readlines()
             file.close()
@@ -407,7 +407,7 @@ class NosystemdTimezone(Timezone):
         try:
             file = open(filename, 'w')
         except IOError:
-            self.abort('cannot write to "%s"' % filename)
+            self.abort('tried to configure %s using a file "%s", but could not write to it' % (key, filename))
         else:
             file.writelines(lines)
             file.close()
@@ -426,14 +426,14 @@ class NosystemdTimezone(Timezone):
             if self._allow_ioerror(err, key):
                 return None
             else:
-                self.abort('cannot read configuration file "%s" for %s' % (filename, key))
+                self.abort('tried to configure %s using a file "%s", but could not read it' % (key, filename))
         else:
             status = file.read()
             file.close()
             try:
                 value = self.regexps[key].search(status).group(1)
             except AttributeError:
-                self.abort('cannot find the valid value from configuration file "%s" for %s' % (filename, key))
+                self.abort('tried to configure %s using a file "%s", but could not find a valid value in it' % (key, filename))
             else:
                 if key == 'hwclock':
                     # For key='hwclock'; convert yes/no -> UTC/local

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -104,10 +104,9 @@ class Timezone(object):
                 rc, stdout, stderr = module.run_command(timedatectl)
                 if rc == 0:
                     return super(Timezone, SystemdTimezone).__new__(SystemdTimezone)
-                elif any(module.get_bin_path(cmd) is not None for cmd in ('dpkg-reconfigure', 'tzdata-update')):
-                    return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
                 else:
-                    module.fail_json(msg='timedatectl command is unavailable in this environment:\n%s\n%s' % (stdout, stderr))
+                    module.warn('timedatectl command was found but not usable: %s. using other method.' % stderr)
+                    return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
             else:
                 return super(Timezone, NosystemdTimezone).__new__(NosystemdTimezone)
         elif re.match('^joyent_.*Z', platform.version()):

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -55,13 +55,7 @@ diff:
   description: The differences about the given arguments.
   returned: success
   type: complex
-  contains:
-    before:
-      description: The values before change
-      type: dict
-    after:
-      description: The values after change
-      type: dict
+  sample: '{"before": {"name": "UTC"},<br>"after": {"name": "Asia/Tokyo"}}'
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -357,7 +357,6 @@ class NosystemdTimezone(Timezone):
             self.conf_files['hwclock'] = '/etc/sysconfig/clock'
             self.regexps['name']       = re.compile(r'^ZONE\s*=\s*"?([^"\s]+)"?', re.MULTILINE)
             self.tzline_format         = 'ZONE="%s"\n'
-        self.update_hwclock  = self.module.get_bin_path('hwclock', required=True)
 
     def _allow_ioerror(self, err, key):
         # In some cases, even if the target file does not exist,

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -55,7 +55,13 @@ diff:
   description: The differences about the given arguments.
   returned: success
   type: complex
-  sample: '{"before": {"name": "UTC"},<br>"after": {"name": "Asia/Tokyo"}}'
+  contains:
+    before:
+      description: The values before change
+      type: dict
+    after:
+      description: The values after change
+      type: dict
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -376,7 +376,7 @@ class NosystemdTimezone(Timezone):
         # Read the file
         try:
             file = open(filename, 'r')
-        except IOError:
+        except IOError as err:
             if self._allow_ioerror(err, key):
                 lines = []
             else:
@@ -417,7 +417,7 @@ class NosystemdTimezone(Timezone):
 
         try:
             file = open(filename, mode='r')
-        except IOError as e:
+        except IOError as err:
             if self._allow_ioerror(err, key):
                 return None
             else:


### PR DESCRIPTION
##### SUMMARY

- Fixes #25819

There're environments where `timedatectl` commands exists but unavailable.
In some of those environments, other commands like `tzdata-update` or `dpkg-reconfigure` is available, while others not.

For the former environments, use those commands (even if the configuration files are absent).

For the latter environments, give better error message.

- ~~Partially fixes #16665~~

##### ISSUE TYPE

- Bugfix Pull Request
- ~~Docs Pull Request~~

##### COMPONENT NAME

`timezone` module

##### ANSIBLE VERSION

```
ansible 2.3
```
