### PR TITLE
unarchive: Fix zip file exclude pattern matching

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -132,6 +132,7 @@ import stat
 import time
 import traceback
 from zipfile import ZipFile, BadZipfile
+from fnmatch import fnmatch
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -165,6 +166,13 @@ def crc32(path):
 def shell_escape(string):
     ''' Quote meta-characters in the args for the unix shell '''
     return re.sub(r'([^A-Za-z0-9_])', r'\\\1', string)
+
+
+def in_pattern_list(name, patterns):
+    for pattern in patterns:
+        if fnmatch(name, pattern):
+            return True
+    return False
 
 
 class UnarchiveError(Exception):
@@ -254,7 +262,7 @@ class ZipArchive(object):
         else:
             try:
                 for member in archive.namelist():
-                    if member not in self.excludes:
+                    if not in_pattern_list(member, self.excludes):
                         self._files_in_archive.append(to_native(member))
             except:
                 archive.close()


### PR DESCRIPTION
##### SUMMARY
The unzip binary performs a filename pattern matching on the exclude
list it get passed from the unarchive module. Hence the module needs
to apply the same exclude pattern matching when generating its
internal file list.

Fixes #26279

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel e7a78f4328) last updated 2017/08/17 11:58:22 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/lab/ansible/devel/lib/ansible
  executable location = /home/andreas/lab/ansible/devel/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```