### PR TITLE
Refactor/fix nxos_nxapi to use show run

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -220,7 +220,7 @@ def parse_https(data):
     return {'https': https_port is not None, 'https_port': https_port}
 
 def parse_sandbox(data):
-    sandbox = filter(re.compile(".*sandbox.*").match, data.split('\n'))
+    sandbox = [item for item in data.split('\n') if re.search(r'.*sandbox.*', item)]
     value = False
     if sandbox and sandbox[0] == 'nxapi sandbox':
         value = True

--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -196,7 +196,7 @@ def map_obj_to_commands(want, have, module):
     return commands
 
 def parse_http(data):
-    http_res = [r'HTTP Port:\s+(\d+)', r'HTTP Listen on port (\d+)']
+    http_res = [r'nxapi http port (\d+)']
     http_port = None
 
     for regex in http_res:
@@ -208,7 +208,7 @@ def parse_http(data):
     return {'http': http_port is not None, 'http_port': http_port}
 
 def parse_https(data):
-    https_res = [r'HTTPS Port:\s+(\d+)', r'HTTPS Listen on port (\d+)']
+    https_res = [r'nxapi https port (\d+)']
     https_port = None
 
     for regex in https_res:
@@ -220,15 +220,19 @@ def parse_https(data):
     return {'https': https_port is not None, 'https_port': https_port}
 
 def parse_sandbox(data):
-    match = re.search(r'Sandbox:\s+(.+)$', data, re.M)
+    sandbox = filter(re.compile(".*sandbox.*").match, data.split('\n'))
     value = False
-    if match:
-        value = match.group(1) == 'Enabled'
+    if sandbox and sandbox[0] == 'nxapi sandbox':
+        value = True
     return {'sandbox': value}
 
 def map_config_to_obj(module):
-    out = run_commands(module, ['show nxapi'], check_rc=False)[0]
-    if out == '':
+    out = run_commands(module, ['show run all | inc nxapi'], check_rc=False)[0]
+    match = re.search(r'no feature nxapi', out, re.M)
+    # There are two possible outcomes when nxapi is disabled on nxos platforms.
+    # 1. Nothing is displayed in the running config.
+    # 2. The 'no feature nxapi' command is displayed in the running config.
+    if match or out == '':
         return {'state': 'absent'}
 
     out = str(out).strip()

--- a/test/integration/targets/nxos_nxapi/tasks/main.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/main.yaml
@@ -1,2 +1,4 @@
 ---
+# Only cli tests for this module since cli is used
+# to test nxapi
 - { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
@@ -1,0 +1,7 @@
+---
+- name: Assert configuration changes
+  assert:
+    that:
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port | string | search("9443")
+      - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
@@ -1,0 +1,7 @@
+---
+- name: Assert configuration changes
+  assert:
+    that:
+      - result.stdout[0].http_port is not defined
+      - result.stdout[0].https_port | string | search("9443")
+      - result.stdout[0].sandbox_status == 'Enabled'

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -1,6 +1,9 @@
 ---
 - debug: msg="START cli/configure.yaml"
 
+- set_fact: nxapi_sandbox_option="yes"
+  when: platform | search('N7K')
+
 - name: Setup - put NXAPI in stopped state
   nxos_nxapi:
     state: absent
@@ -9,7 +12,7 @@
 - name: Configure NXAPI
   nxos_nxapi:
     enable_http: no
-    enable_sandbox: no
+    enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
     enable_https: yes
     https_port: 9443
     provider: "{{ cli }}"
@@ -21,17 +24,16 @@
     provider: "{{ cli }}"
   register: result
 
-- name: Assert configuration changes
-  assert:
-    that:
-      - result.stdout[0].http_port is not defined
-      - result.stdout[0].https_port == 9443
-      - result.stdout[0].sandbox_status == 'Disabled'
+- include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
+  when: platform | match('N7K')
+
+- include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
+  when: not (platform | search('N7K'))
 
 - name: Configure NXAPI again
   nxos_nxapi:
     enable_http: no
-    enable_sandbox: no
+    enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
     enable_https: yes
     https_port: 9443
     provider: "{{ cli }}"

--- a/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
@@ -40,7 +40,5 @@
   assert:
     that:
       result.changed == false
-# FIXME https://github.com/ansible/ansible-modules-core/issues/4955
-  ignore_errors: yes
 
 - debug: msg="END cli/disable.yaml"

--- a/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -9,7 +9,7 @@
 
 - name: Enable NXAPI
   nxos_nxapi:
-      state: started
+      state: present
       provider: "{{ cli }}"
   register: result
 

--- a/test/units/modules/network/nxos/fixtures/nxos_nxapi/n3k/show_nxapi
+++ b/test/units/modules/network/nxos/fixtures/nxos_nxapi/n3k/show_nxapi
@@ -1,2 +1,0 @@
-nxapi enabled
-HTTP Listen on port 80

--- a/test/units/modules/network/nxos/fixtures/nxos_nxapi/n3k/show_run_all
+++ b/test/units/modules/network/nxos/fixtures/nxos_nxapi/n3k/show_run_all
@@ -1,0 +1,2 @@
+feature nxapi
+nxapi http port 80

--- a/test/units/modules/network/nxos/fixtures/nxos_nxapi/n7k/show_nxapi
+++ b/test/units/modules/network/nxos/fixtures/nxos_nxapi/n7k/show_nxapi
@@ -1,4 +1,0 @@
-
-NX-API:       Enabled         Sandbox:      Disabled    
-HTTP Port:    80              HTTPS Port:   Disabled
-

--- a/test/units/modules/network/nxos/fixtures/nxos_nxapi/n7k/show_run_all
+++ b/test/units/modules/network/nxos/fixtures/nxos_nxapi/n7k/show_run_all
@@ -1,0 +1,5 @@
+feature nxapi
+nxapi http port 80
+no nxapi https
+no nxapi sandbox
+


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/27330

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_nxpai

##### ANSIBLE VERSION
```
ansible 2.4.0 (240/fix_nxos_nxapi 0a7eb906ee) last updated 2017/08/25 14:28:18 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
This PR refactors the module to use `show run all | inc nxapi` instead of `show nxapi`.  On older platforms there is a bug in the output of the `show nxapi` command that incorrectly displays https ports as http ports.

Tests pass on all supported nxos versions and platforms.
