### PR TITLE
Add ok_if_missing option to passwordstore lookup (#28702)

### DIFF
--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -120,7 +120,7 @@ Basic lookup. Fails if example/test doesn't exist::
 
     password="{{ lookup('passwordstore', 'example/test')}}"
 
-Return password if it exists, else returns ``False``. Does not fail if password doesn't exist::
+Returns password if it exists, else returns ``False``. Does not fail if password doesn't exist::
 
     password="{{ lookup('passwordstore', 'example/test ok_if_missing=true')}}"
 

--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -120,7 +120,7 @@ Basic lookup. Fails if example/test doesn't exist::
 
     password="{{ lookup('passwordstore', 'example/test')}}"
 
-Returns password if it exists, else returns ``False``. Does not fail if password doesn't exist::
+Return password if it exists, else return ``False``. Does not fail if password doesn't exist::
 
     password="{{ lookup('passwordstore', 'example/test ok_if_missing=true')}}"
 

--- a/docs/docsite/rst/playbooks_lookups.rst
+++ b/docs/docsite/rst/playbooks_lookups.rst
@@ -120,7 +120,11 @@ Basic lookup. Fails if example/test doesn't exist::
 
     password="{{ lookup('passwordstore', 'example/test')}}"
 
-Create pass with random 16 character password. If password exists just give the password::
+Return password if it exists, else returns ``False``. Does not fail if password doesn't exist::
+
+    password="{{ lookup('passwordstore', 'example/test ok_if_missing=true')}}"
+
+Return password if it exists, else create pass with random 16 character password::
 
     password="{{ lookup('passwordstore', 'example/test create=true')}}"
 
@@ -132,7 +136,7 @@ Create password and overwrite the password if it exists. As a bonus, this module
 
     password="{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"
 
-Return the value for user in the KV pair user: username::
+Return the value for user in the KV pair 'user: username'::
 
     password="{{ lookup('passwordstore', 'example/test subkey=user')}}"
 

--- a/lib/ansible/plugins/lookup/passwordstore.py
+++ b/lib/ansible/plugins/lookup/passwordstore.py
@@ -84,7 +84,7 @@ class LookupModule(LookupBase):
                 raise AnsibleError(e)
             # check and convert values
             try:
-                for key in ['create', 'returnall', 'overwrite']:
+                for key in ['create', 'returnall', 'overwrite', 'ok_if_missing']:
                     if not isinstance(self.paramvals[key], bool):
                         self.paramvals[key] = util.strtobool(self.paramvals[key])
             except (ValueError, AssertionError) as e:
@@ -118,10 +118,10 @@ class LookupModule(LookupBase):
             if e.returncode == 1 and 'not in the password store' in e.output:
                 # if pass returns 1 and return string contains 'is not in the password store.'
                 # We need to determine if this is valid or Error.
-                if not self.paramvals['create']:
-                    raise AnsibleError('passname: {} not found, use create=True'.format(self.passname))
-                else:
+                if self.paramvals['create'] or self.paramvals['ok_if_missing']:
                     return False
+                else:
+                    raise AnsibleError('passname: {} not found, use create=True'.format(self.passname))
             else:
                 raise AnsibleError(e)
         return True
@@ -176,6 +176,7 @@ class LookupModule(LookupBase):
             'create': False,
             'returnall': False,
             'overwrite': False,
+            'ok_if_missing': False,
             'userpass': '',
             'length': 16,
         }


### PR DESCRIPTION
##### SUMMARY
Add ok_if_missing option to passwordstore lookup (#28702)

There is currently no way to default to another value if the password is not found. This PR adds an `ok_if_missing` option (default `False`). When set to `True`, it causes a missing password in a passwordstore lookup to return a `False` value rather than failing. This allows a playbook to use a Jinja2 default value easily.

Side note: I was reading through the documentation, and it's not clear to me what these two pieces mean. We should clarify them.
```
Create password and overwrite the password if it exists. As a bonus, this module includes the old password inside the pass file::

    password="{{ lookup('passwordstore', 'example/test create=true overwrite=true')}}"

Return the value for user in the KV pair 'user: username'::

    password="{{ lookup('passwordstore', 'example/test subkey=user')}}"
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
plugins/lookups/passwordstore

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/28702 fccd9915eb) last updated 2017/08/31 22:20:35 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
Test cases:
```
---
- hosts: localhost
  gather_facts: no
  vars:
    password: "{{ lookup('passwordstore', 'example/test') }}"
  tasks:
    - name: Print password
      debug: var=password

[reid@laptop ~/git]$ ansible-playbook pwstore.yml -i hosts.ini 
...
TASK [Print password] *********************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "{{ lookup('passwordstore', 'example/test') }}: An unhandled exception occurred while running the lookup plugin 'passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: passname: example/test not found, use create=True"}
	to retry, use: --limit @/home/reid/git/pwstore.retry

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```

```
---
- hosts: localhost
  gather_facts: no
  vars:
    password: "{{ lookup('passwordstore', 'example/test ok_if_missing=True') }}"
  tasks:
    - name: Print password
      debug: var=password

[reid@laptop ~/git]$ ansible-playbook pwstore.yml -i hosts.ini 
...
TASK [Print password] *********************************************************************************************************************************************************************************************
ok: [localhost] => {
    "password": []
}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0  
```

```
# default not using True second parameter, which catches False values in addition to None values
---
- hosts: localhost
  gather_facts: no
  vars:
    password: "{{ lookup('passwordstore', 'example/test ok_if_missing=True') | default('TEST') }}"
  tasks:
    - name: Print password
      debug: var=password

[reid@laptop ~/git]$ ansible-playbook pwstore.yml -i hosts.ini 
...
TASK [Print password] *********************************************************************************************************************************************************************************************
ok: [localhost] => {
    "password": []
}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0  
```

```
---
- hosts: localhost
  gather_facts: no
  vars:
    password: "{{ lookup('passwordstore', 'example/test ok_if_missing=True') | default('TEST', true) }}"
  tasks:
    - name: Print password
      debug: var=password

[reid@laptop ~/git]$ ansible-playbook pwstore.yml -i hosts.ini 
...
TASK [Print password] *********************************************************************************************************************************************************************************************
ok: [localhost] => {
    "password": "TEST"
}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0  
```

```
# ok_if_missing not set; default does not handle failures
---
- hosts: localhost
  gather_facts: no
  vars:
    password: "{{ lookup('passwordstore', 'example/test') | default('TEST', true) }}"
  tasks:
    - name: Print password
      debug: var=password

[reid@laptop ~/git]$ ansible-playbook pwstore.yml -i hosts.ini 
...
TASK [Print password] *********************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "{{ lookup('passwordstore', 'example/test') | default('TEST', true) }}: An unhandled exception occurred while running the lookup plugin 'passwordstore'. Error was a <class 'ansible.errors.AnsibleError'>, original message: passname: example/test not found, use create=True"}
	to retry, use: --limit @/home/reid/git/pwstore.retry

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```