### PR TITLE
ec2_group: Handle name conflict with empty vpc_id

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -655,12 +655,10 @@ def main():
         else:
             groups[groupName] = sg
 
-        if group_id:
-            if sg['GroupId'] == group_id:
-                group = sg
-        else:
-            if groupName == name and sg.get('VpcId') == vpc_id:
-                group = sg
+        if group_id and sg['GroupId'] == group_id:
+            group = sg
+        elif groupName == name and (vpc_id is None or sg['VpcId'] == vpc_id):
+            group = sg
 
     # Ensure requested group is absent
     if state == 'absent':

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -633,7 +633,7 @@ def main():
         groupName = sg['GroupName']
         if groupName in groups:
             # Prioritise groups from the current VPC
-            if vpc_id is None or sg['VpcId'] == vpc_id:
+            if sg['VpcId'] == vpc_id:
                 groups[groupName] = sg
         else:
             groups[groupName] = sg
@@ -642,7 +642,7 @@ def main():
             if sg['GroupId'] == group_id:
                 group = sg
         else:
-            if groupName == name and (vpc_id is None or sg['VpcId'] == vpc_id):
+            if groupName == name and sg['VpcId'] == vpc_id:
                 group = sg
 
     # Ensure requested group is absent
@@ -831,8 +831,8 @@ def main():
                     # If rule already exists, don't later delete it
                     changed, ip_permission = authorize_ip("out", changed, client, group, groupRules, ipv6,
                                                           ip_permission, module, rule, "ipv6")
-        else:
-            # when no egress rules are specified,
+        elif vpc_id is not None:
+            # when no egress rules are specified and we're in a VPC,
             # we add in a default allow all out rule, which was the
             # default behavior before egress rules were added
             default_egress_rule = 'out--1-None-None-' + group['GroupId'] + '-0.0.0.0/0'
@@ -856,7 +856,7 @@ def main():
                 del groupRules[default_egress_rule]
 
         # Finally, remove anything left in the groupRules -- these will be defunct rules
-        if purge_rules_egress:
+        if purge_rules_egress and vpc_id is not None:
             for (rule, grant) in groupRules.values():
                 # we shouldn't be revoking 0.0.0.0 egress
                 if grant != '0.0.0.0/0':

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -693,7 +693,7 @@ def main():
                 # amazon sometimes takes a couple seconds to update the security group so wait till it exists
                 while True:
                     group = get_security_groups_with_backoff(client, GroupIds=[group['GroupId']])['SecurityGroups'][0]
-                    if vpc_id and not group.get('IpPermissionsEgress'):
+                    if group.get('VpcId') and not group.get('IpPermissionsEgress'):
                         pass
                     else:
                         break

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -641,7 +641,16 @@ def main():
         groupName = sg['GroupName']
         if groupName in groups:
             # Prioritise groups from the current VPC
-            if sg['VpcId'] == vpc_id:
+            # even if current VPC is EC2-Classic
+            if groups[groupName].get('VpcId') == vpc_id:
+                # Group saved already matches current VPC, change nothing
+                pass
+            elif vpc_id is None and groups[groupName].get('VpcId') is None:
+                # We're in EC2 classic, and the group already saved is as well
+                # No VPC groups can be used alongside EC2 classic groups
+                pass
+            else:
+                # the current SG stored has no direct match, so we can replace it
                 groups[groupName] = sg
         else:
             groups[groupName] = sg

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -642,7 +642,7 @@ def main():
             if sg['GroupId'] == group_id:
                 group = sg
         else:
-            if groupName == name and sg['VpcId'] == vpc_id:
+            if groupName == name and sg.get('VpcId') == vpc_id:
                 group = sg
 
     # Ensure requested group is absent
@@ -685,7 +685,7 @@ def main():
                 # amazon sometimes takes a couple seconds to update the security group so wait till it exists
                 while True:
                     group = get_security_groups_with_backoff(client, GroupIds=[group['GroupId']])['SecurityGroups'][0]
-                    if not group['IpPermissionsEgress']:
+                    if vpc_id and not group.get('IpPermissionsEgress'):
                         pass
                     else:
                         break


### PR DESCRIPTION
If several groups exist with the same name (and vpc_id is None) then
treat the group outside the vpc as preferred (same as it would for a vpc
group with vpc_id specified). Also don't run the egress rules code in
that case.

##### SUMMARY
Copied from #25702:
If several groups exist with the same name (and vpc_id is None) then treat the group outside the vpc as preferred (same as it would for a vpc group with vpc_id specified). Also don't run the egress rules code in that case.

Possible errors that could happen and have been fixed here:

Name conflict causing ec2_group trying to add a rule allowing a non-vpc group access to a vpc-group, or vice versa. Causes amazon to raise an error
Name conflict causing ec2_group to duplicate a rule that already exists, because it's comparing against the wrong group object. (amazon error is InvalidPermission.Duplicate)<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
2.4.0
```
