### PR TITLE
s3_sync: add encoding

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -448,7 +448,7 @@ def upload_files(s3, bucket, filelist, params):
         args = {
             'ContentType': entry['mime_type']
         }
-        if 'encoding' in entry:
+        if 'encoding' in entry and entry['encoding'] is not None:
             args['ContentEncoding'] = entry['encoding']
         if params.get('permission'):
             args['ACL'] = params['permission']

--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -448,6 +448,8 @@ def upload_files(s3, bucket, filelist, params):
         args = {
             'ContentType': entry['mime_type']
         }
+        if 'encoding' in entry:
+            args['ContentEncoding'] = entry['encoding']
         if params.get('permission'):
             args['ACL'] = params['permission']
         if params.get('cache_control'):


### PR DESCRIPTION
##### SUMMARY
The module knows about the encoding of files but doesn't use it when uploading to s3.
```python
retentry['mime_type'], retentry['encoding'] = mimetypes.guess_type(localfile, strict=False)
```
When file encoding is defined I've added it to the ExtraArgs of s3.upload_file.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
s3_sync

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
