### PR TITLE
ec2_lc_facts: Use built in paginator and remove paging()

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -332,37 +332,6 @@ def ec2_connect(module):
     return ec2
 
 
-def paging(pause=0, marker_property='marker', result_key=None):
-    """ Adds paging to boto retrieval functions that support a 'marker'
-        this is configurable as not all boto functions seem to use the
-        same name.
-    """
-    def wrapper(f):
-        def page(*args, **kwargs):
-            results = []
-            marker = None
-            while True:
-                try:
-                    if marker:
-                        kwargs[marker_property] = marker
-                    new = f(*args, **kwargs)
-                    marker = new.get(marker_property)
-                    if result_key:
-                        new = new[result_key]
-                    results.extend(new)
-                    if not marker:
-                        break
-                    elif pause:
-                        sleep(pause)
-                except TypeError:
-                    # Older version of boto do not allow for marker param, just run normally
-                    results = f(*args, **kwargs)
-                    break
-            return results
-        return page
-    return wrapper
-
-
 def _camel_to_snake(name):
 
     def prepend_underscore_and_lower(m):

--- a/lib/ansible/modules/cloud/amazon/ec2_lc_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc_facts.py
@@ -165,7 +165,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, camel_dict_to_snake_dict, ec2_argument_spec,
-                                      get_aws_connection_info, paging)
+                                      get_aws_connection_info)
 
 
 def list_launch_configs(connection, module):
@@ -177,8 +177,8 @@ def list_launch_configs(connection, module):
     sort_end = module.params.get('sort_end')
 
     try:
-        launch_configs = {'LaunchConfigurations': paging(pause=0, marker_property='NextToken', result_key='LaunchConfigurations')
-                                                        (connection.describe_launch_configurations)(LaunchConfigurationNames=launch_config_name)}
+        pg = connection.get_paginator('describe_launch_configurations')
+        launch_configs = pg.paginate(LaunchConfigurationNames=launch_config_name).build_full_result()
     except ClientError as e:
         module.fail_json(msg=e.message)
 


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils.ec2 paging() appears to only be used in ec2_lc_facts (which is boto3 and has built-in paginators).


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_lc_facts.py
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
