### PR TITLE
vmware_vswitch: Improve integration tests

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vswitch.py
@@ -18,67 +18,64 @@ DOCUMENTATION = '''
 module: vmware_vswitch
 short_description: Add or remove a VMware Standard Switch to an ESXi host
 description:
-    - Add or remove a VMware Standard Switch to an ESXi host
+- Add or remove a VMware Standard Switch to an ESXi host.
 version_added: 2.0
 author:
-    - Joseph Callen (@jcpowermac)
-    - Russell Teague (@mtnbikenc)
+- Joseph Callen (@jcpowermac)
+- Russell Teague (@mtnbikenc)
 notes:
-    - Tested on vSphere 5.5
+- Tested on vSphere 5.5
 requirements:
-    - "python >= 2.6"
-    - PyVmomi
+- python >= 2.6
+- PyVmomi
 options:
-    switch:
-        description:
-            - vSwitch name to add
-            - Alias C('switch') is added in version 2.4
-        required: True
-        aliases: ['switch_name']
-    nics:
-        description:
-            - A list of vmnic names or vmnic name to attach to vSwitch
-            - Alias C('nics') is added in version 2.4
-        required: False
-        aliases: ['nic_name']
-    number_of_ports:
-        description:
-            - Number of port to configure on vSwitch
-        default: 128
-        required: False
-    mtu:
-        description:
-            - MTU to configure on vSwitch
-        required: False
-    state:
-        description:
-            - Add or remove the switch
-        default: 'present'
-        choices:
-            - 'present'
-            - 'absent'
-        required: False
-extends_documentation_fragment: vmware.documentation
+  switch:
+    description:
+    - vSwitch name to add.
+    - Alias C(switch) is added in version 2.4.
+    required: yes
+    aliases: [ switch_name ]
+  nics:
+    description:
+    - A list of vmnic names or vmnic name to attach to vSwitch.
+    - Alias C(nics) is added in version 2.4.
+    aliases: [ nic_name ]
+  number_of_ports:
+    description:
+    - Number of port to configure on vSwitch.
+    default: 128
+  mtu:
+    description:
+    - MTU to configure on vSwitch.
+  state:
+    description:
+    - Add or remove the switch.
+    default: present
+    choices: [ absent, present ]
+extends_documentation_fragment:
+- vmware.documentation
 '''
 
 EXAMPLES = '''
 - name: Add a VMware vSwitch
-  local_action:
+  action:
     module: vmware_vswitch
     hostname: esxi_hostname
     username: esxi_username
     password: esxi_password
-    switch_name: vswitch_name
-    nic_name: vmnic_name
+    switch: vswitch_name
+    nics: vmnic_name
     mtu: 9000
+  delegate_to: localhost
 
 - name: Add a VMWare vSwitch without any physical NIC attached
   vmware_vswitch:
     hostname: 192.168.10.1
     username: admin
     password: password123
-    switch_name: vswitch_0001
+    switch: vswitch_0001
     mtu: 9000
+  delegate_to: localhost
 
 - name: Add a VMWare vSwitch with multiple NICs
   vmware_vswitch:
@@ -86,8 +83,11 @@ EXAMPLES = '''
     username: esxi_username
     password: esxi_password
     switch: vmware_vswitch_0004
-    nics: ['vmnic1', 'vmnic2']
+    nics:
+    - vmnic1
+    - vmnic2
     mtu: 9000
