### PR TITLE
Fixes #21041: Add note to intro_inventory.rst that the Docker example is a playbook and not an inventory file

### DIFF
--- a/docs/docsite/rst/intro_inventory.rst
+++ b/docs/docsite/rst/intro_inventory.rst
@@ -362,6 +362,9 @@ Here is an example of how to instantly deploy to created containers::
       path: "/var/jenkins_home/.ssh/jupiter"
       state: directory
 
+.. note:: If you're reading the docs from the beginning, this may be the first example you've seen of an Ansible playbook. This is not an inventory file.
+          Playbooks will be covered in great detail later in the docs.
+
 .. seealso::
 
    :doc:`intro_dynamic_inventory`


### PR DESCRIPTION
##### SUMMARY
Fixes #21041: Add note to intro_inventory.rst that the Docker example is a playbook and not an inventory file

User noted that this may be confusing for someone reading the docs front-to-back who has only been exposed to inventory files and has not yet seen a playbook.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/intro_inventory.rst

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A