### PR TITLE
Fix detection of associate-vrf parameter

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
+++ b/lib/ansible/modules/network/nxos/nxos_vxlan_vtep_vni.py
@@ -107,7 +107,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.netcfg import CustomNetworkConfig
 
 BOOL_PARAMS = [
-    'assoc-vrf',
+    'assoc_vrf',
     'suppress_arp',
 ]
 PARAM_TO_COMMAND_KEYMAP = {
@@ -164,8 +164,7 @@ def get_existing(module, args):
         temp_config = netcfg.get_section(parents)
 
         if 'member vni {0} associate-vrf'.format(module.params['vni']) in temp_config:
-            parents.append('member vni {0} associate-vrf'.format(
-                module.params['vni']))
+            parents.append('member vni {0} associate-vrf'.format(module.params['vni']))
             config = netcfg.get_section(parents)
         elif "member vni {0}".format(module.params['vni']) in temp_config:
             parents.append('member vni {0}'.format(module.params['vni']))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #27925

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_vxlan_vtep_vni

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```