### PR TITLE
Remove default description in network DI modules

### DIFF
--- a/lib/ansible/modules/network/ios/ios_interface.py
+++ b/lib/ansible/modules/network/ios/ios_interface.py
@@ -143,8 +143,6 @@ from ansible.module_utils.ios import ios_argument_spec, check_args
 from ansible.module_utils.netcfg import NetworkConfig
 from ansible.module_utils.network_common import conditional, remove_default_spec
 
-DEFAULT_DESCRIPTION = "configured by ios_interface"
-
 
 def validate_mtu(value, module):
     if value and not 64 <= int(value) <= 9600:
@@ -284,13 +282,6 @@ def map_obj_to_commands(updates):
                         if candidate:
                             cmd = item + ' ' + str(candidate)
                             add_command_to_interface(interface, cmd, commands)
-                        elif running:
-                            # if value present in device is default value for
-                            # interface, don't delete
-                            if running == 'auto' and item in ('speed', 'duplex'):
-                                continue
-                            cmd = 'no ' + item + ' ' + str(running)
-                            add_command_to_interface(interface, cmd, commands)
 
                 if disable and not obj_in_have.get('disable', False):
                     add_command_to_interface(interface, 'shutdown', commands)
@@ -360,7 +351,7 @@ def main():
     """
     element_spec = dict(
         name=dict(),
-        description=dict(default=DEFAULT_DESCRIPTION),
+        description=dict(),
         speed=dict(),
         mtu=dict(),
         duplex=dict(choices=['full', 'half', 'auto']),

--- a/lib/ansible/modules/network/junos/junos_linkagg.py
+++ b/lib/ansible/modules/network/junos/junos_linkagg.py
@@ -170,7 +170,6 @@ except ImportError:
     from xml.etree.ElementTree import tostring
 
 USE_PERSISTENT_CONNECTION = True
-DEFAULT_COMMENT = 'configured by junos_linkagg'
 
 
 def validate_device_count(value, module):
@@ -263,7 +262,7 @@ def main():
         members=dict(type='list'),
         min_links=dict(type='int'),
         device_count=dict(type='int'),
-        description=dict(default=DEFAULT_COMMENT),
+        description=dict(),
         state=dict(default='present', choices=['present', 'absent', 'up', 'down']),
         active=dict(default=True, type='bool')
     )

--- a/lib/ansible/modules/network/junos/junos_vlan.py
+++ b/lib/ansible/modules/network/junos/junos_vlan.py
@@ -121,7 +121,6 @@ except ImportError:
     from xml.etree.ElementTree import tostring
 
 USE_PERSISTENT_CONNECTION = True
-DEFAULT_DESCRIPTION = "configured by junos_vlan"
 
 
 def validate_vlan_id(value, module):
@@ -145,7 +144,7 @@ def main():
     element_spec = dict(
         name=dict(),
         vlan_id=dict(type='int'),
-        description=dict(default=DEFAULT_DESCRIPTION),
+        description=dict(),
         interfaces=dict(),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool')

--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -138,8 +138,6 @@ from ansible.module_utils.network_common import conditional, remove_default_spec
 from ansible.module_utils.vyos import load_config, get_config
 from ansible.module_utils.vyos import vyos_argument_spec, check_args
 
-DEFAULT_DESCRIPTION = "'configured by vyos_interface'"
-
 
 def search_obj_in_list(name, lst):
     for o in lst:
@@ -302,7 +300,7 @@ def main():
     """
     element_spec = dict(
         name=dict(),
-        description=dict(default=DEFAULT_DESCRIPTION),
+        description=dict(),
         speed=dict(),
         mtu=dict(type='int'),
         duplex=dict(choices=['full', 'half', 'auto']),

--- a/test/integration/targets/ios_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START ios_interface netconf/basic.yaml"
+- debug: msg="START ios_interface cli/basic.yaml"
 
 - name: Configure interface (setup)
   ios_interface:
@@ -46,7 +46,6 @@
     name: GigabitEthernet0/2
     description: test-interface
     speed: 100
-    duplex: half
     mtu: 512
     state: present
     authorize: yes
@@ -59,7 +58,6 @@
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"description test-interface" in result.commands'
       - '"speed 100" in result.commands'
-      - '"duplex half" in result.commands'
       - '"mtu 512" in result.commands'
 
 - name: Change interface parameters
@@ -67,7 +65,7 @@
     name: GigabitEthernet0/2
     description: test-interface-1
     speed: 10
-    duplex: full
+    duplex: half
     mtu: 256
     state: present
     authorize: yes
@@ -80,37 +78,8 @@
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"description test-interface-1" in result.commands'
       - '"speed 10" in result.commands'
-      - '"duplex full" in result.commands'
+      - '"duplex half" in result.commands'
       - '"mtu 256" in result.commands'
-
-- name: Delete interface parameters
-  ios_interface:
-    name: GigabitEthernet0/2
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"interface GigabitEthernet0/2" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
-      - '"no speed 10" in result.commands'
-      - '"no duplex full" in result.commands'
-      - '"no mtu 256" in result.commands'
-
-- name: Delete interface parameters (idempotent)
-  ios_interface:
-    name: GigabitEthernet0/2
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == false'
 
 - name: Disable interface
   ios_interface:
@@ -145,7 +114,7 @@
     name: GigabitEthernet0/1
     description: test-interface-initial
     speed: 100
-    duplex: full
+    duplex: half
     mtu: 516
     state: present
     authorize: yes
@@ -194,31 +163,6 @@
     that:
       - 'result.changed == false'
 
-
-- name: Change interface parameters in aggregate
-  ios_interface:
-    aggregate:
-    - { name: GigabitEthernet0/1 }
-    - { name: GigabitEthernet0/2 }
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"interface GigabitEthernet0/1" in result.commands'
-      - '"no speed 100" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
-      - '"no duplex full" in result.commands'
-      - '"no mtu 256" in result.commands'
-      - '"interface GigabitEthernet0/2" in result.commands'
-      - '"no speed 100" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
-      - '"no duplex full" in result.commands'
-      - '"no mtu 516" in result.commands'
-
 - name: Disable interface aggregate
   ios_interface:
     aggregate:
@@ -257,6 +201,14 @@
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"no shutdown" in result.commands'
 
+- name: loopback interface setup
+  ios_interface:
+    aggregate:
+    - name: Loopback9
+    - name: Loopback10
+    state: absent
+    authorize: yes
+
 - name: Create loopback interface aggregate
   ios_interface:
     aggregate:
@@ -271,9 +223,7 @@
     that:
       - 'result.changed == true'
       - '"interface Loopback9" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
       - '"interface Loopback10" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
 
 - name: Delete loopback interface aggregate
   ios_interface:

--- a/test/integration/targets/iosxr_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_interface/tests/cli/basic.yaml
@@ -72,28 +72,16 @@
       - '"interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 mtu 256" in result.commands'
 
-- name: Delete interface parameters
+- name: Change interface parameters (idempotent)
   iosxr_interface:
     name: GigabitEthernet0/0/0/2
+    description: test-interface-1
+    speed: 10
+    duplex: full
+    mtu: 256
     state: present
     provider: "{{ cli }}"
   register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"interface GigabitEthernet0/0/0/2 description configured by iosxr_interface" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 speed 10" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 mtu 256" in result.commands'
-
-- name: Delete interface parameters (idempotent)
-  iosxr_interface:
-    name: GigabitEthernet0/0/0/2
-    state: present
-    provider: "{{ cli }}"
-  register: result
-
 - assert:
     that:
       - 'result.changed == false'
@@ -135,11 +123,20 @@
       - 'result.changed == true'
       - '"interface GigabitEthernet0/0/0/3 description test-interface-initial" in result.commands'
 
+- name: Delete interface aggregate (setup)
+  iosxr_interface:
+    aggregate:
+    - name: GigabitEthernet0/0/0/3
+    - name: GigabitEthernet0/0/0/2
+    state: absent
+
 - name: Add interface aggregate
   iosxr_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/3, speed: 10, duplex: half, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/0/0/2, speed: 100, duplex: full, mtu: 516, description: test-interface-2 }
