### PR TITLE
Fix valueerror in vmware_inventory.py

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -745,7 +745,7 @@ class VMWareInventory(object):
             return self.inventory['_meta']['hostvars'][host]
         elif self.args.host and self.inventory['_meta']['hostvars']:
             match = None
-            for k, v in self.inventory['_meta']['hostvars']:
+            for k, v in self.inventory['_meta']['hostvars'].items():
                 if self.inventory['_meta']['hostvars'][k]['name'] == self.args.host:
                     match = k
                     break


### PR DESCRIPTION
##### SUMMARY

Fixes ...

```
[vagrant@localhost ~]$ ./vmware_inventory.py --host=DC0_H0_VM0
Traceback (most recent call last):
  File "./vmware_inventory.py", line 762, in <module>
    print(VMWareInventory().show())
  File "./vmware_inventory.py", line 174, in show
    data_to_print = self.get_host_info(self.args.host)
  File "./vmware_inventory.py", line 748, in get_host_info
    for k, v in self.inventory['_meta']['hostvars']:
ValueError: too many values to unpack
```


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
vmware_inventory.py

##### ANSIBLE VERSION

```
2.4
```


##### ADDITIONAL INFORMATION
