### PR TITLE
fixed #28183 - user module shadowfile update on SunOS

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1347,7 +1347,8 @@ class SunOS(User):
                 minweeks, maxweeks, warnweeks = self.get_password_defaults()
                 try:
                     lines = []
-                    for line in open(self.SHADOWFILE, 'r').readlines():
+                    for line in open(self.SHADOWFILE, 'rb').readlines():
+                        line = to_native(line, errors='surrogate_or_strict')
                         fields = line.strip().split(':')
                         if not fields[0] == self.name:
                             lines.append(line)
@@ -1441,7 +1442,8 @@ class SunOS(User):
                 minweeks, maxweeks, warnweeks = self.get_password_defaults()
                 try:
                     lines = []
-                    for line in open(self.SHADOWFILE, 'r').readlines():
+                    for line in open(self.SHADOWFILE, 'rb').readlines():
+                        line = to_native(line, errors='surrogate_or_strict')
                         fields = line.strip().split(':')
                         if not fields[0] == self.name:
                             lines.append(line)

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -1347,7 +1347,7 @@ class SunOS(User):
                 minweeks, maxweeks, warnweeks = self.get_password_defaults()
                 try:
                     lines = []
-                    for line in open(self.SHADOWFILE, 'rb').readlines():
+                    for line in open(self.SHADOWFILE, 'r').readlines():
                         fields = line.strip().split(':')
                         if not fields[0] == self.name:
                             lines.append(line)
@@ -1441,7 +1441,7 @@ class SunOS(User):
                 minweeks, maxweeks, warnweeks = self.get_password_defaults()
                 try:
                     lines = []
-                    for line in open(self.SHADOWFILE, 'rb').readlines():
+                    for line in open(self.SHADOWFILE, 'r').readlines():
                         fields = line.strip().split(':')
                         if not fields[0] == self.name:
                             lines.append(line)


### PR DESCRIPTION
##### SUMMARY
Fixes #28183  issue for updating user passwords in SunOS systems using Python3 target host.
Tested working on Solaris 10u11 with ansible_python_interpreter v3.4.5.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - user module

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 09cabaf702) last updated 2017/08/14 13:40:16 (GMT -400)
  config file = /home/c0psrul3/.ansible/ansible.cfg
  configured module search path = ['/home/c0psrul3/.ansible/library']
  ansible python module location = /opt/ansible.git/lib/ansible
  executable location = /opt/ansible.git/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
_original error:_
```
fatal: [contgen03]: FAILED! => {
    "changed": false,
    "failed": true,
...
    "msg": "failed to update users password during modify: 'str' does not support the buffer interface"
}
The full traceback is:
  File "/tmp/ansible_tqstex_2/ansible_module_user.py", line 1445, in modify_user_usermod
    fields = line.strip().split(':')
```

_target host python version:_
```
-bash-3.2$ /usr/local/python/bin/python3.4 --version
Python 3.4.5
```
