### PR TITLE
WIP Fixing relative dwim searching when the src path contains ..

### DIFF
--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -381,7 +381,8 @@ class DataLoader:
                             search.append(os.path.join(b_upath, b_dirname, b_source))
                         search.append(os.path.join(b_upath, b_source))
 
-                elif b_dirname not in b_source.split(b'/'):
+                #elif b_dirname not in b_source.split(b'/'):
+                else:
                     # don't add dirname if user already is using it in source
                     if b_source.split(b'/')[0] != dirname:
                         search.append(os.path.join(b_upath, b_dirname, b_source))

--- a/lib/ansible/parsing/dataloader.py
+++ b/lib/ansible/parsing/dataloader.py
@@ -371,17 +371,9 @@ class DataLoader:
                 b_mydir = os.path.dirname(b_upath)
 
                 # if path is in role and 'tasks' not there already, add it into the search
-                if is_role or self._is_role(path):
-                    if b_mydir.endswith(b'tasks'):
-                        search.append(os.path.join(os.path.dirname(b_mydir), b_dirname, b_source))
-                        search.append(os.path.join(b_mydir, b_source))
-                    else:
-                        # don't add dirname if user already is using it in source
-                        if b_source.split(b'/')[0] != b_dirname:
-                            search.append(os.path.join(b_upath, b_dirname, b_source))
-                        search.append(os.path.join(b_upath, b_source))
-
-                #elif b_dirname not in b_source.split(b'/'):
+                if (is_role or self._is_role(path)) and b_mydir.endswith(b'tasks'):
+                    search.append(os.path.join(os.path.dirname(b_mydir), b_dirname, b_source))
+                    search.append(os.path.join(b_mydir, b_source))
                 else:
                     # don't add dirname if user already is using it in source
                     if b_source.split(b'/')[0] != dirname:

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -177,9 +177,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         include_target = templar.template(t.args['_raw_params'])
                         if t._role:
                             new_basedir = os.path.join(t._role._role_path, subdir, cumulative_path)
-                            include_file = loader.path_dwim_relative(new_basedir, subdir, include_target)
+                            include_file = loader.path_dwim_relative_stack([new_basedir]+t.get_search_path(), subdir, include_target)
                         else:
-                            include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
+                            include_file = loader.path_dwim_relative_stack([loader.get_basedir()]+t.get_search_path(), cumulative_path, include_target)
 
                         if os.path.exists(include_file):
                             found = True
@@ -200,7 +200,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                                 suppress_extended_error=True,
                                 orig_exc=e)
                         if t._role:
-                            include_file = loader.path_dwim_relative(t._role._role_path, subdir, include_target)
+                            include_file = loader.path_dwim_relative_stack([t._role._role_path]+t.get_search_path(), subdir, include_target)
                         else:
                             include_file = loader.path_dwim(include_target)
 

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -113,9 +113,9 @@ class IncludedFile:
                                 include_target = templar.template(include_result['include'])
                                 if original_task._role:
                                     new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)
-                                    include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
+                                    include_file = loader.path_dwim_relative_stack([new_basedir]+original_task.get_search_path(), 'tasks', include_target)
                                 else:
-                                    include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
+                                    include_file = loader.path_dwim_relative_stack([loader.get_basedir()]+original_task.get_search_path(), cumulative_path, include_target)
 
                                 if os.path.exists(include_file):
                                     break
@@ -125,7 +125,7 @@ class IncludedFile:
                     if include_file is None:
                         if original_task._role:
                             include_target = templar.template(include_result['include'])
-                            include_file = loader.path_dwim_relative(original_task._role._role_path, 'tasks', include_target)
+                            include_file = loader.path_dwim_relative_stack([original_task._role._role_path]+original_task.get_search_path(), 'tasks', include_target)
                         else:
                             include_file = loader.path_dwim(include_result['include'])
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -99,11 +99,7 @@ class Task(Base, Conditional, Taggable, Become):
 
     def get_path(self):
         ''' return the absolute path of the task with its line number '''
-
-        path = ""
-        if hasattr(self, '_ds') and hasattr(self._ds, '_data_source') and hasattr(self._ds, '_line_number'):
-            path = "%s:%s" % (self._ds._data_source, self._ds._line_number)
-        return path
+        return self._src_path
 
     def get_name(self):
         ''' return the name of the task '''
@@ -444,10 +440,15 @@ class Task(Base, Conditional, Taggable, Become):
         if dep_chain:
             path_stack.extend(reversed([x._role_path for x in dep_chain]))
 
+        parent = self._parent
+        while parent:
+            if parent._src_path is not None and parent._src_path not in path_stack:
+                path_stack.append(parent._src_path)
+            parent = parent._parent
+
         # add path of task itself, unless it is already in the list
-        task_dir = os.path.dirname(self.get_path())
-        if task_dir not in path_stack:
-            path_stack.append(task_dir)
+        if self._src_path not in path_stack:
+            path_stack.append(self._src_path)
 
         return path_stack
 


### PR DESCRIPTION
##### SUMMARY
Also generalizing some of the task file path code into Base for all
playbook objects, and adding parent source paths to the search paths
to aid in relative path discovery when doing includes and/or roles.

Fixes #14341

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
core engine

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue_14341_relative_path_dwim_fixes e12ca80953) last updated 2017/08/24 10:20:43 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /data/devel/ansible/lib/ansible
  executable location = /data/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```


##### ADDITIONAL INFORMATION
