### PR TITLE
fixed up win_robocopy return values

### DIFF
--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -140,7 +140,7 @@ output:
     description: The output of running the robocopy command.
     returned: success
     type: string
-    sample: "----------------------------------------\n   ROBOCOPY     ::     Robust File Copy for Windows         \n----------------------------------------\n"
+    sample: "----------------------------------------\\n   ROBOCOPY     ::     Robust File Copy for Windows         \\n----------------------------------------\\n "
 msg:
     description: Output intrepreted into a concise message.
     returned: always

--- a/lib/ansible/modules/windows/win_robocopy.py
+++ b/lib/ansible/modules/windows/win_robocopy.py
@@ -140,7 +140,7 @@ output:
     description: The output of running the robocopy command.
     returned: success
     type: string
-    sample: "----------------------------------------\\n   ROBOCOPY     ::     Robust File Copy for Windows         \\n----------------------------------------\\n "
+    sample: "------------------------------------\\n   ROBOCOPY     ::     Robust File Copy for Windows         \\n------------------------------------\\n "
 msg:
     description: Output intrepreted into a concise message.
     returned: always


### PR DESCRIPTION
##### SUMMARY
win_robocopy docs are screwed up, escaping the `\n` so it looks correct when the docs are built.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_robocopy

##### ANSIBLE VERSION
```
2.4
```