### PR TITLE
include_vars : auto leef param

### DIFF
--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
     TRANSFERS_FILES = False
 
     VALID_FILE_EXTENSIONS = ['yaml', 'yml', 'json']
-    VALID_DIR_ARGUMENTS = ['dir', 'depth', 'files_matching', 'ignore_files', 'extensions']
+    VALID_DIR_ARGUMENTS = ['dir', 'depth', 'files_matching', 'ignore_files', 'extensions', 'auto_leefs']
     VALID_FILE_ARGUMENTS = ['file', '_raw_params']
     VALID_ALL = ['name']
 
@@ -67,6 +67,8 @@ class ActionModule(ActionBase):
             self.source_file = self._task.args.get('_raw_params')
 
         self.depth = self._task.args.get('depth', None)
+        self.auto_leefs = self._task.args.get('auto_leefs', None)
+
         self.files_matching = self._task.args.get('files_matching', None)
         self.ignore_files = self._task.args.get('ignore_files', None)
         self.valid_extensions = self._task.args.get('extensions', self.VALID_FILE_EXTENSIONS)
@@ -239,8 +241,17 @@ class ActionModule(ActionBase):
                 err_msg = ('{0} must be stored as a dictionary/hash' .format(filename))
             else:
                 self.included_files.append(filename)
+                if self.auto_leefs:
+                    cur_dir = path.dirname(filename)
+                    internal_path = cur_dir.replace(self.source_dir, '')
+                    leefList = internal_path.split('/')
+                    leefList.append(path.splitext(path.basename(filename))[0])
+                    while leefList:
+                        leef = leefList.pop()
+                        data_tmp = dict()
+                        data_tmp[leef] = data
+                        data = data_tmp
                 results.update(data)
-
         return failed, err_msg, results
 
     def _load_files_in_dir(self, root_dir, var_files):


### PR DESCRIPTION
##### SUMMARY
This pull request offers a new boolean param for the include_vars.
It permits to auto add the path name as leefs in the vars dict.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
include_vars

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
For example, if you have a var dir with:
- subdir1/
- subdir1/file1 containing
```
---
- myvar : value1
```
- subdir2
- subdir2/file2 containing
```
---
- myvar : value2
```

without this param you'll only get : 
dict {myvar : value2}

with this param, you'll get:
dict {subdir1 : { file1 : { myvar : value1} } , {subdir2 : { file1 : { myvar : value2} } }

If you like this feature, I'll write the documentation for too. If you have better idea for the param wording, I can change it too.
