### PR TITLE
Allow logging format configuration

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -669,6 +669,20 @@ DEFAULT_LOG_PATH:
   - {key: log_path, section: defaults}
   type: path
   yaml: {key: defaults.log_path}
+DEFAULT_LOG_FORMAT:
+  default: '%(asctime)s %(name)s %(message)s'
+  description: Python logger format string used to format logs.
+  env: [{name: ANSIBLE_LOG_FORMAT}]
+  ini:
+  - {key: log_format, section: defaults}
+  yaml: {key: defaults.log_format}
+DEFAULT_LOG_NAME:
+  default: 'p={mypid} u={user} |'
+  description: Logger name, as python formatted string.
+  env: [{name: ANSIBLE_LOG_NAME}]
+  ini:
+  - {key: log_name, section: defaults}
+  yaml: {key: defaults.log_name}
 DEFAULT_LOOKUP_PLUGIN_PATH:
   default: ~/.ansible/plugins/lookup:/usr/share/ansible/plugins/lookup
   description: 'TODO: write it'

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -272,6 +272,7 @@ CACHE_PLUGIN_TIMEOUT:
   yaml: {key: defaults.fact_caching_timeout}
 COLOR_CHANGED:
   default: yellow
+  type: color
   description: Defines the color to use on 'Changed' status
   env: [{name: ANSIBLE_COLOR_CHANGED}]
   ini:
@@ -279,6 +280,7 @@ COLOR_CHANGED:
   yaml: {key: display.colors.changed}
 COLOR_DEBUG:
   default: dark gray
+  type: color
   description: Defines the color to use when emitting debug messages
   env: [{name: ANSIBLE_COLOR_DEBUG}]
   ini:
@@ -286,6 +288,7 @@ COLOR_DEBUG:
   yaml: {key: colors.debug}
 COLOR_DEPRECATE:
   default: purple
+  type: color
   description: Defines the color to use when emitting deprecation messages
   env: [{name: ANSIBLE_COLOR_DEPRECATE}]
   ini:
@@ -293,6 +296,7 @@ COLOR_DEPRECATE:
   yaml: {key: colors.deprecate}
 COLOR_DIFF_ADD:
   default: green
+  type: color
   description: Defines the color to use when showing added lines in diffs
   env: [{name: ANSIBLE_COLOR_DIFF_ADD}]
   ini:
@@ -300,6 +304,7 @@ COLOR_DIFF_ADD:
   yaml: {key: colors.diff_add}
 COLOR_DIFF_LINES:
   default: cyan
+  type: color
   description: Defines the color to use when showing diffs
   env: [{name: ANSIBLE_COLOR_DIFF_LINES}]
   ini:
@@ -307,6 +312,7 @@ COLOR_DIFF_LINES:
   yaml: {key: colors.diff_lines}
 COLOR_DIFF_REMOVE:
   default: red
+  type: color
   description: Defines the color to use when showing removed lines in diffs
   env: [{name: ANSIBLE_COLOR_DIFF_REMOVE}]
   ini:
@@ -314,6 +320,7 @@ COLOR_DIFF_REMOVE:
   yaml: {key: colors.diff_remove}
 COLOR_ERROR:
   default: red
+  type: color
   description: Defines the color to use when emitting error messages
   env: [{name: ANSIBLE_COLOR_ERROR}]
   ini:
@@ -321,6 +328,7 @@ COLOR_ERROR:
   yaml: {key: colors.error}
 COLOR_HIGHLIGHT:
   default: white
+  type: color
   description: 'TODO: write it'
   env: [{name: ANSIBLE_COLOR_HIGHLIGHT}]
   ini:
@@ -328,6 +336,7 @@ COLOR_HIGHLIGHT:
   yaml: {key: colors.highlight}
 COLOR_OK:
   default: green
+  type: color
   description: Defines the color to use when showing 'OK' status
   env: [{name: ANSIBLE_COLOR_OK}]
   ini:
@@ -335,6 +344,7 @@ COLOR_OK:
   yaml: {key: colors.ok}
 COLOR_SKIP:
   default: cyan
+  type: color
   description: Defines the color to use when showing 'Skipped' status
   env: [{name: ANSIBLE_COLOR_SKIP}]
   ini:
@@ -342,6 +352,7 @@ COLOR_SKIP:
   yaml: {key: colors.skip}
 COLOR_UNREACHABLE:
   default: bright red
+  type: color
   description: Defines the color to use on 'Unreachable' status
   env: [{name: ANSIBLE_COLOR_UNREACHABLE}]
   ini:
@@ -349,6 +360,7 @@ COLOR_UNREACHABLE:
   yaml: {key: colors.unreachable}
 COLOR_VERBOSE:
   default: blue
+  type: color
   description: Defines the color to use when emitting verbose messages
   env: [{name: ANSIBLE_COLOR_VERBOSE}]
   ini:
