### PR TITLE
Remove sleep and switch to pipe for IPC

### DIFF
--- a/lib/ansible/modules/utilities/logic/async_wrapper.py
+++ b/lib/ansible/modules/utilities/logic/async_wrapper.py
@@ -21,11 +21,15 @@ import traceback
 import signal
 import time
 import syslog
+import multiprocessing
 
 PY3 = sys.version_info[0] == 3
 
 syslog.openlog('ansible-%s' % os.path.basename(__file__))
 syslog.syslog(syslog.LOG_NOTICE, 'Invoked with %s' % " ".join(sys.argv[1:]))
+
+# pipe for communication between forked process and parent
+ipc_watcher, ipc_notifier = multiprocessing.Pipe()
 
 
 def notice(msg):
@@ -130,6 +134,11 @@ def _run_module(wrapped_cmd, jid, job_path):
     jobfile = open(tmp_job_path, "w")
     result = {}
 
+    # signal grandchild process started and isolated from being terminated
+    # by the connection being closed sending a signal to the job group
+    ipc_notifier.send(True)
+    ipc_notifier.close()
+
     outdata = ''
     filtered_outdata = ''
     stderr = ''
@@ -141,6 +150,7 @@ def _run_module(wrapped_cmd, jid, job_path):
         if interpreter:
             cmd = interpreter + cmd
         script = subprocess.Popen(cmd, shell=False, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
         (outdata, stderr) = script.communicate()
         if PY3:
             outdata = outdata.decode('utf-8', 'surrogateescape')
@@ -242,14 +252,31 @@ if __name__ == '__main__':
             # to initialize PRIOR to ansible trying to clean up the launch directory (and argsfile)
             # this probably could be done with some IPC later.  Modules should always read
             # the argsfile at the very first start of their execution anyway
+
+            # close off notifier handle in grandparent, probably unnecessary as
+            # this process doesn't hang around long enough
+            ipc_notifier.close()
+
+            # allow waiting up to 2.5 seconds in total should be long enough for worst
+            # loaded environment in practice.
+            retries = 25
+            while retries > 0:
+                if ipc_watcher.poll(0.1):
+                    break
+                else:
+                    retries = retries - 1
+                    continue
+
             notice("Return async_wrapper task started.")
             print(json.dumps({"started": 1, "finished": 0, "ansible_job_id": jid, "results_file": job_path,
                               "_ansible_suppress_tmpdir_delete": not preserve_tmp}))
             sys.stdout.flush()
-            time.sleep(1)
             sys.exit(0)
         else:
             # The actual wrapper process
+
+            # close off the receiving end of the pipe from child process
+            ipc_watcher.close()
 
             # Daemonize, so we keep on running
             daemonize_self()
@@ -259,6 +286,10 @@ if __name__ == '__main__':
 
             sub_pid = os.fork()
             if sub_pid:
+                # close off inherited pipe handles
+                ipc_watcher.close()
+                ipc_notifier.close()
+
                 # the parent stops the process after the time limit
                 remaining = int(time_limit)
 


### PR DESCRIPTION
##### SUMMARY
Use a simple multiprocessing pipe to delay exiting the parent process
until after the child has been doubly forked.

Using a simple IPC to allow the forked process to start avoids the
control node waiting unnecessarily.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
async_wrapper.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/baileybd/.ansible.cfg
  configured module search path = [u'/home/baileybd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/baileybd/git/ansible/.tox/py27/local/lib/python2.7/site-packages/ansible
  executable location = /home/baileybd/git/ansible/.tox/py27/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION

This was originally developed to reduce the chances of a race by ensuring that the async_wrapper only returned once the grandchild process had started reading the remote files so that removal of these wouldn't cause a 'file not found' error on the remote node. #5719 fixed this by switching the deletion of the files to be handled by the async_wrapper module, however it still waits unnecessarily in the main code before returning.

Alternatively could just delete the sleep as being unnecessary anymore.