### PR TITLE
FcoeNetworkFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_fcoe_network_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_fcoe_network_facts.py
@@ -26,7 +26,6 @@ options:
     name:
       description:
         - FCoE Network name.
-
 extends_documentation_fragment:
     - oneview
     - oneview.factsparams
@@ -74,8 +73,8 @@ from ansible.module_utils.oneview import OneViewModuleBase
 class FcoeNetworkFactsModule(OneViewModuleBase):
     def __init__(self):
         argument_spec = dict(
-            name=dict(required=False, type='str'),
-            params=dict(required=False, type='dict')
+            name=dict(type='str'),
+            params=dict(type='dict'),
         )
 
         super(FcoeNetworkFactsModule, self).__init__(additional_arg_spec=argument_spec)

--- a/lib/ansible/modules/remote_management/oneview/oneview_fcoe_network_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_fcoe_network_facts.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_fcoe_network_facts
+short_description: Retrieve the facts about one or more of the OneView FCoE Networks
+description:
+    - Retrieve the facts about one or more of the FCoE Networks from OneView.
+version_added: "2.4"
+requirements:
+    - hpOneView >= 2.0.1
+author:
+    - Felipe Bulsoni (@fgbulsoni)
+    - Thiago Miotto (@tmiotto)
+    - Adriane Cardozo (@adriane-cardozo)
+options:
+    name:
+      description:
+        - FCoE Network name.
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all FCoE Networks
+  oneview_fcoe_network_facts:
+    config: /etc/oneview/oneview_config.json
+  delegate_to: localhost
+
+- debug: var=fcoe_networks
+
+- name: Gather paginated, filtered and sorted facts about FCoE Networks
+  oneview_fcoe_network_facts:
+    config: /etc/oneview/oneview_config.json
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'vlanId=2'
+  delegate_to: localhost
+
+- debug: var=fcoe_networks
+
+- name: Gather facts about a FCoE Network by name
+  oneview_fcoe_network_facts:
+    config: /etc/oneview/oneview_config.json
+    name: Test FCoE Network Facts
+  delegate_to: localhost
+
+- debug: var=fcoe_networks
+'''
+
+RETURN = '''
+fcoe_networks:
+    description: Has all the OneView facts about the FCoE Networks.
+    returned: Always, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class FcoeNetworkFactsModule(OneViewModuleBase):
+    def __init__(self):
+        argument_spec = dict(
+            name=dict(required=False, type='str'),
+            params=dict(required=False, type='dict')
+        )
+
+        super(FcoeNetworkFactsModule, self).__init__(additional_arg_spec=argument_spec)
+
+    def execute_module(self):
+
+        if self.module.params['name']:
+            fcoe_networks = self.oneview_client.fcoe_networks.get_by('name', self.module.params['name'])
+        else:
+            fcoe_networks = self.oneview_client.fcoe_networks.get_all(**self.facts_params)
+
+        return dict(changed=False,
+                    ansible_facts=dict(fcoe_networks=fcoe_networks))
+
+
+def main():
+    FcoeNetworkFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -33,4 +33,5 @@ from ansible.modules.remote_management.oneview.oneview_ethernet_network import E
 from ansible.modules.remote_management.oneview.oneview_fc_network import FcNetworkModule
 from ansible.modules.remote_management.oneview.oneview_fc_network_facts import FcNetworkFactsModule
 from ansible.modules.remote_management.oneview.oneview_fcoe_network import FcoeNetworkModule
+from ansible.modules.remote_management.oneview.oneview_fcoe_network_facts import FcoeNetworkFactsModule
 from ansible.modules.remote_management.oneview.oneview_network_set import NetworkSetModule

--- a/test/units/modules/remote_management/oneview/test_oneview_fcoe_network_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_fcoe_network_facts.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+
+from oneview_module_loader import FcoeNetworkFactsModule
+
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test FCoE Networks"
+)
+
+PRESENT_NETWORKS = [{
+    "name": "Test FCoE Networks",
+    "uri": "/rest/fcoe-networks/c6bf9af9-48e7-4236-b08a-77684dc258a5"
+}]
+
+
+class FcoeNetworkFactsSpec(unittest.TestCase,
+                           FactsParamsTestCase
+                           ):
+    def setUp(self):
+        self.configure_mocks(self, FcoeNetworkFactsModule)
+        self.fcoe_networks = self.mock_ov_client.fcoe_networks
+        FactsParamsTestCase.configure_client_mock(self, self.fcoe_networks)
+
+    def test_should_get_all_fcoe_network(self):
+        self.fcoe_networks.get_all.return_value = PRESENT_NETWORKS
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        FcoeNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fcoe_networks=PRESENT_NETWORKS)
+        )
+
+    def test_should_get_fcoe_network_by_name(self):
+        self.fcoe_networks.get_by.return_value = PRESENT_NETWORKS
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        FcoeNetworkFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(fcoe_networks=PRESENT_NETWORKS)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_fcoe_network_facts module for retrieving [HPE OneView FCoE Network](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/fcoe-networks) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_fcoe_network_facts`

##### ANSIBLE VERSION
```
ansible 2.4.0 (hpe-oneview/fcoe-network-facts edeef2b95b) last updated 2017/08/28 16:30:49 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/dev/core_ansible_related/ansible/lib/ansible
  executable location = /home/vagrant/dev/core_ansible_related/ansible/bin/ansible
  python version = 2.7.9 (default, Aug 21 2017, 11:24:49) [GCC 4.8.4]

```


##### ADDITIONAL INFORMATION
Example of usage:
```
- name: Gather facts about all FCoE Networks
  oneview_fcoe_network_facts:
    config: /etc/oneview/oneview_config.json
  delegate_to: localhost

- debug: var=fcoe_networks

- name: Gather paginated, filtered and sorted facts about FCoE Networks
  oneview_fcoe_network_facts:
    config: /etc/oneview/oneview_config.json
    params:
      start: 0
      count: 3
      sort: 'name:descending'
      filter: 'vlanId=2'
  delegate_to: localhost

- debug: var=fcoe_networks

- name: Gather facts about a FCoE Network by name
  oneview_fcoe_network_facts:
    config: /etc/oneview/oneview_config.json
    name: Test FCoE Network Facts
  delegate_to: localhost

- debug: var=fcoe_networks
```