### PR TITLE
Fix pamd error when inserting a new rule at the end. Fixes #28487

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -459,7 +459,10 @@ def insert_after_rule(service, old_rule, new_rule):
         if (old_rule.rule_type == rule.rule_type and
                 old_rule.rule_control == rule.rule_control and
                 old_rule.rule_module_path == rule.rule_module_path):
-            if (new_rule.rule_type != service.rules[index + 1].rule_type or
+            if (index == len(service.rules) - 1):
+                service.rules.insert(len(service.rules), new_rule)
+                changed = True
+            elif (new_rule.rule_type != service.rules[index + 1].rule_type or
                     new_rule.rule_control !=
                     service.rules[index + 1].rule_control or
                     new_rule.rule_module_path !=

--- a/test/units/modules/system/test_pamd.py
+++ b/test/units/modules/system/test_pamd.py
@@ -167,6 +167,15 @@ session   	required	pam_unix.so"""
         line_to_test += str(new_rule).rstrip()
         self.assertIn(line_to_test, str(self.pamd))
 
+    def test_insert_after_rule_last_rule(self):
+        old_rule = PamdRule.rulefromstring('session   	required	pam_unix.so')
+        new_rule = PamdRule.rulefromstring('session   	required	pam_permit.so arg1 arg2 arg3')
+        insert_after_rule(self.pamd, old_rule, new_rule)
+        line_to_test = str(old_rule).rstrip()
+        line_to_test += '\n'
+        line_to_test += str(new_rule).rstrip()
+        self.assertIn(line_to_test, str(self.pamd))
+
     def test_remove_module_arguments_one(self):
         old_rule = PamdRule.rulefromstring('auth      	sufficient	pam_unix.so nullok try_first_pass')
         new_rule = PamdRule.rulefromstring('auth      	sufficient	pam_unix.so try_first_pass')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #28487. When inserting a new PAM rule using pamd's `insert_after_rule`, check if the old rule is the last rule, and if it is, add the new rule onto the end of the list of rules. Otherwise it attempts to check the next rule in the list to see if it also matches the old rule, which fails at the end of the list. I also added one new test for inserting a new rule at the end.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pamd

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (pamd-insert-rule-fix a77865caf2) last updated 2017/08/21 20:29:53 (GMT -400)
  config file = None
  configured module search path = [u'/home/david/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/david/ansible/lib/ansible
  executable location = /home/david/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
