### PR TITLE
Add passive_interface property to nxos_ospf_vrf module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -115,6 +115,7 @@ options:
     description:
       - Setting to true will suppress routing update on interface.
         Valid values are 'true' and 'false'.
+    version_added: "2.4"
     required: false
     choices: ['true','false']
     default: null

--- a/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
+++ b/lib/ansible/modules/network/nxos/nxos_ospf_vrf.py
@@ -111,6 +111,13 @@ options:
         Valid values are an integer, in Mbps, or the keyword 'default'.
     required: false
     default: null
+  passive_interface:
+    description:
+      - Setting to true will suppress routing update on interface.
+        Valid values are 'true' and 'false'.
+    required: false
+    choices: ['true','false']
+    default: null
 '''
 
 EXAMPLES = '''
@@ -142,6 +149,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.netcfg import CustomNetworkConfig
 
 
+BOOL_PARAMS = [
+    'passive_interface'
+]
 PARAM_TO_COMMAND_KEYMAP = {
     'vrf': 'vrf',
     'router_id': 'router-id',
@@ -153,7 +163,8 @@ PARAM_TO_COMMAND_KEYMAP = {
     'timer_throttle_spf_max': 'timers throttle spf',
     'timer_throttle_spf_start': 'timers throttle spf',
     'timer_throttle_spf_hold': 'timers throttle spf',
-    'auto_cost': 'auto-cost reference-bandwidth'
+    'auto_cost': 'auto-cost reference-bandwidth',
+    'passive_interface': 'passive-interface default'
 }
 PARAM_TO_DEFAULT_KEYMAP = {
     'timer_throttle_lsa_start': '0',
@@ -177,6 +188,11 @@ def get_value(arg, config, module):
                 value = 'detail'
             else:
                 value = 'log'
+        elif arg == 'passive_interface':
+            if 'passive-interface default' in config:
+                value = True
+            else:
+                value = False
         else:
             value_list = command_re.search(config).group('value').split()
             if 'hold' in arg:
@@ -242,7 +258,11 @@ def state_present(module, existing, proposed, candidate):
             commands.append(key)
 
         elif value is False:
-            commands.append('no {0}'.format(key))
+            if key == 'passive-interface default':
+                if existing_commands.get(key):
+                    commands.append('no {0}'.format(key))
+            else:
+                commands.append('no {0}'.format(key))
 
         elif value == 'default':
             if existing_commands.get(key):
@@ -282,7 +302,6 @@ def state_present(module, existing, proposed, candidate):
         parents = ['router ospf {0}'.format(module.params['ospf'])]
         if module.params['vrf'] != 'default':
             parents.append('vrf {0}'.format(module.params['vrf']))
-
         candidate.add(commands, parents=parents)
 
 
@@ -292,8 +311,10 @@ def state_absent(module, existing, proposed, candidate):
     if module.params['vrf'] == 'default':
         existing_commands = apply_key_map(PARAM_TO_COMMAND_KEYMAP, existing)
         for key, value in existing_commands.items():
-            if value:
-                if key == 'timers throttle lsa':
+            if value and key != 'vrf':
+                if key == 'passive-interface default':
+                    command = 'no {0}'.format(key)
+                elif key == 'timers throttle lsa':
                     command = 'no {0} {1} {2} {3}'.format(
                         key,
                         existing['timer_throttle_lsa_start'],
@@ -313,7 +334,9 @@ def state_absent(module, existing, proposed, candidate):
                     commands.append(command)
     else:
         commands = ['no vrf {0}'.format(module.params['vrf'])]
-    candidate.add(commands, parents=parents)
+
+    if commands:
+        candidate.add(commands, parents=parents)
 
 
 def main():
@@ -330,6 +353,7 @@ def main():
         timer_throttle_spf_hold=dict(required=False, type='str'),
         timer_throttle_spf_max=dict(required=False, type='str'),
         auto_cost=dict(required=False, type='str'),
+        passive_interface=dict(required=False, type='bool'),
         state=dict(choices=['present', 'absent'], default='present', required=False),
         include_defaults=dict(default=True),
         config=dict(),

--- a/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tests/common/sanity.yaml
@@ -20,6 +20,7 @@
       timer_throttle_lsa_hold: 1100
       timer_throttle_lsa_max: 3000
       vrf: test
+      passive_interface: true
       state: present
       provider: "{{ connection }}"
     register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add passive interface option to the module. This property can be added to the default vrf as well as `foo` vrf.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_ospf_vrf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxos_ospf_vrf 5f829a3f0c) last updated 2017/08/16 12:55:32 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```