### PR TITLE
Rebase 13939

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -250,6 +250,7 @@ def main():
         if basename:
             params['path'] = path = os.path.join(path, basename)
             b_path = to_bytes(path, errors='surrogate_or_strict')
+            prev_state = get_state(b_path)
 
     # make sure the target path is a directory when we're doing a recursive operation
     if recurse and state != 'directory':

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -331,7 +331,8 @@ class ActionModule(ActionBase):
                 dict(
                     src=source_rel,
                     dest=dest,
-                    original_basename=source_rel
+                    original_basename=source_rel,
+                    state='file',
                 )
             )
             if lmode:

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -156,6 +156,18 @@
        - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
        - "stat_results.stat.mode == '0700'"
 
+- name: Create a hardlink to the file
+  file:
+    src: '{{ remote_file }}'
+    dest: '{{ output_dir }}/hard.lnk'
+    state: hard
+
+- name: copy the same contents into place
+  copy:
+    content: 'modified'
+    dest: '{{ remote_file }}'
+    mode: 0404
+
 - name: Try invalid copy input location fails
   copy:
     src: invalid_file_location_does_not_exist
@@ -1071,6 +1083,34 @@
        - "'content' not in copy_results"
        - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
        - "not stat_results.stat.islnk"
+
+- name: setup directory for test
+  file: state=directory dest={{remote_dir }}/directory mode=0755
+
+- name: set file mode when the destination is a directory
+  copy: src=foo.txt dest={{remote_dir}}/directory/ mode=0705
+
+- name: set file mode when the destination is a directory
+  copy: src=foo.txt dest={{remote_dir}}/directory/ mode=0604
+  register: file_result
+
+- name: check that the file has the correct attributes
+  stat: path={{ remote_dir }}/directory/foo.txt
+  register: file_attrs
+
+- assert:
+    that:
+      - "file_attrs.stat.uid == 0"
+      - "file_attrs.stat.pw_name == 'root'"
+      - "file_attrs.stat.mode == '0604'"
+
+- name: check that the containing directory did not change attributes
+  stat: path={{ remote_dir }}/directory/
+  register: dir_attrs
+
+- assert:
+    that:
+      - "dir_attrs.stat.mode == '0755'"
 
 #
 # I believe the below section is now covered in the recursive copying section.

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -166,7 +166,76 @@
   copy:
     content: 'modified'
     dest: '{{ remote_file }}'
+    mode: 0700
+  register: copy_results
+
+- name: Check the stat results of the file
+  stat:
+    path: "{{ remote_file }}"
+  register: stat_results
+
+- name: Check the stat results of the hard link
+  stat:
+    path: "{{ output_dir }}/hard.lnk"
+  register: hlink_results
+
+- name: Check that the file did not change
+  assert:
+    that:
+      - 'stat_results.stat.inode == hlink_results.stat.inode'
+      - 'copy_results.changed == False'
+      - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
+
+- name: copy the same contents into place but change mode
+  copy:
+    content: 'modified'
+    dest: '{{ remote_file }}'
     mode: 0404
+  register: copy_results
+
+- name: Check the stat results of the file
+  stat:
+    path: "{{ remote_file }}"
+  register: stat_results
+
+- name: Check the stat results of the hard link
+  stat:
+    path: "{{ output_dir }}/hard.lnk"
+  register: hlink_results
+
+- name: Check that the file changed permissions but is still the same
+  assert:
+    that:
+      - 'stat_results.stat.inode == hlink_results.stat.inode'
+      - 'copy_results.changed == True'
+      - 'stat_results.stat.mode == hlink_results.stat.mode'
+      - 'stat_results.stat.mode == "0404"'
+      - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
+
+- name: copy the different contents into place
+  copy:
+    content: 'adjusted'
+    dest: '{{ remote_file }}'
+    mode: 0404
+  register: copy_results
+
+- name: Check the stat results of the file
+  stat:
+    path: "{{ remote_file }}"
+  register: stat_results
+
+- name: Check the stat results of the hard link
+  stat:
+    path: "{{ output_dir }}/hard.lnk"
+  register: hlink_results
+
+- name: Check that the file changed and hardlink was broken
+  assert:
+    that:
+      - 'stat_results.stat.inode != hlink_results.stat.inode'
+      - 'copy_results.changed == True'
+      - "stat_results.stat.checksum == ('adjusted'|hash('sha1'))"
+      - "hlink_results.stat.checksum == ('modified'|hash('sha1'))"
 
 - name: Try invalid copy input location fails
   copy:

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -143,13 +143,42 @@
   stat: path={{output_dir}}/hard.txt
   register: hlstat2
 
-- name: verify that hard link was made
+- name: verify that hard link is still the same after timestamp updated
   assert:
     that:
       - "hlstat1.stat.inode == hlstat2.stat.inode"
 
 - name: create hard link to file 2
   file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
+  register: hlink_result
+
+- name: verify that hard link creation is idempotent
+  assert:
+    that:
+      - "hlink_result.changed == False"
+
+- name: Change mode on a hard link
+  file: src={{output_file}} dest={{output_dir}}/hard.txt mode=0701
+  register: file6_mode_change
+
+- name: verify that the hard link was touched
+  assert:
+    that:
+      - "file6_touch_result.changed == true"
+
+- name: stat1
+  stat: path={{output_file}}
+  register: hlstat1
+
+- name: stat2
+  stat: path={{output_dir}}/hard.txt
+  register: hlstat2
+
+- name: verify that hard link is still the same after timestamp updated
+  assert:
+    that:
+      - "hlstat1.stat.inode == hlstat2.stat.inode"
+      - "hlstat1.stat.mode == '0701'"
 
 - name: create a directory
   file: path={{output_dir}}/foobar state=directory

