### PR TITLE
Fixes : Bug in Image upload to switch. Resolved.

### DIFF
--- a/lib/ansible/module_utils/cnos.py
+++ b/lib/ansible/module_utils/cnos.py
@@ -2986,12 +2986,14 @@ def doImageTransfer(
     else:
         return "Error-110"
     # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "[n]", 3, obj)
+    response = waitForDeviceResponse(command, "[n]", 3, obj)
+    if(response.lower().find("error-101")):
+        retVal = retVal
+    else:
+        retVal = retVal+response
+
     # Confirmation command happens here
     command = "y\n"
-    # debugOutput(command)
-    # retVal = retVal+ waitForDeviceResponse(command, "(yes/no)?", 3, obj)
-    # command = "Yes \n"
     # debugOutput(command)
     if(protocol == "ftp"):
         retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
@@ -3034,12 +3036,20 @@ def doSecureImageTransfer(
     command = "cp " + protocol + " " + protocol + "://" + username + "@" + \
         server + "/" + imgPath + " system-image " + type + " vrf management \n"
     # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "[n]", 3, obj)
+    response = waitForDeviceResponse(command, "[n]", 3, obj)
+    if(response.lower().find("error-101")):
+        retVal = retVal
+    else:
+        retVal = retVal+response
     # Confirmation command happens here
     if(protocol == "scp"):
         command = "y\n"
         # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        response = waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        if(response.lower().find("error-101")):
+            retVal = retVal
+        else:
+            retVal = retVal+response
         command = "Yes\n"
         # debugOutput(command)
         retVal = retVal + waitForDeviceResponse(command, "timeout:", 3, obj)
@@ -3049,7 +3059,12 @@ def doSecureImageTransfer(
     elif(protocol == "sftp"):
         command = "y\n"
         # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        response = waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        if(response.lower().find("error-101")):
+            retVal = retVal
+        else:
+            retVal = retVal+response
+
         command = "Yes\n"
         # debugOutput(command)
         retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
@@ -3160,13 +3175,16 @@ def checkOutputForError(output):
         index = output.lower().find("invalid")
         startIndex = index + 8
         if(index == -1):
-            index = output.lower().find("incorrect")
+            index = output.lower().find("Cannot be enabled in L2 Interface")
             startIndex = index + 9
             if(index == -1):
-                index = output.lower().find("failure")
-                startIndex = index + 8
+                index = output.lower().find("incorrect")
+                startIndex = index + 33
                 if(index == -1):
-                    return None
+                    index = output.lower().find("failure")
+                    startIndex = index + 8
+                    if(index == -1):
+                        return None
 
     endIndex = startIndex + 3
     errorCode = output[startIndex:endIndex]


### PR DESCRIPTION
##### SUMMARY
Fix for the error/bug in image transfer module ie cnos_image.py which facilitates image download to lenovo devices through SCP or SFTP or FTP or TFTP protocols. The issue is that though the image transfer is successful, and logs indicate that too but play book status is getting displayed as failed.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/module_utils/cnos.py

##### ANSIBLE VERSION
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
While transferring image from an SFTP Server to a network element, though the operation succeeds, the playbook status was showing as failure. This was due to an error coming from the output comparision logic in device interaction.

@@ -2986,13 +2986,15 @@ def doImageTransfer(
     else:
         return "Error-110"
     # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "[n]", 3, obj)
+    response = waitForDeviceResponse(command, "[n]", 3, obj)
+    if(response.lower().find("error-101")):
+        retVal = retVal
+    else:
+        retVal = retVal+response
+
     # Confirmation command happens here
     command = "y\n"
     # debugOutput(command)
-    # retVal = retVal+ waitForDeviceResponse(command, "(yes/no)?", 3, obj)
-    # command = "Yes \n"
-    # debugOutput(command)
     if(protocol == "ftp"):
         retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
         # Password entry happens here Only for FTP
@@ -3034,12 +3036,20 @@ def doSecureImageTransfer(
     command = "cp " + protocol + " " + protocol + "://" + username + "@" + \
         server + "/" + imgPath + " system-image " + type + " vrf management \n"
     # debugOutput(command)
-    retVal = retVal + waitForDeviceResponse(command, "[n]", 3, obj)
+    response = waitForDeviceResponse(command, "[n]", 3, obj)
+    if(response.lower().find("error-101")):
+        retVal = retVal
+    else:
+        retVal = retVal+response
     # Confirmation command happens here
     if(protocol == "scp"):
         command = "y\n"
         # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        response = waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        if(response.lower().find("error-101")):
+            retVal = retVal
+        else:
+            retVal = retVal+response
         command = "Yes\n"
         # debugOutput(command)
         retVal = retVal + waitForDeviceResponse(command, "timeout:", 3, obj)
@@ -3049,7 +3059,12 @@ def doSecureImageTransfer(
     elif(protocol == "sftp"):
         command = "y\n"
         # debugOutput(command)
-        retVal = retVal + waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        response = waitForDeviceResponse(command, "(yes/no)?", 3, obj)
+        if(response.lower().find("error-101")):
+            retVal = retVal
+        else:
+            retVal = retVal+response
+
         command = "Yes\n"
         # debugOutput(command)
         retVal = retVal + waitForDeviceResponse(command, "Password:", 3, obj)
@@ -3160,13 +3175,16 @@ def checkOutputForError(output):
         index = output.lower().find("invalid")
         startIndex = index + 8
         if(index == -1):
-            index = output.lower().find("incorrect")
+            index = output.lower().find("Cannot be enabled in L2 Interface")
             startIndex = index + 9
             if(index == -1):
-                index = output.lower().find("failure")
-                startIndex = index + 8
+                index = output.lower().find("incorrect")
+                startIndex = index + 33
                 if(index == -1):
-                    return None
+                    index = output.lower().find("failure")
+                    startIndex = index + 8
+                    if(index == -1):
+                        return None
 
     endIndex = startIndex + 3
     errorCode = output[startIndex:endIndex]