### PR TITLE
Added feature: Setup module's filter parameter accepts list of patterns

### DIFF
--- a/lib/ansible/module_utils/facts/ansible_collector.py
+++ b/lib/ansible/module_utils/facts/ansible_collector.py
@@ -40,11 +40,18 @@ class AnsibleFactCollector(collector.BaseFactCollector):
         self.filter_spec = filter_spec
 
     def _filter(self, facts_dict, filter_spec):
-        # assume a filter_spec='' is equilv to filter_spec='*'
-        if not filter_spec or filter_spec == '*':
+        # assume a filter_spec='' is equilv to filter_spec=['*']
+        if not filter_spec or filter_spec == ['*']:
             return facts_dict
 
-        return [(x, y) for x, y in facts_dict.items() if fnmatch.fnmatch(x, filter_spec)]
+        filtered_dict = {}
+        for x, y in facts_dict.items():
+            for current_filter in filter_spec:
+                if fnmatch.fnmatch(x, current_filter):
+                    filtered_dict[x] = y
+                    break
+
+        return filtered_dict
 
     def collect(self, module=None, collected_facts=None):
         collected_facts = collected_facts or {}
@@ -98,7 +105,7 @@ def get_ansible_collector(all_collector_classes,
                           gather_timeout=None,
                           minimal_gather_subset=None):
 
-    filter_spec = filter_spec or '*'
+    filter_spec = filter_spec or ['*']
     gather_subset = gather_subset or ['all']
     gather_timeout = gather_timeout or timeout.DEFAULT_GATHER_TIMEOUT
     minimal_gather_subset = minimal_gather_subset or frozenset()

--- a/lib/ansible/module_utils/facts/compat.py
+++ b/lib/ansible/module_utils/facts/compat.py
@@ -49,7 +49,7 @@ def ansible_facts(module, gather_subset=None):
 
     gather_subset = gather_subset or module.params.get('gather_subset', ['all'])
     gather_timeout = module.params.get('gather_timeout', 10)
