### PR TITLE
cloud: ovirt: Add option to import SD with sd_type != block storage type

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -39,7 +39,7 @@ options:
         version_added: "2.4"
     name:
         description:
-            - "Name of the storage domain to manage."
+            - "Name of the storage domain to manage. (Not required when state is I(imported))"
     state:
         description:
             - "Should the storage domain be present/absent/maintenance/unattached/imported"
@@ -166,8 +166,19 @@ EXAMPLES = '''
       address: 10.10.10.10
       path: /path/data
 
+# Create export NFS storage domain:
+- ovirt_storage_domains:
+    name: myexportdomain
+    domain_function: export
+    host: myhost
+    data_center: mydatacenter
+    nfs:
+      address: 10.34.63.199
+      path: /path/export
+
 # Import export NFS storage domain:
 - ovirt_storage_domains:
+    state: imported
     domain_function: export
     host: myhost
     data_center: mydatacenter
@@ -261,8 +272,14 @@ class StorageDomainModule(BaseModule):
             name=self._module.params['name'],
             description=self._module.params['description'],
             comment=self._module.params['comment'],
-            import_=True if (self._module.params['state'] == 'imported' and storage_type in ['iscsi', 'fcp']) else None,
-            id=self._module.params['id'] if (self._module.params['state'] == 'imported' and storage_type in ['iscsi', 'fcp']) else None,
+            import_=(
+                True
+                if self._module.params['state'] == 'imported' else None
+            ),
+            id=(
+                self._module.params['id']
+                if self._module.params['state'] == 'imported' else None
+            ),
             type=otypes.StorageDomainType(
                 self._module.params['domain_function']
             ),
@@ -287,7 +304,10 @@ class StorageDomainModule(BaseModule):
                 ] if storage_type in ['iscsi', 'fcp'] else None,
                 override_luns=storage.get('override_luns'),
                 mount_options=storage.get('mount_options'),
-                vfs_type='glusterfs' if storage_type in ['glusterfs'] else storage.get('vfs_type'),
+                vfs_type=(
+                    'glusterfs'
+                    if storage_type in ['glusterfs'] else storage.get('vfs_type')
+                ),
                 address=storage.get('address'),
                 path=storage.get('path'),
                 nfs_retrans=storage.get('retrans'),
@@ -434,7 +454,7 @@ def main():
             default='present',
         ),
         id=dict(default=None),
-        name=dict(required=True),
+        name=dict(default=None),
         description=dict(default=None),
         comment=dict(default=None),
         data_center=dict(required=True),
@@ -481,6 +501,7 @@ def main():
                 action_condition=lambda s: s.status == sdstate.MAINTENANCE,
                 wait_condition=lambda s: s.status == sdstate.ACTIVE,
                 fail_condition=failed_state,
+                search_params={'id': sd_id} if state == 'imported' else None
             )
         elif state == 'maintenance':
             sd_id = storage_domains_module.create()['id']


### PR DESCRIPTION
##### SUMMARY
With this patch I added the option in the ovirt_storage_domains module to import a preconfigured SD  of storage_type != block storage.
https://github.com/ansible/ansible/pull/26568 covers only block storage domains and importing with known storage domains ID.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ovirt-module