### PR TITLE
Use remote_tmp as async_wrapper's jobdir (#28318)

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -134,7 +134,7 @@ class ConfigManager(object):
         self.data = ConfigData()
 
 
-        #FIXME: make dynamic? scan for more? make it's own method?
+        # FIXME: make dynamic? scan for more? make its own method?
         # Create configuration definitions from source
         bconfig_def = to_bytes('%s/base.yml' % os.path.dirname(__file__))
         if os.path.exists(bconfig_def):

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -598,7 +598,7 @@ def _is_binary(b_module_data):
     return bool(start.translate(None, textchars))
 
 
-def _find_module_utils(module_name, b_module_data, module_path, module_args, task_vars, module_compression, async_timeout, become,
+def _find_module_utils(module_name, b_module_data, module_path, module_args, task_vars, module_compression, async_timeout, tmp, become,
                        become_method, become_user, become_password, environment):
     """
     Given the source of the module, convert it to a Jinja2 template to insert
@@ -775,6 +775,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
             exec_manifest["actions"].insert(0, 'async_wrapper')
             exec_manifest["async_wrapper"] = to_text(base64.b64encode(to_bytes(async_wrapper)))
             exec_manifest["async_jid"] = str(random.randint(0, 999999999999))
+            exec_manifest["async_tmpdir"] = tmp
             exec_manifest["async_timeout_sec"] = async_timeout
 
         if become and become_method == 'runas':
@@ -836,7 +837,7 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
     return (b_module_data, module_style, shebang)
 
 
-def modify_module(module_name, module_path, module_args, task_vars=dict(), module_compression='ZIP_STORED', async_timeout=0, become=False,
+def modify_module(module_name, module_path, module_args, task_vars=dict(), module_compression='ZIP_STORED', async_timeout=0, tmp=None, become=False,
                   become_method=None, become_user=None, become_password=None, environment=dict()):
     """
     Used to insert chunks of code into modules before transfer rather than
@@ -864,7 +865,7 @@ def modify_module(module_name, module_path, module_args, task_vars=dict(), modul
         b_module_data = f.read()
 
     (b_module_data, module_style, shebang) = _find_module_utils(module_name, b_module_data, module_path, module_args, task_vars, module_compression,
-                                                                async_timeout=async_timeout, become=become, become_method=become_method,
+                                                                async_timeout=async_timeout, tmp=tmp, become=become, become_method=become_method,
                                                                 become_user=become_user, become_password=become_password,
                                                                 environment=environment)
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -647,11 +647,16 @@ class TaskExecutor:
         if async_jid is None:
             return dict(failed=True, msg="No job id was returned by the async task")
 
+        try:
+            async_jobdir = result.get('ansible_job_dir')
+        except:
+            async_jobdir = '~/.ansible_async'
+
         # Create a new pseudo-task to run the async_status module, and run
         # that (with a sleep for "poll" seconds between each retry) until the
         # async time limit is exceeded.
 
-        async_task = Task().load(dict(action='async_status jid=%s' % async_jid))
+        async_task = Task().load(dict(action='async_status jid=%s jobdir=%s' % (async_jid, async_jobdir)))
 
         # FIXME: this is no longer the case, normal takes care of all, see if this can just be generalized
         # Because this is an async task, the action handler is async. However,

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -648,15 +648,15 @@ class TaskExecutor:
             return dict(failed=True, msg="No job id was returned by the async task")
 
         try:
-            async_jobdir = result.get('ansible_job_dir')
+            async_job_dir = result.get('ansible_job_dir')
         except:
-            async_jobdir = '~/.ansible_async'
+            async_job_dir = '~/.ansible_async'
 
         # Create a new pseudo-task to run the async_status module, and run
         # that (with a sleep for "poll" seconds between each retry) until the
         # async time limit is exceeded.
 
-        async_task = Task().load(dict(action='async_status jid=%s jobdir=%s' % (async_jid, async_jobdir)))
+        async_task = Task().load(dict(action='async_status jid=%s job_dir=%s' % (async_jid, async_job_dir)))
 
         # FIXME: this is no longer the case, normal takes care of all, see if this can just be generalized
         # Because this is an async task, the action handler is async. However,

--- a/lib/ansible/modules/utilities/logic/async_status.py
+++ b/lib/ansible/modules/utilities/logic/async_status.py
@@ -26,6 +26,9 @@ options:
     description:
       - Job or task identifier
     required: true
+  jobdir:
+    description:
+      - Directory in which job data is stored
   mode:
     description:
       - if C(status), obtain the status; if C(cleanup), clean up the async job cache
@@ -51,18 +54,20 @@ def main():
 
     module = AnsibleModule(argument_spec=dict(
         jid=dict(required=True),
+        jobdir=dict(default='~/.ansible_async'),
         mode=dict(default='status', choices=['status', 'cleanup']),
     ))
 
-    mode = module.params['mode']
     jid = module.params['jid']
+    jobdir = module.params['jobdir']
+    mode = module.params['mode']
 
     # setup logging directory
-    logdir = os.path.expanduser("~/.ansible_async")
+    logdir = os.path.expanduser(jobdir)
     log_path = os.path.join(logdir, jid)
 
     if not os.path.exists(log_path):
-        module.fail_json(msg="could not find job", ansible_job_id=jid, started=1, finished=1)
+        module.fail_json(msg="could not find job", ansible_job_id=jid, ansible_job_dir=jobdir, ansible_log_dir=logdir, started=1, finished=1)
 
     if mode == 'cleanup':
         os.unlink(log_path)
@@ -87,6 +92,7 @@ def main():
     if 'started' not in data:
         data['finished'] = 1
         data['ansible_job_id'] = jid
+        data['ansible_job_dir'] = jobdir
     elif 'finished' not in data:
         data['finished'] = 0
 

--- a/lib/ansible/modules/utilities/logic/async_status.py
+++ b/lib/ansible/modules/utilities/logic/async_status.py
@@ -26,7 +26,7 @@ options:
     description:
       - Job or task identifier
     required: true
-  jobdir:
+  job_dir:
     description:
       - Directory in which job data is stored
   mode:
@@ -54,20 +54,20 @@ def main():
 
     module = AnsibleModule(argument_spec=dict(
         jid=dict(required=True),
-        jobdir=dict(default='~/.ansible_async'),
+        job_dir=dict(default='~/.ansible_async'),
         mode=dict(default='status', choices=['status', 'cleanup']),
     ))
 
     jid = module.params['jid']
-    jobdir = module.params['jobdir']
+    job_dir = module.params['job_dir']
     mode = module.params['mode']
 
     # setup logging directory
-    logdir = os.path.expanduser(jobdir)
+    logdir = os.path.expanduser(job_dir)
     log_path = os.path.join(logdir, jid)
 
     if not os.path.exists(log_path):
-        module.fail_json(msg="could not find job", ansible_job_id=jid, ansible_job_dir=jobdir, ansible_log_dir=logdir, started=1, finished=1)
+        module.fail_json(msg="could not find job", ansible_job_id=jid, ansible_job_dir=job_dir, ansible_log_dir=logdir, started=1, finished=1)
 
     if mode == 'cleanup':
         os.unlink(log_path)
@@ -92,7 +92,7 @@ def main():
     if 'started' not in data:
         data['finished'] = 1
         data['ansible_job_id'] = jid
-        data['ansible_job_dir'] = jobdir
+        data['ansible_job_dir'] = job_dir
     elif 'finished' not in data:
         data['finished'] = 0
 

--- a/lib/ansible/modules/utilities/logic/async_wrapper.py
+++ b/lib/ansible/modules/utilities/logic/async_wrapper.py
@@ -120,11 +120,11 @@ def _get_interpreter(module_path):
         module_fd.close()
 
 
-def _run_module(wrapped_cmd, jid, jobdir, job_path):
+def _run_module(wrapped_cmd, jid, job_dir, job_path):
 
     tmp_job_path = job_path + ".tmp"
     jobfile = open(tmp_job_path, "w")
-    jobfile.write(json.dumps({"started": 1, "finished": 0, "ansible_job_id": jid, "ansible_job_dir": jobdir}))
+    jobfile.write(json.dumps({"started": 1, "finished": 0, "ansible_job_id": jid, "ansible_job_dir": job_dir}))
     jobfile.close()
     os.rename(tmp_job_path, job_path)
     jobfile = open(tmp_job_path, "w")
@@ -172,7 +172,7 @@ def _run_module(wrapped_cmd, jid, jobdir, job_path):
             "stderr": stderr
         }
         result['ansible_job_id'] = jid
-        result['ansible_job_dir'] = jobdir
+        result['ansible_job_dir'] = job_dir
         jobfile.write(json.dumps(result))
 
     except (ValueError, Exception):
@@ -184,7 +184,7 @@ def _run_module(wrapped_cmd, jid, jobdir, job_path):
             "msg": traceback.format_exc()
         }
         result['ansible_job_id'] = jid
