### PR TITLE
Split cloud tests into two CI groups.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -56,8 +56,11 @@ matrix:
     - env: TEST=linux/ubuntu1604/3
     - env: TEST=linux/ubuntu1604py3/3
 
-    - env: TEST=cloud/ubuntu1604
-    - env: TEST=cloud/ubuntu1604py3
+    - env: TEST=cloud/ubuntu1604/1
+    - env: TEST=cloud/ubuntu1604py3/1
+
+    - env: TEST=cloud/ubuntu1604/2
+    - env: TEST=cloud/ubuntu1604py3/2
 
 branches:
   except:

--- a/test/integration/targets/aws_api_gateway/aliases
+++ b/test/integration/targets/aws_api_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/aws_lambda/aliases
+++ b/test/integration/targets/aws_lambda/aliases
@@ -1,4 +1,4 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws
 execute_lambda
 lambda

--- a/test/integration/targets/azure_rm_availabilityset/aliases
+++ b/test/integration/targets/azure_rm_availabilityset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_availabilityset_facts/aliases
+++ b/test/integration/targets/azure_rm_availabilityset_facts/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_dnsrecordset/aliases
+++ b/test/integration/targets/azure_rm_dnsrecordset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_dnsrecordset_facts/aliases
+++ b/test/integration/targets/azure_rm_dnsrecordset_facts/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_dnszone/aliases
+++ b/test/integration/targets/azure_rm_dnszone/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_dnszone_facts/aliases
+++ b/test/integration/targets/azure_rm_dnszone_facts/aliases
@@ -1,3 +1,4 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
+posix/ci/cloud/group2/smoketest
 destructive

--- a/test/integration/targets/azure_rm_managed_disk/aliases
+++ b/test/integration/targets/azure_rm_managed_disk/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_publicipaddress/aliases
+++ b/test/integration/targets/azure_rm_publicipaddress/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_storageaccount/aliases
+++ b/test/integration/targets/azure_rm_storageaccount/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_subnet/aliases
+++ b/test/integration/targets/azure_rm_subnet/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_virtualmachine_extension/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine_extension/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_virtualmachine_scaleset/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine_scaleset/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/azure_rm_virtualnetwork/aliases
+++ b/test/integration/targets/azure_rm_virtualnetwork/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/azure
+posix/ci/cloud/group2/azure
 destructive

--- a/test/integration/targets/cs_account/aliases
+++ b/test/integration/targets/cs_account/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_affinitygroup/aliases
+++ b/test/integration/targets/cs_affinitygroup/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_cluster/aliases
+++ b/test/integration/targets/cs_cluster/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_configuration/aliases
+++ b/test/integration/targets/cs_configuration/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_domain/aliases
+++ b/test/integration/targets/cs_domain/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_firewall/aliases
+++ b/test/integration/targets/cs_firewall/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_host/aliases
+++ b/test/integration/targets/cs_host/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_instance/aliases
+++ b/test/integration/targets/cs_instance/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_instance_facts/aliases
+++ b/test/integration/targets/cs_instance_facts/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_instance_nic/aliases
+++ b/test/integration/targets/cs_instance_nic/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_instance_nic_secondaryip/aliases
+++ b/test/integration/targets/cs_instance_nic_secondaryip/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_instancegroup/aliases
+++ b/test/integration/targets/cs_instancegroup/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_iso/aliases
+++ b/test/integration/targets/cs_iso/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_loadbalancer_rule/aliases
+++ b/test/integration/targets/cs_loadbalancer_rule/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_network_acl/aliases
+++ b/test/integration/targets/cs_network_acl/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_network_acl_rule/aliases
+++ b/test/integration/targets/cs_network_acl_rule/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_pod/aliases
+++ b/test/integration/targets/cs_pod/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_portforward/aliases
+++ b/test/integration/targets/cs_portforward/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_project/aliases
+++ b/test/integration/targets/cs_project/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_region/aliases
+++ b/test/integration/targets/cs_region/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_resourcelimit/aliases
+++ b/test/integration/targets/cs_resourcelimit/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_role/aliases
+++ b/test/integration/targets/cs_role/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_router/aliases
+++ b/test/integration/targets/cs_router/aliases
@@ -1,3 +1,3 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs
 destructive

