### PR TITLE
openssl_csr: Ensure array comparison is deterministic

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -354,7 +354,7 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             else:
                 current = [usage.strip() for usage in str(usages_ext[0]).split(',')]
                 expected = [long[usage] if usage in long else usage for usage in expected]
-                return current == expected and usages_ext[0].get_critical() == critical
+                return set(current) == set(expected) and usages_ext[0].get_critical() == critical
 
         def _check_keyUsage(extensions):
             return _check_keyUsage_(extensions, b'keyUsage', self.keyUsage, self.keyUsage_critical, crypto_utils.keyUsageLong)


### PR DESCRIPTION
##### SUMMARY

When comparing expected and current value for keyUsage and
extendedKeyUsage current behavior is not deterministic.

As we compare two arrays, based on the order the value have been
specified, False might be returned when the two arrays actually matches.
In order to have a deterministic comparison we compare sets rather than
arrays.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- openssl_csr

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

- N/A
