### PR TITLE
Add --convert-type flag for use with --extra-vars (#23485)

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -430,8 +430,10 @@ class CLI(with_metaclass(ABCMeta, object)):
                               help="prepend colon-separated path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
                               action="callback", callback=CLI.unfrack_paths, type='str')
         if runtask_opts:
-            parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
-                              help="set additional variables as key=value or YAML/JSON, if filename prepend with @", default=[])
+            parser.add_option('-e', '--extra-vars', dest='extra_vars', action='append',
+                              help='set additional variables as key=value or YAML/JSON, if filename prepend with @', default=[])
+            parser.add_option('--convert-type', dest='convert_type', action='store_true',
+                              help='convert bool, int, and float value strings to their respective types')
 
         if fork_opts:
             parser.add_option('-f', '--forks', dest='forks', default=C.DEFAULT_FORKS, type='int',

--- a/test/integration/targets/parsing/roles/test_bad_parsing/tasks/main.yml
+++ b/test/integration/targets/parsing/roles/test_bad_parsing/tasks/main.yml
@@ -58,3 +58,7 @@
 - assert:
     that:
      - filter_fail|failed
+
+- name: include test that strs are not type-converted without --convert-type
+  include: scenario6.yml
+  tags: scenario6

--- a/test/integration/targets/parsing/roles/test_bad_parsing/tasks/scenario6.yml
+++ b/test/integration/targets/parsing/roles/test_bad_parsing/tasks/scenario6.yml
@@ -1,0 +1,32 @@
+---
+#
+# Ref. https://github.com/ansible/ansible/issues/23485 for type-conv tests
+# Ensure that types are NOT converted successfully without --convert-type flag
+#
+- name: test str2bool non-conversion from extra-vars in single-token conditional
+  shell: echo 'single-token success'
+  register: result
+  when: not str2bool_test
+  ignore_errors: yes
+
+- name: assert that single-token conditional was parsed correctly
+  assert:
+    that:
+      - result | skipped
+
+- name: test str2bool non-conversion from extra-vars in multi-token conditional
+  shell: echo 'multi-token success'
+  register: result
+  when: not (str2bool_test and True)
+  ignore_errors: yes
+
+- name: assert that multi-token conditional was parsed correctly
+  assert:
+    that:
+      - result | skipped
+
+- name: test str2int and str2float non-conversion from extra-vars
+  assert:
+    that:
+      - str2int_test != 3
+      - str2float_test != 3.14

--- a/test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
+++ b/test/integration/targets/parsing/roles/test_good_parsing/tasks/main.yml
@@ -202,3 +202,31 @@
       - should_not_omit_1 is defined
       - should_not_omit_2 is defined
       - should_not_omit_3 == "__omit_place_holder__afb6b9bc3d20bfeaa00a1b23a5930f89"
+
+# Ref. https://github.com/ansible/ansible/issues/23485 for type-conv tests
+# Ensure that types are converted successfully using --convert-type flag
+- name: test str2bool conversion from extra-vars in single-token conditional
+  shell: echo 'single-token success'
+  register: result
+  when: not str2bool_test
+ 
+- name: assert that single-token conditional was parsed correctly
+  assert:
+    that:
+      - result.stdout == 'single-token success'
+
+- name: test str2bool conversion from extra-vars in multi-token conditional
+  shell: echo 'multi-token success'
+  register: result
+  when: not (str2bool_test and True)
+
+- name: assert that multi-token conditional was parsed correctly
+  assert:
+    that:
+      - result.stdout == 'multi-token success'
+
+- name: test str2int and str2float conversion from extra-vars
+  assert:
+    that:
+      - str2int_test == 3
+      - str2float_test == 3.14

--- a/test/integration/targets/parsing/runme.sh
+++ b/test/integration/targets/parsing/runme.sh
@@ -2,5 +2,5 @@
 
 set -eux
 
-ansible-playbook bad_parsing.yml  -i ../../inventory -vvv "$@" --tags prepare,common,scenario5
-ansible-playbook good_parsing.yml -i ../../inventory -v "$@"
+ansible-playbook bad_parsing.yml  -i ../../inventory -vvv "$@" --tags prepare,common,scenario5,scenario6 --extra-vars='str2bool_test=False str2int_test=3 str2float_test=3.14'
+ansible-playbook good_parsing.yml -i ../../inventory -v "$@" --extra-vars='str2bool_test=False str2int_test=3 str2float_test=3.14' --convert-type


### PR DESCRIPTION
##### SUMMARY
Convert bool-ish string values to booleans in parsing/splitter.py (#23485)

The issue that this fixes can be summarized as follows. When a boolean value is passed in as an extra_var (e.g., `extra-vars='foo=False'`), the value `False` is parsed as a string. When used in a simple, single-token conditional (e.g, `when: foo`), it works as expected, thanks to some workaround code in `playbook/conditionals.py` (which I've left intact for now):

```
        try:
            # this allows for direct boolean assignments to conditionals "when: False"
            if isinstance(self.when, bool):
                return self.when

            for conditional in self.when:
                if not self._check_conditional(conditional, templar, all_vars):
                    return False
```

However, when used in a compound, multi-token conditional (e.g, `when: foo and True`), `foo` is interpreted as the string `u'False'` rather than the boolean `False`. A non-empty string is, of course, true. This breaks some conditional tests.

I've modified `parsing/splitter.py` to convert values to booleans at the time of parsing, if they match the set of booleans in `module_utils/parsing/convert_bool.py`:
```
BOOLEANS_TRUE = frozenset(('y', 'yes', 'on', '1', 'true', 't', 1, 1.0, True))
BOOLEANS_FALSE = frozenset(('n', 'no', 'off', '0', 'false', 'f', 0, 0.0, False))
BOOLEANS = BOOLEANS_TRUE.union(BOOLEANS_FALSE)
```

I added a couple of integration tests for good parsing. Let me know if you have ideas for bad parsing tests that this change would affect.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parsing/splitter.py

##### ANSIBLE VERSION
```
ansible 2.4.0 (issue/23485 b797705f17) last updated 2017/09/03 17:26:25 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 26 2017, 10:20:05) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
PLAYBOOK:
```
[reid@laptop ~/git]$ cat playbook.yml 
---
- hosts: localhost
  connection: local
  gather_facts: no
  tasks:
  - debug: msg='true'
    when: foo
  - debug: msg='true'
    when: foo and True
```
BEFORE:
```
[reid@laptop ~/git]$ ansible-playbook playbook.yml -i hosts.ini -e foo=false -v
Using /etc/ansible/ansible.cfg as config file

PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [debug] ******************************************************************************************************************************************************************************************************
skipping: [localhost] => {"skip_reason": "Conditional result was False"}

TASK [debug] ******************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "true"
}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   
```
AFTER:
```

[reid@laptop ~/git]$ ansible-playbook playbook.yml -i hosts.ini -e foo=false -v
Using /etc/ansible/ansible.cfg as config file

PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [debug] ******************************************************************************************************************************************************************************************************
skipping: [localhost] => {"skip_reason": "Conditional result was False"}

TASK [debug] ******************************************************************************************************************************************************************************************************
skipping: [localhost] => {"skip_reason": "Conditional result was False"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=0   
```
