### PR TITLE
Fix ansible-test target completion on Python 3.

### DIFF
--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -7,6 +7,7 @@ import re
 import errno
 import itertools
 import abc
+import sys
 
 from lib.util import ApplicationError
 
@@ -21,7 +22,8 @@ def find_target_completion(target_func, prefix):
     """
     try:
         targets = target_func()
-        prefix = prefix.encode()
+        if sys.version_info[0] == 2:
+            prefix = prefix.encode()
         short = os.environ.get('COMP_TYPE') == '63'  # double tab completion from bash
         matches = walk_completion_targets(targets, prefix, short)
         return matches


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test target completion on Python 3.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-completion-fix cb2e4847ed) last updated 2017/08/15 15:05:40 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
