### PR TITLE
EthernetNetworkFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_ethernet_network_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_ethernet_network_facts.py
@@ -26,13 +26,10 @@ options:
     name:
       description:
         - Ethernet Network name.
-      required: false
     options:
       description:
         - "List with options to gather additional facts about an Ethernet Network and related resources.
           Options allowed: C(associatedProfiles) and C(associatedUplinkGroups)."
-      required: false
-
 extends_documentation_fragment:
     - oneview
     - oneview.factsparams
@@ -101,9 +98,9 @@ from ansible.module_utils.oneview import OneViewModuleBase
 
 class EthernetNetworkFactsModule(OneViewModuleBase):
     argument_spec = dict(
-        name=dict(required=False, type='str'),
-        options=dict(required=False, type='list'),
-        params=dict(required=False, type='dict')
+        name=dict(type='str'),
+        options=dict(type='list'),
+        params=dict(type='dict')
     )
 
     def __init__(self):

--- a/lib/ansible/modules/remote_management/oneview/oneview_ethernet_network_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_ethernet_network_facts.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_ethernet_network_facts
+short_description: Retrieve the facts about one or more of the OneView Ethernet Networks
+description:
+    - Retrieve the facts about one or more of the Ethernet Networks from OneView.
+version_added: "2.4"
+requirements:
+    - hpOneView >= 2.0.1
+author:
+    - Felipe Bulsoni (@fgbulsoni)
+    - Thiago Miotto (@tmiotto)
+    - Adriane Cardozo (@adriane-cardozo)
+options:
+    name:
+      description:
+        - Ethernet Network name.
+      required: false
+    options:
+      description:
+        - "List with options to gather additional facts about an Ethernet Network and related resources.
+          Options allowed: C(associatedProfiles) and C(associatedUplinkGroups)."
+      required: false
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Ethernet Networks
+  oneview_ethernet_network_facts:
+    config: /etc/oneview/oneview_config.json
+  delegate_to: localhost
+
+- debug: var=ethernet_networks
+
+- name: Gather paginated and filtered facts about Ethernet Networks
+  oneview_ethernet_network_facts:
+    config: /etc/oneview/oneview_config.json
+    params:
+      start: 1
+      count: 3
+      sort: 'name:descending'
+      filter: 'purpose=General'
+  delegate_to: localhost
+
+- debug: var=ethernet_networks
+
+- name: Gather facts about an Ethernet Network by name
+  oneview_ethernet_network_facts:
+    config: /etc/oneview/oneview_config.json
+    name: Ethernet network name
+  delegate_to: localhost
+
+- debug: var=ethernet_networks
+
+- name: Gather facts about an Ethernet Network by name with options
+  oneview_ethernet_network_facts:
+    config: /etc/oneview/oneview_config.json
+    name: eth1
+    options:
+      - associatedProfiles
+      - associatedUplinkGroups
+  delegate_to: localhost
+
+- debug: var=enet_associated_profiles
+- debug: var=enet_associated_uplink_groups
+'''
+
+RETURN = '''
+ethernet_networks:
+    description: Has all the OneView facts about the Ethernet Networks.
+    returned: Always, but can be null.
+    type: dict
+
+enet_associated_profiles:
+    description: Has all the OneView facts about the profiles which are using the Ethernet network.
+    returned: When requested, but can be null.
+    type: dict
+
+enet_associated_uplink_groups:
+    description: Has all the OneView facts about the uplink sets which are using the Ethernet network.
+    returned: When requested, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class EthernetNetworkFactsModule(OneViewModuleBase):
+    argument_spec = dict(
+        name=dict(required=False, type='str'),
+        options=dict(required=False, type='list'),
+        params=dict(required=False, type='dict')
+    )
+
+    def __init__(self):
+        super(EthernetNetworkFactsModule, self).__init__(additional_arg_spec=self.argument_spec)
+
+        self.resource_client = self.oneview_client.ethernet_networks
+
+    def execute_module(self):
+        ansible_facts = {}
+        if self.module.params['name']:
+            ethernet_networks = self.resource_client.get_by('name', self.module.params['name'])
+
+            if self.module.params.get('options') and ethernet_networks:
+                ansible_facts = self.__gather_optional_facts(ethernet_networks[0])
+        else:
+            ethernet_networks = self.resource_client.get_all(**self.facts_params)
+
+        ansible_facts['ethernet_networks'] = ethernet_networks
+
+        return dict(changed=False, ansible_facts=ansible_facts)
+
+    def __gather_optional_facts(self, ethernet_network):
+
+        ansible_facts = {}
+
+        if self.options.get('associatedProfiles'):
+            ansible_facts['enet_associated_profiles'] = self.__get_associated_profiles(ethernet_network)
+        if self.options.get('associatedUplinkGroups'):
+            ansible_facts['enet_associated_uplink_groups'] = self.__get_associated_uplink_groups(ethernet_network)
+
+        return ansible_facts
+
+    def __get_associated_profiles(self, ethernet_network):
+        associated_profiles = self.resource_client.get_associated_profiles(ethernet_network['uri'])
+        return [self.oneview_client.server_profiles.get(x) for x in associated_profiles]
+
+    def __get_associated_uplink_groups(self, ethernet_network):
+        uplink_groups = self.resource_client.get_associated_uplink_groups(ethernet_network['uri'])
+        return [self.oneview_client.uplink_sets.get(x) for x in uplink_groups]
+
+
+def main():
+    EthernetNetworkFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -30,6 +30,7 @@ from ansible.module_utils.oneview import (OneViewModuleException,
                                           OneViewModuleBase)
 
 from ansible.modules.remote_management.oneview.oneview_ethernet_network import EthernetNetworkModule
