### PR TITLE
Fixes #28779 eth_mode key error

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -141,7 +141,7 @@ commands:
     sample: ["interface port-channel101", "shutdown"]
 '''
 
-from ansible.module_utils.nxos import get_config, load_config, run_commands
+from ansible.module_utils.nxos import load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
@@ -280,7 +280,7 @@ def get_interface(intf, module):
 
     if body:
         interface_table = body['TABLE_interface']['ROW_interface']
-        if interface_table['eth_mode'] == 'fex-fabric':
+        if interface_table.get('eth_mode') == 'fex-fabric':
             module.fail_json(msg='nxos_interface does not support interfaces with mode "fex-fabric"')
         intf_type = get_interface_type(intf)
         if intf_type in ['portchannel', 'ethernet']:
@@ -701,7 +701,7 @@ def main():
                 end_state, is_default = smart_existing(module, intf_type,
                                                        normalized_interface)
             else:
-                end_state = get_interfaces_dict(module)[interface_type]
+                get_interfaces_dict(module)[interface_type]
             cmds = [cmd for cmd in cmds if cmd != 'configure']
 
     results['commands'] = cmds

--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -700,8 +700,6 @@ def main():
                     cmds.extend(cmds2)
                 end_state, is_default = smart_existing(module, intf_type,
                                                        normalized_interface)
-            else:
-                get_interfaces_dict(module)[interface_type]
             cmds = [cmd for cmd in cmds if cmd != 'configure']
 
     results['commands'] = cmds

--- a/test/units/modules/network/nxos/test_nxos_interface.py
+++ b/test/units/modules/network/nxos/test_nxos_interface.py
@@ -37,13 +37,9 @@ class TestNxosInterfaceModule(TestNxosModule):
         self.mock_load_config = patch('ansible.modules.network.nxos.nxos_interface.load_config')
         self.load_config = self.mock_load_config.start()
 
-        self.mock_get_config = patch('ansible.modules.network.nxos.nxos_interface.get_config')
-        self.get_config = self.mock_get_config.start()
-
     def tearDown(self):
         self.mock_run_commands.stop()
         self.mock_load_config.stop()
-        self.mock_get_config.stop()
 
     def load_fixtures(self, commands=None, device=''):
         self.load_config.return_value = None


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/28779

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_interface

##### ANSIBLE VERSION
```
ansible 2.4.0 (240/fix_nxos_interface 319f685dd8) last updated 2017/08/29 11:45:53 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
This fix addresses the following:
  * Uses get to avoid the key error
  * Removes unused library and variable reference

**All tests pass with the fix:**
