### PR TITLE
Add support for setup targets to ansible-test.

### DIFF
--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -247,14 +247,14 @@ class PathMapper(object):
             return minimal
 
         if path.startswith('lib/ansible/modules/'):
-            module = self.module_names_by_path.get(path)
+            module_name = self.module_names_by_path.get(path)
 
-            if module:
+            if module_name:
                 return {
-                    'units': module if module in self.units_modules else None,
-                    'integration': self.posix_integration_by_module.get(module) if ext == '.py' else None,
-                    'windows-integration': self.windows_integration_by_module.get(module) if ext == '.ps1' else None,
-                    'network-integration': self.network_integration_by_module.get(module),
+                    'units': module_name if module_name in self.units_modules else None,
+                    'integration': self.posix_integration_by_module.get(module_name) if ext == '.py' else None,
+                    'windows-integration': self.windows_integration_by_module.get(module_name) if ext == '.ps1' else None,
+                    'network-integration': self.network_integration_by_module.get(module_name),
                 }
 
             return minimal

--- a/test/runner/lib/cloud/__init__.py
+++ b/test/runner/lib/cloud/__init__.py
@@ -343,7 +343,7 @@ class CloudEnvironment(CloudBase):
 
     def on_failure(self, target, tries):
         """
-        :type target: TestTarget
+        :type target: IntegrationTarget
         :type tries: int
         """
         pass

--- a/test/runner/lib/cover.py
+++ b/test/runner/lib/cover.py
@@ -92,11 +92,11 @@ def command_coverage_combine(args):
                 display.info('%s -> %s' % (filename, new_name), verbosity=3)
                 filename = new_name
             elif '/ansible_module_' in filename:
-                module = re.sub('^.*/ansible_module_(?P<module>.*).py$', '\\g<module>', filename)
-                if module not in modules:
-                    display.warning('Skipping coverage of unknown module: %s' % module)
+                module_name = re.sub('^.*/ansible_module_(?P<module>.*).py$', '\\g<module>', filename)
+                if module_name not in modules:
+                    display.warning('Skipping coverage of unknown module: %s' % module_name)
                     continue
