### PR TITLE
Fix default nxapi port setting when use_ssl set

### DIFF
--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -94,6 +94,10 @@ class ActionModule(_ActionModule):
 
             if provider.get('port') is None:
                 provider['port'] = 80
+                #if provider.get('use_ssl') is None:
+                #    provider['port'] = 80
+                #else:
+                #    provider['port'] = 443
 
             if provider.get('timeout') is None:
                 provider['timeout'] = self._play_context.timeout

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -93,10 +93,10 @@ class ActionModule(_ActionModule):
                 provider['host'] = self._play_context.remote_addr
 
             if provider.get('port') is None:
-                if provider.get('use_ssl') is None or provider.get('use_ssl') is False:
-                    provider['port'] = 80
-                else:
+                if provider.get('use_ssl'):
                     provider['port'] = 443
+                else:
+                    provider['port'] = 80
 
             if provider.get('timeout') is None:
                 provider['timeout'] = self._play_context.timeout

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -93,11 +93,10 @@ class ActionModule(_ActionModule):
                 provider['host'] = self._play_context.remote_addr
 
             if provider.get('port') is None:
-                provider['port'] = 80
-                #if provider.get('use_ssl') is None:
-                #    provider['port'] = 80
-                #else:
-                #    provider['port'] = 443
+                if provider.get('use_ssl') is None:
+                    provider['port'] = 80
+                else:
+                    provider['port'] = 443
 
             if provider.get('timeout') is None:
                 provider['timeout'] = self._play_context.timeout

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -93,7 +93,7 @@ class ActionModule(_ActionModule):
                 provider['host'] = self._play_context.remote_addr
 
             if provider.get('port') is None:
-                if provider.get('use_ssl') is None:
+                if provider.get('use_ssl') is None or provider.get('use_ssl') is False:
                     provider['port'] = 80
                 else:
                     provider['port'] = 443


### PR DESCRIPTION
#### SUMMARY
Fixes https://github.com/ansible/ansible/issues/28233

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
All nxos modules when using transport `nxapi`

##### ANSIBLE VERSION
```
ansible 2.4.0 (24/fix_nxos_use_ssl f65036cbb3) last updated 2017/08/15 14:06:20 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
When the `use_ssl` provider is set for nxapi the port should default to `443`.

This fix adds an additional check in the nxos action plugin to check the use_ssl setting when the provider port value is undefined.

##### TEST RESULTS WITH FIX
```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: true
  validate_certs: no
```
```yaml
- name: Show version
  nxos_command:
    commands: show version
    provider: "{{ nxapi }}"
```

In the results below you will see that the correct default port is used.

```
TASK [nxos_nxapi : Show version] *************************************************************************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_nxapi/tests/cli/test.yaml:1
<n9k.example.comm> connection transport is nxapi
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/six/__init__.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/nxos.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/basic.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/pycompat24.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/network_common.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/netcli.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/_text.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/connection.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/urls.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/parsing/convert_bool.py
Using module_utils file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/module_utils/parsing/__init__.py
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_command.py
<n9k.example.comm> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n9k.example.comm> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.comm> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197 `" && echo ansible-tmp-1502822123.68-218686024435197="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197 `" ) && sleep 0'
<n9k.example.comm> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmpiBMNku TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197/nxos_command.py
<n9k.example.comm> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197/nxos_command.py && sleep 0'
<n9k.example.comm> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197/nxos_command.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1502822123.68-218686024435197/" > /dev/null 2>&1 && sleep 0'
ok: [n9k.example.comm] => {
    "changed": false, 
    "failed": false, 
    "invocation": {
        "module_args": {
            "commands": [
                "show version"
            ], 
            "host": "n9k.example.comm", 
            "interval": 1, 
            "match": "all", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 443, 
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": true, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```

##### ADDITIONAL TESTS

###### port: unset, use_ssl: unset

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  #use_ssl: true
  #port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```

###### port: 80, use_ssl: unset

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  #use_ssl: true
  port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```

###### port: 80, use_ssl: no

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: no
  port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 

```

###### port: 80, use_ssl: false

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: false
  port: 80
  validate_certs: no
```
```shell
           "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 

```

###### port: undefined, use_ssl: no

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: no
  #port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```

###### port: undefined, use_ssl: false

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: false
  #port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```


###### port: undefined, use_ssl: yes

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: yes
  #port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": true, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 

```

###### port: undefined, use_ssl: true

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: true
  #port: 80
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": true, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 

```

###### port: 443, use_ssl: yes

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: yes
  port: 443
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": true, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```


###### port: 443, use_ssl: true

```yaml
# group_vars settings
nxapi:
  host: "{{ inventory_hostname }}"
  username: "{{ nxos_nxapi_user | default('admin') }}"
  password: "{{ nxos_nxapi_pass | default('admin') }}"
  transport: nxapi
  use_ssl: true
  port: 443
  validate_certs: no
```
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 443, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": true, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```

###### port: 65535, use_ssl: true
```shell
            "provider": {
                "host": "n9k.example.comm", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 65535, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": true, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": false
            }, 
```