### PR TITLE
Jinja2 2.9 Templating KeyError Fix (stable-2.3 backport)

### DIFF
--- a/lib/ansible/template/template.py
+++ b/lib/ansible/template/template.py
@@ -33,5 +33,11 @@ class AnsibleJ2Template(jinja2.environment.Template):
     '''
 
     def new_context(self, vars=None, shared=False, locals=None):
-        return self.environment.context_class(self.environment, vars.add_locals(locals), self.name, self.blocks)
-
+        if vars is not None:
+            if isinstance(vars, dict):
+                vars = vars.copy()
+                if locals is not None:
+                    vars.update(locals)
+            else:
+                vars = vars.add_locals(locals)
+        return self.environment.context_class(self.environment, vars, self.name, self.blocks)

--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -20,6 +20,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.compat.six import iteritems
+from collections import Mapping
+
 from jinja2.utils import missing
 from ansible.module_utils._text import to_native
 
@@ -27,7 +29,7 @@ from ansible.module_utils._text import to_native
 __all__ = ['AnsibleJ2Vars']
 
 
-class AnsibleJ2Vars:
+class AnsibleJ2Vars(Mapping):
     '''
     Helper class to template all variable content before jinja2 sees it. This is
     done by hijacking the variable storage that jinja2 uses, and overriding __contains__
@@ -67,6 +69,16 @@ class AnsibleJ2Vars:
         if k in self._globals:
             return True
         return False
+
+    def __iter__(self):
+        keys = set()
+        keys.update(self._templar._available_variables, self._locals, self._globals, *self._extras)
+        return iter(keys)
+
+    def __len__(self):
+        keys = set()
+        keys.update(self._templar._available_variables, self._locals, self._globals, *self._extras)
+        return len(keys)
 
     def __getitem__(self, varname):
         if varname not in self._templar._available_variables:

--- a/test/integration/targets/template/files/import_as.expected
+++ b/test/integration/targets/template/files/import_as.expected
@@ -1,0 +1,3 @@
+hello world import as
+WIBBLE
+Goodbye

--- a/test/integration/targets/template/files/import_as_with_context.expected
+++ b/test/integration/targets/template/files/import_as_with_context.expected
@@ -1,0 +1,2 @@
+hello world as qux with context
+WIBBLE

--- a/test/integration/targets/template/files/import_with_context.expected
+++ b/test/integration/targets/template/files/import_with_context.expected
@@ -1,0 +1,3 @@
+hello world with context
+WIBBLE
+Goodbye

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -51,6 +51,60 @@
     that: 
       - "template_result.changed == true"
 
+# test for import with context on jinja-2.9 See https://github.com/ansible/ansible/issues/20494
+- name: fill in a template using import with context ala issue 20494
+  template: src=import_with_context.j2 dest={{output_dir}}/import_with_context.templated mode=0644
+  register: template_result
+
+- name: copy known good import_with_context.expected into place
+  copy: src=import_with_context.expected dest={{output_dir}}/import_with_context.expected
+
+- name: compare templated file to known good import_with_context
+  shell: diff -uw {{output_dir}}/import_with_context.templated {{output_dir}}/import_with_context.expected
+  register: diff_result
+
+- name: verify templated import_with_context matches known good
+  assert:
+    that:
+        - 'diff_result.stdout == ""'
+        - "diff_result.rc == 0"
+
+# test for 'import as' on jinja-2.9 See https://github.com/ansible/ansible/issues/20494
+- name: fill in a template using import as ala fails2 case in issue 20494
+  template: src=import_as.j2 dest={{output_dir}}/import_as.templated mode=0644
+  register: import_as_template_result
+
+- name: copy known good import_as.expected into place
+  copy: src=import_as.expected dest={{output_dir}}/import_as.expected
+
+- name: compare templated file to known good import_as
+  shell: diff -uw {{output_dir}}/import_as.templated {{output_dir}}/import_as.expected
+  register: import_as_diff_result
+
+- name: verify templated import_as matches known good
+  assert:
+    that:
+        - 'import_as_diff_result.stdout == ""'
+        - "import_as_diff_result.rc == 0"
+
+# test for 'import as with context' on jinja-2.9 See https://github.com/ansible/ansible/issues/20494
+- name: fill in a template using import as with context ala fails2 case in issue 20494
+  template: src=import_as_with_context.j2 dest={{output_dir}}/import_as_with_context.templated mode=0644
+  register: import_as_with_context_template_result
+
+- name: copy known good import_as_with_context.expected into place
+  copy: src=import_as_with_context.expected dest={{output_dir}}/import_as_with_context.expected
+
+- name: compare templated file to known good import_as_with_context
+  shell: diff -uw {{output_dir}}/import_as_with_context.templated {{output_dir}}/import_as_with_context.expected
+  register: import_as_with_context_diff_result
+
+- name: verify templated import_as_with_context matches known good
+  assert:
+    that:
+        - 'import_as_with_context_diff_result.stdout == ""'
+        - "import_as_with_context_diff_result.rc == 0"
+
 # VERIFY CONTENTS
 
 - name: check what python version ansible is running on

