### PR TITLE
Add integration tests for multiline passwordstore lookups (#28436)

### DIFF
--- a/test/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -34,3 +34,35 @@
   assert:
     that:
         - "readpass == newpass"
+
+- name: define multiline password components
+  set_fact:
+    multiline_password: testpassword
+    multiline_rest: |
+      email: example@example.com
+      expires: 01/01/01
+
+- name: aggregate multiline password components into single fact
+  set_fact:
+    multiline_all: |
+      {{ multiline_password }}
+      {{ multiline_rest }}
+
+- name: import multiline password into pass
+  shell: 'echo "{{ multiline_all }}" | pass insert -m test-multiline'
+
+- name: fetch first line of multiline password
+  set_fact:
+    read_first_line: "{{ lookup('passwordstore', 'test-multiline') }}"
+
+- name: fetch all of multiline password
+  set_fact:
+    read_all_lines: "{{ lookup('passwordstore', 'test-multiline returnall=true') }}"
+
+- name: fetch multiline password from an existing file
+  assert:
+    that: "multiline_password == read_first_line"
+
+- name: fetch multiline password from an existing file
+  assert:
+    that: "multiline_all == read_all_lines"


### PR DESCRIPTION
##### SUMMARY
Additional tests for passwordstore lookups.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
passwordstore lookup

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
 ansible 2.4.0 (28436 b07a4a62c4) last updated 2017/08/19 16:53:52 (GMT +100)
  config file = /home/dan/.ansible.cfg
  configured module search path = ['/home/dan/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dan/code/ansible/lib/ansible
  executable location = /home/dan/.virtualenvs/ansible-dev/bin/ansible
  python version = 3.6.2 (default, Jul 20 2017, 03:52:27) [GCC 7.1.1 20170630]
```


##### ADDITIONAL INFORMATION
I wrote these while looking into #28436, which turned out to already be fixed, but I thought you guys might like them anyway :)