### PR TITLE
Pass the remote_tmp_path from controller-side to module side

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -811,7 +811,7 @@ class AnsibleModule(object):
         self.aliases = {}
         self._legal_inputs = ['_ansible_check_mode', '_ansible_no_log', '_ansible_debug', '_ansible_diff', '_ansible_verbosity',
                               '_ansible_selinux_special_fs', '_ansible_module_name', '_ansible_version', '_ansible_syslog_facility',
-                              '_ansible_socket']
+                              '_ansible_socket', '_ansible_remote_tmp']
         self._options_context = list()
 
         if add_file_common_args:
@@ -1612,6 +1612,10 @@ class AnsibleModule(object):
 
             elif k == '_ansible_socket':
                 self._socket_path = v
+
+            elif k == '_ansible_remote_tmp':
+                # Private because we're going to implement a better fix by setting the TMPDIR envvar in 2.5
+                self._remote_tmp_path = v
 
             elif check_invalid_arguments and k not in legal_inputs:
                 unsupported_parameters.add(k)

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -334,13 +334,12 @@ def get_submodule_update_params(module, git_path, cwd):
     return params
 
 
-def write_ssh_wrapper():
-    module_dir = get_module_path()
+def write_ssh_wrapper(tmp_path):
     try:
         # make sure we have full permission to the module_dir, which
         # may not be the case if we're sudo'ing to a non-root user
-        if os.access(module_dir, os.W_OK | os.R_OK | os.X_OK):
-            fd, wrapper_path = tempfile.mkstemp(prefix=module_dir + '/')
+        if os.access(tmp_path, os.W_OK | os.R_OK | os.X_OK):
+            fd, wrapper_path = tempfile.mkstemp(prefix=tmp_path + '/')
         else:
             raise OSError
     except (IOError, OSError):
@@ -1051,7 +1050,7 @@ def main():
     # create a wrapper script and export
     # GIT_SSH=<path> as an environment variable
     # for git to use the wrapper script
-    ssh_wrapper = write_ssh_wrapper()
+    ssh_wrapper = write_ssh_wrapper(module._remote_tmp_path)
     set_git_ssh(ssh_wrapper, key_file, ssh_opts)
     module.add_cleanup_file(path=ssh_wrapper)
 

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -607,6 +607,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
         # give the module the socket for persistent connections
         module_args['_ansible_socket'] = task_vars.get('ansible_socket')
 
+        # Let the module easily make use of the remote_tmp directory
+        module_args['_ansible_remote_tmp'] = self._play_context.remote_tmp_dir
+
     def _execute_module(self, module_name=None, module_args=None, tmp=None, task_vars=None, persist_files=False, delete_remote_tmp=True, wrap_async=False):
         '''
         Transfer and run a module along with its arguments.


### PR DESCRIPTION
Change git to write its ssh wrapper to the remote_tmp_path

Fixes #27699

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/git.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4, 2.3
```


##### ADDITIONAL INFORMATION
For 2.5 we hope to have a better fix that sets TMPDIR when the module is executed.  That will change the location that all tempfile.* functions use to be the module's temp directory.