--- a/test/integration/targets/cs_securitygroup/aliases
+++ b/test/integration/targets/cs_securitygroup/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_securitygroup_rule/aliases
+++ b/test/integration/targets/cs_securitygroup_rule/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_sshkeypair/aliases
+++ b/test/integration/targets/cs_sshkeypair/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_storage_pool/aliases
+++ b/test/integration/targets/cs_storage_pool/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_user/aliases
+++ b/test/integration/targets/cs_user/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_vmsnapshot/aliases
+++ b/test/integration/targets/cs_vmsnapshot/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_volume/aliases
+++ b/test/integration/targets/cs_volume/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_vpc/aliases
+++ b/test/integration/targets/cs_vpc/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_vpn_gateway/aliases
+++ b/test/integration/targets/cs_vpn_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_zone/aliases
+++ b/test/integration/targets/cs_zone/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_zone_facts/aliases
+++ b/test/integration/targets/cs_zone_facts/aliases
@@ -1,2 +1,2 @@
 cloud/cs
-posix/ci/cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/ec2_ami/aliases
+++ b/test/integration/targets/ec2_ami/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/ec2_group/aliases
+++ b/test/integration/targets/ec2_group/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/ec2_key/aliases
+++ b/test/integration/targets/ec2_key/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws
 skip/python3

--- a/test/integration/targets/ec2_metadata_facts/aliases
+++ b/test/integration/targets/ec2_metadata_facts/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/aws
-posix/ci/cloud/smoketest
+posix/ci/cloud/group1/aws
+posix/ci/cloud/group1/smoketest

--- a/test/integration/targets/ec2_tag/aliases
+++ b/test/integration/targets/ec2_tag/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/ec2_vol/aliases
+++ b/test/integration/targets/ec2_vol/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/ec2_vpc/aliases
+++ b/test/integration/targets/ec2_vpc/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/ecs_ecr/aliases
+++ b/test/integration/targets/ecs_ecr/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/elb_classic_lb/aliases
+++ b/test/integration/targets/elb_classic_lb/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/lambda_policy/aliases
+++ b/test/integration/targets/lambda_policy/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/rds_param_group/aliases
+++ b/test/integration/targets/rds_param_group/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/aws
+posix/ci/cloud/group1/aws

--- a/test/integration/targets/vcenter_license/aliases
+++ b/test/integration/targets/vcenter_license/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_cluster/aliases
+++ b/test/integration/targets/vmware_cluster/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_datacenter/aliases
+++ b/test/integration/targets/vmware_datacenter/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_dvswitch/aliases
+++ b/test/integration/targets/vmware_dvswitch/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_guest/aliases
+++ b/test/integration/targets/vmware_guest/aliases
@@ -1,4 +1,4 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_facts/aliases
+++ b/test/integration/targets/vmware_guest_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_guest_find/aliases
+++ b/test/integration/targets/vmware_guest_find/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_guest_tools_wait/aliases
+++ b/test/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_host/aliases
+++ b/test/integration/targets/vmware_host/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_resource_pool/aliases
+++ b/test/integration/targets/vmware_resource_pool/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_vm_facts/aliases
+++ b/test/integration/targets/vmware_vm_facts/aliases
@@ -1,4 +1,4 @@
-posix/ci/cloud/vcenter
-posix/ci/cloud/smoketest
+posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group1/smoketest
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -6,8 +6,8 @@ declare -a args
 IFS='/:' read -ra args <<< "${TEST}"
 
 image="ansible/ansible:${args[1]}"
-target="posix/ci/cloud/"
+target="posix/ci/cloud/group${args[2]}/"
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-    --changed-all-target 'posix/ci/cloud/smoketest/'
+    --changed-all-target "${target}smoketest/"


### PR DESCRIPTION
##### SUMMARY

Split cloud tests into two CI groups.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Integration Tests

##### ANSIBLE VERSION

```
ansible 2.4.0 (cloud-groups 7aedd4af46) last updated 2017/09/01 16:47:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
