### PR TITLE
Clarifies File module docs re: absent state

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -46,7 +46,8 @@ options:
         or M(template) module if you want that behavior.  If C(link), the symbolic
         link will be created or changed. Use C(hard) for hardlinks. If C(absent),
         directories will be recursively deleted, and files or symlinks will be unlinked.
-        Note that C(file) will not fail if the C(path) does not exist as the state did not change.
+        Note that C(absent) will not cause C(file) to fail if the C(path) does not exist
+        as the state did not change.
         If C(touch) (new in 1.4), an empty file will be created if the C(path) does not
         exist, while an existing file or directory will receive updated file access and
         modification times (similar to the way `touch` works from the command line).


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The passage beginning "Note that file will not fail..." was slightly unclear about the fact that it referrs to the behavior of the module when a task's `state` is set to `absent`.

Fixes #23203

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- File module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
$ ansible --version
ansible 2.2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
