### PR TITLE
Remove transport_test for some connection types

### DIFF
--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -130,14 +130,6 @@ class Connection(ConnectionBase):
 
     transport = 'paramiko'
 
-    def transport_test(self, connect_timeout):
-        ''' Test the transport mechanism, if available '''
-        host = self._play_context.remote_addr
-        port = int(self._play_context.port or 22)
-        display.vvv("attempting transport test to %s:%s" % (host, port))
-        sock = socket.create_connection((host, port), connect_timeout)
-        sock.close()
-
     def _cache_key(self):
         return "%s__%s__" % (self._play_context.remote_addr, self._play_context.remote_user)
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -260,13 +260,6 @@ class Connection(ConnectionBase):
     def _connect(self):
         return self
 
-    def transport_test(self, connect_timeout):
-        ''' Test the transport mechanism, if available '''
-        port = int(self.port or 22)
-        display.vvv("attempting transport test to %s:%s" % (self.host, port))
-        sock = socket.create_connection((self.host, port), connect_timeout)
-        sock.close()
-
     @staticmethod
     def _create_control_path(host, port, user):
         '''Make a hash for the controlpath based on con attributes'''

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -90,14 +90,6 @@ class Connection(ConnectionBase):
 
         super(Connection, self).__init__(*args, **kwargs)
 
-    def transport_test(self, connect_timeout):
-        ''' Test the transport mechanism, if available '''
-        host = self._winrm_host
-        port = int(self._winrm_port)
-        display.vvv("attempting transport test to %s:%s" % (host, port))
-        sock = socket.create_connection((host, port), connect_timeout)
-        sock.close()
-
     def set_host_overrides(self, host, hostvars=None):
         '''
         Override WinRM-specific options from host variables.


### PR DESCRIPTION
##### SUMMARY
So we are removing the transport_test for the listed connection types, because they fail to take into account bastion or proxy servers for testing the transport.

The result of removing this, is that modules using this facility will do a complete connection round-trip attempt from the very start, running the ping module, which is a bit heavier but at least is supposed to work.

I have left the transport_test facility in place, since it's not impossible to write lightweight test for connection types.

This fixes #23774 and fixes #23766

This should probably be backported to v2.3

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
wait_for_connection win_reboot

##### ANSIBLE VERSION
v2.4