### PR TITLE
Warn instead of failing when an empty meta/main.yml exists

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -398,28 +398,31 @@ class GalaxyCLI(CLI):
 
             # install dependencies, if we want them
             if not no_deps and installed:
-                role_dependencies = role.metadata.get('dependencies') or []
-                for dep in role_dependencies:
-                    display.debug('Installing dep %s' % dep)
-                    dep_req = RoleRequirement()
-                    dep_info = dep_req.role_yaml_parse(dep)
-                    dep_role = GalaxyRole(self.galaxy, **dep_info)
-                    if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
-                        # we know we can skip this, as it's not going to
-                        # be found on galaxy.ansible.com
-                        continue
-                    if dep_role.install_info is None:
-                        if dep_role not in roles_left:
-                            display.display('- adding dependency: %s' % str(dep_role))
-                            roles_left.append(dep_role)
+                if not role.metadata:
+                    display.warning("Meta file %s is empty. Skipping dependencies." % role.path)
+                else:
+                    role_dependencies = role.metadata.get('dependencies') or []
+                    for dep in role_dependencies:
+                        display.debug('Installing dep %s' % dep)
+                        dep_req = RoleRequirement()
+                        dep_info = dep_req.role_yaml_parse(dep)
+                        dep_role = GalaxyRole(self.galaxy, **dep_info)
+                        if '.' not in dep_role.name and '.' not in dep_role.src and dep_role.scm is None:
+                            # we know we can skip this, as it's not going to
+                            # be found on galaxy.ansible.com
+                            continue
+                        if dep_role.install_info is None:
+                            if dep_role not in roles_left:
+                                display.display('- adding dependency: %s' % str(dep_role))
+                                roles_left.append(dep_role)
+                            else:
+                                display.display('- dependency %s already pending installation.' % dep_role.name)
                         else:
-                            display.display('- dependency %s already pending installation.' % dep_role.name)
-                    else:
-                        if dep_role.install_info['version'] != dep_role.version:
-                            display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
-                                            (str(dep_role), role.name, dep_role.install_info['version']))
-                        else:
-                            display.display('- dependency %s is already installed, skipping.' % dep_role.name)
+                            if dep_role.install_info['version'] != dep_role.version:
+                                display.warning('- dependency %s from role %s differs from already installed version (%s), skipping' %
+                                                (str(dep_role), role.name, dep_role.install_info['version']))
+                            else:
+                                display.display('- dependency %s is already installed, skipping.' % dep_role.name)
 
             if not installed:
                 display.warning("- %s was NOT installed successfully." % role.name)


### PR DESCRIPTION
##### SUMMARY
When installing a role that has an empty `meta/main.yml` using `ansible-galaxy`, an unhelpful exception was return. This PR shows a warning and allows the role installation to continue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
**Steps to reproduce:**
1. Create a role with an empty `meta/main.yml` file
1. Add the role to a requirements file or publish to Ansible Galaxy.
```yaml
- src: git+https://gitlab.samdoran.com/samdoran/brokenrole.git
  scm: git
  name: brokenrole
```
3. Install the role using `ansible-galaxy install -r requirements.yml -p .`

**Actual Results:**
```
ansible-galaxy 2.4.0 (devel dd9db65a9a) last updated 2017/08/30 16:15:49 (GMT -400)
  config file = /Users/sdoran/.ansible.cfg
  configured module search path = [u'/Users/sdoran/Source/ansible/library']
  ansible python module location = /Users/sdoran/Source/ansible/lib/ansible
  executable location = /Users/sdoran/Source/ansible/bin/ansible-galaxy
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
Using /Users/sdoran/.ansible.cfg as config file
Opened /Users/sdoran/.ansible_galaxy
found role {'scm': 'git', 'src': 'https://gitlab.samdoran.com/samdoran/brokenrole.git', 'version': '', 'name': 'brokenrole2'} in yaml file
Processing role brokenrole2
- extracting brokenrole2 to /Users/sdoran/Projects/Vagrant/Ansible Lab/brokenrole2
- brokenrole2 was installed successfully
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object has no attribute 'get'
the full traceback was:

Traceback (most recent call last):
  File "/Users/sdoran/Source/ansible/bin/ansible-galaxy", line 106, in <module>
    exit_code = cli.run()
  File "/Users/sdoran/Source/ansible/lib/ansible/cli/galaxy.py", line 150, in run
    self.execute()
  File "/Users/sdoran/Source/ansible/lib/ansible/cli/__init__.py", line 154, in execute
    fn()
  File "/Users/sdoran/Source/ansible/lib/ansible/cli/galaxy.py", line 401, in execute_install
    role_dependencies = role.metadata.get('dependencies') or []
AttributeError: 'NoneType' object has no attribute 'get'
```

**Expected Results**
The role installs correctly and does not throw an exception.

**Results with the patch**
```
- extracting brokenrole to /Users/sdoran/Projects/Vagrant/Ansible Lab/brokenrole
- brokenrole was installed successfully
 [WARNING]: Meta file /Users/sdoran/Projects/Vagrant/Ansible Lab/brokenrole is empty. Skipping dependencies.
```