### PR TITLE
Use variable for domain name in integration test

### DIFF
--- a/test/integration/targets/azure_rm_dnszone/tasks/main.yml
+++ b/test/integration/targets/azure_rm_dnszone/tasks/main.yml
@@ -1,7 +1,11 @@
+- name: Create random domain name
+  set_fact:
+    domain_name: "{{ resource_group | hash('md5') | truncate(16, True, '') + (65535 | random | string) }}"
+
 - name: Create a DNS zone
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"
-    name: testing.com
+    name: "{{ domain_name }}.com"
     state: present
   register: results
 
@@ -11,7 +15,7 @@
 - name: Update DNS zone with tags
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"
-    name: testing.com
+    name: "{{ domain_name }}.com"
     state: present
     tags:
       test: modified
@@ -25,7 +29,7 @@
 - name: Test check_mode
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"
-    name: testing.com
+    name: "{{ domain_name }}.com"
     state: present
     tags:
       test: new_modified
@@ -41,5 +45,5 @@
 - name: Delete DNS zone
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"
-    name: testing.com
+    name: "{{ domain_name }}.com"
     state: absent


### PR DESCRIPTION
##### SUMMARY
Use a variable for domain name rather than fixed name due to global conflict issues for integration test on azure_rm_dnszone.py


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME


##### ANSIBLE VERSION
```
ansible 2.4.0 (common 393909d0cc) last updated 2017/08/15 15:36:14 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/haroldwong/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/haroldw/Documents/develop/ansible24/lib/ansible
  executable location = /mnt/c/Users/haroldw/Documents/develop/ansible24/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
