### PR TITLE
netscaler_servicegroup: add disable operation 

### DIFF
--- a/test/integration/roles/netscaler_servicegroup/tests/nitro/flap_disabled.yaml
+++ b/test/integration/roles/netscaler_servicegroup/tests/nitro/flap_disabled.yaml
@@ -1,0 +1,9 @@
+---
+
+- include: "{{ role_path }}/tests/nitro/flap_disabled/setup.yaml"
+  vars:
+    check_mode: no
+
+- include: "{{ role_path }}/tests/nitro/flap_disabled/remove.yaml"
+  vars:
+    check_mode: no

--- a/test/integration/roles/netscaler_servicegroup/tests/nitro/flap_disabled/remove.yaml
+++ b/test/integration/roles/netscaler_servicegroup/tests/nitro/flap_disabled/remove.yaml
@@ -1,0 +1,16 @@
+---
+
+- name: Remove servicegroup
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  netscaler_servicegroup:
+
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+
+    state: absent
+
+    servicegroupname: service-group-1
+    servicetype: HTTP

--- a/test/integration/roles/netscaler_servicegroup/tests/nitro/flap_disabled/setup.yaml
+++ b/test/integration/roles/netscaler_servicegroup/tests/nitro/flap_disabled/setup.yaml
@@ -1,0 +1,47 @@
+---
+
+- name: Flap servicegroup
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  netscaler_servicegroup:
+
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+    state: present
+
+
+    servicegroupname: service-group-1
+    servicetype: HTTP
+    servicemembers:
+      - ip: 10.78.78.78
+        port: 80
+        weight: 100
+
+    disabled: "{{ item|int % 2 }}"
+  with_sequence: count=20
+  delay: 1
+
+- name: Flap servicegroup
+  delegate_to: localhost
+  register: result
+  check_mode: "{{ check_mode }}"
+  netscaler_servicegroup:
+
+    nitro_user: "{{nitro_user}}"
+    nitro_pass: "{{nitro_pass}}"
+    nsip: "{{nsip}}"
+    state: present
+
+
+    servicegroupname: service-group-1
+    servicetype: HTTP
+    servicemembers:
+      - ip: 10.78.78.78
+        port: 80
+        weight: 100
+
+    disabled: "{{ item|int % 2 }}"
+  with_sequence: count=20
+  delay: 5

--- a/test/units/modules/network/netscaler/test_netscaler_servicegroup.py
+++ b/test/units/modules/network/netscaler/test_netscaler_servicegroup.py
@@ -163,6 +163,7 @@ class TestNetscalerServicegroupModule(TestModule):
             ConfigProxy=m,
             servicegroup_exists=servicegroup_exists_mock,
             servicemembers_identical=Mock(side_effect=[False, True]),
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
             nitro_exception=self.MockException,
         ):
             self.module = netscaler_servicegroup
@@ -191,6 +192,7 @@ class TestNetscalerServicegroupModule(TestModule):
             servicegroup_identical=servicegroup_identical_mock,
             monitor_bindings_identical=monitor_bindings_identical_mock,
             servicemembers_identical=Mock(side_effect=[True, True]),
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
             nitro_exception=self.MockException,
         ):
             self.module = netscaler_servicegroup
@@ -222,6 +224,7 @@ class TestNetscalerServicegroupModule(TestModule):
             nitro_exception=self.MockException,
             servicemembers_identical=Mock(side_effect=[True, True]),
             sync_monitor_bindings=sync_monitor_bindings_mock,
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_servicegroup
             result = self.exited()
@@ -250,7 +253,7 @@ class TestNetscalerServicegroupModule(TestModule):
             sync_monitor_bindings=Mock(),
             servicemembers_identical=Mock(side_effect=[False, True]),
             sync_service_members=sync_mock,
-
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_servicegroup
             result = self.exited()
@@ -304,7 +307,7 @@ class TestNetscalerServicegroupModule(TestModule):
             servicemembers_identical=Mock(side_effect=[False, True]),
             nitro_exception=self.MockException,
             sync_service_members=sync_mock,
-
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_servicegroup
             result = self.failed()
@@ -332,7 +335,7 @@ class TestNetscalerServicegroupModule(TestModule):
             servicemembers_identical=Mock(side_effect=[False, True]),
             nitro_exception=self.MockException,
             sync_service_members=sync_mock,
-
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_servicegroup
             result = self.failed()
@@ -360,7 +363,7 @@ class TestNetscalerServicegroupModule(TestModule):
             servicemembers_identical=Mock(side_effect=[False, False]),
             nitro_exception=self.MockException,
             sync_service_members=sync_mock,
-
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_servicegroup
             result = self.failed()
@@ -388,7 +391,7 @@ class TestNetscalerServicegroupModule(TestModule):
             servicemembers_identical=Mock(side_effect=[True, True]),
             nitro_exception=self.MockException,
             sync_service_members=sync_mock,
-
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
         ):
             self.module = netscaler_servicegroup
             result = self.failed()
@@ -415,6 +418,7 @@ class TestNetscalerServicegroupModule(TestModule):
             servicegroup_identical=servicegroup_identical_mock,
             servicemembers_identical=Mock(side_effect=[True, True]),
             monitor_bindings_identical=monitor_bindings_identical_mock,
+            do_state_change=Mock(return_value=Mock(errorcode=0)),
             nitro_exception=self.MockException,
         ):
             self.module = netscaler_servicegroup


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds the disable operation for netscaler_servicegroup
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/network/netscaler/netscaler_servicegroup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (netscaler_servicegroup 5aee022244) last updated 2017/08/17 15:15:21 (GMT +300)
  config file = /home/georgen/.ansible.cfg
  configured module search path = ['/home/georgen/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/georgen/repos/ansible_fork/lib/ansible
  executable location = /home/georgen/repos/ansible_fork/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Some unit tests were modified to account for the new operation.
An integration test was added that tests this operation in particular.
