### PR TITLE
digital_ocean_sshkey doc refinement and removal of unused import

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_sshkey.py
@@ -59,12 +59,15 @@ requirements:
 EXAMPLES = '''
 - name: "Create ssh key"
   digital_ocean_sshkey:
+    oauth_token: "{{ oauth_token }}"
     name: "My SSH Public Key"
-    public_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example"
+    ssh_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example"
+    state: present
   register: result
 
 - name: "Delete ssh key"
   digital_ocean_sshkey:
+    oauth_token: "{{ oauth_token }}"
     state: "absent"
     fingerprint: "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa"
 '''
@@ -87,7 +90,6 @@ data:
 '''
 
 import json
-import os
 import hashlib
 import base64
 


### PR DESCRIPTION
ISSUE TYPE

Fixes #28959 

Documentation Report
COMPONENT NAME

digital_ocean_sshkey.py

ANSIBLE VERSION

ansible 2.4.0 (bugfix/28923 6b1f532c03) last updated 2017/09/01 23:20:46 (GMT -400)
  config file = /Users/devMac/ansible.cfg
  configured module search path = [u'/Users/devMac/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/devMac/Development/github/ansible/lib/ansible
  executable location = /Users/devMac/Development/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
CONFIGURATION

Turned off retry files

OS / ENVIRONMENT

macOS 10.11.6

SUMMARY

Updated module doc examples to include api token along with removal of unused import