### PR TITLE
Remove 'net' hardcoding on ansible-test executor

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -681,8 +681,6 @@ def command_integration_role(args, target, start_at_task):
         inventory = args.inventory or 'inventory.networking'
         hosts = target.name[:target.name.find('_')]
         gather_facts = False
-        if hosts == 'net':
-            hosts = 'all'
     else:
         inventory = 'inventory'
         hosts = 'testhost'


### PR DESCRIPTION
We need to run network-integration against platform agnostic modules,
which they all are named as net_* .
There is a hardcoding in executor where if prefix is 'net' the hosts is set
to all, removing these lines to have desired behaviour.