+  delegate_to: localhost
 '''
 
 try:
@@ -197,11 +197,13 @@ class VMwareHostVirtualSwitch(object):
 
 def main():
     argument_spec = vmware_argument_spec()
-    argument_spec.update(dict(switch=dict(required=True, type='str', aliases=['switch_name']),
-                              nics=dict(required=False, type='list', aliases=['nic_name']),
-                              number_of_ports=dict(required=False, type='int', default=128),
-                              mtu=dict(required=False, type='int', default=1500),
-                              state=dict(default='present', choices=['present', 'absent'], type='str')))
+    argument_spec.update(dict(
+        switch=dict(type='str', required=True, aliases=['switch_name']),
+        nics=dict(type='list', aliases=['nic_name']),
+        number_of_ports=dict(type='int', default=128),
+        mtu=dict(type='int', default=1500),
+        state=dict(type='str', default='present', choices=['absent', 'present'])),
+    )
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
 

--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -1,69 +1,128 @@
 # Test code for the vmware_vswitch
-# (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: make sure pyvmomi is installed
+- name: Make sure pyvmomi is installed
   pip:
     name: pyvmomi
     state: latest
 
 - name: store the vcenter container ip
   set_fact:
-    vcsim: "{{ lookup('env', 'vcenter_host') }}"
-- debug: var=vcsim
+    vcsim: '{{ lookup("env", "vcenter_host") }}'
+
+- debug:
+    var: vcsim
 
 - name: Wait for Flask controller to come up online
   wait_for:
-    host: "{{ vcsim }}"
+    host: '{{ vcsim }}'
     port: 5000
     state: started
 
-- name: kill vcsim
+- name: Kill vcsim
   uri:
-    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
-- name: start vcsim
+    url: http://{{ vcsim }}:5000/killall
+
+- name: Start vcsim
   uri:
-    url: "{{ 'http://' + vcsim + ':5000/spawn?cluster=2' }}"
+    url: http://{{ vcsim }}:5000/spawn?cluster=2
   register: vcsim_instance
 
 - name: Wait for Flask controller to come up online
   wait_for:
-    host: "{{ vcsim }}"
+    host: '{{ vcsim }}'
     port: 443
     state: started
 
-- debug: var=vcsim_instance
+- debug:
+    var: vcsim_instance
 
-- name: find folders for each vm
-  vmware_vswitch:
-    validate_certs: False
-    hostname: "{{ vcsim }}"
-    username: "{{ vcsim_instance['json']['username'] }}"
-    password: "{{ vcsim_instance['json']['password'] }}"
-    switch_name: vmswitch_0001
-    nic_name: vnic_1
-  register: vswitch
+# FIXME: Implement check-mode support
+- name: Add a nic to a switch (check-mode)
+  vmware_vswitch: &add_nic
+    hostname: '{{ vcsim }}'
+    username: '{{ vcsim_instance.json.username }}'
+    password: '{{ vcsim_instance.json.password }}'
+    validate_certs: no
+    switch: vmswitch_0001
+    nics: vnic_1
+    state: present
+  check_mode: yes
+  register: add_nic_check
 
-- debug: var=vswitch
-
-# Currently, we don't return anything about vswitch, will
-# extend this TC once we have something to test more than
-# the state of task.
 - assert:
     that:
-        - "{{ vswitch.changed == true }}"
+#    - add_nic_check.changed == true
+    - add_nic_check.skipped == true
+
+- name: Add a nic to a switch
+  vmware_vswitch: *add_nic
+  register: add_nic_run
+
+- assert:
+    that:
+    - add_nic_run.changed == true
+
+## FIXME: Implement check-mode support
+#- name: Add a nic to a switch again (check-mode)
+#  vmware_vswitch: *add_nic
+#  check_mode: yes
+#  register: add_nic_again_check
+#
+#- assert:
+#    that:
+#    - add_nic_again_check.changed == false
+#
+#- name: Add a nic to a switch again
+#  vmware_vswitch: *add_nic
+#  register: add_nic_again_run
+#
+#- assert:
+#    that:
+#    - add_nic_again_run.changed == false
+#
+#- name: Remove a switch (check-mode)
+#  vmware_vswitch: &remove_nic
+#    hostname: '{{ vcsim }}'
+#    username: '{{ vcsim_instance.json.username }}'
+#    password: '{{ vcsim_instance.json.password }}'
+#    validate_certs: no
+#    switch: vmswitch_0001
+#    state: absent
+#  check_mode: yes
+#  register: remove_nic_check
+#
+## FIXME: Implement check-mode support
+#- assert:
+#    that:
+#    - remove_nic_check.changed == true
+
+## FIXME: Removing a switch fails
+#- name: Remove a switch
+#  vmware_vswitch: *remove_nic
+#  register: remove_nic_run
+#
+#- assert:
+#    that:
+#    - remove_nic_run.changed == true
+#
+#- name: Remove a switch again (check-mode)
+#  vmware_vswitch: *remove_nic
+#  check_mode: yes
+#  register: remove_nic_again_check
+#
+## FIXME: Implement check-mode support
+#- assert:
+#    that:
+#    - remove_nic_again_check_mode.changed == false
+#
+## FIXME: Removing a switch fails
+#- name: Remove a switch again
+#  vmware_vswitch: *remove_nic
+#  register: remove_nic_again_run
+#
+#- assert:
+#    that:
+#    - remove_nic_again_run.changed == false


### PR DESCRIPTION
##### SUMMARY
So the module was now not doing anything except adding a nic to a vswitch. This PR adds idempotency checks, and removal checks.

We should probably add modification checks as well, but I don't know what the limitations are for vcsim.

**Update:** And when doing I realize that this module is not idempotent, doesn't support check-mode and doesn't implement removing nics from vswitches. Personally I am not convinced we should manage both vswitches and nics.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_vswitch

##### ANSIBLE VERSION
v2.4