+    - { name: GigabitEthernet0/0/0/3, mtu: 256, description: test-interface-1 }
+    - { name: GigabitEthernet0/0/0/2, mtu: 516, description: test-interface-2 }
+    speed: 100
+    duplex: full
     state: present
     provider: "{{ cli }}"
   register: result
@@ -147,20 +144,23 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/0/0/3 speed 10" in result.commands'
+      - '"interface GigabitEthernet0/0/0/3 speed 100" in result.commands'
       - '"interface GigabitEthernet0/0/0/3 description test-interface-1" in result.commands'
-      - '"interface GigabitEthernet0/0/0/3 duplex half" in result.commands'
+      - '"interface GigabitEthernet0/0/0/3 duplex full" in result.commands'
       - '"interface GigabitEthernet0/0/0/3 mtu 256" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 speed 100" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 description test-interface-2" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 mtu 516" in result.commands'
 
+
 - name: Add interface aggregate (idempotent)
   iosxr_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/3, speed: 10, duplex: half, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/0/0/2, speed: 100, duplex: full, mtu: 516, description: test-interface-2 }
+    - { name: GigabitEthernet0/0/0/3, mtu: 256, description: test-interface-1 }
+    - { name: GigabitEthernet0/0/0/2, mtu: 516, description: test-interface-2 }
+    speed: 100
+    duplex: full
     state: present
     provider: "{{ cli }}"
   register: result
