### PR TITLE
doc: replace play_hosts with ansible_play_batch

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -699,7 +699,7 @@ Looping over the inventory
 ``````````````````````````
 
 If you wish to loop over the inventory, or just a subset of it, there is multiple ways.
-One can use a regular ``with_items`` with the ``play_hosts`` or ``groups`` variables, like this::
+One can use a regular ``with_items`` with the ``ansible_play_batch`` or ``groups`` variables, like this::
 
     # show all the hosts in the inventory
     - debug:
@@ -711,7 +711,7 @@ One can use a regular ``with_items`` with the ``play_hosts`` or ``groups`` varia
     - debug:
         msg: "{{ item }}"
       with_items:
-        - "{{ play_hosts }}"
+        - "{{ ansible_play_batch }}"
 
 There is also a specific lookup plugin ``inventory_hostnames`` that can be used like this::
 


### PR DESCRIPTION
##### SUMMARY
play_hosts is deprectated since 2.2. Replaced by ansible_play_batch

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
docs

##### ANSIBLE VERSION
2.3, 2.4


##### ADDITIONAL INFORMATION