-        result['ansible_job_dir'] = jobdir
+        result['ansible_job_dir'] = job_dir
         jobfile.write(json.dumps(result))
 
     jobfile.close()
@@ -221,18 +221,18 @@ if __name__ == '__main__':
 
     # setup job output directory
     if tmpdir != '_':
-        jobdir = os.path.join(os.path.expanduser(tmpdir), '.ansible_async')
+        job_dir = os.path.join(os.path.expanduser(tmpdir), '.ansible_async')
     else:
-        jobdir = os.path.expanduser("~/.ansible_async")
-    job_path = os.path.join(jobdir, jid)
+        job_dir = os.path.expanduser("~/.ansible_async")
+    job_path = os.path.join(job_dir, jid)
 
-    if not os.path.exists(jobdir):
+    if not os.path.exists(job_dir):
         try:
-            os.makedirs(jobdir)
+            os.makedirs(job_dir)
         except:
             print(json.dumps({
                 "failed": 1,
-                "msg": "could not create: %s" % jobdir
+                "msg": "could not create: %s" % job_dir
             }))
     # immediately exit this process, leaving an orphaned process
     # running which immediately forks a supervisory timing process
@@ -247,7 +247,7 @@ if __name__ == '__main__':
             # this probably could be done with some IPC later.  Modules should always read
             # the argsfile at the very first start of their execution anyway
             notice("Return async_wrapper task started.")
