### PR TITLE
Fix SID Lookup Issues on Assorted Windows Modules

### DIFF
--- a/lib/ansible/modules/windows/win_acl.ps1
+++ b/lib/ansible/modules/windows/win_acl.ps1
@@ -1,113 +1,43 @@
 #!powershell
-# This file is part of Ansible
-#
 # Copyright 2015, Phil Schwartz <schwartzmx@gmail.com>
 # Copyright 2015, Trond Hindenes
 # Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
- 
-# WANT_JSON
-# POWERSHELL_COMMON
- 
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#Requires -Module Ansible.ModuleUtils.SID.psm1
+
 # win_acl module (File/Resources Permission Additions/Removal)
- 
- 
+
 #Functions
-Function UserSearch
-{
-    Param ([string]$accountName)
-    #Check if there's a realm specified
+function Get-UserSID {
+    param(
+        [String]$AccountName
+    )
 
-    $searchDomain = $false
-    $searchDomainUPN = $false
-    $SearchAppPools = $false
-    if ($accountName.Split("\").count -gt 1)
-    {
-        if ($accountName.Split("\")[0] -eq $env:COMPUTERNAME)
-        {
+    $userSID = $null
+    $searchAppPools = $false
 
-        }
-        elseif ($accountName.Split("\")[0] -eq "IIS APPPOOL")
-        {
-            $SearchAppPools = $true
-            $accountName = $accountName.split("\")[1]
-        }
-        else
-        {
-            $searchDomain = $true
-            $accountName = $accountName.split("\")[1]
+    if ($AccountName.Split("\").Count -gt 1) {
+        if ($AccountName.Split("\")[0] -eq "IIS APPPOOL") {
+            $searchAppPools = $true
+            $AccountName = $AccountName.Split("\")[1]
         }
     }
-    Elseif ($accountName.contains("@"))
-    {
-        $searchDomain = $true
-        $searchDomainUPN = $true
-    }
-    Else
-    {
-        #Default to local user account
-        $accountName = $env:COMPUTERNAME + "\" + $accountName
-    }
 
-    if (($searchDomain -eq $false) -and ($SearchAppPools -eq $false))
-    {
-        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
-        $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $accountName}
-        if ($localaccount)
-        {
-            return $localaccount.SID
+    if ($searchAppPools) {
+        Import-Module -Name WebAdministration
+        $testIISPath = Test-Path -Path "IIS:"
+        if ($testIISPath) {
+            $appPoolObj = Get-ItemProperty -Path "IIS:\AppPools\$AccountName"
+            $userSID = $appPoolObj.applicationPoolSid
         }
     }
-    Elseif ($SearchAppPools -eq $true)
-    {
-        Import-Module WebAdministration
-        $testiispath = Test-path "IIS:"
-        if ($testiispath -eq $false)
-        {
-            return $null
-        }
-        else
-        {
-            $apppoolobj = Get-ItemProperty IIS:\AppPools\$accountName
-            return $apppoolobj.applicationPoolSid
-        }
+    else {
+        $userSID = Convert-ToSID -account_name $AccountName
     }
-    Else
-    {
-        #Search by samaccountname
-        $Searcher = [adsisearcher]""
 
-        If ($searchDomainUPN -eq $false) {
-            $Searcher.Filter = "sAMAccountName=$($accountName)"
-        }
-        Else {
-            $Searcher.Filter = "userPrincipalName=$($accountName)"
-        }
-
-        $result = $Searcher.FindOne() 
-        if ($result)
-        {
-            $user = $result.GetDirectoryEntry()
-
-            # get binary SID from AD account
-            $binarySID = $user.ObjectSid.Value
-
-            # convert to string SID
-            return (New-Object System.Security.Principal.SecurityIdentifier($binarySID,0)).Value
-        }
-    }
+    return $userSID
 }
 
 # Need to adjust token privs when executing Set-ACL in certain cases.
@@ -234,9 +164,8 @@ If (-Not (Test-Path -Path $path)) {
 }
 
 # Test that the user/group is resolvable on the local machine
-$sid = UserSearch -AccountName ($user)
-if (!$sid)
-{
+$sid = Get-UserSID -AccountName $user
+if (!$sid) {
     Fail-Json $result "$user is not a valid user or group on the host machine or domain"
 }
 
@@ -260,14 +189,14 @@ Try {
 
     $InheritanceFlag = [System.Security.AccessControl.InheritanceFlags]$inherit
     $PropagationFlag = [System.Security.AccessControl.PropagationFlags]$propagation
- 
+
     If ($type -eq "allow") {
         $objType =[System.Security.AccessControl.AccessControlType]::Allow
     }
     Else {
         $objType =[System.Security.AccessControl.AccessControlType]::Deny
     }
- 
+
     $objUser = New-Object System.Security.Principal.SecurityIdentifier($sid)
     If ($path -match "^HK(CC|CR|CU|LM|U):\\") {
         $objACE = New-Object System.Security.AccessControl.RegistryAccessRule ($objUser, $colRights, $InheritanceFlag, $PropagationFlag, $objType)
@@ -276,7 +205,7 @@ Try {
         $objACE = New-Object System.Security.AccessControl.FileSystemAccessRule ($objUser, $colRights, $InheritanceFlag, $PropagationFlag, $objType)
     }
     $objACL = Get-ACL $path
- 
+
     # Check if the ACE exists already in the objects ACL list
     $match = $false
 
@@ -300,7 +229,7 @@ Try {
                 Break
             }
         } else {
-            If (($rule.FileSystemRights -eq $objACE.FileSystemRights) -And ($rule.AccessControlType -eq $objACE.AccessControlType) -And ($ruleIdentity -eq $objACE.IdentityReference) -And ($rule.IsInherited -eq $objACE.IsInherited) -And ($rule.InheritanceFlags -eq $objACE.InheritanceFlags) -And ($rule.PropagationFlags -eq $objACE.PropagationFlags)) { 
+            If (($rule.FileSystemRights -eq $objACE.FileSystemRights) -And ($rule.AccessControlType -eq $objACE.AccessControlType) -And ($ruleIdentity -eq $objACE.IdentityReference) -And ($rule.IsInherited -eq $objACE.IsInherited) -And ($rule.InheritanceFlags -eq $objACE.InheritanceFlags) -And ($rule.PropagationFlags -eq $objACE.PropagationFlags)) {
                 $match = $true
                 Break
             }
@@ -335,11 +264,11 @@ Try {
         # A rule didn't exist that was trying to be removed
         Else {
             Exit-Json $result "the specified rule does not exist"
-        }       
+        }
     }
 }
 Catch {
     Fail-Json $result "an error occurred when attempting to $state $rights permission(s) on $path for $user - $($_.Exception.Message)"
 }
- 
+
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_acl.py
+++ b/lib/ansible/modules/windows/win_acl.py
@@ -1,27 +1,8 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
-
 # Copyright 2015, Phil Schwartz <schwartzmx@gmail.com>
 # Copyright 2015, Trond Hindenes
 # Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-# this is a windows documentation stub.  actual code lives in the .ps1
-# file of the same name
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/lib/ansible/modules/windows/win_owner.ps1
+++ b/lib/ansible/modules/windows/win_owner.ps1
@@ -5,16 +5,6 @@
 #Requires -Module Ansible.ModuleUtils.Legacy.psm1
 #Requires -Module Ansible.ModuleUtils.SID.psm1
 
-#Functions
-function Get-UserSID {
-    param(
-        [String]$AccountName
-    )
-
-    $userSID = Convert-ToSID -account_name $AccountName
-    return $userSID
-}
-
 $result = @{
     changed = $false
 }
@@ -31,7 +21,7 @@ If (-Not (Test-Path -Path $path)) {
 }
 
 # Test that the user/group is resolvable on the local machine
-$sid = Get-UserSID -AccountName $user
+$sid = Convert-ToSID -account_name $user
 if (!$sid) {
     Fail-Json $result "$user is not a valid user or group on the host machine or domain"
 }

--- a/lib/ansible/modules/windows/win_owner.py
+++ b/lib/ansible/modules/windows/win_owner.py
@@ -1,25 +1,6 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
-
 # Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-# this is a windows documentation stub.  actual code lives in the .ps1
-# file of the same name
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -1,87 +1,21 @@
 #!powershell
-# This file is part of Ansible
-
 # Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# WANT_JSON
-# POWERSHELL_COMMON
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#Requires -Module Ansible.ModuleUtils.SID.psm1
 
 #Functions
-Function UserSearch
-{
-    Param ([string]$accountName)
-    #Check if there's a realm specified
+function Get-UserSID {
+    param(
+        [String]$AccountName
+    )
 
-    $searchDomain = $false
-    $searchDomainUPN = $false
-    if ($accountName.Split("\").count -gt 1)
-    {
-        if ($accountName.Split("\")[0] -ne $env:COMPUTERNAME)
-        {
-            $searchDomain = $true
-            $accountName = $accountName.split("\")[1]
-        }
-    }
-    Elseif ($accountName.contains("@"))
-    {
-        $searchDomain = $true
-        $searchDomainUPN = $true
-    }
-    Else
-    {
-        #Default to local user account
-        $accountName = $env:COMPUTERNAME + "\" + $accountName
-    }
-
-    if ($searchDomain -eq $false)
-    {
-        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
-        $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $accountName}
-        if ($localaccount)
-        {
-            return $localaccount.SID
-        }
-    }
-    Else
-    {
-        #Search by samaccountname
-        $Searcher = [adsisearcher]""
-
-        If ($searchDomainUPN -eq $false) {
-            $Searcher.Filter = "sAMAccountName=$($accountName)"
-        }
-        Else {
-            $Searcher.Filter = "userPrincipalName=$($accountName)"
-        }
-
-        $result = $Searcher.FindOne()
-        if ($result)
-        {
-            $user = $result.GetDirectoryEntry()
-
-            # get binary SID from AD account
-            $binarySID = $user.ObjectSid.Value
-
-            # convert to string SID
-            return (New-Object System.Security.Principal.SecurityIdentifier($binarySID,0)).Value
-        }
-    }
+    $userSID = Convert-ToSID -account_name $AccountName
+    return $userSID
 }
-Function NormalizeAccounts
-{
+
+Function NormalizeAccounts {
     param(
         [parameter(valuefrompipeline=$true)]
         $users
@@ -89,17 +23,17 @@ Function NormalizeAccounts
 
     $users = $users.Trim()
     If ($users -eq "") {
-        $splittedUsers = [Collections.Generic.List[String]] @()
+        $splitUsers = [Collections.Generic.List[String]] @()
     }
     Else {
-        $splittedUsers = [Collections.Generic.List[String]] $users.Split(",")
+        $splitUsers = [Collections.Generic.List[String]] $users.Split(",")
     }
 
     $normalizedUsers = [Collections.Generic.List[String]] @()
-    ForEach($splittedUser in $splittedUsers) {
-        $sid = UserSearch $splittedUser
-        If (!$sid) {
-            Fail-Json $result "$splittedUser is not a valid user or group on the host machine or domain"
+    ForEach($splitUser in $splitUsers) {
+        $sid = Get-UserSID -AccountName $splitUser
+        if (!$sid) {
+            Fail-Json $result "$splitUser is not a valid user or group on the host machine or domain"
         }
 
         $normalizedUser = (New-Object System.Security.Principal.SecurityIdentifier($sid)).Translate([System.Security.Principal.NTAccount])

--- a/lib/ansible/modules/windows/win_share.ps1
+++ b/lib/ansible/modules/windows/win_share.ps1
@@ -6,15 +6,6 @@
 #Requires -Module Ansible.ModuleUtils.SID.psm1
 
 #Functions
-function Get-UserSID {
-    param(
-        [String]$AccountName
-    )
-
-    $userSID = Convert-ToSID -account_name $AccountName
-    return $userSID
-}
-
 Function NormalizeAccounts {
     param(
         [parameter(valuefrompipeline=$true)]
@@ -31,7 +22,7 @@ Function NormalizeAccounts {
 
     $normalizedUsers = [Collections.Generic.List[String]] @()
     ForEach($splitUser in $splitUsers) {
-        $sid = Get-UserSID -AccountName $splitUser
+        $sid = Convert-ToSID -account_name $splitUser
         if (!$sid) {
             Fail-Json $result "$splitUser is not a valid user or group on the host machine or domain"
         }

--- a/lib/ansible/modules/windows/win_share.py
+++ b/lib/ansible/modules/windows/win_share.py
@@ -1,25 +1,6 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
-
 # Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-# this is a windows documentation stub.  actual code lives in the .ps1
-# file of the same name
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],

--- a/test/integration/targets/win_owner/tasks/main.yml
+++ b/test/integration/targets/win_owner/tasks/main.yml
@@ -45,7 +45,7 @@
     path: "{{test_win_owner_path}}"
     user: invalid-user
   register: invalid_user
-  failed_when: invalid_user.msg != 'invalid-user is not a valid user or group on the host machine or domain'
+  failed_when: invalid_user.msg is not search("account_name invalid-user is not a valid account, cannot get SID.*")
 
 - name: set owner defaults check
   win_owner:


### PR DESCRIPTION
##### SUMMARY
As noted in #19219, the following modules contain dependencies on both ADSISearcher and WMI for performing SID lookups:

- win_acl
- win_owner
- win_share

ADSISearcher in particular has issues looking up users and verifying an account is resolvable on a target machine.  This renders select connection types (e.g. local) unusable for any of the above modules when acting on domain-based accounts, and Kerberos connections as well without specifying `ansible_winrm_kerberos_delegation: yes`, among others.

This fixes #19218, #23215, etc. by utilizing the `Convert-ToSID` function in the recently implemented Ansible.ModuleUtils.SID module_utils (#27091), retrieving SIDs in a consistent way without the aforementioned dependencies.  Additionally, license and copyright information has been updated for these modules to reflect the latest format [noted here](http://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#copyright).

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/windows/win_acl.ps1
lib/ansible/modules/windows/win_owner.ps1
lib/ansible/modules/windows/win_share.ps1

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0
```
