### PR TITLE
Fixes #20752: Prevent AIX get_vgs_facts from failing on offline lvols

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -146,7 +146,7 @@ class AIXHardware(Hardware):
         vgs_facts = {}
         lsvg_path = self.module.get_bin_path("lsvg")
         xargs_path = self.module.get_bin_path("xargs")
-        cmd = "%s | %s %s -p" % (lsvg_path, xargs_path, lsvg_path)
+        cmd = "%s -o | %s %s -p" % (lsvg_path, xargs_path, lsvg_path)
         if lsvg_path and xargs_path:
             rc, out, err = self.module.run_command(cmd, use_unsafe_shell=True)
             if rc == 0 and out:


### PR DESCRIPTION
##### SUMMARY
Fixes #20752: Prevent AIX get_vgs_facts from failing on offline lvols

Added `-o` switch to `lsvg` to show only online lvols per user suggestion. I've verified in the AIX `lsvg` man page that this is correct. However, I do not have an AIX system where I'm able to take down any lvols, so I'll need others to test if we're going to do any manual testing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_plugins/hardware/aix.py

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A
