### PR TITLE
Record host specific messages to log files

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -183,7 +183,7 @@ class Display:
             if host is None:
                 self.display(msg, color=C.COLOR_VERBOSE)
             else:
-                self.display("<%s> %s" % (host, msg), color=C.COLOR_VERBOSE, screen_only=True)
+                self.display("<%s> %s" % (host, msg), color=C.COLOR_VERBOSE)
 
     def deprecated(self, msg, version=None, removed=False):
         ''' used to print out a deprecation message.'''


### PR DESCRIPTION
Fixes #28660

Change-Id: I0028f16320fd63c6ee0fa3be942fc88c555e4dcb
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

##### SUMMARY
The is clearly no reason for dropping host specific messages from the log files. 
Using the screen_only=True as a parameter seems more like a copy/paste error or some sort.

See #28660

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
core

##### ANSIBLE VERSION
```
2.4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
