### PR TITLE
netscaler_service: add disable operation

### DIFF
--- a/test/integration/roles/netscaler_service/tests/nitro/flap_disabled.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/flap_disabled.yaml
@@ -1,0 +1,10 @@
+---
+
+- include: "{{ role_path }}/tests/nitro/flap_disabled/setup.yaml"
+  vars:
+    check_mode: no
+
+
+- include: "{{ role_path }}/tests/nitro/flap_disabled/remove.yaml"
+  vars:
+    check_mode: no

--- a/test/integration/roles/netscaler_service/tests/nitro/flap_disabled/remove.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/flap_disabled/remove.yaml
@@ -1,0 +1,16 @@
+---
+
+- name: Remove htttp service
+  netscaler_service:
+
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: absent
+
+    name: service-http
+
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"

--- a/test/integration/roles/netscaler_service/tests/nitro/flap_disabled/setup.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/flap_disabled/setup.yaml
@@ -1,0 +1,47 @@
+---
+
+- name: Flap service
+  netscaler_service:
+
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: present
+
+    name: service-http
+    ip: 192.168.1.1
+    ipaddress: 192.168.1.1
+    port: 80
+    servicetype: HTTP
+
+    disabled: "{{ item|int % 2 }}"
+  with_sequence: count=20
+  delay: 1
+
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+
+- name: Flap service
+  netscaler_service:
+
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: present
+
+    name: service-http
+    ip: 192.168.1.1
+    ipaddress: 192.168.1.1
+    port: 80
+    servicetype: HTTP
+
+    disabled: "{{ item|int % 2 }}"
+  with_sequence: count=20
+  delay: 5
+
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"

--- a/test/integration/roles/netscaler_service/tests/nitro/http_service/setup.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/http_service/setup.yaml
@@ -19,7 +19,7 @@
     healthmonitor: no
     maxreq: 200
     cacheable: no
-    cip: ENABLED
+    cip: enabled
     cipheader: client-ip
     usip: yes
     useproxyport: yes
@@ -34,11 +34,11 @@
     maxbandwidth: 10000
     accessdown: "NO"
     monthreshold: 100
-    downstateflush: ENABLED
+    downstateflush: enabled
     hashid: 10
     comment: some comment
-    appflowlog: ENABLED
-    processlocal: ENABLED
+    appflowlog: enabled
+    processlocal: enabled
     graceful: no
 
     monitor_bindings:

--- a/test/integration/roles/netscaler_service/tests/nitro/http_service/update.yaml
+++ b/test/integration/roles/netscaler_service/tests/nitro/http_service/update.yaml
@@ -19,7 +19,7 @@
     healthmonitor: no
     maxreq: 200
     cacheable: no
-    cip: ENABLED
+    cip: enabled
     cipheader: client-ip
     usip: yes
     useproxyport: yes
@@ -34,11 +34,11 @@
     maxbandwidth: 20000
     accessdown: "NO"
     monthreshold: 100
-    downstateflush: ENABLED
+    downstateflush: enabled
     hashid: 10
     comment: some comment
-    appflowlog: ENABLED
-    processlocal: ENABLED
+    appflowlog: enabled
+    processlocal: enabled
 
     monitor_bindings:
       - monitorname: http

--- a/test/units/modules/network/netscaler/test_netscaler_service.py
+++ b/test/units/modules/network/netscaler/test_netscaler_service.py
@@ -162,6 +162,7 @@ class TestNetscalerServiceModule(TestModule):
             'ansible.modules.network.netscaler.netscaler_service',
             ConfigProxy=m,
             service_exists=service_exists_mock,
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_service
             result = self.exited()
@@ -190,6 +191,7 @@ class TestNetscalerServiceModule(TestModule):
             service_identical=service_identical_mock,
             monitor_bindings_identical=monitor_bindings_identical_mock,
             all_identical=all_identical_mock,
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_service
             result = self.exited()
@@ -220,6 +222,7 @@ class TestNetscalerServiceModule(TestModule):
             monitor_bindings_identical=monitor_bindings_identical_mock,
             all_identical=all_identical_mock,
             sync_monitor_bindings=sync_monitor_bindings_mock,
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_service
             result = self.exited()
@@ -247,6 +250,7 @@ class TestNetscalerServiceModule(TestModule):
             service_exists=service_exists_mock,
             service_identical=service_identical_mock,
             monitor_bindings_identical=monitor_bindings_identical_mock,
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_service
             result = self.exited()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds the disable operation for the netscaler_service module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

lib/ansible/modules/network/netscaler/netscaler_service.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (netscaler_service f18e5b788a) last updated 2017/08/17 13:59:06 (GMT +300)
  config file = /home/georgen/.ansible.cfg
  configured module search path = ['/home/georgen/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/georgen/repos/ansible_fork/lib/ansible
  executable location = /home/georgen/repos/ansible_fork/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Some unit tests were modified to take into account the new operation.
An integration test was added to test the disable operation.
