### PR TITLE
Create persistent socket path using port and connection type

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -295,7 +295,7 @@ def main():
         sys.exit("FAIL: %s" % e)
 
     ssh = connection_loader.get('ssh', class_only=True)
-    cp = ssh._create_control_path(pc.remote_addr, pc.port, pc.remote_user)
+    cp = ssh._create_control_path(pc.remote_addr, str(pc.port) + pc.connection, pc.remote_user)
 
     # create the persistent connection dir if need be and create the paths
     # which we will be using later

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -295,7 +295,7 @@ def main():
         sys.exit("FAIL: %s" % e)
 
     ssh = connection_loader.get('ssh', class_only=True)
-    cp = ssh._create_control_path(pc.remote_addr, str(pc.port) + pc.connection, pc.remote_user)
+    cp = ssh._create_control_path(pc.remote_addr, pc.port, pc.remote_user, pc.connection)
 
     # create the persistent connection dir if need be and create the paths
     # which we will be using later

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -268,9 +268,11 @@ class Connection(ConnectionBase):
         sock.close()
 
     @staticmethod
-    def _create_control_path(host, port, user):
+    def _create_control_path(host, port, user, connection=None):
         '''Make a hash for the controlpath based on con attributes'''
         pstring = '%s-%s-%s' % (host, port, user)
+        if connection:
+            pstring += '-%s' % connection
         m = hashlib.sha1()
         m.update(to_bytes(pstring))
         digest = m.hexdigest()


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Use remote address, port, connection type and remote user
   to create a socket path.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
