### PR TITLE
Add single_branch option in git module.

### DIFF
--- a/changelogs/fragments/git-add-single_branch.yml
+++ b/changelogs/fragments/git-add-single_branch.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - git - add ``single_branch`` parameter (https://github.com/ansible/ansible/pull/28465)

--- a/lib/ansible/modules/git.py
+++ b/lib/ansible/modules/git.py
@@ -266,7 +266,7 @@ warnings:
     description: List of warnings if requested features were not available due to a too old git version.
     returned: error
     type: str
-    sample: Your git version is too old to fully support the depth argument. Falling back to full checkouts.
+    sample: git version is too old to fully support the depth argument. Falling back to full checkouts.
 git_dir_now:
     description: Contains the new path of .git directory if it's changed
     returned: success
@@ -499,7 +499,7 @@ def clone(git_path, module, repo, dest, remote, depth, version, bare,
             module.fail_json(msg='Cannot find git executable at %s' % git_path)
 
         if git_version_used < LooseVersion('1.7.10'):
-            module.warn("The git version '%s' is too old to use 'single-branch'" % git_version_used)
+            module.warn("git version '%s' is too old to use 'single-branch'. Ignoring." % git_version_used)
         else:
             cmd.append("--single-branch")
 
@@ -1183,7 +1183,7 @@ def main():
     git_version_used = git_version(git_path, module)
 
     if depth is not None and git_version_used < LooseVersion('1.9.1'):
-        result['warnings'].append("Your git version is too old to fully support the depth argument. Falling back to full checkouts.")
+        module.warn("git version is too old to fully support the depth argument. Falling back to full checkouts.")
         depth = None
 
     recursive = module.params['recursive']

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -26,6 +26,7 @@
 - import_tasks: submodules.yml
 - import_tasks: change-repo-url.yml
 - import_tasks: depth.yml
+- import_tasks: single-branch.yml
 - import_tasks: checkout-new-tag.yml
 - include_tasks: gpg-verification.yml
   when:

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -16,25 +16,25 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- include_tasks: setup.yml
-- include_tasks: setup-local-repos.yml
+- import_tasks: setup.yml
+- import_tasks: setup-local-repos.yml
 
-- include_tasks: formats.yml
-- include_tasks: missing_hostkey.yml
-- include_tasks: no-destination.yml
-- include_tasks: specific-revision.yml
-- include_tasks: submodules.yml
-- include_tasks: change-repo-url.yml
-- include_tasks: depth.yml
-- include_tasks: checkout-new-tag.yml
+- import_tasks: formats.yml
+- import_tasks: missing_hostkey.yml
+- import_tasks: no-destination.yml
+- import_tasks: specific-revision.yml
+- import_tasks: submodules.yml
+- import_tasks: change-repo-url.yml
+- import_tasks: depth.yml
+- import_tasks: checkout-new-tag.yml
 - include_tasks: gpg-verification.yml
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
     - git_version.stdout is version("2.1.0", '>=')
-- include_tasks: localmods.yml
-- include_tasks: reset-origin.yml
-- include_tasks: ambiguous-ref.yml
-- include_tasks: archive.yml
-- include_tasks: separate-git-dir.yml
-- include_tasks: forcefully-fetch-tag.yml
+- import_tasks: localmods.yml
+- import_tasks: reset-origin.yml
+- import_tasks: ambiguous-ref.yml
+- import_tasks: archive.yml
+- import_tasks: separate-git-dir.yml
+- import_tasks: forcefully-fetch-tag.yml

--- a/test/integration/targets/git/tasks/single-branch.yml
+++ b/test/integration/targets/git/tasks/single-branch.yml
@@ -1,0 +1,68 @@
+# Test single_branch parameter
+
+- name: SINGLE_BRANCH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
+
+- name: SINGLE_BRANCH | Clone example git repo using single_branch
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
+    dest: '{{ checkout_dir }}'
+    single_branch: yes
+  register: single_branch_1
+
+- name: SINGLE_BRANCH | Clone example git repo using single_branch again
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
+    dest: '{{ checkout_dir }}'
+    single_branch: yes
+  register: single_branch_2
+
+- name: SINGLE_BRANCH | List revisions
+  command: git rev-list --all --count
+  args:
+    chdir: '{{ checkout_dir }}'
+  register: rev_list1
+
+- name: SINGLE_BRANCH | Ensure single_branch did the right thing
+  assert:
+    that:
+      - single_branch_1 is changed
+      - single_branch_2 is not changed
+      - rev_list1.stdout == '3'
+
+
+- name: SINGLE_BRANCH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
+
+- name: SINGLE_BRANCH | Clone example git repo using single_branch with version
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
+    dest: '{{ checkout_dir }}'
+    single_branch: yes
+    version: master
+  register: single_branch_3
+
+- name: SINGLE_BRANCH | Clone example git repo using single_branch with version again
+  git:
+    repo: 'file://{{ repo_dir|expanduser }}/shallow_branches'
+    dest: '{{ checkout_dir }}'
+    single_branch: yes
+    version: master
+  register: single_branch_4
+
+- name: SINGLE_BRANCH | List revisions
+  command: git rev-list --all --count
+  args:
+    chdir: '{{ checkout_dir }}'
+  register: rev_list2
+
+- name: SINGLE_BRANCH | Ensure single_branch did the right thing
+  assert:
+    that:
+      - single_branch_3 is changed
+      - single_branch_4 is not changed
+      - rev_list2.stdout == '1'

--- a/test/integration/targets/git/tasks/single-branch.yml
+++ b/test/integration/targets/git/tasks/single-branch.yml
@@ -24,13 +24,22 @@
   args:
     chdir: '{{ checkout_dir }}'
   register: rev_list1
+  when: git_version.stdout is version(git_version_supporting_single_branch, '>=')
 
-- name: SINGLE_BRANCH | Ensure single_branch did the right thing
+- name: SINGLE_BRANCH | Ensure single_branch did the right thing with git >= {{ git_version_supporting_single_branch }}
   assert:
     that:
       - single_branch_1 is changed
       - single_branch_2 is not changed
-      - rev_list1.stdout == '3'
+  when: git_version.stdout is version(git_version_supporting_single_branch, '>=')
+
+- name: SINGLE_BRANCH | Ensure single_branch did the right thing with git < {{ git_version_supporting_single_branch }}
+  assert:
+    that:
+      - single_branch_1 is changed
+      - single_branch_1.warnings | length == 1
+      - single_branch_2 is not changed
+  when: git_version.stdout is version(git_version_supporting_single_branch, '<')
 
 
 - name: SINGLE_BRANCH | clear checkout_dir
@@ -59,10 +68,20 @@
   args:
     chdir: '{{ checkout_dir }}'
   register: rev_list2
+  when: git_version.stdout is version(git_version_supporting_single_branch, '>=')
 
-- name: SINGLE_BRANCH | Ensure single_branch did the right thing
+- name: SINGLE_BRANCH | Ensure single_branch did the right thing with git >= {{ git_version_supporting_single_branch }}
   assert:
     that:
       - single_branch_3 is changed
       - single_branch_4 is not changed
       - rev_list2.stdout == '1'
+  when: git_version.stdout is version(git_version_supporting_single_branch, '>=')
+
+- name: SINGLE_BRANCH | Ensure single_branch did the right thing with git < {{ git_version_supporting_single_branch }}
+  assert:
+    that:
+      - single_branch_3 is changed
+      - single_branch_3.warnings | length == 1
+      - single_branch_4 is not changed
+  when: git_version.stdout is version(git_version_supporting_single_branch, '<')

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -43,6 +43,7 @@ known_host_files:
   - '/etc/ssh/ssh_known_hosts'
 git_version_supporting_depth: 1.9.1
 git_version_supporting_ls_remote: 1.7.5
+git_version_supporting_single_branch: 1.7.10
 # path to a SSH private key for use with github.com (tests skipped if undefined)
 # github_ssh_private_key: "{{ lookup('env', 'HOME') }}/.ssh/id_rsa"
 git_gpg_testkey: |


### PR DESCRIPTION
##### SUMMARY

In some usecases, we want to be able to clone a single branch
of a repository, without using --depth (which implies --single-branch).

Fixes https://github.com/ansible/ansible-modules-core/issues/1463

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
source_control/git

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (git_single_branch 127b28cbab) last updated 2017/08/21 11:16:53 (GMT +200)
  config file = None
  configured module search path = [u'/home/ed/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ed/ansible/lib/ansible
  executable location = /home/ed/ansible/bin/ansible
  python version = 2.7.13+ (default, Jul 19 2017, 18:15:03) [GCC 6.4.0 20170704]
```