### PR TITLE
Pip doesn't upgrade pyopenssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ PyYAML
 paramiko
 cryptography
 setuptools
+pyopenssl


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Issue#28829 Upgrading to Ansible 2.3.2.0 via pip doesn't upgrade pyopenssl causing fatal errors to occur in some cases. 

Added Pyopenssl to requirements.txt
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request



##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Added pyopenssl to requirements.txt causes pip install --upgrade ansible to also upgrade pyopenssl
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
