### PR TITLE
Add sql_log_bin option to mysql_db module

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -69,7 +69,7 @@ options:
     required: false
     choices: [ "yes", "no" ]
     default: "yes"
-    version_added: "2.3"
+    version_added: "2.4"
 author: "Ansible Core Team"
 requirements:
    - mysql (command line binary)
@@ -107,12 +107,12 @@ EXAMPLES = '''
     state: import
     name: all
     target: /tmp/{{ inventory_hostname }}.sql
-    
- # Example of skipping binary logging while creating database 'metrics_eu'
- - mysql_db: 
-     name: metrics_eu
-     state: present
-     sql_log_bin: no
+
+- name: Create a database with binary log turned off
+  mysql_db:
+    name: metrics_eu
+    state: present
+    sql_log_bin: no
 '''
 
 import os
@@ -335,8 +335,8 @@ def main():
             module.fail_json(msg="unable to find %s. Exception message: %s" % (config_file, to_native(e)))
 
     if not sql_log_bin:
-      cursor.execute("SET SQL_LOG_BIN=0;")
-            
+        cursor.execute("SET SQL_LOG_BIN=0;")
+
     changed = False
     if not os.path.exists(config_file):
         config_file = None


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Added option to disable MySQL bin log for the connection used to create the database (like mysql_user module)

Implementation "based on" ansible/ansible-modules-core#2639 and "copy-pasted" from https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/database/mysql/mysql_user.py

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

`mysql_db` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
