### PR TITLE
messaging: Add new modules for kafka-configs

### DIFF
--- a/lib/ansible/modules/messaging/kafka_configs.py
+++ b/lib/ansible/modules/messaging/kafka_configs.py
@@ -1,0 +1,303 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Guillaume Delpierre <gde@llew.me>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# -*- coding: utf-8 -*-
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: kafka_configs
+author: "Guillaume Delpierre (@gdelpierre)"
+version_added: "2.5"
+short_description: Add/Remove entity config.
+description:
+    - 'Add/Remove entity config for a topic, client, user or broker'
+requirements:
+    - 'kafka-configs.sh'
+options:
+    add_configs:
+        type: dict
+        description:
+            - Key Value pairs of configs to add.
+    del_configs:
+        type: list
+        description:
+            - Configs key to remove.
+    describe:
+        type: bool
+        default: False
+        description:
+            - List configs for the given entity.
+    entity_default:
+        type: str
+        description:
+            - Default entity name for clients/users.
+    entity_name:
+        type: str
+        description:
+            - Name of entity.
+    entity_type:
+        required: True
+        type: str
+        description:
+            - Type of entity.
+    jaas_auth_file:
+        type: path
+        description:
+            - JAAS authentification path file.
+    kafka_path:
+        type: path
+        description:
+            - Kafka path.
+    pretty:
+        required:
+        type:
+        description:
+            - Print a dict of the output.
+    zookeeper:
+        required: True
+        type: list
+        description:
+            - The connection string for the zookeeper connection.
+'''
+
+EXAMPLES = '''
+name: 'list config'
+kafka_configs:
+  kafka_path: '/opt/foobar/kafka'
+  entity_type: 'topics'
+  describe: True
+  pretty: True
+  zookeeper:
+    - foo.baz.org:2181
+    - bar.baz.org:2181
+
+name: 'Add config'
+kafka_configs:
+  jaas_auth_file: 'jaas-kafka.conf'
+  entity_name: 'chocolatine'
+  entity_type: 'topics'
+  add_configs:
+    cleanup.policy: 'delete'
+    compression.type: 'gzip'
+  zookeeper:
+    - foo.baz.org:2181
+    - bar.baz.org:2181
+
+name: 'Remove config'
+kafka_configs:
+  jaas_auth_file: 'jaas-kafka.conf'
+  entity_name: 'chocolatine'
+  entity_type: 'topics'
+  del_configs:
+    - cleanup.policy
+    - compression.type
+  zookeeper:
+    - foo.baz.org:2181
+    - bar.baz.org:2181
+'''
+
+RETURN = '''
+'''
+
+import re
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+class KafkaError(Exception):
+    ''' '''
+    pass
+ 
+class KafkaConfigs(object):
+
+    def __init__(self, module):
+
+        self.add_configs = module.params['add_configs']
+        self.del_configs = module.params['del_configs']
+        self.ent_def = module.params['entity_default']
+        self.ent_name = module.params['entity_name']
+        self.ent_type = module.params['entity_type']
+        self.pretty = module.params['pretty']
+        self.zookeeper  = ','.join(module.params['zookeeper'])
+
+        self.executable = module.params['kafka_path'] + '/bin/kafka-configs.sh'
+
+        self.module = module
+
+    def manage_configs(self):
+        ''' Alter (add or remove configs) for the entity. '''
+
+        if self.module.params['jaas_auth_file']:
+            kafka_env_opts = '-Djava.security.auth.login.config=' + \
+                self.module.params['jaas_auth_file']
+   
+        entity = {
+                '--entity-default': self.ent_def,
+                '--entity-name': self.ent_name,
+                '--entity-type': self.ent_type,
+        }
+        entity_join = ''.join(" %s %r" % (k, v) for k,v in entity.iteritems() if v)
+
+        if self.add_configs:
+            configs = ''
+            for k,v in self.add_configs.iteritems():
+                if v:
+                    if isinstance(v, list):
+                        if configs:
+                            configs += ','
+                        configs += ''.join("%s=%r" % (k, ','.join(v)))
+                    else:
+                        if configs:
+                            configs += ','
+                        configs += ''.join("%s=%r" % (k, v))
+
+            cmd = ('%s --alter --zookeeper %s %s '
+                    '--add-config %s') % (self.executable,
+                                            self.zookeeper,
+                                            entity_join,
+                                            configs)
+        elif self.del_configs:
+            cmd = ('%s --alter --zookeeper %s %s '
+                    '--delete-config %s') % (self.executable,
+                                            self.zookeeper,
+                                            entity_join,
+                                            ','.join(self.del_configs))
+        else:
+            msg = 'add/del action required at least one config to add/del'
+            return self.module.fail_json(msg=msg)
+
+        try:
+            env = ''
+            if self.module.params['jaas_auth_file']:
+                env = { 'KAFKA_OPTS': kafka_env_opts }
+
+            return self.module.run_command(cmd, environ_update=env)
+
+        except KafkaError as exc:
+            self.module.fail_json(msg=to_native(exc))
+
+    def describe(self):
+        ''' List configs for the given entity. '''
+
+        entity = {
+                '--entity-default': self.ent_def,
+                '--entity-name': self.ent_name,
+                '--entity-type': self.ent_type,
+        }
+        entity_join = ''.join(" %s %r" % (k, v) for k,v in entity.iteritems() if v)
+
+        try:
+            cmd = '%s --describe --zookeeper %s %s' % (self.executable,
+                                                       self.zookeeper,
+                                                       entity_join)
+            if self.pretty:
+                (rc, out, err) = self.module.run_command(cmd)
+
+                formatted = {}
+
+                for line in out.splitlines():
+                    if not 'are' in line.split()[-1]:
+                        if len(line.split()[-1].split(',')) > 1:
+                            formatted[line.split()[3].strip('\'')] = line.split()[-1].split(',')
+                        else:
+                            formatted[line.split()[3].strip('\'')] = line.split()[-1]
+                    else:
+                        formatted[line.split()[3].strip('\'')] = 'null'
+
+                return (rc, formatted, err)
+
+            return self.module.run_command(cmd)
+
+        except KafkaError as exc:
+            module.fail_json(msg=to_native(exc))
+
+def main():
+    argument_spec = dict(
+        describe=dict(type='bool'),
+        add_configs=dict(type='dict'),
+        del_configs=dict(type='list'),
+        entity_default=dict(type='str'),
+        entity_name=dict(type='str'),
+        entity_type=dict(required=True, type='str'),
+        zookeeper=dict(required=True, type='list'),
+
+        jaas_auth_file = dict(type='path'),
+        kafka_path = dict(default='/opt/kafka',
+                          type='path'),
+
+        pretty = dict(type='bool'),
+    )
+
+
+    required_if = [
+        ['add_configs', True, ['entity_name', 'entity_type']],
+        ['add_configs', True, ['jaas_auth_file']],
+        ['del_configs', True, ['jaas_auth_file']],
+    ]
+
+    required_one_of = [
+        ['describe', 'add_configs', 'del_configs'],
+    ]
+
+    mutually_exclusive = [
+        ['add_configs', 'del_configs', 'describe'],
+    ]
+
+    module = AnsibleModule(
+        argument_spec = argument_spec,
+        required_if = required_if,
+        required_one_of = required_one_of,
+        mutually_exclusive = mutually_exclusive,
+        supports_check_mode = True,
+    )
+
+    kafka_bin = os.path.isfile(module.params['kafka_path'] + \
+                    '/bin/kafka-configs.sh')
+    jaas_auth_file = module.params['jaas_auth_file']
+
+    changed = False
+
+    if not kafka_bin:
+        module.fail_json(msg='%s not found.' % (kafka_bin))
+
+    if module.params['jaas_auth_file']:
+        is_jaas_auth_file = os.path.isfile(jaas_auth_file)
+        if not is_jaas_auth_file:
+            module.fail_json(msg='%s not found.' % (jaas_auth_file))
+
+    try:
+        kc = KafkaConfigs(module)
+
+        if not module.check_mode:
+            if module.params['describe']:
+                (rc, out, err) = kc.describe()
+                result = {
+                    'stdout': to_native(out),
+                    'stderr_lines': err.splitlines(),
+                    'rc': rc,
+                    'changed': changed,
+                }
+            else:
+                (rc, out, err) = kc.manage_configs()
+                if re.search('^Updated config for entity:', out):
+                    changed = True
+                result = {
+                    'stdout': out,
+                    'stdout_lines': out.splitlines(),
+                    'stderr_lines': err.splitlines(),
+                    'rc': rc,
+                    'changed': changed,
+                }
+
+    except KafkaError as e:
+        module.fail_json(msg=to_native(e))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/messaging/kafka_configs.py
+++ b/lib/ansible/modules/messaging/kafka_configs.py
@@ -261,7 +261,7 @@ def main():
     failed = False
     result = {}
 
-    if module.params['executable'] is None:
+    if not module.get_bin_path('kafka-configs') and module.params['executable'] is None:
         module.fail_json(msg='Executable not provided.')
     if not os.path.isfile(module.params['executable']):
         module.fail_json(msg='%s not found.' % (module.params['executable']))

--- a/lib/ansible/modules/messaging/kafka_configs.py
+++ b/lib/ansible/modules/messaging/kafka_configs.py
@@ -263,7 +263,7 @@ def main():
 
     if not module.get_bin_path('kafka-configs') and module.params['executable'] is None:
         module.fail_json(msg='Executable not provided.')
-    if not os.path.isfile(module.params['executable']):
+    if module.params['executable'] is not None and not os.path.isfile(module.params['executable']):
         module.fail_json(msg='%s not found.' % (module.params['executable']))
     if not is_executable(module.params['executable']):
         module.fail_json(msg='%s not executable.' % (module.params['executable']))

--- a/lib/ansible/modules/messaging/kafka_configs.py
+++ b/lib/ansible/modules/messaging/kafka_configs.py
@@ -91,12 +91,12 @@ stdout:
   description: Output from stdout after execution
   returned: success or changed
   type: string
-  sample: "Configs for topic 'wassingue' are cleanup.policy=delete,compression.type=gzip\n"
+  sample: "Configs for topic 'wassingue' are cleanup.policy=delete,compression.type=gzip\\\n"
 msg:
   description: Output from stderr
   returned: failed
   type: string
-  sample: "Error while executing config command Unknown Log configuration producer_byte_rate.\n"
+  sample: "Error while executing config command Unknown Log configuration producer_byte_rate.\\\n"
 '''
 
 import re

