### PR TITLE
standardized agreggate resources for network user modules

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -40,7 +40,7 @@ options:
       - The set of username objects to be configured on the remote
         Arista EOS device.  The list entries can either be the username
         or a hash of username and properties.  This argument is mutually
-        exclusive with the C(username) argument.
+        exclusive with the C(username) argument. alias C(users).
     version_added: "2.4"
   username:
     description:

--- a/lib/ansible/modules/network/ios/ios_user.py
+++ b/lib/ansible/modules/network/ios/ios_user.py
@@ -36,12 +36,12 @@ description:
     current running config. It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
-  users:
+  aggregate:
     description:
       - The set of username objects to be configured on the remote
         Cisco IOS device. The list entries can either be the username
         or a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument.
+        exclusive with the C(name) argument. alias C(users).
   name:
     description:
       - The username to be configured on the Cisco IOS device.
@@ -110,7 +110,7 @@ EXAMPLES = """
     purge: yes
 - name: set multiple users to privilege level 15
   ios_user:
-    users:
+    aggregate:
       - name: netop
       - name: netend
     privilege: 15
@@ -249,7 +249,7 @@ def get_param_value(key, item, module):
 
 
 def map_params_to_obj(module):
-    users = module.params['users']
+    users = module.params['aggregate']
     if not users:
         if not module.params['name'] and module.params['purge']:
             return list()
@@ -298,7 +298,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['aggregate']),
+        aggregate=dict(type='list', aliases=['users', 'collection']),
         name=dict(),
 
         password=dict(no_log=True),
@@ -313,7 +313,7 @@ def main():
     )
 
     argument_spec.update(ios_argument_spec)
-    mutually_exclusive = [('name', 'users')]
+    mutually_exclusive = [('name', 'aggregate')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/iosxr/iosxr_user.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_user.py
@@ -25,12 +25,12 @@ description:
     current running config. It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
-  users:
+  aggregate:
     description:
       - The set of username objects to be configured on the remote
         Cisco IOS XR device. The list entries can either be the username
         or a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument, alias C(aggregate).
+        exclusive with the C(name) argument, alias C(users).
   name:
     description:
       - The username to be configured on the Cisco IOS XR device.
@@ -88,7 +88,7 @@ EXAMPLES = """
     purge: yes
 - name: set multiple users to group sys-admin
   iosxr_user:
-    users:
+    aggregate:
       - name: netop
       - name: netend
     group: sysadmin
@@ -210,7 +210,7 @@ def get_param_value(key, item, module):
 
 
 def map_params_to_obj(module):
-    users = module.params['users']
+    users = module.params['aggregate']
     if not users:
         if not module.params['name'] and module.params['purge']:
             return list()
@@ -244,7 +244,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        users=dict(type='list', aliases=['aggregate']),
+        aggregate=dict(type='list', aliases=['users', 'collection']),
         name=dict(),
 
         password=dict(no_log=True),
@@ -257,7 +257,7 @@ def main():
     )
 
     argument_spec.update(iosxr_argument_spec)
-    mutually_exclusive = [('name', 'users')]
+    mutually_exclusive = [('name', 'aggregate')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/junos/junos_user.py
+++ b/lib/ansible/modules/network/junos/junos_user.py
@@ -32,7 +32,7 @@ options:
         on the remote device.  The list of users will be compared against
         the current users and only changes will be added or removed from
         the device configuration.  This argument is mutually exclusive with
-        the name argument.
+        the name argument. alias C(users).
     version_added: "2.4"
     required: False
     default: null

--- a/lib/ansible/modules/network/nxos/nxos_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_user.py
@@ -40,7 +40,7 @@ options:
       - The set of username objects to be configured on the remote
         Cisco Nexus device.  The list entries can either be the username
         or a hash of username and properties.  This argument is mutually
-        exclusive with the C(name) argument.
+        exclusive with the C(name) argument. alias C(users).
     version_added: "2.4"
     required: false
     default: null

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -36,12 +36,12 @@ description:
     current running config. It also supports purging usernames from the
     configuration that are not explicitly defined.
 options:
-  users:
+  aggregate:
     description:
       - The set of username objects to be configured on the remote
         VyOS device. The list entries can either be the username or
         a hash of username and properties. This argument is mutually
-        exclusive with the C(name) argument. alias C(aggregate).
+        exclusive with the C(name) argument. alias C(users).
   name:
     description:
       - The username to be configured on the VyOS device.
@@ -102,7 +102,7 @@ EXAMPLES = """
     purge: yes
 - name: set multiple users to level operator
   vyos_user:
-    users:
+    aggregate:
       - name: netop
       - name: netend
     level: operator
@@ -289,7 +289,7 @@ def main():
     remove_default_spec(aggregate_spec)
 
     argument_spec = dict(
-        aggregate=dict(type='list', elements='dict', options=aggregate_spec, aliases=['users']),
+        aggregate=dict(type='list', elements='dict', options=aggregate_spec, aliases=['users', 'collection']),
     )
 
     argument_spec.update(element_spec)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
All arguments are now `aggregate` with `collection` and `users` as aliases for aggregate resources. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- ios_user
- nxos_user
- iosxr_user
- junos_user
- eos_user
- vyos_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
