### PR TITLE
Allow creating AnsibleModule from DOCUMENTATION

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -234,6 +234,11 @@ The following fields can be used and are all required unless specified otherwise
     This is a string, and not a float, i.e. ``version_added: "2.3"``.
   :suboptions:
     If this option takes a dict, you can define it here. See `azure_rm_securitygroup`, `os_ironic_node` for examples.
+  :no_log:
+    If this option is unsafe to be included in logs, this field should be set to true.
+  :removed_in_version:
+    If an option is deprecated, this can be provided to indicated the version in which it is expected to be removed.
+    This is a string, and not a float, i.e. ``removed_in_version: "2.7"``.
 :requirements:
   List of requirements, and minimum versions (if applicable)
 :notes:

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -83,6 +83,9 @@ Options
     <td>{% if v['choices'] -%}<ul>{% for choice in v.get('choices',[]) -%}<li>@{ choice }@</li>{% endfor -%}</ul>{% endif -%}</td>
 {% endif %}
     <td>
+{% if v.get('removed_in_version') %}
+        <div>DEPRECATED. Scheduled for removal in @{ v.removed_in_version }@</div>
+{% endif %}
 {% if v.description is string %}
         <div>@{ v.description | replace('\n', '\n    ') | html_ify }@</div>
 {% else %}
@@ -92,6 +95,9 @@ Options
 {% endif %}
 {% if 'aliases' in v and v.aliases %}
         </br><div style="font-size: small;">aliases: @{ v.aliases|join(', ') }@</div>
+{% endif %}
+{% if v.get('no_log', False) %}
+        </br><div>Contents will not be logged</div>
 {% endif %}
 {% else %}
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -312,12 +312,21 @@ class DocCLI(CLI):
 
             text.append("%s %s" % (opt_leadin, o))
 
