### PR TITLE
Docs: Fix exported SSL_CERT_FILE variable

### DIFF
--- a/docs/docsite/rst/guide_gce.rst
+++ b/docs/docsite/rst/guide_gce.rst
@@ -168,7 +168,7 @@ For the following use case, let's use this small shell script as a wrapper.
     exit 1
   fi
 
-  export SSL_CERT_FILE=$(pwd)/cacert.cer
+  export SSL_CERT_FILE=$(pwd)/cacert.pem
   export ANSIBLE_HOST_KEY_CHECKING=False
 
   if [[ ! -f "$SSL_CERT_FILE" ]]; then


### PR DESCRIPTION
##### SUMMARY
The variable was pointing to a file with a `.cer` extension but the curl command downloads a `.pem` file which makes executions of the bash script fail

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Google Container Engine Docs