### PR TITLE
AWS lambda module - improved authentication error handling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -238,8 +238,13 @@ def get_current_function(connection, function_name, qualifier=None):
         if qualifier is not None:
             return connection.get_function(FunctionName=function_name, Qualifier=qualifier)
         return connection.get_function(FunctionName=function_name)
-    except ClientError:
-        return None
+    except ClientError as e:
+        try:
+            if e.response['Error']['Code'] == 'ResourceNotFoundException':
+                return None
+        except (KeyError, AttributeError):
+            pass
+        raise e
 
 
 def sha256sum(filename):


### PR DESCRIPTION
##### SUMMARY

In the case where the the user running Ansible does not have get permissions on the function, or some other ClientError happens whilst getting the function information, this now raises an exception instead of returning empty (None) function information 

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

lambda module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (mdd-lambda-getfunction-exception-fix 9d873483dc) last updated 2017/09/01 10:53:09 (GMT +100)
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION

Currently there's an error message but it looks like the function doesn't exist so it's potentially really confusing.  

This is in a function that doesn't have module passed to it.  Really lambda should be restructured so that this whole error handling is nicer, however given we are in freeze I am doing the minimal fix to make this work right.  
