### PR TITLE
fixes 28859: Add missing variable declation for data_disk_storage_account

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -904,7 +904,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                     count += 1
 
                                 if data_disk.get('storage_account_name'):
-                                    self.get_storage_account(data_disk['storage_account_name'])
+                                    data_disk_storage_account = self.get_storage_account(data_disk['storage_account_name'])
                                     data_disk_storage_account.name = data_disk['storage_account_name']
                                 else:
                                     data_disk_storage_account = self.create_default_storage_account()


### PR DESCRIPTION
##### SUMMARY
Fixes the crash when creating an Azure Machine data disk in existing storage account.

Declares the missing `data_disk_storage_account` variable. Assigns the storage account lookup to it.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/azure/azure_rm_virtualmachine

##### ANSIBLE VERSION
```
gamlor@gamlor-turboro:~/remoteapp-web/ansible$ ansible --version
ansible 2.4.0 (devel 7cc3c05) last updated 2017/08/31 09:28:15 (GMT +900)
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/home/gamlor/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /home/gamlor/ansible/lib/ansible
executable location = /home/gamlor/ansible/bin/ansible
python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
