### PR TITLE
crypto: Add new module openssl_pkcs12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -230,6 +230,7 @@ Ansible Changes By Release
 #### Crypto
   * openssl_certificate
   * openssl_csr
+  * openssl_pkcs12
 
 #### Files
   * xml

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -205,7 +205,7 @@ def main():
         friendly_name=dict(required=True, type='str'),
         iter_size=dict(default=2048, type='int'),
         maciter_size=dict(default=1, type='int'),
-        mode=dict(default=0600, type='int'),
+        mode=dict(default=0400, type='int'),
         passphrase=dict(type='str', no_log=True),
         path=dict(required=True, type='path'),
         privatekey_path=dict(required=True, type='path'),

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -215,7 +215,6 @@ class Pkcs(crypto_utils.OpenSSLObject):
                             self.maciter_size
                         )
                     )
-                #module.set_mode_if_different(self.path, this_mode, False)
                 self.changed = True
             except (IOError, OSError) as exc:
                 self.remove()

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -15,9 +15,9 @@ DOCUMENTATION = '''
 module: openssl_pkcs12
 author: "Guillaume Delpierre (@gdelpierre)"
 version_added: "2.4"
-short_description: Generate OpenSSL pkcs12 archive.
+short_description: Generate OpenSSL PKCS#12 archive.
 description:
-    - "This module allows one to (re-)generate PKCS #12."
+    - "This module allows one to (re-)generate PKCS#12."
 requirements:
     - "python-pyOpenSSL"
 options:
@@ -26,8 +26,8 @@ options:
         default: None
         choices: ['parse', 'export', None]
         description:
-            - Create (export) or parse a PKCS #12.
-              Use None with state 'absent'.
+            - Create (export) or parse a PKCS#12.
+              None is used with absent state.
     ca_certificates:
         required: False
         description:
@@ -62,7 +62,7 @@ options:
         required: False
         default: 0400
         description:
-            - Default mode for the generated PKCS #12 file.
+            - Default mode for the generated PKCS#12 file.
     passphrase:
         required: False
         default: null
@@ -289,9 +289,9 @@ class Pkcs(crypto_utils.OpenSSLObject):
         if not self.check(module, perms_required=False) or module.params['force']:
             try:
                 self.remove()
-            
+
                 p12 = crypto.load_pkcs12(open(self.src, 'rb').read(),
-                                        passphrase=self.passphrase)
+                                         passphrase=self.passphrase)
                 pkey = crypto.dump_privatekey(crypto.FILETYPE_PEM,
                                               p12.get_privatekey())
                 crt = crypto.dump_certificate(crypto.FILETYPE_PEM,
@@ -309,6 +309,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
         if module.set_fs_attributes_if_different(file_args, False):
             module.set_mode_if_different(self.path, this_mode, False)
             self.changed = True
+
 
 def main():
     argument_spec = dict(
@@ -369,9 +370,9 @@ def main():
 
         try:
             if module.params['action'] == 'export':
-               pkcs12.generate(module)
+                pkcs12.generate(module)
             else:
-               pkcs12.parse(module)
+                pkcs12.parse(module)
         except PkcsError as exc:
             module.fail_json(msg=to_native(exc))
     else:

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -193,6 +193,9 @@ class Pkcs(crypto_utils.OpenSSLObject):
         self.privatekey_passphrase = module.params['privatekey_passphrase']
         self.privatekey_path = module.params['privatekey_path']
         self.src = module.params['src']
+        self.mode = module.params['mode']
+        if not self.mode:
+            self.mode = int('0400', 8)
 
     def check(self, module, perms_required=True):
         ''' Ensure the resource is in its desired state. '''
@@ -229,10 +232,6 @@ class Pkcs(crypto_utils.OpenSSLObject):
     def generate(self, module):
         ''' Generate PKCS#12 file archive. '''
 
-        this_mode = module.params['mode']
-        if not this_mode:
-            this_mode = int('0400', 8)
-
         if not self.check(module, perms_required=False) or module.params['force']:
             self.pkcs12 = crypto.PKCS12()
 
