### PR TITLE
vmware: Only add configured network interfaces to facts

### DIFF
--- a/changelogs/fragments/vmware-only-add-configured-interfaces.yml
+++ b/changelogs/fragments/vmware-only-add-configured-interfaces.yml
@@ -1,0 +1,2 @@
+minor_changes:
+    - vmware.py - Only add configured network interfaces to facts.

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -365,7 +365,8 @@ def gather_vm_facts(content, vm):
     vmnet = _get_vm_prop(vm, ('guest', 'net'))
     if vmnet:
         for device in vmnet:
-            net_dict[device.macAddress] = list(device.ipAddress)
+            if device.deviceConfigId > 0:
+                net_dict[device.macAddress] = list(device.ipAddress)
 
     if vm.guest.ipAddress:
         if ':' in vm.guest.ipAddress:


### PR DESCRIPTION
##### SUMMARY
This change effectively filters out any network interfaces which were not explicitly configured for the guest. This fixes some unexpected behavior where a machine with multiple IP addresses (for example, when Docker is installed, an internal IPv4 interface is added to communicate with the container) would show one of the internal addresses in the 'ipv4' field, but then no other information about the corresponding hardware interface.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware

##### ANSIBLE VERSION
```
2.4.0
```