### PR TITLE
haproxy: connect via TCP socket in addition to UNIX socket

### DIFF
--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -253,7 +253,7 @@ class HAProxy(object):
         a TCP socket, depending on the format of the configuration option.
         """
         if self.socket.startswith('tcp:'):
-            match = re.search('^tcp://(.+):(\d+)$', self.socket)
+            match = re.search('^tcp:(?://)?(.+):(\d+)$', self.socket)
             if not match:
                 self.module.fail_json(msg="Invalid TCP address: '%s'" % self.socket)
             address = (match.group(1), int(match.group(2)))

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -255,7 +255,7 @@ class HAProxy(object):
         if self.socket.startswith('tcp:'):
             match = re.search('^tcp://(.+):(\d+)$', self.socket)
             if not match:
-                raise Exception('Invalid TCP address: %s' % self.socket)
+                self.module.fail_json(msg="Invalid TCP address: '%s'" % self.socket)
             address = (match.group(1), int(match.group(2)))
             client = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             client.connect(address)

--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -49,7 +49,7 @@ options:
     default: false
   socket:
     description:
-      - Path to the HAProxy socket file. If you want to connect via TCP, use the format 'tcp://host:port'.
+      - Path to the HAProxy socket file. If you want to connect via TCP, use the format 'tcp://host:port' or 'tcp:host:port'.
     required: false
     default: /var/run/haproxy.sock
   state:


### PR DESCRIPTION
##### SUMMARY
Adds a new configuration option to the `haproxy` module to connect to the HAProxy admin port via TCP in addition to local UNIX sockets.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module: haproxy

##### ADDITIONAL INFORMATION
I'm not a python maven. The parsing of the `tcp://host:port` url in line 256 with regular expressions looks very clumsy to me. Maybe someone with more python foo can suggest a better way?