### PR TITLE
Make vmware_guest aware of powerstate

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -187,6 +187,14 @@ options:
     - ' - C(runonce) (list): List of commands to run at first user logon.'
     - ' - C(timezone) (int): Timezone (See U(https://msdn.microsoft.com/en-us/library/ms912391.aspx)).'
     version_added: '2.3'
+  action:
+    description:
+    - Specify action to be performed with related to virtual machine
+    - If set C(powerstate), module will try to find virtual machine and set power state of virtual machine to user specified.
+    - If set C(clone), module will deploy or reconfigure virtual machine.
+    choices: ['clone', 'powerstate']
+    default: clone
+    version_added: '2.4'
 extends_documentation_fragment: vmware.documentation
 '''
 
@@ -1444,6 +1452,7 @@ def main():
         networks=dict(type='list', default=[]),
         resource_pool=dict(type='str'),
         customization=dict(type='dict', default={}, no_log=True),
+        action=dict(type='str', default='clone', choices=['clone', 'powerstate'])
     )
 
     module = AnsibleModule(argument_spec=argument_spec,
@@ -1463,31 +1472,37 @@ def main():
 
     # Check if the VM exists before continuing
     vm = pyv.getvm(name=module.params['name'], folder=module.params['folder'], uuid=module.params['uuid'])
+    action = module.params['action']
+    state = module.params['state']
 
-    # VM already exists
     if vm:
-        if module.params['state'] == 'absent':
-            # destroy it
+        if state == 'present' and action == 'clone':
+            # VM is present, user wants to reconfigure it
+            result = pyv.reconfigure_vm()
+        elif state == 'absent':
+            # VM is present, user wants to remove it
             if module.params['force']:
-                # has to be poweredoff first
+                # VM has to be poweredoff first
                 pyv.set_powerstate(vm, 'poweredoff', module.params['force'])
             result = pyv.remove_vm(vm)
-        elif module.params['state'] == 'present':
-            result = pyv.reconfigure_vm()
-        elif module.params['state'] in ['poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest']:
+        elif state in ['poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest'] and action == 'powerstate':
             # set powerstate
-            tmp_result = pyv.set_powerstate(vm, module.params['state'], module.params['force'])
+            tmp_result = pyv.set_powerstate(vm, state, module.params['force'])
             if tmp_result['changed']:
                 result["changed"] = True
             if not tmp_result["failed"]:
                 result["failed"] = False
-        else:
-            # This should not happen
-            assert False
-    # VM doesn't exist
+        elif state == 'present' and action == 'powerstate':
+            result['changed'] = False
+            result['msg'] = "No state specified. Please specify state from one of " \
+                            "'poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest'"
     else:
-        if module.params['state'] in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended']:
-            # Create it ...
+        # VM does not exists
+        if state in ['poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest'] and action == 'powerstate':
+            result['changed'] = False
+            result['msg'] = 'Unable to find virtual machine named [%(name)s] to set power state as [%(state)s]' % module.params
+        elif state in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended'] and action == 'clone':
+            # Create VM
             result = pyv.deploy_vm()
 
     if result['failed']:


### PR DESCRIPTION
##### SUMMARY
There is need of extra parameter which can exactly define
user action. With this fix, user need to specify action that
needs to be performed with respective available and unavailable
virtual machine. User can now change power state of machine
without reconfigure parameters.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```