### PR TITLE
Ensure proper conversion while backing up of junos config (#28958)

### DIFF
--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -112,7 +112,7 @@ def load_configuration(module, candidate=None, action='merge', rollback=None, fo
             if format == 'xml':
                 cfg.append(fromstring(candidate))
             else:
-                cfg.text = to_text(candidate, encoding='latin1')
+                cfg.text = to_text(candidate, encoding='latin-1')
         else:
             cfg.append(candidate)
     return send_request(module, obj)
@@ -164,7 +164,7 @@ def get_diff(module):
     reply = get_configuration(module, compare=True, format='text')
     output = reply.find('.//configuration-output')
     if output is not None:
-        return to_text(output.text, encoding='latin1').strip()
+        return to_text(output.text, encoding='latin-1').strip()
 
 def load_config(module, candidate, warnings, action='merge', commit=False, format='xml',
                 comment=None, confirm=False, confirm_timeout=None):

--- a/lib/ansible/modules/network/junos/junos_config.py
+++ b/lib/ansible/modules/network/junos/junos_config.py
@@ -229,7 +229,7 @@ def filter_delete_statements(module, candidate):
     if match is None:
         # Could not find configuration-set in reply, perhaps device does not support it?
         return candidate
-    config = to_native(match.text, encoding='latin1')
+    config = to_native(match.text, encoding='latin-1')
 
     modified_candidate = candidate[:]
     for index, line in reversed(list(enumerate(candidate))):

--- a/lib/ansible/plugins/action/junos_config.py
+++ b/lib/ansible/plugins/action/junos_config.py
@@ -27,7 +27,7 @@ import glob
 from ansible.plugins.action.junos import ActionModule as _ActionModule
 from ansible.module_utils._text import to_text
 from ansible.module_utils.six.moves.urllib.parse import urlsplit
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_bytes
 from ansible.utils.vars import merge_hash
 
 PRIVATE_KEYS_RE = re.compile('__.+__')
@@ -75,7 +75,8 @@ class ActionModule(_ActionModule):
             os.remove(fn)
         tstamp = time.strftime("%Y-%m-%d@%H:%M:%S", time.localtime(time.time()))
         filename = '%s/%s_config.%s' % (backup_path, host, tstamp)
-        open(filename, 'w').write(to_native(contents, encoding='latin1'))
+        with open(filename, 'wb') as f:
+            f.write(to_bytes(to_text(contents, encoding='latin-1'), encoding='utf-8'))
         return filename
 
     def _handle_template(self):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Ensure proper conversion while backing up of junos config
*  Minor changes
*  Fix review comment
*  Open config backup file in binary mode

Merged to devel https://github.com/ansible/ansible/pull/28958
(cherry picked from commit cc9ed352dd547b19439cb5c9373f8529e6385314)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
