### PR TITLE
ACI Rest: Fix issue with XML response

### DIFF
--- a/lib/ansible/modules/network/aci/aci_rest.py
+++ b/lib/ansible/modules/network/aci/aci_rest.py
@@ -192,7 +192,8 @@ def aci_response(result, rawoutput, rest_type='xml'):
     if rest_type == 'json':
         aci_response_json(result, rawoutput)
 
-    aci_response_xml(result, rawoutput)
+    else:
+        aci_response_xml(result, rawoutput)
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update aci_rest module to handle JSON data correctly. The XML response was outside of the if/else clause causing JSON data to be treated as XML.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aci_rest
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
