### PR TITLE
On Py3, nonexistent files raise OSError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ def _maintain_symlinks(symlink_type, base_path):
         # only time we know that we're going to cache correctly
         with open(SYMLINK_CACHE, 'r') as f:
             symlink_data = json.loads(f.read())
-    except IOError as e:
+    except (IOError, OSError) as e:
+        # IOError on py2, OSError on py3.  Both have errno
         if e.errno == 2:
             # SYMLINKS_CACHE doesn't exist.  Fallback to trying to create the
             # cache now.  Will work if we're running directly from a git


### PR DESCRIPTION
##### SUMMARY
skipping an sdist and attempting to install straight from a github tarball would still fail on python3.

This was due to not having a symlink cache file in the github tarball and the cache only being created when it didn't exist.  The code checking for a nonexistent file relied upon IOError being raised but on python-3.3+, OSError is raised instead.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
setup.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

