### PR TITLE
s3_sync: add delete option - fixes #25884

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -94,6 +94,7 @@ options:
     - Remove files that exist in bucket but are not present in the file root.
     required: false
     default: no
+    version_added: "2.4"
 
 requirements:
   - boto3 >= 1.4.4

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -467,7 +467,7 @@ def remove_files(s3, sourcelist, params):
     delete_keys = list(current_keys - keep_keys)
 
     # can delete 1000 objects at a time
-    groups_of_keys = [delete_keys[i:i+1000] for i in range(0, len(delete_keys), 1000)]
+    groups_of_keys = [delete_keys[i:i + 1000] for i in range(0, len(delete_keys), 1000)]
     for keys in groups_of_keys:
         s3.delete_objects(Bucket=bucket, Delete={'Objects': [{'Key': key} for key in keys]})
 

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -40,6 +40,7 @@ options:
     - date_size will upload if file sizes don't match or if local file modified date is newer than s3's version
     - checksum will compare etag values based on s3's implementation of chunked md5s.
     - force will always upload all files.
+    - delete will remove files that exist in the bucket but are not present in the file root.
     required: false
     default: 'date_size'
     choices: [ force, checksum, date_size ]
@@ -208,7 +209,7 @@ from dateutil import tz
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info, HAS_BOTO3, boto_exception
-
+from ansible.module_utils._text import to_text
 
 try:
     import botocore
@@ -390,7 +391,7 @@ def filter_list(s3, bucket, s3filelist, strategy):
         e['_strategy'] = strategy
 
     # init/fetch info from S3 if we're going to use it for comparisons
-    if not strategy == 'force':
+    if not strategy == 'force' and not strategy == 'delete':
         keeplist = head_s3(s3, bucket, s3filelist)
 
     # now actually run the strategies
@@ -428,6 +429,10 @@ def filter_list(s3, bucket, s3filelist, strategy):
                     entry['skip_flag'] = True
             else:
                 entry['why'] = "no s3_head"
+    elif strategy == 'delete':
+        current_keys = [to_text(object_key['Key']) for object_key in s3.list_objects(Bucket=bucket)['Contents']]
+        keep_keys = [to_text(keep_key['s3_path']) for keep_key in keeplist]
+        return [x for x in current_keys if x not in keep_keys]
     # else: probably 'force'. Basically we don't skip with any with other strategies.
     else:
         pass
@@ -452,11 +457,19 @@ def upload_files(s3, bucket, filelist, params):
     return ret
 
 
+def remove_files(s3, bucket, filelist, params):
+    ret = []
+    for entry in filelist:
+        s3.delete_object(Bucket=bucket, Key=entry)
+        ret.append(entry)
+    return ret
+
+
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         mode=dict(choices=['push'], default='push'),
-        file_change_strategy=dict(choices=['force', 'date_size', 'checksum'], default='date_size'),
+        file_change_strategy=dict(choices=['force', 'date_size', 'checksum', 'delete'], default='date_size'),
         bucket=dict(required=True),
         key_prefix=dict(required=False, default=''),
         file_root=dict(required=True, type='path'),
@@ -492,10 +505,13 @@ def main():
             result['filelist_s3'] = calculate_s3_path(result['filelist_typed'], module.params['key_prefix'])
             result['filelist_local_etag'] = calculate_local_etag(result['filelist_s3'])
             result['filelist_actionable'] = filter_list(s3, module.params['bucket'], result['filelist_local_etag'], module.params['file_change_strategy'])
-            result['uploads'] = upload_files(s3, module.params['bucket'], result['filelist_actionable'], module.params)
+            if module.params['file_change_strategy'] == 'delete':
+                result['removed'] = remove_files(s3, module.params['bucket'], result['filelist_actionable'], module.params)
+            else:
+                result['uploads'] = upload_files(s3, module.params['bucket'], result['filelist_actionable'], module.params)
 
             # mark changed if we actually upload something.
-            if result.get('uploads') and len(result.get('uploads')):
+            if result.get('uploads') or result.get('removed'):
                 result['changed'] = True
             # result.update(filelist=actionable_filelist)
         except botocore.exceptions.ClientError as err:


### PR DESCRIPTION
##### SUMMARY

Add `delete` option. Maintain existing upload strategies. When delete is requested objects present on remote that are not in source list are removed after upload.

Based on work from @s-hertel in #25912, in response to #25884

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/s3_sync.py

##### ANSIBLE VERSION

```
2.4.0
```