### PR TITLE
Fix ovirt_disk.py example of adding a disk

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -153,6 +153,7 @@ EXAMPLES = '''
     size: 10GiB
     format: cow
     interface: virtio
+    storage_domain: data
 
 # Attach logical unit to VM rhel7
 - ovirt_disk:


### PR DESCRIPTION
##### SUMMARY
It was missing a required field - the storage_domain field.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ovirt_disk

##### ANSIBLE VERSION
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