--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -135,6 +135,22 @@
     that:
       - "file6_touch_result.changed == true"
 
+- name: stat1
+  stat: path={{output_file}}
+  register: hlstat1
+
+- name: stat2
+  stat: path={{output_dir}}/hard.txt
+  register: hlstat2
+
+- name: verify that hard link was made
+  assert:
+    that:
+      - "hlstat1.stat.inode == hlstat2.stat.inode"
+
+- name: create hard link to file 2
+  file: src={{output_file}} dest={{output_dir}}/hard.txt state=hard
+
 - name: create a directory
   file: path={{output_dir}}/foobar state=directory
   register: file7_result

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -306,6 +306,46 @@
     that:
     - "template_result|changed"
 
+## demonstrate copy module failing to overwrite a file that's been hard linked
+## https://github.com/ansible/ansible/issues/10834
+
+- name: ensure test dir is absent
+  file:
+    path: /tmp/10834.2_test
+    state: absent
+
+- name: create test dir
+  file:
+    path: /tmp/10834.2_test
+    state: directory
+
+- name: template out test file to system 1
+  template:
+    src: foo.j2
+    dest: /tmp/10834.2_test/test_file
+
+# not an issue when not hard linked
+- name: template out test file to system 2
+  template:
+    src: foo.j2
+    dest: /tmp/10834.2_test/test_file
+
+- name: make hard link
+  file:
+    src: /tmp/10834.2_test/test_file
+    dest: /tmp/10834.2_test/test_file_hardlink
+    state: hard
+
+- name: template out test file to system 3
+  template:
+    src: foo.j2
+    dest: /tmp/10834.2_test/test_file
+
+- name: cleanup
+  file:
+    path: /tmp/10834.2_test
+    state: absent
+
 - name: change var for the template
   set_fact:
     templated_var: "templated_var_loaded"

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -306,45 +306,53 @@
     that:
     - "template_result|changed"
 
-## demonstrate copy module failing to overwrite a file that's been hard linked
-## https://github.com/ansible/ansible/issues/10834
+#
+# template module can overwrite a file that's been hard linked
+# https://github.com/ansible/ansible/issues/10834
+#
 
 - name: ensure test dir is absent
   file:
-    path: /tmp/10834.2_test
+    path: '{{ output_dir | expanduser }}/hlink_dir'
     state: absent
 
 - name: create test dir
   file:
-    path: /tmp/10834.2_test
+    path: '{{ output_dir | expanduser }}/hlink_dir'
     state: directory
 
 - name: template out test file to system 1
   template:
     src: foo.j2
-    dest: /tmp/10834.2_test/test_file
-
-# not an issue when not hard linked
-- name: template out test file to system 2
-  template:
-    src: foo.j2
-    dest: /tmp/10834.2_test/test_file
+    dest: '{{ output_dir | expanduser }}/hlink_dir/test_file'
 
 - name: make hard link
   file:
-    src: /tmp/10834.2_test/test_file
-    dest: /tmp/10834.2_test/test_file_hardlink
+    src: '{{ output_dir | expanduser }}/hlink_dir/test_file'
+    dest: '{{ output_dir | expanduser }}/hlink_dir/test_file_hlink'
     state: hard
 
-- name: template out test file to system 3
+- name: template out test file to system 2
   template:
     src: foo.j2
-    dest: /tmp/10834.2_test/test_file
+    dest: '{{ output_dir | expanduser }}/hlink_dir/test_file'
+  register: hlink_result
 
-- name: cleanup
-  file:
-    path: /tmp/10834.2_test
-    state: absent
+- name: check that the files are still hardlinked
+  stat:
+    path: '{{ output_dir | expanduser }}/hlink_dir/test_file'
+  register: orig_file
+
+- name: check that the files are still hardlinked
+  stat:
+    path: '{{ output_dir | expanduser }}/hlink_dir/test_file_hlink'
+  register: hlink_file
+
+# We've done nothing at this point to update the content of the file so it should still be hardlinked
+- assert:
+    that:
+      - "hlink_result.changed == False"
+      - "orig_file.stat.inode == hlink_file.stat.inode"
 
 - name: change var for the template
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Fixes and tests for file/template/copy and hardlinks.

This change rebases the  following fixes by @SeMeKh:
* https://github.com/ansible/ansible/pull/13939
* https://github.com/ansible/ansible-modules-core/pull/2827

Rebases the following additional integration tests by @aerickson:
* https://github.com/ansible/ansible/pull/22181

And adds a few new tests as well.

People affected "recently" by this: @aerickson @rbu @marcjay @garbled1 @kwerey

If any of you would care to test this out I would appreciate it.  Since this fix does make the new tests pass, if any of you still experience the bug with this applied, I'd love to have a new test case from you as well.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
* lib/ansible/module/files/file.py
* lib/ansible/module/files/copy.py
* lib/ansible/module/files/template.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
2.3
```


##### ADDITIONAL INFORMATION
There are many tickets with duplicate bugs on this.

The following issues should be closed when this is merged:
* closes #13939 
* fixes #10834
* resolves #22028
* fixes #26897
* closes #22181
