### PR TITLE
Adding public key type for ECDSA sub-types

### DIFF
--- a/lib/ansible/module_utils/facts/system/ssh_pub_keys.py
+++ b/lib/ansible/module_utils/facts/system/ssh_pub_keys.py
@@ -47,6 +47,9 @@ class SshPubKeyFactCollector(BaseFactCollector):
                 key_filename = '%s/ssh_host_%s_key.pub' % (keydir, type_)
                 keydata = get_file_content(key_filename)
                 if keydata is not None:
-                    ssh_pub_key_facts[factname] = keydata.split()[1]
+                    (key_type, keydata) = keydata.split(None, 1)
+                    ssh_pub_key_facts[factname] = keydata
+                    type_factname = '{}_type'.format(factname)
+                    ssh_pub_key_facts[type_factname] = key_type
 
         return ssh_pub_key_facts


### PR DESCRIPTION
This exposes the type in the file, so that it is not lost while
gathering facts.

Closes #28325

Signed-off-by: Clint Byrum <clint@fewbar.com>