### PR TITLE
Added nopackages option and Fix #24997

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -86,7 +86,7 @@ options:
             - If true, the registered node will not upload its installed packages information to Satellite server
         required: false
         default: false
-        version_added: "2.4"
+        version_added: "2.5"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -84,8 +84,9 @@ options:
     nopackages:
         description:
             - If true, the registered node will not upload its installed packages information to Satellite server
-        requires: false
-        default: false        
+        required: false
+        default: false
+        version_added: "2.4"        
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -81,7 +81,7 @@ options:
             - If true, extended update support will be requested.
         required: false
         default: false
-	    nopackages:
+    nopackages:
         description:
             - If true, the registered node will not upload its installed packages information to Satellite server
         requires: false

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -306,9 +306,7 @@ class Rhn(redhat.RegistrationBase):
         # Remove systemid file
         os.unlink(self.config['systemIdPath'])
 
-    def subscribe(self, channels=[]):
-        if len(channels) <= 0:
-            return
+    def subscribe(self, channels):
         if self._is_hosted():
             current_channels = self.api('channel.software.listSystemChannels', self.systemid)
             new_channels = [item['channel_label'] for item in current_channels]

--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -86,7 +86,7 @@ options:
             - If true, the registered node will not upload its installed packages information to Satellite server
         required: false
         default: false
-        version_added: "2.4"        
+        version_added: "2.4"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Adding a new option - nopackages.

##### SUMMARY
This enables the option to add the --nopackages flag while registering a new node to RHN Satellite. We are not uploading the rpm data on our nodes and since we started utilizing ansible for nodes registration, I figures it would be useful for others as well.
Also- 
Fixes #24997 (verified in my lab)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
rhn_register

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0.0
```


##### ADDITIONAL INFORMATION

