### PR TITLE
Change inventory_hostname to ansible_ssh_host on nxos group_vars

### DIFF
--- a/test/integration/group_vars/nxos.yaml
+++ b/test/integration/group_vars/nxos.yaml
@@ -1,13 +1,13 @@
 ---
 cli:
-  host: "{{ inventory_hostname }}"
-  username: "{{ nxos_cli_user | default('admin') }}"
-  password: "{{ nxos_cli_pass | default('admin') }}"
+  host: "{{ ansible_ssh_host }}"
+  #username: "{{ nxos_cli_user | default('admin') }}"
+  #password: "{{ nxos_cli_pass | default('admin') }}"
   transport: cli
 
 nxapi:
-  host: "{{ inventory_hostname }}"
-  username: "{{ nxos_nxapi_user | default('admin') }}"
-  password: "{{ nxos_nxapi_pass | default('admin') }}"
+  host: "{{ ansible_ssh_host }}"
+  #username: "{{ nxos_nxapi_user | default('admin') }}"
+  #password: "{{ nxos_nxapi_pass | default('admin') }}"
   transport: nxapi
   use_ssl: no


### PR DESCRIPTION
We need to use IP address, as inventory_hostname returns an UUID from
openstack.py inventory in our CI.
Also, commenting the username/pass as we set them in the inventory (we shall
change this in the future).