### PR TITLE
Fix unwanted deprecation message in network module args

### DIFF
--- a/lib/ansible/module_utils/aireos.py
+++ b/lib/ansible/module_utils/aireos.py
@@ -43,10 +43,16 @@ aireos_provider_spec = {
 aireos_argument_spec = {
     'provider': dict(type='dict', options=aireos_provider_spec)
 }
-aireos_argument_spec.update(aireos_provider_spec)
 
-# Add argument's default value here
-ARGS_DEFAULT_VALUE = {}
+aireos_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+aireos_argument_spec.update(aireos_top_spec)
 
 
 def sanitize(resp):
@@ -59,21 +65,12 @@ def sanitize(resp):
     return '\n'.join(cleaned).strip()
 
 
-def get_argspec():
-    return aireos_argument_spec
+def get_provider_argspec():
+    return aireos_provider_spec
 
 
 def check_args(module, warnings):
-    for key in aireos_argument_spec:
-        if key not in ['provider', 'authorize'] and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    # set argument's default value if not provided in input
-    # This is done to avoid unwanted argument deprecation warning
-    # in case argument is not given as input (outside provider).
-    for key in ARGS_DEFAULT_VALUE:
-        if not module.params.get(key, None):
-            module.params[key] = ARGS_DEFAULT_VALUE[key]
+    pass
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/aruba.py
+++ b/lib/ansible/module_utils/aruba.py
@@ -43,27 +43,25 @@ aruba_provider_spec = {
 aruba_argument_spec = {
     'provider': dict(type='dict', options=aruba_provider_spec)
 }
-aruba_argument_spec.update(aruba_provider_spec)
 
-# Add argument's default value here
-ARGS_DEFAULT_VALUE = {}
+aruba_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+
+aruba_argument_spec.update(aruba_top_spec)
 
 
-def get_argspec():
-    return aruba_argument_spec
+def get_provider_argspec():
+    return aruba_provider_spec
 
 
 def check_args(module, warnings):
-    for key in aruba_argument_spec:
-        if key not in ['provider', 'authorize'] and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    # set argument's default value if not provided in input
-    # This is done to avoid unwanted argument deprecation warning
-    # in case argument is not given as input (outside provider).
-    for key in ARGS_DEFAULT_VALUE:
-        if not module.params.get(key, None):
-            module.params[key] = ARGS_DEFAULT_VALUE[key]
+    pass
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -33,7 +33,7 @@ from ansible.module_utils.connection import Connection, exec_command
 _DEVICE_CONFIGS = {}
 _CONNECTION = None
 
-asa_argument_spec = {
+asa_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -42,10 +42,27 @@ asa_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
     'context': dict(),
     'passwords': dict()
 }
+
+asa_argument_spec = {
+    'provider': dict(type='dict', options=asa_provider_spec),
+}
+
+asa_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'authorize': dict(type='bool'),
+    'auth_pass': dict(removed_in_version=2.3, no_log=True),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+    'context': dict(),
+    'passwords': dict()
+}
+asa_argument_spec.update(asa_top_spec)
 
 command_spec = {
     'command': dict(key=True),
@@ -54,21 +71,12 @@ command_spec = {
 }
 
 
-def get_argspec():
-    return asa_argument_spec
+def get_provider_argspec():
+    return asa_provider_spec
 
 
 def check_args(module):
-    provider = module.params['provider'] or {}
-
-    for key in asa_argument_spec:
-        if key not in ['provider', 'authorize'] and module.params[key]:
-            module.warn('argument %s has been deprecated and will be removed in a future version' % key)
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
+    pass
 
 
 def get_connection(module):

--- a/lib/ansible/module_utils/ce.py
+++ b/lib/ansible/module_utils/ce.py
@@ -66,14 +66,21 @@ ce_provider_spec = {
 ce_argument_spec = {
     'provider': dict(type='dict', options=ce_provider_spec),
 }
-ce_argument_spec.update(ce_provider_spec)
+ce_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'use_ssl': dict(removed_in_version=2.3, type='bool'),
+    'validate_certs': dict(removed_in_version=2.3, type='bool'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+    'transport': dict(choices=['cli']),
+}
+ce_argument_spec.update(ce_top_spec)
 
 
 def check_args(module, warnings):
-    for key in ce_argument_spec:
-        if key not in ['provider', 'transport'] and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                            'removed in a future version' % key)
+    pass
 
 
 def load_params(module):

--- a/lib/ansible/module_utils/dellos10.py
+++ b/lib/ansible/module_utils/dellos10.py
@@ -58,14 +58,21 @@ dellos10_provider_spec = {
 dellos10_argument_spec = {
     'provider': dict(type='dict', options=dellos10_provider_spec),
 }
-dellos10_argument_spec.update(dellos10_provider_spec)
+dellos10_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'authorize': dict(removed_in_version=2.3, type='bool'),
+    'auth_pass': dict(removed_in_version=2.3, no_log=True),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+dellos10_argument_spec.update(dellos10_top_spec)
 
 
 def check_args(module, warnings):
-    for key in dellos10_argument_spec:
-        if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                            'removed in a future version' % key)
+    pass
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -57,14 +57,21 @@ dellos6_provider_spec = {
 dellos6_argument_spec = {
     'provider': dict(type='dict', options=dellos6_provider_spec),
 }
-dellos6_argument_spec.update(dellos6_provider_spec)
+dellos6_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'authorize': dict(removed_in_version=2.3, type='bool'),
+    'auth_pass': dict(removed_in_version=2.3, no_log=True),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+dellos6_argument_spec.update(dellos6_top_spec)
 
 
 def check_args(module, warnings):
-    for key in dellos6_argument_spec:
-        if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                            'removed in a future version' % key)
+    pass
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -58,14 +58,20 @@ dellos9_provider_spec = {
 dellos9_argument_spec = {
     'provider': dict(type='dict', options=dellos9_provider_spec),
 }
-dellos9_argument_spec.update(dellos9_provider_spec)
-
+dellos9_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'authorize': dict(removed_in_version=2.3, type='bool'),
+    'auth_pass': dict(removed_in_version=2.3, no_log=True),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+dellos9_argument_spec.update(dellos9_top_spec)
 
 def check_args(module, warnings):
-    for key in dellos9_argument_spec:
-        if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                            'removed in a future version' % key)
+    pass
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -70,6 +70,7 @@ dellos9_top_spec = {
 }
 dellos9_argument_spec.update(dellos9_top_spec)
 
+
 def check_args(module, warnings):
     pass
 

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -49,23 +49,32 @@ eos_provider_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
 
-    'use_ssl': dict(type='bool'),
-    'validate_certs': dict(type='bool'),
+    'use_ssl': dict(default=True, type='bool'),
+    'validate_certs': dict(default=True, type='bool'),
     'timeout': dict(type='int'),
 
-    'transport': dict(choices=['cli', 'eapi'])
+    'transport': dict(default='cli', choices=['cli', 'eapi'])
 }
 eos_argument_spec = {
     'provider': dict(type='dict', options=eos_provider_spec),
 }
-eos_argument_spec.update(eos_provider_spec)
+eos_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
 
-# Add argument's default value here
-ARGS_DEFAULT_VALUE = {
-    'transport': 'cli',
-    'use_ssl': True,
-    'validate_certs': True
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(no_log=True, removed_in_version=2.3),
+
+    'use_ssl': dict(removed_in_version=2.3, type='bool'),
+    'validate_certs': dict(removed_in_version=2.3, type='bool'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+
+    'transport': dict(removed_in_version=2.3, choices=['cli', 'eapi'])
 }
+eos_argument_spec.update(eos_top_spec)
 
 
 def get_argspec():
@@ -73,21 +82,7 @@ def get_argspec():
 
 
 def check_args(module, warnings):
-    for key in eos_argument_spec:
-        if module._name == 'eos_user':
-            if (key not in ['username', 'password', 'provider', 'transport', 'authorize'] and
-                    module.params[key]):
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-        else:
-            if key not in ['provider', 'authorize'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    # set argument's default value if not provided in input
-    # This is done to avoid unwanted argument deprecation warning
-    # in case argument is not given as input (outside provider).
-    for key in ARGS_DEFAULT_VALUE:
-        if not module.params.get(key, None):
-            module.params[key] = ARGS_DEFAULT_VALUE[key]
+    pass
 
 
 def load_params(module):

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -40,26 +40,31 @@ ios_provider_spec = {
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
-    'timeout': dict(type='int'),
+    'timeout': dict(type='int')
 }
 ios_argument_spec = {
     'provider': dict(type='dict', options=ios_provider_spec),
 }
-ios_argument_spec.update(ios_provider_spec)
+
+ios_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(removed_in_version=2.3, no_log=True),
+    'timeout': dict(removed_in_version=2.3, type='int')
+}
+ios_argument_spec.update(ios_top_spec)
 
 
-def get_argspec():
-    return ios_argument_spec
+def get_provider_argspec():
+    return ios_provider_spec
 
 
 def check_args(module, warnings):
-    for key in ios_argument_spec:
-        if module._name == 'ios_user':
-            if key not in ['password', 'provider', 'authorize'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be in a future version' % key)
-        else:
-            if key not in ['provider', 'authorize'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
+    pass
 
 
 def get_defaults_flag(module):

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -44,21 +44,23 @@ iosxr_provider_spec = {
 iosxr_argument_spec = {
     'provider': dict(type='dict', options=iosxr_provider_spec)
 }
-iosxr_argument_spec.update(iosxr_provider_spec)
+iosxr_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+iosxr_argument_spec.update(iosxr_top_spec)
 
 
-def get_argspec():
-    return iosxr_argument_spec
+def get_provider_argspec():
+    return iosxr_provider_spec
 
 
 def check_args(module, warnings):
-    for key in iosxr_argument_spec:
-        if module._name == 'iosxr_user':
-            if key not in ['password', 'provider'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be in a future version' % key)
-        else:
-            if key != 'provider' and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
+    pass
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -50,28 +50,20 @@ junos_provider_spec = {
 junos_argument_spec = {
     'provider': dict(type='dict', options=junos_provider_spec),
 }
-junos_argument_spec.update(junos_provider_spec)
+junos_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+    'transport': dict(removed_in_version=2.3)
+}
+junos_argument_spec.update(junos_top_spec)
 
-# Add argument's default value here
-ARGS_DEFAULT_VALUE = {}
 
-
-def get_argspec():
-    return junos_argument_spec
-
-
-def check_args(module, warnings):
-    for key in junos_argument_spec:
-        if key not in ('provider',) and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be '
-                            'removed in a future version' % key)
-
-    # set argument's default value if not provided in input
-    # This is done to avoid unwanted argument deprecation warning
-    # in case argument is not given as input (outside provider).
-    for key in ARGS_DEFAULT_VALUE:
-        if not module.params.get(key, None):
-            module.params[key] = ARGS_DEFAULT_VALUE[key]
+def get_provider_argspec():
+    return junos_provider_spec
 
 
 def _validate_rollback_id(module, value):

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -66,6 +66,10 @@ def get_provider_argspec():
     return junos_provider_spec
 
 
+def check_args(module, warnings):
+    pass
+
+
 def _validate_rollback_id(module, value):
     try:
         if not 0 <= int(value) <= 49:

--- a/lib/ansible/module_utils/network_common.py
+++ b/lib/ansible/module_utils/network_common.py
@@ -335,6 +335,37 @@ def remove_default_spec(spec):
             del spec[item]['default']
 
 
+def load_provider(spec, args):
+    provider = args.get('provider', {})
+    for key, value in iteritems(spec):
+        if key not in provider:
+            if key in args:
+                provider[key] = args[key]
+            elif 'fallback' in value:
+                provider[key] = _fallback(value['fallback'])
+            elif 'default' in value:
+                provider[key] = value['default']
+            else:
+                provider[key] = None
+    args['provider'] = provider
+    return provider
+
+
+def _fallback(fallback):
+    strategy = fallback[0]
+    args = []
+    kwargs = {}
+
+    for item in fallback[1:]:
+        if isinstance(item, dict):
+            kwargs = item
+        else:
+            args = item
+    try:
+        return strategy(*args, **kwargs)
+    except AnsibleFallbackNotFound:
+        pass
+
 class Template:
 
     def __init__(self):

--- a/lib/ansible/module_utils/network_common.py
+++ b/lib/ansible/module_utils/network_common.py
@@ -366,6 +366,7 @@ def _fallback(fallback):
     except AnsibleFallbackNotFound:
         pass
 
+
 class Template:
 
     def __init__(self):

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -51,38 +51,34 @@ nxos_provider_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'transport': dict(choices=['cli', 'nxapi'])
+    'transport': dict(default='cli', choices=['cli', 'nxapi'])
 }
 nxos_argument_spec = {
     'provider': dict(type='dict', options=nxos_provider_spec),
 }
-nxos_argument_spec.update(nxos_provider_spec)
+nxos_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
 
-# Add argument's default value here
-ARGS_DEFAULT_VALUE = {
-    'transport': 'cli'
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3),
+
+    'use_ssl': dict(removed_in_version=2.3, type='bool'),
+    'validate_certs': dict(removed_in_version=2.3, type='bool'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+
+    'transport': dict(default='cli', choices=['cli', 'nxapi'])
 }
+nxos_argument_spec.update(nxos_top_spec)
 
 
-def get_argspec():
-    return nxos_argument_spec
+def get_provider_argspec():
+    return nxos_provider_spec
 
 
 def check_args(module, warnings):
-    for key in nxos_argument_spec:
-        if module._name == 'nxos_user':
-            if key not in ['password', 'provider', 'transport'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be in a future version' % key)
-        else:
-            if key not in ['provider', 'transport'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-    # set argument's default value if not provided in input
-    # This is done to avoid unwanted argument deprecation warning
-    # in case argument is not given as input (outside provider).
-    for key in ARGS_DEFAULT_VALUE:
-        if not module.params.get(key, None):
-            module.params[key] = ARGS_DEFAULT_VALUE[key]
+    pass
 
 
 def load_params(module):

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -60,6 +60,10 @@ sros_top_spec = {
 sros_argument_spec.update(sros_top_spec)
 
 
+def check_args(module, warnings):
+    pass
+
+
 def get_config(module, flags=[]):
     cmd = 'admin display-config '
     cmd += ' '.join(flags)

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -49,13 +49,15 @@ sros_provider_spec = {
 sros_argument_spec = {
     'provider': dict(type='dict', options=sros_provider_spec),
 }
-sros_argument_spec.update(sros_provider_spec)
-
-
-def check_args(module, warnings):
-    for key in sros_argument_spec:
-        if key != 'provider' and module.params[key]:
-            warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
+sros_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+sros_argument_spec.update(sros_top_spec)
 
 
 def get_config(module, flags=[]):

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -45,11 +45,21 @@ vyos_provider_spec = {
 vyos_argument_spec = {
     'provider': dict(type='dict', options=vyos_provider_spec),
 }
-vyos_argument_spec.update(vyos_provider_spec)
+vyos_top_spec = {
+    'host': dict(removed_in_version=2.3),
+    'port': dict(removed_in_version=2.3, type='int'),
+
+    'username': dict(removed_in_version=2.3),
+    'password': dict(removed_in_version=2.3, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+
+    'timeout': dict(removed_in_version=2.3, type='int'),
+}
+vyos_argument_spec.update(vyos_top_spec)
 
 
-def get_argspec():
-    return vyos_argument_spec
+def get_provider_argspec():
+    return vyos_provider_spec
 
 
 def check_args(module, warnings):

--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -24,9 +24,9 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.aireos import aireos_argument_spec
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.aireos import aireos_provider_spec
+from ansible.module_utils.network_common import load_provider
+
 
 try:
     from __main__ import display
@@ -46,7 +46,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(aireos_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -82,30 +82,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(aireos_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -24,9 +24,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.aruba import aruba_argument_spec
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.aruba import aruba_provider_spec
+from ansible.module_utils.network_common import load_provider
 
 try:
     from __main__ import display
@@ -46,7 +45,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(aruba_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -83,30 +82,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(aruba_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -25,10 +25,9 @@ import json
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.asa import asa_argument_spec
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.connection import request_builder
+from ansible.module_utils.aruba import asa_provider_spec
+from ansible.module_utils.network_common import load_provider
+
 
 try:
     from __main__ import display
@@ -48,7 +47,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(asa_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -78,30 +77,3 @@ class ActionModule(_ActionModule):
         result = super(ActionModule, self).run(tmp, task_vars)
 
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(asa_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/asa.py
+++ b/lib/ansible/plugins/action/asa.py
@@ -27,6 +27,7 @@ from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.aruba import asa_provider_spec
 from ansible.module_utils.network_common import load_provider
+from ansible.module_utils.connection import request_builder
 
 
 try:

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -24,9 +24,9 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.ce import ce_argument_spec
-from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.ce import ce_provider_spec
+from ansible.module_utils.network_common import load_provider
+
 
 try:
     from __main__ import display
@@ -45,7 +45,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(ce_provider_spec, self._task.args)
         transport = provider['transport'] or 'cli'
 
         display.vvvv('connection transport is %s' % transport, self._play_context.remote_addr)
@@ -91,30 +91,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(ce_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -26,9 +26,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.dellos10 import dellos10_argument_spec
-from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.dellos10 import dellos10_provider_spec
+from ansible.module_utils.network_common import load_provider
 
 try:
     from __main__ import display
@@ -48,7 +47,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(dellos10_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -87,30 +86,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(dellos10_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -26,9 +26,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.dellos9 import dellos9_argument_spec
-from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.dellos9 import dellos9_provider_spec
+from ansible.module_utils.network_common import load_provider
 
 try:
     from __main__ import display
@@ -48,7 +47,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(dellos9_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -87,30 +86,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(dellos9_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -24,9 +24,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.ios import ios_argument_spec
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.network_common import load_provider
+from ansible.module_utils.ios import ios_provider_spec
 
 try:
     from __main__ import display
@@ -46,7 +45,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(ios_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -85,30 +84,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(ios_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -23,10 +23,9 @@ import sys
 import copy
 
 from ansible import constants as C
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.iosxr import iosxr_argument_spec
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.iosxr import iosxr_provider_spec
 from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.module_utils.network_common import load_provider
 
 try:
     from __main__ import display
@@ -46,7 +45,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(iosxr_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -79,30 +78,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(iosxr_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -24,9 +24,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.nxos import nxos_argument_spec
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.network_common import load_provider
+from ansible.module_utils.nxos import nxos_provider_spec
 
 try:
     from __main__ import display
@@ -45,7 +44,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(nxos_provider_spec, self._task.args)
         transport = provider['transport'] or 'cli'
 
         display.vvvv('connection transport is %s' % transport, self._play_context.remote_addr)
@@ -120,30 +119,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(nxos_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -24,9 +24,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.sros import sros_argument_spec
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.sros import sros_provider_spec
+from ansible.module_utils.network_common import load_provider
 
 try:
     from __main__ import display
@@ -46,7 +45,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(sros_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -72,30 +71,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(sros_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -24,9 +24,8 @@ import copy
 
 from ansible import constants as C
 from ansible.plugins.action.normal import ActionModule as _ActionModule
-from ansible.module_utils.basic import AnsibleFallbackNotFound
-from ansible.module_utils.six import iteritems
-from ansible.module_utils.vyos import vyos_argument_spec
+from ansible.module_utils.network_common import load_provider
+from ansible.module_utils.vyos import vyos_provider_spec
 
 try:
     from __main__ import display
@@ -45,7 +44,7 @@ class ActionModule(_ActionModule):
                     'got %s' % self._play_context.connection
             )
 
-        provider = self.load_provider()
+        provider = load_provider(vyos_provider_spec, self._task.args)
 
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
@@ -79,30 +78,3 @@ class ActionModule(_ActionModule):
 
         result = super(ActionModule, self).run(tmp, task_vars)
         return result
-
-    def load_provider(self):
-        provider = self._task.args.get('provider', {})
-        for key, value in iteritems(vyos_argument_spec):
-            if key != 'provider' and key not in provider:
-                if key in self._task.args:
-                    provider[key] = self._task.args[key]
-                elif 'fallback' in value:
-                    provider[key] = self._fallback(value['fallback'])
-                elif key not in provider:
-                    provider[key] = None
-        return provider
-
-    def _fallback(self, fallback):
-        strategy = fallback[0]
-        args = []
-        kwargs = {}
-
-        for item in fallback[1:]:
-            if isinstance(item, dict):
-                kwargs = item
-            else:
-                args = item
-        try:
-            return strategy(*args, **kwargs)
-        except AnsibleFallbackNotFound:
-            pass


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #25663
Fixes #24537

*  segregate provider spec and top level arg spec
*  add depreciation key in top level arg spec and ensure warning is not thrown when 
    the corresponding environment variable is set
*  remove action plugin code to load provider and add
   that logic at a common place in network_common.py file
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/aireos.py
module_utils/aruba.py
module_utils/asa.py
module_utils/ce.py
module_utils/dellos10.py
module_utils/dellos6.py
module_utils/dellos9.py
module_utils/eos.py
module_utils/ios.py
module_utils/iosxr.py
module_utils/junos.py
module_utils/network_common.py
module_utils/nxos.py
module_utils/sros.py
plugins/action/aireos.py
plugins/action/aruba.py
plugins/action/asa.py
plugins/action/ce.py
plugins/action/dellos10.py
plugins/action/dellos6.py
plugins/action/dellos9.py
plugins/action/eos.py
plugins/action/ios.py
plugins/action/iosxr.py
plugins/action/junos.py
plugins/action/net_base.py
plugins/action/nxos.py
plugins/action/sros.py
plugins/action/vyos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before
```
TASK [Get Version] ***************************************************************************************************************************************************************************************************************************
 [WARNING]: argument username has been deprecated and will be removed in a future version

 [WARNING]: argument password has been deprecated and will be removed in a future version

 [WARNING]: argument transport has been deprecated and will be removed in a future version
```

After
(In case environment variable for password, username etc is set and top level argument value is not given in playbook, corresponding warning will not be displayed in output. )
```
[DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information.
This feature will be
removed in version 2.3. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information.
This feature will
be removed in version 2.3. Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```
