### PR TITLE
Fix py3 string issue in jail connection plugin (take 2)

### DIFF
--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -40,7 +40,7 @@ import traceback
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 
 try:
@@ -94,16 +94,7 @@ class Connection(ConnectionBase):
 
         stdout, stderr = p.communicate()
 
-        return to_native(stdout).split()
-
-    def get_jail_path(self):
-        p = subprocess.Popen([self.jls_cmd, '-j', to_bytes(self.jail), '-q', 'path'],
-                             stdin=subprocess.PIPE,
-                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-        stdout, stderr = p.communicate()
-        # remove \n
-        return to_native(stdout)[:-1]
+        return to_text(stdout, errors='surrogate_or_strict').split()
 
     def _connect(self):
         ''' connect to the jail; nothing to do here '''

--- a/lib/ansible/plugins/connection/jail.py
+++ b/lib/ansible/plugins/connection/jail.py
@@ -40,7 +40,7 @@ import traceback
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.plugins.connection import ConnectionBase, BUFSIZE
 
 try:
@@ -94,7 +94,7 @@ class Connection(ConnectionBase):
 
         stdout, stderr = p.communicate()
 
-        return stdout.split()
+        return to_native(stdout).split()
 
     def get_jail_path(self):
         p = subprocess.Popen([self.jls_cmd, '-j', to_bytes(self.jail), '-q', 'path'],
@@ -103,7 +103,7 @@ class Connection(ConnectionBase):
 
         stdout, stderr = p.communicate()
         # remove \n
-        return stdout[:-1]
+        return to_native(stdout)[:-1]
 
     def _connect(self):
         ''' connect to the jail; nothing to do here '''
@@ -179,7 +179,7 @@ class Connection(ConnectionBase):
                     traceback.print_exc()
                     raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
                 if p.returncode != 0:
-                    raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+                    raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, to_native(stdout), to_native(stderr)))
         except IOError:
             raise AnsibleError("file or module does not exist at: %s" % in_path)
 
@@ -205,7 +205,7 @@ class Connection(ConnectionBase):
                 raise AnsibleError("failed to transfer file %s to %s" % (in_path, out_path))
             stdout, stderr = p.communicate()
             if p.returncode != 0:
-                raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, stdout, stderr))
+                raise AnsibleError("failed to transfer file %s to %s:\n%s\n%s" % (in_path, out_path, to_native(stdout), to_native(stderr)))
 
     def close(self):
         ''' terminate the connection; nothing to do here '''


### PR DESCRIPTION
(new PR because Shippable was confused in #28192)

##### SUMMARY
Fix issues with strings and Python 3 in jail connection plugin by using to_native(). The main issue was that the plugin wasn't able to find the jail name in the jail list.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/connection/jail.py

##### ANSIBLE VERSION
```
ansible 2.3.2.0                                                                                                                                                                                                                               
  config file = /usr/local/etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.6.2 (default, Aug  3 2017, 20:11:42) [GCC 4.2.1 Compatible FreeBSD Clang 3.8.0 (tags/RELEASE_380/final 262564)]
```

##### ADDITIONAL INFORMATION
