### PR TITLE
Influxdb HTTPs connection option

### DIFF
--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -58,13 +58,13 @@ options:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
         default: false
-        version_added: 2.4
+        version_added: 2.5
     validate_certs:
         description:
             - verify SSL certificates for HTTPS requests, defaults to True
         required: false
         default: true
-        version_added: 2.4
+        version_added: 2.5
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -57,11 +57,13 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
+        default: false
         version_added: 2.4
     validate_certs:
         description:
             - verify SSL certificates for HTTPS requests, defaults to True
         required: false
+        default: true
         version_added: 2.4
 '''
 
@@ -139,7 +141,7 @@ def connect_to_influxdb(module):
         password=password,
         database=database_name,
         ssl=ssl,
-        validate_certs=validate_certs
+        verify_ssl=validate_certs
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -58,9 +58,9 @@ options:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
         version_added: 2.4
-    verify_ssl:
+    validate_certs:
         description:
-            - verify SSL certificates for HTTPS requests, defaults to False
+            - verify SSL certificates for HTTPS requests, defaults to True
         required: false
         version_added: 2.4
 '''
@@ -78,7 +78,7 @@ EXAMPLES = '''
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
       ssl: true
-      verify_ssl: true
+      validate_certs: true
       state: present
 
 - name: Destroy database
@@ -119,7 +119,7 @@ def influxdb_argument_spec():
         password=dict(default='root', type='str', no_log=True),
         database_name=dict(required=True, type='str'),
         ssl=dict(required=False, type="bool", default=False),
-        verify_ssl=dict(required=False, type="bool", default=False)
+        validate_certs=dict(required=False, type="bool", default=True)
     )
 
 
@@ -130,7 +130,7 @@ def connect_to_influxdb(module):
     password = module.params['password']
     database_name = module.params['database_name']
     ssl = module.params['ssl']
-    verify_ssl = module.params['verify_ssl']
+    validate_certs = module.params['validate_certs']
 
     client = InfluxDBClient(
         host=hostname,
@@ -139,7 +139,7 @@ def connect_to_influxdb(module):
         password=password,
         database=database_name,
         ssl=ssl,
-        verify_ssl=verify_ssl
+        validate_certs=validate_certs
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -57,12 +57,12 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
-        version_added: 2.4
+        version_added: 2.5
     verify_ssl:
         description:
             - verify SSL certificates for HTTPS requests, defaults to False
         required: false
-        version_added: 2.4
+        version_added: 2.5
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -53,6 +53,14 @@ options:
         choices: ['present', 'absent']
         default: present
         required: false
+    ssl:
+        description:
+            - Use https instead of http to connect to InfluxDB, defaults to False
+        required: false
+    verify_ssl:
+        description:
+            - verify SSL certificates for HTTPS requests, defaults to False
+        required: false
 '''
 
 EXAMPLES = '''
@@ -61,6 +69,14 @@ EXAMPLES = '''
   influxdb_database:
       hostname: "{{influxdb_ip_address}}"
       database_name: "{{influxdb_database_name}}"
+      state: present
+
+- name: Create database, use HTTPs to connect to the server and validate the cert
+  influxdb_database:
+      hostname: "{{influxdb_ip_address}}"
+      database_name: "{{influxdb_database_name}}"
+      ssl: true
+      verify_ssl: true
       state: present
 
 - name: Destroy database
@@ -99,7 +115,9 @@ def influxdb_argument_spec():
         port=dict(default=8086, type='int'),
         username=dict(default='root', type='str'),
         password=dict(default='root', type='str', no_log=True),
-        database_name=dict(required=True, type='str')
+        database_name=dict(required=True, type='str'),
+        ssl=dict(required=False, type="bool", default=False),
+        verify_ssl=dict(required=False, type="bool", default=False)
     )
 
 
@@ -109,13 +127,17 @@ def connect_to_influxdb(module):
     username = module.params['username']
     password = module.params['password']
     database_name = module.params['database_name']
