### PR TITLE
Move networking provider options to subspec

### DIFF
--- a/lib/ansible/module_utils/aireos.py
+++ b/lib/ansible/module_utils/aireos.py
@@ -32,15 +32,18 @@ from ansible.module_utils.connection import exec_command
 
 _DEVICE_CONFIGS = {}
 
-aireos_argument_spec = {
+aireos_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict')
 }
+aireos_argument_spec = {
+    'provider': dict(type='dict', options=aireos_provider_spec)
+}
+aireos_argument_spec.update(aireos_provider_spec)
 
 # Add argument's default value here
 ARGS_DEFAULT_VALUE = {}
@@ -61,7 +64,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in aireos_argument_spec:
         if key not in ['provider', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
@@ -72,11 +74,6 @@ def check_args(module, warnings):
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/aruba.py
+++ b/lib/ansible/module_utils/aruba.py
@@ -32,15 +32,18 @@ from ansible.module_utils.connection import exec_command
 
 _DEVICE_CONFIGS = {}
 
-aruba_argument_spec = {
+aruba_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict')
 }
+aruba_argument_spec = {
+    'provider': dict(type='dict', options=aruba_provider_spec)
+}
+aruba_argument_spec.update(aruba_provider_spec)
 
 # Add argument's default value here
 ARGS_DEFAULT_VALUE = {}
@@ -51,7 +54,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in aruba_argument_spec:
         if key not in ['provider', 'authorize'] and module.params[key]:
             warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
@@ -62,11 +64,6 @@ def check_args(module, warnings):
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/ce.py
+++ b/lib/ansible/module_utils/ce.py
@@ -53,7 +53,7 @@ except ImportError:
 _DEVICE_CLI_CONNECTION = None
 _DEVICE_NC_CONNECTION = None
 
-ce_argument_spec = {
+ce_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -61,9 +61,12 @@ ce_argument_spec = {
     'use_ssl': dict(type='bool'),
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict', no_log=True),
-    'transport': dict(choices=['cli'])
+    'transport': dict(choices=['cli']),
 }
+ce_argument_spec = {
+    'provider': dict(type='dict', options=ce_provider_spec),
+}
+ce_argument_spec.update(ce_provider_spec)
 
 
 def check_args(module, warnings):

--- a/lib/ansible/module_utils/dellos10.py
+++ b/lib/ansible/module_utils/dellos10.py
@@ -45,7 +45,7 @@ WARNING_PROMPTS_RE = [
     r"[\r\n]?\[yes/no\]:\s?$"
 ]
 
-dellos10_argument_spec = {
+dellos10_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -54,21 +54,18 @@ dellos10_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
 }
+dellos10_argument_spec = {
+    'provider': dict(type='dict', options=dellos10_provider_spec),
+}
+dellos10_argument_spec.update(dellos10_provider_spec)
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in dellos10_argument_spec:
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                             'removed in a future version' % key)
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -44,7 +44,7 @@ WARNING_PROMPTS_RE = [
     r"[\r\n]?\[yes/no\]:\s?$"
 ]
 
-dellos6_argument_spec = {
+dellos6_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -53,21 +53,18 @@ dellos6_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
 }
+dellos6_argument_spec = {
+    'provider': dict(type='dict', options=dellos6_provider_spec),
+}
+dellos6_argument_spec.update(dellos6_provider_spec)
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in dellos6_argument_spec:
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                             'removed in a future version' % key)
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -45,7 +45,7 @@ WARNING_PROMPTS_RE = [
     r"[\r\n]?\[yes/no\]:\s?$"
 ]
 
-dellos9_argument_spec = {
+dellos9_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -54,21 +54,18 @@ dellos9_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
 }
