### PR TITLE
test: yum: add test cases for state=latest

### DIFF
--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -59,6 +59,58 @@
     that:
         - "not yum_result.changed"
 
+# INSTALL AGAIN WITH LATEST
+- name: install sos again with state latest in check mode
+  yum: name=sos state=latest
+  check_mode: true
+  register: yum_result
+- name: verify install sos again with state latest in check mode
+  assert:
+    that:
+        - "not yum_result.changed"
+
+- name: install sos again with state latest idempotence
+  yum: name=sos state=latest
+  register: yum_result
+- name: verify install sos again with state latest idempotence
+  assert:
+    that:
+        - "not yum_result.changed"
+
+# INSTALL WITH LATEST
+- name: uninstall sos
+  yum: name=sos state=removed
+  register: yum_result
+- name: verify uninstall sos
+  assert:
+    that:
+        - "yum_result|success"
+
+- name: install sos with state latest in check mode
+  yum: name=sos state=latest
+  check_mode: true
+  register: yum_result
+- name: verify install sos with state latest in check mode
+  assert:
+    that:
+        - "yum_result.changed"
+
+- name: install sos with state latest
+  yum: name=sos state=latest
+  register: yum_result
+- name: verify install sos with state latest
+  assert:
+    that:
+        - "yum_result.changed"
+
+- name: install sos with state latest idempotence
+  yum: name=sos state=latest
+  register: yum_result
+- name: verify install sos with state latest idempotence
+  assert:
+    that:
+        - "not yum_result.changed"
+
 # Multiple packages
 - name: uninstall sos and bc
   yum: name=sos,bc state=removed

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -15,6 +15,16 @@
         - "rpm_result.rc == 1"
 
 # UNINSTALL AGAIN
+- name: uninstall sos again in check mode
+  yum: name=sos state=removed
+  check_mode: true
+  register: yum_result
+
+- name: verify no change on re-uninstall in check mdoe
+  assert:
+    that:
+        - "not yum_result.changed"
+
 - name: uninstall sos again
   yum: name=sos state=removed
   register: yum_result
@@ -25,6 +35,16 @@
         - "not yum_result.changed"
 
 # INSTALL
+- name: install sos in check mode
+  yum: name=sos state=present
+  check_mode: true
+  register: yum_result
+
+- name: verify installation of sos in check mode
+  assert:
+    that:
+        - "yum_result.changed"
+
 - name: install sos
   yum: name=sos state=present
   register: yum_result
@@ -50,10 +70,18 @@
         - "'results' in yum_result"
 
 # INSTALL AGAIN
+- name: install sos again in check mode
+  yum: name=sos state=present
+  check_mode: true
+  register: yum_result
+- name: verify no change on second install in check mode
+  assert:
+    that:
+        - "not yum_result.changed"
+
 - name: install sos again
   yum: name=sos state=present
   register: yum_result
-
 - name: verify no change on second install
   assert:
     that:
@@ -215,7 +243,7 @@
 - name: uninstall sos and bc
   yum: name=sos,bc state=removed
 
-- name: install non-existent rpm 
+- name: install non-existent rpm
   yum: name="{{ item }}"
   with_items:
   - does-not-exist


### PR DESCRIPTION
##### SUMMARY
extend test cases for an undiscovered issue fixed by #28547. Without the fix the failing test in this PR would have been
~~~
TASK [yum : install sos again with state latest idempotence] *******************
fatal: [testhost]: FAILED! => {"changed": false, "failed": true, "msg": "", "rc": 100, "results": ["All packages providing sos are up to date", "Loaded plugins: fastestmirror, ovl\nLoading mirror speeds from cached hostfile\n * base: mirror.switch.ch\n * epel: mirrors.ircam.fr\n * extras: mirror.switch.ch\n * updates: mirror.switch.ch\n\nbind-license.noarch                    32:9.9.4-50.el7_3.1               updates\nca-certificates.noarch                 2017.2.14-70.1.el7_3              updates\nchkconfig.x86_64                       1.7.2-1.el7_3.1                   updates\ndevice-mapper.x86_64                   7:1.02.135-1.el7_3.5              updates\ndevice-mapper-libs.x86_64              7:1.02.135-1.el7_3.5              updates\ndracut.x86_64                          033-463.el7_3.2                   updates\nepel-release.noarch                    7-10                              epel   \ngawk.x86_64                            4.0.2-4.el7_3.1                   updates\nghostscript.x86_64                     9.07-20.el7_3.7                   updates\nglibc.x86_64                           2.17-157.el7_3.5                  updates\nglibc-common.x86_64                    2.17-157.el7_3.5                  updates\nglibc-devel.x86_64                     2.17-157.el7_3.5                  updates\nglibc-headers.x86_64                   2.17-157.el7_3.5                  updates\ngraphite2.x86_64                       1.3.10-1.el7_3                    updates\nkernel-headers.x86_64                  3.10.0-514.26.2.el7               updates\nlibtomcrypt.x86_64                     1.17-25.el7                       epel   \nlibtommath.x86_64                      0.42.0-5.el7                      epel   \nmercurial.x86_64                       2.6.2-7.el7_3                     updates\n"]}
	to retry, use: --limit @/root/ansible/test/integration/yum-9kBW8f.retry

PLAY RECAP *********************************************************************
testhost                   : ok=20   changed=4    unreachable=0    failed=1   

NOTICE: To resume at this test target, use the option: --start-at yum
ERROR: Command "ansible-playbook yum-9kBW8f.yml -i inventory -e @integration_config.yml" returned exit status 2.
ERROR: Command "docker exec dba0c57d117f4238ffbfe401204285127b868986bcdcd767e7dad14c33b05a72 /root/ansible/test/runner/test.py integration --require yum --metadata metadata-qSrN66.json --color yes --requirements --allow-destructive" returned exit status 1.
~~~

Extended also integration tests with some check mode tests.

/cc @mkrizek
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
yum

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
