### PR TITLE
support ecs task resource for cloudwatchevent_rule

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -71,14 +71,17 @@ options:
   targets:
     description:
       - "A dictionary array of targets to add to or update for the rule, in the
-        form C({ id: [string], arn: [string], input: [valid JSON string], input_path: [valid JSONPath string] }).
+        form C({ id: [string], arn: [string], input: [valid JSON string], input_path: [valid JSONPath string],
+         ecs_parameters: {task_definition_arn: [string], task_count: [int]}}).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
         is the Amazon Resource Name associated with the target. I(input)
         (optional) is a JSON object that will override the event data when
         passed to the target.  I(input_path) (optional) is a JSONPath string
         (e.g. C($.detail)) that specifies the part of the event data to be
         passed to the target. If neither I(input) nor I(input_path) is
-        specified, then the entire event is passed to the target in JSON form."
+        specified, then the entire event is passed to the target in JSON form.
+        I(task_definition_arn) [optional] is ecs task definition arn.
+        I(task_count) [optional] is ecs task count."
     required: false
 '''
 
@@ -231,6 +234,13 @@ class CloudWatchEventRule(object):
                 target_request['Input'] = target['input']
             if 'input_path' in target:
                 target_request['InputPath'] = target['input_path']
+            if 'ecs_parameters' in target:
+                target_request['EcsParameters'] = {}
+                ecs_parameters = target['ecs_parameters']
+                if 'task_definition_arn' in target['ecs_parameters']:
+                    target_request['EcsParameters']['TaskDefinitionArn'] = ecs_parameters['task_definition_arn']
+                if 'task_count' in target['ecs_parameters']:
+                    target_request['EcsParameters']['TaskCount'] = ecs_parameters['task_count']
             targets_request.append(target_request)
         return targets_request
 

--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -71,10 +71,11 @@ options:
   targets:
     description:
       - "A dictionary array of targets to add to or update for the rule, in the
-        form C({ id: [string], arn: [string], input: [valid JSON string], input_path: [valid JSONPath string],
-         ecs_parameters: {task_definition_arn: [string], task_count: [int]}}).
+        form C({ id: [string], arn: [string], role_arn: [string], input: [valid JSON string],
+        input_path: [valid JSONPath string], ecs_parameters: {task_definition_arn: [string], task_count: [int]}}).
         I(id) [required] is the unique target assignment ID. I(arn) (required)
-        is the Amazon Resource Name associated with the target. I(input)
+        is the Amazon Resource Name associated with the target. I(role_arn) (optional) is The Amazon Resource Name
+        of the IAM role to be used for this target when the rule is triggered. I(input)
         (optional) is a JSON object that will override the event data when
         passed to the target.  I(input_path) (optional) is a JSONPath string
         (e.g. C($.detail)) that specifies the part of the event data to be
@@ -234,6 +235,8 @@ class CloudWatchEventRule(object):
                 target_request['Input'] = target['input']
             if 'input_path' in target:
                 target_request['InputPath'] = target['input_path']
+            if 'role_arn' in target:
+                target_request['RoleArn'] = target['role_arn']
             if 'ecs_parameters' in target:
                 target_request['EcsParameters'] = {}
                 ecs_parameters = target['ecs_parameters']


### PR DESCRIPTION
##### SUMMARY

add suport ecs task resource for cloudwatchevent_rule

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py

##### ANSIBLE VERSION

```
2.4.0
```