@@ -260,7 +259,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
                                            )
 
             try:
-                with open(self.path, 'wb', this_mode) as archive:
+                with open(self.path, 'wb') as archive:
                     archive.write(
                         self.pkcs12.export(
                             self.passphrase,
@@ -268,7 +267,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
                             self.maciter_size
                         )
                     )
-                module.set_mode_if_different(self.path, this_mode, False)
+                module.set_mode_if_different(self.path, self.mode, False)
                 self.changed = True
             except (IOError, OSError) as exc:
                 self.remove()
@@ -276,15 +275,11 @@ class Pkcs(crypto_utils.OpenSSLObject):
 
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):
-            module.set_mode_if_different(self.path, this_mode, False)
+            module.set_mode_if_different(self.path, self.mode, False)
             self.changed = True
 
     def parse(self, module):
         ''' Read PKCS#12 file. '''
-
-        this_mode = module.params['mode']
-        if not this_mode:
-            this_mode = int('0400', 8)
 
         if not self.check(module, perms_required=False) or module.params['force']:
             try:
@@ -299,7 +294,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
 
                 with open(self.path, 'wb') as content:
                     content.write("%s%s" % (pkey, crt))
-                module.set_mode_if_different(self.path, this_mode, False)
+                module.set_mode_if_different(self.path, self.mode, False)
                 self.changed = True
             except IOError as exc:
                 self.remove()
@@ -307,7 +302,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
 
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):
-            module.set_mode_if_different(self.path, this_mode, False)
+            module.set_mode_if_different(self.path, self.mode, False)
             self.changed = True
 
 

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -6,7 +6,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.0',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -17,79 +17,61 @@ author: "Guillaume Delpierre (@gdelpierre)"
 version_added: "2.4"
 short_description: Generate OpenSSL PKCS#12 archive.
 description:
-    - "This module allows one to (re-)generate PKCS#12."
+    - This module allows one to (re-)generate PKCS#12.
 requirements:
-    - "python-pyOpenSSL"
+    - python-pyOpenSSL
 options:
     action:
-        required: False
-        default: None
-        choices: ['parse', 'export', None]
+        default: export
+        choices: ['parse', 'export']
         description:
-            - Create (export) or parse a PKCS#12.
-              None is used with absent state.
+            - C(export) or C(parse) a PKCS#12.
     ca_certificates:
-        required: False
         description:
             - List of CA certificate to include.
-    cert_path:
-        required: False
+    certificate_path:
         description:
-            - The path to read certificates and private keys from.
-              Must be in PEM format.
+            - The path to read certificates and private keys from.  Must be in PEM format.
     force:
-        required: False
         default: False
+        type: bool
         description:
             - Should the file be regenerated even it it already exists.
     friendly_name:
-        required: False
-        default: null
         aliases: 'name'
         description:
             - Specifies the friendly name for the certificate and private key.
     iter_size:
-        required: False
         default: 2048
         description:
             - Number of times to repeat the encryption step.
     maciter_size:
-        required: False
         default: 1
         description:
             - Number of times to repeat the MAC step.
     mode:
-        required: False
         default: 0400
         description:
             - Default mode for the generated PKCS#12 file.
     passphrase:
-        required: False
-        default: null
         description:
             - The PKCS#12 password.
     path:
         required: True
-        default: null
         description:
             - Filename to write the PKCS#12 file to.
     privatekey_passphrase:
-        required: False
-        default: null
         description:
             - Passphrase source to decrypt any input private keys with.
     privatekey_path:
-        required: False
         description:
             - File to read private key from.
     state:
-        required: False
         default: 'present'
         choices: ['present', 'absent']
         description:
             - Whether the file should exist or not.
     src:
-        required: False
         description:
             - PKCS#12 file path to parse.
 '''
@@ -101,7 +83,7 @@ EXAMPLES = '''
     path: '/opt/certs/ansible.p12'
     friendly_name: 'raclette'
     privatekey_path: '/opt/certs/keys/key.pem'
