### PR TITLE
messaging: Add new modules for kafka-topics

### DIFF
--- a/lib/ansible/modules/messaging/kafka_topics.py
+++ b/lib/ansible/modules/messaging/kafka_topics.py
@@ -1,0 +1,398 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Guillaume Delpierre <gde@llew.me>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# -*- coding: utf-8 -*-
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: kafka_topics
+author: "Guillaume Delpierre (@gdelpierre)"
+version_added: "2.5"
+short_description: Deal with kafka topics.
+description:
+    - "Alter/Create/Delete kafka topics"
+requirements:
+    - "kafka-topics.sh"
+options:
+    action:
+        default: list
+        choices: ['list', 'describe', 'alter', 'create', 'delete']
+        type: str
+        description:
+            - Specifies the action we want to perform.
+    topic:
+        type: list
+        description:
+            - The topic to be create, alter or describe (single).
+              The topics to be describe or list (multiple).
+    config:
+        type: dict
+        description:
+            - A topic configuration override for the topic being created.
+    zookeeper:
+        required: True
+        type: list
+        description:
+            - The connection string for the zookeeper connection. 
+    replication_factor:
+        type: int
+        description:
+            -  The replication factor for each partition in the topic being created.
+    partitions:
+        type: int
+        description:
+            - The number of partitions for the topic being created or altered.
+    kafka_path:
+        default: '/opt/kafka'
+        type: path
+        description:
+            - Kafka path.
+    jaas_auth_file:
+        type: path
+        description:
+            - JAAS authentification path file.
+'''
+
+EXAMPLES = '''
+name: 'list all topic'
+kafka_topics:
+  zookeeper:
+    - zookeeper1.foo.bar:2181
+    - zookeeper2.foo.bar:2181
+
+name: 'list specific topic'
+kafka_topics:
+  topic: 'foobar'
+  zookeeper:
+    - zookeeper1.foo.bar:2181
+    - zookeeper2.foo.bar:2181
+
+name: 'Create topic foobar'
+kafka_topics:
+  action: 'create'
+  topic: 'foobar'
+  config:
+    cleanup.policy: 'delete'
+    compression.type: 'gzip'
+  partitions: 2
+  replication_factor: 1
+  kafka_path: '/opt/kafka/kafka_2.11-0.10.1.1'
+  jaas_auth_file: '/opt/kafka/sec/jaas-kafka.conf'
+  zookeeper:
+    - zookeeper1.foo.bar:2181
+    - zookeeper2.foo.bar:2181
+
+name: 'describe specific topic foobar'
+kafka_topics:
+  action: 'describe'
+  topic: 'foobar'
+  zookeeper:
+    - zookeeper1.foo.bar:2181
+    - zookeeper2.foo.bar:2181
+
+name: 'alter partitions for topic foobar'
+kafka_topics:
+  action: 'alter'
+  topic: 'foobar'
+  partitions: 3
+  jaas_auth_file: '/opt/kafka/sec/jaas-kafka.conf'
+  zookeeper:
+    - zookeeper1.foo.bar:2181
+    - zookeeper2.foo.bar:2181
+
+name: 'delete topic foobar'
+kafka_topics:
+  action: 'delete'
+  topic: 'foobar'
+  jaas_auth_file: '/opt/kafka/sec/jaas-kafka.conf'
+  zookeeper:
+    - zookeeper1.foo.bar:2181
+    - zookeeper2.foo.bar:2181
+'''
+
+RETURN = '''
+stdout:
+  description: Output from stdout of kafka-topics command after execution of given command.
+  returned: success
+  type: string
+  sample: "Created topic raclette"
+
+stdout_lines:
+  description: kafka-topics command execution return value
+  returned: always
+  type: list
+  sample: ["Created topic raclette"]
+
+stderr:
+  description: kafka-topics command execution return value
+  returned: failed
+  type: string
+  sample: "[2017-07-11 14:46:04,092] ERROR org.apache.kafka.common.errors.InvalidTopicException: topic name [foobar] is illegal, contains a character other than ASCII alphanumerics, '.', '_' and '-'\n (kafka.admin.TopicCommand$)\n"
+
+rc:
+  description: kafka-topics command execution return value
+  returned: always
+  type: int
+  sample: 0
+'''
+
+import re
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+
+class KafkaError(Exception):
+    ''' '''
+    pass
+ 
+class KafkaTopics(object):
+
+    def __init__(self, module):
+
+        self.config = module.params['config']
+        self.partitions = module.params['partitions']
+        self.replication_factor = module.params['replication_factor']
+        self.topic = module.params['topic']
+        self.zookeeper  = ','.join(module.params['zookeeper'])
+
+        self.kafka_path = module.params['kafka_path']
+        self.executable = self.kafka_path + '/bin/kafka-topics.sh'
+
+        if module.params['jaas_auth_file']:
+            self.jaas_auth_file = module.params['jaas_auth_file']
+            self.kafka_env_opts = '-Djava.security.auth.login.config=' + \
+                self.jaas_auth_file
+
+        self.module = module
+
+    def get(self):
+        ''' List kafka topics. '''
+
+        if self.topic:
+            # list supports multiple topics
+            topics = ','.join(self.topic)
+            cmd = '%s --list --zookeeper %s --topic %s' % (self.executable,
+                                                           self.zookeeper,
+                                                           topics)
+        else:
+            cmd = "%s --list --zookeeper %s" % (self.executable,
+                                                self.zookeeper)
+
+        try:
+            return self.module.run_command(cmd)
+
+        except KafkaError as exc:
+            module.fail_json(msg=to_native(exc))
+
+    def describe(self):
+        ''' Describe kafka topics. '''
+
+        if self.topic:
+            # describe supports multiple topics
+            topics = ','.join(self.topic)
+            cmd = '%s --describe --zookeeper %s --topic %s' % (self.executable,
+                                                               self.zookeeper,
+                                                               topics)
+        else:
+            cmd = '%s --describe --zookeeper %s' % (self.executable,
+                                                    self.zookeeper)
+
+        try:
+            return self.module.run_command(cmd)
+
+        except KafkaError as exc:
+            module.fail_json(msg=to_native(exc))
+
+    def alter(self):
+        ''' alter kafka topics. '''
+
+        cmd_get_partitions = self.describe()
+        # For a specific topic, we want the PartitionCount value.
+        get_partitions = (cmd_get_partitions[1]
+                          .splitlines()[0]
+                          .split('\t')[1]
+                          .split(':')[1]
+                          )
+        # alter supports only 1 topic
+        if len(self.topic) > 1:
+                msg = 'alter action supports only 1 topic'
+                return self.module.fail_json(msg)
+        else:
+            topic = ''.join(self.topic)
+            cmd = ('%s --alter --if-exists --zookeeper %s '
+                    '--partitions %s --topic %s') % (self.executable,
+                                                     self.zookeeper,
+                                                     self.partitions,
+                                                     topic)
+
+        try:
+            env = ''
+            if self.jaas_auth_file:
+                env = { 'KAFKA_OPTS': self.kafka_env_opts }
+
+            if int(get_partitions) < int(self.partitions):
+                return self.module.run_command(cmd, environ_update=env)
+            else:
+                err_msg="""
+                The number of partitions for a topic can only be increased.
+                """
+                return self.module.fail_json(msg=to_native(err_msg))
+
+        except KafkaError as exc:
+            module.fail_json(msg=to_native(exc))
+
+    def create(self):
+        ''' Create new kafka topic. '''
+
+        # create action supports only 1 topic
+        if len(self.topic) > 1:
+                msg = 'alter action supports only 1 topic'
+                return self.module.fail_json(msg)
+        else:
+            topic = ''.join(self.topic)
+            if self.config:
+                config = ' --config '.join(
+                    "%s=%r" % (key, value) for (key, value) in self.config.iteritems())
+
+                cmd = ('%s --create --if-not-exists --zookeeper %s '
+                        '--replication-factor %s --partitions %s '
+                        '--topic %s --config %s') % (self.executable,
+                                                     self.zookeeper,
+                                                     self.replication_factor,
+                                                     self.partitions,
+                                                     topic,
+                                                     config)
+
+            else:
+                cmd = ('%s --create --if-not-exists --zookeeper %s '
+                        '--replication-factor %s --partitions %s '
+                        '--topic %s') % (self.executable,
+                                         self.zookeeper,
+                                         self.replication_factor,
+                                         self.partitions,
+                                         topic)
+
+        try:
+            env = ''
+            if self.jaas_auth_file:
+                env = { 'KAFKA_OPTS': self.kafka_env_opts }
+
+            return self.module.run_command(cmd, environ_update=env)
+
+        except KafkaError as exc:
+            module.fail_json(msg=to_native(exc))
+
+    def delete(self):
+        ''' Delete a kafka topic. '''
+        # create action supports only 1 topic
+        if len(self.topic) > 1:
+                msg = 'alter action supports only 1 topic'
+                return self.module.fail_json(msg)
+        else:
+            topic = ''.join(self.topic)
+            cmd = ('%s --delete --zookeeper %s '
+                    '--topic %s --if-exists') % (self.executable,
+                                                  self.zookeeper,
+                                                  topic)
+
+        try:
+            env = ''
+            if self.jaas_auth_file:
+                env = { 'KAFKA_OPTS': self.kafka_env_opts }
+            return self.module.run_command(cmd, environ_update=env)
+
+        except KafkaError as exc:
+            module.fail_json(msg=to_native(exc))
+
+def main():
+    argument_spec = dict(
+        action = dict(default='list',
+                        choices=['list', 'describe', 'alter',
+                                 'create', 'delete'],
+                        type='str'),
+        topic = dict(type='list'),
+        config = dict(type='dict'),
+        zookeeper = dict(required=True, type='list'),
+        replication_factor = dict(type='int'),
+        partitions = dict(type='int'),
+        kafka_path = dict(default='/opt/kafka',
+                                type='path'),
+        jaas_auth_file = dict(type='path'),
+    )
+
+    required_if = [
+        ['action', 'alter',
+         [ 'topic', 'partitions', ]
+         ],
+        ['action', 'create',
+         [ 'topic', 'replication_factor', 'partitions', ]
+         ],
+        ['action', 'delete',
+         [ 'topic', ]
+         ],
+    ]
+
+    module = AnsibleModule(
+        argument_spec = argument_spec,
+        required_if = required_if,
+        supports_check_mode = True,
+    )
+
+    kafka_bin = module.params['kafka_path'] + '/bin/kafka-topics.sh'
+    jaas_auth_file = module.params['jaas_auth_file']
+
+    is_kafka_bin = os.path.isfile(kafka_bin)
+    
+    changed = False
+
+    if not is_kafka_bin:
+        module.fail_json(msg='%s not found.' % (kafka_bin))
+
+    if module.params['jaas_auth_file']:
+        is_jaas_auth_file = os.path.isfile(jaas_auth_file)
+        if not is_jaas_auth_file:
+           module.fail_json(msg='%s not found.' % (jaas_auth_file))
+
+    try:
+        kt = KafkaTopics(module)
+
+        action = module.params['action']
+        if not module.check_mode:
+            if module.params['action'] == 'list':
+                (rc, out, err) = kt.get()
+            elif module.params['action'] == 'describe':
+                (rc, out, err) = kt.describe()
+            elif module.params['action'] == 'alter':
+                (rc, out, err) = kt.alter()
+                if re.search('Adding partitions succeeded!', out):
+                    changed = True
+            elif module.params['action'] == 'create':
+                (rc, out, err) = kt.create()
+                if re.search('^Created topic', out):
+                    changed = True
+            elif module.params['action'] == 'delete':
+                (rc, out, err) = kt.delete()
+                if re.search('^Topic [a-zA-Z0-9_\-]+ is marked for deletion.', out):
+                    changed = True
+
+            result = {
+                    'stdout': out,
+                    'stdout_lines': out.splitlines(),
+                    'stderr': err,
+                    'rc': rc,
+                    'changed': changed,
+            }
+            
+    except KafkaError as exc:
+        module.fail_json(msg=to_native(exc))
+
+    module.exit_json(**result)
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/messaging/kafka_topics.py
+++ b/lib/ansible/modules/messaging/kafka_topics.py
@@ -160,6 +160,7 @@ class KafkaTopics(object):
 
         self.executable = module.params['executable']
 
+        self.jaas_auth_file = None
         if module.params['jaas_auth_file']:
             self.jaas_auth_file = module.params['jaas_auth_file']
             self.kafka_env_opts = '-Djava.security.auth.login.config=' + \

--- a/lib/ansible/modules/messaging/kafka_topics.py
+++ b/lib/ansible/modules/messaging/kafka_topics.py
@@ -38,7 +38,7 @@ options:
     zookeeper:
         required: True
         description:
-            - The connection string for the zookeeper connection. 
+            - The connection string for the zookeeper connection.
     replication_factor:
         description:
             -  The replication factor for each partition in the topic being created.
@@ -142,6 +142,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+
 
 class KafkaError(Exception):
     pass
@@ -305,7 +306,7 @@ class KafkaTopics(object):
 
 
 def main():
-    argument_spec=dict(
+    argument_spec = dict(
         action=dict(default='list',
                     choices=['list', 'describe', 'alter',
                              'create', 'delete'],
@@ -321,11 +322,11 @@ def main():
     )
 
     required_if = [
-        ['action', 'alter', ['topic', 'partitions',]],
+        ['action', 'alter', ['topic', 'partitions']],
         ['action', 'create',
-         ['topic', 'replication_factor', 'partitions',]
+         ['topic', 'replication_factor', 'partitions']
          ],
-        ['action', 'delete', ['topic',]],
+        ['action', 'delete', ['topic']],
     ]
 
     module = AnsibleModule(

--- a/lib/ansible/modules/messaging/kafka_topics.py
+++ b/lib/ansible/modules/messaging/kafka_topics.py
@@ -4,6 +4,9 @@
 #
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
@@ -13,47 +16,40 @@ DOCUMENTATION = '''
 module: kafka_topics
 author: "Guillaume Delpierre (@gdelpierre)"
 version_added: "2.5"
