### PR TITLE
Use 'test' label only for test related pull request

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -28,7 +28,8 @@
 #           deprecated - this file is deprecated but probably not yet renamed
 #           keywords - used to identify this file based on the issue description
 #           support - used for files without internal metadata
-#           labels - list of GitHub labels to apply
+#           labels - list of GitHub labels to apply. Path components of 'file' parent key
+#                    which are valid GitHub labels are automatically added.
 #
 
 automerge: False
@@ -1076,13 +1077,13 @@ files:
     keywords:
     - validate-modules
   test/:
-    labels: test_pull_requests
+    # 'test' automatically added to labels
   docs/:
     labels: docs_pull_request
     notify:
       - dharmabumstead
   packaging/:
-    labels: packaging
+    # 'packaging' automatically added to labels
 macros:
   module_utils: lib/ansible/module_utils
   modules: lib/ansible/modules


### PR DESCRIPTION
##### SUMMARY
Since 3334407c71e21d378df424c2459a5403954bbd7b/#28926, test related pull requests are labeled with both `test` and `test_pull_requests`. This pull request removes the `test_pull_requests` label.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel 13b2bedae6) last updated 2017/09/02 13:05:43 (GMT +200)
```