### PR TITLE
Add fs_type option in parted module

### DIFF
--- a/lib/ansible/modules/system/parted.py
+++ b/lib/ansible/modules/system/parted.py
@@ -97,6 +97,12 @@ options:
        only return the device information.
     choices: ['present', 'absent', 'info']
     default: info
+  fs_type:
+    description:
+     - If specified, will set filesystem type to given partition
+    choices: ['btrfs', 'ext2', 'ext3', 'ext4', 'fat16', 'fat32', 'hfs', 'hfs+', 'linux-swap', 'ntfs', 'reiserfs', 'xfs']
+    default: 'ext4'
+    version_added: '2.4'
 '''
 
 RETURN = '''
@@ -564,6 +570,14 @@ def main():
             },
             'part_start': {'default': '0%', 'type': 'str'},
             'part_end': {'default': '100%', 'type': 'str'},
+            'fs_type': {
+                'default': 'ext4',
+                'choices': [
+                    'btrfs', 'ext2', 'ext3', 'ext4', 'fat16', 'fat32', 'hfs',
+                    'hfs+', 'linux-swap', 'ntfs', 'reiserfs', 'xfs'
+                ],
+                'type': 'str'
+            },
 
             # name <partition> <name> command
             'name': {'type': 'str'},
@@ -594,6 +608,7 @@ def main():
     name = module.params['name']
     state = module.params['state']
     flags = module.params['flags']
+    fs_type = module.params['fs_type']
 
     # Parted executable
     parted_exec = module.get_bin_path('parted', True)
@@ -629,8 +644,9 @@ def main():
 
         # Create partition if required
         if part_type and not part_exists(current_parts, 'num', number):
-            script += "mkpart %s %s %s " % (
+            script += "mkpart %s %s %s %s " % (
                 part_type,
+                fs_type,
                 part_start,
                 part_end
             )

--- a/test/units/modules/system/test_parted.py
+++ b/test/units/modules/system/test_parted.py
@@ -188,7 +188,7 @@ class TestParted(unittest.TestCase):
             'state': 'present',
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 0% 100%')
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext4 0% 100%')
 
     def test_create_new_partition_1G(self):
         set_module_args({
@@ -198,7 +198,7 @@ class TestParted(unittest.TestCase):
             'part_end': '1GiB',
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 0% 1GiB')
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext4 0% 1GiB')
 
     def test_remove_partition_number_1(self):
         set_module_args({
@@ -246,7 +246,7 @@ class TestParted(unittest.TestCase):
             '_ansible_check_mode': True,
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict1):
-            self.execute_module(changed=True, script='unit KiB mkpart primary 257GiB 100% unit KiB set 4 boot on')
+            self.execute_module(changed=True, script='unit KiB mkpart primary ext4 257GiB 100% unit KiB set 4 boot on')
 
     def test_create_label_gpt(self):
         # Like previous test, current implementation use parted to create the partition and
@@ -262,4 +262,4 @@ class TestParted(unittest.TestCase):
             '_ansible_check_mode': True,
         })
         with patch('ansible.modules.system.parted.get_device_info', return_value=parted_dict2):
-            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary 0% 100% unit KiB name 1 lvmpartition set 1 lvm on')
+            self.execute_module(changed=True, script='unit KiB mklabel gpt mkpart primary ext4 0% 100% unit KiB name 1 lvmpartition set 1 lvm on')


### PR DESCRIPTION
##### SUMMARY
With this fix user can specify optional fs_type parameter
in mkpart subcommand of parted command.

Fixes: #28126

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/parted.py

##### ANSIBLE VERSION
```
2.4devel
```