### PR TITLE
NetworkSetFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/module_utils/oneview.py
+++ b/lib/ansible/module_utils/oneview.py
@@ -202,7 +202,12 @@ class OneViewModuleBase(object):
     HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
 
     ONEVIEW_COMMON_ARGS = dict(
-        config=dict(required=False, type='str')
+        config=dict(required=False, type='path'),
+        hostname=dict(required=False, type='str'),
+        username=dict(required=False, type='str'),
+        password=dict(required=False, type='str'),
+        api_version=dict(required=False, type='int'),
+        image_streamer_hostname=dict(required=False, type='str')
     )
 
     ONEVIEW_VALIDATE_ETAG_ARGS = dict(
@@ -257,7 +262,13 @@ class OneViewModuleBase(object):
             self.module.fail_json(msg=self.HPE_ONEVIEW_SDK_REQUIRED)
 
     def _create_oneview_client(self):
-        if not self.module.params['config']:
+        if self.module.params.get('hostname'):
+            config = dict(ip=self.module.params['hostname'],
+                          credentials=dict(userName=self.module.params['username'], password=self.module.params['password']),
+                          api_version=self.module.params['api_version'],
+                          image_streamer_ip=self.module.params['image_streamer_hostname'])
+            self.oneview_client = OneViewClient(config)
+        elif not self.module.params['config']:
             self.oneview_client = OneViewClient.from_environment_variables()
         else:
             self.oneview_client = OneViewClient.from_json_file(self.module.params['config'])

--- a/lib/ansible/module_utils/oneview.py
+++ b/lib/ansible/module_utils/oneview.py
@@ -202,20 +202,15 @@ class OneViewModuleBase(object):
     HPE_ONEVIEW_SDK_REQUIRED = 'HPE OneView Python SDK is required for this module.'
 
     ONEVIEW_COMMON_ARGS = dict(
-        config=dict(required=False, type='path'),
-        hostname=dict(required=False, type='str'),
-        username=dict(required=False, type='str'),
-        password=dict(required=False, type='str'),
-        api_version=dict(required=False, type='int'),
-        image_streamer_hostname=dict(required=False, type='str')
+        config=dict(type='path'),
+        hostname=dict(type='str'),
+        username=dict(type='str'),
+        password=dict(type='str'),
+        api_version=dict(type='int'),
+        image_streamer_hostname=dict(type='str')
     )
 
-    ONEVIEW_VALIDATE_ETAG_ARGS = dict(
-        validate_etag=dict(
-            required=False,
-            type='bool',
-            default=True)
-    )
+    ONEVIEW_VALIDATE_ETAG_ARGS = dict(validate_etag=dict(type='bool', default=True))
 
     resource_client = None
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
@@ -100,9 +100,9 @@ from ansible.module_utils.oneview import OneViewModuleBase
 
 class NetworkSetFactsModule(OneViewModuleBase):
     argument_spec = dict(
-        name=dict(required=False, type='str'),
-        options=dict(required=False, type='list'),
-        params=dict(required=False, type='dict'),
+        name=dict(type='str'),
+        options=dict(type='list'),
+        params=dict(type='dict'),
     )
 
     def __init__(self):
@@ -113,7 +113,7 @@ class NetworkSetFactsModule(OneViewModuleBase):
         name = self.module.params.get('name')
 
         if 'withoutEthernet' in self.options:
-            filter_by_name = "\"'name'='{}'\"".format(name) if name else ''
+            filter_by_name = ("\"'name'='%s'\"" % name) if name else ''
             network_sets = self.oneview_client.network_sets.get_all_without_ethernet(filter=filter_by_name)
         elif name:
             network_sets = self.oneview_client.network_sets.get_by('name', name)

--- a/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
@@ -41,28 +41,40 @@ extends_documentation_fragment:
 EXAMPLES = '''
 - name: Gather facts about all Network Sets
   oneview_network_set_facts:
-    config: /etc/oneview/oneview_config.json
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
   delegate_to: localhost
 
 - debug: var=network_sets
 
 - name: Gather paginated, filtered, and sorted facts about Network Sets
   oneview_network_set_facts:
-    config: /etc/oneview/oneview_config.json
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     params:
       start: 0
       count: 3
       sort: 'name:descending'
       filter: name='netset001'
+  no_log: true
   delegate_to: localhost
 
 - debug: var=network_sets
 
 - name: Gather facts about all Network Sets, excluding Ethernet networks
   oneview_network_set_facts:
-    config: /etc/oneview/oneview_config.json
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     options:
         - withoutEthernet
+  no_log: true
   delegate_to: localhost
 
 - debug: var=network_sets
@@ -70,8 +82,12 @@ EXAMPLES = '''
 
 - name: Gather facts about a Network Set by name
   oneview_network_set_facts:
-    config: /etc/oneview/oneview_config.json
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     name: Name of the Network Set
+  no_log: true
   delegate_to: localhost
 
 - debug: var=network_sets
@@ -79,10 +95,14 @@ EXAMPLES = '''
 
 - name: Gather facts about a Network Set by name, excluding Ethernet networks
   oneview_network_set_facts:
-    config: /etc/oneview/oneview_config.json
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     name: Name of the Network Set
     options:
         - withoutEthernet
+  no_log: true
   delegate_to: localhost
 
 - debug: var=network_sets

--- a/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_network_set_facts
+short_description: Retrieve facts about the OneView Network Sets
+description:
+    - Retrieve facts about the Network Sets from OneView.
+version_added: "2.4"
+requirements:
+    - hpOneView >= 2.0.1
+author:
+    - Felipe Bulsoni (@fgbulsoni)
+    - Thiago Miotto (@tmiotto)
+    - Adriane Cardozo (@adriane-cardozo)
+options:
+    name:
+      description:
+        - Network Set name.
+
+    options:
+      description:
+        - "List with options to gather facts about Network Set.
+          Option allowed: C(withoutEthernet).
+          The option C(withoutEthernet) retrieves the list of network_sets excluding Ethernet networks."
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Network Sets
+  oneview_network_set_facts:
+    config: /etc/oneview/oneview_config.json
+  delegate_to: localhost
+
+- debug: var=network_sets
+
+- name: Gather paginated, filtered, and sorted facts about Network Sets
+  oneview_network_set_facts:
+    config: /etc/oneview/oneview_config.json
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: name='netset001'
+  delegate_to: localhost
+
+- debug: var=network_sets
+
+- name: Gather facts about all Network Sets, excluding Ethernet networks
+  oneview_network_set_facts:
+    config: /etc/oneview/oneview_config.json
+    options:
+        - withoutEthernet
+  delegate_to: localhost
+
+- debug: var=network_sets
+
+
+- name: Gather facts about a Network Set by name
+  oneview_network_set_facts:
+    config: /etc/oneview/oneview_config.json
+    name: Name of the Network Set
+  delegate_to: localhost
+
+- debug: var=network_sets
+
+
+- name: Gather facts about a Network Set by name, excluding Ethernet networks
+  oneview_network_set_facts:
+    config: /etc/oneview/oneview_config.json
+    name: Name of the Network Set
+    options:
+        - withoutEthernet
+  delegate_to: localhost
+
+- debug: var=network_sets
+'''
+
+RETURN = '''
+network_sets:
+    description: Has all the OneView facts about the Network Sets.
+    returned: Always, but can be empty.
+    type: complex
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class NetworkSetFactsModule(OneViewModuleBase):
+    argument_spec = dict(
+        name=dict(required=False, type='str'),
+        options=dict(required=False, type='list'),
+        params=dict(required=False, type='dict'),
+    )
+
+    def __init__(self):
+        super(NetworkSetFactsModule, self).__init__(additional_arg_spec=self.argument_spec)
+
+    def execute_module(self):
+
+        name = self.module.params.get('name')
+
+        if 'withoutEthernet' in self.options:
+            filter_by_name = "\"'name'='{}'\"".format(name) if name else ''
+            network_sets = self.oneview_client.network_sets.get_all_without_ethernet(filter=filter_by_name)
+        elif name:
+            network_sets = self.oneview_client.network_sets.get_by('name', name)
+        else:
+            network_sets = self.oneview_client.network_sets.get_all(**self.facts_params)
+
+        return dict(changed=False,
+                    ansible_facts=dict(network_sets=network_sets))
+
+
+def main():
+    NetworkSetFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_network_set_facts.py
@@ -92,7 +92,7 @@ RETURN = '''
 network_sets:
     description: Has all the OneView facts about the Network Sets.
     returned: Always, but can be empty.
-    type: complex
+    type: dict
 '''
 
 from ansible.module_utils.oneview import OneViewModuleBase

--- a/lib/ansible/utils/module_docs_fragments/oneview.py
+++ b/lib/ansible/utils/module_docs_fragments/oneview.py
@@ -27,10 +27,9 @@ options:
           The configuration file is optional and when used should be present in the host running the ansible commands.
           If the file path is not provided, the configuration will be loaded from environment variables.
           For links to example configuration files or how to use the environment variables verify the notes section.
-      required: false
 
 requirements:
-  - "python >= 2.7.9"
+  - python >= 2.7.9
 
 notes:
     - "A sample configuration file for the config parameter can be found at:
@@ -39,6 +38,9 @@ notes:
        U(https://github.com/HewlettPackard/oneview-ansible#environment-variables)"
     - "Additional Playbooks for the HPE OneView Ansible modules can be found at:
        U(https://github.com/HewlettPackard/oneview-ansible/tree/master/examples)"
+    - "The OneView API version used will directly affect returned and expected fields in resources.
+       Information on setting the desired API version and can be found at:
+       U(https://github.com/HewlettPackard/oneview-ansible#setting-your-oneview-version)"
     '''
 
     VALIDATEETAG = '''
@@ -57,9 +59,8 @@ options:
         description:
         - List of params to delimit, filter and sort the list of resources.
         - "params allowed:
-            C(start): The first item to return, using 0-based indexing.
-            C(count): The number of resources to return.
-            C(filter): A general filter/query string to narrow the list of items returned.
-            C(sort): The sort order of the returned data set."
-        required: false
+            - C(start): The first item to return, using 0-based indexing.
+            - C(count): The number of resources to return.
+            - C(filter): A general filter/query string to narrow the list of items returned.
+            - C(sort): The sort order of the returned data set."
 '''

--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -1,19 +1,5 @@
-# -*- coding: utf-8 -*-
-#
-# Copyright (2016-2017) Hewlett Packard Enterprise Development LP
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program. If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import sys
 from ansible.compat.tests.mock import patch, Mock
@@ -34,3 +20,4 @@ from ansible.modules.remote_management.oneview.oneview_fc_network import FcNetwo
 from ansible.modules.remote_management.oneview.oneview_fc_network_facts import FcNetworkFactsModule
 from ansible.modules.remote_management.oneview.oneview_fcoe_network import FcoeNetworkModule
 from ansible.modules.remote_management.oneview.oneview_network_set import NetworkSetModule
+from ansible.modules.remote_management.oneview.oneview_network_set_facts import NetworkSetFactsModule

--- a/test/units/modules/remote_management/oneview/test_oneview_network_set_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_network_set_facts.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import NetworkSetFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_ALL_WITHOUT_ETHERNET = dict(
+    config='config.json',
+    name=None,
+    options=['withoutEthernet']
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name='Network Set 1'
+)
+
+PARAMS_GET_BY_NAME_WITHOUT_ETHERNET = dict(
+    config='config.json',
+    name='Network Set 1',
+    options=['withoutEthernet']
+)
+
+
+class NetworkSetFactsSpec(unittest.TestCase,
+                          FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, NetworkSetFactsModule)
+        self.network_sets = self.mock_ov_client.network_sets
+        FactsParamsTestCase.configure_client_mock(self, self.network_sets)
+
+    def test_should_get_all_network_sets(self):
+        network_sets = [{
+            "name": "Network Set 1",
+            "networkUris": ['/rest/ethernet-networks/aaa-bbb-ccc']
+        }, {
+            "name": "Network Set 2",
+            "networkUris": ['/rest/ethernet-networks/ddd-eee-fff', '/rest/ethernet-networks/ggg-hhh-fff']
+        }]
+
+        self.network_sets.get_all.return_value = network_sets
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        NetworkSetFactsModule().run()
+
+        self.network_sets.get_all.assert_called_once_with()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(network_sets=network_sets))
+
+    def test_should_get_all_network_sets_without_ethernet(self):
+        network_sets = [{
+            "name": "Network Set 1",
+            "networkUris": []
+        }, {
+            "name": "Network Set 2",
+            "networkUris": []
+        }]
+
+        self.network_sets.get_all.return_value = network_sets
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        NetworkSetFactsModule().run()
+
+        self.network_sets.get_all.assert_called_once_with()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(network_sets=network_sets))
+
+    def test_should_get_network_set_by_name(self):
+        network_sets = [{
+            "name": "Network Set 1",
+            "networkUris": ['/rest/ethernet-networks/aaa-bbb-ccc']
+        }]
+
+        self.network_sets.get_by.return_value = network_sets
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        NetworkSetFactsModule().run()
+
+        self.network_sets.get_by.assert_called_once_with('name', 'Network Set 1')
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(network_sets=network_sets))
+
+    def test_should_get_network_set_by_name_without_ethernet(self):
+        network_sets = [{
+            "name": "Network Set 1",
+            "networkUris": []
+        }]
+
+        self.network_sets.get_all_without_ethernet.return_value = network_sets
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME_WITHOUT_ETHERNET
+
+        NetworkSetFactsModule().run()
+
+        expected_filter = "\"'name'='Network Set 1'\""
+        self.network_sets.get_all_without_ethernet.assert_called_once_with(filter=expected_filter)
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(network_sets=network_sets))


