### PR TITLE
ovirt_hosts: Add upgrade_check action

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -123,6 +123,12 @@ options:
           - "If C(state) is I(iscsilogin) it means that the iscsi attribute is being
              used to login to the specified targets passed as part of the iscsi attribute"
         version_added: "2.4"
+    check_upgrade:
+        description:
+            - "If I(true) and C(state) is I(upgraded) run check for upgrade
+               action before executing upgrade action."
+        default: True
+        version_added: 2.4
 extends_documentation_fragment: ovirt
 '''
 
@@ -385,6 +391,7 @@ def main():
         power_management_enabled=dict(default=None, type='bool'),
         activate=dict(default=True, type='bool'),
         iscsi=dict(default=None, type='dict'),
+        check_upgrade=dict(default=True, type='bool'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -435,6 +442,31 @@ def main():
             ret = hosts_module.create()
         elif state == 'upgraded':
             result_state = hoststate.MAINTENANCE if host.status == hoststate.MAINTENANCE else hoststate.UP
+            events_service = connection.system_service().events_service()
+            last_event = events_service.list(max=1)[0]
+
+            if module.params['check_upgrade']:
+                hosts_module.action(
+                    action='upgrade_check',
+                    action_condition=lambda host: not host.update_available,
+                    wait_condition=lambda host: host.update_available or
+                        len([
+                            event
+                            for event in events_service.list(
+                                from_=int(last_event.id),
+                                search='type=885 and host.name=%s' % host.name,
+                            )
+                        ]) > 0,
+                    fail_condition=lambda host: len([
+                        event
+                        for event in events_service.list(
+                            from_=int(last_event.id),
+                            search='type=839 or type=887 and host.name=%s' % host.name,
+                        )
+                    ]) > 0,
+                )
+                # Set to False, because upgrade_check isn't 'changing' action:
+                hosts_module._changed = False
             ret = hosts_module.action(
                 action='upgrade',
                 action_condition=lambda h: h.update_available,

--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -449,14 +449,15 @@ def main():
                 hosts_module.action(
                     action='upgrade_check',
                     action_condition=lambda host: not host.update_available,
-                    wait_condition=lambda host: host.update_available or
+                    wait_condition=lambda host: host.update_available or (
                         len([
                             event
                             for event in events_service.list(
                                 from_=int(last_event.id),
                                 search='type=885 and host.name=%s' % host.name,
                             )
-                        ]) > 0,
+                        ]) > 0
+                    ),
                     fail_condition=lambda host: len([
                         event
                         for event in events_service.list(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch add new action called 'check_for_upgrade' it's used before the actual upgrade procces of host happen.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
User can now descide if he want to check for upgrade before running the upgrade:
```yaml
---
- hosts: localhost
  connection: local
  vars_files:
    - ../vars.yml

  tasks:
  - name: Obtain SSO token
    ovirt_auth:
      url: "{{ url }}"
      username: "{{ username }}"
      password: "{{ password }}"
      insecure: "{{ insecure }}"

  - name: Upgrade
    ovirt_hosts:
      auth: "{{ ovirt_auth }}"
      state: upgraded
      name: host2
      check:true
```