+
 short_description: Deal with kafka topics.
 description:
     - "Alter/Create/Delete kafka topics"
 requirements:
-    - "kafka-topics.sh"
+    - "kafka-topics"
 options:
     action:
         default: list
         choices: ['list', 'describe', 'alter', 'create', 'delete']
-        type: str
         description:
             - Specifies the action we want to perform.
     topic:
-        type: list
         description:
             - The topic to be create, alter or describe (single).
               The topics to be describe or list (multiple).
     config:
-        type: dict
         description:
             - A topic configuration override for the topic being created.
     zookeeper:
         required: True
-        type: list
         description:
             - The connection string for the zookeeper connection. 
     replication_factor:
-        type: int
         description:
             -  The replication factor for each partition in the topic being created.
     partitions:
-        type: int
         description:
             - The number of partitions for the topic being created or altered.
-    kafka_path:
-        default: '/opt/kafka'
-        type: path
+    executable:
+        default: '/usr/bin/kafka-topics'
         description:
-            - Kafka path.
+            - Kafka executable path.
     jaas_auth_file:
-        type: path
         description:
             - JAAS authentification path file.
 '''
@@ -81,7 +77,7 @@ kafka_topics:
     compression.type: 'gzip'
   partitions: 2
   replication_factor: 1
-  kafka_path: '/opt/kafka/kafka_2.11-0.10.1.1'
+  executable: '/opt/kafka/kafka_2.11-0.10.1.1/bin/kafka-topics.sh'
   jaas_auth_file: '/opt/kafka/sec/jaas-kafka.conf'
   zookeeper:
     - zookeeper1.foo.bar:2181
@@ -132,7 +128,7 @@ stderr:
   description: kafka-topics command execution return value
   returned: failed
   type: string
-  sample: "[2017-07-11 14:46:04,092] ERROR org.apache.kafka.common.errors.InvalidTopicException: topic name [foobar] is illegal, contains a character other than ASCII alphanumerics, '.', '_' and '-'\n (kafka.admin.TopicCommand$)\n"
+  sample: "[2017-07-11 14:46:04,092] ERROR org.apache.kafka.common.errors.InvalidTopicException: topic name [foobar] is illegal"
 
 rc:
   description: kafka-topics command execution return value
@@ -148,9 +144,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
 class KafkaError(Exception):
-    ''' '''
     pass
- 
+
+
 class KafkaTopics(object):
 
     def __init__(self, module):
@@ -159,10 +155,9 @@ class KafkaTopics(object):
         self.partitions = module.params['partitions']
         self.replication_factor = module.params['replication_factor']
         self.topic = module.params['topic']
-        self.zookeeper  = ','.join(module.params['zookeeper'])
+        self.zookeeper = ','.join(module.params['zookeeper'])
 
-        self.kafka_path = module.params['kafka_path']
-        self.executable = self.kafka_path + '/bin/kafka-topics.sh'
+        self.executable = module.params['executable']
 
         if module.params['jaas_auth_file']:
             self.jaas_auth_file = module.params['jaas_auth_file']
@@ -188,17 +183,16 @@ class KafkaTopics(object):
             return self.module.run_command(cmd)
 
         except KafkaError as exc:
-            module.fail_json(msg=to_native(exc))
+            self.module.fail_json(msg=to_native(exc))
 
     def describe(self):
         ''' Describe kafka topics. '''
 
         if self.topic:
             # describe supports multiple topics
-            topics = ','.join(self.topic)
             cmd = '%s --describe --zookeeper %s --topic %s' % (self.executable,
                                                                self.zookeeper,
-                                                               topics)
+                                                               ','.join(self.topic))
         else:
             cmd = '%s --describe --zookeeper %s' % (self.executable,
                                                     self.zookeeper)
@@ -207,7 +201,7 @@ class KafkaTopics(object):
             return self.module.run_command(cmd)
 
         except KafkaError as exc:
-            module.fail_json(msg=to_native(exc))
+            self.module.fail_json(msg=to_native(exc))
 
     def alter(self):
         ''' alter kafka topics. '''
@@ -224,28 +218,27 @@ class KafkaTopics(object):
                 msg = 'alter action supports only 1 topic'
                 return self.module.fail_json(msg)
         else:
-            topic = ''.join(self.topic)
             cmd = ('%s --alter --if-exists --zookeeper %s '
-                    '--partitions %s --topic %s') % (self.executable,
-                                                     self.zookeeper,
-                                                     self.partitions,
-                                                     topic)
+                   '--partitions %s --topic %s') % (self.executable,
+                                                    self.zookeeper,
+                                                    self.partitions,
+                                                    ''.join(self.topic))
 
         try:
             env = ''
             if self.jaas_auth_file:
-                env = { 'KAFKA_OPTS': self.kafka_env_opts }
+                env = {'KAFKA_OPTS': self.kafka_env_opts}
 
             if int(get_partitions) < int(self.partitions):
                 return self.module.run_command(cmd, environ_update=env)
             else:
-                err_msg="""
+                err_msg = """
                 The number of partitions for a topic can only be increased.
                 """
                 return self.module.fail_json(msg=to_native(err_msg))
 
         except KafkaError as exc:
-            module.fail_json(msg=to_native(exc))
+            self.module.fail_json(msg=to_native(exc))
 
     def create(self):
         ''' Create new kafka topic. '''
@@ -255,109 +248,100 @@ class KafkaTopics(object):
                 msg = 'alter action supports only 1 topic'
                 return self.module.fail_json(msg)
         else:
-            topic = ''.join(self.topic)
             if self.config:
                 config = ' --config '.join(
-                    "%s=%r" % (key, value) for (key, value) in self.config.iteritems())
+                    "%s=%r" % (key, value) for (key, value) in self.config.items())
 
                 cmd = ('%s --create --if-not-exists --zookeeper %s '
-                        '--replication-factor %s --partitions %s '
-                        '--topic %s --config %s') % (self.executable,
-                                                     self.zookeeper,
-                                                     self.replication_factor,
-                                                     self.partitions,
-                                                     topic,
-                                                     config)
+                       '--replication-factor %s --partitions %s '
+                       '--topic %s --config %s') % (self.executable,
+                                                    self.zookeeper,
+                                                    self.replication_factor,
+                                                    self.partitions,
+                                                    ''.join(self.topic),
+                                                    config)
 
             else:
                 cmd = ('%s --create --if-not-exists --zookeeper %s '
-                        '--replication-factor %s --partitions %s '
-                        '--topic %s') % (self.executable,
-                                         self.zookeeper,
-                                         self.replication_factor,
-                                         self.partitions,
-                                         topic)
+                       '--replication-factor %s --partitions %s '
+                       '--topic %s') % (self.executable,
+                                        self.zookeeper,
+                                        self.replication_factor,
+                                        self.partitions,
+                                        ''.join(self.topic))
 
         try:
             env = ''
             if self.jaas_auth_file:
-                env = { 'KAFKA_OPTS': self.kafka_env_opts }
+                env = {'KAFKA_OPTS': self.kafka_env_opts}
 
             return self.module.run_command(cmd, environ_update=env)
 
         except KafkaError as exc:
-            module.fail_json(msg=to_native(exc))
+            self.module.fail_json(msg=to_native(exc))
 
     def delete(self):
         ''' Delete a kafka topic. '''
+
         # create action supports only 1 topic
         if len(self.topic) > 1:
                 msg = 'alter action supports only 1 topic'
                 return self.module.fail_json(msg)
         else:
-            topic = ''.join(self.topic)
             cmd = ('%s --delete --zookeeper %s '
-                    '--topic %s --if-exists') % (self.executable,
-                                                  self.zookeeper,
-                                                  topic)
+                   '--topic %s --if-exists') % (self.executable,
+                                                self.zookeeper,
+                                                ''.join(self.topic))
 
         try:
             env = ''
             if self.jaas_auth_file:
-                env = { 'KAFKA_OPTS': self.kafka_env_opts }
+                env = {'KAFKA_OPTS': self.kafka_env_opts}
+
             return self.module.run_command(cmd, environ_update=env)
 
         except KafkaError as exc:
-            module.fail_json(msg=to_native(exc))
+            self.module.fail_json(msg=to_native(exc))
+
 
 def main():
-    argument_spec = dict(
-        action = dict(default='list',
-                        choices=['list', 'describe', 'alter',
-                                 'create', 'delete'],
-                        type='str'),
-        topic = dict(type='list'),
-        config = dict(type='dict'),
-        zookeeper = dict(required=True, type='list'),
-        replication_factor = dict(type='int'),
-        partitions = dict(type='int'),
-        kafka_path = dict(default='/opt/kafka',
-                                type='path'),
-        jaas_auth_file = dict(type='path'),
+    argument_spec=dict(
+        action=dict(default='list',
+                    choices=['list', 'describe', 'alter',
+                             'create', 'delete'],
+                    type='str'),
+        topic=dict(type='list'),
+        config=dict(type='dict'),
+        zookeeper=dict(required=True, type='list'),
+        replication_factor=dict(type='int'),
+        partitions=dict(type='int'),
+        executable=dict(default='/usr/bin/kafka-topics',
+                        type='path'),
+        jaas_auth_file=dict(type='path'),
     )
 
     required_if = [
-        ['action', 'alter',
-         [ 'topic', 'partitions', ]
-         ],
+        ['action', 'alter', ['topic', 'partitions',]],
         ['action', 'create',
-         [ 'topic', 'replication_factor', 'partitions', ]
+         ['topic', 'replication_factor', 'partitions',]
          ],
-        ['action', 'delete',
-         [ 'topic', ]
-         ],
+        ['action', 'delete', ['topic',]],
     ]
 
     module = AnsibleModule(
-        argument_spec = argument_spec,
-        required_if = required_if,
-        supports_check_mode = True,
+        argument_spec=argument_spec,
+        required_if=required_if,
+        supports_check_mode=True,
     )
 
-    kafka_bin = module.params['kafka_path'] + '/bin/kafka-topics.sh'
-    jaas_auth_file = module.params['jaas_auth_file']
-
-    is_kafka_bin = os.path.isfile(kafka_bin)
-    
     changed = False
 
-    if not is_kafka_bin:
-        module.fail_json(msg='%s not found.' % (kafka_bin))
+    if not os.path.isfile(module.params['executable']):
+        module.fail_json(msg='%s not found.' % (module.params['executable']))
 
     if module.params['jaas_auth_file']:
-        is_jaas_auth_file = os.path.isfile(jaas_auth_file)
-        if not is_jaas_auth_file:
-           module.fail_json(msg='%s not found.' % (jaas_auth_file))
+        if not os.path.isfile(module.params['jaas_auth_file']):
+            module.fail_json(msg='%s not found.' % (module.params['jaas_auth_file']))
 
     try:
         kt = KafkaTopics(module)
@@ -382,13 +366,13 @@ def main():
                     changed = True
 
             result = {
-                    'stdout': out,
-                    'stdout_lines': out.splitlines(),
-                    'stderr': err,
-                    'rc': rc,
-                    'changed': changed,
+                'stdout': out,
+                'stdout_lines': out.splitlines(),
+                'stderr': err,
+                'rc': rc,
+                'changed': changed,
             }
-            
+
     except KafkaError as exc:
         module.fail_json(msg=to_native(exc))
 

--- a/lib/ansible/modules/messaging/kafka_topics.py
+++ b/lib/ansible/modules/messaging/kafka_topics.py
@@ -343,7 +343,9 @@ def main():
                 changed = True
         elif module.params['action'] == 'create':
             (rc, out, err) = kt.create()
-            if re.search('^Created topic', out):
+            # according to
+            # https://github.com/apache/kafka/blob/0.10.1/core/src/main/scala/kafka/common/Topic.scala
+            if re.search('Created topic "[a-zA-Z0-9\\._\\-]{1,249}"', out):
                 changed = True
             if not out:
                 out = 'Nothing has changed.'

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -1,0 +1,63 @@
+import json
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
+from ansible.modules.messaging import kafka_topics
+
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
+
+    
+class AnsibleExitJson(Exception):
+    pass
+
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+def exit_json(*args, **kwargs):
+    if 'changed' not in kwargs:
+        kwargs['changed'] = False
+    raise AnsibleExitJson(kwargs)
+
+
+def fail_json(*args, **kwargs):
+    kwargs['failed'] = True
+    raise AnsibleFailJson(kwargs)
+    
+
+class TestKafka(unittest.TestCase):
+    
+    def setUp(self):
+        self.mock_exit_fail = patch.multiple(basic.AnsibleModule,
+                                             exit_json=exit_json,
+                                             fail_json=fail_json)
+        self.mock_exit_fail.start()
+        self.addCleanup(self.mock_exit_fail.stop)
+
+    def tearDown(self):
+        pass
+
+    def test_kafka_topics(self):
+        set_module_args({
+            'topic': 'jambon',
+            'zookeeper': 'carotte.localhost:2181',
+            'describe': True,
+        })
+
+        with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
+            stdout = "__consumer_offsets\\\\njambon\\\\nfromage\\\\ntartiflette\\\\n"
+            stderr = "[2017-09-15 15:33:35,307] ERROR org.apache.kafka.common.errors.InvalidTopicException: topic name tes@@#(23 is illegal, contains a character other than ASCII alphanumerics, '.', '_' and '-'\\\\n (kafka.admin.TopicCommand$)\\\\n"
+            mock_run_command.return_value = 0, stdout, stderr  # successful execution
+
+            with self.assertRaises(AnsibleExitJson) as result:
+                kafka_topics.main()
+            self.assertFalse(result.exception.args[0]['changed'])
+
+        self.assertEqual(mock_run_command.call_count, 1)
+        self.assertEqual(mock_run_command.call_args[0][0][0], '/usr/bin/kafka-configs')

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -107,7 +107,7 @@ class TestKafka(unittest.TestCase):
 
             with self.assertRaises(AnsibleExitJson) as result:
                 kafka_topics.main()
-            self.assertFalse(result.exception.args[0]['changed'])
+            self.assertTrue(result.exception.args[0]['changed'])
 
     def test_kafka_topics_delete(self):
         set_module_args({
@@ -126,7 +126,7 @@ class TestKafka(unittest.TestCase):
 
             with self.assertRaises(AnsibleExitJson) as result:
                 kafka_topics.main()
-            self.assertFalse(result.exception.args[0]['changed'])
+            self.assertTrue(result.exception.args[0]['changed'])
         mock_run_command.assert_called_once_with('/usr/bin/kafka-topics --delete --zookeeper carotte.localhost:2181 --topic jambon --if-exists')
 
     def test_kafka_topics_describe_specific(self):

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -47,7 +47,6 @@ class TestKafka(unittest.TestCase):
         set_module_args({
             'topic': 'jambon',
             'zookeeper': 'carotte.localhost:2181',
-            'describe': True,
         })
 
         with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
@@ -60,4 +59,4 @@ class TestKafka(unittest.TestCase):
             self.assertFalse(result.exception.args[0]['changed'])
 
         self.assertEqual(mock_run_command.call_count, 1)
-        self.assertEqual(mock_run_command.call_args[0][0][0], '/usr/bin/kafka-configs')
+        self.assertEqual(mock_run_command.call_args[0][0][0], '/usr/bin/kafka-topics')

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -11,7 +11,7 @@ def set_module_args(args):
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
     basic._ANSIBLE_ARGS = to_bytes(args)
 
-    
+
 class AnsibleExitJson(Exception):
     pass
 
@@ -29,10 +29,10 @@ def exit_json(*args, **kwargs):
 def fail_json(*args, **kwargs):
     kwargs['failed'] = True
     raise AnsibleFailJson(kwargs)
-    
+
 
 class TestKafka(unittest.TestCase):
-    
+
     def setUp(self):
         self.mock_exit_fail = patch.multiple(basic.AnsibleModule,
                                              exit_json=exit_json,
@@ -51,7 +51,10 @@ class TestKafka(unittest.TestCase):
 
         with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
             stdout = "__consumer_offsets\\\\njambon\\\\nfromage\\\\ntartiflette\\\\n"
-            stderr = "[2017-09-15 15:33:35,307] ERROR org.apache.kafka.common.errors.InvalidTopicException: topic name tes@@#(23 is illegal, contains a character other than ASCII alphanumerics, '.', '_' and '-'\\\\n (kafka.admin.TopicCommand$)\\\\n"
+            stderr = "[2017-09-15 15:33:35,307] " + \
+                "ERROR org.apache.kafka.common.errors.InvalidTopicException: " + \
+                "topic name tes@@#(23 is illegal, contains a character other " + \
+                "than ASCII alphanumerics, '.', '_' and '-'\\\\n (kafka.admin.TopicCommand$)\\\\n"
             mock_run_command.return_value = 0, stdout, stderr  # successful execution
 
             with self.assertRaises(AnsibleExitJson) as result:

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -31,7 +31,7 @@ def fail_json(*args, **kwargs):
     raise AnsibleFailJson(kwargs)
 
 
-def get_bin_path(self, arg, required=False, opt_dirs=[]):
+def get_bin_path(self, arg, required=False):
     if arg.endswith('kafka-topics'):
         return '/usr/bin/kafka-topics'
     else:
@@ -92,11 +92,13 @@ class TestKafka(unittest.TestCase):
             'executable': None,
             'topic': 'jambon',
             'action': 'create',
+            'replication_factor': '1',
+            'partitions': '2',
             'zookeeper': 'carotte.localhost:2181',
         })
 
         with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
-            stdout = "Created topic \\\"test-GDE\\\".\\\\n"
+            stdout = "Created topic \\\"jambon\\\".\\\\n"
             stderr = "[2017-09-15 15:33:35,307] " + \
                 "ERROR org.apache.kafka.common.errors.InvalidTopicException: " + \
                 "topic name tes@@#(23 is illegal, contains a character other " + \
@@ -116,7 +118,7 @@ class TestKafka(unittest.TestCase):
         })
 
         with patch.object(basic.AnsibleModule, 'run_command') as mock_run_command:
-            stdout = "Topic test-GDE is marked for deletion.\\\\n" + \
+            stdout = "Topic jambon is marked for deletion.\\\\n" + \
                 "Note: This will have no impact if " + \
                 "delete.topic.enable is not set to true.\\\\n"
             stderr = ""

--- a/test/units/modules/messaging/test_kafka.py
+++ b/test/units/modules/messaging/test_kafka.py
@@ -43,9 +43,9 @@ class TestKafka(unittest.TestCase):
 
     def setUp(self):
         self.mock_module_helper = patch.multiple(basic.AnsibleModule,
-                                             exit_json=exit_json,
-                                             fail_json=fail_json,
-                                             get_bin_path=get_bin_path)
+                                                 exit_json=exit_json,
+                                                 fail_json=fail_json,
+                                                 get_bin_path=get_bin_path)
         self.mock_module_helper.start()
         self.addCleanup(self.mock_module_helper.stop)
 
@@ -164,13 +164,13 @@ class TestKafka(unittest.TestCase):
                 "Configs:\\\\t" + \
                 "Topic: __consumer_offsets\\\\tPartition: 0\\\\tLeader: 2\\\\t" + \
                 "Replicas: 2\\\\tIsr: 2\\\\n\\\\tTopic: __consumer_offsets\\\\t" + \
-                "Partition: 1\\\\tLeader: 3\\\\tReplicas: 3\\\\tIsr: 3\\\\n"
+                "Partition: 1\\\\tLeader: 3\\\\tReplicas: 3\\\\tIsr: 3\\\\n" + \
                 "ReplicationFactor:1\\\\t" + \
                 "Topic:jambon\\\\tPartitionCount:2\\\\t" + \
                 "Configs:compression.type=gzip,cleanup.policy=delete\\\\n\\\\t" + \
                 "Topic: jambon\\\\tPartition: 0\\\\tLeader: 2\\\\t" + \
                 "Replicas: 2\\\\tIsr: 2\\\\n\\\\t" + \
-                "Topic: jambon\\\\tPartition: 1\\\\tLeader: 3\\\\tReplicas: 3\\\\tIsr: 3\\\\n"
+                "Topic: jambon\\\\tPartition: 1\\\\tLeader: 3\\\\tReplicas: 3\\\\tIsr: 3\\\\n" + \
                 "Topic:fromage\\\\tPartitionCount:2\\\\t" + \
                 "Configs:compression.type=gzip\\\\n\\\\t" + \
                 "Topic: fromage\\\\tPartition: 0\\\\tLeader: 2\\\\t" + \


### PR DESCRIPTION
##### SUMMARY
This module aims to allow a user to manage Kafka topics  

Internally it relies on kafka scripts (kafka-topics.sh).

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

 - kafka_topics.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/gdelpierre/devel/roles/ansible.cfg
  configured module search path = [u'./library/']
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```