### PR TITLE
aci_rest: Add integration tests

### DIFF
--- a/test/integration/targets/aci_rest/aliases
+++ b/test/integration/targets/aci_rest/aliases
@@ -1,0 +1,1 @@
+# No ACI Simulator yet, so not enabled

--- a/test/integration/targets/aci_rest/tasks/main.yml
+++ b/test/integration/targets/aci_rest/tasks/main.yml
@@ -1,0 +1,156 @@
+# Test code for the ACI modules
+# Copyright 2017, Dag Wieers <dag@wieers.com>
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Test that we have an ACI APIC host, ACI username and ACI password
+  fail:
+    msg: 'Please define the following variables: aci_hostname, aci_username and aci_password.'
+  when: aci_hostname is not defined or aci_username is not defined or aci_password is not defined
+
+# CLEAN ENVIRONMENT
+- name: Remove tenant
+  aci_rest: &tenant_absent
+    hostname: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: no
+    path: /api/mo/uni/tn-[ansible_test].json
+    method: delete
+  delegate_to: localhost
+
+# ADD TENANT
+- name: Add tenant (normal mode)
+  aci_rest: &tenant_present
+    hostname: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: no
+    path: /api/mo/uni/tn-[ansible_test].json
+    method: post
+    content: |
+      {
+          "fvTenant": {
+              "attributes": {
+                  "name": "ansible_test"
+              }
+          }
+      }
+  delegate_to: localhost
+  register: nm_add_tenant
+
+- name: Add tenant again (normal mode)
+  aci_rest: *tenant_present
+  delegate_to: localhost
+  register: nm_add_tenant_again
+
+- name: Verify add_tenant
+  assert:
+    that:
+    - nm_add_tenant.changed == true
+    - nm_add_tenant_again.changed == false
+
+# CHANGE TENANT
+- name: Change description of tenant (normal mode)
+  aci_rest: &tenant_changed
+    hostname: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: no
+    path: /api/mo/uni/tn-[ansible_test].json
+    method: post
+    content: |
+      {
+          "fvTenant": {
+              "attributes": {
+                  "descr": "Ansible test tenant",
+                  "name": "ansible_test"
+              }
+          }
+      }
+  delegate_to: localhost
+  register: nm_add_tenant_descr
+
+- name: Change description of tenant again (normal mode)
+  aci_rest: *tenant_changed
+  delegate_to: localhost
+  register: nm_add_tenant_descr_again
+
+- name: Verify add_tenant_descr
+  assert:
+    that:
+    - nm_add_tenant_descr.changed == true
+    - nm_add_tenant_descr_again.changed == false
+
+# ADD TENANT AGAIN
+- name: Add tenant again with no description (normal mode)
+  aci_rest: *tenant_present
+  delegate_to: localhost
+  register: nm_add_tenant_again_no_descr
+
+- name: Verify add_tenant_again_no_descr
+  assert:
+    that:
+    - nm_add_tenant_again_no_descr.changed == false
+
+# QUERY ALL TENANTS
+- name: Query all tenants (normal mode)
+  aci_rest: &tenant_query_all
+    hostname: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: no
+    path: /api/mo/uni/tn-[ansible_test].json
+    method: get
+  delegate_to: localhost
+  register: nm_query_all_tenants
+
+- name: Verify query_all_tenants
+  assert:
+    that:
+    - nm_query_all_tenants.changed == false
+
+# QUERY A TENANT
+- name: Query our tenant
+  aci_rest: &tenant_query
+    hostname: '{{ aci_hostname }}'
+    username: '{{ aci_username }}'
+    password: '{{ aci_password }}'
+    validate_certs: no
+    path: /api/mo/uni/tn-[ansible_test].json
+    method: get
+  delegate_to: localhost
+  register: nm_query_tenant
+
+- name: Verify query_tenant
+  assert:
+    that:
+    - nm_query_tenant.changed == false
+
+# REMOVE TENANT
+- name: Remove tenant (normal mode)
+  aci_rest: *tenant_absent
+  delegate_to: localhost
+  register: nm_remove_tenant
+
+- name: Remove tenant again (normal mode)
+  aci_rest: *tenant_absent
+  delegate_to: localhost
+  register: nm_remove_tenant_again
+
+- name: Verify remove_tenant
+  assert:
+    that:
+    - nm_remove_tenant.changed == true
+    - nm_remove_tenant_again.changed == false
+
+# QUERY NON-EXISTING TENANT
+- name: Query non-existing tenant (normal mode)
+  aci_rest: *tenant_query
+  delegate_to: localhost
+  register: nm_query_non_tenant
+
+- name: Verify query_non_tenant
+  assert:
+    that:
+    - nm_query_non_tenant.changed == false


### PR DESCRIPTION
##### SUMMARY
Integration tests for aci_rest to upstream.

It follows the same flow as aci_tenant to create, change and remove a tenant idempotently.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aci_rest

##### ANSIBLE VERSION
v2.4