### PR TITLE
yum: use envra instead of nevra

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -274,7 +274,7 @@ from ansible.module_utils.urls import fetch_url
 # 64k.  Number of bytes to read at a time when manually downloading pkgs via a url
 BUFSIZE = 65536
 
-def_qf = "%{name}-%{version}-%{release}.%{arch}"
+def_qf = "%{epoch}:%{name}-%{version}-%{release}.%{arch}"
 rpmbin = None
 
 
@@ -335,12 +335,11 @@ def fetch_rpm_from_url(spec, module=None):
             module.fail_json(msg="Failure downloading %s, %s" % (spec, e))
     return package_file.name
 
-def po_to_nevra(po):
-
-    if hasattr(po, 'ui_nevra'):
-        return po.ui_nevra
+def po_to_envra(po):
+    if hasattr(po, 'ui_envra'):
+        return po.ui_envra
     else:
-        return '%s-%s-%s.%s' % (po.name, po.version, po.release, po.arch)
+        return '%s:%s-%s-%s.%s' % (po.epoch, po.name, po.version, po.release, po.arch)
 
 def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_repos=None, is_pkg=False, installroot='/'):
     if en_repos is None:
@@ -365,7 +364,7 @@ def is_installed(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, di
             e = get_exception()
             module.fail_json(msg="Failure talking to yum: %s" % e)
 
-        return [po_to_nevra(p) for p in pkgs]
+        return [po_to_envra(p) for p in pkgs]
 
     else:
         global rpmbin
@@ -426,7 +425,7 @@ def is_available(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, di
             e = get_exception()
             module.fail_json(msg="Failure talking to yum: %s" % e)
 
-        return [po_to_nevra(p) for p in pkgs]
+        return [po_to_envra(p) for p in pkgs]
 
     else:
         myrepoq = list(repoq)
@@ -478,7 +477,7 @@ def is_update(module, repoq, pkgspec, conf_file, qf=def_qf, en_repos=None, dis_r
             if pkg in updates:
                 retpkgs.append(pkg)
 
-        return set([po_to_nevra(p) for p in retpkgs])
+        return set([po_to_envra(p) for p in retpkgs])
 
     else:
         myrepoq = list(repoq)
@@ -526,7 +525,7 @@ def what_provides(module, repoq, req_spec, conf_file, qf=def_qf, en_repos=None, 
             e = get_exception()
             module.fail_json(msg="Failure talking to yum: %s" % e)
 
-        return set([po_to_nevra(p) for p in pkgs])
+        return set([po_to_envra(p) for p in pkgs])
 
     else:
         myrepoq = list(repoq)
@@ -590,8 +589,8 @@ def transaction_exists(pkglist):
                     break
     return conflicts
 
-def local_nvra(module, path):
-    """return nvra of a local rpm passed in"""
+def local_envra(module, path):
+    """return envra of a local rpm passed in"""
 
     ts = rpm.TransactionSet()
     ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
@@ -601,10 +600,11 @@ def local_nvra(module, path):
     finally:
         os.close(fd)
 
-    return '%s-%s-%s.%s' % (header[rpm.RPMTAG_NAME],
-                            header[rpm.RPMTAG_VERSION],
-                            header[rpm.RPMTAG_RELEASE],
-                            header[rpm.RPMTAG_ARCH])
+    return '%s:%s-%s-%s.%s' % (header[rpm.RPMTAG_EPOCH],
+                               header[rpm.RPMTAG_NAME],
+                               header[rpm.RPMTAG_VERSION],
+                               header[rpm.RPMTAG_RELEASE],
+                               header[rpm.RPMTAG_ARCH])
 
 def pkg_to_dict(pkgstr):
 
@@ -620,7 +620,7 @@ def pkg_to_dict(pkgstr):
         'release':r,
         'version':v,
         'repo':repo,
-        'nevra': '%s:%s-%s-%s.%s' % (e, n, v, r, a)
+        'envra': '%s:%s-%s-%s.%s' % (e, n, v, r, a)
     }
 
     if repo == 'installed':
@@ -729,10 +729,10 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
                 res['rc'] = 127 # Ensure the task fails in with-loop
                 module.fail_json(**res)
 
-            nvra = local_nvra(module, spec)
+            envra = local_envra(module, spec)
 
             # look for them in the rpmdb
-            if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
+            if is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
                 # if they are there, skip it
                 continue
             pkg = spec
@@ -741,8 +741,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
         elif '://' in spec:
             # download package so that we can check if it's already installed
             package = fetch_rpm_from_url(spec, module=module)
-            nvra = local_nvra(module, package)
-            if is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
+            envra = local_envra(module, package)
+            if is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
                 # if it's there, skip it
                 continue
             pkg = package
@@ -996,11 +996,11 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
                     res['rc'] = 127 # Ensure the task fails in with-loop
                     module.fail_json(**res)
 
-                # get the pkg name-v-r.arch
-                nvra = local_nvra(module, spec)
+                # get the pkg e:name-v-r.arch
+                envra = local_envra(module, spec)
 
                 # local rpm files can't be updated
-                if not is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
+                if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
                     pkgs['install'].append(spec)
                 continue
 
@@ -1008,10 +1008,10 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
             elif '://' in spec:
                 # download package so that we can check if it's already installed
                 package = fetch_rpm_from_url(spec, module=module)
-                nvra = local_nvra(module, package)
+                envra = local_envra(module, package)
 
                 # local rpm files can't be updated
-                if not is_installed(module, repoq, nvra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
+                if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
                     pkgs['install'].append(package)
                 continue
 


### PR DESCRIPTION
##### SUMMARY
`envra` is easier to parse and some of the tools and libraries don't work well with `nevra` like `rpmUtils.miscutils.splitFilename` (https://bugzilla.redhat.com/show_bug.cgi?id=1117773) which is used in the module.

One of the use cases where using `envra` fixes the incorrect behavior is:
Add this repo http://nginx.org/packages/centos/7/x86_64/RPMS/ and install the latest version of nginx, then run:
```
-m yum -a "name=nginx-1.10.2 state=present allow_downgrade=yes"
```


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