-    filter_spec = module.params.get('filter', '*')
+    filter_spec = module.params.get('filter', ['*'])
 
     minimal_gather_subset = frozenset(['apparmor', 'caps', 'cmdline', 'date_time',
                                        'distribution', 'dns', 'env', 'fips', 'local', 'lsb',

--- a/lib/ansible/modules/cloud/cloudstack/cs_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_facts.py
@@ -131,7 +131,7 @@ class CloudStackFacts(object):
 
     def __init__(self):
         collector = ansible_collector.get_ansible_collector(all_collector_classes=default_collectors.collectors,
-                                                            filter_spec='default_ipv4',
+                                                            filter_spec=['default_ipv4'],
                                                             gather_subset=['!all', 'network'],
                                                             gather_timeout=10)
         self.facts = collector.collect(module)

--- a/lib/ansible/modules/system/setup.py
+++ b/lib/ansible/modules/system/setup.py
@@ -20,9 +20,8 @@ version_added: historical
 short_description: Gathers facts about remote hosts
 options:
     gather_subset:
-        version_added: "2.1"
         description:
-            - "if supplied, restrict the additional facts collected to the given subset.
+            - "If supplied, restrict the additional facts collected to the given subset.
               Possible values: all, min, hardware, network, virtual, ohai, and
               facter Can specify a list of values to specify a larger subset.
               Values can also be used with an initial C(!) to specify that
@@ -33,53 +32,56 @@ options:
               use !all, !min, and specify the particular fact subsets.
               Use the filter parameter if you do not want to display some collected
               facts."
-        required: false
-        default: 'all'
+        default: ["all"]
+        version_added: "2.1"
     gather_timeout:
-        version_added: "2.2"
         description:
             - "Set the default timeout in seconds for individual fact gathering"
-        required: false
         default: 10
+        version_added: "2.2"
     filter:
+        description:
+            - "If supplied, only return facts that match these shell-style (fnmatch) wildcard patterns."
+            - "If multiple filters are specified, they are inclusive: the results from each filter
+              are effectively merged into a resulting facts hash."
+            - "An empty string as a list item is treated as a splat (C(*)) and will result in the entire
+              fact hash being returned."
+        default: ["*"]
         version_added: "1.1"
-        description:
-            - if supplied, only return facts that match this shell-style (fnmatch) wildcard.
-        required: false
-        default: '*'
     fact_path:
-        version_added: "1.3"
         description:
-            - path used for local ansible facts (*.fact) - files in this dir
-              will be run (if executable) and their results be added to ansible_local facts
-              if a file is not executable it is read. Check notes for Windows options. (from 2.1 on)
-              File/results format can be json or ini-format
-        required: false
-        default: '/etc/ansible/facts.d'
+            - "Path used for local ansible facts (*.fact). Files in this dir
+              will be run (if executable) and their results be added to ansible_local facts.
+              If a file is not executable, it will be read."
+            - "Check notes for Windows options (from 2.1 on)."
+            - "File/results format can be JSON or INI."
+        default: /etc/ansible/facts.d
+        version_added: "1.3"
 description:
-     - This module is automatically called by playbooks to gather useful
-       variables about remote hosts that can be used in playbooks. It can also be
-       executed directly by C(/usr/bin/ansible) to check what variables are
-       available to a host. Ansible provides many I(facts) about the system,
-       automatically.
-     - This module is also supported for Windows targets.
+    - "This module is automatically called by playbooks to gather useful
+      variables about remote hosts that can be used in playbooks. It can also be
+      executed directly by C(/usr/bin/ansible) to check what variables are
+      available to a host. Ansible provides many I(facts) about the system,
+      automatically."
+    - "This module is also supported for Windows targets."
 notes:
-    - More ansible facts will be added with successive releases. If I(facter) or
-      I(ohai) are installed, variables from these programs will also be snapshotted
+    - "More ansible facts will be added with successive releases. If I(facter) or
+      I(ohai) is installed, variables from these programs will also be snapshotted
       into the JSON file for usage in templating. These variables are prefixed
       with C(facter_) and C(ohai_) so it's easy to tell their source. All variables are
-      bubbled up to the caller. Using the ansible facts and choosing to not
+      bubbled up to the caller. Using the ansible facts and choosing not to
       install I(facter) and I(ohai) means you can avoid Ruby-dependencies on your
-      remote systems. (See also M(facter) and M(ohai).)
-    - The filter option filters only the first level subkey below ansible_facts.
-    - If the target host is Windows, you will not currently have the ability to use
-      C(filter) as this is provided by a simpler implementation of the module.
-    - If the target host is Windows you can now use C(fact_path). Make sure that this path
+      remote systems. (See also M(facter) and M(ohai).)"
+    - "The filter option filters only the first level subkey below ansible_facts."
+    - "If the target host is Windows, you will not currently have the ability to use
+      C(filter) as this is provided by a simpler implementation of the module."
+    - "If the target host is Windows you can now use C(fact_path). Make sure that this path
       exists on the target host. Files in this path MUST be PowerShell scripts (``*.ps1``) and
       their output must be formattable in JSON (Ansible will take care of this). Test the
       output of your scripts.
-      This option was added in Ansible 2.1.
-    - This module is also supported for Windows targets.
+      This option was added in Ansible 2.1."
+    - "This module is also supported for Windows targets."
+    - "The filter option accepts a list rather than a string as of Ansible 2.4."
 author:
     - "Ansible Core Team"
     - "Michael DeHaan"
@@ -101,6 +103,9 @@ EXAMPLES = """
 
 # Display only facts about certain interfaces.
 # ansible all -m setup -a 'filter=ansible_eth[0-2]'
+
+# Display facts matching any of three filter patterns.
+# ansible all -m setup -a 'filter=ansible_hostname,ansible*ipv?,ansible__dist*'
 
 # Restrict additional gathered facts to network and virtual (includes default minimum facts)
 # ansible all -m setup -a 'gather_subset=network,virtual'
@@ -135,7 +140,7 @@ def main():
         argument_spec=dict(
             gather_subset=dict(default=["all"], required=False, type='list'),
             gather_timeout=dict(default=10, required=False, type='int'),
-            filter=dict(default="*", required=False),
+            filter=dict(default=["*"], required=False, type='list'),
             fact_path=dict(default='/etc/ansible/facts.d', required=False, type='path'),
         ),
         supports_check_mode=True,
@@ -143,7 +148,13 @@ def main():
 
     gather_subset = module.params['gather_subset']
     gather_timeout = module.params['gather_timeout']
-    filter_spec = module.params['filter']
+
+    # Handle empty string values as required by integration test
+    if len(module.params['filter']) and not any(module.params['filter']):
+        filter = ['*']
+    else:
+        filter = module.params['filter']
+    filter_spec = [x.strip() for x in filter]
 
     # TODO: this mimics existing behavior where gather_subset=["!all"] actually means
     #       to collect nothing except for the below list


### PR DESCRIPTION
##### SUMMARY
Fixes #19220: Added feature: Setup module's filter parameter accepts comma-separated list of patterns

I accomplished this by having `filter_spec` take a list rather than a string. In `setup.py`, `filter_spec` is now getting its value from a list comprehension that splits `module.params['filter']` on commas and strips whitespace. I replaced default string values `'*'` with single-element lists `['*']` wherever I found them, to avoid breaking existing code that assigns a string to `filter_spec`.

In `ansible_collector.py`, I went with nested `for` loops both for the ability to break after finding a match and for code clarity. The comprehension had become unwieldy.

My intent is to maintain compatibility with existing code. The `filter` parameter itself still takes a string value, which can be either simple as before or a comma-separated list of values. The changes were made to `filter_spec` on the back end.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
setup

##### ANSIBLE VERSION
```
ansible 2.4.0 (nrwahl2-setup_filter_accepts_list 8d65fe19fd) last updated 2017/08/22 21:35:57 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/u/nwahl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /u/nwahl/ansible/lib/ansible
  executable location = /u/nwahl/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```

##### ADDITIONAL INFORMATION
The four files modified are the only ones I found that depend on `filter_spec` or `ansible_collector`. I grepped recursively for `filter_spec` and `ansible_collector` in the `ansible/lib/ansible` directory.

If maintainers know of more dependencies, let's put the PR on hold and revise as needed.

Demonstration:
```
# Test with single pattern (legacy feature)
$ ansible localhost -c local -i hosts.ini -m setup -a 'filter=ansible_hostname'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_hostname": "<hostname>"
    },
    "changed": false,
    "failed": false
}

# Test with multiple patterns (new feature)
$ ansible localhost -c local -i hosts.ini -m setup -a 'filter="ansible_hostname, ansible_all_ipv?_addresses, ansible_distribution, ansible_distribution_major_version, ansible_distribution_release"'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_all_ipv4_addresses": [
            "10.246.170.70"
        ],
        "ansible_all_ipv6_addresses": [
            "fe80::250:56ff:fe8e:7f1b"
        ],
        "ansible_distribution": "RedHat",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_release": "Maipo",
        "ansible_hostname": "<hostname>"
    },
    "changed": false,
    "failed": false
}
```