--- a/test/integration/targets/template/templates/bar
+++ b/test/integration/targets/template/templates/bar
@@ -1,0 +1,1 @@
+Goodbye

--- a/test/integration/targets/template/templates/import_as.j2
+++ b/test/integration/targets/template/templates/import_as.j2
@@ -1,0 +1,4 @@
+{% import 'qux' as qux %}
+hello world import as
+{{ qux.wibble }}
+{% include 'bar' %}

--- a/test/integration/targets/template/templates/import_as_with_context.j2
+++ b/test/integration/targets/template/templates/import_as_with_context.j2
@@ -1,0 +1,3 @@
+{% import 'qux' as qux with context %}
+hello world as qux with context
+{{ qux.wibble }}

--- a/test/integration/targets/template/templates/import_as_with_context.js
+++ b/test/integration/targets/template/templates/import_as_with_context.js
@@ -1,0 +1,3 @@
+{% import 'qux' as qux with context %}
+hello world as qux with context
+{{ qux.wibble }}

--- a/test/integration/targets/template/templates/import_with_context.j2
+++ b/test/integration/targets/template/templates/import_with_context.j2
@@ -1,0 +1,4 @@
+{% import 'qux' as qux with context %}
+hello world with context
+{{ qux.wibble }}
+{% include 'bar' %}

--- a/test/integration/targets/template/templates/qux
+++ b/test/integration/targets/template/templates/qux
@@ -1,0 +1,1 @@
+{% set wibble = "WIBBLE" %}

--- a/test/units/template/test_vars.py
+++ b/test/units/template/test_vars.py
@@ -19,3 +19,63 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import MagicMock
+
+from ansible.template.vars import AnsibleJ2Vars
+
+
+class TestVars(unittest.TestCase):
+    def setUp(self):
+        self.mock_templar = MagicMock(name='mock_templar')
+
+    def test(self):
+        ajvars = AnsibleJ2Vars(None, None)
+        print(ajvars)
+
+    def test_globals_empty_2_8(self):
+        ajvars = AnsibleJ2Vars(self.mock_templar, {})
+        res28 = self._dict_jinja28(ajvars)
+        self.assertIsInstance(res28, dict)
+
+    def test_globals_empty_2_9(self):
+        ajvars = AnsibleJ2Vars(self.mock_templar, {})
+        res29 = self._dict_jinja29(ajvars)
+        self.assertIsInstance(res29, dict)
+
+    def _assert_globals(self, res):
+        self.assertIsInstance(res, dict)
+        self.assertIn('foo', res)
+        self.assertEqual(res['foo'], 'bar')
+
+    def test_globals_2_8(self):
+        ajvars = AnsibleJ2Vars(self.mock_templar, {'foo': 'bar', 'blip': [1, 2, 3]})
+        res28 = self._dict_jinja28(ajvars)
+        self._assert_globals(res28)
+
+    def test_globals_2_9(self):
+        ajvars = AnsibleJ2Vars(self.mock_templar, {'foo': 'bar', 'blip': [1, 2, 3]})
+        res29 = self._dict_jinja29(ajvars)
+        self._assert_globals(res29)
+
+    def _dicts(self, ajvars):
+        print(ajvars)
+        res28 = self._dict_jinja28(ajvars)
+        res29 = self._dict_jinja29(ajvars)
+        # res28_other = self._dict_jinja28(ajvars, {'other_key': 'other_value'})
+        # other = {'other_key': 'other_value'}
+        # res29_other = self._dict_jinja29(ajvars, *other)
+        print('res28: %s' % res28)
+        print('res29: %s' % res29)
+        # print('res28_other: %s' % res28_other)
+        # print('res29_other: %s' % res29_other)
+        # return (res28, res29, res28_other, res29_other)
+        # assert ajvars == res28
+        # assert ajvars == res29
+        return (res28, res29)
+
+    def _dict_jinja28(self, *args, **kwargs):
+        return dict(*args, **kwargs)
+
+    def _dict_jinja29(self, the_vars):
+        return dict(the_vars)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes Jinja2 2.9 templating on stable-2.3
Fixes #20494
Fixes #27494

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Badly needed fix to get Jinja2 templating usable on ansible 2.3 with Jinja2>=2.9.
