### PR TITLE
ec2: fixes #19521, fixes #29456 - create instance-store AMI instances with correct shutdown behavior

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1197,7 +1197,8 @@ def create_instances(module, ec2, vpc, override_count=None):
                 try:
                     res = ec2.run_instances(**params)
                 except boto.exception.EC2ResponseError as e:
-                    if "InvalidParameterCombination" == e.error_code:
+                    if (params['instance_initiated_shutdown_behavior'] != 'terminate'
+                            and "InvalidParameterCombination" == e.error_code):
                         params['instance_initiated_shutdown_behavior'] = 'terminate'
                         res = ec2.run_instances(**params)
                     else:

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1197,8 +1197,8 @@ def create_instances(module, ec2, vpc, override_count=None):
                 try:
                     res = ec2.run_instances(**params)
                 except boto.exception.EC2ResponseError as e:
-                    if (params['instance_initiated_shutdown_behavior'] != 'terminate'
-                            and "InvalidParameterCombination" == e.error_code):
+                    if (params['instance_initiated_shutdown_behavior'] != 'terminate' and
+                            "InvalidParameterCombination" == e.error_code):
                         params['instance_initiated_shutdown_behavior'] = 'terminate'
                         res = ec2.run_instances(**params)
                     else:

--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1197,7 +1197,7 @@ def create_instances(module, ec2, vpc, override_count=None):
                 try:
                     res = ec2.run_instances(**params)
                 except boto.exception.EC2ResponseError as e:
-                    if "The attribute instanceInitiatedShutdownBehavior can only be used for EBS-backed images." in e.message:
+                    if "InvalidParameterCombination" == e.error_code:
                         params['instance_initiated_shutdown_behavior'] = 'terminate'
                         res = ec2.run_instances(**params)
                     else:


### PR DESCRIPTION
##### SUMMARY
Termination is the required shutdown behavior of instance-store AMIs. The ec2 module option for the shutdown behavior defaults to 'stop' so I added a try/except to account for non-EBS-backed images and allow the default to be corrected. Added a note to the module option. Fixes #19521

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.4.0
```
