### PR TITLE
Fix pep8/pylint tests when deleting files.

### DIFF
--- a/test/runner/lib/sanity.py
+++ b/test/runner/lib/sanity.py
@@ -206,7 +206,7 @@ def command_sanity_validate_modules(args, targets):
         raise SubprocessError(cmd=cmd, status=status, stderr=stderr, stdout=stdout)
 
     if args.explain:
-        return SanitySkipped(test)
+        return SanitySuccess(test)
 
     messages = json.loads(stdout)
 
@@ -268,7 +268,7 @@ def command_sanity_shellcheck(args, targets):
         raise SubprocessError(cmd=cmd, status=status, stderr=stderr, stdout=stdout)
 
     if args.explain:
-        return SanitySkipped(test)
+        return SanitySuccess(test)
 
     # json output is missing file paths in older versions of shellcheck, so we'll use xml instead
     root = fromstring(stdout)  # type: Element
@@ -339,7 +339,7 @@ def command_sanity_pep8(args, targets):
         stdout = None
 
     if args.explain:
-        return SanitySkipped(test)
+        return SanitySuccess(test)
 
     if stdout:
         pattern = '^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): (?P<code>[WE][0-9]{3}) (?P<message>.*)$'
@@ -492,7 +492,7 @@ def command_sanity_pylint(args, targets):
         stdout = None
 
     if args.explain:
-        return SanitySkipped(test)
+        return SanitySuccess(test)
 
     if stdout:
         messages = json.loads(stdout)
@@ -560,7 +560,7 @@ def command_sanity_yamllint(args, targets):
         raise SubprocessError(cmd=cmd, status=status, stderr=stderr, stdout=stdout)
 
     if args.explain:
-        return SanitySkipped(test)
+        return SanitySuccess(test)
 
     pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+):(?P<column>[0-9]+): \[(?P<level>warning|error)\] (?P<message>.*)$'
 
@@ -614,7 +614,7 @@ def command_sanity_rstcheck(args, targets):
         raise SubprocessError(cmd=cmd, status=status, stderr=stderr, stdout=stdout)
 
     if args.explain:
-        return SanitySkipped(test)
+        return SanitySuccess(test)
 
     pattern = r'^(?P<path>[^:]*):(?P<line>[0-9]+): \((?P<level>INFO|WARNING|ERROR|SEVERE)/[0-4]\) (?P<message>.*)$'
 

--- a/test/runner/lib/test.py
+++ b/test/runner/lib/test.py
@@ -200,8 +200,10 @@ class TestFailure(TestResult):
 
         if messages:
             messages = sorted(messages, key=lambda m: m.sort_key)
+        else:
+            messages = []
 
-        self.messages = messages or []
+        self.messages = messages
         self.summary = summary
 
     def write(self, args):


### PR DESCRIPTION
##### SUMMARY

This change allows the pep8 and pylint tests to check for references to non-existent files when the tests are run, but there are no .py files to check. It does not yet handle the case where the tests are skipped due to having no files to check.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (at-fix 1cd682c6c0) last updated 2017/08/18 09:59:39 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