--- a/lib/ansible/modules/messaging/kafka_configs.py
+++ b/lib/ansible/modules/messaging/kafka_configs.py
@@ -263,10 +263,10 @@ def main():
 
     if not module.get_bin_path('kafka-configs') and module.params['executable'] is None:
         module.fail_json(msg='Executable not provided.')
-    if module.params['executable'] is not None and not os.path.isfile(module.params['executable']):
-        module.fail_json(msg='%s not found.' % (module.params['executable']))
-    if not is_executable(module.params['executable']):
-        module.fail_json(msg='%s not executable.' % (module.params['executable']))
+    if module.params['executable'] is not None and \
+            (not os.path.isfile(module.params['executable']) or
+             not is_executable(module.params['executable'])):
+        module.fail_json(msg='%s not found or not executable.' % (module.params['executable']))
 
     try:
         kc = KafkaConfigs(module)

--- a/lib/ansible/modules/messaging/kafka_configs.py
+++ b/lib/ansible/modules/messaging/kafka_configs.py
@@ -89,14 +89,14 @@ rc:
   sample: 0
 stdout:
   description: Output from stdout after execution
-  returned: success
+  returned: success or changed
   type: string
   sample: "Configs for topic 'wassingue' are cleanup.policy=delete,compression.type=gzip\n"
 msg:
   description: Output from stderr
   returned: failed
   type: string
