### PR TITLE
Fix junos_netconf integration test provider param

### DIFF
--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -5,7 +5,6 @@
 - name: Setup
   junos_netconf:
     state: present
-    provider: "{{ cli }}"
   register: result
 
 
@@ -14,7 +13,6 @@
   junos_netconf:
     state: present
     netconf_port: 22
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -25,7 +23,6 @@
   junos_netconf:
     state: present
     netconf_port: 22
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -63,7 +60,6 @@
 - name: Set back netconf to default port
   junos_netconf:
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - name: Ensure we can communicate over netconf

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -5,13 +5,11 @@
 - name: Ensure netconf is enabled
   junos_netconf:
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - name: idempotent tests
   junos_netconf:
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -30,7 +28,6 @@
 - name: Disable netconf
   junos_netconf:
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -40,7 +37,6 @@
 - name: idempotent tests
   junos_netconf:
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -66,7 +62,6 @@
 - name: re-enable netconf
   junos_netconf:
     state: present
-    provider: "{{ cli }}"
   register: result
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
junos_netconf defaults to `cli` and is not required to metion explicilty. 
Remove provider value to avoid failure in dci.
 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
