### PR TITLE
Add diff mode support to hostname module

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -748,13 +748,28 @@ def main():
 
     hostname = Hostname(module)
     name = module.params['name']
+
+    current_hostname = hostname.get_current_hostname()
+    permanent_hostname = hostname.get_permanent_hostname()
+
     changed = hostname.update_current_and_permanent_hostname()
 
-    module.exit_json(changed=changed, name=name,
-                     ansible_facts=dict(ansible_hostname=name.split('.')[0],
-                                        ansible_nodename=name,
-                                        ansible_fqdn=socket.getfqdn(),
-                                        ansible_domain='.'.join(socket.getfqdn().split('.')[1:])))
+    if name != current_hostname:
+        name_before = current_hostname
+    elif name != permanent_hostname:
+        name_before = permanent_hostname
+
+    kw = dict(changed=changed, name=name,
+              ansible_facts=dict(ansible_hostname=name.split('.')[0],
+                                 ansible_nodename=name,
+                                 ansible_fqdn=socket.getfqdn(),
+                                 ansible_domain='.'.join(socket.getfqdn().split('.')[1:])))
+
+    if changed:
+        kw['diff'] = {'after': 'hostname = ' + name + '\n',
+                      'before': 'hostname = ' + name_before + '\n'}
+
+    module.exit_json(**kw)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
More or less a rebase of https://github.com/ansible/ansible/pull/23271

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for check_mode and diff to the hostname module
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/system/hostname

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (hostname_diff_mode 155dccc6c0) last updated 2017/08/29 11:32:58 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