### PR DESCRIPTION
##### SUMMARY
Added new oneview_network_set_facts module for retrieving [HPE OneView Network Set](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/network-sets) resource and unit tests.

Also updated oneview_module_loader to use short GPL3 copyright header.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_network_set_facts`

##### ANSIBLE VERSION
```
ansible 2.4.0 (hpe-oneview/network-set-facts b40e4077f6) last updated 2017/08/28 17:33:00 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/dev/core_ansible_related/ansible/lib/ansible
  executable location = /home/vagrant/dev/core_ansible_related/ansible/bin/ansible
  python version = 2.7.9 (default, Aug 21 2017, 11:24:49) [GCC 4.8.4]

```


##### ADDITIONAL INFORMATION
Example of usage:
```
- name: Gather facts about all Network Sets
  oneview_network_set_facts:
    config: /etc/oneview/oneview_config.json
  delegate_to: localhost

- debug: var=network_sets

- name: Gather paginated, filtered, and sorted facts about Network Sets
  oneview_network_set_facts:
    config: /etc/oneview/oneview_config.json
    params:
      start: 0
      count: 3
      sort: 'name:descending'
      filter: name='netset001'
  delegate_to: localhost

- debug: var=network_sets

- name: Gather facts about all Network Sets, excluding Ethernet networks
  oneview_network_set_facts:
    config: /etc/oneview/oneview_config.json
    options:
        - withoutEthernet
  delegate_to: localhost

- debug: var=network_sets


- name: Gather facts about a Network Set by name
  oneview_network_set_facts:
    config: /etc/oneview/oneview_config.json
    name: Name of the Network Set
  delegate_to: localhost

- debug: var=network_sets


- name: Gather facts about a Network Set by name, excluding Ethernet networks
  oneview_network_set_facts:
    config: /etc/oneview/oneview_config.json
    name: Name of the Network Set
    options:
        - withoutEthernet
  delegate_to: localhost

- debug: var=network_sets
```