### PR TITLE
Fix trailing space in ec2_vol example, fix 'the the' typos

### DIFF
--- a/contrib/inventory/consul_io.ini
+++ b/contrib/inventory/consul_io.ini
@@ -5,7 +5,7 @@
 # restrict included nodes to those from this datacenter
 #datacenter = nyc1
 
-# url of the the consul cluster to query
+# url of the consul cluster to query
 #url = http://demo.consul.io
 url = http://localhost:8500
 

--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -288,7 +288,7 @@ class ConsulInventory(object):
 
     def load_node_metadata_from_kv(self, node_data):
         ''' load the json dict at the metadata path defined by the kv_metadata value
-            and the node name add each entry in the dictionary to the the node's
+            and the node name add each entry in the dictionary to the node's
             metadata '''
         node = node_data['Node']
         if self.config.has_config('kv_metadata'):

--- a/docs/docsite/rst/guide_aws.rst
+++ b/docs/docsite/rst/guide_aws.rst
@@ -117,7 +117,7 @@ From this, we'll use the add_host module to dynamically create a host group cons
          add_host: hostname={{ item.public_ip }} groups=ec2hosts
          with_items: "{{ ec2.instances }}"
 
-With the host group now created, a second play at the bottom of the the same provisioning playbook file might now have some configuration steps::
+With the host group now created, a second play at the bottom of the same provisioning playbook file might now have some configuration steps::
 
     # demo_setup.yml
 

