### PR TITLE
Fix know_hosts hash_host parameter ignored when adding new key

### DIFF
--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -99,16 +99,19 @@ def enforce_state(module, params):
     # Find the ssh-keygen binary
     sshkeygen = module.get_bin_path("ssh-keygen", True)
 
+    if key is None and state != "absent":
+        module.fail_json(msg="No key specified when adding a host")
+
+    if key is not None and hash_host is True:
+        key = hash_host_key(module, sshkeygen, host, key)
+
     # Trailing newline in files gets lost, so re-add if necessary
     if key and key[-1] != '\n':
         key += '\n'
 
-    if key is None and state != "absent":
-        module.fail_json(msg="No key specified when adding a host")
-
     sanity_check(module, host, key, sshkeygen)
 
-    found, replace_or_add, found_line, key = search_for_host_key(module, host, key, hash_host, path, sshkeygen)
+    found, replace_or_add, found_line = search_for_host_key(module, host, key, path, sshkeygen)
 
     params['diff'] = compute_diff(path, found_line, replace_or_add, state, key)
 
@@ -201,7 +204,7 @@ def sanity_check(module, host, key, sshkeygen):
         module.fail_json(msg="Host parameter does not match hashed host field in supplied key")
 
 
-def search_for_host_key(module, host, key, hash_host, path, sshkeygen):
+def search_for_host_key(module, host, key, path, sshkeygen):
     '''search_for_host_key(module,host,key,path,sshkeygen) -> (found,replace_or_add,found_line)
 
     Looks up host and keytype in the known_hosts file path; if it's there, looks to see
@@ -213,7 +216,7 @@ def search_for_host_key(module, host, key, hash_host, path, sshkeygen):
     sshkeygen is the path to ssh-keygen, found earlier with get_bin_path
     '''
     if os.path.exists(path) is False:
-        return False, False, None, key
+        return False, False, None
 
     sshkeygen_command = [sshkeygen, '-F', host, '-f', path]
 
@@ -221,22 +224,16 @@ def search_for_host_key(module, host, key, hash_host, path, sshkeygen):
     # 1 if no host is found, whereas previously it returned 0
     rc, stdout, stderr = module.run_command(sshkeygen_command, check_rc=False)
     if stdout == '' and stderr == '' and (rc == 0 or rc == 1):
-        return False, False, None, key  # host not found, no other errors
+        return False, False, None  # host not found, no other errors
     if rc != 0:  # something went wrong
         module.fail_json(msg="ssh-keygen failed (rc=%d, stdout='%s',stderr='%s')" % (rc, stdout, stderr))
 
     # If user supplied no key, we don't want to try and replace anything with it
     if key is None:
-        return True, False, None, key
+        return True, False, None
 
     lines = stdout.split('\n')
     new_key = normalize_known_hosts_key(key)
-
-    sshkeygen_command.insert(1, '-H')
-    rc, stdout, stderr = module.run_command(sshkeygen_command, check_rc=False)
-    if rc not in (0, 1) or stderr != '':  # something went wrong
-        module.fail_json(msg="ssh-keygen failed to hash host (rc=%d, stdout='%s',stderr='%s')" % (rc, stdout, stderr))
-    hashed_lines = stdout.split('\n')
 
     for lnum, l in enumerate(lines):
         if l == '':
@@ -250,19 +247,30 @@ def search_for_host_key(module, host, key, hash_host, path, sshkeygen):
                 module.fail_json(msg="failed to parse output of ssh-keygen for line number: '%s'" % l)
         else:
             found_key = normalize_known_hosts_key(l)
-            if hash_host is True:
-                if found_key['host'][:3] == '|1|':
-                    new_key['host'] = found_key['host']
-                else:
-                    hashed_host = normalize_known_hosts_key(hashed_lines[lnum])
-                    found_key['host'] = hashed_host['host']
-                key = key.replace(host, found_key['host'])
+            if new_key['host'][:3]=='|1|' and found_key['host'][:3]=='|1|': # do not change host hash if already hashed
+               new_key['host'] = found_key['host']
             if new_key == found_key:  # found a match
-                return True, False, found_line, key  # found exactly the same key, don't replace
-            elif new_key['type'] == found_key['type']:  # found a different key for the same key type
-                return True, True, found_line, key
+                return True, False, found_line  # found exactly the same key, don't replace
+            elif new_key['type'] == found_key['type']:
+                return True, True, found_line
     # No match found, return found and replace, but no line
-    return True, True, None, key
+    return True, True, None
+
+
+def hash_host_key(module, sshkeygen, host, key):
+    outf = tempfile.NamedTemporaryFile(mode='w+')
+    outf.write(key + '\n')
+    outf.flush()
+
+    sshkeygen_command = [sshkeygen, '-F', host, '-f', outf.name, '-H']
+    rc, stdout, stderr = module.run_command(sshkeygen_command, check_rc=False)
+    if rc not in (0, 1) or stderr != '':  # something went wrong
+        module.fail_json(msg="ssh-keygen failed to hash host (rc=%d, stdout='%s',stderr='%s')" % (rc, stdout, stderr))
+    hashed_line = stdout.split('\n')[1]
+
+    outf.close()
+
+    return hashed_line
 
 
 def normalize_known_hosts_key(key):

--- a/lib/ansible/modules/system/known_hosts.py
+++ b/lib/ansible/modules/system/known_hosts.py
@@ -247,8 +247,8 @@ def search_for_host_key(module, host, key, path, sshkeygen):
                 module.fail_json(msg="failed to parse output of ssh-keygen for line number: '%s'" % l)
         else:
             found_key = normalize_known_hosts_key(l)
-            if new_key['host'][:3]=='|1|' and found_key['host'][:3]=='|1|': # do not change host hash if already hashed
-               new_key['host'] = found_key['host']
+            if new_key['host'][:3] == '|1|' and found_key['host'][:3] == '|1|':  # do not change host hash if already hashed
+                new_key['host'] = found_key['host']
             if new_key == found_key:  # found a match
                 return True, False, found_line  # found exactly the same key, don't replace
             elif new_key['type'] == found_key['type']:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix know_hosts hash_host parameter ignored when adding new key.
Fixes #24651.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
known_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.3 (default, Jun 21 2016, 18:38:19) [GCC 4.7.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
