### PR TITLE
Rel240/fix nxos interface ospf

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -394,7 +394,9 @@ def main():
                                                'message_digest_password']],
                            supports_check_mode=True)
 
-    if not module.params['interface'].startswith('loopback') and not module.params['interface'].startswith('port-channel'):
+    if re.match(r'(port-channel|loopback)', module.params['interface'], re.I):
+        module.params['interface'] = module.params['interface'].lower()
+    else:
         module.params['interface'] = module.params['interface'].capitalize()
 
     warnings = list()

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -403,7 +403,6 @@ def main():
     if re.match(r'(port-channel|loopback)', module.params['interface'], re.I):
         module.params['interface'] = module.params['interface'].lower()
     else:
-        module.params['interface'] = module.params['interface'].lower()
         module.params['interface'] = module.params['interface'].capitalize()
 
     warnings = list()

--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -394,9 +394,16 @@ def main():
                                                'message_digest_password']],
                            supports_check_mode=True)
 
+    # Normalize interface input data.
+    #
+    # * For port-channel and loopback interfaces expection is all lower case names.
+    # * All other interfaces the expectation is an uppercase leading character
+    #   followed by lower case characters.
+    #
     if re.match(r'(port-channel|loopback)', module.params['interface'], re.I):
         module.params['interface'] = module.params['interface'].lower()
     else:
+        module.params['interface'] = module.params['interface'].lower()
         module.params['interface'] = module.params['interface'].capitalize()
 
     warnings = list()

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -33,6 +33,16 @@
     provider: "{{ connection }}"
   ignore_errors: yes
 
+- name: "Remove possibly existing port-channel and loopback ints"
+  nxos_config: &removepcandlb
+    commands:
+      - no interface port-channel10
+      - no interface port-channel11
+      - no interface loopback55
+      - no interface loopback77
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
 - block:
   - name: configure ospf interface
     nxos_interface_ospf: &configure
@@ -80,6 +90,109 @@
 
   - assert: *false
 
+  - name: create port-channel and loopback interfaces
+    nxos_config:
+      commands:
+        - interface port-channel10
+        - interface port-channel11
+        - interface loopback55
+        - interface loopback77
+      match: none
+      provider: "{{ connection }}"
+
+  - name: "Ensure port-channels are layer3"
+    nxos_config:
+      commands:
+        - no switchport
+      parents:
+        - "interface {{ item }}"
+      provider: "{{ connection }}"
+    with_items:
+      - port-channel10
+      - port-channel11
+
+  - name: configure ospf interface port-channel10
+    nxos_interface_ospf: &configurepc
+      interface: Port-channel10
+      ospf: 1
+      area: 1
+      cost: 55
+      passive_interface: true
+      hello_interval: 15
+      dead_interval: 75
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence for port-channel10"
+    nxos_interface_ospf: *configurepc
+    register: result
+
+  - assert: *false
+
+  - name: configure ospf interface port-channel11 using lower case name
+    nxos_interface_ospf: &configurepclower
+      interface: port-channel11
+      ospf: 1
+      area: 1
+      cost: 55
+      passive_interface: true
+      hello_interval: 15
+      dead_interval: 75
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence for port-channel11"
+    nxos_interface_ospf: *configurepclower
+    register: result
+
+  - assert: *false
+
+  - name: configure ospf interface loopback55
+    nxos_interface_ospf: &configurelb
+      interface: Loopback55
+      ospf: 1
+      area: 1
+      cost: 55
+      hello_interval: 15
+      dead_interval: 75
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence for loopback55"
+    nxos_interface_ospf: *configurelb
+    register: result
+
+  - assert: *false
+
+  - name: configure ospf interface loopback77 using lower case name
+    nxos_interface_ospf: &configurelblower
+      interface: loopback77
+      ospf: 1
+      area: 1
+      cost: 77
+      hello_interval: 45
+      dead_interval: 75
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence for loopback77"
+    nxos_interface_ospf: *configurelblower
+    register: result
+
+  - assert: *false
+
   - name: remove ospf interface config
     nxos_interface_ospf: &removeconfig
       interface: "{{ testint }}"
@@ -114,6 +227,9 @@
 
   - name: "Interface cleanup"
     nxos_config: *intdefault
+
+  - name: "Remove port-channel and loopback ints"
+    nxos_config: *removepcandlb
 
   always:
   - debug: msg="END TRANSPORT:{{ connection.transport }} nxos_interface_ospf sanity test"

--- a/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tests/common/sanity.yaml
@@ -46,7 +46,7 @@
 - block:
   - name: configure ospf interface
     nxos_interface_ospf: &configure
-      interface: "{{ testint }}"
+      interface: "{{ nxos_int1|upper }}"
       ospf: 1
       area: 1
       cost: 55
@@ -155,7 +155,7 @@
 
   - name: configure ospf interface loopback55
     nxos_interface_ospf: &configurelb
-      interface: Loopback55
+      interface: LOOPBACK55
       ospf: 1
       area: 1
       cost: 55


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/28897
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_interface_ospf

##### ANSIBLE VERSION
```
ansible 2.4.0 (rel240/fix_nxos_interface_ospf d5930c22b3) last updated 2017/08/31 15:04:42 (GMT -400)
  config file = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
This PR addresses a problem where the interface name can be specified in the playbook where the leading character is either upper or lower case.

This PR resolves that issue and adds additional integration tests to avoid regressions.