### PR TITLE
Update qos parameter for volume manager and update example. (#27594)

### DIFF
--- a/lib/ansible/modules/storage/netapp/sf_volume_manager.py
+++ b/lib/ansible/modules/storage/netapp/sf_volume_manager.py
@@ -49,7 +49,7 @@ options:
         required: false
 
     qos:
-        description: Initial quality of service settings for this volume.
+        description: Initial quality of service settings for this volume. Configure as dict in playbooks.
         required: false
         default: None
 
@@ -102,6 +102,7 @@ EXAMPLES = """
        password: "{{ solidfire_password }}"
        state: present
        name: AnsibleVol
+       qos: {minIOPS: 1000, maxIOPS: 20000, burstIOPS: 50000}
        account_id: 3
        enable512e: False
        size: 1
@@ -156,7 +157,7 @@ class SolidFireVolume(object):
             account_id=dict(required=True, type='int'),
 
             enable512e=dict(type='bool', aliases=['512emulation']),
-            qos=dict(required=False, type='str', default=None),
+            qos=dict(required=False, type='dict', default=None),
             attributes=dict(required=False, type='dict', default=None),
 
             volume_id=dict(type='int', default=None),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Similar to #27596 but branch is up to date.  Update quality of service parameter to be of type dict.  
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #27594. 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/storage/netapp/sf_volume_mananger.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (sf-volume-qos e1bde4754e) last updated 2017/08/19 11:05:58 (GMT -600)
  config file = None
  configured module search path = ['/home/khulques/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/khulques/src/projects/ansible/lib/ansible
  executable location = /home/khulques/src/projects/ansible/bin/ansible
  python version = 3.6.2 (default, Jul 17 2017, 23:14:31) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
(py36) (khulques):ansible $ git checkout devel
Switched to branch 'devel'
Your branch is up-to-date with 'origin/devel'.
(py36) (khulques):ansible $ ansible-playbook -i localhost sf-playbook.yml 
 [WARNING]: Host file not found: localhost

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [Testing SF Stuff] ********************************************************

TASK [Remove volume] ***********************************************************
changed: [localhost]

TASK [Create Volume] ***********************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ApiServerError(method_name="CreateVolume", err_json={"error": {"code": 500, "message": "qos: Invalid type: expected object but found \"{'minIOPS': 1000, 'maxIOPS': 20000, 'burstIOPS': 50000}\"\n", "name": "xInvalidParameterType"}, "id": 2})
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Error provisioning volume ansibleVolume of size 1000000000"}
	to retry, use: --limit @/home/khulques/src/projects/ansible/sf-playbook.retry

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=1   

```
After:
```
(py36) (khulques):ansible $ ansible-playbook -i localhost sf-playbook.yml 
 [WARNING]: Unable to parse /home/khulques/src/projects/ansible/localhost as an
inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: Could not match supplied host pattern, ignoring: all

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [Testing SF Stuff] ********************************************************

TASK [Remove volume] ***********************************************************
changed: [localhost]

TASK [Create Volume] ***********************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=2    unreachable=0    failed=0   

```
