### PR TITLE
Fix documentation for import_playbook - should be list of elements.

### DIFF
--- a/docs/docsite/rst/playbooks_reuse_includes.rst
+++ b/docs/docsite/rst/playbooks_reuse_includes.rst
@@ -19,8 +19,8 @@ Importing Playbooks
 It is possible to include playbooks inside a master playbook. For example::
 
     ---
-    import_playbook: webservers.yml
-    import_playbook: databases.yml
+    - import_playbook: webservers.yml
+    - import_playbook: databases.yml
 
 Each playbook listed will be run in the order they are listed.
 
@@ -114,4 +114,3 @@ Please refer to :doc:`playbooks_reuse_roles` for details on including and import
        Complete playbook files from the GitHub project source
    `Mailing List <http://groups.google.com/group/ansible-project>`_
        Questions? Help? Ideas?  Stop by the list on Google Groups
-

--- a/docs/docsite/rst/playbooks_reuse_includes.rst
+++ b/docs/docsite/rst/playbooks_reuse_includes.rst
@@ -16,13 +16,13 @@ Please refer to  :doc:`playbooks_reuse` for documentation concerning the trade-o
 Importing Playbooks
 ```````````````````
 
-It is possible to include playbooks inside a master playbook. For example::
+It is possible to import playbooks inside a master playbook. For example::
 
     ---
     - import_playbook: webservers.yml
     - import_playbook: databases.yml
 
-Each playbook listed will be run in the order they are listed.
+Each playbook listed will be imported in the order they are listed.  (import_playbook was added in 2.4)
 
 
 Including and Importing Task Files

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -87,7 +87,7 @@ class Playbook:
             if not isinstance(entry, dict):
                 # restore the basedir in case this error is caught and handled
                 self._loader.set_basedir(cur_basedir)
-                raise AnsibleParserError("playbook entries must be either a valid play or an include statement", obj=entry)
+                raise AnsibleParserError("playbook entries must be either a valid play or an 'import_playbook' statement", obj=entry)
 
             if 'include' in entry or 'import_playbook' in entry:
                 if 'include' in entry:

--- a/lib/ansible/playbook/__init__.py
+++ b/lib/ansible/playbook/__init__.py
@@ -93,10 +93,7 @@ class Playbook:
                 if 'include' in entry:
                     display.deprecated("You should use 'import_playbook' instead of 'include' for playbook includes")
                 pb = PlaybookInclude.load(entry, basedir=self._basedir, variable_manager=variable_manager, loader=self._loader)
-                if pb is not None:
-                    self._entries.extend(pb._entries)
-                else:
-                    display.display("skipping playbook include '%s' due to conditional test failure" % entry.get('include', entry), color=C.COLOR_SKIP)
+                self._entries.extend(pb._entries)
             else:
                 entry_obj = Play.load(entry, variable_manager=variable_manager, loader=self._loader)
                 self._entries.append(entry_obj)


### PR DESCRIPTION
Fix exception to refer to 'import_playbook' instead of deprecated 'include'

##### SUMMARY
Documentation incorrectly describes import_playbook.  Additionally, an exception from parsing still refers to deprecated 'include' keyword.

Fixes #28223

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/playbook

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 5c06bea088) last updated 2017/08/17 10:17:23 (GMT -400)
  config file = /Users/mgreenberg/.ansible.cfg
  configured module search path = [u'/Users/mgreenberg/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mgreenberg/wc/ansible/lib/ansible
  executable location = /Users/mgreenberg/wc/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```

##### ADDITIONAL INFORMATION
