### PR TITLE
fix sts_session_token parameter example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sts_session_token.py
+++ b/lib/ansible/modules/cloud/amazon/sts_session_token.py
@@ -70,7 +70,7 @@ EXAMPLES = '''
 
 # Get a session token (more details: http://docs.aws.amazon.com/STS/latest/APIReference/API_GetSessionToken.html)
 sts_session_token:
-  duration: 3600
+  duration_seconds: 3600
 register: session_credentials
 
 # Use the session token obtained above to tag an instance in account 123456789012


### PR DESCRIPTION
##### SUMMARY
Fix sts_session_token parameter example. Current example state the parameter is duration where it should be duration_seconds

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
sts_session_token

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/playbooks/library', u'library']
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
