### PR TITLE
Check Windows service status before nssm STOP

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -96,9 +96,10 @@ Function Nssm-Remove
 
     if (Service-Exists -name $name)
     {
-        $cmd = "stop ""$name"""
-        $results = Nssm-Invoke $cmd
-
+        if ((get-service $name).Status -ne "Stopped") {
+            $cmd = "stop ""$name"""
+            $results = Nssm-Invoke $cmd
+        }
         $cmd = "remove ""$name"" confirm"
         $results = Nssm-Invoke $cmd
 

--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -96,7 +96,7 @@ Function Nssm-Remove
 
     if (Service-Exists -name $name)
     {
-        if ((get-service $name).Status -ne "Stopped") {
+        if ((Get-Service -Name $name).Status -ne "Stopped") {
             $cmd = "stop ""$name"""
             $results = Nssm-Invoke $cmd
         }


### PR DESCRIPTION
Add a condition on calling nssm STOP inside Nssm-Remove, to check whether or not a service has already been stopped. Currently nssm throws an exception:

```
failed: [...] (item=...) => {"changed": false, "failed": true, "item": "...", "msg": "an exception occurred when invoking NSSM: serviceName: STOP: The service has not been started."}
failed: [...] (item=...) => {"changed": false, "failed": true, "item": "...", "msg": "an exception occurred when invoking NSSM: serviceName: The service has not been started."}
```

Behaviour after change:

```
ok: [...] => (item=...)
ok: [...] => (item=...)
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
