### PR TITLE
Add documentation note and warning of retries without until

### DIFF
--- a/docs/docsite/rst/playbooks_loops.rst
+++ b/docs/docsite/rst/playbooks_loops.rst
@@ -449,6 +449,8 @@ been retried for 5 times with a delay of 10 seconds. The default value for "retr
 The task returns the results returned by the last task run. The results of individual retries can be viewed by -vv option.
 The registered variable will also have a new key "attempts" which will have the number of the retries for the task.
 
+.. note:: If "until" parameter isn't defined, the value for "retries" is forced to 1.
+
 .. _with_first_found:
 
 Finding First Matched Files

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -509,6 +509,7 @@ class TaskExecutor:
                 retries += 1
         else:
             retries = 1
+            display.warning("The parameter 'retries' hasn't been defined, the value for 'retries' is forced to 1.")
 
         delay = self._task.delay
         if delay < 0:


### PR DESCRIPTION
##### SUMMARY
Fixes #28078 
In ansible 2.3/2.4 the use of retries task parameter without using the parameter until will force silently the value of retries parameter to 1.
The documentation doesn't explain well this behavior.
The comment https://github.com/ansible/ansible/issues/28078#issuecomment-326000971 contains details related to the code causing this behavior and the current documentation related to this issue.

This pull request add a note in the documentation and a warning in playbook when the parameter retries is used without the parameter until.

I'm not a english mothertongue, fell free to give review to improve the readability of the two messages included in this PR.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
task_executor.py

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.4.0 (devel 189375c611) last updated 2017/08/30 19:59:34 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Example playbook
```
$ cat /tmp/uri.yml 
- hosts: localhost
  gather_facts: no
  tasks:
    # using a non-existent url to fail
    - name: "check retry"
      uri:
        url: https://yahoo.com/1
      retries: 3
      delay: 1
      register: uri_output
```
Before this commit
```
$ ./bin/ansible-playbook /tmp/uri.yml 

PLAY [localhost] *****************************************************************************************************************************************************************************

TASK [check retry] ***************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"age": "0", "cache_control": "private", "changed": false, "connection": "close", "content": "<html>\n<meta charset='utf-8'>\n<script>\nvar u='https://www.yahoo.com/?err=404&err_url=https%3a%2f%2fwww.yahoo.com%2f1';\nif(window!=window.top){\n  document.write('<p>Content is currently unavailable.</p><img src=\"//geo.yahoo.com/p?s=1197757039&t='+new Date().getTime()+'&_R='+encodeURIComponent(document.referrer)+'&err=404&err_url='+u+'\" width=\"0px\" height=\"0px\"/>');\n}else{\n  window.location.replace(u);\n}\n</script>\n<noscript><META http-equiv=\"refresh\" content=\"0;URL='https://www.yahoo.com/?err=404&err_url=https%3a%2f%2fwww.yahoo.com%2f1'\"></noscript>\n</html>\n", "content_length": "562", "content_type": "text/html; charset=UTF-8", "date": "Wed, 30 Aug 2017 18:26:58 GMT", "failed": true, "msg": "Status code was not [200]: HTTP Error 404: Not Found", "p3p": "policyref=\"https://policies.yahoo.com/w3c/p3p.xml\", CP=\"CAO DSP COR CUR ADM DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV\"", "redirected": false, "server": "ATS", "status": 404, "url": "https://yahoo.com/1", "via": "http/1.1 usproxy2.fp.bf1.yahoo.com (ApacheTrafficServer), http/1.1 ir28.fp.ir2.yahoo.com (ApacheTrafficServer)"}
	to retry, use: --limit @/tmp/uri.retry

PLAY RECAP ***********************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```
After this commit
```
$ ./bin/ansible-playbook /tmp/uri.yml 

PLAY [localhost] *****************************************************************************************************************************************************************************

TASK [check retry] ***************************************************************************************************************************************************************************
 [WARNING]: The parameter 'retries' hasn't been defined, the value for 'retries' is forced to 1.

fatal: [localhost]: FAILED! => {"age": "0", "cache_control": "private", "changed": false, "connection": "close", "content": "<html>\n<meta charset='utf-8'>\n<script>\nvar u='https://www.yahoo.com/?err=404&err_url=https%3a%2f%2fwww.yahoo.com%2f1';\nif(window!=window.top){\n  document.write('<p>Content is currently unavailable.</p><img src=\"//geo.yahoo.com/p?s=1197757039&t='+new Date().getTime()+'&_R='+encodeURIComponent(document.referrer)+'&err=404&err_url='+u+'\" width=\"0px\" height=\"0px\"/>');\n}else{\n  window.location.replace(u);\n}\n</script>\n<noscript><META http-equiv=\"refresh\" content=\"0;URL='https://www.yahoo.com/?err=404&err_url=https%3a%2f%2fwww.yahoo.com%2f1'\"></noscript>\n</html>\n", "content_length": "562", "content_type": "text/html; charset=UTF-8", "date": "Wed, 30 Aug 2017 18:26:36 GMT", "failed": true, "msg": "Status code was not [200]: HTTP Error 404: Not Found", "p3p": "policyref=\"https://policies.yahoo.com/w3c/p3p.xml\", CP=\"CAO DSP COR CUR ADM DEV TAI PSA PSD IVAi IVDi CONi TELo OTPi OUR DELi SAMi OTRi UNRi PUBi IND PHY ONL UNI PUR FIN COM NAV INT DEM CNT STA POL HEA PRE LOC GOV\"", "redirected": false, "server": "ATS", "status": 404, "url": "https://yahoo.com/1", "via": "http/1.1 usproxy3.fp.ne1.yahoo.com (ApacheTrafficServer), http/1.1 ir28.fp.ir2.yahoo.com (ApacheTrafficServer)"}
	to retry, use: --limit @/tmp/uri.retry

PLAY RECAP ***********************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```
