### PR TITLE
change generated playbooks_keywords.rst to use an rst 'glossary'

### DIFF
--- a/docs/docsite/keyword_desc.yml
+++ b/docs/docsite/keyword_desc.yml
@@ -1,55 +1,55 @@
 accelerate: DEPRECATED, set to True to use accelerate connection plugin.
-accelerate_ipv6: DEPRECATED, set to True to force accelerate plugin to use ipv6 for it's connection.
+accelerate_ipv6: "DEPRECATED, set to True to force accelerate plugin to use ipv6 for it's connection."
 accelerate_port: DEPRECATED, set to override default port use for accelerate connection.
-action: The 'action' to execute for a task, it normally translates into a C(module) or action plugin.
+action: "The 'action' to execute for a task, it normally translates into a C(module) or action plugin."
 args: DEPRECATED, A secondary way to add arguments into a task, it takes a dictionary in which keys map to options and values .. well you get it.
 always: List of tasks, in a block, that execute no matter if there is an error in the block or not.
-always_run: DEPRECATED, forces a task to run even in check mode, use check_mode directive instead.
+always_run: DEPRECATED, forces a task to run even in check mode, use :term:`check_mode` directive instead.
 any_errors_fatal: Force any un-handled task errors on any host to propagate to all hosts and end the play.
 async: Run a task asyncronouslly if the C(action) supports this.
-become: Boolean that controls if privilege escalation is used or not on Task execution.
-become_flags: A string of flag(s) to pass to the privilege escalation program when ``become`` is True.
+become: Boolean that controls if privilege escalation is used or not on :term:`Task` execution.
+become_flags: A string of flag(s) to pass to the privilege escalation program when :term:`become` is True.
 become_method: Which method of privilege escalation to use. i.e. sudo/su/etc.
-become_user: User that you 'become' after using privilege escalation, the remote/login user must have permissions to become this user.
+become_user: "User that you 'become' after using privilege escalation, the remote/login user must have permissions to become this user."
 block: List of tasks in a block.
-changed_when: Conditional expression that overrides the task's normal 'changed' status.
-check_mode: A boolean that controls if a task is executed in 'check' mode
+changed_when: "Conditional expression that overrides the task's normal 'changed' status."
+check_mode: "A boolean that controls if a task is executed in 'check' mode"
 connection: Allows you to change the connection plugin used for tasks to execute on the target.
-delay: Number of seconds to delay between retries, this setting only makes sense when used with 'until'.
+delay: Number of seconds to delay between retries, this setting is only used in combination with :term:`until`.
 delegate_facts: Boolean that allows you to apply facts to delegated host instead of inventory_hostname.
 delegate_to: Host to execute task instead of the target (inventory_hostname), connection vars from the delegated host will also be used for the task.
-diff: Toggle to make tasks return 'diff' information or not.
+diff: "Toggle to make tasks return 'diff' information or not."
 environment: A dictionary that gets converted into environment vars to be provided for the task upon execution.
-fact_path: Set the fact path option for the fact gathering plugin controlled by ``gather_facts``.
-failed_when: Conditional expression that overrides the task's normal 'failed' status.
+fact_path: Set the fact path option for the fact gathering plugin controlled by :term:`gather_facts`.
+failed_when: "Conditional expression that overrides the task's normal 'failed' status."
 force_handlers: Will force notified handler execution for hosts even if they failed during the play, it will not trigger if the play itself fails.
-gather_facts: A boolean that controls if the play will automatically run the 'setup' task to gather facts for the hosts.
-gather_subset: Allows you to pass subset options to the  fact gathering plugin controlled by ``gather_facts``.
-gather_timeout: Allows you to set the timeout for the fact gathering plugin controlled by ``gather_facts``.
-handlers: A section with tasks that are treated as handlers, these won't get executed normally, only when notified. After each section of tasks is complete.
-hosts: A list of groups, hosts or host pattern that translates into a list of hosts that are the play's target.
+gather_facts: "A boolean that controls if the play will automatically run the 'setup' task to gather facts for the hosts."
+gather_subset: Allows you to pass subset options to the  fact gathering plugin controlled by :term:`gather_facts`.
+gather_timeout: Allows you to set the timeout for the fact gathering plugin controlled by :term:`gather_facts`.
+handlers: "A section with tasks that are treated as handlers, these won't get executed normally, only when notified. After each section of tasks is complete."
+hosts: "A list of groups, hosts or host pattern that translates into a list of hosts that are the play's target."
 ignore_errors: Boolean that allows you to ignore task failures and continue with play. It does not affect connection errors.
