### PR TITLE
Stop toggling nxapi

### DIFF
--- a/test/integration/nxos.yaml
+++ b/test/integration/nxos.yaml
@@ -316,56 +316,72 @@
           name: nxos_logging
         when: "limit_to in ['*', 'nxos_logging']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_logging' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_bgp
         when: "limit_to in ['*', 'nxos_bgp']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_bgp' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_bgp_af
         when: "limit_to in ['*', 'nxos_bgp_af']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_bgp_af' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_bgp_neighbor
         when: "limit_to in ['*', 'nxos_bgp_neighbor']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_bgp_neighbor' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_bgp_neighbor_af
         when: "limit_to in ['*', 'nxos_bgp_neighbor_af']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_bgp_neighbor_af' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_overlay_global
         when: "limit_to in ['*', 'nxos_overlay_global']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_overlay_global' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_pim_interface
         when: "limit_to in ['*', 'nxos_pim_interface']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_pim_interface' ]"
+            test_failed: true
 
     - block:
       - include_role:
           name: nxos_snmp_community
         when: "limit_to in ['*', 'nxos_snmp_community']"
       rescue:
-        - set_fact: test_failed=true
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'nxos_snmp_community' ]"
+            test_failed: true
 ###########
     - debug: var=failed_modules
       when: test_failed

--- a/test/integration/targets/nxos_acl/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_acl/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_banner/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_banner/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_command/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_command/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_feature/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_feature/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_igmp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_igmp/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_interface/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ip_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ip_interface/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_logging/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_logging/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_mtu/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_mtu/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ntp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ntp/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_nxapi/tasks/cli.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/cli.yaml
@@ -13,3 +13,7 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
+
+- name: Reset nxapi to default state
+  nxos_nxapi:
+      provider: "{{ cli }}"

--- a/test/integration/targets/nxos_nxapi/tasks/cli.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/cli.yaml
@@ -13,9 +13,3 @@
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ospf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ospf/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_pim_interface/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_portchannel/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_portchannel/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_rollback/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_rollback/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_snmp_community/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_switchport/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_switchport/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_system/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_system/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_user/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_user/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vlan/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vlan/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vpc/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vpc/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
@@ -8,21 +8,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrrp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrrp/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
@@ -18,21 +18,8 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: enable nxapi
-  nxos_config:
-    lines:
-      - feature nxapi
-      - nxapi http port 80
-    provider: "{{ cli }}"
-
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run
-
-- name: disable nxapi
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -6,6 +6,10 @@
     provider: "{{ cli }}"
   ignore_errors: yes
 
+- name: Set nxapi to default state
+  nxos_nxapi:
+      provider: "{{ cli }}"
+
 # Gather the list of interfaces on this device and make the list
 # available for integration tests that need them.
 #

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -1,30 +1,10 @@
 ---
-# There is a bug currently where the nxapi server can get
-# stuck in a bad state when enabling/disabling rapidly by
-# the integration tests.
-#
-# Toggle the command off/on as mitigation.
-- name: Toggle feature nxapi - Disable
-  nxos_config:
-    lines:
-      - no feature nxapi
-    provider: "{{ cli }}"
-  ignore_errors: yes
-
-# Pause after disabling nxapi
-- pause:
-    seconds: 3
-
 - name: Toggle feature nxapi - Enable
   nxos_config:
     lines:
       - feature nxapi
     provider: "{{ cli }}"
   ignore_errors: yes
-
-# Pause after enabling nxapi
-- pause:
-    seconds: 3
 
 # Gather the list of interfaces on this device and make the list
 # available for integration tests that need them.
@@ -35,7 +15,7 @@
 #
 #   - name: "Interface selected for this test"
 #     debug: msg="{{ testint }}"
-#
+
 - name: "Collect interface list"
   nxos_command:
     commands: ['show interface brief | json']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
I don't know why we are waiting 6+ seconds per nxos test to toggle nxapi, because I don't know why we're toggling nxapi each task in the first place.

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.5
```
