### PR TITLE
Use pip list output for package verification

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -544,9 +544,7 @@ def main():
                         break
             module.exit_json(changed=changed, cmd=pkg_cmd, stdout=out, stderr=err)
 
-        out_freeze_before = None
-        if requirements or has_vcs:
-            _, out_freeze_before, _ = _get_packages(module, pip, chdir)
+        _, out_freeze_before, _ = _get_packages(module, pip, chdir)
 
         rc, out_pip, err_pip = module.run_command(cmd, path_prefix=path_prefix, cwd=chdir)
         out += out_pip
@@ -560,11 +558,8 @@ def main():
         if state == 'absent':
             changed = 'Successfully uninstalled' in out_pip
         else:
-            if out_freeze_before is None:
-                changed = 'Successfully installed' in out_pip
-            else:
-                _, out_freeze_after, _ = _get_packages(module, pip, chdir)
-                changed = out_freeze_before != out_freeze_after
+            _, out_freeze_after, _ = _get_packages(module, pip, chdir)
+            changed = out_freeze_before != out_freeze_after
 
         module.exit_json(changed=changed, cmd=cmd, name=name, version=version,
                          state=state, requirements=requirements, virtualenv=env,

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -166,3 +166,22 @@
   assert:
     that:
       - "not q_check_mode.changed"
+
+# Any package which is higher than standard lib reports changed state
+- name: ensure tarsnapper package is not installed (precondition setup)
+  pip: name=tarsnapper state=absent
+
+- name: check for tarsnapper package
+  pip: name=tarsnapper state=present
+
+- name: check for tarsnapper package
+  pip: name=tarsnapper state=present
+  register: tarsnapper_result
+
+- name: make sure tarsnapper package doesn't report changed
+  assert:
+    that:
+      - "not tarsnapper_result.changed"
+
+- name: Cleanup
+  pip: name=tarsnapper state=absent


### PR DESCRIPTION
##### SUMMARY
This fix adds logic to verify package installation on
`pip list` output instead of `pip install` stdandard output.
`pip install` output differs if package version is higher than
the standard Python library package version.

Fixes: #28952

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/language/pip.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4devel
```