### PR TITLE
Fix digital_ocean module_util api_token bug

### DIFF
--- a/lib/ansible/module_utils/digital_ocean.py
+++ b/lib/ansible/module_utils/digital_ocean.py
@@ -93,8 +93,8 @@ class DigitalOceanHelper:
 
     def get_do_oauth_token(self):
         try:
-            self.oauth_token = self.module.params['oauth_token'] or \
-                self.module.params['api_token'] or \
+            self.oauth_token = self.module.params.get('oauth_token') or \
+                self.module.params.get('api_token') or \
                 os.environ['DO_API_TOKEN'] or \
                 os.environ['DO_API_KEY'] or \
                 os.environ['OAUTH_TOKEN']

--- a/lib/ansible/module_utils/digital_ocean.py
+++ b/lib/ansible/module_utils/digital_ocean.py
@@ -92,11 +92,10 @@ class DigitalOceanHelper:
         return self.send('DELETE', path, data)
 
     def get_do_oauth_token(self):
-        try:
-            self.oauth_token = self.module.params.get('oauth_token') or \
-                self.module.params.get('api_token') or \
-                os.environ.get('DO_API_TOKEN') or \
-                os.environ.get('DO_API_KEY') or \
-                os.environ.get('OAUTH_TOKEN')
-        except KeyError as e:
-            self.module.fail_json(msg='Unable to load %s' % e.message)
+        self.oauth_token = self.module.params.get('oauth_token') or \
+            self.module.params.get('api_token') or \
+            os.environ.get('DO_API_TOKEN') or \
+            os.environ.get('DO_API_KEY') or \
+            os.environ.get('OAUTH_TOKEN')
+        if self.oauth_token is None:
+            self.module.fail_json(msg='Unable to load api key: oauth_token')

--- a/lib/ansible/module_utils/digital_ocean.py
+++ b/lib/ansible/module_utils/digital_ocean.py
@@ -95,8 +95,8 @@ class DigitalOceanHelper:
         try:
             self.oauth_token = self.module.params.get('oauth_token') or \
                 self.module.params.get('api_token') or \
-                os.environ['DO_API_TOKEN'] or \
-                os.environ['DO_API_KEY'] or \
-                os.environ['OAUTH_TOKEN']
+                os.environ.get('DO_API_TOKEN') or \
+                os.environ.get('DO_API_KEY') or \
+                os.environ.get('OAUTH_TOKEN')
         except KeyError as e:
             self.module.fail_json(msg='Unable to load %s' % e.message)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update the self.module.params to a get('key') to prevent an exception when the param cannot be found.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_util/digital_ocean.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel ae6d27fa29) last updated 2017/09/01 08:43:30 (GMT -400)
  config file = /Users/devMac/ansible.cfg
  configured module search path = [u'/Users/devMac/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/devMac/Development/github/ansible/lib/ansible
  executable location = /Users/devMac/Development/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```
This PR addresses issue: #28923 