### PR TITLE
elb_application_lb fails with KeyError

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -717,7 +717,8 @@ def create_or_update_elb_listeners(connection, module, elb):
         try:
             listener_to_add['LoadBalancerArn'] = elb['LoadBalancerArn']
             # Rules is not a valid parameter for create_listener
-            listener_to_add.pop('Rules')
+            if 'Rules' in listener_to_add:
+                listener_to_add.pop('Rules')
             response = connection.create_listener(**listener_to_add)
             # Add the new listener
             current_listeners.append(response['Listeners'][0])
@@ -729,7 +730,8 @@ def create_or_update_elb_listeners(connection, module, elb):
     for listener_to_modify in listeners_to_modify:
         try:
             # Rules is not a valid parameter for modify_listener
-            listener_to_modify.pop('Rules')
+            if 'Rules' in listener_to_modify:
+                listener_to_modify.pop('Rules')
             connection.modify_listener(**listener_to_modify)
             listener_changed = True
         except ClientError as e:


### PR DESCRIPTION
##### SUMMARY
elb_application_lb fails in some instances complaining about KeyError: 'Rules'
Occurs for me when creating a load balancer without a Rules section or when updating an existing load balancer.
Check if the key exists before removing it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 1733900daf) last updated 2017/08/28 14:17:58 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mstudd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/mstudd/dev/oss/ansible/lib/ansible
  executable location = /home/mstudd/dev/oss/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
