### PR TITLE
fix for getting vars and hostvars without specifying the host

### DIFF
--- a/lib/ansible/vars/hostvars.py
+++ b/lib/ansible/vars/hostvars.py
@@ -106,7 +106,7 @@ class HostVars(collections.Mapping):
 
     def __iter__(self):
         for host in self._inventory.hosts:
-            yield host.name
+            yield host
 
     def __len__(self):
         return len(self._inventory.hosts)
@@ -114,6 +114,5 @@ class HostVars(collections.Mapping):
     def __repr__(self):
         out = {}
         for host in self._inventory.hosts:
-            name = host.name
-            out[name] = self.get(name)
+            out[host] = self.get(host)
         return repr(out)


### PR DESCRIPTION
##### SUMMARY
When trying to run the following command with a populated inventory

`ansible localhost -m debug -a var=vars`
or
`ansible localhost -m debug -a var=hostvars`

you receive the following error

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'unicode' object has no attribute 'name'
localhost | FAILED! => {
    "failed": true, 
    "msg": "Unexpected failure during module execution.", 
    "stdout": ""
}
```

See https://github.com/ansible/ansible/issues/28906

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
```
2.4
```