### PR TITLE
lambda integration tests - more test(s) - check environment

### DIFF
--- a/test/integration/targets/aws_lambda/files/mini_lambda.py
+++ b/test/integration/targets/aws_lambda/files/mini_lambda.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import json
+import os
 
 
 def handler(event, context):
@@ -17,7 +18,16 @@ def handler(event, context):
 
     name = event["name"]
 
-    return {"message": "hello " + name}
+    # we can use environment variables as part of the configuration of the lambda
+    # which can change the behaviour of the lambda without needing a new upload
+
+    extra = os.environ.get("EXTRA_MESSAGE")
+    if extra is not None and len(extra) > 0:
+        greeting = "hello {0}. {1}".format(name, extra)
+    else:
+        greeting = "hello " + name
+
+    return {"message": greeting}
 
 
 def main():

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -185,11 +185,52 @@
         dead_letter_arn:
       register: result
 
-    - name: assert lambda was updated as expected
+    - name: assert lambda remains as before
       assert:
         that:
            - 'not result|failed'
            - 'result.changed == False'
+
+
+
+    # ============================================================
+    - name: test putting an environment variable changes lambda
+      lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "python2.7"
+        handler: "mini_lambda.handler"
+        role: "ansible_lambda_role"
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        zip_file: "{{zip_res.dest}}"
+        environment_variables:
+            EXTRA_MESSAGE: "I think you are great!!"
+      register: result
+
+    - name: assert lambda upload succeeded
+      assert:
+        that:
+           - 'not result|failed'
+           - 'result.changed == True'
+
+    - name: test lambda works
+      execute_lambda:
+        name: "{{lambda_function_name}}"
+        payload:
+          name: "Mr Ansible Tests"
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: result
+
+    - name: assert lambda manages to respond as expected
+      assert:
+        that:
+           - 'not result|failed'
+           - 'result.result.output.message == "hello Mr Ansible Tests. I think you are great!!"'
 
     # ============================================================
     - name: test state=present triggering a network exception due to bad url


### PR DESCRIPTION
Currently this contains changes to the test cases for AWS lambda only.  

##### SUMMARY

The AWS lambda module changes environment variable configuration which modifies the lambda execution environment.  This includes a test case which shows that the function is actually working.  

* this tests that the environment variable function is working
* this also tests that lambda configuration modification is working since no other test currently does that

I may merge directory renames into this PR depending on discussion on the AWS IRC

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lambda integration tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (mdd-lambda-env-test 6888011fc4) last updated 2017/08/30 11:31:12 (GMT +100)
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION

there are no functional changes to Ansible included in this PR.  