+dellos9_argument_spec = {
+    'provider': dict(type='dict', options=dellos9_provider_spec),
+}
+dellos9_argument_spec.update(dellos9_provider_spec)
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in dellos9_argument_spec:
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
                             'removed in a future version' % key)
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -73,7 +73,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in eos_argument_spec:
         if module._name == 'eos_user':
             if (key not in ['username', 'password', 'provider', 'transport', 'authorize'] and
@@ -89,11 +88,6 @@ def check_args(module, warnings):
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def load_params(module):

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -39,13 +39,12 @@ from ansible.module_utils.urls import fetch_url
 
 _DEVICE_CONNECTION = None
 
-eos_argument_spec = {
+eos_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
-
 
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
@@ -54,9 +53,12 @@ eos_argument_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'provider': dict(type='dict'),
     'transport': dict(choices=['cli', 'eapi'])
 }
+eos_argument_spec = {
+    'provider': dict(type='dict', options=eos_provider_spec),
+}
+eos_argument_spec.update(eos_provider_spec)
 
 # Add argument's default value here
 ARGS_DEFAULT_VALUE = {

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -53,7 +53,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in ios_argument_spec:
         if module._name == 'ios_user':
             if key not in ['password', 'provider', 'authorize'] and module.params[key]:
@@ -61,11 +60,6 @@ def check_args(module, warnings):
         else:
             if key not in ['provider', 'authorize'] and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_defaults_flag(module):

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -32,7 +32,7 @@ from ansible.module_utils.connection import exec_command
 
 _DEVICE_CONFIGS = {}
 
-ios_argument_spec = {
+ios_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -41,8 +41,11 @@ ios_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
 }
+ios_argument_spec = {
+    'provider': dict(type='dict', options=ios_provider_spec),
+}
+ios_argument_spec.update(ios_provider_spec)
 
 
 def get_argspec():

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -52,7 +52,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in iosxr_argument_spec:
         if module._name == 'iosxr_user':
             if key not in ['password', 'provider'] and module.params[key]:
@@ -60,11 +59,6 @@ def check_args(module, warnings):
         else:
             if key != 'provider' and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    if provider:
-        for param in ('password',):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -33,15 +33,18 @@ from ansible.module_utils.connection import exec_command
 
 _DEVICE_CONFIGS = {}
 
-iosxr_argument_spec = {
+iosxr_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict')
 }
+iosxr_argument_spec = {
+    'provider': dict(type='dict', options=iosxr_provider_spec)
+}
+iosxr_argument_spec.update(iosxr_provider_spec)
 
 
 def get_argspec():

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -61,7 +61,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in junos_argument_spec:
         if key not in ('provider',) and module.params[key]:
             warnings.append('argument %s has been deprecated and will be '
@@ -73,11 +72,6 @@ def check_args(module, warnings):
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]
-
-    if provider:
-        for param in ('password',):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def _validate_rollback_id(module, value):

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -38,16 +38,19 @@ JSON_ACTIONS = frozenset(['merge', 'override', 'update'])
 FORMATS = frozenset(['xml', 'text', 'json'])
 CONFIG_FORMATS = frozenset(['xml', 'text', 'json', 'set'])
 
-junos_argument_spec = {
+junos_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
     'transport': dict()
 }
+junos_argument_spec = {
+    'provider': dict(type='dict', options=junos_provider_spec),
+}
+junos_argument_spec.update(junos_provider_spec)
 
 # Add argument's default value here
 ARGS_DEFAULT_VALUE = {}

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -39,7 +39,7 @@ from ansible.module_utils.urls import fetch_url
 
 _DEVICE_CONNECTION = None
 
-nxos_argument_spec = {
+nxos_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
 
@@ -51,9 +51,12 @@ nxos_argument_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'provider': dict(type='dict'),
     'transport': dict(choices=['cli', 'nxapi'])
 }
+nxos_argument_spec = {
+    'provider': dict(type='dict', options=nxos_provider_spec),
+}
+nxos_argument_spec.update(nxos_provider_spec)
 
 # Add argument's default value here
 ARGS_DEFAULT_VALUE = {

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -69,7 +69,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in nxos_argument_spec:
         if module._name == 'nxos_user':
             if key not in ['password', 'provider', 'transport'] and module.params[key]:
@@ -84,11 +83,6 @@ def check_args(module, warnings):
     for key in ARGS_DEFAULT_VALUE:
         if not module.params.get(key, None):
             module.params[key] = ARGS_DEFAULT_VALUE[key]
-
-    if provider:
-        for param in ('password',):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def load_params(module):

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -38,27 +38,24 @@ from ansible.module_utils.connection import exec_command
 
 _DEVICE_CONFIGS = {}
 
-sros_argument_spec = {
+sros_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
     'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict')
 }
+sros_argument_spec = {
+    'provider': dict(type='dict', options=sros_provider_spec),
+}
+sros_argument_spec.update(sros_provider_spec)
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in sros_argument_spec:
         if key != 'provider' and module.params[key]:
             warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    if provider:
-        for param in ('password',):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -32,7 +32,7 @@ from ansible.module_utils.connection import exec_command
 
 _DEVICE_CONFIGS = {}
 
-vyos_argument_spec = {
+vyos_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
 
@@ -41,8 +41,11 @@ vyos_argument_spec = {
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
 
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
 }
+vyos_argument_spec = {
+    'provider': dict(type='dict', options=vyos_provider_spec),
+}
+vyos_argument_spec.update(vyos_provider_spec)
 
 
 def get_argspec():

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -53,7 +53,6 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    provider = module.params['provider'] or {}
     for key in vyos_argument_spec:
         if module._name == 'vyos_user':
             if key not in ['password', 'provider'] and module.params[key]:
@@ -61,11 +60,6 @@ def check_args(module, warnings):
         else:
             if key != 'provider' and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    if provider:
-        for param in ('password',):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_config(module, target='commands'):

--- a/test/integration/group_vars/vyos.yaml
+++ b/test/integration/group_vars/vyos.yaml
@@ -3,4 +3,3 @@ cli:
   host: "{{ ansible_ssh_host }}"
 #  username: "{{ vyos_cli_user | default('ansible-admin') }}"
 #  password: "{{ vyos_cli_pass | default('adminpw') }}"
-  transport: cli


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This should help mask provider no_log options from within provider.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
networking

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
(from `journalctl -f | grep Invoked`)

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
Aug 31 14:42:47 redmagic ansible-nxos_command[11213]: Invoked with username=None retries=10
commands=['show interface brief | json'] ssh_keyfile=None password=NOT_LOGGING_PARAMETER
interval=1 host=None transport=nxapi timeout=60 provider={'username': 'username',
'ssh_keyfile': None, 'host': 'nxos01', 'timeout': 60, 'use_ssl': False,
'password': 'my_pass', 'validate_certs': True, 'port': 80, 'transport': 'nxapi'}
use_ssl=None wait_for=None validate_certs=None port=None match=all
```

After:
```
Aug 31 14:44:55 redmagic ansible-nxos_command[14761]: Invoked with username=None retries=10
commands=['show interface brief | json'] ssh_keyfile=None password=NOT_LOGGING_PARAMETER
interval=1 host=None transport=nxapi timeout=60 provider={'username': 'username',
'ssh_keyfile': None, 'host': 'nxos01', 'timeout': 60, 'use_ssl': False,
'password': '********', 'validate_certs': True, 'port': 80, 'transport': 'nxapi'}
use_ssl=None wait_for=None validate_certs=None port=None match=all
```