### PR TITLE
Fix ec2_win_password to allow blank key_passphrase

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -133,7 +133,10 @@ def main():
 
     instance_id = module.params.get('instance_id')
     key_file = module.params.get('key_file')
-    b_key_passphrase = to_bytes(module.params.get('key_passphrase'), errors='surrogate_or_strict')
+    if module.params.get('key_passphrase') is None:
+        b_key_passphrase = None
+    else:
+        b_key_passphrase = to_bytes(module.params.get('key_passphrase'), errors='surrogate_or_strict')
     wait = module.params.get('wait')
     wait_timeout = int(module.params.get('wait_timeout'))
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There was a change between ansible 2.3.2 and ansible 2.4.0 that broke the ec2_win_password module if using a key without a passphrase.  The below task worked in 2.3.2 and fails in 2.4.0: 

    - name: obtain windows passwords for instances
      ec2_win_password:
        region: "us-east-1"
        instance_id: "i-09b943879876303ea"
        key_file: "/home/jjozwiak/.ssh/id_rsa"
        wait: yes
        wait_timeout: 45
      register: ec2_password

In 2.4.0 this returns a failure indicating the private key is given a passphrase, but the key isn't encrypted.  

The full traceback is:
  File "/tmp/ansible_6K5Q9I/ansible_module_ec2_win_password.py", line 167, in main
    key = load_pem_private_key(f.read(), b_key_passphrase, BACKEND)
  File "/usr/lib64/python2.7/site-packages/cryptography/hazmat/primitives/serialization.py", line 20, in load_pem_private_key
    return backend.load_pem_private_key(data, password)
  File "/usr/lib64/python2.7/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1006, in load_pem_private_key
    password,
  File "/usr/lib64/python2.7/site-packages/cryptography/hazmat/backends/openssl/backend.py", line 1231, in _load_key
    "Password was given but private key is not encrypted.")

This can be fixed by passing a None as the passphrase if one isn't defined

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/amazon/ec2_win_password.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jjozwiak/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
After change, I get a successful run: 
PLAY [localhost] ***********************************************************************************************

TASK [obtain windows passwords for instances] ******************************************************************
changed: [localhost]

TASK [debug] ***************************************************************************************************
ok: [localhost] => {
    "ec2_password": {
        "changed": true, 
        "elapsed": 0, 
        "failed": false, 
        "win_password": "******************************"
    }
}

PLAY RECAP *****************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0  


```