-    cert_path: '/opt/certs/cert.pem'
+    certificate_path: '/opt/certs/cert.pem'
     ca_certificates: '/opt/certs/ca.pem'
     state: present
 
@@ -111,7 +93,7 @@ EXAMPLES = '''
     path: '/opt/certs/ansible.p12'
     friendly_name: 'raclette'
     privatekey_path: '/opt/certs/keys/key.pem'
-    cert_path: '/opt/certs/cert.pem'
+    certificate_path: '/opt/certs/cert.pem'
     ca_certificates: '/opt/certs/ca.pem'
     state: present
     mode: 0600
@@ -123,7 +105,7 @@ EXAMPLES = '''
     path: '/opt/certs/ansible.p12'
     friendly_name: 'raclette'
     privatekey_path: '/opt/certs/keys/key.pem'
-    cert_path: '/opt/certs/cert.pem'
+    certificate_path: '/opt/certs/cert.pem'
     ca_certificates: '/opt/certs/ca.pem'
     state: present
     mode: 0600
@@ -184,7 +166,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
         )
         self.action = module.params['action']
         self.ca_certificates = module.params['ca_certificates']
-        self.cert_path = module.params['cert_path']
+        self.certificate_path = module.params['certificate_path']
         self.friendly_name = module.params['friendly_name']
         self.iter_size = module.params['iter_size']
         self.maciter_size = module.params['maciter_size']
@@ -198,7 +180,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
             self.mode = int('0400', 8)
 
     def check(self, module, perms_required=True):
-        ''' Ensure the resource is in its desired state. '''
+        """Ensure the resource is in its desired state."""
 
         state_and_perms = super(Pkcs, self).check(module, perms_required)
 
@@ -218,7 +200,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
         return _check_pkey_passphrase
 
     def dump(self):
-        ''' Serialize the object into a dictionary. '''
+        """Serialize the object into a dictionary."""
 
         result = {
             'changed': self.changed,
@@ -230,7 +212,7 @@ class Pkcs(crypto_utils.OpenSSLObject):
         return result
 
     def generate(self, module):
-        ''' Generate PKCS#12 file archive. '''
+        """Generate PKCS#12 file archive."""
 
         if not self.check(module, perms_required=False) or module.params['force']:
             self.pkcs12 = crypto.PKCS12()
@@ -245,9 +227,9 @@ class Pkcs(crypto_utils.OpenSSLObject):
                             in self.ca_certificates]
                 self.pkcs12.set_ca_certificates(ca_certs)
 
-            if self.cert_path:
+            if self.certificate_path:
                 self.pkcs12.set_certificate(crypto_utils.load_certificate(
-                                            self.cert_path))
+                                            self.certificate_path))
 
             if self.friendly_name:
                 self.pkcs12.set_friendlyname(self.friendly_name)
@@ -259,15 +241,11 @@ class Pkcs(crypto_utils.OpenSSLObject):
                                            )
 
             try:
-                with open(self.path, 'wb') as archive:
-                    archive.write(
-                        self.pkcs12.export(
-                            self.passphrase,
-                            self.iter_size,
-                            self.maciter_size
-                        )
-                    )
-                module.set_mode_if_different(self.path, self.mode, False)
+                pkcs12_file = os.open(self.path,
+                                      os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                                      self.mode)
+                os.write(pkcs12_file, self.pkcs12.export(self.passphrase, self.iter_size, self.maciter_size))
+                os.close(pkcs12_file)
                 self.changed = True
             except (IOError, OSError) as exc:
                 self.remove()
@@ -275,26 +253,27 @@ class Pkcs(crypto_utils.OpenSSLObject):
 
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):
-            module.set_mode_if_different(self.path, self.mode, False)
             self.changed = True
 
     def parse(self, module):
