### PR TITLE
Fixes #22335: Adds filename extension to tempfile for Vault

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -662,7 +662,8 @@ class VaultEditor:
                           existing_data=None, force_save=False, vault_id=None):
 
         # Create a tempfile
-        fd, tmp_path = tempfile.mkstemp()
+        root, ext = os.path.splitext(os.path.realpath(filename))
+        fd, tmp_path = tempfile.mkstemp(suffix=ext)
         os.close(fd)
 
         try:


### PR DESCRIPTION
##### SUMMARY
Fixes #22335: Adds filename extension to tempfile for Vault

With these changes, the temporary file that Vault creates for `ansible-vault create FILENAME` and `ansible-vault edit FILENAME` will have a filename extension matching that of `FILENAME`. This will allow text editors to highlight syntax appropriately.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
parsing

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/22335 fd26b9f7e0) last updated 2017/08/26 18:47:58 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

##### ADDITIONAL INFORMATION
N/A
