### PR TITLE
cloudformation: allow changeset to be created successfully regardless of last event. Fixes #27853

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -558,6 +558,7 @@ def main():
             result = update_stack(module, stack_params, cfn)
 
         # format the stack output
+
         stack = get_stack_facts(cfn, stack_params['StackName'])
         if result.get('stack_outputs') is None:
             # always define stack_outputs, but it may be empty


### PR DESCRIPTION
##### SUMMARY
Fix appearance of failure when creating a cloudformation changeset after a rollback. When creating a cloudformation changeset it shouldn't matter if the last event was *_ROLLBACK_COMPLETE since creating a changeset is not an event. Fixes #27853.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudformation.py

##### ANSIBLE VERSION
```
2.4.0
```