### PR TITLE
Fix 'format' method syntax to support Python 2.6 (#28198)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -274,12 +274,12 @@ def calculate_multipart_etag(source_path, chunk_size=DEFAULT_CHUNK_SIZE):
             md5s.append(hashlib.md5(data))
 
     if len(md5s) == 1:
-        new_etag = '"{}"'.format(md5s[0].hexdigest())
+        new_etag = '"{0}"'.format(md5s[0].hexdigest())
     else:  # > 1
         digests = b"".join(m.digest() for m in md5s)
 
         new_md5 = hashlib.md5(digests)
-        new_etag = '"{}-{}"'.format(new_md5.hexdigest(), len(md5s))
+        new_etag = '"{0}-{1}"'.format(new_md5.hexdigest(), len(md5s))
 
     return new_etag
 
@@ -429,8 +429,8 @@ def filter_list(s3, bucket, s3filelist, strategy):
 
                 remote_size = entry['s3_head']['ContentLength']
 
-                entry['whytime'] = '{} / {}'.format(local_modified_epoch, remote_modified_epoch)
-                entry['whysize'] = '{} / {}'.format(local_size, remote_size)
+                entry['whytime'] = '{0} / {1}'.format(local_modified_epoch, remote_modified_epoch)
+                entry['whysize'] = '{0} / {1}'.format(local_size, remote_size)
 
                 if local_modified_epoch <= remote_modified_epoch or local_size == remote_size:
                     entry['skip_flag'] = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #28198
Changed how string format method is used to support Python 2.6 syntax. By adding in positional arguments to braces in format method (e.g. {0}, {1}), Python 2.6 can support this module, without causing issues in newer versions of Python.

See ref for info on format differences w/ 2.6:
https://docs.python.org/2/library/string.html#format-string-syntax
<!---

-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
s3_sync

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0 (stable-2.3 af018b75f0) last updated 2017/08/10 13:31:56 (GMT +1000)
  config file = /home/mulrddep/.ansible.cfg
  configured module search path = [u'/apps/ansible/library', u'/apps/mule-platform/ansible/library', u'/apps/ansible-playbooks/common/library']
  python version = 2.6.6 (r266:84292, Aug 18 2016, 15:13:37) [GCC 4.4.7 20120313 (Red Hat 4.4.7-17)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Before fix:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Upload to s3 bucket] ****************************************************************************************
task path: /apps/mule-platform/mule/s3.yml:36
Using module file /apps/ansible/lib/ansible/modules/cloud/amazon/s3_sync.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: mulrddep
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487 `" && echo ansible-tmp-1502754251.47-153974990253487="` echo /home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487 `" ) && sleep 0'
<localhost> PUT /tmp/tmpL1iEtj TO /home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487/s3_sync.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487/ /home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487/s3_sync.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487/s3_sync.py; rm -rf "/home/mulrddep/.ansible/tmp/ansible-tmp-1502754251.47-153974990253487/" > /dev/null 2>&1 && sleep 0'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "aws_access_key": "ASIAILNFILJ74DT75P3A",
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "bucket": "suncorp-mule-connector-updatesites",
            "ec2_url": null,
            "exclude": ".*",
            "file_change_strategy": "force",
            "file_root": "/tmp/connector-life400/",
            "include": "*",
            "key_prefix": "connector-life400",
            "mime_map": null,
            "mode": "push",
            "permission": null,
            "profile": null,
            "region": "ap-southeast-2",
            "retries": null,
            "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": true
        }
    },
    "msg": "zero length field name in format zero length field name in format - <type 'exceptions.ValueError'>",
    "traceback": [
        "Traceback (most recent call last):",
        "  File \"/tmp/ansible_ZjFzBU/ansible_module_s3_sync.py\", line 478, in main",
        "    result['filelist_local_etag'] = calculate_local_etag(result['filelist_s3'])",
        "  File \"/tmp/ansible_ZjFzBU/ansible_module_s3_sync.py\", line 330, in calculate_local_etag",
        "    retentry['local_etag'] = calculate_multipart_etag(fileentry['fullpath'])",
        "  File \"/tmp/ansible_ZjFzBU/ansible_module_s3_sync.py\", line 265, in calculate_multipart_etag",
        "    new_etag = '\"{}\"'.format(md5s[0].hexdigest())",
        "ValueError: zero length field name in format"
    ]
}
        to retry, use: --limit @/apps/mule-platform/mule/s3.retry

PLAY RECAP ********************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1

```