--- a/docs/docsite/rst/playbook_pathing.rst
+++ b/docs/docsite/rst/playbook_pathing.rst
@@ -20,7 +20,7 @@ Some tasks that require 'local' resources use action plugins (template and copy 
 The magic of 'local' paths
 --------------------------
 
-Lookups and action plugins both use a special 'search magic' to find things, taking the current play into account, it uses from most specific to most general the the playbook dir in which a task is contained (this includes roles and includes).
+Lookups and action plugins both use a special 'search magic' to find things, taking the current play into account, it uses from most specific to most general playbook dir in which a task is contained (this includes roles and includes).
 
 Using this magic, relative paths get attempted first with a 'files|templates|vars' appended (if not already present), depending on action being taken, 'files' is the default. (i.e include_vars will use vars/).  The paths will be searched from most specific to most general (i.e role before play).
 dependent roles WILL be traversed (i.e task is in role2, role2 is a dependency of role1, role2 will be looked at first, then role1, then play).

--- a/docs/docsite/rst/playbooks_checkmode.rst
+++ b/docs/docsite/rst/playbooks_checkmode.rst
@@ -33,7 +33,7 @@ There are two options:
 1. Force a task to **run in check mode**, even when the playbook is called **without** ``--check``. This is called ``check_mode: yes``.
 2. Force a task to **run in normal mode** and make changes to the system, even when the playbook is called **with** ``--check``. This is called ``check_mode: no``.
 
-.. note:: Prior to version 2.2 only the the equivalent of ``check_mode: no`` existed. The notation for that was ``always_run: yes``.
+.. note:: Prior to version 2.2 only the equivalent of ``check_mode: no`` existed. The notation for that was ``always_run: yes``.
 
 Instead of ``yes``/``no`` you can use a Jinja2 expression, just like the ``when`` clause.
 
@@ -51,7 +51,7 @@ Example::
 
 
 Running single tasks with ``check_mode: yes`` can be useful to write tests for
-ansible modules, either to test the module itself or to the the conditions under
+ansible modules, either to test the module itself or to the conditions under
 which a module would make changes. 
 With ``register`` (see :doc:`playbooks_conditionals`) you can check the
 potential changes.

--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -6,7 +6,7 @@ Filters
 
 Filters in Ansible are from Jinja2, and are used for transforming data inside a template expression.  Jinja2 ships with many filters. See `builtin filters`_ in the official Jinja2 template documentation.
 
-Take into account that templating happens on the the Ansible controller, **not** on the task's target host, so filters also execute on the controller as they manipulate local data.
+Take into account that templating happens on the Ansible controller, **not** on the task's target host, so filters also execute on the controller as they manipulate local data.
 
 In addition the ones provided by Jinja2, Ansible ships with it's own and allows users to add their own custom filters.
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vol.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vol.py
@@ -151,7 +151,7 @@ EXAMPLES = '''
     count: 3
   register: ec2
 - ec2_vol:
-    instance: "{{ item.id }} "
+    instance: "{{ item.id }}"
     volume_size: 5
   with_items: "{{ ec2.instances }}"
   register: ec2_vol

--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -351,7 +351,7 @@ def find_stream(client, stream_name, check_mode=False):
 
 def wait_for_status(client, stream_name, status, wait_timeout=300,
                     check_mode=False):
-    """Wait for the the status to change for a Kinesis Stream.
+    """Wait for the status to change for a Kinesis Stream.
     Args:
         client (botocore.client.EC2): Boto3 client
         stream_name (str): The name of the kinesis stream.

--- a/lib/ansible/modules/cloud/centurylink/clc_modify_server.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_modify_server.py
@@ -661,7 +661,7 @@ class ClcModifyServer:
     def _ensure_aa_policy_absent(
             self, server, server_params):
         """
-        ensures the the provided anti affinity policy is removed from the server
+        ensures the provided anti affinity policy is removed from the server
         :param server: the CLC server object
         :param server_params: the dictionary of server parameters
         :return: (changed, group) -

--- a/lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
@@ -145,7 +145,7 @@ description:
   type: string
   sample: snapshot brought to you by Ansible
 domain:
-  description: Domain the the vm snapshot is related to.
+  description: Domain the vm snapshot is related to.
   returned: success
   type: string
   sample: example domain

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_connections.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_connections.py
@@ -34,7 +34,7 @@ description:
 options:
     id:
         description:
-            - "Id of the the storage connection to manage."
+            - "Id of the storage connection to manage."
     state:
         description:
             - "Should the storage connection be present or absent."
@@ -42,7 +42,7 @@ options:
         default: present
     storage:
         description:
-            - "Name of the the storage domain to be used with storage connection."
+            - "Name of the storage domain to be used with storage connection."
     address:
         description:
             - "Address of the storage server. E.g.: myserver.mydomain.com"

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -341,7 +341,7 @@ def main():
             storage_domain_service = storage_domains_service.storage_domain_service(sd_id)
             templates_service = storage_domain_service.templates_service()
 
-            # Find the the unregistered Template we want to register:
+            # Find the unregistered Template we want to register:
             templates = templates_service.list(unregistered=True)
             template = next(
                 (t for t in templates if t.name == module.params['name']),

--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -306,7 +306,7 @@ def remove_check(module, check_id):
 
 
 def add_service(module, service):
-    ''' registers a service with the the current agent '''
+    ''' registers a service with the current agent '''
     result = service
     changed = False
 

--- a/lib/ansible/modules/files/xml.py
+++ b/lib/ansible/modules/files/xml.py
@@ -78,7 +78,7 @@ options:
       or a hash where the key is an element name and the value is the element value.
   set_children:
     description:
-    - Set the the child-element(s) of a selected element.
+    - Set the child-element(s) of a selected element.
     - Removes any existing children.
     - Child elements must be specified as in C(add_children).
   count:

--- a/lib/ansible/modules/monitoring/librato_annotation.py
+++ b/lib/ansible/modules/monitoring/librato_annotation.py
@@ -52,11 +52,11 @@ options:
         required: false
     start_time:
         description:
-            - The unix timestamp indicating the the time at which the event referenced by this annotation started
+            - The unix timestamp indicating the time at which the event referenced by this annotation started
         required: false
     end_time:
         description:
-            - The unix timestamp indicating the the time at which the event referenced by this annotation ended
+            - The unix timestamp indicating the time at which the event referenced by this annotation ended
             - For events that have a duration, this is a useful way to annotate the duration of the event
         required: false
     links:

--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -35,7 +35,7 @@ options:
   timeout:
     description:
       - If there are pending actions for the service monitored by monit, then Ansible will check
-        for up to this many seconds to verify the the requested action has been performed.
+        for up to this many seconds to verify the requested action has been performed.
         Ansible will sleep for five seconds between each check.
     required: false
     default: 300

--- a/lib/ansible/modules/network/aos/aos_blueprint_param.py
+++ b/lib/ansible/modules/network/aos/aos_blueprint_param.py
@@ -54,7 +54,7 @@ options:
   value:
     description:
       - Blueprint parameter value.  This value may be transformed by using the
-        I(param_map) field; used when the the blueprint parameter requires
+        I(param_map) field; used when the blueprint parameter requires
         an AOS unique ID value.
   get_param_list:
     description:

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -124,7 +124,7 @@ options:
         True.  If the argument is set to I(modified), then the running-config
         will only be copied to the startup-config if it has changed since
         the last save to startup-config.  If the argument is set to
-        I(never), the running-config will never be copied to the the
+        I(never), the running-config will never be copied to the
         startup-config
     required: false
     default: never

--- a/lib/ansible/modules/network/bigswitch/bigmon_chain.py
+++ b/lib/ansible/modules/network/bigswitch/bigmon_chain.py
@@ -45,7 +45,7 @@ options:
     choices: [true, false]
   access_token:
     description:
-     - Bigmon access token. If this isn't set the the environment variable C(BIGSWITCH_ACCESS_TOKEN) is used.
+     - Bigmon access token. If this isn't set, the environment variable C(BIGSWITCH_ACCESS_TOKEN) is used.
 '''
 
 

--- a/lib/ansible/modules/network/bigswitch/bigmon_policy.py
+++ b/lib/ansible/modules/network/bigswitch/bigmon_policy.py
@@ -70,7 +70,7 @@ options:
     choices: [true, false]
   access_token:
     description:
-     - Bigmon access token. If this isn't set the the environment variable C(BIGSWITCH_ACCESS_TOKEN) is used.
+     - Bigmon access token. If this isn't set, the environment variable C(BIGSWITCH_ACCESS_TOKEN) is used.
 
 '''
 

--- a/lib/ansible/modules/network/cloudengine/ce_sflow.py
+++ b/lib/ansible/modules/network/cloudengine/ce_sflow.py
@@ -128,7 +128,7 @@ options:
         default: null
     counter_interval:
         description:
-            - Indicates the the counter sampling interval.
+            - Indicates the counter sampling interval.
               The value is an integer that ranges from 10 to 4294967295, in seconds. The default value is 20.
         required: false
         default: null

--- a/lib/ansible/modules/network/cumulus/nclu.py
+++ b/lib/ansible/modules/network/cumulus/nclu.py
@@ -138,7 +138,7 @@ def run_nclu(module, command_list, command_string, commit, atomic, abort, descri
 
     # First, look at the staged commands.
     before = check_pending(module)
-    # Run all of the the net commands
+    # Run all of the net commands
     output_lines = []
     for line in commands:
         output_lines += [command_helper(module, line.strip(), "Failed on line %s"%line)]

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -174,7 +174,7 @@ options:
         True.  If the argument is set to I(modified), then the running-config
         will only be copied to the startup-config if it has changed since
         the last save to startup-config.  If the argument is set to
-        I(never), the running-config will never be copied to the the
+        I(never), the running-config will never be copied to the
         startup-config
     required: false
     default: never

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -178,7 +178,7 @@ options:
         True.  If the argument is set to I(modified), then the running-config
         will only be copied to the startup-config if it has changed since
         the last save to startup-config.  If the argument is set to
-        I(never), the running-config will never be copied to the the
+        I(never), the running-config will never be copied to the
         startup-config
     required: false
     default: never

--- a/lib/ansible/modules/network/netconf/netconf_config.py
+++ b/lib/ansible/modules/network/netconf/netconf_config.py
@@ -24,7 +24,7 @@ description:
     - This module allows the user to send a configuration XML file to a netconf
       device, and detects if there was a configuration change.
 notes:
-    - This module supports devices with and without the the candidate and
+    - This module supports devices with and without the candidate and
       confirmed-commit capabilities. It always use the safer feature.
 version_added: "2.2"
 options:

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -174,7 +174,7 @@ options:
         True.  If the argument is set to I(modified), then the running-config
         will only be copied to the startup-config if it has changed since
         the last save to startup-config.  If the argument is set to
-        I(never), the running-config will never be copied to the the
+        I(never), the running-config will never be copied to the
         startup-config
     required: false
     default: never

--- a/lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py
+++ b/lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py
@@ -42,17 +42,17 @@ options:
         - Should https certificates be validated?
     source_volume_id:
         description:
-            - The the id of the volume copy source.
+            - The id of the volume copy source.
             - If used, must be paired with destination_volume_id
             - Mutually exclusive with volume_copy_pair_id, and search_volume_id
     destination_volume_id:
         description:
-            - The the id of the volume copy destination.
+            - The id of the volume copy destination.
             - If used, must be paired with source_volume_id
             - Mutually exclusive with volume_copy_pair_id, and search_volume_id
     volume_copy_pair_id:
         description:
-            - The the id of a given volume copy pair
+            - The id of a given volume copy pair
             - Mutually exclusive with destination_volume_id, source_volume_id, and search_volume_id
             - Can use to delete or check presence of volume pairs
             - Must specify this or (destination_volume_id and source_volume_id)

--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -654,7 +654,7 @@ def main():
             if not module.check_mode:
                 partition = [p for p in current_parts if p['num'] == number][0]
 
-            # Assign name to the the partition
+            # Assign name to the partition
             if name is not None and partition.get('name', None) != name:
                 script += "name %s %s " % (number, name)
 

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -43,7 +43,7 @@ requirements:
 options:
   account_key:
     description:
-      - "File containing the the Let's Encrypt account RSA key."
+      - "File containing the Let's Encrypt account RSA key."
       - "Can be created with C(openssl rsa ...)."
     required: true
   account_email:

--- a/test/integration/asa.yaml
+++ b/test/integration/asa.yaml
@@ -7,7 +7,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/eos.yaml
+++ b/test/integration/eos.yaml
@@ -7,7 +7,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/ios.yaml
+++ b/test/integration/ios.yaml
@@ -6,7 +6,7 @@
   vars:
     limit_to: "*"
     debug: false
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/iosxr.yaml
+++ b/test/integration/iosxr.yaml
@@ -7,7 +7,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/junos.yaml
+++ b/test/integration/junos.yaml
@@ -8,7 +8,7 @@
     debug: false
 
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/nxos.yaml
+++ b/test/integration/nxos.yaml
@@ -7,7 +7,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/ops.yaml
+++ b/test/integration/ops.yaml
@@ -7,7 +7,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/ovs.yaml
+++ b/test/integration/ovs.yaml
@@ -8,7 +8,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/platform_agnostic.yaml
+++ b/test/integration/platform_agnostic.yaml
@@ -8,7 +8,7 @@
     debug: false
 
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 

--- a/test/integration/vyos.yaml
+++ b/test/integration/vyos.yaml
@@ -7,7 +7,7 @@
     limit_to: "*"
     debug: false
 
-# Run the tests within blocks allows the the next module to be tested if the previous one fails.
+# Run the tests within blocks allows the next module to be tested if the previous one fails.
 # This is done to allow https://github.com/ansible/dci-partner-ansible/ to run the full set of tests.
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Fix a trailing space in an ec2_vol module example, in `instance: "{{ item.id }} "`. The trailing space makes the example fail because Ansible looks for `instance: "i-xxxxx "`, which is an invalid EC2 instance ID.
* Fix all 'the the' typos to a single 'the'. This affects many files.
* Fix the filename of `playbook_pahting.rst` to `playbook_pathing.rst`. I don't think this file is used anywhere though.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/consul_io.ini
contrib/inventory/consul_io.py
docs/docsite/rst/guide_aws.rst
docs/docsite/rst/{playbook_pahting.rst → playbook_pathing.rst}
docs/docsite/rst/playbooks_checkmode.rst
docs/docsite/rst/playbooks_filters.rst
lib/ansible/modules/cloud/amazon/ec2_vol.py
lib/ansible/modules/cloud/amazon/kinesis_stream.py
lib/ansible/modules/cloud/centurylink/clc_modify_server.py
lib/ansible/modules/cloud/cloudstack/cs_vmsnapshot.py
lib/ansible/modules/cloud/ovirt/ovirt_storage_connections.py
lib/ansible/modules/cloud/ovirt/ovirt_templates.py
lib/ansible/modules/clustering/consul.py
lib/ansible/modules/files/xml.py
lib/ansible/modules/monitoring/librato_annotation.py
lib/ansible/modules/monitoring/monit.py
lib/ansible/modules/network/aos/aos_blueprint_param.py
lib/ansible/modules/network/aruba/aruba_config.py
lib/ansible/modules/network/bigswitch/bigmon_chain.py
lib/ansible/modules/network/bigswitch/bigmon_policy.py
lib/ansible/modules/network/cloudengine/ce_sflow.py
lib/ansible/modules/network/cumulus/nclu.py
lib/ansible/modules/network/eos/eos_config.py
lib/ansible/modules/network/ios/ios_config.py
lib/ansible/modules/network/netconf/netconf_config.py
lib/ansible/modules/network/nxos/nxos_config.py
lib/ansible/modules/storage/netapp/netapp_e_volume_copy.py
lib/ansible/modules/system/parted.py
lib/ansible/modules/web_infrastructure/letsencrypt.py
test/integration/asa.yaml
test/integration/eos.yaml
test/integration/ios.yaml
test/integration/iosxr.yaml
test/integration/junos.yaml
test/integration/nxos.yaml
test/integration/ops.yaml
test/integration/ovs.yaml
test/integration/platform_agnostic.yaml
test/integration/vyos.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 76bcce7e72) last updated 2017/08/19 16:20:08 (GMT +000)
  config file = None
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/ansible/lib/ansible
  executable location = /home/ubuntu/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
