### PR TITLE
win_package; documentation; add jdk installation example to win_package

### DIFF
--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -216,6 +216,15 @@ EXAMPLES = r'''
     arguments: '/q /norestart'
     state: present
     expected_return_code: [0, 666, 3010]
+
+# See http://docs.oracle.com/javase/8/docs/technotes/guides/install/config.html#table_config_file_options 
+# for further java installation options
+- name: Install Java JDK and turn off auto update feature
+  win_package:
+    path: "jdk-{{ jdk_major_version }}u{{ jdk_minor_version }}-windows-x64.exe"
+    product_id: "{{jdk_product_id}}"
+    state: present
+    arguments: INSTALL_SILENT=1 AUTO_UPDATE=0 WEB_JAVA=0 WEB_ANALYTICS=0 /s  > /L C:\ansible\log\java-installation.log
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_package.py
+++ b/lib/ansible/modules/windows/win_package.py
@@ -217,7 +217,7 @@ EXAMPLES = r'''
     state: present
     expected_return_code: [0, 666, 3010]
 
-# See http://docs.oracle.com/javase/8/docs/technotes/guides/install/config.html#table_config_file_options 
+# See http://docs.oracle.com/javase/8/docs/technotes/guides/install/config.html#table_config_file_options
 # for further java installation options
 - name: Install Java JDK and turn off auto update feature
   win_package:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Dag suggested long ago that I add this example.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Doesn't fix anything but hopefully makes win_package documentation even more useful
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_package
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (win_package_java_example 8f7b98232d) last updated 2017/08/31 08:34:01 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
before:

ansible-doc win_package
> WIN_PACKAGE    (/home/jon/ansible-dev/lib/ansible/modules/windows/win_package.py)

        Installs or uninstalls a package in either an MSI or EXE format. These packages can be
        sources from the local file system, network file share or a url. Please read the notes
        section around some caveats with this module.

OPTIONS (= is mandatory):

- arguments
        Any arguments the installer needs to either install or uninstall the package.
        If the package is an MSI do not supply the `/qn', `/log' or `/norestart' arguments.
        [Default: (null)]

- creates_path
        Will check the existance of the path specified and use the result to determine whether
        the package is already installed.
        You can use this in conjunction with `product_id' and other `creates_*'.
        [Default: (null)]
        version_added: 2.4

- creates_service
        Will check the existing of the service specified and use the result to determine whether
        the package is already installed.
        You can use this in conjunction with `product_id' and other `creates_*'.
        [Default: (null)]
        version_added: 2.4

- creates_version
        Will check the file version property of the file at `creates_path' and use the result to
        determine whether the package is already installed.
        `creates_path' MUST be set and is a file.
        You can use this in conjunction with `product_id' and other `creates_*'.
        [Default: (null)]
        version_added: 2.4

- expected_return_code
        One or more return codes from the package installation that indicates success.
        Before Ansible 2.4 this was just 0 but since 2.4 this is both `0' and `3010'.
        A return code of `3010' usually means that a reboot is required, the `reboot_required'
        return value is set if the return code is `3010'.
        [Default: [0, 3010]]

- name
        Name of the package, if name isn't specified the path will be used for log messages.
        As of Ansible 2.4 this is deprecated and no longer required.
        [Default: (null)]

- password
        The password for `user_name', must be set when `user_name' is.
        (Aliases: user_password)[Default: (null)]

- path
        Location of the package to be installed or uninstalled.
        This package can either be on the local file system, network share or a url.
        If the path is on a network share and the current WinRM transport doesn't support
        credential delegation, then `user_name' and `user_password' must be set to access the
        file.
        There are cases where this file will be copied locally to the server so it can access
        it, see the notes for more info.
        If `state=present' then this value MUST be set.
        If `state=absent' then this value does not need to be set if `product_id' is.
        [Default: (null)]

- product_id
        The product id of the installed packaged.
        This is used for checking whether the product is already installed and getting the
        uninstall information if `state=absent'.
        You can find product ids for installed programs in the Windows registry editor either at
        `HKLM:Software\Microsoft\Windows\CurrentVersion\Uninstall' or for 32 bit programs at
        `HKLM:Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall'.
        This SHOULD be set when the package is not an MSI, or the path is a url or a network
        share and credential delegation is not being used. The `creates_*' options can be used
        instead but is not recommended.
        (Aliases: productid)[Default: (null)]

