### PR TITLE
Added the Set-FileAttributes

### DIFF
--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -117,6 +117,8 @@ If (Test-Path -Path $path)
     $result.stat.isarchive = $attributes -contains "Archive"
     $result.stat.ishidden = $attributes -contains "Hidden"
     $result.stat.isreadonly = $attributes -contains "ReadOnly"
+    $result.stat.issystem = $attributes -contains "System"
+    $result.stat.isnormal = $attributes -contains "Normal"
 
     If ($info)
     {


### PR DESCRIPTION
##### SUMMARY

Added functionally inside of the win_file.ps1 module in order to make modifications to file attributes.  The following attributes, at this time, can be modified: Read Only, Hidden, System, and Archive.

Additionally, users of the function can set the file to Normal which resets all attributes of a windows file.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/windows/win_file.ps1

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
```
The Set-FileAttribute function has an attribute parser built into itself for understanding the intention of the user.  Users can use +h or h to turn on the hidden attribute while using -h to remove the bit which makes the file hidden.  The same applies for: a,h,s,r,n - archive, hidden, system, readonly, normal respectively. 

Moreover, touch state was updated to be able to handle read only files.  Additionally, other CMD-let's used in the module assumed files weren't hidden.
```