-  sample: ""Error while executing config command Unknown Log configuration producer_byte_rate.\norg.apache.kafka.common.errors.InvalidConfigurationException: Unknown Log configuration producer_byte_rate.\n\n"
+  sample: "Error while executing config command Unknown Log configuration producer_byte_rate.\n"
 '''
 
 import re

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -1,0 +1,201 @@
+import json
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible.modules.messaging import kafka_configs
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+
+
+def get_bin_path(self, arg, required=False):
+    if arg.endswith('kafka-topics'):
+        return '/usr/bin/kafka-topics'
+    elif arg.endswith('kafka-configs'):
+        return '/usr/bin/kafka-configs'
+    else:
+        if required:
+            fail_json(msg='%r not found !' % arg)
+
+
+class TestKafka(unittest.TestCase):
+
+    def setUp(self):
+        self.mock_module_helper = patch.multiple(basic.AnsibleModule,
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json,
+                                                 get_bin_path=get_bin_path)
+        self.mock_module_helper.start()
+        self.addCleanup(self.mock_module_helper.stop)
+
+    def tearDown(self):
+        pass
+
+    def test_kafka_configs_describe_one(self):
+        set_module_args({
+            'executable': None,
+			'entity_type': 'topics',
+            'entity_name': 'georgette',
+            'zookeeper': 'carotte.localhost:2181',
+            'describe': True,
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "Configs for topic 'test-GDE' are " + \
+                "cleanup.policy=delete,compression.type=gzip,flush.ms=1000\\\\n"
+            stderr = ""
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_configs.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --describe --zookeeper carotte.localhost:2181 --entity-type topics --entity-name georgette')
+
+    def test_kafka_configs_describe_all(self):
+        set_module_args({
+            'executable': None,
+			'entity_type': 'topics',
+            'zookeeper': 'carotte.localhost:2181',
+            'describe': True,
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "Configs for topic 'georgette' are " + \
+                "cleanup.policy=delete,compression.type=gzip,flush.ms=1000\\\\n" + \
+                "Configs for topic '__consumer_offsets' are " + \
+                "segment.bytes=104857600,cleanup.policy=compact\\\\n" + \
+                "Configs for topic 'admin-filtrage-topic' are \\\\n"
+            stderr = ""
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_configs.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --describe --zookeeper carotte.localhost:2181 --entity-type topics')
+
+    def test_kafka_configs_add_config(self):
+        set_module_args({
+            'executable': None,
+			'entity_type': 'topics',
+            'entity_name': 'georgette',
+            'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
+            'zookeeper': 'carotte.localhost:2181',
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "Updated config for entity: topics 'georgette'"
+            stderr = ""
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_configs.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
+                                                 --zookeeper carotte.localhost:2181
+                                                 --entity-type topics
+                                                 --entity-name georgette
+                                                 --add-config cleanup.policy=delete,
+                                                 compression.type=gzip')
+
+    def test_kafka_configs_add_config_no_change(self):
+        set_module_args({
+            'executable': None,
+			'entity_type': 'topics',
+            'entity_name': 'georgette',
+            'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
+            'zookeeper': 'carotte.localhost:2181',
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "Nothing to do for config entity: topics 'georgette'"
+            stderr = ""
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_configs.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
+                                                 --zookeeper carotte.localhost:2181
+                                                 --entity-type topics
+                                                 --entity-name georgette
+                                                 --add-config cleanup.policy=delete,
+                                                 compression.type=gzip')
+
+    def test_kafka_configs_del_config(self):
+        set_module_args({
+            'executable': None,
+			'entity_type': 'topics',
+            'entity_name': 'georgette',
+            'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
+            'zookeeper': 'carotte.localhost:2181',
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "Updated config for entity: topics 'georgette'"
+            stderr = ""
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_configs.main()
+            self.assertTrue(result.exception.args[0]['changed'])
+
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
+                                                 --zookeeper carotte.localhost:2181
+                                                 --entity-type topics
+                                                 --entity-name georgette
+                                                 --delete-config cleanup.policy=delete,
+                                                 compression.type=gzip')
+
+    # Whether you have something to delete or not,
+    # the kafka output is still the same: 'Updated config for [...]'
+    def test_kafka_configs_del_config_no_change(self):
+        set_module_args({
+            'executable': None,
+			'entity_type': 'topics',
+            'entity_name': 'georgette',
+            'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
+            'zookeeper': 'carotte.localhost:2181',
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "Updated config for entity: topics 'georgette'"
+            stderr = ""
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_configs.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
+                                                 --zookeeper carotte.localhost:2181
+                                                 --entity-type topics
+                                                 --entity-name georgette
+                                                 --delete-config cleanup.policy=delete,
+                                                 compression.type=gzip')

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -57,7 +57,7 @@ class TestKafka(unittest.TestCase):
     def test_kafka_configs_describe_one(self):
         set_module_args({
             'executable': None,
-			'entity_type': 'topics',
+            'entity_type': 'topics',
             'entity_name': 'georgette',
             'zookeeper': 'carotte.localhost:2181',
             'describe': True,
@@ -73,12 +73,15 @@ class TestKafka(unittest.TestCase):
                 kafka_configs.main()
             self.assertFalse(result.exception.args[0]['changed'])
 
-        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --describe --zookeeper carotte.localhost:2181 --entity-type topics --entity-name georgette')
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --describe '
+                                                 '--zookeeper carotte.localhost:2181 '
+                                                 '--entity-type topics '
+                                                 '--entity-name georgette')
 
     def test_kafka_configs_describe_all(self):
         set_module_args({
             'executable': None,
-			'entity_type': 'topics',
+            'entity_type': 'topics',
             'zookeeper': 'carotte.localhost:2181',
             'describe': True,
         })
@@ -96,12 +99,14 @@ class TestKafka(unittest.TestCase):
                 kafka_configs.main()
             self.assertFalse(result.exception.args[0]['changed'])
 
-        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --describe --zookeeper carotte.localhost:2181 --entity-type topics')
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --describe '
+                                                 '--zookeeper carotte.localhost:2181 '
+                                                 '--entity-type topics')
 
     def test_kafka_configs_add_config(self):
         set_module_args({
             'executable': None,
-			'entity_type': 'topics',
+            'entity_type': 'topics',
             'entity_name': 'georgette',
             'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
             'zookeeper': 'carotte.localhost:2181',
@@ -116,17 +121,17 @@ class TestKafka(unittest.TestCase):
                 kafka_configs.main()
             self.assertTrue(result.exception.args[0]['changed'])
 
-        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
-                                                 --zookeeper carotte.localhost:2181
-                                                 --entity-type topics
-                                                 --entity-name georgette
-                                                 --add-config cleanup.policy=delete,
-                                                 compression.type=gzip')
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter '
+                                                 '--zookeeper carotte.localhost:2181 '
+                                                 '--entity-type topics '
+                                                 '--entity-name georgette '
+                                                 '--add-config cleanup.policy=delete,'
+                                                 'compression.type=gzip')
 
     def test_kafka_configs_add_config_no_change(self):
         set_module_args({
             'executable': None,
-			'entity_type': 'topics',
+            'entity_type': 'topics',
             'entity_name': 'georgette',
             'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
             'zookeeper': 'carotte.localhost:2181',
@@ -141,17 +146,17 @@ class TestKafka(unittest.TestCase):
                 kafka_configs.main()
             self.assertFalse(result.exception.args[0]['changed'])
 
-        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
-                                                 --zookeeper carotte.localhost:2181
-                                                 --entity-type topics
-                                                 --entity-name georgette
-                                                 --add-config cleanup.policy=delete,
-                                                 compression.type=gzip')
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter '
+                                                 '--zookeeper carotte.localhost:2181 '
+                                                 '--entity-type topics '
+                                                 '--entity-name georgette '
+                                                 '--add-config cleanup.policy=delete,'
+                                                 'compression.type=gzip')
 
     def test_kafka_configs_del_config(self):
         set_module_args({
             'executable': None,
-			'entity_type': 'topics',
+            'entity_type': 'topics',
             'entity_name': 'georgette',
             'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
             'zookeeper': 'carotte.localhost:2181',
@@ -166,19 +171,19 @@ class TestKafka(unittest.TestCase):
                 kafka_configs.main()
             self.assertTrue(result.exception.args[0]['changed'])
 
-        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
-                                                 --zookeeper carotte.localhost:2181
-                                                 --entity-type topics
-                                                 --entity-name georgette
-                                                 --delete-config cleanup.policy=delete,
-                                                 compression.type=gzip')
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter '
+                                                 '--zookeeper carotte.localhost:2181 '
+                                                 '--entity-type topics '
+                                                 '--entity-name georgette '
+                                                 '--delete-config cleanup.policy=delete,'
+                                                 'compression.type=gzip')
 
     # Whether you have something to delete or not,
     # the kafka output is still the same: 'Updated config for [...]'
     def test_kafka_configs_del_config_no_change(self):
         set_module_args({
             'executable': None,
-			'entity_type': 'topics',
+            'entity_type': 'topics',
             'entity_name': 'georgette',
             'configs': {'cleanup.policy': 'delete', 'compression.type': 'gzip'},
             'zookeeper': 'carotte.localhost:2181',
@@ -193,9 +198,9 @@ class TestKafka(unittest.TestCase):
                 kafka_configs.main()
             self.assertFalse(result.exception.args[0]['changed'])
 
-        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter
-                                                 --zookeeper carotte.localhost:2181
-                                                 --entity-type topics
-                                                 --entity-name georgette
-                                                 --delete-config cleanup.policy=delete,
-                                                 compression.type=gzip')
+        mock_run_command.assert_called_once_with('/usr/bin/kafka-configs --alter '
+                                                 '--zookeeper carotte.localhost:2181 '
+                                                 '--entity-type topics '
+                                                 '--entity-name georgette '
+                                                 '--delete-config cleanup.policy=delete,'
+                                                 'compression.type=gzip')


### PR DESCRIPTION
##### SUMMARY
This module aims to allow a user to manage Kafka configs  

Internally it relies on kafka scripts (kafka-configs.sh).

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

 - kafka_configs.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/gdelpierre/devel/roles/ansible.cfg
  configured module search path = [u'./library/']
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```