### PR TITLE
Add junos_vrf vrf-table-label support

### DIFF
--- a/lib/ansible/modules/network/junos/junos_vrf.py
+++ b/lib/ansible/modules/network/junos/junos_vrf.py
@@ -49,6 +49,11 @@ options:
     description:
       - It configures VRF target community configuration. The target value takes
         the form of C(target:A:B) where C(A) and C(B) are both numeric values.
+  table_label:
+    description:
+      - Causes JUNOS to allocate a VPN label per VRF rather than per VPN FEC.
+        This allows for forwarding of traffic to directly connected subnets, COS
+        Egress filtering etc.
   aggregate:
     description:
       - The set of VRF definition objects to be configured on the remote
@@ -186,7 +191,7 @@ def main():
         target=dict(type='list'),
         state=dict(default='present', choices=['present', 'absent']),
         active=dict(default=True, type='bool'),
-        table_label=dict(default=False, type='bool')
+        table_label=dict(default=True, type='bool')
     )
 
     aggregate_spec = deepcopy(element_spec)

--- a/lib/ansible/modules/network/junos/junos_vrf.py
+++ b/lib/ansible/modules/network/junos/junos_vrf.py
@@ -185,7 +185,8 @@ def main():
         interfaces=dict(type='list'),
         target=dict(type='list'),
         state=dict(default='present', choices=['present', 'absent']),
-        active=dict(default=True, type='bool')
+        active=dict(default=True, type='bool'),
+        table_label=dict(default=False, type='bool')
     )
 
     aggregate_spec = deepcopy(element_spec)
@@ -227,6 +228,7 @@ def main():
         ('rd', 'route-distinguisher/rd-type'),
         ('interfaces', 'interface/name'),
         ('target', 'vrf-target/community'),
+        ('table_label', {'xpath': 'vrf-table-label', 'tag_only': True}),
     ])
 
     params = to_param_list(module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #28726 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_rf
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Adds in the vrf-table-label tag to each VRF so that they support COS/Egress filtering/locally connected subnets.

I've tested this sucessfully on:
4 x MX104s running 17.1

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