@@ -356,6 +368,7 @@ COLOR_VERBOSE:
   yaml: {key: colors.verbose}
 COLOR_WARN:
   default: bright purple
+  type: color
   description: Defines the color to use when emitting warning messages
   env: [{name: ANSIBLE_COLOR_WARN}]
   ini:
@@ -363,6 +376,7 @@ COLOR_WARN:
   yaml: {key: colors.warn}
 COMMAND_WARNINGS:
   default: True
+  type: color
   description: 'TODO: write it'
   env: [{name: ANSIBLE_COMMAND_WARNINGS}]
   ini:

--- a/lib/ansible/config/log.py
+++ b/lib/ansible/config/log.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+import logging
+import warnings
+
+
+log_color_to_level = {
+    'blue': 5,  # less than debug : COLOR_VERBOSE
+    'dark gray': logging.DEBUG,  # 10 : COLOR_DEBUG
+    'cyan': logging.INFO-3,  # 17 : COLOR_SKIP
+    'green': logging.INFO,  # 20 : COLOR_OK
+    'yellow': logging.INFO+3,  # 23 : COLOR_CHANGED
+    'white': logging.INFO+6,  # 26 : COLOR_HIGHLIGHT
+    'purple': logging.WARNING,  # 30 : COLOR_DEPRECATE
+    'bright purple': logging.WARNING,  # 30 : COLOR_WARN
+    'red': logging.ERROR,  # 40 : COLOR_ERROR
+    'bright red': logging.FATAL  # 50 : COLOR_UNREACHABLE
+}
+
+
+class LogStyle:
+    '''LogStyle is designed to behave like a simple string color in ordered
+    to keep code that was using C.COLOR_* backwards compatible.
+
+    The class enables the logging facility to receive more detailed information
+    about the message being logged, not only color.
+
+    Current implementation includes `value` attribute which is the mapped
+    python logging level for that color (style).
+
+    This allows sorting and filtering messages based on their levels.
+    '''
+
+    def __init__(self, color):
+        self.color = color
+        self.value = 0  # undefined log level
+        try:
+            self.value = log_color_to_level[color]
+        except Exception as e:
+            warnigns.warn("Unknown style '%s' mapped to log level 0 (unset)")
+
+    def __str__(self):
+        return self.color
+
+    def __repr__(self):
+        return self.color
+
+    # http://portingguide.readthedocs.io/en/latest/comparisons.html
+    def __eq__(self, other):
+        return self.value == getattr(other, 'value', 0)
+
+    def __ne__(self, other):
+        return self.value == getattr(other, 'value', 0)
+
+    def __lt__(self, other):
+        return self.value < getattr(other, 'value', 0)
+
+    def __le__(self, other):
+        return self.value <= getattr(other, 'value', 0)
+
+    def __gt__(self, other):
+        return self.value > getattr(other, 'value', 0)
+
+    def __ge__(self, other):
+        return self.value >= getattr(other, 'value', 0)

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -13,6 +13,7 @@ import yaml
 from collections import namedtuple
 
 from ansible.config.data import ConfigData
+from ansible.config.log import LogStyle
 from ansible.errors import AnsibleOptionsError, AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import configparser
@@ -77,6 +78,9 @@ def ensure_type(value, value_type):
         elif value_type == 'pathlist':
             if isinstance(value, string_types):
                 value = [resolve_path(x) for x in value.split(os.pathsep)]
+
+        elif value_type == 'color':
+            value = LogStyle(unquote(value))
 
         # defaults to string types
         elif isinstance(value, string_types):

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -52,10 +52,10 @@ logger = None
 if C.DEFAULT_LOG_PATH:
     path = C.DEFAULT_LOG_PATH
     if (os.path.exists(path) and os.access(path, os.W_OK)) or os.access(os.path.dirname(path), os.W_OK):
-        logging.basicConfig(filename=path, level=logging.DEBUG, format='%(asctime)s %(name)s %(message)s')
+        logging.basicConfig(filename=path, level=logging.DEBUG, format=C.DEFAULT_LOG_FORMAT)
         mypid = str(os.getpid())
         user = getpass.getuser()
-        logger = logging.getLogger("p=%s u=%s | " % (mypid, user))
+        logger = logging.getLogger(C.DEFAULT_LOG_NAME.format(**locals()))
     else:
         print("[WARNING]: log file at %s is not writeable and we cannot create it, aborting\n" % path, file=sys.stderr)
 


### PR DESCRIPTION
Allow logging format configuration

This allows user to control log formatting strings.

Change-Id: I4c6aaddd1be241ec161be24571cf254d9217584d
Signed-off-by: Sorin Sbarnea <ssbarnea@redhat.com>

##### SUMMARY

This allows us to change the format of the log files which until now was hardcoded in ansible.

Relates to #13702 

##### ISSUE TYPE
 - Feature Pull Request