### PR TITLE
[unarchive] Introducing option download_pipe Fixes: #28569

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -904,6 +904,11 @@ def main():
             res_args['changed'] = not check_results['unarchived']
         elif check_results['unarchived']:
             res_args['changed'] = False
+        elif 'err' in res_args:
+            # error occurs during check
+            # try to unpack
+            check_results['unarchived'] = True
+            res_args['changed'] = False
         # Get diff if required
         if check_results.get('diff', False):
             res_args['diff'] = {'prepared': check_results['diff']}
@@ -935,6 +940,10 @@ def main():
         for filename in handler.files_in_archive:
             file_args['path'] = os.path.join(dest, filename)
             try:
+                # don't know why changed is not in 
+                # res args but in case it is not 
+                if 'changed' not in res_args:
+                    res_args['changed'] = False
                 res_args['changed'] = module.set_fs_attributes_if_different(file_args, res_args['changed'], expand=False)
             except (IOError, OSError) as e:
                 module.fail_json(msg="Unexpected error when accessing exploded file: %s" % to_native(e), **res_args)

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -764,6 +764,7 @@ def pick_handler(src, dest, file_args, module,pipe):
     # can not read src whem using named pipes
     # so guessing handler by file extentsion
     if pipe:
+        handler=None
         (f,ext) = os.path.splitext(src)
         ext = ext.lower()
         if ext == ".zip":
@@ -774,7 +775,10 @@ def pick_handler(src, dest, file_args, module,pipe):
             handler=TarBzipArchive
         elif ext == ".xz":
             handler=TarXzArchive
-        return handler(src, dest, file_args, module)
+        if handler:
+            return handler(src, dest, file_args, module)
+        else:
+            raise Exception("No Handler found for download_pipe and {}".format(src))
     # try to open file and read archive
     handlers = [ZipArchive, TgzArchive, TarArchive, TarBzipArchive, TarXzArchive]
     reasons = set()

--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -907,6 +907,9 @@ def main():
         # Get diff if required
         if check_results.get('diff', False):
             res_args['diff'] = {'prepared': check_results['diff']}
+    else:
+        # Always changed using download_pipe
+        res_args['changed'] = True
 
     # do the unpack
     if download_pipe or (not module.check_mode and check_results['unarchived']):


### PR DESCRIPTION
Fixes: #28569
 download_pipe:
    description:
      - Set to C(yes) to indicate the archived file will by downloaded
	to named pipe. It does not require additional space in temporary
	directory. But does not support check_mode.
      - This option is mutually exclusive with C(copy).

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Introducing option download_pipe, which allows to download big files 
 directly to destination, not using temporary directory.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/files/unarchive.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (download_pipe d4aff3b576) last updated 2017/08/24 09:50:12 (GMT +200)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/src/aaa/ansible/lib/ansible
  executable location = /usr/src/aaa/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
this command will not fail 
#ansible -i localhost, -c local -m unarchive -a "src=https://<myserver>/sklad/veritas/Veritas_InfoScale_7.1_RHEL.tar.gz dest=/var/crash/veritas/base_path remote_src=yes validate_certs=no download_pipe=yes" -vvvvvvvv localhost

# df -h /tmp
Filesystem              Size  Used Avail Use% Mounted on
/dev/mapper/rootdg-tmp  976M   19M  891M   2% /tmp

ls -lah Veritas_InfoScale_7.1_RHEL.tar.gz
-rw-r--r-- 2 root root 1000M Apr 19  2016 Veritas_InfoScale_7.1_RHEL.tar.gz

```
