### PR TITLE
Disable vyos_command in shippable till we fix the inventory issue

### DIFF
--- a/test/integration/targets/vyos_command/aliases
+++ b/test/integration/targets/vyos_command/aliases
@@ -1,2 +1,2 @@
-network/ci
+#network/ci
 skip/python3


### PR DESCRIPTION
##### SUMMARY
We are refactoring how credentials are passed to network tests.

So we can continue with DCI we will temporarily disable the running of `vyos_command` in Shippable.

After AnsibleFest SF I'll get this working again. The plan will be to get `ansible-test` to add the credentials into the inventory file as this will match how we are using DCI & manual testing

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