+            if 'removed_in_version' in opt:
+                text.append(textwrap.fill(CLI.tty_ify('DEPRECATED. Scheduled for removal in %s' % opt['removed_in_version']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
+                del opt['removed_in_version']
+
             if isinstance(opt['description'], list):
                 for entry in opt['description']:
                     text.append(textwrap.fill(CLI.tty_ify(entry), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
             else:
                 text.append(textwrap.fill(CLI.tty_ify(opt['description']), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
             del opt['description']
+
+            no_log = opt.pop('no_log', False)
+            if not isinstance(required, bool):
+                raise AnsibleError("Incorrect value for 'no_log', a boolean is needed.: %s" % no_log)
+            text.append(textwrap.fill(CLI.tty_ify('* Will not be included in logs'), limit, initial_indent=opt_indent, subsequent_indent=opt_indent))
 
             aliases = ''
             if 'aliases' in opt:

--- a/lib/ansible/parsing/plugin_docs.py
+++ b/lib/ansible/parsing/plugin_docs.py
@@ -43,62 +43,71 @@ def read_docstring(filename, verbose=True, ignore_errors=True):
         'metadata': None
     }
 
+    try:
+        b_module_data = open(filename, 'rb').read()
+        data = _read_docstring(b_module_data, data, filename)
+    except:
+        if verbose:
+            display.error("unable to parse %s" % filename)
+        if not ignore_errors:
+            raise
+
+    return data
+
+
+def _read_docstring(b_module_data, data, filename):
+    # Separate function so that we can call it with already-ready module data
+    # from the executor.
+
     string_to_vars = {
         'DOCUMENTATION': 'doc',
         'EXAMPLES': 'plainexamples',
         'RETURN': 'returndocs',
     }
 
+    M = ast.parse(b_module_data)
     try:
-        b_module_data = open(filename, 'rb').read()
-        M = ast.parse(b_module_data)
-        try:
-            display.debug('Attempt first docstring is yaml docs')
-            docstring = yaml.load(M.body[0].value.s)
-            for string in string_to_vars.keys():
-                if string in docstring:
-                    data[string_to_vars[string]] = docstring[string]
-                display.debug('assigned :%s' % string_to_vars[string])
-        except Exception as e:
-            display.debug('failed docstring parsing: %s' % str(e))
+        display.debug('Attempt first docstring is yaml docs')
+        docstring = yaml.load(M.body[0].value.s)
+        for string in string_to_vars.keys():
+            if string in docstring:
+                data[string_to_vars[string]] = docstring[string]
+            display.debug('assigned :%s' % string_to_vars[string])
+    except Exception as e:
+        display.debug('failed docstring parsing: %s' % str(e))
 
-        if 'docs' not in data or not data['docs']:
-            display.debug('Fallback to vars parsing')
-            for child in M.body:
-                if isinstance(child, ast.Assign):
-                    for t in child.targets:
-                        try:
-                            theid = t.id
-                        except AttributeError:
-                            # skip errors can happen when trying to use the normal code
-                            display.warning("Failed to assign id for %s on %s, skipping" % (t, filename))
-                            continue
+    if 'docs' not in data or not data['docs']:
+        display.debug('Fallback to vars parsing')
+        for child in M.body:
+            if isinstance(child, ast.Assign):
+                for t in child.targets:
+                    try:
+                        theid = t.id
+                    except AttributeError:
+                        # skip errors can happen when trying to use the normal code
+                        display.warning("Failed to assign id for %s on %s, skipping" % (t, filename))
+                        continue
 
-                        if theid in string_to_vars:
-                            varkey = string_to_vars[theid]
-                            if isinstance(child.value, ast.Dict):
-                                data[varkey] = ast.literal_eval(child.value)
+                    if theid in string_to_vars:
+                        varkey = string_to_vars[theid]
+                        if isinstance(child.value, ast.Dict):
+                            data[varkey] = ast.literal_eval(child.value)
+                        else:
+                            if theid == 'DOCUMENTATION':
+                                # string should be yaml
+                                data[varkey] = AnsibleLoader(child.value.s, file_name=filename).get_single_data()
                             else:
-                                if theid == 'DOCUMENTATION':
-                                    # string should be yaml
-                                    data[varkey] = AnsibleLoader(child.value.s, file_name=filename).get_single_data()
-                                else:
-                                    # not yaml, should be a simple string
-                                    data[varkey] = child.value.s
-                            display.debug('assigned :%s' % varkey)
+                                # not yaml, should be a simple string
+                                data[varkey] = child.value.s
+                        display.debug('assigned :%s' % varkey)
 
-        # Metadata is per-file and a dict rather than per-plugin/function and yaml
-        data['metadata'] = extract_metadata(module_ast=M)[0]
+    # Metadata is per-file and a dict rather than per-plugin/function and yaml
+    data['metadata'] = extract_metadata(module_ast=M)[0]
 
-        # remove version
-        if data['metadata']:
-            for x in ('version', 'metadata_version'):
-                if x in data['metadata']:
-                    del data['metadata'][x]
-    except:
-        if verbose:
-            display.error("unable to parse %s" % filename)
-        if not ignore_errors:
-            raise
+    # remove version
+    if data['metadata']:
+        for x in ('version', 'metadata_version'):
+            if x in data['metadata']:
+                del data['metadata'][x]
 
     return data


### PR DESCRIPTION
##### SUMMARY

As a module author it is currently necessary to list all of the module's
arguments twice. Once in the DOCUMENTATION string and once in the
argument_spec argument to AnsibleModule. The data is essentially the
same, with the exception of the descriptions in the docs, and the no_log
parameter which isn't accounted for in the docs.

CI jobs exit now to ensure that modules have properly validated DOCUMENTATION.

Since the DOCUMENTATION is required and is required to be correctly
parsable yaml, it's not terribly hard to parse it server-side when we
read the module and then to send it in the json we send over the wire
with the parameters. Doing so invocation-side avoids needing yaml or the
AST parsing bits on the remote end.

Once it's passed over the wire, the AnsibleModule constructor can allow
argument_spec to be empty, and if so fill it in with the data passed
received. This is obviously optional, as breaking AnsibleModule
would be double-plus bad, so explicitly provided argument_spec wins over
a received argument spec.

The docsite generation tool and the ansible-doc command-line tool have
been updated to understand no_log and removed_in_version in the docs and
to emit text indicating the effects of both options.

As a next step we could add support for specifying:

  * mutually_exclusive
  * required_together
  * required_one_of
  * required_if
  * supports_check_mode

in the DOCUMENTATION and reading them back out in AnsibleModule. Those
items are currently not exposed in the documentation as it is, so even
just being able to document them would be a win.

add_file_common_args is already handled because documentation fragements
are processed by the doc parser. As long as a module that does
add_file_common_args=True lists extends_documentation_fragment: files
in its DOCUMENTATION section no special support is needed.

Once we add support to the DOCUMENTATION for the additional flags above,
there will no longer be things one can specify in AnsibleModule constructor
args that cannot be specified in a DOCUMENTATION block. It should be possible
for rich and complex modules to simply do:

  module = AnsibleModule()

and work properly if they have correct and well-formed DOCUMENTATION.

Finally, having a parsed version of the DOCUMENTATION available at
module execution time means it's possible to do parameter validation
before making remote connections at all. Doing that may be a terrible
idea though, so it's also left as a follow-up idea.

##### ISSUE TYPE
 - Feature Pull Request