### PR TITLE
fix seport default mismatch

### DIFF
--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -39,7 +39,6 @@ options:
   state:
     description:
       - Desired boolean value.
-    required: true
     default: present
     choices: [ 'present', 'absent' ]
   reload:
@@ -244,7 +243,6 @@ def main():
                 'required': True,
                 },
             'state': {
-                'required': True,
                 'choices': ['present', 'absent'],
                 'default': 'present',
                 },

--- a/lib/ansible/modules/system/seport.py
+++ b/lib/ansible/modules/system/seport.py
@@ -246,6 +246,7 @@ def main():
             'state': {
                 'required': True,
                 'choices': ['present', 'absent'],
+                'default': 'present',
                 },
             'reload': {
                 'required': False,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #28653 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
sport

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.2.0
  config file = /home/ansible/roles/mariadb/tests/cluster/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
