### PR TITLE
re-add auth tests with ansible_ssh_host

### DIFF
--- a/test/integration/targets/eos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/eos_user/tests/cli/auth.yaml
@@ -1,0 +1,39 @@
+---
+- block:
+  - name: Create user with password
+    eos_user:
+      name: auth_user
+      privilege: 15
+      role: network-operator
+      state: present
+      authorize: yes
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (should fail)
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    eos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+      authorize: yes
+    register: result

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -1,0 +1,39 @@
+---
+- block:
+  - name: Create user with password
+    ios_user:
+      name: auth_user
+      privilege: 15
+      role: network-operator
+      state: present
+      authorize: yes
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (should fail)
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    ios_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+      authorize: yes
+    register: result

--- a/test/integration/targets/iosxr_user/tests/cli/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/auth.yaml
@@ -1,0 +1,35 @@
+---
+- block:
+  - name: Create user with password
+    iosxr_user:
+      name: auth_user
+      state: present
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (should fail)
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    iosxr_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+    register: result

--- a/test/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/common/auth.yaml
@@ -1,0 +1,36 @@
+---
+- block:
+  - name: Create user with password
+    nxos_user:
+      name: auth_user
+      role: network-operator
+      state: present
+      provider: "{{ connection }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (should fail)
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    nxos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ connection }}"
+    register: result

--- a/test/integration/targets/vyos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/auth.yaml
@@ -1,0 +1,36 @@
+---
+- block:
+  - name: Create user with password
+    vyos_user:
+      name: auth_user
+      role: admin
+      state: present
+      provider: "{{ cli }}"
+      configured_password: pass123
+
+  - name: test login
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
+      responses:
+        (?i)password: "pass123"
+
+  - name: test login with invalid password (should fail)
+    expect:
+      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'"
+      responses:
+        (?i)password: "badpass"
+    ignore_errors: yes
+    register: results
+
+  - name: check that attempt failed
+    assert:
+      that:
+        - results.failed
+
+  always:
+  - name: delete user
+    vyos_user:
+      name: auth_user
+      state: absent
+      provider: "{{ cli }}"
+    register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Re-add and fix tests removed in  #28364.

Old tests were breaking on nodepool because they were using `{{ inventory_hostname }}` which provided an invalid host to ssh to:

```
[nodepool@nodepool ansible-testrunner]$ ansible -i inventory/ -m "debug" -a "var=inventory_hostname" vyos
682bf740-807d-4144-b912-330d99419575 | SUCCESS => {
    "inventory_hostname": "682bf740-807d-4144-b912-330d99419575"
}
```

New tests use `{{ ansible_ssh_host }}` which provides a valid IP address on nodepool:

```
[nodepool@nodepool ansible-testrunner]$ ansible -i inventory/ -m "debug" -a "var=ansible_ssh_host" vyos
682bf740-807d-4144-b912-330d99419575 | SUCCESS => {
    "ansible_ssh_host": "46.231.133.23"
}

[nodepool@nodepool ansible-testrunner]$ ssh vyos@46.231.133.23 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no '/opt/vyatta/sbin/vyatta-cfg-cmd-wrapper show version'

Warning: Permanently added '46.231.133.23' (RSA) to the list of known hosts.
Welcome to VyOS
vyos@46.231.133.23's password:
interfaces {
    ethernet eth0 {
        address dhcp
        description OUTSIDE
        duplex auto
[...]
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- test pull request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- eos_user
- ios_user
- iosxr_user
- nxos_user
- vyos_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix-user-auth-tests 371599981a) last updated 2017/08/18 10:32:47 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/dnewswan/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dnewswan/code/ansible/lib/ansible
  executable location = /Users/dnewswan/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
