### PR TITLE
Fix rule purging in elb_application_lb

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -753,6 +753,14 @@ def create_or_update_elb_listeners(connection, module, elb):
             # Get listener based on port so we can use ARN
             looked_up_listener = get_listener(connection, module, elb['LoadBalancerArn'], listener['Port'])
 
+            # Delete rules
+            for rule in rules_to_delete:
+                try:
+                    connection.delete_rule(RuleArn=rule)
+                    listener_changed = True
+                except ClientError as e:
+                    module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+
             # Add rules
             for rule in rules_to_add:
                 try:
@@ -768,14 +776,6 @@ def create_or_update_elb_listeners(connection, module, elb):
                 try:
                     del rule['Priority']
                     connection.modify_rule(**rule)
-                    listener_changed = True
-                except ClientError as e:
-                    module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-
-            # Delete rules
-            for rule in rules_to_delete:
-                try:
-                    connection.delete_rule(RuleArn=rule)
                     listener_changed = True
                 except ClientError as e:
                     module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))


### PR DESCRIPTION
##### SUMMARY
Currently rule purging is done after new rules are added. This causes issues when adding new rules that, for example, have the same priority of an existing rule that will be purged.
Making the rule deletion the first step will allow adding rules that would otherwise cause errors.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 8e6c0ca599) last updated 2017/08/29 10:40:16 (GMT +300)
```