+from ansible.modules.remote_management.oneview.oneview_ethernet_network_facts import EthernetNetworkFactsModule
 from ansible.modules.remote_management.oneview.oneview_fc_network import FcNetworkModule
 from ansible.modules.remote_management.oneview.oneview_fc_network_facts import FcNetworkFactsModule
 from ansible.modules.remote_management.oneview.oneview_fcoe_network import FcoeNetworkModule

--- a/test/units/modules/remote_management/oneview/test_oneview_ethernet_network_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_ethernet_network_facts.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest, mock
+
+from oneview_module_loader import EthernetNetworkFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test Ethernet Network",
+    options=[]
+)
+
+PARAMS_GET_BY_NAME_WITH_OPTIONS = dict(
+    config='config.json',
+    name="Test Ethernet Network",
+    options=['associatedProfiles', 'associatedUplinkGroups']
+)
+
+PRESENT_ENETS = [{
+    "name": "Test Ethernet Network",
+    "uri": "/rest/ethernet-networks/d34dcf5e-0d8e-441c-b00d-e1dd6a067188"
+}]
+
+ENET_ASSOCIATED_UPLINK_GROUP_URIS = [
+    "/rest/uplink-sets/c6bf9af9-48e7-4236-b08a-77684dc258a5",
+    "/rest/uplink-sets/e2f0031b-52bd-4223-9ac1-d91cb519d548"
+]
+
+ENET_ASSOCIATED_PROFILE_URIS = [
+    "/rest/server-profiles/83e2e117-59dc-4e33-9f24-462af951cbbe",
+    "/rest/server-profiles/57d3af2a-b6d2-4446-8645-f38dd808ea4d"
+]
+
+ENET_ASSOCIATED_UPLINK_GROUPS = [dict(uri=ENET_ASSOCIATED_UPLINK_GROUP_URIS[0], name='Uplink Set 1'),
+                                 dict(uri=ENET_ASSOCIATED_UPLINK_GROUP_URIS[1], name='Uplink Set 2')]
+
+ENET_ASSOCIATED_PROFILES = [dict(uri=ENET_ASSOCIATED_PROFILE_URIS[0], name='Server Profile 1'),
+                            dict(uri=ENET_ASSOCIATED_PROFILE_URIS[1], name='Server Profile 2')]
+
+
+class EthernetNetworkFactsSpec(unittest.TestCase,
+                               FactsParamsTestCase
+                               ):
+    def setUp(self):
+        self.configure_mocks(self, EthernetNetworkFactsModule)
+        self.ethernet_networks = self.mock_ov_client.ethernet_networks
+        FactsParamsTestCase.configure_client_mock(self, self.ethernet_networks)
+
+    def test_should_get_all_enets(self):
+        self.ethernet_networks.get_all.return_value = PRESENT_ENETS
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        EthernetNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(ethernet_networks=(PRESENT_ENETS))
+        )
+
+    def test_should_get_enet_by_name(self):
+        self.ethernet_networks.get_by.return_value = PRESENT_ENETS
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        EthernetNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(ethernet_networks=(PRESENT_ENETS))
+        )
+
+    def test_should_get_enet_by_name_with_options(self):
+        self.ethernet_networks.get_by.return_value = PRESENT_ENETS
+        self.ethernet_networks.get_associated_profiles.return_value = ENET_ASSOCIATED_PROFILE_URIS
+        self.ethernet_networks.get_associated_uplink_groups.return_value = ENET_ASSOCIATED_UPLINK_GROUP_URIS
+        self.mock_ov_client.server_profiles.get.side_effect = ENET_ASSOCIATED_PROFILES
+        self.mock_ov_client.uplink_sets.get.side_effect = ENET_ASSOCIATED_UPLINK_GROUPS
+
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME_WITH_OPTIONS
+
+        EthernetNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(ethernet_networks=PRESENT_ENETS,
+                               enet_associated_profiles=ENET_ASSOCIATED_PROFILES,
+                               enet_associated_uplink_groups=ENET_ASSOCIATED_UPLINK_GROUPS)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_ethernet_network_facts module for retrieving [HPE OneView Ethernet Network](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/ethernet-networks) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_ethernet_network_facts`

##### ANSIBLE VERSION
```
ansible 2.4.0 (hpe-oneview/ethernet-network-facts 095709ed06) last updated 2017/08/28 14:38:12 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/dev/core_ansible_related/ansible/lib/ansible
  executable location = /home/vagrant/dev/core_ansible_related/ansible/bin/ansible
  python version = 2.7.9 (default, Aug 21 2017, 11:24:49) [GCC 4.8.4]

```


##### ADDITIONAL INFORMATION
Example of usage:
```
- name: Gather facts about all Ethernet Networks
  oneview_ethernet_network_facts:
    config: /etc/oneview/oneview_config.json
  delegate_to: localhost

- debug: var=ethernet_networks

- name: Gather paginated and filtered facts about Ethernet Networks
  oneview_ethernet_network_facts:
    config: /etc/oneview/oneview_config.json
    params:
      start: 1
      count: 3
      sort: 'name:descending'
      filter: 'purpose=General'
  delegate_to: localhost

- debug: var=ethernet_networks

- name: Gather facts about an Ethernet Network by name
  oneview_ethernet_network_facts:
    config: /etc/oneview/oneview_config.json
    name: Ethernet network name
  delegate_to: localhost

- debug: var=ethernet_networks

- name: Gather facts about an Ethernet Network by name with options
  oneview_ethernet_network_facts:
    config: /etc/oneview/oneview_config.json
    name: eth1
    options:
      - associatedProfiles
      - associatedUplinkGroups
  delegate_to: localhost

- debug: var=enet_associated_profiles
- debug: var=enet_associated_uplink_groups
```