### PR TITLE
Fix networks update issue

### DIFF
--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -136,7 +136,7 @@ options:
     required: false
   format:
     description:
-      - Target drive’s backing file’s data format.
+      - Target drive's backing file's data format.
       - Used only with clone
     default: qcow2
     choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk" ]
@@ -162,7 +162,7 @@ options:
       - Values allowed are -  C("host="HOSTPCIID[;HOSTPCIID2...]",pcie="1|0",rombar="1|0",x-vga="1|0"").
       - The C(host) parameter is Host PCI device pass through. HOSTPCIID syntax is C(bus:dev.func) (hexadecimal numbers).
       - C(pcie=boolean) I(default=0) Choose the PCI-express bus (needs the q35 machine model).
-      - C(rombar=boolean) I(default=1) Specify whether or not the device’s ROM will be visible in the guest’s memory map.
+      - C(rombar=boolean) I(default=1) Specify whether or not the device's ROM will be visible in the guest's memory map.
       - C(x-vga=boolean) I(default=0) Enable vfio-vga device support.
       - /!\ This option allows direct access to host hardware. So it is no longer possible to migrate such machines - use with special care.
     required: false
@@ -187,7 +187,7 @@ options:
       - Values allowed are - C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
+      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
     required: false
     default: null
   keyboard:
@@ -327,7 +327,7 @@ options:
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
+      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
     default: null
     required: false
   scsi:
@@ -337,7 +337,7 @@ options:
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
+      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
     default: null
     required: false
   scsihw:
@@ -469,7 +469,7 @@ options:
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
+      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
     required: false
     default: null
   vmid:

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -434,7 +434,7 @@ options:
     choices: [ "yes", "no" ]
   timeout:
     description:
-      - Timeout for operations. C(clone) can take a while. Increase the timeout if need.
+      - Timeout for operations.
     default: 30
     required: false
   update:

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -434,7 +434,7 @@ options:
     choices: [ "yes", "no" ]
   timeout:
     description:
-      - Timeout for operations.
+      - Timeout for operations. C(clone) can take a while. Increase the timeout if need.
     default: 30
     required: false
   update:
@@ -478,6 +478,7 @@ options:
       - If vmid is not set, the next available VM ID will be fetched from ProxmoxAPI.
     default: null
     required: false
+    type: integer
   watchdog:
     description:
       - Creates a virtual hardware watchdog device.

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -478,7 +478,6 @@ options:
       - If vmid is not set, the next available VM ID will be fetched from ProxmoxAPI.
     default: null
     required: false
-    type: integer
   watchdog:
     description:
       - Creates a virtual hardware watchdog device.

--- a/lib/ansible/modules/cloud/misc/proxmox_kvm.py
+++ b/lib/ansible/modules/cloud/misc/proxmox_kvm.py
@@ -136,7 +136,7 @@ options:
     required: false
   format:
     description:
-      - Target drive's backing file's data format.
+      - Target drive’s backing file’s data format.
       - Used only with clone
     default: qcow2
     choices: [ "cloop", "cow", "qcow", "qcow2", "qed", "raw", "vmdk" ]
@@ -162,7 +162,7 @@ options:
       - Values allowed are -  C("host="HOSTPCIID[;HOSTPCIID2...]",pcie="1|0",rombar="1|0",x-vga="1|0"").
       - The C(host) parameter is Host PCI device pass through. HOSTPCIID syntax is C(bus:dev.func) (hexadecimal numbers).
       - C(pcie=boolean) I(default=0) Choose the PCI-express bus (needs the q35 machine model).
-      - C(rombar=boolean) I(default=1) Specify whether or not the device's ROM will be visible in the guest's memory map.
+      - C(rombar=boolean) I(default=1) Specify whether or not the device’s ROM will be visible in the guest’s memory map.
       - C(x-vga=boolean) I(default=0) Enable vfio-vga device support.
       - /!\ This option allows direct access to host hardware. So it is no longer possible to migrate such machines - use with special care.
     required: false
@@ -187,7 +187,7 @@ options:
       - Values allowed are - C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
+      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     required: false
     default: null
   keyboard:
@@ -327,7 +327,7 @@ options:
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
+      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     default: null
     required: false
   scsi:
@@ -337,7 +337,7 @@ options:
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
+      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     default: null
     required: false
   scsihw:
@@ -441,7 +441,7 @@ options:
     description:
       - If C(yes), the VM will be update with new value.
       - Cause of the operations of the API and security reasons, I have disabled the update of the following parameters
-      - C(net, virtio, ide, sata, scsi). Per example updating C(net) update the MAC address and C(virtio) create always new disk...
+      - C(virtio, ide, sata, scsi). Per example updating C(virtio) create always new disk...
     default: "no"
     choices: [ "yes", "no" ]
     required: false
@@ -469,7 +469,7 @@ options:
       - Values allowed are -  C("storage:size,format=value").
       - C(storage) is the storage identifier where to create the disk.
       - C(size) is the size of the disk in GB.
-      - C(format) is the drive's backing file's data format. C(qcow2|raw|subvol).
+      - C(format) is the drive’s backing file’s data format. C(qcow2|raw|subvol).
     required: false
     default: null
   vmid:
@@ -817,8 +817,6 @@ def create_vm(module, proxmox, vmid, newid, node, name, memory, cpu, cores, sock
             del kwargs['scsi']
         if 'ide' in kwargs:
             del kwargs['ide']
-        if 'net' in kwargs:
-            del kwargs['net']
 
     # Convert all dict in kwargs to elements. For hostpci[n], ide[n], net[n], numa[n], parallel[n], sata[n], scsi[n], serial[n], virtio[n]
     for k in kwargs.keys():

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -319,7 +319,7 @@ class Host(object):
                     flag = False
                     interface_str = interface
                     for exist_interface in exist_interface_list:
-                        interface_type = interface['type']
+                        interface_type = int(interface['type'])
                         exist_interface_type = int(exist_interface['type'])
                         if interface_type == exist_interface_type:
                             # update


### PR DESCRIPTION
##### SUMMARY
Now is possible to update networks interface with any driver.

Fixes #28277 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
[ansible/lib/ansible/modules/cloud/misc/proxmox_kvm.py](ansible/lib/ansible/modules/cloud/misc/proxmox_kvm.py)

##### ANSIBLE VERSION
```
ansible --version
ansible 2.3.2.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```

##### ADDITIONAL INFORMATION
Please note, in production modifying the MAC address can cause unexpected failures in your network infrastructure. 

Make sure you can modify the MAC address without any problem in your infrastructure or use the return values form the library to get the real MAC address from the API. See [Return values](https://docs.ansible.com/ansible/latest/proxmox_kvm_module.html#return-values)
