### PR TITLE
Set sphinx default_role='any' so `some_target` lnks work

### DIFF
--- a/docs/docsite/rst/conf.py
+++ b/docs/docsite/rst/conf.py
@@ -84,7 +84,7 @@ exclude_patterns = ['modules']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
-# default_role = None
+default_role = 'any'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 # add_function_parentheses = True


### PR DESCRIPTION
The default_role on doc/docsite/rst/conf.py was not set
so no default_role was set. For rst cross references like:

``` rst
See `playbooks_intro` for more info.
```

The 'default_role' determines how the 'playbooks_intro' name
is resolved against potential targets. Since it wasn't set,
only explicit references to targets by role worked. ie
the following worked:

``` rst
See :ref:`playbooks_intro`
```

But not:

``` rst
  See `playbooks_intro`
```

Setting it to 'any' is suggested by the sphinx docs
at http://www.sphinx-doc.org/en/stable/markup/inline.html
since that also enabled intersphinx cross references.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docsite/rst/conf.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (docsite_rst_default_role 5d61dd2319) last updated 2017/08/18 13:21:21 (GMT -400)
  config file = None
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