- state
        Whether to install or uninstall the package.
        The module uses `product_id' and whether it exists at the registry path to see whether
        it needs to install or uninstall the package.
        (Aliases: ensure)[Default: present]

- username
        Username of an account with access to the package if it is located on a file share.
        This is only needed if the WinRM transport is over an auth method that does not support
        credential delegation like Basic or NTLM.
        (Aliases: user_name)[Default: (null)]

- validate_certs
        If `no', SSL certificates will not be validated. This should only be used on personally
        controlled sites using self-signed certificates.
        Before Ansible 2.4 this defaulted to `no'.
        [Default: yes]
        type: bool
        version_added: 2.4


NOTES:
      * For non Windows targets, use the [package] module instead.
      * When `state=absent' and the product is an exe, the path may be different from what
        was used to install the package originally. If path is not set then the path used
        will be what is set under `UninstallString' in the registry for that product_id.
      * Not all product ids are in a GUID form, some programs incorrectly use a different
        structure but this module should support any format.
      * By default all msi installs and uninstalls will be run with the options `/log,
        /qn, /norestart'.
      * It is recommended you download the pacakge first from the URL using the
        [win_get_url] module as it opens up more flexibility with what must be set when
        calling `win_package'.
      * Packages will be temporarily downloaded or copied locally when path is a network
        location and credential delegation is not set, or path is a URL and the file is
        not an MSI.
      * All the installation checks under `product_id' and `creates_*' add together, if
        one fails then the program is considered to be absent.

AUTHOR: Trond Hindenes (@trondhindenes), Jordan Borean (@jborean93)
        METADATA:
          status:
          - preview
          supported_by: core


EXAMPLES:
- name: Install the Visual C thingy
  win_package:
    path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
    product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
    arguments: /install /passive /norestart

- name: Install Remote Desktop Connection Manager from msi
  win_package:
    path: https://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi
    product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
    state: present

- name: Uninstall Remote Desktop Connection Manager
  win_package:
    product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
    state: absent

- name: Install Remote Desktop Connection Manager locally omitting the product_id
  win_package:
    path: C:\temp\rdcman.msi
    state: present

- name: Uninstall Remote Desktop Connection Manager from local MSI omitting the product_id
  win_package:
    path: C:\temp\rdcman.msi
    state: absent

# 7-Zip exe doesn't use a guid for the Product ID
- name: Install 7zip from a network share specifying the credentials
  win_package:
    path: \\domain\programs\7z.exe
    product_id: 7-Zip
    arguments: /S
    state: present
    user_name: DOMAIN\User
    user_password: Password

- name: Install 7zip and use a file version for the installation check
  win_package:
    path: C:\temp\7z.exe
    creates_path: C:\Program Files\7-Zip\7z.exe
    creates_version: 16.04
    state: present

- name: Uninstall 7zip from the exe
  win_package:
    path: C:\Program Files\7-Zip\Uninstall.exe
    product_id: 7-Zip
    arguments: /S
    state: absent

- name: Uninstall 7zip without specifying the path
  win_package:
    product_id: 7-Zip
    arguments: /S
    state: absent

- name: Install application and override expected return codes
  win_package:
    path: https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-Al
    product_id: '{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}'
    arguments: '/q /norestart'
    state: present
    expected_return_code: [0, 666, 3010]

RETURN VALUES:


exit_code:
  description: See rc, this will be removed in favour of rc in Ansible 2.6.
  returned: change occured
  type: int
  sample: 0
log:
  description: The contents of the MSI log.
  returned: change occured and package is an MSI
  type: str
  sample: Installation completed successfully
rc:
  description: The return code of the pacakge process.
  returned: change occured
  type: int
  sample: 0
reboot_required:
  description: Whether a reboot is required to finalise package. This is set
    to true if the executable return code is 3010.
  returned: always
  type: bool
  sample: True
restart_required:
  description: See reboot_required, this will be removed in favour of
    reboot_required in Ansible 2.6
  returned: always
  type: bool
  sample: True
