### PR TITLE
make groups magic var dependant on inventory

### DIFF
--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -457,10 +457,6 @@ class VariableManager:
         variables['playbook_dir'] = os.path.abspath(self._loader.get_basedir())
         variables['ansible_playbook_python'] = sys.executable
 
-        if host:
-            # host already provides some magic vars via host.get_vars()
-            if self._inventory:
-                variables['groups'] = self._inventory.get_groups_dict()
         if play:
             variables['role_names'] = [r._role_name for r in play.roles]
 
@@ -471,6 +467,7 @@ class VariableManager:
                 variables['role_uuid'] = text_type(task._role._uuid)
 
         if self._inventory is not None:
+            variables['groups'] = self._inventory.get_groups_dict()
             if play:
                 templar = Templar(loader=self._loader)
                 if templar.is_template(play.hosts):

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -52,7 +52,6 @@ class TestVariableManager(unittest.TestCase):
         v = VariableManager(loader=fake_loader, inventory=mock_inventory)
         variables = v.get_vars(use_cache=False)
 
-
         # Check var manager expected values,  never check: ['omit', 'vars']
         # FIXME:  add the following ['ansible_version', 'ansible_playbook_python', 'groups']
         for varname, value in (('playbook_dir', os.path.abspath('.')), ):

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -50,14 +50,13 @@ class TestVariableManager(unittest.TestCase):
 
         mock_inventory = MagicMock()
         v = VariableManager(loader=fake_loader, inventory=mock_inventory)
-        vars = v.get_vars(use_cache=False)
+        variables = v.get_vars(use_cache=False)
 
-        # FIXME: not sure why we remove all and only test playbook_dir
-        for remove in ['omit', 'vars', 'ansible_version', 'ansible_check_mode', 'ansible_playbook_python']:
-            if remove in vars:
-                del vars[remove]
 
-        self.assertEqual(vars, dict(playbook_dir=os.path.abspath('.')))
+        # Check var manager expected values,  never check: ['omit', 'vars']
+        # FIXME:  add the following ['ansible_version', 'ansible_playbook_python', 'groups']
+        for varname, value in (('playbook_dir', os.path.abspath('.')), ):
+            self.assertEqual(variables[varname], value)
 
     def test_variable_manager_extra_vars(self):
         fake_loader = DictDataLoader({})


### PR DESCRIPTION
##### SUMMARY

it was overtly restricted by 'host', also allows simplifying code further
minor fixes to test_var_manager.py, need to test other values also
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vars
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```