### PR TITLE
Use data center UUID/name in storage domains module

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -137,6 +137,15 @@ EXAMPLES = '''
       address: 10.34.63.199
       path: /path/data
 
+# Add data NFS storage domain with id for data center
+- ovirt_storage_domains:
+    name: data_nfs
+    host: myhost
+    data_center: 11111
+    nfs:
+      address: 10.34.63.199
+      path: /path/data
+
 # Add data localfs storage domain
 - ovirt_storage_domains:
     name: data_localfs
@@ -301,9 +310,13 @@ class StorageDomainModule(BaseModule):
     def _attached_sds_service(self):
         # Get data center object of the storage domain:
         dcs_service = self._connection.system_service().data_centers_service()
+
+        # Serach the data_center name, if it does not exists, try to search by guid.
         dc = search_by_name(dcs_service, self._module.params['data_center'])
         if dc is None:
-            return
+            dc = dcs_service.service(self._module.params['data_center']).get()
+            if dc is None:
+                return
 
         dc_service = dcs_service.data_center_service(dc.id)
         return dc_service.storage_domains_service()


### PR DESCRIPTION
The ansible action ovirt_storage_domains obligates a data center
name of the attached storage domain as part of its action's arguments,
so it will get the attached_sd_service as part of the functionality
of changing the storage domain status (to maintenance for example).

On the other hand, ovirt_storage_domains_facts retrieves a storage
domain entity with information about the data center which the storage
domain is attached to as a UUID identifier (without name).
So for the user to use that storage domain, fetched from the facts
module, one will have to fetch the DC entity to get the name.

We could use the search which is used today using:
   service.list(search=...)
but that type of search does not support search by Guid.
Therefor this patch provides the ability to use ovirt_storage_domains
action with state change using also a DC UUID instead of a DC name.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