+    ssl = module.params['ssl']
+    verify_ssl = module.params['verify_ssl']
 
     client = InfluxDBClient(
         host=hostname,
         port=port,
         username=username,
         password=password,
-        database=database_name
+        database=database_name,
+        ssl,
+        verify_ssl
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -57,12 +57,12 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
-        version_added: 2.5
+        version_added: 2.4
     verify_ssl:
         description:
             - verify SSL certificates for HTTPS requests, defaults to False
         required: false
-        version_added: 2.5
+        version_added: 2.4
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -136,8 +136,8 @@ def connect_to_influxdb(module):
         username=username,
         password=password,
         database=database_name,
-        ssl,
-        verify_ssl
+        ssl=ssl,
+        verify_ssl=verify_ssl
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -57,10 +57,12 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
+        version_added: 2.4
     verify_ssl:
         description:
             - verify SSL certificates for HTTPS requests, defaults to False
         required: false
+        version_added: 2.4
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -67,11 +67,13 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
+        default: false
         version_added: 2.4
     validate_certs:
         description:
             - verify SSL certificates for HTTPS requests, defaults to True
         required: false
+        default: true
         version_added: 2.4
 '''
 
@@ -165,7 +167,7 @@ def connect_to_influxdb(module):
         password=password,
         database=database_name,
         ssl=ssl,
-        validate_certs=validate_certs
+        verify_ssl=validate_certs
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -68,13 +68,13 @@ options:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
         default: false
-        version_added: 2.4
+        version_added: 2.5
     validate_certs:
         description:
             - verify SSL certificates for HTTPS requests, defaults to True
         required: false
         default: true
-        version_added: 2.4
+        version_added: 2.5
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -68,9 +68,9 @@ options:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
         version_added: 2.4
-    verify_ssl:
+    validate_certs:
         description:
-            - verify SSL certificates for HTTPS requests, defaults to False
+            - verify SSL certificates for HTTPS requests, defaults to True
         required: false
         version_added: 2.4
 '''
@@ -93,7 +93,7 @@ EXAMPLES = '''
       duration: 1h
       replication: 1
       ssl: true
-      verify_ssl: true
+      validate_certs: true
 
 - name: create 1 day retention policy
   influxdb_retention_policy:
@@ -145,7 +145,7 @@ def influxdb_argument_spec():
         password=dict(default='root', type='str', no_log=True),
         database_name=dict(required=True, type='str'),
         ssl=dict(required=False, type="bool", default=False),
-        verify_ssl=dict(required=False, type="bool", default=False)
+        validate_certs=dict(required=False, type="bool", default=True)
     )
 
 
@@ -156,7 +156,7 @@ def connect_to_influxdb(module):
     password = module.params['password']
     database_name = module.params['database_name']
     ssl = module.params['ssl']
-    verify_ssl = module.params['verify_ssl']
+    validate_certs = module.params['validate_certs']
 
     client = InfluxDBClient(
         host=hostname,
@@ -165,7 +165,7 @@ def connect_to_influxdb(module):
         password=password,
         database=database_name,
         ssl=ssl,
-        verify_ssl=verify_ssl
+        validate_certs=validate_certs
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -67,12 +67,12 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
-        version_added: 2.5
+        version_added: 2.4
     verify_ssl:
         description:
             - verify SSL certificates for HTTPS requests, defaults to False
         required: false
-        version_added: 2.5
+        version_added: 2.4
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -67,12 +67,12 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
-        version_added: 2.4
+        version_added: 2.5
     verify_ssl:
         description:
             - verify SSL certificates for HTTPS requests, defaults to False
         required: false
-        version_added: 2.4
+        version_added: 2.5
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -67,10 +67,12 @@ options:
         description:
             - Use https instead of http to connect to InfluxDB, defaults to False
         required: false
+        version_added: 2.4
     verify_ssl:
         description:
             - verify SSL certificates for HTTPS requests, defaults to False
         required: false
+        version_added: 2.4
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -63,6 +63,14 @@ options:
         description:
             - Sets the retention policy as default retention policy
         required: true
+    ssl:
+        description:
+            - Use https instead of http to connect to InfluxDB, defaults to False
+        required: false
+    verify_ssl:
+        description:
+            - verify SSL certificates for HTTPS requests, defaults to False
+        required: false
 '''
 
 EXAMPLES = '''
@@ -74,6 +82,16 @@ EXAMPLES = '''
       policy_name: test
       duration: 1h
       replication: 1
+
+- name: create 1 hour retention policy, use HTTPs to connect to the server and validate the cert
+  influxdb_retention_policy:
+      hostname: "{{influxdb_ip_address}}"
+      database_name: "{{influxdb_database_name}}"
+      policy_name: test
+      duration: 1h
+      replication: 1
+      ssl: true
+      verify_ssl: true
 
 - name: create 1 day retention policy
   influxdb_retention_policy:
@@ -123,7 +141,9 @@ def influxdb_argument_spec():
         port=dict(default=8086, type='int'),
         username=dict(default='root', type='str'),
         password=dict(default='root', type='str', no_log=True),
-        database_name=dict(required=True, type='str')
+        database_name=dict(required=True, type='str'),
+        ssl=dict(required=False, type="bool", default=False),
+        verify_ssl=dict(required=False, type="bool", default=False)
     )
 
 
