### PR TITLE
Update ec2_vpc_igw.py

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -241,9 +241,10 @@ def main():
     state = module.params.get('state', 'present')
     tags = module.params.get('tags')
 
-    nonstring_tags = [k for k, v in tags.items() if not isinstance(v, string_types)]
+    nonstring_tags = [k for k, v in tags.items() if not isinstance(v, (string_types, bool))]
+
     if nonstring_tags:
-        module.fail_json(msg='One or more tags contain non-string values: {0}'.format(nonstring_tags))
+        module.fail_json(msg='One or more tags contain non-string or non-boolean values: {0}'.format(nonstring_tags))
 
     try:
         if state == 'present':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
If you have a tag, where the value parses as a bool ('yes', 'true', 'True') etc - which are valid tags values, this module breaks.

Patch to add 'bool' to the 'classinfo' tuple, to allow Boolean values through.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_vpc_igw

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /Users/tom/repos/aws-codecommit/ansible-tower/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```

Latest checkout of module from `devel`.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
