### PR TITLE
elb_application_lb: cast port to an integer. Fixes #28221

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -628,6 +628,7 @@ def compare_listeners(connection, module, current_listeners, new_listeners, purg
     for current_listener in current_listeners:
         current_listener_passed_to_module = False
         for new_listener in new_listeners[:]:
+            new_listener['Port'] = int(new_listener['Port'])
             if current_listener['Port'] == new_listener['Port']:
                 current_listener_passed_to_module = True
                 # Remove what we match so that what is left can be marked as 'to be added'


### PR DESCRIPTION
##### SUMMARY
Fixes #28221. Since there is no suboption spec to ensure port is an integer, cast it to an int before using.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elb_application_lb.py

##### ANSIBLE VERSION
```
2.4.0
```