-                new_name = os.path.abspath(modules[module])
+                new_name = os.path.abspath(modules[module_name])
                 display.info('%s -> %s' % (filename, new_name), verbosity=3)
                 filename = new_name
             elif re.search('^(/.*?)?/root/ansible/', filename):

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -635,7 +635,7 @@ def run_setup_targets(args, test_dir, target_names, targets_dict, targets_execut
     :param args: IntegrationConfig
     :param test_dir: str
     :param target_names: list[str]
-    :param targets_dict: list[IntegrationTarget]
+    :param targets_dict: dict[str, IntegrationTarget]
     :param targets_executed: set[str]
     :param always: bool
     """

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, print_function
 
 import json
 import os
+import collections
 import re
 import tempfile
 import time

--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -244,8 +244,9 @@ def command_posix_integration(args):
     """
     :type args: PosixIntegrationConfig
     """
-    internal_targets = command_integration_filter(args, walk_posix_integration_targets())
-    command_integration_filtered(args, internal_targets)
+    all_targets = tuple(walk_posix_integration_targets(include_hidden=True))
+    internal_targets = command_integration_filter(args, all_targets)
+    command_integration_filtered(args, internal_targets, all_targets)
 
 
 def command_network_integration(args):
@@ -270,7 +271,8 @@ def command_network_integration(args):
             'See also inventory template: %s.template' % (filename, default_filename)
         )
 
-    internal_targets = command_integration_filter(args, walk_network_integration_targets())
+    all_targets = tuple(walk_network_integration_targets(include_hidden=True))
+    internal_targets = command_integration_filter(args, all_targets)
     platform_targets = set(a for t in internal_targets for a in t.aliases if a.startswith('network/'))
 
     if args.platform:
@@ -309,7 +311,7 @@ def command_network_integration(args):
     else:
         install_command_requirements(args)
 
-    command_integration_filtered(args, internal_targets)
+    command_integration_filtered(args, internal_targets, all_targets)
 
 
 def network_run(args, platform, version):
@@ -377,7 +379,8 @@ def command_windows_integration(args):
     if not args.explain and not args.windows and not os.path.isfile(filename):
         raise ApplicationError('Use the --windows option or provide an inventory file (see %s.template).' % filename)
 
-    internal_targets = command_integration_filter(args, walk_windows_integration_targets())
+    all_targets = tuple(walk_windows_integration_targets(include_hidden=True))
+    internal_targets = command_integration_filter(args, all_targets)
 
     if args.windows:
         instances = []  # type: list [lib.thread.WrappedThread]
@@ -405,7 +408,7 @@ def command_windows_integration(args):
         install_command_requirements(args)
 
     try:
-        command_integration_filtered(args, internal_targets)
+        command_integration_filtered(args, internal_targets, all_targets)
     finally:
         pass
 
@@ -477,7 +480,7 @@ def command_integration_filter(args, targets):
     :type targets: collections.Iterable[IntegrationTarget]
     :rtype: tuple[IntegrationTarget]
     """
-    targets = tuple(targets)
+    targets = tuple(target for target in targets if 'hidden/' not in target.aliases)
     changes = get_changes_filter(args)
     require = (args.require or []) + changes
     exclude = (args.exclude or [])
@@ -507,16 +510,29 @@ def command_integration_filter(args, targets):
     return internal_targets
 
 
-def command_integration_filtered(args, targets):
+def command_integration_filtered(args, targets, all_targets):
     """
     :type args: IntegrationConfig
     :type targets: tuple[IntegrationTarget]
+    :type all_targets: tuple[IntegrationTarget]
     """
     found = False
     passed = []
     failed = []
 
     targets_iter = iter(targets)
+    all_targets_dict = dict((target.name, target) for target in all_targets)
+
+    setup_errors = []
+    setup_targets_executed = set()
+
+    for target in all_targets:
+        for setup_target in target.setup_once + target.setup_always:
+            if setup_target not in all_targets_dict:
+                setup_errors.append('Target "%s" contains invalid setup target: %s' % (target.name, setup_target))
+
+    if setup_errors:
+        raise ApplicationError('Found %d invalid setup aliases:\n%s' % (len(setup_errors), '\n'.join(setup_errors)))
 
     test_dir = os.path.expanduser('~/ansible_testing')
 
@@ -561,12 +577,15 @@ def command_integration_filtered(args, targets):
             while tries:
                 tries -= 1
 
-                if not args.explain:
-                    # create a fresh test directory for each test target
-                    remove_tree(test_dir)
-                    make_dirs(test_dir)
-
                 try:
+                    run_setup_targets(args, test_dir, target.setup_once, all_targets_dict, setup_targets_executed, False)
+                    run_setup_targets(args, test_dir, target.setup_always, all_targets_dict, setup_targets_executed, True)
+
+                    if not args.explain:
+                        # create a fresh test directory for each test target
+                        remove_tree(test_dir)
+                        make_dirs(test_dir)
+
                     if target.script_path:
                         command_integration_script(args, target)
                     else:
@@ -609,6 +628,34 @@ def command_integration_filtered(args, targets):
     if failed:
         raise ApplicationError('The %d integration test(s) listed below (out of %d) failed. See error output above for details:\n%s' % (
             len(failed), len(passed) + len(failed), '\n'.join(target.name for target in failed)))
+
+
+def run_setup_targets(args, test_dir, target_names, targets_dict, targets_executed, always):
+    """
+    :param args: IntegrationConfig
+    :param test_dir: str
+    :param target_names: list[str]
+    :param targets_dict: list[IntegrationTarget]
+    :param targets_executed: set[str]
+    :param always: bool
+    """
+    for target_name in target_names:
+        if not always and target_name in targets_executed:
+            continue
+
+        target = targets_dict[target_name]
+
+        if not args.explain:
+            # create a fresh test directory for each test target
+            remove_tree(test_dir)
+            make_dirs(test_dir)
+
+        if target.script_path:
+            command_integration_script(args, target)
+        else:
+            command_integration_role(args, target, None)
+
+        targets_executed.add(target_name)
 
 
 def integration_environment(args, target, cmd):
@@ -667,7 +714,7 @@ def command_integration_role(args, target, start_at_task):
     """
     :type args: IntegrationConfig
     :type target: IntegrationTarget
-    :type start_at_task: str
+    :type start_at_task: str | None
     """
     display.info('Running %s integration test role' % target.name)
 

--- a/test/runner/lib/metadata.py
+++ b/test/runner/lib/metadata.py
@@ -10,6 +10,7 @@ from lib.util import (
 
 from lib.diff import (
     parse_diff,
+    FileDiff,
 )
 
 

--- a/test/runner/lib/target.py
+++ b/test/runner/lib/target.py
@@ -12,7 +12,6 @@ import sys
 
 from lib.util import (
     ApplicationError,
-    ABC,
 )
 
 MODULE_EXTENSIONS = '.py', '.ps1'
@@ -520,13 +519,13 @@ class IntegrationTarget(CompletionTarget):
         # modules
 
         if self.name in modules:
-            module = self.name
+            module_name = self.name
         elif self.name.startswith('win_') and self.name[4:] in modules:
-            module = self.name[4:]
+            module_name = self.name[4:]
         else:
-            module = None
+            module_name = None
 
-        self.modules = tuple(sorted(a for a in static_aliases + tuple([module]) if a in modules))
+        self.modules = tuple(sorted(a for a in static_aliases + tuple([module_name]) if a in modules))
 
         # groups
 


### PR DESCRIPTION
##### SUMMARY

Add support for setup targets to ansible-test.

This permits declaration of setup targets to be run before a test target:

* `setup/always/setup_target_name` - Always run the `setup_target_name` target.
* `setup/once/setup_target_name` - Run the `setup_target_name` target if it hasn't been run yet.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.4.0 (devel a9458ca609) last updated 2017/08/22 20:45:55 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
