### PR TITLE
Fixes #28290: Added missing colon for paramiko host_key_auto_add line in network_debug_troubleshooting.rst

### DIFF
--- a/docs/docsite/rst/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network_debug_troubleshooting.rst
@@ -276,7 +276,7 @@ Environment variable method::
 
 ansible.cfg
 
-.. code-block: ini
+.. code-block:: ini
 
   [paramiko_connection]
   host_key_auto_add = True


### PR DESCRIPTION
##### SUMMARY
Fixes #28290: Added missing colon for paramiko host_key_auto_add line in network_debug_troubleshooting.rst

Syntax error prevented code block from displaying in network debugging doc.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/network_debug_troubleshooting.rst

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/28290 679d3ecb8c) last updated 2017/08/26 18:03:24 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

##### ADDITIONAL INFORMATION
N/A; added one character