### PR TITLE
LogicalInterconnectGroupFactsModule for HPE OneView 

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_facts.py
@@ -35,27 +35,39 @@ extends_documentation_fragment:
 EXAMPLES = '''
 - name: Gather facts about all Logical Interconnect Groups
   oneview_logical_interconnect_group_facts:
-    config: /etc/oneview/oneview_config.json
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
   delegate_to: localhost
 
 - debug: var=logical_interconnect_groups
 
 - name: Gather paginated, filtered and sorted facts about Logical Interconnect Groups
   oneview_logical_interconnect_group_facts:
-    config: /etc/oneview/oneview_config.json
     params:
       start: 0
       count: 3
       sort: name:descending
       filter: name=LIGName
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
   delegate_to: localhost
 
 - debug: var=logical_interconnect_groups
 
 - name: Gather facts about a Logical Interconnect Group by name
   oneview_logical_interconnect_group_facts:
-    config: /etc/oneview/oneview_config.json
     name: logical lnterconnect group name
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
   delegate_to: localhost
 
 - debug: var=logical_interconnect_groups

--- a/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_facts.py
@@ -1,0 +1,97 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_logical_interconnect_group_facts
+short_description: Retrieve facts about one or more of the OneView Logical Interconnect Groups
+description:
+    - Retrieve facts about one or more of the Logical Interconnect Groups from OneView
+version_added: "2.5"
+requirements:
+    - hpOneView >= 2.0.1
+author:
+    - Felipe Bulsoni (@fgbulsoni)
+    - Thiago Miotto (@tmiotto)
+    - Adriane Cardozo (@adriane-cardozo)
+options:
+    name:
+      description:
+        - Logical Interconnect Group name.
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Logical Interconnect Groups
+  oneview_logical_interconnect_group_facts:
+    config: /etc/oneview/oneview_config.json
+  delegate_to: localhost
+
+- debug: var=logical_interconnect_groups
+
+- name: Gather paginated, filtered and sorted facts about Logical Interconnect Groups
+  oneview_logical_interconnect_group_facts:
+    config: /etc/oneview/oneview_config.json
+    params:
+      start: 0
+      count: 3
+      sort: name:descending
+      filter: name=LIGName
+  delegate_to: localhost
+
+- debug: var=logical_interconnect_groups
+
+- name: Gather facts about a Logical Interconnect Group by name
+  oneview_logical_interconnect_group_facts:
+    config: /etc/oneview/oneview_config.json
+    name: logical lnterconnect group name
+  delegate_to: localhost
+
+- debug: var=logical_interconnect_groups
+'''
+
+RETURN = '''
+logical_interconnect_groups:
+    description: Has all the OneView facts about the Logical Interconnect Groups.
+    returned: Always, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class LogicalInterconnectGroupFactsModule(OneViewModuleBase):
+    def __init__(self):
+
+        argument_spec = dict(
+            name=dict(type='str'),
+            params=dict(type='dict'),
+        )
+
+        super(LogicalInterconnectGroupFactsModule, self).__init__(additional_arg_spec=argument_spec)
+
+    def execute_module(self):
+        if self.module.params.get('name'):
+            ligs = self.oneview_client.logical_interconnect_groups.get_by('name', self.module.params['name'])
+        else:
+            ligs = self.oneview_client.logical_interconnect_groups.get_all(**self.facts_params)
+
+        return dict(changed=False, ansible_facts=dict(logical_interconnect_groups=ligs))
+
+
+def main():
+    LogicalInterconnectGroupFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_logical_interconnect_group_facts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
-# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)

--- a/test/units/modules/remote_management/oneview/test_oneview_logical_interconnect_group_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_logical_interconnect_group_facts.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import OneViewModuleBase
+from ansible.modules.remote_management.oneview.oneview_logical_interconnect_group_facts import LogicalInterconnectGroupFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test Logical Interconnect Group"
+)
+
+PRESENT_LIGS = [{
+    "name": "Test Logical Interconnect Group",
+    "uri": "/rest/logical-interconnect-groups/ebb4ada8-08df-400e-8fac-9ff987ac5140"
+}]
+
+
+class LogicalInterconnectGroupFactsSpec(unittest.TestCase, FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, LogicalInterconnectGroupFactsModule)
+        self.logical_interconnect_groups = self.mock_ov_client.logical_interconnect_groups
+        FactsParamsTestCase.configure_client_mock(self, self.logical_interconnect_groups)
+
+    def test_should_get_all_ligs(self):
+        self.logical_interconnect_groups.get_all.return_value = PRESENT_LIGS
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        LogicalInterconnectGroupFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(logical_interconnect_groups=(PRESENT_LIGS))
+        )
+
+    def test_should_get_lig_by_name(self):
+        self.logical_interconnect_groups.get_by.return_value = PRESENT_LIGS
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        LogicalInterconnectGroupFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(logical_interconnect_groups=(PRESENT_LIGS))
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_logical_interconnect_group_facts module for retrieving [HPE OneView Logical Interconnect Groups](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.0/cic-api/en/api-docs/current/index.html#rest/logical-interconnect-groups) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_logical_interconnect_group_facts`

##### ANSIBLE VERSION
```
ansible 2.4.0 (hpe-oneview/logical-interconnect-group-facts 023f2e7af2) last updated 2017/08/30 19:11:13 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/dev/core_ansible_related/ansible/lib/ansible
  executable location = /home/vagrant/dev/core_ansible_related/ansible/bin/ansible
  python version = 2.7.9 (default, Aug 21 2017, 11:24:49) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
Example of usage:
```yaml
- name: Gather facts about all Logical Interconnect Groups
  oneview_logical_interconnect_group_facts:
    config: /etc/oneview/oneview_config.json
  delegate_to: localhost

- debug: var=logical_interconnect_groups

- name: Gather paginated, filtered and sorted facts about Logical Interconnect Groups
  oneview_logical_interconnect_group_facts:
    config: /etc/oneview/oneview_config.json
    params:
      start: 0
      count: 3
      sort: name:descending
      filter: name=LIGName
  delegate_to: localhost

- debug: var=logical_interconnect_groups

- name: Gather facts about a Logical Interconnect Group by name
  oneview_logical_interconnect_group_facts:
    config: /etc/oneview/oneview_config.json
    name: logical lnterconnect group name
  delegate_to: localhost

- debug: var=logical_interconnect_groups
```