@@ -169,33 +169,12 @@
     that:
       - 'result.changed == false'
 
-
-- name: Change interface parameters in aggregate
+- name: Disable interface aggregate
   iosxr_interface:
     aggregate:
     - name: GigabitEthernet0/0/0/3
     - name: GigabitEthernet0/0/0/2
-    state: present
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"no interface GigabitEthernet0/0/0/3 speed 10" in result.commands'
-      - '"interface GigabitEthernet0/0/0/3 description configured by iosxr_interface" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/3 duplex half" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/3 mtu 256" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 speed 100" in result.commands'
-      - '"interface GigabitEthernet0/0/0/2 description configured by iosxr_interface" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 mtu 516" in result.commands'
-
-- name: Disable interface aggregate
-  iosxr_interface:
-    aggregate:
-    - { name: GigabitEthernet0/0/0/3, enabled: False }
-    - { name: GigabitEthernet0/0/0/2, enabled: False }
+    enabled: False
     state: present
     provider: "{{ cli }}"
   register: result
@@ -235,7 +214,9 @@
   iosxr_interface:
     aggregate:
     - name: GigabitEthernet0/0/0/4
+      description: test_interface_1
     - name: GigabitEthernet0/0/0/5
+      description: test_interface_2
     state: present
     provider: "{{ cli }}"
   register: result
@@ -243,8 +224,8 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/0/0/4 description configured by iosxr_interface" in result.commands'
-      - '"interface GigabitEthernet0/0/0/5 description configured by iosxr_interface" in result.commands'
+      - '"interface GigabitEthernet0/0/0/4 description test_interface_1" in result.commands'
+      - '"interface GigabitEthernet0/0/0/5 description test_interface_2" in result.commands'
 
 - name: Delete interface aggregate
   iosxr_interface:

--- a/test/integration/targets/iosxr_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/iosxr_interface/tests/cli/intent.yaml
@@ -4,6 +4,7 @@
 - name: Setup (interface is up)
   iosxr_interface:
     name: GigabitEthernet0/0/0/5
+    description: test_interface_5
     enabled: True
     state: present
     provider: "{{ cli }}"

--- a/test/integration/targets/junos_linkagg/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_linkagg/tests/netconf/basic.yaml
@@ -37,7 +37,6 @@
       - "'<device-count>4</device-count>' in config.xml"
       - "'<bundle>ae0</bundle>' in config.xml"
       - "'<active/>' in config.xml"
-      - "'<description>configured by junos_linkagg</description>' in config.xml"
 
 - name: configure linkagg (idempotent)
   junos_linkagg:

--- a/test/integration/targets/junos_vlan/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_vlan/tests/netconf/basic.yaml
@@ -126,7 +126,6 @@
       - result.diff.prepared | search("\+ *test_vlan_1")
       - result.diff.prepared | search("\+ *vlan-id 159")
       - result.diff.prepared | search("\+ *test_vlan_2")
-      - result.diff.prepared | search("\+ *description \"configured by junos_vlan\"")
 
 - name: Deactivate vlan configuration using aggregate
   junos_vlan:

--- a/test/integration/targets/net_interface/tests/ios/basic.yaml
+++ b/test/integration/targets/net_interface/tests/ios/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START net_interface ios/basic.yaml"
+- debug: msg="START net_interface cli/basic.yaml"
 
 - name: Configure interface (setup)
   net_interface:
@@ -46,7 +46,6 @@
     name: GigabitEthernet0/2
     description: test-interface
     speed: 100
-    duplex: half
     mtu: 512
     state: present
     authorize: yes
