### PR TITLE
Fix config value type for VAULT_IDENTITY_LIST

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -756,8 +756,12 @@ class CLI(with_metaclass(ABCMeta, object)):
         # all needs loader
         loader = DataLoader()
 
+        vault_ids = options.vault_ids
+        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
+        vault_ids = default_vault_ids + vault_ids
+
         vault_secrets = CLI.setup_vault_secrets(loader,
-                                                vault_ids=options.vault_ids,
+                                                vault_ids=vault_ids,
                                                 vault_password_files=options.vault_password_files,
                                                 ask_vault_pass=options.ask_vault_pass)
         loader.set_vault_secrets(vault_secrets)

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1067,7 +1067,7 @@ DEFAULT_VAULT_IDENTITY_LIST:
   env: [{name: ANSIBLE_VAULT_IDENTITY_LIST}]
   ini:
   - {key: vault_identity_list, section: defaults}
-  value_type: list
+  type: list
   vars: []
   yaml: {key: defaults.vault_identity_list}
 DEFAULT_VAULT_PASSWORD_FILE:

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -15,6 +15,7 @@ echo "This is a test file for format 1.2" > "${TEST_FILE_1_2}"
 TEST_FILE_OUTPUT="${MYTMPDIR}/test_file_output"
 
 
+
 # old format
 ansible-vault view "$@" --vault-password-file vault-password-ansible format_1_0_AES.yml
 
@@ -63,6 +64,9 @@ ansible-vault view "$@" --vault-password-file password-script.py format_1_2_AES2
 
 # new 1.2 format, view, using password script with vault-id
 ansible-vault view "$@" --vault-id password-script.py format_1_2_AES256.yml
+
+# newish 1.1 format, view, using a vault-id list from config env var
+ANSIBLE_VAULT_IDENTITY_LIST='wrong-password@vault-password-wrong,default@vault-password' ansible-vault view "$@" --vault-id password-script.py format_1_1_AES256.yml
 
 # new 1.2 format, view, ENFORCE_IDENTITY_MATCH=true, should fail, no 'test_vault_id' vault_id
 ANSIBLE_VAULT_ID_MATCH=1 ansible-vault view "$@" --vault-password-file vault-password format_1_2_AES256.yml && :
@@ -254,6 +258,9 @@ ansible-playbook test_vault_embedded.yml -i ../../inventory -v "$@" --vault-pass
 
 # test with a default vault password file set in config
 ANSIBLE_VAULT_PASSWORD_FILE=vault-password ansible-playbook test_vault_embedded.yml -i ../../inventory -v "$@" --vault-password-file vault-password-wrong
+
+# test using vault_identity_list config
+ANSIBLE_VAULT_IDENTITY_LIST='wrong-password@vault-password-wrong,default@vault-password' ansible-playbook test_vault.yml -i ../../inventory -v "$@"
 
 # test that we can have a vault encrypted yaml file that includes embedded vault vars
 # that were encrypted with a different vault secret


### PR DESCRIPTION
Was using the 'value_type' key, but didn't get updated
to the new 'type' key in merge.

Fix playbooks cli so it uses VAULT_IDENTITY_LIST as well.



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (vault_id_list_fix ab0c6b30d3) last updated 2017/08/25 15:59:42 (GMT -400)
  config file = /home/adrian/src/vault-demo/example.com/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
