### PR TITLE
Allow logging format configuration

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -669,6 +669,20 @@ DEFAULT_LOG_PATH:
   - {key: log_path, section: defaults}
   type: path
   yaml: {key: defaults.log_path}
+DEFAULT_LOG_FORMAT:
+  default: '%(asctime)s %(name)s %(message)s'
+  description: Python logger format string used to format logs.
+  env: [{name: ANSIBLE_LOG_FORMAT}]
+  ini:
+  - {key: log_format, section: defaults}
+  yaml: {key: defaults.log_format}
+DEFAULT_LOG_NAME:
+  default: 'p={mypid} u={user} |'
+  description: Logger name, as python formatted string.
+  env: [{name: ANSIBLE_LOG_NAME}]
+  ini:
+  - {key: log_name, section: defaults}
+  yaml: {key: defaults.log_format}
 DEFAULT_LOOKUP_PLUGIN_PATH:
   default: ~/.ansible/plugins/lookup:/usr/share/ansible/plugins/lookup
   description: 'TODO: write it'

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -52,10 +52,10 @@ logger = None
 if C.DEFAULT_LOG_PATH:
     path = C.DEFAULT_LOG_PATH
     if (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
-        logging.basicConfig(filename=path, level=logging.DEBUG, format='%(asctime)s %(name)s %(message)s')
+        logging.basicConfig(filename=path, level=logging.DEBUG, format=C.DEFAULT_LOG_FORMAT)
         mypid = str(os.getpid())
         user = getpass.getuser()
-        logger = logging.getLogger("p=%s u=%s | " % (mypid, user))
+        logger = logging.getLogger(C.DEFAULT_LOG_NAME.format(**locals()))
     else:
         print("[WARNING]: log file at %s is not writeable and we cannot create it, aborting\n" % path, file=sys.stderr)
 
@@ -113,7 +113,7 @@ class Display:
         if color:
             msg = stringc(msg, color)
 
-        if not log_only:
+        if not log_only and color not in [C.COLOR_DEBUG]:
             if not msg.endswith(u'\n'):
                 msg2 = msg + u'\n'
             else:


### PR DESCRIPTION
This allows user to control log formatting strings.

Change-Id: I4c6aaddd1be241ec161be24571cf254d9217584d
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

##### SUMMARY

This allows us to change the format of the log files which until now was hardcoded in ansible.

Relates to #13702 

##### ISSUE TYPE
 - Feature Pull Request