### PR TITLE
Fixes #28540: Corrected ansible_host value for facthost[0:20] from 1270.0.0.1 to 127.0.0.1

### DIFF
--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -5,7 +5,7 @@ testhost2 ansible_ssh_host=127.0.0.1 ansible_connection=local
 testhost3 ansible_ssh_host=127.0.0.3
 testhost4 ansible_ssh_host=127.0.0.4
 # For testing fact gathering
-facthost[0:20] ansible_host=1270.0.0.1 ansible_connection=local
+facthost[0:20] ansible_host=127.0.0.1 ansible_connection=local
 
 [binary_modules]
 testhost_binary_modules ansible_host=127.0.0.1 ansible_connection=local


### PR DESCRIPTION
##### SUMMARY
Fixes #28540: Corrected ansible_host value for facthost[0:20] from 1270.0.0.1 to 127.0.0.1 in `ansible/test/integration/inventory`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/28540 6d66395629) last updated 2017/08/22 22:34:42 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/ansible/lib/ansible
  executable location = /home/ansible/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
BEFORE:
```
[ansible@nrwahl1 integration]$ grep facthost inventory
facthost[0:20] ansible_host=127.0.0.1 ansible_connection=local
```

AFTER:
```
[ansible@nrwahl1 integration]$ grep facthost inventory
facthost[0:20] ansible_host=127.0.0.1 ansible_connection=local
```