-        ''' Read PKCS#12 file. '''
+        """Read PKCS#12 file."""
 
         if not self.check(module, perms_required=False) or module.params['force']:
             try:
                 self.remove()
 
                 p12 = crypto.load_pkcs12(open(self.src, 'rb').read(),
-                                         passphrase=self.passphrase)
+                                         self.passphrase)
                 pkey = crypto.dump_privatekey(crypto.FILETYPE_PEM,
                                               p12.get_privatekey())
                 crt = crypto.dump_certificate(crypto.FILETYPE_PEM,
                                               p12.get_certificate())
 
-                with open(self.path, 'wb') as content:
-                    content.write("%s%s" % (pkey, crt))
-                module.set_mode_if_different(self.path, self.mode, False)
+                pkcs12_file = os.open(self.path,
+                                      os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                                      self.mode)
+                os.write(pkcs12_file, '%s%s' % (pkey, crt))
+                os.close(pkcs12_file)
                 self.changed = True
             except IOError as exc:
                 self.remove()
@@ -302,28 +281,25 @@ class Pkcs(crypto_utils.OpenSSLObject):
 
         file_args = module.load_file_common_arguments(module.params)
         if module.set_fs_attributes_if_different(file_args, False):
-            module.set_mode_if_different(self.path, self.mode, False)
             self.changed = True
 
 
 def main():
     argument_spec = dict(
-        action=dict(default=None,
-                    choices=['parse', 'export'],
-                    type='str'),
+        action=dict(type='str', default='export',
+                    choices=['parse', 'export']),
         ca_certificates=dict(type='list'),
-        cert_path=dict(type='path'),
-        force=dict(default=False, type='bool'),
+        certificate_path=dict(type='path'),
+        force=dict(type='bool', default=False),
         friendly_name=dict(type='str', aliases=['name']),
-        iter_size=dict(default=2048, type='int'),
-        maciter_size=dict(default=1, type='int'),
+        iter_size=dict(type='int', default=2048),
+        maciter_size=dict(type='int', default=1),
         passphrase=dict(type='str', no_log=True),
-        path=dict(required=True, type='path'),
+        path=dict(type='path', required=True),
         privatekey_passphrase=dict(type='str', no_log=True),
         privatekey_path=dict(type='path'),
-        state=dict(default='present',
-                   choices=['present', 'absent'],
-                   type='str'),
+        state=dict(type='str', default='present',
+                   choices=['present', 'absent']),
         src=dict(type='path'),
     )
 

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -99,14 +99,14 @@ options:
 '''
 
 EXAMPLES = '''
