### PR TITLE
pam_limits creates custom file if not exist (#26989)

### DIFF
--- a/lib/ansible/modules/system/pam_limits.py
+++ b/lib/ansible/modules/system/pam_limits.py
@@ -94,6 +94,8 @@ options:
       - Comment associated with the limit.
     required: false
     default: ''
+notes:
+  - If dest file doesn't exists, it is created.
 '''
 
 EXAMPLES = '''
@@ -168,12 +170,17 @@ def main():
 
     if os.path.isfile(limits_conf):
         if not os.access(limits_conf, os.W_OK):
-            module.fail_json(msg="%s is not writable. Use sudo" % (limits_conf) )
+            module.fail_json(msg="%s is not writable. Use sudo" % limits_conf)
     else:
-        module.fail_json(msg="%s is not visible (check presence, access rights, use sudo)" % (limits_conf) )
+        limits_conf_dir = os.path.dirname(limits_conf)
+        if os.path.isdir(limits_conf_dir) and os.access(limits_conf_dir, os.W_OK):
+            open(limits_conf, 'a').close()
+            changed = True
+        else:
+            module.fail_json(msg="directory %s is not writable (check presence, access rights, use sudo)" % limits_conf_dir)
 
     if use_max and use_min:
-        module.fail_json(msg="Cannot use use_min and use_max at the same time." )
+        module.fail_json(msg="Cannot use use_min and use_max at the same time.")
 
     if not (value in ['unlimited', 'infinity', '-1'] or value.isdigit()):
         module.fail_json(msg="Argument 'value' can be one of 'unlimited', 'infinity', '-1' or positive number. Refer to manual pages for more details.")


### PR DESCRIPTION
##### SUMMARY
Fixes #26989 
Before this commit, pam_limits give an error message if dest file doesn't exists
After this commit, pam_limits create the new dest file if not exists and if its parent directory is a writable directory

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
pam_limits

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.4.0 (pull-issue-26989 657eaf7cd8) last updated 2017/08/24 22:54:33 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/g/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/g/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Before commit
```
$ ./bin/ansible r7node1 -m pam_limits -a "domain=james limit_type='-' limit_item=memlock value=unlimited comment='unlimited memory lock for james' dest=/etc/security/limits.d/20-test.conf" -b
r7node1 | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "/etc/security/limits.d/20-test.conf is not visible (check presence, access rights, use sudo)"
}
```
After commit
```
$ ./bin/ansible r7node1 -m pam_limits -a "domain=james limit_type='-' limit_item=memlock value=unlimited comment='unlimited memory lock for james' dest=/etc/security/limits.d/20-test.conf" -b
r7node1 | SUCCESS => {
    "changed": true, 
    "failed": false, 
    "msg": "james\t-\tmemlock\tunlimited\t#unlimited memory lock for james\n"
}
```