stdout:
  description: The stdout stream of the package process.
  returned: failure during install or uninstall
  type: str
  sample: Installing program
stderr:
  description: The stderr stream of the package process.
  returned: failure during install or uninstall
  type: str
  sample: Failed to install program



after 

ansible-doc win_package
> WIN_PACKAGE    (/home/jon/ansible-dev/lib/ansible/modules/windows/win_package.py)

        Installs or uninstalls a package in either an MSI or EXE format. These packages can be
        sources from the local file system, network file share or a url. Please read the notes
        section around some caveats with this module.

OPTIONS (= is mandatory):

- arguments
        Any arguments the installer needs to either install or uninstall the package.
        If the package is an MSI do not supply the `/qn', `/log' or `/norestart' arguments.
        [Default: (null)]

- creates_path
        Will check the existance of the path specified and use the result to determine whether
        the package is already installed.
        You can use this in conjunction with `product_id' and other `creates_*'.
        [Default: (null)]
        version_added: 2.4

- creates_service
        Will check the existing of the service specified and use the result to determine whether
        the package is already installed.
        You can use this in conjunction with `product_id' and other `creates_*'.
        [Default: (null)]
        version_added: 2.4

- creates_version
        Will check the file version property of the file at `creates_path' and use the result to
        determine whether the package is already installed.
        `creates_path' MUST be set and is a file.
        You can use this in conjunction with `product_id' and other `creates_*'.
        [Default: (null)]
        version_added: 2.4

- expected_return_code
        One or more return codes from the package installation that indicates success.
        Before Ansible 2.4 this was just 0 but since 2.4 this is both `0' and `3010'.
        A return code of `3010' usually means that a reboot is required, the `reboot_required'
        return value is set if the return code is `3010'.
        [Default: [0, 3010]]

- name
        Name of the package, if name isn't specified the path will be used for log messages.
        As of Ansible 2.4 this is deprecated and no longer required.
        [Default: (null)]

- password
        The password for `user_name', must be set when `user_name' is.
        (Aliases: user_password)[Default: (null)]

- path
        Location of the package to be installed or uninstalled.
        This package can either be on the local file system, network share or a url.
        If the path is on a network share and the current WinRM transport doesn't support
        credential delegation, then `user_name' and `user_password' must be set to access the
        file.
        There are cases where this file will be copied locally to the server so it can access
        it, see the notes for more info.
        If `state=present' then this value MUST be set.
        If `state=absent' then this value does not need to be set if `product_id' is.
        [Default: (null)]

- product_id
        The product id of the installed packaged.
        This is used for checking whether the product is already installed and getting the
        uninstall information if `state=absent'.
        You can find product ids for installed programs in the Windows registry editor either at
        `HKLM:Software\Microsoft\Windows\CurrentVersion\Uninstall' or for 32 bit programs at
        `HKLM:Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall'.
        This SHOULD be set when the package is not an MSI, or the path is a url or a network
        share and credential delegation is not being used. The `creates_*' options can be used
        instead but is not recommended.
        (Aliases: productid)[Default: (null)]

- state
        Whether to install or uninstall the package.
        The module uses `product_id' and whether it exists at the registry path to see whether
        it needs to install or uninstall the package.
        (Aliases: ensure)[Default: present]

- username
        Username of an account with access to the package if it is located on a file share.
        This is only needed if the WinRM transport is over an auth method that does not support
        credential delegation like Basic or NTLM.
        (Aliases: user_name)[Default: (null)]

- validate_certs
        If `no', SSL certificates will not be validated. This should only be used on personally
        controlled sites using self-signed certificates.
        Before Ansible 2.4 this defaulted to `no'.
        [Default: yes]
        type: bool
        version_added: 2.4


NOTES:
      * For non Windows targets, use the [package] module instead.
      * When `state=absent' and the product is an exe, the path may be different from what
        was used to install the package originally. If path is not set then the path used
        will be what is set under `UninstallString' in the registry for that product_id.
      * Not all product ids are in a GUID form, some programs incorrectly use a different
        structure but this module should support any format.
      * By default all msi installs and uninstalls will be run with the options `/log,
        /qn, /norestart'.
      * It is recommended you download the pacakge first from the URL using the
        [win_get_url] module as it opens up more flexibility with what must be set when
        calling `win_package'.
      * Packages will be temporarily downloaded or copied locally when path is a network
        location and credential delegation is not set, or path is a URL and the file is
        not an MSI.
      * All the installation checks under `product_id' and `creates_*' add together, if
        one fails then the program is considered to be absent.

