### PR TITLE
alternatives: test that path parameter is checked

### DIFF
--- a/test/integration/targets/alternatives/tasks/main.yml
+++ b/test/integration/targets/alternatives/tasks/main.yml
@@ -40,6 +40,10 @@
     vars:
       with_alternatives: False
       mode: auto
+
+  # Test that path is checked: alternatives must fail when path is nonexistent
+  - import_tasks: path_is_checked.yml
+
   always:
     - include_tasks: remove_links.yml
 

--- a/test/integration/targets/alternatives/tasks/path_is_checked.yml
+++ b/test/integration/targets/alternatives/tasks/path_is_checked.yml
@@ -1,0 +1,12 @@
+- name: Try with nonexistent path
+  alternatives:
+    name: dummy
+    path: '/non/existent/path/there'
+    link: '/usr/bin/dummy'
+  ignore_errors: True
+  register: alternative
+
+- name: Check previous task failed
+  assert:
+    that:
+      - 'alternative|failed'


### PR DESCRIPTION
##### SUMMARY
Test that `path` parameter of alternatives module is checked (see #24800).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
system/alternatives

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 0c9c0c59f2) last updated 2017/08/29 16:12:25 (GMT +200)
```