### PR TITLE
wait_for: treat broken connections as "unready"

### DIFF
--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -168,6 +168,7 @@ EXAMPLES = r'''
 
 import binascii
 import datetime
+import errno
 import math
 import os
 import re
@@ -563,7 +564,7 @@ def main():
                         except socket.error as e:
                             if e.errno != errno.ENOTCONN:
                                 raise
-                            #else, the server broke the connection on its end, assume it's not ready
+                        # else, the server broke the connection on its end, assume it's not ready
                         else:
                             s.close()
                         if matched:
@@ -576,7 +577,7 @@ def main():
                         except socket.error as e:
                             if e.errno != errno.ENOTCONN:
                                 raise
-                            #else, the server broke the connection on its end, assume it's not ready
+                        # else, the server broke the connection on its end, assume it's not ready
                         else:
                             s.close()
                         break

--- a/lib/ansible/modules/utilities/logic/wait_for.py
+++ b/lib/ansible/modules/utilities/logic/wait_for.py
@@ -558,15 +558,27 @@ def main():
                                 break
 
                         # Shutdown the client socket
-                        s.shutdown(socket.SHUT_RDWR)
-                        s.close()
+                        try:
+                            s.shutdown(socket.SHUT_RDWR)
+                        except socket.error as e:
+                            if e.errno != errno.ENOTCONN:
+                                raise
+                            #else, the server broke the connection on its end, assume it's not ready
+                        else:
+                            s.close()
                         if matched:
                             # Found our string, success!
                             break
                     else:
                         # Connection established, success!
-                        s.shutdown(socket.SHUT_RDWR)
-                        s.close()
+                        try:
+                            s.shutdown(socket.SHUT_RDWR)
+                        except socket.error as e:
+                            if e.errno != errno.ENOTCONN:
+                                raise
+                            #else, the server broke the connection on its end, assume it's not ready
+                        else:
+                            s.close()
                         break
 
             # Conditions not yet met, wait and try again


### PR DESCRIPTION
##### SUMMARY

We have observed the following condition while waiting for hosts:

```
Traceback (most recent call last):
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_8hxm4_/ansible_module_wait_for.py", line 585, in <module>
    main()
  File "/var/folders/f8/23xp00654plcv2b2tcc028680000gn/T/ansible_8hxm4_/ansible_module_wait_for.py", line 535, in main
    s.shutdown(socket.SHUT_RDWR)
  File "/usr/local/opt/python/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 228, in meth
    return getattr(self._sock,name)(*args)
socket.error: [Errno 57] Socket is not connected
```

This appears to happen while the host is still starting; we believe something is
accepting our connection but immediately resetting it. In these cases, we'd
prefer to continue waiting instead of immediately failing the play.

This patch has been applied locally for some time, and we have seen no adverse
effects.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
wait_for module


##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```