@@ -59,7 +58,6 @@
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"description test-interface" in result.commands'
       - '"speed 100" in result.commands'
-      - '"duplex half" in result.commands'
       - '"mtu 512" in result.commands'
 
 - name: Change interface parameters
@@ -67,7 +65,7 @@
     name: GigabitEthernet0/2
     description: test-interface-1
     speed: 10
-    duplex: full
+    duplex: half
     mtu: 256
     state: present
     authorize: yes
@@ -80,37 +78,8 @@
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"description test-interface-1" in result.commands'
       - '"speed 10" in result.commands'
-      - '"duplex full" in result.commands'
+      - '"duplex half" in result.commands'
       - '"mtu 256" in result.commands'
-
-- name: Delete interface parameters
-  net_interface:
-    name: GigabitEthernet0/2
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"interface GigabitEthernet0/2" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
-      - '"no speed 10" in result.commands'
-      - '"no duplex full" in result.commands'
-      - '"no mtu 256" in result.commands'
-
-- name: Delete interface parameters (idempotent)
-  net_interface:
-    name: GigabitEthernet0/2
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == false'
 
 - name: Disable interface
   net_interface:
@@ -145,7 +114,7 @@
     name: GigabitEthernet0/1
     description: test-interface-initial
     speed: 100
-    duplex: full
+    duplex: half
     mtu: 516
     state: present
     authorize: yes
@@ -155,8 +124,10 @@
 - name: Add interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/1, speed: 10, duplex: half, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/2, speed: 100, duplex: full, mtu: 516, description: test-interface-2 }
+    - { name: GigabitEthernet0/1, mtu: 256, description: test-interface-1 }
+    - { name: GigabitEthernet0/2, mtu: 516, description: test-interface-2 }
+    duplex: full
+    speed: 100
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -166,9 +137,9 @@
     that:
       - 'result.changed == true'
       - '"interface GigabitEthernet0/1" in result.commands'
-      - '"speed 10" in result.commands'
+      - '"speed 100" in result.commands'
       - '"description test-interface-1" in result.commands'
-      - '"duplex half" in result.commands'
+      - '"duplex full" in result.commands'
       - '"mtu 256" in result.commands'
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"speed 100" in result.commands'
@@ -179,8 +150,10 @@
 - name: Add interface aggregate (idempotent)
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/1, speed: 10, duplex: half, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/2, speed: 100, duplex: full, mtu: 516, description: test-interface-2 }
+    - { name: GigabitEthernet0/1, mtu: 256, description: test-interface-1 }
+    - { name: GigabitEthernet0/2, mtu: 516, description: test-interface-2 }
+    duplex: full
+    speed: 100
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -190,36 +163,12 @@
     that:
       - 'result.changed == false'
 
-
-- name: Change interface parameters in aggregate
-  net_interface:
-    aggregate:
-    - { name: GigabitEthernet0/1 }
-    - { name: GigabitEthernet0/2 }
-    state: present
-    authorize: yes
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"interface GigabitEthernet0/1" in result.commands'
-      - '"no speed 10" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
-      - '"no duplex half" in result.commands'
-      - '"no mtu 256" in result.commands'
-      - '"interface GigabitEthernet0/2" in result.commands'
-      - '"no speed 100" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
-      - '"no duplex full" in result.commands'
-      - '"no mtu 516" in result.commands'
-
 - name: Disable interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/1, enabled: False }
-    - { name: GigabitEthernet0/2, enabled: False }
+    - name: GigabitEthernet0/1
+    - name: GigabitEthernet0/2
+    enabled: False
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -236,8 +185,9 @@
 - name: Enable interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/1, enabled: True }
-    - { name: GigabitEthernet0/2, enabled: True }
+    - name: GigabitEthernet0/1
+    - name: GigabitEthernet0/2
+    enabled: True
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -251,11 +201,19 @@
       - '"interface GigabitEthernet0/2" in result.commands'
       - '"no shutdown" in result.commands'
 
+- name: loopback interface setup
+  net_interface:
+    aggregate:
+    - name: Loopback9
+    - name: Loopback10
+    state: absent
+    authorize: yes
+
 - name: Create loopback interface aggregate
   net_interface:
     aggregate:
-    - { name: Loopback9 }
-    - { name: Loopback10 }
+    - name: Loopback9
+    - name: Loopback10
     state: present
     authorize: yes
     provider: "{{ cli }}"
