### PR TITLE
Fixup the property collection for dictionaries vs. objects

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -713,8 +713,7 @@ class VMWareInventory(object):
             methods = dir(vobj)
             methods = [str(x) for x in methods if not x.startswith('_')]
             methods = [x for x in methods if x not in self.bad_types]
-            if inkey:
-                methods = [x for x in methods if not inkey + '.' + x.lower() in self.skip_keys]
+            methods = [x for x in methods if not inkey + '.' + x.lower() in self.skip_keys]
             methods = sorted(methods)
 
             for method in methods:

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -731,21 +731,12 @@ class VMWareInventory(object):
                     method = method.lower()
                 if level + 1 <= self.maxlevel:
                     try:
-                        if inkey:
-                            rdata[method] = self._process_object_types(
-                                methodToCall,
-                                thisvm=thisvm,
-                                inkey=inkey + '.' + method,
-                                level=(level + 1)
-                            )
-                        else:
-                            rdata[method] = self._process_object_types(
-                                methodToCall,
-                                thisvm=thisvm,
-                                inkey=method,
-                                level=(level + 1)
-                            )
-
+                        rdata[method] = self._process_object_types(
+                            methodToCall,
+                            thisvm=thisvm,
+                            inkey=inkey + '.' + method,
+                            level=(level + 1)
+                        )
                     except vim.fault.NoPermission:
                         self.debugl("Skipping method %s (NoPermission)" % method)
         else:

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -579,7 +579,10 @@ class VMWareInventory(object):
                 for idx, x in enumerate(parts):
 
                     if isinstance(val, dict):
-                        val = val.get(x)
+                        if x in val:
+                            val = val.get(x)
+                        elif x.lower() in val:
+                            val = val.get(x.lower())
                     else:
                         # if the val wasn't set yet, get it from the parent
                         if not val:

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -580,8 +580,6 @@ class VMWareInventory(object):
 
                     if isinstance(val, dict):
                         val = val.get(x)
-                        self.debugl('val set to ' + str(val))
-                        #import epdb; epdb.st()
                     else:
                         # if the val wasn't set yet, get it from the parent
                         if not val:
@@ -597,9 +595,7 @@ class VMWareInventory(object):
                                 self.debugl(e)
 
                         # make sure it serializes
-                        #val = self.facts_from_vobj(val)
                         val = self._process_object_types(val)
-                        self.debugl('val is now {}'.format(val))
 
                     # lowercase keys if requested
                     if self.lowerkeys:

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -175,7 +175,7 @@ class VMWareInventory(object):
         elif self.args.list:
             # Display list of instances for inventory
             data_to_print = self.inventory
-        return json.dumps(data_to_print, sort_keys=True, indent=2)
+        return json.dumps(data_to_print, indent=2)
 
     def is_cache_valid(self):
 


### PR DESCRIPTION
##### SUMMARY
If using the explicit properties, we may still want to serialize their values and crawl through lower layers.

Example vmware_inventory.ini this was tested with ...

```
$ cat vmware_inventory.ini | egrep -v ^\# | egrep -v ^\$ | egrep -v ^server | egrep -v ^username | egrep -v ^pass
[vmware]
cache_max_age = 0
max_object_level=5
alias_pattern={{ name }}
host_pattern={{ guest.net[1].ipaddress[0] }}
host_filters={{ guest.net|length > 1  and guest.gueststate == 'running' }}
[properties]
prop01=name
prop02=config.name
prop03=config.uuid
prop08=guest.hostName
prop11=guest.guestState
prop13=guest.net
```


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
contrib/inventory/vmware_guest.py

##### ANSIBLE VERSION

```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
