### PR TITLE
module should fail if eos_user is added without configured_password or nopassword or sshkey

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -200,6 +200,11 @@ def map_obj_to_commands(updates, module):
             else:
                 add('no username %s nopassword' % want['name'])
 
+        if want.get('state') == 'present' and want.get('name'):
+            value = [want.get('configured_password'), want.get('nopassword'), want.get('sshkey')]
+            if all(v is None for v in value) is True:
+                module.fail_json(msg='configured_password, sshkey or nopassword should be provided')
+
     return commands
 
 

--- a/test/integration/targets/eos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_user/tests/cli/basic.yaml
@@ -13,6 +13,7 @@
     privilege: 15
     role: network-operator
     state: present
+    configured_password: test1
     authorize: yes
     provider: "{{ cli }}"
   register: result
@@ -20,13 +21,16 @@
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["username ansibletest1 role network-operator", "username ansibletest1 privilege 15"]'
+      - '"username" in result.commands[0]'
+      - '"role network-operator" in result.commands[0]'
+      - '"privilege 15" in result.commands[1]'
+      - '"secret" in result.commands[2]'
 
 - name: Collection of users
   eos_user:
     aggregate:
-      - name: ansibletest2
-      - name: ansibletest3
+      - { name: ansibletest2, configured_password: test2 }
+      - { name: ansibletest3, configured_password: test3 }
     authorize: yes
     state: present
     role: network-operator
@@ -36,7 +40,28 @@
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["username ansibletest2 role network-operator", "username ansibletest3 role network-operator"]'
+      - '"username" in result.commands[0]'
+      - '"role network-operator" in result.commands[0]'
+      - '"secret" in result.commands[1]'
+      - '"username" in result.commands[2]'
+      - '"role network-operator" in result.commands[2]'
+      - '"secret" in result.commands[3]'
+
+- name: Add user without password or nopassword arg(Should fail)
+  eos_user:
+    name: faileduser1
+    privilege: 15
+    state: present
+    authorize: yes
+    provider: "{{ cli }}"
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == false'
+      - 'result.failed == true'
+      - 'result.msg == "configured_password, sshkey or nopassword should be provided"'
 
 - name: tearDown
   eos_config:

--- a/test/units/modules/network/eos/test_eos_user.py
+++ b/test/units/modules/network/eos/test_eos_user.py
@@ -59,12 +59,12 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_privilege(self):
-        set_module_args(dict(name='ansible', privilege=15))
-        commands = ['username ansible privilege 15']
-        self.execute_module(changed=True, commands=commands)
+        set_module_args(dict(name='ansible', privilege=15, configured_password='test'))
+        result = self.execute_module(changed=True)
+        self.assertIn('username ansible privilege 15', result['commands'])
 
     def test_eos_user_privilege_invalid(self):
-        set_module_args(dict(name='ansible', privilege=25))
+        set_module_args(dict(name='ansible', privilege=25, configured_password='test'))
         self.execute_module(failed=True)
 
     def test_eos_user_purge(self):
@@ -73,9 +73,9 @@ class TestEosUserModule(TestEosModule):
         self.execute_module(changed=True, commands=commands)
 
     def test_eos_user_role(self):
-        set_module_args(dict(name='ansible', role='test'))
-        commands = ['username ansible role test']
-        self.execute_module(changed=True, commands=commands)
+        set_module_args(dict(name='ansible', role='test', configured_password='test'))
+        result = self.execute_module(changed=True)
+        self.assertIn('username ansible role test', result['commands'])
 
     def test_eos_user_sshkey(self):
         set_module_args(dict(name='ansible', sshkey='test'))


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/28388
Bug: eos_user pass silently without configuring the user on host when password/nopassword/sshkey is not provided.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/eos/eos_user.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```