### PR TITLE
Changed string check to verify that EOS device is not in config mode.

### DIFF
--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -76,7 +76,7 @@ class ActionModule(_ActionModule):
             # make sure we are in the right cli context which should be
             # enable mode and not config module
             rc, out, err = connection.exec_command('prompt()')
-            while str(out).strip().endswith(')#'):
+            while '(config' in str(out):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                 connection.exec_command('exit')
                 rc, out, err = connection.exec_command('prompt()')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Changed string check to verify that EOS device is not in config mode. This was required in order to work with Arista 7500 series modular switches.
Resolves #28309 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
EOS Networking action plugin
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /aos/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 22 2016, 09:22:15) [GCC 6.2.1 20160822]
```
