### PR TITLE
yum: restore state=latest

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -1104,6 +1104,8 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, in
         if not out_lower.endswith("no packages marked for update") and \
                 not out_lower.endswith("nothing to do"):
             res['changed'] = True
+    else:
+        rc, out, err = [0, '', '']
 
     res['rc'] = rc
     res['msg'] += err


### PR DESCRIPTION
##### SUMMARY
re-add "else behaviour" removed in c59f3f841e3b553d07e38491c015c4e206da866a by a dublicate code optimization. fixes error in yum using state=latest  
 
fixes build, see dummy PR in which it was reproduced #28546 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
