### PR TITLE
Correct config manager deprecation warning

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -365,4 +365,5 @@ class ConfigManager(object):
             sys.stderr.write("Unable to set correct type for:\n\t%s\n" % '\n\t'.join(self.UNABLE))
         if self.DEPRECATED:
             for k, reason in self.DEPRECATED:
-                sys.stderr.write("[DEPRECATED] %s: %(why)s. It will be removed in %(version)s. As alternative %(alternative)s", (k, reason))
+                sys.stderr.write("[DEPRECATED] %(k)s: %(why)s. It will be removed in %(version)s. As alternative use one of [%(alternatives)s]\n"
+                                 % dict(k=k, **reason))


### PR DESCRIPTION
##### SUMMARY
Fixes a TypeError generated by the deprecation warning, introduced by https://github.com/ansible/ansible/commit/f921369445900dcc756821e40c9257d5359087af

```
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 40, in <module>
    import ansible.constants as C
  File "/usr/lib/python2.7/dist-packages/ansible/constants.py", line 96, in <module>
    config = ConfigManager()
  File "/usr/lib/python2.7/dist-packages/ansible/config/manager.py", line 156, in __init__
    self.update_config_data()
  File "/usr/lib/python2.7/dist-packages/ansible/config/manager.py", line 368, in update_config_data
    sys.stderr.write("[DEPRECATED] %s: %(why)s. It will be removed in %(version)s. As alternative %(alternative)s", (k, reason))
TypeError: function takes exactly 1 argument (2 given)
```

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ansible config

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```
