### PR TITLE
Change A and AAAA record checks to allow round robin setup

### DIFF
--- a/lib/ansible/modules/net_tools/dnsmadeeasy.py
+++ b/lib/ansible/modules/net_tools/dnsmadeeasy.py
@@ -471,12 +471,12 @@ class DME2(object):
         if not self.all_records:
             self.all_records = self.getRecords()
 
-        if record_type in ["A", "AAAA", "CNAME", "ANAME", "HTTPRED", "PTR"]:
+        if record_type in ["CNAME", "ANAME", "HTTPRED", "PTR"]:
             for result in self.all_records:
                 if result['name'] == record_name and result['type'] == record_type:
                     return result
             return False
-        elif record_type in ["MX", "NS", "TXT", "SRV"]:
+        elif record_type in ["A", "AAAA", "MX", "NS", "TXT", "SRV"]:
             for result in self.all_records:
                 if record_type == "MX":
                     value = record_value.split(" ")[1]


### PR DESCRIPTION
##### SUMMARY

Fixes #28386

With these changes I'm able successfully set up [round robin](http://help.dnsmadeeasy.com/managed-dns/records/round-robin/) DNS records with dnsmadeeasy.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Module: dnsmadeeasy

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 3e893f2178) last updated 2017/08/25 21:32:03 (GMT +1300)
  config file = None
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = ~/Downloads/ansible/lib/ansible
  executable location = ~/Downloads/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
