### PR TITLE
Fix typo in dev_guide (s/certfied/certified/)

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -121,7 +121,7 @@ Fields
 
    * core
    * network
-   * certfied
+   * certified
    * community
    * curated (Deprecated.  Modules in this category should probably be core or
      certified instead)


### PR DESCRIPTION
##### SUMMARY
Fix a typo: s/certfied/certified/

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
dev_guide

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 13b2bedae6) last updated 2017/09/02 13:05:43 (GMT +200)
```