### PR TITLE
Add lvs_full subfact to ansible_lvm, to handle clashing lvol names in different volgroups

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -575,9 +575,10 @@ class LinuxHardware(Hardware):
             for key in ['vendor', 'model']:
                 d[key] = get_file_content(sysdir + "/device/" + key)
 
-            for key, test in [('removable', '/removable'),
-                              ('support_discard', '/queue/discard_granularity'),
-                              ]:
+            for key, test in [
+                    ('removable', '/removable'),
+                    ('support_discard', '/queue/discard_granularity'),
+            ]:
                 d[key] = get_file_content(sysdir + test)
 
             if diskname in devs_wwn:
@@ -675,20 +676,25 @@ class LinuxHardware(Hardware):
                 rc, vg_lines, err = self.module.run_command('%s %s' % (vgs_path, lvm_util_options))
                 for vg_line in vg_lines.splitlines():
                     items = vg_line.strip().split(',')
-                    vgs[items[0]] = {'size_g': items[-2],
-                                     'free_g': items[-1],
-                                     'num_lvs': items[2],
-                                     'num_pvs': items[1]}
+                    vgs[items[0]] = {
+                        'size_g': items[-2],
+                        'free_g': items[-1],
+                        'num_lvs': items[2],
+                        'num_pvs': items[1],
+                    }
 
             lvs_path = self.module.get_bin_path('lvs')
             # lvs fields:
             # LV VG Attr LSize Pool Origin Data% Move Log Copy% Convert
             lvs = {}
+            lvs_full = {}
             if lvs_path:
                 rc, lv_lines, err = self.module.run_command('%s %s' % (lvs_path, lvm_util_options))
                 for lv_line in lv_lines.splitlines():
                     items = lv_line.strip().split(',')
                     lvs[items[0]] = {'size_g': items[3], 'vg': items[1]}
+                    key = '%s/%s' % (items[1], items[0])  # 'vg/lv'
+                    lvs_full[key] = {'size_g': items[3]}
 
             pvs_path = self.module.get_bin_path('pvs')
             # pvs fields: PV VG #Fmt #Attr PSize PFree
@@ -700,9 +706,10 @@ class LinuxHardware(Hardware):
                     pvs[self._find_mapper_device_name(items[0])] = {
                         'size_g': items[4],
                         'free_g': items[5],
-                        'vg': items[1]}
+                        'vg': items[1] or 'None',
+                    }
 
-            lvm_facts['lvm'] = {'lvs': lvs, 'vgs': vgs, 'pvs': pvs}
+            lvm_facts['lvm'] = {'lvs': lvs, 'lvs_full': lvs_full, 'vgs': vgs, 'pvs': pvs}
 
         return lvm_facts
 


### PR DESCRIPTION
##### SUMMARY
Fixes #28679: Adds lvm_tree subfact to ansible_lvm fact, to avoid clashes with same-named lvols in different volgroups

Currently, if two different volume groups each have a logical volume with the same name, only one of them will appear in the `ansible_lvm` fact. The `lvs` dictionary within it uses the simple non-prefixed name of the lvol as the key, so any duplicates will overwrite previous values.

This PR adds a new subfact of `ansible_lvm` called `lvm_tree`. This is a first pass and the details of the implementation are up for discussion. My thought is to set up a new, independent subfact side-by-side with the existing ones, and start the existing ones on the path to deprecation. Any changes to the existing subfacts that would resolve this issue we're seeing, would also break lots of existing code.

Edit: I rebased to use a new `lvs_full` fact of the format `vg/lv`, per discussion in the comments.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/module_utils/facts/hardware/linux.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/28679 ed4702b2e8) last updated 2017/08/26 00:19:35 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
The below output illustrates the need for the new fact. The `fedora` and `centos` volume groups each have logical volumes named `home`, `root`, and `swap`. Only the `fedora` instances appear in the existing `lvs` subfact. The `lvm_tree` subfact shows all of them.

```
[reid@laptop ~/git]$ ansible localhost -b -c local -i hosts.ini -m setup -a 'filter=*lvm*'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_lvm": {
            "lvm_tree": {
                "centos": {
                    "free_g": "0.01", 
                    "lvs": {
                        "home": {
                            "size_g": "1.00"
                        }, 
                        "root": {
                            "size_g": "27.05"
                        }, 
                        "swap": {
                            "size_g": "7.75"
                        }
                    }, 
                    "num_lvs": "3", 
                    "num_pvs": "1", 
                    "pvs": {
                        "/dev/sda9": {
                            "free_g": "0.01", 
                            "size_g": "35.80"
                        }
                    }, 
                    "size_g": "35.80"
                }, 
                "fedora": {
                    "free_g": "19.00", 
                    "lvs": {
                        "home": {
                            "size_g": "319.92"
                        }, 
                        "root": {
                            "size_g": "50.00"
                        }, 
                        "swap": {
                            "size_g": "7.75"
                        }
                    }, 
                    "num_lvs": "3", 
                    "num_pvs": "1", 
                    "pvs": {
                        "/dev/sda7": {
                            "free_g": "19.00", 
                            "size_g": "396.67"
                        }
                    }, 
                    "size_g": "396.67"
                }
            }, 
            "lvs": {
                "home": {
                    "size_g": "319.92", 
                    "vg": "fedora"
                }, 
                "root": {
                    "size_g": "50.00", 
                    "vg": "fedora"
                }, 
                "swap": {
                    "size_g": "7.75", 
                    "vg": "fedora"
                }
            }, 
            "pvs": {
                "/dev/sda7": {
                    "free_g": "19.00", 
                    "size_g": "396.67", 
                    "vg": "fedora"
                }, 
                "/dev/sda9": {
                    "free_g": "0.01", 
                    "size_g": "35.80", 
                    "vg": "centos"
                }
            }, 
            "vgs": {
                "centos": {
                    "free_g": "0.01", 
                    "num_lvs": "3", 
                    "num_pvs": "1", 
                    "size_g": "35.80"
                }, 
                "fedora": {
                    "free_g": "19.00", 
                    "num_lvs": "3", 
                    "num_pvs": "1", 
                    "size_g": "396.67"
                }
            }
        }
    }, 
    "changed": false, 
    "failed": false
}
```
