### PR TITLE
Add state option to git_config module for --unset

### DIFF
--- a/lib/ansible/modules/source_control/git_config.py
+++ b/lib/ansible/modules/source_control/git_config.py
@@ -66,8 +66,9 @@ options:
     default: null
   state:
     description:
-      - Specify if a config should be C(set) or C(unset).
+      - Specify if a config should be C(present) or C(absent).
     required: false
+    choices: ["present", "absent"]
     default: null
     version_added: "2.4"
 '''
@@ -137,12 +138,12 @@ EXAMPLES = '''
 # Unset the global color.ui setting
 - git_config:
     name: color.ui
-    state: unset
+    state: absent
 
 # Unset a local setting
 - git_config:
     name: core.editor
-    state: unset
+    state: absent
     scope: local
     repo: /path/to/repo
 '''
@@ -176,7 +177,7 @@ def main():
             repo=dict(type='path'),
             scope=dict(required=False, type='str', choices=['local', 'global', 'system']),
             value=dict(required=False),
-            state=dict(required=False, choices=['set', 'unset'])
+            state=dict(required=False, choices=['present', 'absent'])
         ),
         mutually_exclusive=[['list_all', 'name'], ['list_all', 'value'], ['list_all', 'state']],
         required_if=[('scope', 'local', ['repo'])],
@@ -207,7 +208,7 @@ def main():
     else:
         new_value = None
 
-    if params['state'] == "unset":
+    if params['state'] == "absent":
         config_state = params['state']
     else:
         config_state = None
@@ -240,7 +241,7 @@ def main():
     if config_state and out:
         # if the setting is present, insert --unset in args list and .run_command
         old_val = out.rstrip()
-        args.insert(-1, "--" + config_state)
+        args.insert(-1, "--unset")
         (rc, out, err) = module.run_command(' '.join(args), cwd=dir)
         module.exit_json(changed=True, msg="Unsetting %s:%s" % (name, old_val))
     elif config_state:

--- a/lib/ansible/modules/source_control/git_config.py
+++ b/lib/ansible/modules/source_control/git_config.py
@@ -69,6 +69,7 @@ options:
       - Specify if a config should be C(set) or C(unset).
     required: false
     default: null
+    version_added: "2.4"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/source_control/git_config.py
+++ b/lib/ansible/modules/source_control/git_config.py
@@ -70,7 +70,7 @@ options:
     required: false
     choices: ["present", "absent"]
     default: null
-    version_added: "2.4"
+    version_added: "2.5"
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
Fixes #28567

New option state: will accept value of set or unset. Calling the
git_config module with a config option defined by name: and state: unset
will remove that config option from git on the remote host. Tested on
Python 2.7.10 against a CentOS 7 VM. Tested to work with and without a
scope: defined. Also doesn't break (in my tests) if state: set. This patch
will simply apply the defined value: to the git config defined by name:.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
git_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel b69d17a862) last updated 2017/08/30 20:04:01 (GMT -500)
  config file = None
  configured module search path = [u'/Users/jvhester/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jvhester/code/ansible-devel/lib/ansible
  executable location = /Users/jvhester/code/ansible-devel/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```