@@ -265,16 +223,14 @@
     that:
       - 'result.changed == true'
       - '"interface Loopback9" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
       - '"interface Loopback10" in result.commands'
-      - '"description configured by ios_interface" in result.commands'
 
 - name: Delete loopback interface aggregate
   net_interface:
     aggregate:
-    - { name: Loopback9, state: absent }
-    - { name: Loopback10, state: absent }
-    state: present
+    - name: Loopback9
+    - name: Loopback10
+    state: absent
     authorize: yes
     provider: "{{ cli }}"
   register: result
@@ -288,9 +244,9 @@
 - name: Delete loopback interface aggregate (idempotent)
   net_interface:
     aggregate:
-    - { name: Loopback9, state: absent }
-    - { name: Loopback10, state: absent }
-    state: present
+    - name: Loopback9
+    - name: Loopback10
+    state: absent
     authorize: yes
     provider: "{{ cli }}"
   register: result
@@ -299,4 +255,4 @@
     that:
       - 'result.changed == false'
 
-- debug: msg="END net_interface ios/basic.yaml"
+- debug: msg="END net_interface cli/basic.yaml"

--- a/test/integration/targets/net_interface/tests/iosxr/basic.yaml
+++ b/test/integration/targets/net_interface/tests/iosxr/basic.yaml
@@ -72,28 +72,16 @@
       - '"interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 mtu 256" in result.commands'
 
-- name: Delete interface parameters
+- name: Change interface parameters (idempotent)
   net_interface:
     name: GigabitEthernet0/0/0/2
+    description: test-interface-1
+    speed: 10
+    duplex: full
+    mtu: 256
     state: present
     provider: "{{ cli }}"
   register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"interface GigabitEthernet0/0/0/2 description configured by iosxr_interface" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 speed 10" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 mtu 256" in result.commands'
-
-- name: Delete interface parameters (idempotent)
-  net_interface:
-    name: GigabitEthernet0/0/0/2
-    state: present
-    provider: "{{ cli }}"
-  register: result
-
 - assert:
     that:
       - 'result.changed == false'
@@ -135,11 +123,20 @@
       - 'result.changed == true'
       - '"interface GigabitEthernet0/0/0/3 description test-interface-initial" in result.commands'
 
+- name: Delete interface aggregate (setup)
+  net_interface:
+    aggregate:
+    - name: GigabitEthernet0/0/0/3
+    - name: GigabitEthernet0/0/0/2
+    state: absent
+
 - name: Add interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/3, speed: 10, duplex: half, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/0/0/2, speed: 100, duplex: full, mtu: 516, description: test-interface-2 }
+    - { name: GigabitEthernet0/0/0/3, mtu: 256, description: test-interface-1 }
+    - { name: GigabitEthernet0/0/0/2, mtu: 516, description: test-interface-2 }
+    speed: 100
+    duplex: full
     state: present
     provider: "{{ cli }}"
   register: result
@@ -147,20 +144,23 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/0/0/3 speed 10" in result.commands'
+      - '"interface GigabitEthernet0/0/0/3 speed 100" in result.commands'
       - '"interface GigabitEthernet0/0/0/3 description test-interface-1" in result.commands'
-      - '"interface GigabitEthernet0/0/0/3 duplex half" in result.commands'
+      - '"interface GigabitEthernet0/0/0/3 duplex full" in result.commands'
       - '"interface GigabitEthernet0/0/0/3 mtu 256" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 speed 100" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 description test-interface-2" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
       - '"interface GigabitEthernet0/0/0/2 mtu 516" in result.commands'
 
+
 - name: Add interface aggregate (idempotent)
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/3, speed: 10, duplex: half, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/0/0/2, speed: 100, duplex: full, mtu: 516, description: test-interface-2 }
+    - { name: GigabitEthernet0/0/0/3, mtu: 256, description: test-interface-1 }
+    - { name: GigabitEthernet0/0/0/2, mtu: 516, description: test-interface-2 }
+    speed: 100
+    duplex: full
     state: present
     provider: "{{ cli }}"
   register: result
@@ -169,33 +169,12 @@
     that:
       - 'result.changed == false'
 
