### PR TITLE
Rename ACI modules according to new conventions

### DIFF
--- a/lib/ansible/modules/network/aci/aci_aep.py
+++ b/lib/ansible/modules/network/aci/aci_aep.py
@@ -13,9 +13,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_aep
-short_description: Manage Attachable Access Entity Profile on Cisco ACI fabrics
+short_description: Manage attachable Access Entity Profile (AEP) on Cisco ACI fabrics (infra:AttEntityP)
 description:
-- Connect to external virtual and physical domains by using Attachable Access Entity Profiles on Cisco ACI fabrics.
+- Connect to external virtual and physical domains by using
+  attachable Access Entity Profiles (AEP) on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(infra:AttEntityP) at U(https://developer.cisco.com/media/mim-ref/MO-infraAttEntityP.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)

--- a/lib/ansible/modules/network/aci/aci_ap.py
+++ b/lib/ansible/modules/network/aci/aci_ap.py
@@ -12,11 +12,16 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_anp
-short_description: Manage top level application network profile objects on Cisco ACI fabrics
+module: aci_ap
+short_description: Manage top level Application Profile (AP) objects on Cisco ACI fabrics (fv:Ap)
 description:
-- Manage top level application network profile objects on Cisco ACI fabrics
-- This modules does not manage EPGs, see M(aci_epg) to do this.
+- Manage top level Application Profile (AP) objects on Cisco ACI fabrics
+- More information from the internal APIC class
+  I(fv:Ap) at U(https://developer.cisco.com/media/mim-ref/MO-fvAp.html).
+notes:
+- This module does not manage EPGs, see M(aci_epg) to do this.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -24,8 +29,6 @@ author:
 version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
-notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
 options:
    tenant:
      description:
@@ -36,10 +39,10 @@ options:
      description:
      - The name of the application network profile.
      required: yes
-     aliases: [ app_profile_name, name ]
+     aliases: [ ap, app_profile_name, name ]
    descr:
      description:
-     - Description for the ANP.
+     - Description for the AP.
    state:
      description:
      - Use C(present) or C(absent) for adding or removing.
@@ -50,8 +53,8 @@ extends_documentation_fragment: aci
 '''
 
 EXAMPLES = r'''
-- name: Add a new ANP
-  aci_anp:
+- name: Add a new AP
+  aci_ap:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -60,8 +63,8 @@ EXAMPLES = r'''
     description: default ap
     state: present
 
-- name: Remove an ANP
-  aci_anp:
+- name: Remove an AP
+  aci_ap:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -69,8 +72,8 @@ EXAMPLES = r'''
     app_profile: default
     state: absent
 
-- name: Query an ANP
-  aci_anp:
+- name: Query an AP
+  aci_ap:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -78,8 +81,8 @@ EXAMPLES = r'''
     app_profile: default
     state: query
 
-- name: Query all ANPs
-  aci_anp:
+- name: Query all APs
+  aci_ap:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -97,8 +100,8 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec
     argument_spec.update(
-        tenant=dict(type='str', aliases=['tenant_name']),  # tenant not required for querying all anps
-        app_profile=dict(type='str', aliases=['app_profile_name', 'name']),
+        tenant=dict(type='str', aliases=['tenant_name']),  # tenant not required for querying all APs
+        app_profile=dict(type='str', aliases=['ap', 'app_profile_name', 'name']),
         description=dict(type='str', aliases=['descr'], required=False),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6

--- a/lib/ansible/modules/network/aci/aci_bd.py
+++ b/lib/ansible/modules/network/aci/aci_bd.py
@@ -10,13 +10,14 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-
 DOCUMENTATION = r'''
 ---
-module: aci_bridge_domain
-short_description: Manage Bridge Domains on Cisco ACI Fabrics
+module: aci_bd
+short_description: Manage Bridge Domains (BD) on Cisco ACI Fabrics (fv:BD)
 description:
-- Manages Bridge Domains on Cisco ACI Fabrics.
+- Manages Bridge Domains (BD) on Cisco ACI Fabrics.
+- More information from the internal APIC class
+  I(fv:BD) at U(https://developer.cisco.com/media/mim-ref/MO-fvBD.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -25,7 +26,8 @@ requirements:
 - ACI Fabric 1.0(3f)+
 version_added: '2.4'
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
   arp_flooding:
     description:
@@ -125,7 +127,7 @@ options:
 
 EXAMPLES = r'''
 - name: Add Bridge Domain
-  aci_bridge_domain:
+  aci_bd:
     action: "{{ action }}"
     tenant: "{{ tenant }}"
     bd: "{{ bd }}"

--- a/lib/ansible/modules/network/aci/aci_bd_subnet.py
+++ b/lib/ansible/modules/network/aci/aci_bd_subnet.py
@@ -11,10 +11,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
-module: aci_subnet
-short_description: Manage subnets on Cisco ACI fabrics
+---
+module: aci_bd_subnet
+short_description: Manage Subnets on Cisco ACI fabrics (fv:Subnet)
 description:
-- Manage subnets on Cisco ACI fabrics.
+- Manage Subnets on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(fv:Subnet) at U(https://developer.cisco.com/media/mim-ref/MO-fvSubnet.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -23,10 +26,10 @@ version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:
-- The gateway parameter is the root key used to access the Subnet (not name), so the gateway
-  is required when the state is 'absent' or 'present'.
-- The tenant and bridge domain used must exist before using this module in your playbook.
-  The M(aci_tenant) module and M(aci_bridge_domain) can be used for these.
+- The C(gateway) parameter is the root key used to access the Subnet (not name), so the C(gateway)
+  is required when the state is C(absent) or C(present).
+- The C(tenant) and C(bd) used must exist before using this module in your playbook.
+  The M(aci_tenant) module and M(aci_bd) can be used for these.
 options:
   bd:
     description:

--- a/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
+++ b/lib/ansible/modules/network/aci/aci_bd_to_l3out.py
@@ -11,10 +11,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
-module: aci_bd_l3out_binding
-short_description: Manage Bridge Domain to L3 Out Bindings on Cisco ACI fabrics
+---
+module: aci_bd_to_l3out
+short_description: Bind Bridge Domain to L3 Out on Cisco ACI fabrics (fv:RsBDToOut)
 description:
-- Manage Bridge Domain to L3 Out Bindings on Cisco ACI fabrics.
+- Bind Bridge Domain to L3 Out on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(fv:RsBDToOut) at U(https://developer.cisco.com/media/mim-ref/MO-fvRsBDToOut.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -24,7 +27,7 @@ requirements:
 - ACI Fabric 1.0(3f)+
 notes:
 - The C(bd) and C(l3out) parameters should exist before using this module.
-  The M(aci_bridge_domain) and M(aci_l3out) can be used for these.
+  The M(aci_bd) and M(aci_l3out) can be used for these.
 options:
   bd:
     description:

--- a/lib/ansible/modules/network/aci/aci_contract.py
+++ b/lib/ansible/modules/network/aci/aci_contract.py
@@ -11,11 +11,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
+---
 module: aci_contract
-short_description: Manage contract resources on Cisco ACI fabrics
+short_description: Manage contract resources on Cisco ACI fabrics (vz:BrCP)
 description:
-- Manage contract resources on Cisco ACI fabrics.
-- This does not include subjects although subjects can be removed using this module.
+- Manage Contract resources on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(vz:BrCP) at U(https://developer.cisco.com/media/mim-ref/MO-vzBrCP.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -24,7 +26,10 @@ version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+- This module does not manage Contract Subjects, see M(aci_contract_subject) to do this.
+  Contract Subjects can still be removed using this module.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
   contract:
     description:

--- a/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
+++ b/lib/ansible/modules/network/aci/aci_contract_subject_to_filter.py
@@ -11,10 +11,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
-module: aci_subject_filter_binding
-short_description: Manage filters belonging to contracts on Cisco ACI fabrics
+---
+module: aci_contract_subject_to_filter
+short_description: Bind Contract Subjects to Filters on Cisco ACI fabrics (vz:RsSubjFiltAtt)
 description:
-- Manage Contract Subject to Filter Bindings on Cisco ACI fabrics.
+- Bind Contract Subjects to Filters on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(vz:RsSubjFiltAtt) at U(https://developer.cisco.com/media/mim-ref/MO-vzRsSubjFiltAtt.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)

--- a/lib/ansible/modules/network/aci/aci_epg.py
+++ b/lib/ansible/modules/network/aci/aci_epg.py
@@ -13,9 +13,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_epg
-short_description: Manage end point groups on Cisco ACI fabrics
+short_description: Manage End Point Groups (EPG) on Cisco ACI fabrics (fv:AEPg)
 description:
-- Manage end point groups on Cisco ACI fabrics.
+- Manage End Point Groups (EPG) on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(fv:AEPg) at U(https://developer.cisco.com/media/mim-ref/MO-fvAEPg.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -25,7 +27,7 @@ requirements:
 - ACI Fabric 1.0(3f)+
 notes:
 - The C(tenant) and C(app_profile) used must exist before using this module in your playbook.
-  The M(aci_tenant) and M(aci_anp) modules can be used for this.
+  The M(aci_tenant) and M(aci_ap) modules can be used for this.
 options:
   tenant:
     description:

--- a/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
+++ b/lib/ansible/modules/network/aci/aci_epg_monitoring_policy.py
@@ -12,10 +12,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_port_security
-short_description: Manage port security on Cisco ACI fabrics
+module: aci_epg_monitoring_policy
+short_description: Manage monitoring policies on Cisco ACI fabrics (mon:EPGPol)
 description:
-- Manage port security on Cisco ACI fabrics.
+- Manage monitoring policies on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(mon:EPGPol) at U(https://developer.cisco.com/media/mim-ref/MO-monEPGPol.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -23,20 +25,24 @@ author:
 version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
+notes:
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
-  port_security:
+  monitoring_policy:
     description:
-    - The name of the port security.
+    - The name of the monitoring policy.
     required: yes
     aliases: [ name ]
   description:
     description:
-    - Description for the contract.
+    - Description for the monitoring policy.
     aliases: [ descr ]
-  max_end_points:
+  tenant:
     description:
-    - Maximum number of end points (range 0-12000).
-    - The APIC defaults new port-security policies to a max End Points of 0.
+    - The name of the tenant.
+    required: yes
+    aliases: [ tenant_name ]
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -48,13 +54,13 @@ extends_documentation_fragment: aci
 
 # FIXME: Add more, better examples
 EXAMPLES = r'''
-- aci_port_security:
-    hostname: '{{ inventory_hostname }}'
+- aci_epg_monitoring_policy:
+    hostname: '{{ hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
-    port_security: '{{ port_security }}'
-    description: '{{ descr }}'
-    max_end_points: '{{ max_end_points }}'
+    monitoring_policy: '{{ monitoring_policy }}'
+    description: '{{ description }}'
+    tenant: '{{ tenant }}'
 '''
 
 RETURN = r'''
@@ -68,9 +74,9 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec
     argument_spec.update(
-        port_security=dict(type='str', required=False, aliases=['name']),  # Not required for querying all objects
+        monitoring_policy=dict(type='str', required=False, aliases=['name']),  # Not required for querying all objects
+        tenant=dict(type='str', required=False, aliases=['tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
-        max_end_points=dict(type='int'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
     )
@@ -80,22 +86,27 @@ def main():
         supports_check_mode=True,
     )
 
-    port_security = module.params['port_security']
+    monitoring_policy = module.params['monitoring_policy']
+    tenant = module.params['tenant']
     description = module.params['description']
-    # TODO: validate that max_end_points is in the acceptable range
-    max_end_points = module.params['max_end_points']
     state = module.params['state']
 
     aci = ACIModule(module)
 
-    # TODO: This logic could be cleaner.
-    if port_security is not None:
-        path = 'api/mo/uni/infra/portsecurityP-%(port_security)s.json' % module.params
+    if monitoring_policy is not None:
+        # Work with a specific object
+        if tenant is not None:
+            path = 'api/mo/uni/tn-%(tenant)s/monepg-%(monitoring_policy)s.json' % module.params
+        elif state == 'query':
+            path = 'api/class/monEPGPol.json?query-target-filter=eq(monEPGPol.name,"%(monitoring_policy)s")' % module.params
     elif state == 'query':
         # Query all objects
-        path = 'api/node/class/l2PortSecurityPol.json'
+        if tenant is not None:
+            path = 'api/mo/uni/tn-%(tenant)s.json?rsp-subtree=children&rsp-subtree-class=monEPGPol&rsp-subtree-include=no-scoped' % module.params
+        else:
+            path = 'api/node/class/monEPGPol.json'
     else:
-        module.fail_json(msg="Parameter 'port_security' is required for state 'absent' or 'present'")
+        module.fail_json(msg="Parameter 'monitoring_policy' is required for state 'absent' or 'present'")
 
     aci.result['url'] = '%(protocol)s://%(hostname)s/' % aci.params + path
 
@@ -103,10 +114,10 @@ def main():
 
     if state == 'present':
         # Filter out module parameters with null values
-        aci.payload(aci_class='l2PortSecurityPol', class_config=dict(name=port_security, descr=description, maximum=max_end_points))
+        aci.payload(aci_class='monEPGPol', class_config=dict(name=monitoring_policy, descr=description))
 
         # Generate config diff which will be used as POST request body
-        aci.get_diff(aci_class='l2PortSecurityPol')
+        aci.get_diff(aci_class='monEPGPol')
 
         # Submit changes if module not in check_mode and the proposed is different than existing
         aci.post_config()

--- a/lib/ansible/modules/network/aci/aci_epg_to_contract.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_contract.py
@@ -12,10 +12,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_epg_contract_binding
-short_description: Manage EPG to Contract bindings on Cisco ACI fabrics
+module: aci_epg_to_contract
+short_description: Bind EPGs to Contracts on Cisco ACI fabrics (fv:RsCons and fvRsProv)
 description:
-- Manage EPG to Contract bindings on Cisco ACI fabrics.
+- Bind EPGs to Contracts on Cisco ACI fabrics.
+- More information from the internal APIC classes
+  I(fv:RsCons) at U(https://developer.cisco.com/media/mim-ref/MO-fvRsCons.html) and
+  I(fv:RsProv) at U(https://developer.cisco.com/media/mim-ref/MO-fvRsProv.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -25,7 +28,7 @@ requirements:
 - ACI Fabric 1.0(3f)+
 notes:
 - The C(tenant), C(app_profile), C(EPG), and C(Contract) used must exist before using this module in your playbook.
-  The M(aci_tenant), M(aci_anp), M(aci_epg), and M(aci_contract) modules can be used for this.
+  The M(aci_tenant), M(aci_ap), M(aci_epg), and M(aci_contract) modules can be used for this.
 options:
   app_profile:
     description:

--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -12,10 +12,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_epg_domain_binding
-short_description: Manage EPG to Domain bindings on Cisco ACI fabrics
+module: aci_epg_to_domain
+short_description: Bind EPGs to Domains on Cisco ACI fabrics (fv:RsDomAtt)
 description:
-- Manage EPG to Physical and Virtual Domains on Cisco ACI fabrics.
+- Bind EPGs to Physical and Virtual Domains on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(fv:RsDomAtt) at U(https://developer.cisco.com/media/mim-ref/MO-fvRsDomAtt.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -25,7 +27,7 @@ requirements:
 - ACI Fabric 1.0(3f)+
 notes:
 - The C(tenant), C(app_profile), C(epg), and C(domain) used must exist before using this module in your playbook.
-  The M(aci_tenant) M(aci_anp), M(aci_epg) M(aci_domain) modules can be used for this.
+  The M(aci_tenant) M(aci_ap), M(aci_epg) M(aci_domain) modules can be used for this.
 options:
   allow_useg:
     description:

--- a/lib/ansible/modules/network/aci/aci_filter.py
+++ b/lib/ansible/modules/network/aci/aci_filter.py
@@ -13,9 +13,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_filter
-short_description: Manages top level filter objects on Cisco ACI fabrics
+short_description: Manages top level filter objects on Cisco ACI fabrics (vz:Filter)
 description:
 - Manages top level filter objects on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(vz:Filter) at U(https://developer.cisco.com/media/mim-ref/MO-vzFilter.html).
 - This modules does not manage filter entries, see M(aci_filter_entry) for this functionality.
 author:
 - Swetha Chunduri (@schunduri)
@@ -25,7 +27,8 @@ version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
   filter:
     description:

--- a/lib/ansible/modules/network/aci/aci_filter_entry.py
+++ b/lib/ansible/modules/network/aci/aci_filter_entry.py
@@ -13,9 +13,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_filter_entry
-short_description: Manage filter entries on Cisco ACI fabrics
+short_description: Manage filter entries on Cisco ACI fabrics (vz:Entry)
 description:
 - Manage filter entries for a filter on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(vz:Entry) at U(https://developer.cisco.com/media/mim-ref/MO-vzEntry.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -24,8 +26,8 @@ version_added: '2.4'
 requirements:
 - Tested with ACI Fabric 1.0(3f)+
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
-- The filter used must exist before using this module in your playbook. The M(aci_filter) module can be used for this.
+- The C(tenant) and C(filter) used must exist before using this module in your playbook.
+  The M(aci_tenant) and M(aci_filter) modules can be used for this.
 options:
   arp_flag:
     description:

--- a/lib/ansible/modules/network/aci/aci_intf_policy_port_security.py
+++ b/lib/ansible/modules/network/aci/aci_intf_policy_port_security.py
@@ -12,10 +12,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_route_tag_policy
-short_description: Manage route tag policies on Cisco ACI fabrics
+module: aci_intf_policy_port_security
+short_description: Manage port security on Cisco ACI fabrics (l2:PortSecurityPol)
 description:
-- Manage route tag policies on Cisco ACI fabrics.
+- Manage port security on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(l2:PortSecurityPol) at U(https://developer.cisco.com/media/mim-ref/MO-l2PortSecurityPol.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -23,27 +25,20 @@ author:
 version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
-notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
 options:
-  rtp:
+  port_security:
     description:
-    - The name of the route tag policy.
+    - The name of the port security.
     required: yes
-    aliases: [ name, rtp_name ]
+    aliases: [ name ]
   description:
     description:
-    - Description for the route tag policy.
+    - The description for the contract.
     aliases: [ descr ]
-  tenant:
+  max_end_points:
     description:
-    - The name of the tenant.
-    required: yes
-    aliases: [ tenant_name ]
-  tag:
-    description:
-    - The value of the route tag (range 0-4294967295).
-    default: '4294967295'
+    - Maximum number of end points (range 0-12000).
+    - The APIC defaults new port-security policies to a max End Points of 0.
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -55,14 +50,13 @@ extends_documentation_fragment: aci
 
 # FIXME: Add more, better examples
 EXAMPLES = r'''
-- aci_route_tag_policy:
-    hostname: apic
-    username: admin
-    password: SomeSecretPassword
-    rtp: '{{ rtp_name }}'
-    tenant: production
-    tag: '{{ tag }}'
-    description: '{{ description }}'
+- aci_intf_policy_port_security:
+    hostname: '{{ inventory_hostname }}'
+    username: '{{ username }}'
+    password: '{{ password }}'
+    port_security: '{{ port_security }}'
+    description: '{{ descr }}'
+    max_end_points: '{{ max_end_points }}'
 '''
 
 RETURN = r'''
@@ -76,10 +70,9 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec
     argument_spec.update(
-        rtp=dict(type='str', required=False, aliases=['name', 'rtp_name']),  # Not required for querying all objects
-        tenant=dict(type='str', required=False, aliases=['tenant_name']),  # Not required for quering all objects
+        port_security=dict(type='str', required=False, aliases=['name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
-        tag=dict(type='int'),
+        max_end_points=dict(type='int'),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
     )
@@ -89,28 +82,22 @@ def main():
         supports_check_mode=True,
     )
 
-    rtp = module.params['rtp']
-    tenant = module.params['tenant']
+    port_security = module.params['port_security']
     description = module.params['description']
-    tag = module.params['tag']
+    # TODO: validate that max_end_points is in the acceptable range
+    max_end_points = module.params['max_end_points']
     state = module.params['state']
 
     aci = ACIModule(module)
 
-    if rtp is not None:
-        # Work with a specific object
-        if tenant is not None:
-            path = 'api/mo/uni/tn-%(tenant)s/rttag-%(rtp)s.json' % module.params
-        else:
-            path = 'api/class/l3extRouteTagPol.json?query-target-filter=eq(l3extRouteTagPol.name,"%(rtp)s")' % module.params
+    # TODO: This logic could be cleaner.
+    if port_security is not None:
+        path = 'api/mo/uni/infra/portsecurityP-%(port_security)s.json' % module.params
     elif state == 'query':
         # Query all objects
-        if tenant is not None:
-            path = 'api/mo/uni/tn-%(tenant)s.json?rsp-subtree=children&rsp-subtree-class=l3extRouteTagPol&rsp-subtree-include=no-scoped' % module.params
-        else:
-            path = 'api/node/class/l3extRouteTagPol.json'
+        path = 'api/node/class/l2PortSecurityPol.json'
     else:
-        module.fail_json(msg="Parameter 'rtp' is required for state 'absent' or 'present'")
+        module.fail_json(msg="Parameter 'port_security' is required for state 'absent' or 'present'")
 
     aci.result['url'] = '%(protocol)s://%(hostname)s/' % aci.params + path
 
@@ -118,10 +105,10 @@ def main():
 
     if state == 'present':
         # Filter out module parameters with null values
-        aci.payload(aci_class='l3extRouteTagPol', class_config=dict(name=rtp, descr=description, tag=tag))
+        aci.payload(aci_class='l2PortSecurityPol', class_config=dict(name=port_security, descr=description, maximum=max_end_points))
 
         # Generate config diff which will be used as POST request body
-        aci.get_diff(aci_class='l3extRouteTagPol')
+        aci.get_diff(aci_class='l2PortSecurityPol')
 
         # Submit changes if module not in check_mode and the proposed is different than existing
         aci.post_config()

--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -11,6 +11,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
+---
 module: aci_rest
 short_description: Direct access to the Cisco APIC REST API
 description:
@@ -167,6 +168,7 @@ import os
 # Optional, only used for XML payload
 try:
     import lxml.etree
+    assert lxml.etree  # silence pyflakes
     HAS_LXML_ETREE = True
 except ImportError:
     HAS_LXML_ETREE = False
@@ -174,6 +176,7 @@ except ImportError:
 # Optional, only used for XML payload
 try:
     from xmljson import cobra
+    assert cobra  # silence pyflakes
     HAS_XMLJSON_COBRA = True
 except ImportError:
     HAS_XMLJSON_COBRA = False

--- a/lib/ansible/modules/network/aci/aci_taboo_contract.py
+++ b/lib/ansible/modules/network/aci/aci_taboo_contract.py
@@ -13,9 +13,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_taboo_contract
-short_description: Manage taboo contracts on Cisco ACI fabrics
+short_description: Manage taboo contracts on Cisco ACI fabrics (vz:BrCP)
 description:
 - Manage taboo contracts on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(vz:BrCP) at U(https://developer.cisco.com/media/mim-ref/MO-vzBrCP.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -24,16 +26,17 @@ version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
   taboo_contract:
     description:
-    - Taboo Contract name.
+    - The name of the Taboo Contract.
     required: yes
     aliases: [ name ]
   description:
     description:
-    - Description for the filter.
+    - The description for the Taboo Contract.
     aliases: [ descr ]
   tenant:
     description:

--- a/lib/ansible/modules/network/aci/aci_tenant.py
+++ b/lib/ansible/modules/network/aci/aci_tenant.py
@@ -13,9 +13,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = r'''
 ---
 module: aci_tenant
-short_description: Manage tenants on Cisco ACI fabrics
+short_description: Manage tenants on Cisco ACI fabrics (fv:Tenant)
 description:
 - Manage tenants on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(fv:Tenant) at U(https://developer.cisco.com/media/mim-ref/MO-fvTenant.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)

--- a/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
+++ b/lib/ansible/modules/network/aci/aci_tenant_action_rule_profile.py
@@ -12,10 +12,12 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_span_dst_group
-short_description: Manage span destination groups on Cisco ACI fabrics
+module: aci_tenant_action_rule_profile
+short_description: Manage action rule profiles on Cisco ACI fabrics (rtctrl:AttrP)
 description:
-- Manage span destination groups on Cisco ACI fabrics.
+- Manage action rule profiles on Cisco ACI fabrics.
+- More information from the internal APIC class
+  I(rtctrl:AttrP) at U(https://developer.cisco.com/media/mim-ref/MO-rtctrlAttrP.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -24,21 +26,20 @@ version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
-  dst_group:
+  action_rule:
     description:
-    - The name of the span destination group.
-    required: yes
-    aliases: [ name ]
+    - The name of the action rule profile.
+    aliases: [ action_rule_name, name ]
   description:
     description:
-    - Description of the span destination group.
+    - The description for the action rule profile.
     aliases: [ descr ]
   tenant:
     description:
     - The name of the tenant.
-    required: yes
     aliases: [ tenant_name ]
   state:
     description:
@@ -51,11 +52,11 @@ extends_documentation_fragment: aci
 
 # FIXME: Add more, better examples
 EXAMPLES = r'''
-- aci_span_dst_group:
+- aci_tenant_action_rule_profile:
     hostname: '{{ inventory_hostname }}'
     username: '{{ username }}'
     password: '{{ password }}'
-    dst_group: '{{ dst_group }}'
+    action_rule: '{{ action_rule }}'
     description: '{{ descr }}'
     tenant: '{{ tenant }}'
 '''
@@ -71,8 +72,8 @@ from ansible.module_utils.basic import AnsibleModule
 def main():
     argument_spec = aci_argument_spec
     argument_spec.update(
-        dst_group=dict(type='str', required=False, aliases=['name']),  # Not required for querying all objects
-        tenant=dict(type='str', required=True, aliases=['tenant_name']),  # Not required for querying all objects
+        action_rule=dict(type='str', required=False, aliases=['action_rule_name', 'name']),  # Not required for querying all objects
+        tenant=dict(type='str', required=False, aliases=['tenant_name']),  # Not required for querying all objects
         description=dict(type='str', aliases=['descr']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
@@ -83,7 +84,7 @@ def main():
         supports_check_mode=True,
     )
 
-    dst_group = module.params['dst_group']
+    action_rule = module.params['action_rule']
     # tenant = module.params['tenant']
     description = module.params['description']
     state = module.params['state']
@@ -91,13 +92,13 @@ def main():
     aci = ACIModule(module)
 
     # TODO: This logic could be cleaner.
-    if dst_group is not None:
-        path = 'api/mo/uni/tn-%(tenant)s/destgrp-%(dst_group)s.json' % module.params
+    if action_rule is not None:
+        path = 'api/mo/uni/tn-%(tenant)s/attr-%(action_rule)s.json' % module.params
     elif state == 'query':
-        # Query all contracts
-        path = 'api/node/class/spanDestGrp.json'
+        # Query all objects
+        path = 'api/node/class/rtctrlAttrP.json'
     else:
-        module.fail_json(msg="Parameter 'dst_group' is required for state 'absent' or 'present'")
+        module.fail_json(msg="Parameter 'action_rule' is required for state 'absent' or 'present'")
 
     aci.result['url'] = '%(protocol)s://%(hostname)s/' % aci.params + path
 
@@ -105,10 +106,10 @@ def main():
 
     if state == 'present':
         # Filter out module parameters with null values
-        aci.payload(aci_class='spanDestGrp', class_config=dict(name=dst_group, descr=description))
+        aci.payload(aci_class='rtctrlAttrP', class_config=dict(name=action_rule, descr=description))
 
         # Generate config diff which will be used as POST request body
-        aci.get_diff(aci_class='spanDestGrp')
+        aci.get_diff(aci_class='rtctrlAttrP')
 
         # Submit changes if module not in check_mode and the proposed is different than existing
         aci.post_config()

--- a/lib/ansible/modules/network/aci/aci_vrf.py
+++ b/lib/ansible/modules/network/aci/aci_vrf.py
@@ -12,11 +12,13 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = r'''
 ---
-module: aci_context
-short_description: Manage private networks (aka. contexts) on Cisco ACI fabrics
+module: aci_vrf
+short_description: Manage VRF (private networks aka. contexts) on Cisco ACI fabrics (fv:Ctx)
 description:
-- Manage private networks (aka. contexts) on Cisco ACI fabrics.
+- Manage VRF (private networks aka. contexts) on Cisco ACI fabrics.
 - Each context is a private network associated to a tenant, i.e. VRF.
+- More information from the internal APIC class
+  I(fv:Ctx) at U(https://developer.cisco.com/media/mim-ref/MO-fvCtx.html).
 author:
 - Swetha Chunduri (@schunduri)
 - Dag Wieers (@dagwieers)
@@ -25,7 +27,8 @@ version_added: '2.4'
 requirements:
 - Tested with ACI Fabric 1.0(3f)+
 notes:
-- The tenant used must exist before using this module in your playbook. The M(aci_tenant) module can be used for this.
+- The C(tenant) used must exist before using this module in your playbook.
+  The M(aci_tenant) module can be used for this.
 options:
   tenant:
     description:
@@ -45,7 +48,7 @@ options:
     choices: [ enforced, unenforced ]
   description:
     description:
-    - Description for the VRF.
+    - The description for the VRF.
   state:
     description:
     - Use C(present) or C(absent) for adding or removing.
@@ -57,7 +60,7 @@ extends_documentation_fragment: aci
 
 EXAMPLES = r'''
 - name: Add a new VRF to a tenant
-  aci_context:
+  aci_vrf:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -69,7 +72,7 @@ EXAMPLES = r'''
     state: present
 
 - name: Remove a VRF for a tenant
-  aci_context:
+  aci_vrf:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -78,7 +81,7 @@ EXAMPLES = r'''
     state: absent
 
 - name: Query a VRF of a tenant
-  aci_context:
+  aci_vrf:
     hostname: apic
     username: admin
     password: SomeSecretPassword
@@ -87,7 +90,7 @@ EXAMPLES = r'''
     state: query
 
 - name: Query all VRFs
-  aci_context:
+  aci_vrf:
     hostname: apic
     username: admin
     password: SomeSecretPassword


### PR DESCRIPTION

##### SUMMARY
As discussed in full at https://github.com/datacenter/aci-ansible
we desired a better naming convention for ACI modules before they ship
with Ansible v2.4

The result is summarized in this PR.

The modules now also include the classes from the object model, as well
as a link to the documentation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ACI modules

##### ANSIBLE VERSION
v2.4