### PR TITLE
Fix hostname GenericStrategy.update_current_hostname()

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -154,7 +154,7 @@ class GenericStrategy(object):
         current_name = self.get_current_hostname()
         if current_name != name:
             if not self.module.check_mode:
-                self.set_curent_hostname(name)
+                self.set_current_hostname(name)
             self.changed = True
 
     def update_permanent_hostname(self):


### PR DESCRIPTION
##### SUMMARY
https://github.com/ansible/ansible/pull/27700 was busted, this fixes it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/system/hostname.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (hostname_fix 3d7178cc93) last updated 2017/08/29 11:12:25 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
