### PR TITLE
Update documentation

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -56,7 +56,7 @@ EXAMPLES = '''
 
 - name: Show openstack facts
   debug:
-    var: openstack
+    var: openstack_image
 '''
 
 RETURN = '''


### PR DESCRIPTION
To show the return of os_images_facts, you should use openstack_image in debug task instead of openstack which does not exist.

SUMMARY

Change the debug task of the example in documentation.

ISSUE TYPE

Docs Pull Request
COMPONENT NAME

os_images_facts

ANSIBLE VERSION

ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
ADDITIONAL INFORMATION

In the documentation example, to show the return of os_images_facts, I changed openstack in openstack _image in the debug task because openstack does not exist.