### PR TITLE
Add a select_chain_match filter to vmware_inventory

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -41,6 +41,7 @@ from __future__ import print_function
 import atexit
 import datetime
 import getpass
+import itertools
 import json
 import os
 import re
@@ -82,6 +83,14 @@ def regex_match(s, pattern):
         return True
     else:
         return False
+
+
+def select_chain_match(inlist, key, pattern):
+    '''Get a key from a list of dicts, squash values to a single list, then filter'''
+    outlist = [x[key] for x in inlist]
+    outlist = list(itertools.chain(*outlist))
+    outlist = [x for x in outlist if regex_match(x, pattern)]
+    return outlist
 
 
 class VMwareMissingHostException(Exception):
@@ -127,6 +136,7 @@ class VMWareInventory(object):
     # use jinja environments to allow for custom filters
     env = Environment()
     env.filters['regex_match'] = regex_match
+    env.filters['select_chain_match'] = select_chain_match
 
     # translation table for attributes to fetch for known vim types
 


### PR DESCRIPTION
##### SUMMARY
Allows a user to extract an IP address by regex out of the list of nics+ips for vmware guests.

Example config:
```
$ cat vmware_inventory.ini | egrep -v ^\$ | egrep -v ^\# | egrep -v password                                                                                                                             
[vmware]
server=10.0.2.10
username=jctanner
cache_max_age = 0
max_object_level=5
alias_pattern={{ name }}
host_pattern={{ (guest.net|select_chain_match('ipaddress', '^10.0'))[0] }}
host_filters={{ guest.net|length > 1  and guest.gueststate == 'running' }}
[properties]
prop01=name
prop02=config.name
prop03=config.uuid
prop08=guest.hostName
prop11=guest.guestState
prop13=guest.net
```

For a machine with a guest.net datastructure such as ...

```
        "guest": {
          "net": [
            {
              "macaddress": "00:50:56:87:c3:e8",
              "network": "RHLab",
              "dnsconfig": null,
              "dynamictype": null,
              "ipconfig": {
                "dynamictype": null,
                "dhcp": null,
                "dynamicproperty": [],
                "autoconfigurationenabled": null,
                "ipaddress": []
              },
              "dynamicproperty": [],
              "netbiosconfig": null,
              "connected": true,
              "ipaddress": [
                "10.0.100.57",
                "fe80::d5c1:afe2:cdff:c44e"
              ],
              "deviceconfigid": 4000
            },
            {
              "macaddress": "02:42:a6:41:96:48",
              "network": null,
              "dnsconfig": null,
              "dynamictype": null,
              "ipconfig": {
                "dynamictype": null,
                "dhcp": null,
                "dynamicproperty": [],
                "autoconfigurationenabled": null,
                "ipaddress": []
              },
              "dynamicproperty": [],
              "netbiosconfig": null,
              "connected": true,
              "ipaddress": [
                "172.17.0.1",
                "fe80::42:a6ff:fe41:9648"
              ],
              "deviceconfigid": -1
            }
          ],
```

The new filter would find the "10.0.100.57" address and use it for the ansible_ssh_host.


##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME
vmware_inventory.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
