### PR TITLE
win_reboot: Bugfix to check-mode and async support, and features

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -1,28 +1,11 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-# this is a windows documentation stub.  actual code lives in the .ps1
-# file of the same name
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
-
 
 DOCUMENTATION = r'''
 ---
@@ -36,6 +19,12 @@ options:
     description:
     - Seconds for shutdown to wait before requesting reboot
     default: 2
+  post_reboot_delay_sec:
+    description:
+    - Seconds to wait after the reboot was successful and the connection was re-established
+    - This is useful if you want wait for something to settle despite your connection already working
+    default: 0
+    version_added: '2.4'
   shutdown_timeout_sec:
     description:
     - Maximum seconds to wait for shutdown to occur
@@ -86,4 +75,9 @@ rebooted:
     returned: always
     type: boolean
     sample: true
+elapsed:
+  description: The number of seconds that elapsed waiting for the system to be rebooted.
+  returned: always
+  type: int
+  sample: 23
 '''


### PR DESCRIPTION
##### SUMMARY
These gems were hidden in an old PR #22178, I decoupled them from the more experimental stuff.

This PR includes:
- Check-mode support, the module will now report as if it was rebooted, without making the actual reboot.
- Async-support, this potentially fixes #23835
- The module now also returns the elapsed time, like the **wait_for** and **wait_for_connection** modules do. This fixes #18108
- Add `post_reboot_delay_sec` parameter
- A fix for **win_reboot** and **wait_for_connection** related to `e` not being always set

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
win_reboot

##### ANSIBLE VERSION
v2.4