### PR TITLE
New module: xmlrpc_client

### DIFF
--- a/lib/ansible/modules/commands/xmlrpc_client.py
+++ b/lib/ansible/modules/commands/xmlrpc_client.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 ANSIBLE_METADATA = {
     'metadata_version': '1.0',
     'status': ['preview'],
-    'supported_by': 'curated'
+    'supported_by': 'community'
 }
 
 DOCUMENTATION = '''

--- a/lib/ansible/modules/commands/xmlrpc_client.py
+++ b/lib/ansible/modules/commands/xmlrpc_client.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 ANSIBLE_METADATA = {
-    'metadata_version': '1.0',
+    'metadata_version': '1.1',
     'status': ['preview'],
     'supported_by': 'community'
 }

--- a/lib/ansible/modules/commands/xmlrpc_client.py
+++ b/lib/ansible/modules/commands/xmlrpc_client.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Stefan Midjich <swehack at gmail dot com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'status': ['preview'],
+    'supported_by': 'curated'
+}
+
+DOCUMENTATION = '''
+---
+module: xmlrpc_client
+
+short_description: Run XMLRPC commands
+
+version_added: "2.4"
+
+description:
+    - This module lets you establish an XMLRPC session and call any method
+      by its xmlrpc path. On dry run this module will only establish API
+      connection and check if your method exists in the method list but not
+      call it.
+
+options:
+    url:
+        description:
+            - The API URL you connect to.
+        required: true
+    path:
+        description:
+            - The RPC path/method you are calling.
+        required: true
+    args:
+        description:
+            - A list of arguments for the RPC call. Placed first in any RPC call.
+    kwargs:
+        description:
+            - A dictionary of arguments for the RPC call. Comes after the args list.
+
+author:
+    - Stefan Midjich (@stemid)
+'''
+
+EXAMPLES = '''
+---
+
+vars:
+  api_url: https://api.localhost:9002
+
+tasks:
+  # Establish session
+  - name: login to api
+    xmlrpc_client:
+      url: "{{api_url}}"
+      path: login
+      args:
+        - admin
+        - secret password.
+    register: sid
+
+  # Use session to execute privileged command. In this case server.group.add
+  # returns a group ID from the API.
+  - name: create new server group
+    xmlrpc_client:
+      url: "{{api_url}}"
+      path: server.group.add
+      args:
+        - "{{sid.returned}}"
+        - Dev environment web server group - Sweden, Malmoe
+        - web
+    register: server_group_id
+    when: sid|changed
+
+  # Use previous value in more API calls.
+  - name: create new server
+    xmlrpc_client:
+      url: "{{api_url}}"
+      path: server.add
+      args:
+        - "{{sid.returned}}"
+        - vm-web01
+        - 80
+        - "{{server_group_id.returned}}"
+    register: server_id
+    when: server_group_id.returned
+'''
+
+RETURN = '''
+returned:
+  description: The output value that the RPC call returns
+  type: string
+  returned: success, changed
+'''
+
+
+try:
+    from xmlrpc.client import ServerProxy
+except ImportError:
+    from xmlrpclib import ServerProxy
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+def run_module():
+    module_args = dict(
+        url=dict(type='str', required=True),
+        path=dict(type='str', required=True),
+        args=dict(type='list', default=[]),
+        kwargs=dict(type='dict', default={})
+    )
+
+    result = dict(
+        changed=False,
+        returned=None
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    try:
+        server = ServerProxy(module.params['url'])
+    except Exception as e:
+        # Perhaps handle this with fail_json, that's why it's in a try block.
+        raise
+
+    # Only check if the RPC path exists in dry run
+    if module.check_mode:
+        if module.params['path'] in server.listMethods():
+            result['returned'] = 'RPC call exists'
+        else:
+            result['returned'] = 'RPC call does not exist'
+        return result
+
+    try:
+        returned_data = getattr(server, module.params['path'])(
+            *module.params['args'],
+            **module.params['kwargs']
+        )
+    except Exception as e:
+        module.fail_json(
+            msg='RPC call exception: {error}'.format(
+                error=str(e)
+            ),
+            **result
+        )
+
+    result['returned'] = returned_data
+    result['changed'] = True
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
It's the most basic xmlrpc API client that forwards any call to the API along with positional arguments and keyword arguments. This way the ansible user can decide how to use the xmlrpc api along with the relevant API docs.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/commands/xmlrpc_client
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (xmlrpc_client-module 5224579d9e) last updated 2017/08/11 16:08:55 (GMT +200)
  config file = None
  configured module search path = ['/home/stemid/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stemid/Utveckling/ansible/lib/ansible
  executable location = /home/stemid/Utveckling/ansible/bin/ansible
  python version = 3.6.2 (default, Jul 19 2017, 13:09:21) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I have an API internally where this module helps a lot because it lets me use ansible for the entire deployment process. 

Looking at other ansible modules for xmlrpc APIs I can see that a basic xmlrpc client module would be able to perform their tasks as well but with less abstractions between the user and the API.

I wasn't sure which category to put the module in. I'm sure people will have issue with placing it under commands, in that case just know that I have no problem with moving it to another category if a more suitable one can be found.

I have run sanity checks and there is only one unresolved issue. 

    ERROR: lib/ansible/modules/commands/xmlrpc_client.py:0:0: E316 ANSIBLE_METADATA.metadata_version: not a valid value for dictionary value @ data['metadata_version']. Got '1.0'

The docs say to use 1.0 so I can't resolve that.

This module will become more useful once #23943 is resolved. Until then this use will not send integer to the backend API.

```
my_var: 2

- name: xmlrpc api call
  xmlrpc_client:
    args:
      - "{{my_var | int}}"
```
