### PR TITLE
Avoid calling maintenace or detach on destroy storage domain.

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -350,6 +350,10 @@ class StorageDomainModule(BaseModule):
             )
 
     def pre_remove(self, storage_domain):
+        # In case the user chose to destroy the storage domain there is no need to
+        # move it to maintenance or detach it, it should simply be removed from the DB.
+        if self._module.params['destroy']:
+            return
         # Before removing storage domain we need to put it into maintenance state:
         self._maintenance(storage_domain)
 


### PR DESCRIPTION
As part of the absent state of ovirt_storage_domains module,
the pre_remove method tries to move the stoage domain to
maintenance and detach it.

In case a destroy of a storage domain is being called there is no need
for those operations since the destroy might be merely a DB operation.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`ovirt_storage_domains.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