-- name: 'Generate PKCS #12 file'
-  openssl_pkcs12:
-    path: '/opt/certs/ansible.p12'
-    friendly_name: 'raclette'
-    privatekey_path: '/opt/certs/keys/key.pem'
-    cert_path: '/opt/certs/cert.pem'
-    ca_certificates: '/opt/certs/ca.pem'
-    state: present
+name: 'Generate PKCS #12 file'
+openssl_pkcs12:
+  path: '/opt/certs/ansible.p12'
+  friendly_name: 'raclette'
+  privatekey_path: '/opt/certs/keys/key.pem'
+  cert_path: '/opt/certs/cert.pem'
+  ca_certificates: '/opt/certs/ca.pem'
+  state: present
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {'metadata_version': '1.0',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: openssl_pkcs12
+author: "Guillaume Delpierre (@gdelpierre)"
+version_added: "2.4"
+short_description: Generate OpenSSL pkcs12 archive.
+description:
+    - "This module allows one to (re-)generate PKCS #12."
+requirements:
+    - "python-pyOpenSSL"
+options:
+    ca_certificates:
+        required: False
+        description:
+            - List of CA certificate to include.
+    certificate:
+        required: False
+        description:
+            - The path to read certificates and private keys from.
+              Must be in PEM format.
+    action:
+        required: False
+        default: 'export'
+        choices: [ 'parse', 'export' ]
+        description:
+            - Create (export) or parse a PKCS #12.
+    dest:
+        required: True
+        default: null
+        aliases: ['path', 'destfile']
+        description:
+            - Filename to write the PKCS#12 file to.
+    force:
+        required: False
+        default: False
+        choices: [ True, False ]
+        description:
+            - Should the PKCS #12 be regenerated even if it already exists.
+    friendly_name:
+        required: True
+        default: null
+        aliases: 'name'
+        description:
+            - Specifies the "friendly name" for the certificate and private key.
+    iter_size:
+        required: False
+        default: 2048
+        description:
+            - Number of times to repeat the encryption step.
+    maciter_size:
+        required: False
+        default: 1
+        description:
+            - Number of times to repeat the MAC step.
+    mode:
+        required: False
+        default: 0400
+        description:
+            - Default mode for the generated PKCS #12 file.
+    passphrase:
+        required: False
+        default: null
+        description:
+            - The PKCS#12 password.
+    privatekey:
+        required: True
+        description:
+            - File to read private key from.
+    privatekey_passphrase:
+        required: False
+        default: null
+        description:
+            - Passphrase source to decrypt any input private keys with.
+    state:
+        required: False
+        default: 'present'
+        choices: [ 'present', 'absent' ]
+        description:
+            - Whether the file should exist or not.
+'''
+
+EXAMPLES = '''
+- name: 'Generate temporary PKCS12 keystore'
+  openssl_pkcs12:
+    path: '/tmp/ansible.p12'
+    friendly_name: 'raclette'
+    privatekey_path: '/tmp/jambon.pem'
+    cert_path: '/tmp/fromage.pem'
+    ca_certificates: '/tmp/patates.cer'
+    state: present
+
+- name: 'generate kafka keystore'
+  java_cert:
+    state: present
+    src_keystore_path: '/tmp/ansible.p12'
+    keystore_path: '/tmp/ansible.jks'
+    src_store_type: 'pkcs12'
+    src_store_pass: ''
+    keystore_pass: 'totototo'
+    alias: 'raclette'
+
+- name: 'Generate truststore'
+  java_cert:
+    state: present
+    keystore_create: True
+    keystore_path: '/tmp/truststore.jks'
+    keystore_pass: 'totototo'
+    cert_path: '/tmp/cert.pem'
+    cert_alias: 'raymond'
+'''
+
+RETURN = '''
+'''
+
+import os
+
+try:
+    from OpenSSL import crypto
+except ImportError:
+    pyopenssl_found = False
+else:
+    pyopenssl_found = True
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.crypto import OpenSSLModule, OpenSSLModuleError, load_certificate, load_privatekey
+from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils._text import to_native
+
+class PkcsError(OpenSSLModuleError):
+    pass
+
+class Pkcs(OpenSSLModule):
+
+    def __init__(self, module):
+        super(Pkcs, self).__init__(module)
+        self.action = module.params['action']
+        self.iter_size = module.params['iter_size']
+        self.maciter_size = module.params['maciter_size']
+        self.privatekey_path = module.params['privatekey_path']
+        self.privatekey_passphrase = module.params['privatekey_passphrase']
+        self.cert_path = module.params['cert_path']
+        self.ca_certificates = module.params['ca_certificates']
+        self.friendly_name = module.params['friendly_name']
+        self.passphrase = module.params['passphrase']
+        self.mode = module.params['mode']
+
+    def export(self):
+        ''' Generate PKCS #12 file. '''
+
+        if os.path.exists(self.path) and not self.force:
+            self.changed = False
+            return
+
+        self.pkcs12 = crypto.PKCS12()
+
+        if self.ca_certificates:
+            ca_certs = tuple([load_certificate(ca_cert) for ca_cert in self.ca_certificates])
+            self.pkcs12.set_ca_certificates(ca_certs)
+
+        if self.cert_path:
+            self.pkcs12.set_certificate(load_certificate(self.cert_path))
+
+        if self.friendly_name:
+            self.pkcs12.set_friendlyname(self.friendly_name)
+
+        if self.privatekey_path:
+            self.pkcs12.set_privatekey(load_privatekey(
+                                        self.privatekey_path,
+                                        self.privatekey_passphrase)
+                                        )
+
+        try:
+            with open(self.path, 'w', self.mode) as archive:
+                archive.write(
+                    self.pkcs12.export(
+                        self.passphrase,
+                        self.iter_size,
+                        self.maciter_size
+                    )
+                )
+        except (IOError, OSError) as exc:
+            raise PkcsError(exc)
+            
+    def parse(self):
+        ''' Parse PKCS #12 file. '''
+        pass
+
+    def check(self):
+        return True
+
+    def dump(self):
+        result = {
+            'changed': self.changed,
+            'path': self.path,
+        }
+        return result
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            path=dict(required=True, type='path'),
+            force=dict(default=False, type='bool'),
+            action=dict(default='export', choices=['parse', 'export'], type='str'),
+            ca_certificates=dict(type='list'),
+            cert_path=dict(type='path'),
+            friendly_name=dict(required=True, type='str'),
+            iter_size=dict(default=2048, type='int'),
+            maciter_size=dict(default=1, type='int'),
+            mode=dict(default=0400, type='int'),
+            passphrase=dict(type='str', no_log=True),
+            privatekey_path=dict(required=True, type='path'),
+            privatekey_passphrase=dict(type='str', no_log=True),
+        ),
+        required_together = [
+            ['path', 'privatekey_path', 'friendly_name'],
+        ],
+        supports_check_mode = True,
+        add_file_common_args = True,
+    )
+
+    if not pyopenssl_found:
+        module.fail_json(msg='The python pyOpenSSL library is required')
+
+    pkcs12 = Pkcs(module)
+
+    if module.params['state'] == 'present':
+        if module.check_mode:
+            result = pkcs12.dump()
+            result['changed'] = module.params['force'] or not pkcs12.check()
+            module.exit_json(**result)
+
+        try:
+            pkcs12.export()
+        except PkcsError as exc:
+            module.fail_json(msg=to_native(exc))
+    else:
+        if module.check_mode:
+            result = pkcs12.dump()
+            result['changed'] = pkcs12.check()
+            module.exit_json(**result)
+
+        try:
+            pkcs12.remove()
+        except PkcsError as exc:
+            module.fail_json(msg=to_native(exc))
+
+    result = pkcs12.dump()
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/crypto/openssl_pkcs12.py
+++ b/lib/ansible/modules/crypto/openssl_pkcs12.py
@@ -217,7 +217,7 @@ def main():
 
     required_together = [
         ['path', 'privatekey_path', 'friendly_name'],
-    ],
+    ]
 
     module = AnsibleModule(
         argument_spec = argument_spec,


### PR DESCRIPTION
##### SUMMARY

**Disclaimer**: This pull request is an addition on top of https://github.com/ansible/ansible/pull/27320. Since the module freeze happens on Aug 29 and the author of the original PR seems to be on holidays.

This module aims to allow a user to manage PKCS#12.
Internally it relies on the pyOpenSSL python library to interact with openssl.

##### ISSUE TYPE

 - New Module Pull Request


##### COMPONENT NAME

- openssl_pkcs12

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

A playbook example:

```
---
- hosts: localhost
  tasks:
    - openssl_privatekey:
        path: /tmp/ansible/private.key
        cipher: aes256
        passphrase: ansible

    - openssl_csr:
        path: /tmp/ansible/my.csr
        privatekey_path: /tmp/ansible/private.key
        privatekey_passphrase: ansible
        commonName: www.ansible.com

    - openssl_certificate:
        path: /tmp/ansible/my.crt
        csr_path: /tmp/ansible/my.csr
        privatekey_path: /tmp/ansible/private.key
        privatekey_passphrase: ansible
        provider: selfsigned

    - openssl_pkcs12:
        path: /tmp/ansible/mypkcs12.p12
        friendly_name: ansible
        privatekey_path: /tmp/ansible/private.key
        privatekey_passphrase: ansible
        certificate_path: /tmp/ansible/my.crt
        passphrase: ansible
        force: true

    - openssl_pkcs12:
        src: /tmp/ansible/mypkcs12.p12
        path: /tmp/ansible/bis.p12
        passphrase: ansible
        action: parse
```
