### PR TITLE
Fix junos integration test failure

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -25,6 +25,7 @@ import json
 from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure, AnsibleError
 from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
 from ansible.plugins.loader import netconf_loader
 from ansible.plugins.connection import ConnectionBase, ensure_connect
 from ansible.utils.jsonrpc import Rpc
@@ -86,8 +87,10 @@ class Connection(Rpc, ConnectionBase):
             raise AnsibleConnectionFailure('Unable to automatically determine host network os. Please ansible_network_os value')
 
         ssh_config = os.getenv('ANSIBLE_NETCONF_SSH_CONFIG', False)
-        if ssh_config == 'True':
+        if ssh_config in BOOLEANS_TRUE:
             ssh_config = True
+        else:
+            ssh_config = None
 
         try:
             self._manager = manager.connect(


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #28505
Pass ssh_config value to ncclient manager api as None
if it is not set.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_netconf

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