-            print(json.dumps({"started": 1, "finished": 0, "ansible_job_id": jid, "ansible_job_dir": jobdir,
+            print(json.dumps({"started": 1, "finished": 0, "ansible_job_id": jid, "ansible_job_dir": job_dir,
                               "results_file": job_path, "_ansible_suppress_tmpdir_delete": not preserve_tmp}))
             sys.stdout.flush()
             time.sleep(1)
@@ -290,7 +290,7 @@ if __name__ == '__main__':
             else:
                 # the child process runs the actual module
                 notice("Start module (%s)" % os.getpid())
-                _run_module(cmd, jid, jobdir, job_path)
+                _run_module(cmd, jid, job_dir, job_path)
                 notice("Module complete (%s)" % os.getpid())
                 sys.exit(0)
 

--- a/lib/ansible/modules/utilities/logic/async_wrapper.py
+++ b/lib/ansible/modules/utilities/logic/async_wrapper.py
@@ -196,7 +196,7 @@ if __name__ == '__main__':
     if len(sys.argv) < 6:
         print(json.dumps({
             "failed": True,
-            "msg": "usage: async_wrapper <jid> <time_limit> <modulescript> <argsfile> [-preserve_tmp]  "
+            "msg": "usage: async_wrapper <jid> <time_limit> <modulescript> <argsfile> <tmpdir> [-preserve_tmp]  "
                    "Humans, do not call directly!"
         }))
         sys.exit(1)

--- a/lib/ansible/modules/windows/async_status.ps1
+++ b/lib/ansible/modules/windows/async_status.ps1
@@ -21,19 +21,19 @@ $results = @{changed=$false}
 
 $parsed_args = Parse-Args $args
 $jid = Get-AnsibleParam $parsed_args "jid" -failifempty $true -resultobj $results
-# $jobdir currently only for compatibility with non-Windows async. Unused.
-$jobdir = Get-AnsibleParam $parsed_args "jobdir" -Default [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+# $job_dir currently only for compatibility with non-Windows async. Unused.
+$job_dir = Get-AnsibleParam $parsed_args "job_dir" -Default [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
 $mode = Get-AnsibleParam $parsed_args "mode" -Default "status" -ValidateSet "status","cleanup"
 
 # setup logging directory
-# FUTURE: Add jobdir override functionality here; set to default for now
-$jobdir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
-$logdir = $jobdir
-$log_path = [System.IO.Path]::Combine($jobdir, $jid)
+# FUTURE: Add job_dir override functionality here; set to default for now
+#$job_dir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+$logdir = $job_dir
+$log_path = [System.IO.Path]::Combine($job_dir, $jid)
 
 If(-not $(Test-Path $log_path))
 {
-    Fail-Json @{ansible_job_id=$jid; ansible_job_dir=$jobdir; ansible_log_path=$log_path; started=1; finished=1} "could not find job"
+    Fail-Json @{ansible_job_id=$jid; ansible_job_dir=$job_dir; ansible_log_path=$log_path; started=1; finished=1} "could not find job"
 }
 
 If($mode -eq "cleanup") {
@@ -66,7 +66,7 @@ Catch {
 If (-not $data.ContainsKey("started")) {
     $data['finished'] = 1
     $data['ansible_job_id'] = $jid
-    $data['ansible_job_dir'] = $jobdir
+    $data['ansible_job_dir'] = $job_dir
 }
 ElseIf (-not $data.ContainsKey("finished")) {
     $data['finished'] = 0

--- a/lib/ansible/modules/windows/async_status.ps1
+++ b/lib/ansible/modules/windows/async_status.ps1
@@ -21,14 +21,19 @@ $results = @{changed=$false}
 
 $parsed_args = Parse-Args $args
 $jid = Get-AnsibleParam $parsed_args "jid" -failifempty $true -resultobj $results
+# $jobdir currently only for compatibility with non-Windows async. Unused.
+$jobdir = Get-AnsibleParam $parsed_args "jobdir" -Default [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
 $mode = Get-AnsibleParam $parsed_args "mode" -Default "status" -ValidateSet "status","cleanup"
 
 # setup logging directory
-$log_path = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async", $jid)
+# FUTURE: Add jobdir override functionality here; set to default for now
+$jobdir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+$logdir = $jobdir
+$log_path = [System.IO.Path]::Combine($jobdir, $jid)
 
 If(-not $(Test-Path $log_path))
 {
-    Fail-Json @{ansible_job_id=$jid; started=1; finished=1} "could not find job"
+    Fail-Json @{ansible_job_id=$jid; ansible_job_dir=$jobdir; ansible_log_path=$log_path; started=1; finished=1} "could not find job"
 }
 
 If($mode -eq "cleanup") {
@@ -61,6 +66,7 @@ Catch {
 If (-not $data.ContainsKey("started")) {
     $data['finished'] = 1
     $data['ansible_job_id'] = $jid
+    $data['ansible_job_dir'] = $jobdir
 }
 ElseIf (-not $data.ContainsKey("finished")) {
     $data['finished'] = 0

--- a/lib/ansible/modules/windows/async_wrapper.ps1
+++ b/lib/ansible/modules/windows/async_wrapper.ps1
@@ -410,10 +410,15 @@ Function Start-Watchdog {
 
 $local_jid = $jid + "." + $pid
 
-# FUTURE: Use remote_tmp for $jobdir
-$jobdir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+# FUTURE: Use remote_tmp for $job_dir
+If($tmpdir -and $tmpdir -ne '_') {
+    $job_dir = [System.IO.Path]::Combine($tmpdir, ".ansible_async")
+}
+Else {
+    $job_dir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+}
 
-$results_path = [System.IO.Path]::Combine($jobdir, $local_jid)
+$results_path = [System.IO.Path]::Combine($job_dir, $local_jid)
 
 [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($results_path)) | Out-Null
 
@@ -439,7 +444,7 @@ $result = @{
     finished=0;
     results_file=$results_path;
     ansible_job_id=$local_jid;
-    ansible_job_dir=$jobdir;
+    ansible_job_dir=$job_dir;
     _ansible_suppress_tmpdir_delete=$true;
     ansible_async_watchdog_pid=$watchdog_pid
 }

--- a/lib/ansible/modules/windows/async_wrapper.ps1
+++ b/lib/ansible/modules/windows/async_wrapper.ps1
@@ -21,6 +21,7 @@ Param(
     [int]$max_exec_time_sec,
     [string]$module_path,
     [string]$argfile_path,
+    [string]$tmpdir,
     [switch]$preserve_tmp
 )
 
@@ -409,7 +410,10 @@ Function Start-Watchdog {
 
 $local_jid = $jid + "." + $pid
 
-$results_path = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async", $local_jid)
+# FUTURE: Use remote_tmp for $jobdir
+$jobdir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+
+$results_path = [System.IO.Path]::Combine($jobdir, $local_jid)
 
 [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($results_path)) | Out-Null
 
@@ -435,6 +439,7 @@ $result = @{
     finished=0;
     results_file=$results_path;
     ansible_job_id=$local_jid;
+    ansible_job_dir=$jobdir;
     _ansible_suppress_tmpdir_delete=$true;
     ansible_async_watchdog_pid=$watchdog_pid
 }

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -701,6 +701,12 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                 # maintain a fixed number of positional parameters for async_wrapper
                 async_cmd.append('_')
 
+            # Ensure that async jobdir matches remote_tmp if set
+            if tmp:
+                async_cmd.append(tmp)
+            else:
+                async_cmd.append('_')
+
             if not self._should_remove_tmp_path(tmp):
                 async_cmd.append("-preserve_tmp")
 

--- a/lib/ansible/plugins/shell/__init__.py
+++ b/lib/ansible/plugins/shell/__init__.py
@@ -51,6 +51,9 @@ class ShellBase(object):
     def join_path(self, *args):
         return os.path.join(*args)
 
+    def split_path(self, path):
+        return path.split(os.path.sep, 1)
+
     # some shells (eg, powershell) are snooty about filenames/extensions, this lets the shell plugin have a say
     def get_remote_filename(self, pathname):
         base_name = os.path.basename(pathname.strip())
@@ -99,14 +102,14 @@ class ShellBase(object):
         # When system is specified we have to create this in a directory where
         # other users can read and access the temp directory.  This is because
         # we use system to create tmp dirs for unprivileged users who are
-        # sudo'ing to a second unprivileged user.  The only dirctories where
+        # sudo'ing to a second unprivileged user.  The only directories where
         # that is standard are the tmp dirs, /tmp and /var/tmp.  So we only
         # allow one of those two locations if system=True.  However, users
         # might want to have some say over which of /tmp or /var/tmp is used
         # (because /tmp may be a tmpfs and want to conserve RAM or persist the
         # tmp files beyond a reboot.  So we check if the user set REMOTE_TMP
         # to somewhere in or below /var/tmp and if so use /var/tmp.  If
-        # anything else we use /tmp (because /tmp is specified by POSIX nad
+        # anything else we use /tmp (because /tmp is specified by POSIX and
         # /var/tmp is not).
 
         if system:

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1482,7 +1482,7 @@ class ShellModule(object):
         ''' % dict(path=path)
         return self._encode_script(script)
 
-    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None):
+    def build_module_command(self, env_string, shebang, cmd, arg_path=None, tmpdir="_", rm_tmp=None):
         # pipelining bypass
         if cmd == '':
             return '-'

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1108,7 +1108,17 @@ Function Run($payload) {
     $jid = $payload.async_jid
     $local_jid = $jid + "." + $pid
 
-    $results_path = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async", $local_jid)
+    # Is this the correct name for the variable at this particular time?
+    $tmpdir = $payload.async_tmpdir
+
+    If($tmpdir -and $tmpdir -ne '_') {
+        $job_dir = [System.IO.Path]::Combine($tmpdir, ".ansible_async")
+    }
+    Else {
+        $job_dir = [System.IO.Path]::Combine($env:LOCALAPPDATA, ".ansible_async")
+    }
+
+    $results_path = [System.IO.Path]::Combine($job_dir, $local_jid)
 
     $payload.async_results_path = $results_path
 
@@ -1215,6 +1225,7 @@ Function Run($payload) {
         finished=0;
         results_file=$results_path;
         ansible_job_id=$local_jid;
+        ansible_job_dir=$job_dir;
         _ansible_suppress_tmpdir_delete=$true;
         ansible_async_watchdog_pid=$watchdog_pid
     }
@@ -1502,7 +1513,7 @@ class ShellModule(object):
         ''' % dict(path=path)
         return self._encode_script(script)
 
-    def build_module_command(self, env_string, shebang, cmd, arg_path=None, tmpdir="_", rm_tmp=None):
+    def build_module_command(self, env_string, shebang, cmd, arg_path=None, rm_tmp=None):
         # pipelining bypass
         if cmd == '':
             return '-'

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -77,7 +77,7 @@
     - "'ansible_job_id' in fnf_task"
 
 - name: 'check on task started as a "fire-and-forget"'
-  async_status: jid={{ fnf_task.ansible_job_id }} jobdir={{ fnf_task.ansible_job_dir }}
+  async_status: jid={{ fnf_task.ansible_job_id }} job_dir={{ fnf_task.ansible_job_dir }}
   register: fnf_result
   until: fnf_result.finished
   retries: 10

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -77,7 +77,7 @@
     - "'ansible_job_id' in fnf_task"
 
 - name: 'check on task started as a "fire-and-forget"'
-  async_status: jid={{ fnf_task.ansible_job_id }}
+  async_status: jid={{ fnf_task.ansible_job_id }} jobdir={{ fnf_task.ansible_job_dir }}
   register: fnf_result
   until: fnf_result.finished
   retries: 10

--- a/test/integration/targets/win_async_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_async_wrapper/tasks/main.yml
@@ -15,7 +15,7 @@
     - asyncresult.ansible_job_id is match('\d+\.\d+')
     - asyncresult.started == 1
     - asyncresult.finished == 0
-    #- asyncresult.results_file is search('\.ansible_async.+\d+\.\d+')
+    - asyncresult.results_file is search('\.ansible_async.+\d+\.\d+')
      # ensure that async is actually async- this test will fail if # hosts > forks or if the target host is VERY slow
     - (lookup('pipe', 'date +%s') | int) - (start_timestamp | int) < 8
 

--- a/test/integration/targets/win_async_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_async_wrapper/tasks/main.yml
@@ -15,7 +15,7 @@
     - asyncresult.ansible_job_id is match('\d+\.\d+')
     - asyncresult.started == 1
     - asyncresult.finished == 0
-    - asyncresult.results_file is search('\.ansible_async.+\d+\.\d+')
+    #- asyncresult.results_file is search('\.ansible_async.+\d+\.\d+')
      # ensure that async is actually async- this test will fail if # hosts > forks or if the target host is VERY slow
     - (lookup('pipe', 'date +%s') | int) - (start_timestamp | int) < 8
 

--- a/test/units/executor/test_task_executor.py
+++ b/test/units/executor/test_task_executor.py
@@ -471,7 +471,7 @@ class TestTaskExecutor(unittest.TestCase):
             mock_templar = MagicMock()
             res = te._poll_async_result(result=dict(), templar=mock_templar)
             self.assertIn('failed', res)
-            res = te._poll_async_result(result=dict(ansible_job_id=1), templar=mock_templar)
+            res = te._poll_async_result(result=dict(ansible_job_id=1, ansible_job_dir='~/.ansible_async'), templar=mock_templar)
             self.assertIn('failed', res)
 
         def _get(*args, **kwargs):
@@ -482,5 +482,5 @@ class TestTaskExecutor(unittest.TestCase):
         # now testing with good values
         with patch.object(action_loader, 'get', _get):
             mock_templar = MagicMock()
-            res = te._poll_async_result(result=dict(ansible_job_id=1), templar=mock_templar)
+            res = te._poll_async_result(result=dict(ansible_job_id=1, ansible_job_dir='~/.ansible_async'), templar=mock_templar)
             self.assertEqual(res, dict(finished=1))


### PR DESCRIPTION
#### SUMMARY
Use remote_tmp as async_wrapper's jobdir (#28318)

The previous version hardcoded the async_wrapper's jobdir to `~/.ansible-async`. This created problems when, as in the linked issue, the user's `home` was on a read-only filesystem. The new behavior is more intuitive and adapts to user configuration: it uses `{{ remote_tmp }}/.ansible-async` if `remote_tmp` is set, and `~/ansible.async` otherwise.

I used an underscore as an argument placeholder to keep with existing style. I inserted the `tmpdir` argument into `preserve_tmp`'s place at `sys.argv[5]`. I think this is more intuitive/logical than appending it after the boolean, and it doesn't look like it will break any existing code. The only code I found that depends on the argument order of `async_wrapper` is `plugins/action/__init__.py`, which is also updated in this PR.

Edit: Updated `executor/task_executor.py` and `modules/utilities/logic/async_status.py`, which needed to be passed the `jobdir` to check status.

Edit: I wanted to make `jobdir` a required parameter in `async_status.main()`, but that caused the existing integration test to fail, so I set a default value of `~/.ansible_async`. Testing that now.

Edit: See my comments below. The CI build is going to continue failing until we get the integration test updated. The `async_status.main()` in the new version needs a `jobdir` argument or it doesn't know where to find the job. The existing integration test does not have the `jobdir` argument. Also, the need for changes on Windows is unknown.

#### ISSUE TYPE
- Bugfix Pull Request

#### COMPONENT NAME
modules/utilities/logic/async_wrapper.py

#### ANSIBLE VERSION
```
ansible 2.4.0 (issue/22402 bd8ab912e8) last updated 2017/08/27 17:40:28 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

#### ADDITIONAL INFORMATION
Ansible config file:
```
[defaults]

# /home dirs are not writable. Use /tmp instead
local_tmp = /tmp
remote_tmp = /tmp
host_key_checking = False

[ssh_connection]

pipelining = True

ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30
```

Playbook:
```
[reid@laptop ~/git]$ cat async-test.yml 
---
- hosts: localhost
  gather_facts: no
  tasks:
    - name: test_async
      command: "sleep 15"
      async: 9
      poll: 0
```

Results before:
```
[reid@laptop ~/git]$ ANSIBLE_CONFIG=ansible_async_test.cfg ansible-playbook async-test.yml -i hosts.ini -vvv
ansible-playbook 2.4.0 (issue/18904 e127024c31) last updated 2017/08/27 00:11:49 (GMT -500)
  config file = /home/reid/git/ansible_async_test.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible-playbook
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
Using /home/reid/git/ansible_async_test.cfg as config file
Parsed /home/reid/git/hosts.ini inventory source with ini plugin

PLAYBOOK: async-test.yml ******************************************************************************************************************************************************************************************
1 plays in async-test.yml

PLAY [localhost] **************************************************************************************************************************************************************************************************
META: ran handlers

TASK [test_async] *************************************************************************************************************************************************************************************************
task path: /home/reid/git/async-test.yml:5
Using module file /home/reid/git/ansible/lib/ansible/modules/commands/command.py
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /tmp/ansible-tmp-1503891835.81-28810327044951 `" && echo ansible-tmp-1503891835.81-28810327044951="` echo /tmp/ansible-tmp-1503891835.81-28810327044951 `" ) && sleep 0'"'"''
<localhost> (0, 'ansible-tmp-1503891835.81-28810327044951=/tmp/ansible-tmp-1503891835.81-28810327044951\n', '')
<localhost> PUT /tmp/tmpxVQGdp TO /tmp/ansible-tmp-1503891835.81-28810327044951/command.py
<localhost> SSH: EXEC sftp -b - -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 '[localhost]'
<localhost> (0, 'sftp> put /tmp/tmpxVQGdp /tmp/ansible-tmp-1503891835.81-28810327044951/command.py\n', '')
<localhost> PUT /tmp/tmpUTHO47 TO /tmp/ansible-tmp-1503891835.81-28810327044951/async_wrapper.py
<localhost> SSH: EXEC sftp -b - -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 '[localhost]'
<localhost> (0, 'sftp> put /tmp/tmpUTHO47 /tmp/ansible-tmp-1503891835.81-28810327044951/async_wrapper.py\n', '')
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 localhost '/bin/sh -c '"'"'chmod u+x /tmp/ansible-tmp-1503891835.81-28810327044951/ /tmp/ansible-tmp-1503891835.81-28810327044951/command.py /tmp/ansible-tmp-1503891835.81-28810327044951/async_wrapper.py && sleep 0'"'"''
<localhost> (0, '', '')
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 -tt localhost '/bin/sh -c '"'"'/usr/bin/python /tmp/ansible-tmp-1503891835.81-28810327044951/async_wrapper.py 529886084275 9 /tmp/ansible-tmp-1503891835.81-28810327044951/command.py _ && sleep 0'"'"''
<localhost> (0, '{"started": 1, "_ansible_suppress_tmpdir_delete": true, "finished": 0, "results_file": "/home/reid/.ansible_async/529886084275.18397", "ansible_job_id": "529886084275.18397"}\r\n', 'Shared connection to localhost closed.\r\n')
changed: [localhost] => {
    "ansible_job_id": "529886084275.18397", 
    "changed": true, 
    "failed": false, 
    "finished": 0, 
    "results_file": "/home/reid/.ansible_async/529886084275.18397", 
    "started": 1
}
META: ran handlers
META: ran handlers

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0  
```

Results after:
```
[reid@laptop ~/git]$ ANSIBLE_CONFIG=ansible_async_test.cfg ansible-playbook async-test.yml -i hosts.ini -vvv
ansible-playbook 2.4.0 (issue/28318 6de1984639) last updated 2017/08/27 22:18:45 (GMT -500)
  config file = /home/reid/git/ansible_async_test.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible-playbook
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
Using /home/reid/git/ansible_async_test.cfg as config file
Parsed /home/reid/git/hosts.ini inventory source with ini plugin

PLAYBOOK: async-test.yml ******************************************************************************************************************************************************************************************
1 plays in async-test.yml

PLAY [localhost] **************************************************************************************************************************************************************************************************
META: ran handlers

TASK [test_async] *************************************************************************************************************************************************************************************************
task path: /home/reid/git/async-test.yml:5
Using module file /home/reid/git/ansible/lib/ansible/modules/commands/command.py
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 localhost '/bin/sh -c '"'"'( umask 77 && mkdir -p "` echo /tmp/ansible-tmp-1503891758.86-271282503014568 `" && echo ansible-tmp-1503891758.86-271282503014568="` echo /tmp/ansible-tmp-1503891758.86-271282503014568 `" ) && sleep 0'"'"''
<localhost> (0, 'ansible-tmp-1503891758.86-271282503014568=/tmp/ansible-tmp-1503891758.86-271282503014568\n', '')
<localhost> PUT /tmp/tmpjCuPGM TO /tmp/ansible-tmp-1503891758.86-271282503014568/command.py
<localhost> SSH: EXEC sftp -b - -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 '[localhost]'
<localhost> (0, 'sftp> put /tmp/tmpjCuPGM /tmp/ansible-tmp-1503891758.86-271282503014568/command.py\n', '')
<localhost> PUT /tmp/tmptRooie TO /tmp/ansible-tmp-1503891758.86-271282503014568/async_wrapper.py
<localhost> SSH: EXEC sftp -b - -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 '[localhost]'
<localhost> (0, 'sftp> put /tmp/tmptRooie /tmp/ansible-tmp-1503891758.86-271282503014568/async_wrapper.py\n', '')
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 localhost '/bin/sh -c '"'"'chmod u+x /tmp/ansible-tmp-1503891758.86-271282503014568/ /tmp/ansible-tmp-1503891758.86-271282503014568/command.py /tmp/ansible-tmp-1503891758.86-271282503014568/async_wrapper.py && sleep 0'"'"''
<localhost> (0, '', '')
<localhost> ESTABLISH SSH CONNECTION FOR USER: None
<localhost> SSH: EXEC ssh -o ControlMaster=auto -o ControlPersist=60s -o ConnectTimeout=30 -o StrictHostKeyChecking=no -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o ConnectTimeout=10 -o ControlPath=/home/reid/.ansible/cp/8a5a4c6a60 -tt localhost '/bin/sh -c '"'"'/usr/bin/python /tmp/ansible-tmp-1503891758.86-271282503014568/async_wrapper.py 442851886450 9 /tmp/ansible-tmp-1503891758.86-271282503014568/command.py _ /tmp/ansible-tmp-1503891758.86-271282503014568/ && sleep 0'"'"''
<localhost> (0, '{"started": 1, "_ansible_suppress_tmpdir_delete": true, "finished": 0, "results_file": "/tmp/ansible-tmp-1503891758.86-271282503014568/.ansible_async/442851886450.17964", "ansible_job_id": "442851886450.17964"}\r\n', 'Shared connection to localhost closed.\r\n')
changed: [localhost] => {
    "ansible_job_id": "442851886450.17964", 
    "changed": true, 
    "failed": false, 
    "finished": 0, 
    "results_file": "/tmp/ansible-tmp-1503891758.86-271282503014568/.ansible_async/442851886450.17964", 
    "started": 1
}
META: ran handlers
META: ran handlers

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0   
```