### PR TITLE
Update playbooks_filters.rst

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -397,7 +397,7 @@ To get a sha256 password hash with a specific salt::
 
 
 Hash types available depend on the master system running ansible,
-'hash' depends on hashlib password_hash depends on crypt.
+'hash' depends on hashlib password_hash depends on passlib (http://passlib.readthedocs.io/en/stable/lib/passlib.hash.html).
 
 .. _combine_filter:
 


### PR DESCRIPTION
See #17266, password_hash has been updated to support passlib. The available hashes are listed on http://docs.ansible.com/ansible/latest/playbooks_prompts.html, but not here.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
filter docs

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
