### PR TITLE
Add Check Mode to consul_kv

### DIFF
--- a/lib/ansible/modules/clustering/consul_kv.py
+++ b/lib/ansible/modules/clustering/consul_kv.py
@@ -304,7 +304,7 @@ def main():
             value=dict(type='str', default=NOT_SET),
             session=dict(type='str'),
         ),
-        supports_check_mode=False
+        supports_check_mode=True
     )
 
     test_dependencies(module)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The `consul_kv` module has the logic for supporting check mode, yet has it disabled. After reviewing the history of the module, I see no comments for the not supporting check mode and based on my review this is able to be supported.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

consul_kv
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.2.0
  config file = /home/marc/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May  4 2017, 08:55:18) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

@sgargan If there is a reason you see for this not to be enabled, please let me know. The modules are great, but for my uses for the KV module, I would hope that check mode could be enabled.