### PR TITLE
Prevents parsing/splitter.py from treating quote characters specially in comments

### DIFF
--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -165,6 +165,39 @@
       - "shell_result0.stderr == ''"
       - "shell_result0.stdout == 'win'"
 
+- name: execute shell command with comment
+  shell: "{{output_dir_test | expanduser}}/test.sh  # here is a commment"
+  register: shell_result1
+
+- name: assert that the script executed correctly
+  assert:
+    that:
+      - "shell_result1.rc == 0"
+      - "shell_result1.stderr == ''"
+      - "shell_result1.stdout == 'win'"
+
+- name: execute shell command with comment and apostrophe
+  shell: "{{output_dir_test | expanduser}}/test.sh  # here's a commment"
+  register: shell_result2
+
+- name: assert that the script executed correctly
+  assert:
+    that:
+      - "shell_result2.rc == 0"
+      - "shell_result2.stderr == ''"
+      - "shell_result2.stdout == 'win'"
+
+- name: execute shell command with beginning with comment
+  shell: "# here is a commment"
+  register: shell_result3
+
+- name: assert that the script executed correctly
+  assert:
+    that:
+      - "shell_result3.rc == 0"
+      - "shell_result3.stderr == ''"
+      - "shell_result3.stdout == ''"
+
 # executable
 
 # FIXME doesn't pass the expected stdout


### PR DESCRIPTION
##### SUMMARY
Fixes #28674: Prevents parsing/splitter.py from treating quote characters specially in comments

Issue example:
```
[reid@laptop ~/git]$ ansible localhost -c local -i hosts.ini -m shell -a "# there is a comment block"
localhost | SUCCESS | rc=0 >>
```
```
[reid@laptop ~/git]$ ansible localhost -c local -i hosts.ini -m shell -a "# there's a comment block"
ERROR! failed at splitting arguments, either an unbalanced jinja2 block or quotes: # there's a comment block
```
Quote characters should not be treated specially inside a comment.

I've added a boolean `inside_comment` to `parsing/splitter.py` that seems to fix the immediate issue. If it passes the integration tests, I would like your input on whether this will cause any issues with jinja2 parsing elsewhere.

NOTE: I have not changed anything in `module_utils/splitter.py`, whose `split_args` function looks very similar or identical to that of `parsing/splitter.py`. I'm not sure what that file is used for and whether it's necessary to modify its function. Modifying the function in `parsing` did the trick for `shell`/`command`. Please advise.

Also note: Looking at the code, I don't believe `line_continuation` is going to behave as the author intended. Unless it's the last token on the line, the `\\` should be meaningless. I haven't tested it in order to create an issue because I haven't come up with a use case for it with the shell or command module. If you come up with a way to test it and find a problem, we can work on it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parsing/splitter.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/28674 578277720c) last updated 2017/08/26 17:37:39 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

##### ADDITIONAL INFORMATION
See summary
