### PR TITLE
Add support for use private ip instead public ip

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -20,3 +20,6 @@ group_by_resource_group=yes
 group_by_location=yes
 group_by_security_group=yes
 group_by_tag=yes
+
+# Active flag if you want to use private ip instead public ip
+use_private_ip=yes

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -634,6 +634,8 @@ class AzureInventory(object):
                     for ip_config in network_interface.ip_configurations:
                         host_vars['private_ip'] = ip_config.private_ip_address
                         host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method
+                        if self.use_private_ip:
+                            host_vars['ansible_host'] = ip_config.private_ip_address
                         if ip_config.public_ip_address:
                             public_ip_reference = self._parse_ref_id(ip_config.public_ip_address.id)
                             public_ip_address = self._network_client.public_ip_addresses.get(

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -237,7 +237,8 @@ AZURE_CONFIG_SETTINGS = dict(
     group_by_resource_group='AZURE_GROUP_BY_RESOURCE_GROUP',
     group_by_location='AZURE_GROUP_BY_LOCATION',
     group_by_security_group='AZURE_GROUP_BY_SECURITY_GROUP',
-    group_by_tag='AZURE_GROUP_BY_TAG'
+    group_by_tag='AZURE_GROUP_BY_TAG',
+    use_private_ip=False
 )
 
 AZURE_MIN_VERSION = "2.0.0"
@@ -638,7 +639,7 @@ class AzureInventory(object):
                             public_ip_address = self._network_client.public_ip_addresses.get(
                                 public_ip_reference['resourceGroups'],
                                 public_ip_reference['publicIPAddresses'])
-                            host_vars['ansible_host'] = public_ip_address.ip_address
+                            host_vars['ansible_host'] = ip_config.private_ip_address if self.use_private_ip else public_ip_address.ip_address
                             host_vars['public_ip'] = public_ip_address.ip_address
                             host_vars['public_ip_name'] = public_ip_address.name
                             host_vars['public_ip_alloc_method'] = public_ip_address.public_ip_allocation_method


### PR DESCRIPTION
##### SUMMARY
Modify azure dynamic inventory to add support for private ip instead public ip.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /usr/local/etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```