### PR TITLE
influxdb_retention_policy: don't fail with empty error message

### DIFF
--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -6,7 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -101,11 +100,13 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.influxdb import InfluxDb
+from ansible.module_utils._text import to_native
 
 
 def find_retention_policy(module, client):
     database_name = module.params['database_name']
     policy_name = module.params['policy_name']
+    hostname = module.params['hostname']
     retention_policy = None
 
     try:
@@ -115,7 +116,7 @@ def find_retention_policy(module, client):
                 retention_policy = policy
                 break
     except requests.exceptions.ConnectionError as e:
-        module.fail_json(msg=str(e))
+        module.fail_json(msg="Cannot connect to database %s on %s : %s" % (database_name, hostname, to_native(e)))
     return retention_policy
 
 


### PR DESCRIPTION
##### SUMMARY
On connection errors the influxdb python module raises an exception with
an empty message leading to a fail_json with an empty error message:

    https://github.com/influxdata/influxdb-python/blob/265d14736bb739aed0f357d8da248d51f549244b/influxdb/influxdb08/client.py#L252

Fail with a more descriptive error in this case.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
influxdb_retention_policy

##### ANSIBLE VERSION
```
ansible 2.4.0 (influxdb-connection-error daad4b3d86) last updated 2017/08/29 20:12:04 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/agx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /var/scratch/src/ansible/ansible/lib/ansible
  executable location = /var/scratch/src/ansible/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
