### PR TITLE
iam.py: return iam.role dict when creating roles

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam.py
+++ b/lib/ansible/modules/cloud/amazon/iam.py
@@ -160,6 +160,31 @@ task:
           Service: lambda.amazonaws.com
 
 '''
+RETURN = '''
+role_result:
+    description: the IAM.role dict returned by Boto
+    type: string
+    returned: if iam_type=role and state=present
+    sample: {
+                "arn": "arn:aws:iam::A1B2C3D4E5F6:role/my-new-role",
+                "assume_role_policy_document": "...truncated...",
+                "create_date": "2017-09-02T14:32:23Z",
+                "path": "/",
+                "role_id": "AROAA1B2C3D4E5F6G7H8I",
+                "role_name": "my-new-role"
+            }
+roles:
+    description: a list containing the name of the currently defined roles
+    type: list
+    returned: if iam_type=role and state=present
+    sample: [
+        "my-new-role",
+        "my-existing-role-1",
+        "my-existing-role-2",
+        "my-existing-role-3",
+        "my-existing-role-...",
+    ]
+'''
 
 import json
 import itertools
@@ -536,7 +561,7 @@ def create_role(module, iam, name, path, role_list, prof_list, trust_policy_doc)
             changed = True
             iam_role_result = iam.create_role(name,
                 assume_role_policy_document=trust_policy_doc,
-                path=path).create_role_response.create_role_result.role.role_name
+                path=path).create_role_response.create_role_result.role
 
             if name not in prof_list:
                 instance_profile_result = iam.create_instance_profile(name,
@@ -548,6 +573,7 @@ def create_role(module, iam, name, path, role_list, prof_list, trust_policy_doc)
         module.fail_json(changed=changed, msg=str(err))
     else:
         updated_role_list = list_all_roles(iam)
+        iam_role_result = iam.get_role(name).get_role_response.get_role_result.role
     return changed, updated_role_list, iam_role_result, instance_profile_result
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I couldn't find an easy way to retrieve the 'role_id' associated to a given AWS IAM role.

The 'iam_role' module returns the 'role_id' but providing 'assume_role_policy_document' is mandatory, which is cumbersome when you just need to fetch the 'role_id' of a existing role.

Example use case where the 'role_id' is required: [restrict access to S3 Buckets to specific IAM roles](https://aws.amazon.com/blogs/security/how-to-restrict-amazon-s3-bucket-access-to-a-specific-iam-role/)


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/amazon/iam.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.2.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before this patch
    "role_result": "role_name": "my-new-role"

After this patch
    "role_result": {
        "arn": "arn:aws:iam::A1B2C3D4E5F6:role/my-new-role",
        "assume_role_policy_document": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D",
        "create_date": "2017-09-02T14:32:23Z",
        "path": "/",
        "role_id": "AROAA1B2C3D4E5F6G7H8I",
        "role_name": "my-new-role"
    }, 
```