-
-- name: Change interface parameters in aggregate
-  net_interface:
-    aggregate:
-    - { name: GigabitEthernet0/0/0/3 }
-    - { name: GigabitEthernet0/0/0/2 }
-    state: present
-    provider: "{{ cli }}"
-  register: result
-
-- assert:
-    that:
-      - 'result.changed == true'
-      - '"no interface GigabitEthernet0/0/0/3 speed 10" in result.commands'
-      - '"interface GigabitEthernet0/0/0/3 description configured by iosxr_interface" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/3 duplex half" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/3 mtu 256" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 speed 100" in result.commands'
-      - '"interface GigabitEthernet0/0/0/2 description configured by iosxr_interface" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 duplex full" in result.commands'
-      - '"no interface GigabitEthernet0/0/0/2 mtu 516" in result.commands'
-
 - name: Disable interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/3, enabled: False }
-    - { name: GigabitEthernet0/0/0/2, enabled: False }
+    - name: GigabitEthernet0/0/0/3
+    - name: GigabitEthernet0/0/0/2
+    enabled: False
     state: present
     provider: "{{ cli }}"
   register: result
@@ -209,8 +188,9 @@
 - name: Enable interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/3, enabled: True }
-    - { name: GigabitEthernet0/0/0/2, enabled: True }
+    - name: GigabitEthernet0/0/0/3
+    - name: GigabitEthernet0/0/0/2
+    enabled: True
     state: present
     provider: "{{ cli }}"
   register: result
@@ -221,11 +201,22 @@
       - '"no interface GigabitEthernet0/0/0/3 shutdown" in result.commands'
       - '"no interface GigabitEthernet0/0/0/2 shutdown" in result.commands'
 
+- name: interface aggregate (setup)
+  net_interface:
+    aggregate:
+    - name: GigabitEthernet0/0/0/4
+    - name: GigabitEthernet0/0/0/5
+    description: test-interface-initial
+    provider: "{{ cli }}"
+  register: result
+
 - name: Create interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/4 }
-    - { name: GigabitEthernet0/0/0/5 }
+    - name: GigabitEthernet0/0/0/4
+      description: test_interface_1
+    - name: GigabitEthernet0/0/0/5
+      description: test_interface_2
     state: present
     provider: "{{ cli }}"
   register: result
@@ -233,15 +224,15 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/0/0/4 description configured by iosxr_interface" in result.commands'
-      - '"interface GigabitEthernet0/0/0/5 description configured by iosxr_interface" in result.commands'
+      - '"interface GigabitEthernet0/0/0/4 description test_interface_1" in result.commands'
+      - '"interface GigabitEthernet0/0/0/5 description test_interface_2" in result.commands'
 
 - name: Delete interface aggregate
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/4, state: absent }
-    - { name: GigabitEthernet0/0/0/5, state: absent }
-    state: present
+    - name: GigabitEthernet0/0/0/4
+    - name: GigabitEthernet0/0/0/5
+    state: absent
     provider: "{{ cli }}"
   register: result
 
@@ -254,9 +245,9 @@
 - name: Delete interface aggregate (idempotent)
   net_interface:
     aggregate:
-    - { name: GigabitEthernet0/0/0/4, state: absent }
-    - { name: GigabitEthernet0/0/0/5, state: absent }
-    state: present
+    - name: GigabitEthernet0/0/0/4
+    - name: GigabitEthernet0/0/0/5
+    state: absent
     provider: "{{ cli }}"
   register: result
 

--- a/test/integration/targets/net_interface/tests/iosxr/intent.yaml
+++ b/test/integration/targets/net_interface/tests/iosxr/intent.yaml
@@ -1,9 +1,10 @@
 ---
-- debug: msg="START net_interface cli/intent.yaml"
+- debug: msg="START net_interface iosxr/intent.yaml"
 
 - name: Setup (interface is up)
   net_interface:
     name: GigabitEthernet0/0/0/5
+    description: test_interface_5
     enabled: True
     state: present
     provider: "{{ cli }}"

--- a/test/integration/targets/net_linkagg/tests/junos/basic.yaml
+++ b/test/integration/targets/net_linkagg/tests/junos/basic.yaml
@@ -37,7 +37,6 @@
       - "'<device-count>4</device-count>' in config.xml"
       - "'<bundle>ae0</bundle>' in config.xml"
       - "'<active/>' in config.xml"
-      - "'<description>configured by junos_linkagg</description>' in config.xml"
 
 - name: configure linkagg (idempotent)
   net_linkagg:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Remove default description in Network DI modules. 
*  Refactor integration test accordingly.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_interface
iosxr_interface
vyos_interface
junos_vlan
junos_linkagg

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
