### PR TITLE
ec2_group: Allow rule source to be a security group in a peered VPC. Fixes #19759

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -385,7 +385,7 @@ def get_target_from_rule(module, client, rule, name, group, groups, vpc_id):
             group_id = group['GroupId']
             groups[group_id] = group
             groups[group_name] = group
-        elif group_name in groups and (vpc_id is None or groups[group_name]['VpcId'] == vpc_id):
+        elif group_name in groups:
             group_id = groups[group_name]['GroupId']
         else:
             if not rule.get('group_desc', '').strip():


### PR DESCRIPTION
##### SUMMARY
Fixes #19759. Removed an unnecessary check that the group specified in a rule is in the same VPC to allow for peered VPCs. Now this works:
```
---
- hosts: localhost
  connection: local
  tasks:
    - name: try group in the rules from a peered VPC
      ec2_group:
        name: "{{ name }}"
        description: "{{ description }}"
        state: present
        vpc_id: "{{ vpc }}"
        rules:
          - proto: tcp
            from_port: 22
            to_port: 22
            group_name: "{{ peered_vpc_sg }}"
```
If a security group in a non-peered VPC is specified boto provides a helpful error message:
```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "error": {
        "code": "InvalidGroup.NotFound",
        "message": "You have specified two resources that belong to different networks."
    },
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
2.4.0
```
