### PR TITLE
Fix docker inventory script (https://github.com/ansible/ansible/issue…

### DIFF
--- a/contrib/inventory/docker.py
+++ b/contrib/inventory/docker.py
@@ -371,7 +371,10 @@ HAS_DOCKER_PY = True
 HAS_DOCKER_ERROR = False
 
 try:
-    from docker import Client
+    try:
+        from docker import APIClient
+    except ImportError as exc:
+        from docker import Client as APIClient
     from docker.errors import APIError, TLSParameterError
     from docker.tls import TLSConfig
     from docker.constants import DEFAULT_TIMEOUT_SECONDS, DEFAULT_DOCKER_API_VERSION
@@ -415,7 +418,7 @@ def log(msg, pretty_print=False):
         print(msg + u'\n')
 
 
-class AnsibleDockerClient(Client):
+class AnsibleDockerClient(APIClient):
     def __init__(self, auth_params, debug):
 
         self.auth_params = auth_params


### PR DESCRIPTION
Fix https://github.com/ansible/ansible/issue/28322

In docker-py 2.0 or newer, low-level API is docker.APIClient not docker.Client.
This modification is backward compatible.

##### SUMMARY

Fix docker API

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

docker inventory plugin

##### ANSIBLE VERSION

```
ansible 2.4.0 (fix-docker-api 97db9683af) last updated 2017/08/17 13:15:08 (GMT +200)                                                                                                                             
  config file = /home/yannig/.ansible.cfg                                                                                                                                                                         
  configured module search path = [u'/home/yannig/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/yannig/dev/ansible/lib/ansible
  executable location = /home/yannig/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION

https://github.com/ansible/ansible/issue/28322
