### PR TITLE
Handle AttributeError in vmware module_utils

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -238,13 +238,18 @@ def gather_vm_facts(content, vm):
         if not hasattr(entry, 'macAddress'):
             continue
 
+        mac_addr = mac_addr_dash = None
+        if entry.macAddress:
+            mac_addr_dash = entry.macAddress.replace(':', '-')
+            mac_addr = entry.macAddress
+
         factname = 'hw_eth' + str(ethernet_idx)
         facts[factname] = {
             'addresstype': entry.addressType,
             'label': entry.deviceInfo.label,
-            'macaddress': entry.macAddress,
+            'macaddress': mac_addr,
             'ipaddresses': net_dict.get(entry.macAddress, None),
-            'macaddress_dash': entry.macAddress.replace(':', '-'),
+            'macaddress_dash': mac_addr_dash,
             'summary': entry.deviceInfo.summary,
         }
         facts['hw_interfaces'].append('eth' + str(ethernet_idx))


### PR DESCRIPTION
##### SUMMARY
When vm has no MAC address assigned to it. Fix handles
attribute error if MAC address is not set.

Fixes: #28471

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
```
2.3-stable
```