### PR TITLE
Support retrieving Facts about Fibre Channel resource of HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_fc_network_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_fc_network_facts.py
@@ -17,7 +17,7 @@ description:
     - Retrieve the facts about one or more of the Fibre Channel Networks from OneView.
 version_added: "2.4"
 requirements:
-    - "hpOneView >= 2.0.1"
+    - hpOneView >= 2.0.1
 author:
     - Felipe Bulsoni (@fgbulsoni)
     - Thiago Miotto (@tmiotto)
@@ -26,7 +26,6 @@ options:
     name:
       description:
         - Fibre Channel Network name.
-      required: false
 
 extends_documentation_fragment:
     - oneview
@@ -36,14 +35,14 @@ extends_documentation_fragment:
 EXAMPLES = '''
 - name: Gather facts about all Fibre Channel Networks
   oneview_fc_network_facts:
-    config: '/etc/oneview/oneview_config.json'
+    config: /etc/oneview/oneview_config.json
   delegate_to: localhost
 
 - debug: var=fc_networks
 
 - name: Gather paginated, filtered and sorted facts about Fibre Channel Networks
   oneview_fc_network_facts:
-    config: '/etc/oneview/oneview_config.json'
+    config: /etc/oneview/oneview_config.json
     params:
       start: 1
       count: 3
@@ -54,7 +53,7 @@ EXAMPLES = '''
 
 - name: Gather facts about a Fibre Channel Network by name
   oneview_fc_network_facts:
-    config: '/etc/oneview/oneview_config.json'
+    config: /etc/oneview/oneview_config.json
     name: network name
   delegate_to: localhost
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_fc_network_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_fc_network_facts.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_fc_network_facts
+short_description: Retrieve the facts about one or more of the OneView Fibre Channel Networks
+description:
+    - Retrieve the facts about one or more of the Fibre Channel Networks from OneView.
+version_added: "2.4"
+requirements:
+    - "hpOneView >= 2.0.1"
+author:
+    - Felipe Bulsoni (@fgbulsoni)
+    - Thiago Miotto (@tmiotto)
+    - Adriane Cardozo (@adriane-cardozo)
+options:
+    name:
+      description:
+        - Fibre Channel Network name.
+      required: false
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Fibre Channel Networks
+  oneview_fc_network_facts:
+    config: '/etc/oneview/oneview_config.json'
+  delegate_to: localhost
+
+- debug: var=fc_networks
+
+- name: Gather paginated, filtered and sorted facts about Fibre Channel Networks
+  oneview_fc_network_facts:
+    config: '/etc/oneview/oneview_config.json'
+    params:
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'fabricType=FabricAttach'
+  delegate_to: localhost
+- debug: var=fc_networks
+
+- name: Gather facts about a Fibre Channel Network by name
+  oneview_fc_network_facts:
+    config: '/etc/oneview/oneview_config.json'
+    name: network name
+  delegate_to: localhost
+
+- debug: var=fc_networks
+'''
+
+RETURN = '''
+fc_networks:
+    description: Has all the OneView facts about the Fibre Channel Networks.
+    returned: Always, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class FcNetworkFactsModule(OneViewModuleBase):
+    def __init__(self):
+
+        argument_spec = dict(
+            name=dict(required=False, type='str'),
+            params=dict(required=False, type='dict')
+        )
+
+        super(FcNetworkFactsModule, self).__init__(additional_arg_spec=argument_spec)
+
+    def execute_module(self):
+
+        if self.module.params['name']:
+            fc_networks = self.oneview_client.fc_networks.get_by('name', self.module.params['name'])
+        else:
+            fc_networks = self.oneview_client.fc_networks.get_all(**self.facts_params)
+
+        return dict(changed=False, ansible_facts=dict(fc_networks=fc_networks))
+
+
+def main():
+    FcNetworkFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -31,4 +31,5 @@ from ansible.module_utils.oneview import (OneViewModuleException,
 
 from ansible.modules.remote_management.oneview.oneview_ethernet_network import EthernetNetworkModule
 from ansible.modules.remote_management.oneview.oneview_fc_network import FcNetworkModule
+from ansible.modules.remote_management.oneview.oneview_fc_network_facts import FcNetworkFactsModule
 from ansible.modules.remote_management.oneview.oneview_fcoe_network import FcoeNetworkModule

--- a/test/units/modules/remote_management/oneview/test_oneview_fc_network_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_fc_network_facts.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import FcNetworkFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test FC Network"
+)
+
+PRESENT_NETWORKS = [{
+    "name": "Test FC Network",
+    "uri": "/rest/fc-networks/c6bf9af9-48e7-4236-b08a-77684dc258a5"
+}]
+
+
+class FcNetworkFactsSpec(unittest.TestCase,
+                         FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, FcNetworkFactsModule)
+        self.fc_networks = self.mock_ov_client.fc_networks
+        FactsParamsTestCase.configure_client_mock(self, self.fc_networks)
+
+    def test_should_get_all_fc_networks(self):
+        self.fc_networks.get_all.return_value = PRESENT_NETWORKS
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        FcNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fc_networks=PRESENT_NETWORKS)
+        )
+
+    def test_should_get_fc_network_by_name(self):
+        self.fc_networks.get_by.return_value = PRESENT_NETWORKS
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        FcNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fc_networks=PRESENT_NETWORKS)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_fc_network_facts module for retrieving [HPE OneView Fibre Channel](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/fc-networks) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_fc_network_facts`

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 655667527d) last updated 2017/08/17 17:56:40 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/dev/core_ansible_related/ansible/lib/ansible
  executable location = /home/vagrant/dev/core_ansible_related/ansible/bin/ansible
  python version = 2.7.9 (default, Aug  1 2017, 20:38:26) [GCC 4.8.4]

```


##### ADDITIONAL INFORMATION
Example of usage:
```
- name: Gather facts about all Fibre Channel Networks
  oneview_fc_network_facts:
    config: '/etc/oneview/oneview_config.json'
  delegate_to: localhost

- debug: var=fc_networks

- name: Gather paginated, filtered and sorted facts about Fibre Channel Networks
  oneview_fc_network_facts:
    config: '/etc/oneview/oneview_config.json'
    params:
      start: 1
      count: 3
      sort: 'name:descending'
      filter: 'fabricType=FabricAttach'
  delegate_to: localhost
- debug: var=fc_networks

- name: Gather facts about a Fibre Channel Network by name
  oneview_fc_network_facts:
    config: '/etc/oneview/oneview_config.json'
    name: network name
  delegate_to: localhost

- debug: var=fc_networks
```
