### PR TITLE
allow pesky 'bridge' facts to bypass facts filter

### DIFF
--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -25,7 +25,7 @@ from ansible.errors import AnsibleError, AnsibleParserError, AnsibleUndefinedVar
 from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils._text import to_native
 from ansible.parsing.mod_args import ModuleArgsParser
-from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleMapping, AnsibleUnicode
+from ansible.parsing.yaml.objects import AnsibleBaseYAMLObject, AnsibleMapping
 from ansible.plugins.loader import lookup_loader
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.base import Base
@@ -205,23 +205,24 @@ class Task(Base, Conditional, Taggable, Become):
 
         for (k, v) in iteritems(ds):
             if k in ('action', 'local_action', 'args', 'delegate_to') or k == action or k == 'shell':
-                # we don't want to re-assign these values, which were
-                # determined by the ModuleArgsParser() above
+                # we don't want to re-assign these values, which were determined by the ModuleArgsParser() above
                 continue
             elif k.replace("with_", "") in lookup_loader:
+                # transform into loop property
                 self._preprocess_loop(ds, new_ds, k, v)
             else:
-                # pre-2.0 syntax allowed variables for include statements at the
-                # top level of the task, so we move those into the 'vars' dictionary
-                # here, and show a deprecation message as we will remove this at
-                # some point in the future.
+                # pre-2.0 syntax allowed variables for include statements at the top level of the task,
+                # so we move those into the 'vars' dictionary here, and show a deprecation message
+                # as we will remove this at some point in the future.
                 if action in ('include', 'include_tasks') and k not in self._valid_attrs and k not in self.DEPRECATED_ATTRIBUTES:
                     display.deprecated("Specifying include variables at the top-level of the task is deprecated."
                                        " Please see:\nhttp://docs.ansible.com/ansible/playbooks_roles.html#task-include-files-and-encouraging-reuse\n\n"
                                        " for currently supported syntax regarding included files and variables", version="2.7")
                     new_ds['vars'][k] = v
-                else:
+                elif k in self._valid_attrs:
                     new_ds[k] = v
+                else:
+                    display.warning("Ignoring invalid attribute: %s" % k)
 
         return super(Task, self).preprocess_data(new_ds)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -780,7 +780,8 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 conn_name = os.path.splitext(os.path.basename(conn_path))[0]
                 re_key = re.compile('^ansible_%s_' % conn_name)
                 for fact_key in fact_keys:
-                    if re_key.match(fact_key):
+                    # exception for lvm tech, whic normally returns asnible_x_bridge facts that get filterd out (docker,lxc, etc)
+                    if re_key.match(fact_key) and not fact_key.endswith(('_bridge','_gwbridge')):
                         remove_keys.add(fact_key)
             except AttributeError:
                 pass

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -781,7 +781,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 re_key = re.compile('^ansible_%s_' % conn_name)
                 for fact_key in fact_keys:
                     # exception for lvm tech, whic normally returns asnible_x_bridge facts that get filterd out (docker,lxc, etc)
-                    if re_key.match(fact_key) and not fact_key.endswith(('_bridge','_gwbridge')):
+                    if re_key.match(fact_key) and not fact_key.endswith(('_bridge', '_gwbridge')):
                         remove_keys.add(fact_key)
             except AttributeError:
                 pass


### PR DESCRIPTION
##### SUMMARY
most light weight vm or container tech creates devices with this pattern, this avoids filtering them out.

fixes #27729, #23577


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4/2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
