### PR TITLE
SanManagerFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_san_manager_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_san_manager_facts.py
@@ -1,0 +1,109 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_san_manager_facts
+short_description: Retrieve facts about one or more of the OneView SAN Managers.
+description:
+    - Retrieve facts about one or more of the SAN Managers from OneView
+version_added: "2.4"
+requirements:
+    - hpOneView >= 2.0.1
+author:
+    - Felipe Bulsoni (@fgbulsoni)
+    - Thiago Miotto (@tmiotto)
+    - Adriane Cardozo (@adriane-cardozo)
+options:
+    provider_display_name:
+      description:
+        - Provider Display Name.
+    params:
+      description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+           - C(start): The first item to return, using 0-based indexing.
+           - C(count): The number of resources to return.
+           - C(query): A general query string to narrow the list of resources returned.
+           - C(sort): The sort order of the returned data set."
+extends_documentation_fragment:
+    - oneview
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all SAN Managers
+  oneview_san_manager_facts:
+    config: /etc/oneview/oneview_config.json
+  delegate_to: localhost
+
+- debug: var=san_managers
+
+- name: Gather paginated, filtered and sorted facts about SAN Managers
+  oneview_san_manager_facts:
+    config: /etc/oneview/oneview_config.json
+    params:
+      start: 0
+      count: 3
+      sort: name:ascending
+      query: isInternal eq false
+  delegate_to: localhost
+
+- debug: var=san_managers
+
+- name: Gather facts about a SAN Manager by provider display name
+  oneview_san_manager_facts:
+    config: /etc/oneview/oneview_config.json
+    provider_display_name: Brocade Network Advisor
+  delegate_to: localhost
+
+- debug: var=san_managers
+'''
+
+RETURN = '''
+san_managers:
+    description: Has all the OneView facts about the SAN Managers.
+    returned: Always, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class SanManagerFactsModule(OneViewModuleBase):
+    argument_spec = dict(
+        provider_display_name=dict(type='str'),
+        params=dict(type='dict')
+    )
+
+    def __init__(self):
+        super(SanManagerFactsModule, self).__init__(additional_arg_spec=self.argument_spec)
+        self.resource_client = self.oneview_client.san_managers
+
+    def execute_module(self):
+        if self.module.params.get('provider_display_name'):
+            provider_display_name = self.module.params['provider_display_name']
+            san_manager = self.oneview_client.san_managers.get_by_provider_display_name(provider_display_name)
+            if san_manager:
+                resources = [san_manager]
+            else:
+                resources = []
+        else:
+            resources = self.oneview_client.san_managers.get_all(**self.facts_params)
+
+        return dict(changed=False, ansible_facts=dict(san_managers=resources))
+
+
+def main():
+    SanManagerFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_san_manager_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_san_manager_facts.py
@@ -12,10 +12,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: oneview_san_manager_facts
-short_description: Retrieve facts about one or more of the OneView SAN Managers.
+short_description: Retrieve facts about one or more of the OneView SAN Managers
 description:
     - Retrieve facts about one or more of the SAN Managers from OneView
-version_added: "2.4"
+version_added: "2.5"
 requirements:
     - hpOneView >= 2.0.1
 author:

--- a/test/units/modules/remote_management/oneview/oneview_module_loader.py
+++ b/test/units/modules/remote_management/oneview/oneview_module_loader.py
@@ -24,3 +24,4 @@ from ansible.modules.remote_management.oneview.oneview_fcoe_network_facts import
 from ansible.modules.remote_management.oneview.oneview_network_set import NetworkSetModule
 from ansible.modules.remote_management.oneview.oneview_network_set_facts import NetworkSetFactsModule
 from ansible.modules.remote_management.oneview.oneview_san_manager import SanManagerModule
+from ansible.modules.remote_management.oneview.oneview_san_manager_facts import SanManagerFactsModule

--- a/test/units/modules/remote_management/oneview/test_oneview_fc_network.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_fc_network.py
@@ -172,3 +172,7 @@ class FcNetworkModuleSpec(unittest.TestCase,
             ansible_facts=dict(fc_network=resource_data),
             msg=FcNetworkModule.MSG_ALREADY_PRESENT
         )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/remote_management/oneview/test_oneview_network_set_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_network_set_facts.py
@@ -111,3 +111,7 @@ class NetworkSetFactsSpec(unittest.TestCase,
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(network_sets=network_sets))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/remote_management/oneview/test_oneview_san_manager_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_san_manager_facts.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import SanManagerFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+
+class SanManagerFactsSpec(unittest.TestCase, FactsParamsTestCase):
+    ERROR_MSG = 'Fake message error'
+
+    PARAMS_GET_ALL = dict(
+        config='config.json',
+        provider_display_name=None
+    )
+
+    PARAMS_GET_BY_PROVIDER_DISPLAY_NAME = dict(
+        config='config.json',
+        provider_display_name="Brocade Network Advisor"
+    )
+
+    PRESENT_SAN_MANAGERS = [{
+        "providerDisplayName": "Brocade Network Advisor",
+        "uri": "/rest/fc-sans/device-managers//d60efc8a-15b8-470c-8470-738d16d6b319"
+    }]
+
+    def setUp(self):
+        self.configure_mocks(self, SanManagerFactsModule)
+        self.san_managers = self.mock_ov_client.san_managers
+
+        FactsParamsTestCase.configure_client_mock(self, self.san_managers)
+
+    def test_should_get_all(self):
+        self.san_managers.get_all.return_value = self.PRESENT_SAN_MANAGERS
+        self.mock_ansible_module.params = self.PARAMS_GET_ALL
+
+        SanManagerFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(san_managers=self.PRESENT_SAN_MANAGERS)
+        )
+
+    def test_should_get_by_display_name(self):
+        self.san_managers.get_by_provider_display_name.return_value = self.PRESENT_SAN_MANAGERS[0]
+        self.mock_ansible_module.params = self.PARAMS_GET_BY_PROVIDER_DISPLAY_NAME
+
+        SanManagerFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(san_managers=self.PRESENT_SAN_MANAGERS)
+        )
+
+    def test_should_return_empty_list_when_get_by_display_name_is_null(self):
+        self.san_managers.get_by_provider_display_name.return_value = None
+        self.mock_ansible_module.params = self.PARAMS_GET_BY_PROVIDER_DISPLAY_NAME
+
+        SanManagerFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(san_managers=[])
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_san_manager_facts module for retrieving [HPE OneView SAN Manager](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/san-managers) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_san_manager_facts`

##### ANSIBLE VERSION
```
ansible 2.4.0 (hpe-oneview/san-manager-facts 040692a420) last updated 2017/08/30 18:19:20 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/dev/core_ansible_related/ansible/lib/ansible
  executable location = /home/vagrant/dev/core_ansible_related/ansible/bin/ansible
  python version = 2.7.9 (default, Aug 21 2017, 11:24:49) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
Example of usage:
```yaml
- name: Gather facts about all SAN Managers
  oneview_san_manager_facts:
    config: /etc/oneview/oneview_config.json
  delegate_to: localhost

- debug: var=san_managers

- name: Gather paginated, filtered and sorted facts about SAN Managers
  oneview_san_manager_facts:
    config: /etc/oneview/oneview_config.json
    params:
      start: 0
      count: 3
      sort: name:ascending
      query: isInternal eq false
  delegate_to: localhost

- debug: var=san_managers

- name: Gather facts about a SAN Manager by provider display name
  oneview_san_manager_facts:
    config: /etc/oneview/oneview_config.json
    provider_display_name: Brocade Network Advisor
  delegate_to: localhost

- debug: var=san_managers
```