### PR TITLE
ec2_group: Don't fail if there are host bits set on the cidr_ip - fixes #25403

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -500,10 +500,10 @@ def authorize_ip(type, changed, client, group, groupRules,
                             client.authorize_security_group_egress(GroupId=group['GroupId'],
                                                                    IpPermissions=[ip_permission])
                     except botocore.exceptions.ClientError as e:
-                        if "(InvalidPermission.Duplicate)" in e.message:
+                        if e.response['Error']['Code'] == "InvalidPermission.Duplicate":
                             # There are host bits but only the network bits get authorized so it appears there is a conflict.
                             # Allow graceful completion with a warning.
-                            actual_ip = re.search(r"(?<!\d\.)(?<!\d)(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}(?!\d|(?:\.\d))", e.message).group()
+                            actual_ip = re.search(r"(?<!\d\.)(?<!\d)(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}(?!\d|(?:\.\d))", e.response['Error']['Message']).group()
                             rule_id = make_rule_key(type, rule, group['GroupId'], actual_ip)
                             if rule_id in groupRules:
                                 del groupRules[rule_id]

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -509,7 +509,7 @@ def authorize_ip(type, changed, client, group, groupRules,
                             found_actual_ip = re.search(r"(?<!\d\.)(?<!\d)(?:\d{1,3}\.){3}\d{1,3}/\d{1,2}(?!\d|(?:\.\d))", e.response['Error']['Message'])
                             if not found_actual_ip:
 
-                                # If an IPv4 CIDR isn't found so check for IPv6; This is an unfortunate regex, so I factored out the common variables because
+                                # If an IPv4 CIDR isn't found check for IPv6. This is an unfortunate regex, so I factored out the common variables because
                                 # this pattern was easier for me to read.
                                 _x = "[0-9A-Fa-f]{1,4}"
                                 _y = "(25[0-5]|2[0-4]d|1dd|[1-9]?d)"

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -436,6 +436,112 @@
           - 'result.group_id.startswith("sg-")'
 
     # ============================================================
+
+    - name: test adding a rule with a IPv4 CIDR with host bits set (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        # set purge_rules to false so we don't get a false positive from previously added rules
+        purge_rules: false
+        rules:
+        - proto: "tcp"
+          ports:
+            - 8195
+          cidr_ip: 10.0.0.1/8
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+          - 'result.changed'
+          - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+
+    - name: test adding the same rule with a IPv4 CIDR with host bits set (expected changed=false and a warning)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        # set purge_rules to false so we don't get a false positive from previously added rules
+        purge_rules: false
+        rules:
+        - proto: "tcp"
+          ports:
+            - 8195
+          cidr_ip: 10.0.0.1/8
+      register: result
+
+    - name: assert state=present (expected changed=false and a warning)
+      assert:
+        that:
+          # No way to assert for warnings?
+          - 'not result.changed'
+          - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+
+    - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        # set purge_rules to false so we don't get a false positive from previously added rules
+        purge_rules: false
+        rules:
+        - proto: "tcp"
+          ports:
+            - 8196
+          cidr_ipv6: '2001:db00::1/24'
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+          - 'result.changed'
+          - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+
+    - name: test adding a rule again with a IPv6 CIDR with host bits set (expected changed=false and a warning)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        # set purge_rules to false so we don't get a false positive from previously added rules
+        purge_rules: false
+        rules:
+        - proto: "tcp"
+          ports:
+            - 8196
+          cidr_ipv6: '2001:db00::1/24'
+      register: result
+
+    - name: assert state=present (expected changed=false and a warning)
+      assert:
+        that:
+          # No way to assert for warnings?
+          - 'not result.changed'
+          - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
     - name: test state=absent (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'


### PR DESCRIPTION
##### SUMMARY
Fixes #25403. Since a cidr ip with host bits set won't match the network bits that are set, add a warning and allow graceful completion. Check mode was already broken for cases like this, but remains so. Added a FIXME note.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
2.4.0
```