### PR TITLE
Add ansible_ssh_host_key_ecdsa_public_subtype fact

### DIFF
--- a/lib/ansible/module_utils/facts/system/ssh_pub_keys.py
+++ b/lib/ansible/module_utils/facts/system/ssh_pub_keys.py
@@ -31,22 +31,24 @@ class SshPubKeyFactCollector(BaseFactCollector):
 
     def collect(self, module=None, collected_facts=None):
         ssh_pub_key_facts = {}
-        keytypes = ('dsa', 'rsa', 'ecdsa', 'ed25519')
+        algos = ('dsa', 'rsa', 'ecdsa', 'ed25519')
 
         # list of directories to check for ssh keys
         # used in the order listed here, the first one with keys is used
         keydirs = ['/etc/ssh', '/etc/openssh', '/etc']
 
         for keydir in keydirs:
-            for type_ in keytypes:
-                factname = 'ssh_host_key_%s_public' % type_
+            for algo in algos:
+                factname = 'ssh_host_key_%s_public' % algo
                 if factname in ssh_pub_key_facts:
                     # a previous keydir was already successful, stop looking
                     # for keys
                     return ssh_pub_key_facts
-                key_filename = '%s/ssh_host_%s_key.pub' % (keydir, type_)
+                key_filename = '%s/ssh_host_%s_key.pub' % (keydir, algo)
                 keydata = get_file_content(key_filename)
                 if keydata is not None:
-                    ssh_pub_key_facts[factname] = keydata.split()[1]
+                    (keytype, key) = keydata.split()[0:2]
+                    ssh_pub_key_facts[factname] = key
+                    ssh_pub_key_facts[factname + '_keytype'] = keytype
 
         return ssh_pub_key_facts


### PR DESCRIPTION
##### SUMMARY
Fixes #28325: Add ansible_ssh_host_key_ecdsa_public_subtype fact

For SSH host key type ecdsa, there are at least three subtypes. User requested a fact to specify the subtype of the ecdsa key found by the setup module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible/lib/ansible/module_utils/facts/system/ssh_pub_keys.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (nrwahl2-ssh_host_key_ecdsa_public_type d70516ce91) last updated 2017/08/20 02:51:58 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/u/nwahl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /u/nwahl/ansible/lib/ansible
  executable location = /u/nwahl/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
BEFORE:
```
$ ansible localhost -c local -i hosts.ini -m setup -a 'filter=*ecdsa*'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_ssh_host_key_ecdsa_public": "<key>"
    },
    "changed": false,
    "failed": false
}
```
AFTER:
```
$ ansible localhost -c local -i hosts.ini -m setup -a 'filter=*ecdsa*'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_ssh_host_key_ecdsa_public": "<key>",
        "ansible_ssh_host_key_ecdsa_public_subtype": "ecdsa-sha2-nistp256"
    },
    "changed": false,
    "failed": false
}
```