### PR TITLE
fix to get azure_rm inventory working with newer SDK

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -412,7 +412,7 @@ class AzureRM(object):
     def network_client(self):
         self.log('Getting network client')
         if not self._network_client:
-            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id, base_url=self._cloud_environment.endpoints.management)
+            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id, base_url=self._cloud_environment.endpoints.resource_manager)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -422,14 +422,14 @@ class AzureRM(object):
         if not self._resource_client:
             self._resource_client = ResourceManagementClient(self.azure_credentials,
                                                              self.subscription_id,
-                                                             base_url=self._cloud_environment.endpoints.management)
+                                                             base_url=self._cloud_environment.endpoints.resource_manager)
         return self._resource_client
 
     @property
     def compute_client(self):
         self.log('Getting compute client')
         if not self._compute_client:
-            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id, base_url=self._cloud_environment.endpoints.management)
+            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id, base_url=self._cloud_environment.endpoints.resource_manager)
             self._register('Microsoft.Compute')
         return self._compute_client
 

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -412,7 +412,9 @@ class AzureRM(object):
     def network_client(self):
         self.log('Getting network client')
         if not self._network_client:
-            self._network_client = NetworkManagementClient(self.azure_credentials, self.subscription_id, base_url=self._cloud_environment.endpoints.resource_manager)
+            self._network_client = NetworkManagementClient(self.azure_credentials,
+                                                           self.subscription_id,
+                                                           base_url=self._cloud_environment.endpoints.resource_manager)
             self._register('Microsoft.Network')
         return self._network_client
 
@@ -429,7 +431,9 @@ class AzureRM(object):
     def compute_client(self):
         self.log('Getting compute client')
         if not self._compute_client:
-            self._compute_client = ComputeManagementClient(self.azure_credentials, self.subscription_id, base_url=self._cloud_environment.endpoints.resource_manager)
+            self._compute_client = ComputeManagementClient(self.azure_credentials,
+                                                           self.subscription_id,
+                                                           base_url=self._cloud_environment.endpoints.resource_manager)
             self._register('Microsoft.Compute')
         return self._compute_client
 


### PR DESCRIPTION
##### SUMMARY
No idea if this is the right move, I don't know enough about Azure but this got the script to work for me with the latest SDK. The changes are taken from the azure module utils so I am hoping it can be translated across.

Related to https://github.com/ansible/ansible/issues/28909#issuecomment-326483892

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm

##### ANSIBLE VERSION
```
ansible 2.4.0 (azure-inventory 1b4e6602cf) last updated 2017/09/01 16:54:28 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/jborean/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jborean/dev/ansible/lib/ansible
  executable location = /Users/jborean/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Aug  4 2017, 13:45:28) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```