### PR TITLE
Use variable for domain name

### DIFF
--- a/test/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
+++ b/test/integration/targets/azure_rm_dnsrecordset/tasks/main.yml
@@ -1,7 +1,11 @@
+- name: Create random domain name
+  set_fact:
+    domain_name: "{{ resource_group | hash('md5') | truncate(16, True, '') + (65535 | random | string) }}"
+
 - name: Create a DNS zone
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"
-    name: testing01010.com
+    name: "{{ domain_name }}.com"
     state: present
   register: results
 
@@ -13,7 +17,7 @@
   azure_rm_dnsrecordset:
     resource_group: "{{ resource_group }}"
     relative_name: www
-    zone_name: testing01010.com
+    zone_name: "{{ domain_name }}.com"
     record_type: A
     record_set_state: present
     record_state: present
@@ -31,7 +35,7 @@
   azure_rm_dnsrecordset:
     resource_group: "{{ resource_group }}"
     relative_name: www
-    zone_name: testing01010.com
+    zone_name: "{{ domain_name }}.com"
     record_type: A
     record_set_state: present
     record_state: present
@@ -49,7 +53,7 @@
   azure_rm_dnsrecordset:
     resource_group: "{{ resource_group }}"
     relative_name: www
-    zone_name: testing01010.com
+    zone_name: "{{ domain_name }}.com"
     record_type: A
     record_set_state: present
     record_state: present
@@ -68,7 +72,7 @@
   azure_rm_dnsrecordset:
     resource_group: "{{ resource_group }}"
     relative_name: www
-    zone_name: testing01010.com
+    zone_name: "{{ domain_name }}.com"
     record_type: A
     record_set_state: present
     record_state: absent
@@ -85,7 +89,7 @@
   azure_rm_dnsrecordset:
     resource_group: "{{ resource_group }}"
     relative_name: www
-    zone_name: testing01010.com
+    zone_name: "{{ domain_name }}.com"
     record_type: A
     record_set_state: absent
   register: results
@@ -97,11 +101,11 @@
 - name: create SRV records in a new record set
   azure_rm_dnsrecordset:
     resource_group: "{{ resource_group }}"
-    relative_name: _sip._tcp.testing.com
-    zone_name: testing01010.com
+    relative_name: "_sip._tcp.{{ domain_name }}.com"
+    zone_name: "{{ domain_name }}.com"
     record_type: SRV
     record_set_state: present
-    records: sip.testing01010.com
+    records: "sip.{{ domain_name }}.com"
     preference: 10
     record_state: present
     time_to_live: 7200
@@ -114,11 +118,11 @@
   assert:
     that: 
       - results.changed
-      - results.record_set_state.full_list[0] == 'sip.testing01010.com'
-      - results.record_set_state.name == '_sip._tcp.testing.com'
+      - results.record_set_state.full_list[0] == 'sip.{{ domain_name }}.com'
+      - results.record_set_state.name == '_sip._tcp.{{ domain_name }}.com'
 
 - name: Delete DNS zone
   azure_rm_dnszone:
     resource_group: "{{ resource_group }}"
-    name: testing01010.com
+    name: "{{ domain_name }}.com"
     state: absent


### PR DESCRIPTION
##### SUMMARY
Use a variable for domain name rather than fixed name due to global conflict issues for integration test on azure_rm_dnsrecordset.py

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME


##### ANSIBLE VERSION

```
ansible 2.4.0 (common 393909d0cc) last updated 2017/08/15 15:36:14 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/haroldwong/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /mnt/c/Users/haroldw/Documents/develop/ansible24/lib/ansible
  executable location = /mnt/c/Users/haroldw/Documents/develop/ansible24/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