AUTHOR: Trond Hindenes (@trondhindenes), Jordan Borean (@jborean93)
        METADATA:
          status:
          - preview
          supported_by: core


EXAMPLES:
- name: Install the Visual C thingy
  win_package:
    path: http://download.microsoft.com/download/1/6/B/16B06F60-3B20-4FF2-B699-5E9B7962F9AE/VSU_4/vcredist_x64.exe
    product_id: '{CF2BEA3C-26EA-32F8-AA9B-331F7E34BA97}'
    arguments: /install /passive /norestart

- name: Install Remote Desktop Connection Manager from msi
  win_package:
    path: https://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi
    product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
    state: present

- name: Uninstall Remote Desktop Connection Manager
  win_package:
    product_id: '{0240359E-6A4C-4884-9E94-B397A02D893C}'
    state: absent

- name: Install Remote Desktop Connection Manager locally omitting the product_id
  win_package:
    path: C:\temp\rdcman.msi
    state: present

- name: Uninstall Remote Desktop Connection Manager from local MSI omitting the product_id
  win_package:
    path: C:\temp\rdcman.msi
    state: absent

# 7-Zip exe doesn't use a guid for the Product ID
- name: Install 7zip from a network share specifying the credentials
  win_package:
    path: \\domain\programs\7z.exe
    product_id: 7-Zip
    arguments: /S
    state: present
    user_name: DOMAIN\User
    user_password: Password

- name: Install 7zip and use a file version for the installation check
  win_package:
    path: C:\temp\7z.exe
    creates_path: C:\Program Files\7-Zip\7z.exe
    creates_version: 16.04
    state: present

- name: Uninstall 7zip from the exe
  win_package:
    path: C:\Program Files\7-Zip\Uninstall.exe
    product_id: 7-Zip
    arguments: /S
    state: absent

- name: Uninstall 7zip without specifying the path
  win_package:
    product_id: 7-Zip
    arguments: /S
    state: absent

- name: Install application and override expected return codes
  win_package:
    path: https://download.microsoft.com/download/1/6/7/167F0D79-9317-48AE-AEDB-17120579F8E2/NDP451-KB2858728-x86-x64-Al
    product_id: '{7DEBE4EB-6B40-3766-BB35-5CBBC385DA37}'
    arguments: '/q /norestart'
    state: present
    expected_return_code: [0, 666, 3010]

# See http://docs.oracle.com/javase/8/docs/technotes/guides/install/config.html#table_config_file_options
# for further java installation options
- name: Install Java JDK and turn off auto update feature
  win_package:
    path: "jdk-{{ jdk_major_version }}u{{ jdk_minor_version }}-windows-x64.exe"
    product_id: "{{jdk_product_id}}"
    state: present
    arguments: INSTALL_SILENT=1 AUTO_UPDATE=0 WEB_JAVA=0 WEB_ANALYTICS=0 /s  > /L C:\ansible\log\java-installation.log

RETURN VALUES:


exit_code:
  description: See rc, this will be removed in favour of rc in Ansible 2.6.
  returned: change occured
  type: int
  sample: 0
log:
  description: The contents of the MSI log.
  returned: change occured and package is an MSI
  type: str
  sample: Installation completed successfully
rc:
  description: The return code of the pacakge process.
  returned: change occured
  type: int
  sample: 0
reboot_required:
  description: Whether a reboot is required to finalise package. This is set
    to true if the executable return code is 3010.
  returned: always
  type: bool
  sample: True
restart_required:
  description: See reboot_required, this will be removed in favour of
    reboot_required in Ansible 2.6
  returned: always
  type: bool
  sample: True
stdout:
  description: The stdout stream of the package process.
  returned: failure during install or uninstall
  type: str
  sample: Installing program
stderr:
  description: The stderr stream of the package process.
  returned: failure during install or uninstall
  type: str
  sample: Failed to install program


```
