### PR TITLE
Fix config base.yml defs with wrong keywords.

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1047,32 +1047,29 @@ DEFAULT_VAR_COMPRESSION_LEVEL:
   yaml: {key: defaults.var_compression_level}
 DEFAULT_VAULT_ID_MATCH:
   default: False
-  desc: 'If true, decrypting vaults with a vault id will only try the password from the matching vault-id'
+  description: 'If true, decrypting vaults with a vault id will only try the password from the matching vault-id'
   env: [{name: ANSIBLE_VAULT_ID_MATCH}]
   ini:
   - {key: vault_id_match, section: defaults}
-  vars: []
   yaml: {key: defaults.vault_id_match}
 DEFAULT_VAULT_IDENTITY:
   default: default
-  desc: 'TODO: write it'
+  description: 'The label to use for the default vault id label in cases where a vault id label is not provided'
   env: [{name: ANSIBLE_VAULT_IDENTITY}]
   ini:
   - {key: vault_identity, section: defaults}
-  vars: []
   yaml: {key: defaults.vault_identity}
 DEFAULT_VAULT_IDENTITY_LIST:
   default: []
-  desc: 'A list of vault-ids to use by default. Equivalent to multiple --vault-id args. Vault-ids are tried in order.'
+  description: 'A list of vault-ids to use by default. Equivalent to multiple --vault-id args. Vault-ids are tried in order.'
   env: [{name: ANSIBLE_VAULT_IDENTITY_LIST}]
   ini:
   - {key: vault_identity_list, section: defaults}
   type: list
-  vars: []
   yaml: {key: defaults.vault_identity_list}
 DEFAULT_VAULT_PASSWORD_FILE:
   default: ~
-  description: 'TODO: write it'
+  description: 'The vault password file to use. Equivalent to --vault-password-file or --vault-id'
   env: [{name: ANSIBLE_VAULT_PASSWORD_FILE}]
   ini:
   - {key: vault_password_file, section: defaults}


### PR DESCRIPTION
Mostly vault related items using 'desc' instead of 'description'

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/config/base.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (fix_vault_config_yml ee2fdcfc13) last updated 2017/08/30 13:04:05 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