-loop_control: Several keys here allow you to modify/set loop behaviour in a task see http://docs.ansible.com/ansible/latest/playbooks_loops.html#loop-control for details.
+loop_control: "Several keys here allow you to modify/set loop behaviour in a task see http://docs.ansible.com/ansible/latest/playbooks_loops.html#loop-control for details."
 max_fail_percentage: can be used to abort the run after a given percentage of hosts in the current batch has failed.
-name: It's a name, works mostly for documentation, in the case of tasks/handlers it can be an identifier.
+name: "It's a name, works mostly for documentation, in the case of tasks/handlers it can be an identifier."
 no_log: Boolean that controls information disclosure.
-notify: list of handlers to notify when the task returns a 'changed=True' status.
+notify: "list of handlers to notify when the task returns a 'changed=True' status."
 order: Controls the sorting of hosts as they are used for executing the play. Possible values are inventory (default), sorted, reverse_sorted, reverse_inventory and shuffle.
 poll: Sets the polling interval in seconds for async tasks (default 10s).
 port: Used to override the default port used in a connection.
-post_tasks: A list of tasks to execute after the ``tasks`` section.
-pre_tasks: A list of tasks to execute before ``roles``.
+post_tasks: A list of tasks to execute after the :term:`tasks` section.
+pre_tasks: A list of tasks to execute before :term:`roles`.
 remote_user: User used to log into the target via the connection plugin. AKA login user.
 register: Name of variable that will contain task status and module return data.
-rescue: List of tasks in a block that run if there is a task error in the main ``block`` list.
-retries: Number of retries before giving up in a 'until' loop, this setting is ignored on it's own.
+rescue: List of tasks in a :term:`block` that run if there is a task error in the main :term:`block` list.
+retries: "Number of retries before giving up in a :term:`until` loop. This setting is only used in combination with :term:`until`."
 roles: List of roles to be imported into the play
 run_once: Boolean that will bypass the host loop, forcing the task to execute on the first host available and will also apply any facts to all active hosts.
 serial: Defines the 'batch' of hosts to execute the current play until the end.
 strategy: Allows you to choose the connection plugin to use for the play.
 tags: Tags applied to the task or included tasks, this allows selecting subsets of tasks from the command line.
-tasks: Main list of tasks to execute in the play, they run after ``roles`` and before ``post_tasks``.
-until: This keyword implies a 'retry loop' that will go on until the condition supplied here is met or we hit the retry limit.
+tasks: Main list of tasks to execute in the play, they run after :term:`roles` and before :term:`post_tasks`.
+until: "This keyword implies a ':term:`retries` loop' that will go on until the condition supplied here is met or we hit the :term:`retries` limit."
 vars: Dictionary/map of variables
 vars_files: List of files that contain vars to include in the play.
 vars_prompt: list of variables to prompt for.

--- a/docs/docsite/rst/glossary.rst
+++ b/docs/docsite/rst/glossary.rst
@@ -436,13 +436,16 @@ when a term comes up on the mailing list.
         labeled ``ntp``, and then run just the ``ntp`` steps to reconfigure
         the time server information on a remote host.
 
-    Tasks
+    Task
         :term:`Playbooks` exist to run tasks.  Tasks combine an :term:`action`
         (a module and its arguments) with a name and optionally some other
         keywords (like :term:`looping directives <loops>`).   :term:`Handlers`
         are also tasks, but they are a special kind of task that do not run
         unless they are notified by name when a task reports an underlying
         change on a remote system.
+
+    Tasks
+        A list of :term:`Task`.
 
     Templates
         Ansible can easily transfer files to remote systems but often it is

--- a/docs/templates/playbooks_keywords.rst.j2
+++ b/docs/templates/playbooks_keywords.rst.j2
@@ -15,8 +15,12 @@ Be aware that this reflects the 'current development branch' and that the keywor
 
 {{ name }}
 {{ '-' * name|length }}
+.. glossary::
+
 {% for attribute in oblist[name]|sort %}
-  - **{{ attribute }}:** {{ oblist[name][attribute] }}
+    {{ attribute }}
+        {{ oblist[name][attribute] }}
+
 {% endfor %}
 
 {% endfor %}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Use a rst glossary for playbooks_keywords docs.

Update keywords desc, use :term: rst ref, some quoting.

Make it more obvious that 'retries' and 'until' need to
    be used in combination.

Add a 'Task' and 'Tasks' to glossary.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docsite/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (playbooks_keywords_glossary a212ad052d) last updated 2017/08/30 14:44:56 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