@@ -133,13 +153,17 @@ def connect_to_influxdb(module):
     username = module.params['username']
     password = module.params['password']
     database_name = module.params['database_name']
+    ssl = module.params['ssl']
+    verify_ssl = module.params['verify_ssl']
 
     client = InfluxDBClient(
         host=hostname,
         port=port,
         username=username,
         password=password,
-        database=database_name
+        database=database_name,
+        ssl,
+        verify_ssl
     )
     return client
 

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -162,8 +162,8 @@ def connect_to_influxdb(module):
         username=username,
         password=password,
         database=database_name,
-        ssl,
-        verify_ssl
+        ssl=ssl,
+        verify_ssl=verify_ssl
     )
     return client
 


### PR DESCRIPTION
##### SUMMARY
Enable influxdb_database and influxdb_retention_policy modules to connect to influxdb using HTTPs


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/database/influxdb

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.2.0
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Influxdb can terminate SSL. I added 2 extra parameters to the influxdb modules:
1. use HTTPs to connect to influxdb
2. verify the certificate when connecting to influxdb over HTTPs
this should allow you to manage influxdb databases and retention policies on database instances where you have your self signed certificates configured
<!--- Paste verbatim command output below, e.g. before and after your change -->
before fix:
```
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/database/influxdb/influxdb_database.py
<192.168.1.1> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
failed: [192.168.1.1] (item={u'name': u'mydb'}) => {
    "failed": true,
    "invocation": {
        "module_args": {
            "database_name": "mydb",
            "hostname": "127.0.0.1",
            "password": "root",
            "port": 8086,
            "state": "present",
            "username": "root"
        }
    },
    "item": {
        "name": "mydb"
    },
    "msg": ""
}
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/database/influxdb/influxdb_database.py
<192.168.1.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<192.168.1.1> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/database/influxdb/influxdb_database.py
<192.168.1.1> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
failed: [192.168.1.1] (item={u'name': u'mydb', u'retention': u'90d'}) => {
    "failed": true,
    "invocation": {
        "module_args": {
            "database_name": "mydb",
            "hostname": "127.0.0.1",
            "password": "root",
            "port": 8086,
            "state": "present",
            "username": "root"
        }
    },
    "item": {
        "name": "mydb",
        "retention": "90d"
    },
    "msg": ""
}
```

after fix:
```
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/database/influxdb/influxdb_database.py
<192.168.1.1> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
ok: [192.168.1.1] => (item={u'name': u'mydb'}) => {
    "changed": false,
    "invocation": {
        "module_args": {
            "database_name": "mydb",
            "hostname": "127.0.0.1",
            "password": "root",
            "port": 8086,
            "ssl": true,
            "state": "present",
            "username": "root",
            "verify_ssl": false
        }
    },
    "item": {
        "name": "mydb"
    }
}
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/database/influxdb/influxdb_retention_policy.py
<192.168.1.1> EXEC /bin/sh -c '/usr/bin/python && sleep 0'
ok: [192.168.1.1] => (item={u'name': u'mydb', u'retention': u'90d'}) => {
    "changed": false,
    "invocation": {
        "module_args": {
            "database_name": "mydb",
            "default": true,
            "duration": "90d",
            "hostname": "127.0.0.1",
            "password": "root",
            "policy_name": "mydb",
            "port": 8086,
            "replication": 1,
            "ssl": true,
            "username": "root",
            "verify_ssl": false
        }
    },
    "item": {
        "name": "mydb",
        "retention": "90d"
    }
}
```
