### PR TITLE
zabbix_inventory PEP8 compliance.

### DIFF
--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -37,7 +37,10 @@ from __future__ import print_function
 import os
 import sys
 import argparse
-import ConfigParser
+try:
+    import ConfigParser as configparser
+except ImportError:
+    import configparser
 
 try:
     from zabbix_api import ZabbixAPI
@@ -55,7 +58,7 @@ except:
 class ZabbixInventory(object):
 
     def read_settings(self):
-        config = ConfigParser.SafeConfigParser()
+        config = configparser.SafeConfigParser()
         conf_path = './zabbix.ini'
         if not os.path.exists(conf_path):
             conf_path = os.path.dirname(os.path.realpath(__file__)) + '/zabbix.ini'


### PR DESCRIPTION
##### SUMMARY
Handle `ConfigParser` ImportError exception due to renaming of the module for PEP8 compliance.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

`contrib/inventory/zabbix.py`

##### ANSIBLE VERSION

```
❯ ansible --version
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```


##### ADDITIONAL INFORMATION
```
>>> import sys
>>> print (sys.version)
3.6.2 (default, Jul 20 2017, 03:52:27) 
[GCC 7.1.1 20170630]
```

##### BEFORE
```
❯ ansible all -i zabbix.py -m ping --limit="Linux*servers"
ERROR! Attempted to execute "zabbix.py" as inventory script: Inventory script (zabbix.py) had an execution error: Traceback (most recent call last):
  File "/tmp/ansible/contrib/inventory/zabbix.py", line 40, in <module>
    import ConfigParser
ModuleNotFoundError: No module named 'ConfigParser'
```
##### AFTER
```
❯ ansible all -i zabbix.py -m ping --limit="Linux*servers"
example.com | SUCCESS => {
    "changed": false,
    "failed": false,
    "ping": "pong"
}
```
