### PR TITLE
Document maven_artifact keep_name default

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -102,7 +102,7 @@ options:
             - If C(yes), the downloaded artifact's name is preserved, i.e the version number remains part of it.
             - This option only has effect when C(dest) is a directory and C(version) is set to C(latest).
         required: false
-        default: no
+        default: 'no'
         choices: ['yes', 'no']
         version_added: "2.4"
 '''


### PR DESCRIPTION
Display the string 'no' as default for the keep_name attribute.

##### SUMMARY
There's obviously a difference between `no` and `'no'` in documentation strings. If not explicitly marked as string, it doesn't show up.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel c9cfc9be07) last updated 2017/08/16 20:43:46 (GMT +200)
```