### PR TITLE
BOTMETA: Add setup for test, docs and packaging labels

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1075,6 +1075,14 @@ files:
   test/sanity/validate-modules:
     keywords:
     - validate-modules
+  test/:
+    labels: test_pull_requests
+  docs/:
+    labels: docs_pull_request
+    notify:
+      - dharmabumstead
+  packaging/:
+    labels: packaging
 macros:
   module_utils: lib/ansible/module_utils
   modules: lib/ansible/modules


### PR DESCRIPTION
##### SUMMARY

[`test_pull_requests` label](https://meetbot-raw.fedoraproject.org/ansible-meeting/2017-08-31/testing_working_group.2017-08-31-17.04.log.html#l-198) should automatically be added by Ansibot to tests related pull requests but it isn't (for example: https://github.com/ansible/ansible/pull/28775).

Since https://github.com/ansible/ansibullbot/commit/f9e1325521d2ec2a47ed7cf844ff2c2177d40bb4, [BOTMETA.yml](https://github.com/ansible/ansible/blob/devel/.github/BOTMETA.yml) is used instead of `FILEMAP.json`. `docs/`, `packaging/` and `tests/` entries were present in `FILEMAP.json` but are missing in `BOTMETA.yml`, then `docs_pull_request`, `packaging` and ̀test_pull_requests` aren't added by the bot.

This pull requests adds `docs/`, `packaging/` and `tests/` entries to `BOTMETA.yml`.

__I am not sure about the `notify` value of `docs/` entry.__

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml