### PR TITLE
Fix plugin_formatter.py -l / MODULES=none make webdocs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -179,7 +179,7 @@ def get_module_info(module_dir, limit_to_modules=None, verbose=False):
 
         # If requested, limit module documentation building only to passed-in
         # modules.
-        if limit_to_modules is not None and module.lower() in limit_to_modules:
+        if limit_to_modules is not None and module.lower() not in limit_to_modules:
             continue
 
         deprecated = False


### PR DESCRIPTION

##### SUMMARY
Fix plugin_formatter.py -l / MODULES=none make webdocs

Fix the get_module_info check against the limit_to_modules
list so building a subset/none of the module docs works again.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/bin/plugin_formatter.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (plugin_formatter_limit_to_modules_fix 1018ae2c63) last updated 2017/08/18 10:36:36 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
