### PR TITLE
Fixed typo in resolution_immediacy values dict

### DIFF
--- a/lib/ansible/modules/network/aci/aci_epg_to_domain.py
+++ b/lib/ansible/modules/network/aci/aci_epg_to_domain.py
@@ -121,7 +121,7 @@ def main():
         epg=dict(type='str', aliases=['name', 'epg_name']),
         netflow=dict(type='str', choices=['disabled', 'enabled']),
         primary_encap=dict(type='int'),
-        resolution_immediacy=dict(type='str', choices=['immdediate', 'lazy', 'pre-provision']),
+        resolution_immediacy=dict(type='str', choices=['immediate', 'lazy', 'pre-provision']),
         state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
         tenant=dict(type='str', aliases=['tenant_name']),
         vm_provider=dict(type='str', choices=['vmware']),  # TODO: Find out OVS and Hyper-V options


### PR DESCRIPTION
## SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixed typo
Fixes #29013 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aci_epg_to_domain

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 60d0139844) last updated 2017/09/04 11:27:17 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [Associate EPGs to VMM Domain] ************************************************************************************************************************************************************************
task path: /home/user/lab/lab-ansible/3tierapp.yml:71
Using module file /home/user/lab/ansible/lib/ansible/modules/network/aci/aci_epg_to_domain.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: user
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301 `" && echo ansible-tmp-1504615170.26-116019065767301="` echo /home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301 `" ) && sleep 0'
<localhost> PUT /tmp/tmpRf3vKx TO /home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301/aci_epg_to_domain.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301/ /home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301/aci_epg_to_domain.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301/aci_epg_to_domain.py; rm -rf "/home/user/.ansible/tmp/ansible-tmp-1504615170.26-116019065767301/" > /dev/null 2>&1 && sleep 0'
ok: [localhost] => (item={u'epg': u'web', u'domain': u'DVS1', u'vm_provider': u'vmware'}) => {
    "changed": false, 
    "config": {}, 
    "existing": [
        {
            "fvRsDomAtt": {
                "attributes": {
                    "classPref": "encap", 
                    "delimiter": "", 
                    "dn": "uni/tn-SDNLAB/ap-Demo_3Tier_App/epg-web/rsdomAtt-[uni/vmmp-VMware/dom-DVS1]", 
                    "encap": "unknown", 
                    "encapMode": "auto", 
                    "epgCos": "Cos0", 
                    "epgCosPref": "disabled", 
                    "instrImedcy": "lazy", 
                    "netflowDir": "both", 
                    "netflowPref": "disabled", 
                    "primaryEncap": "unknown", 
                    "resImedcy": "immediate", 
                    "tDn": "uni/vmmp-VMware/dom-DVS1"
                }
            }
        }
    ], 
    "failed": false, 
    "filter_string": "?rsp-prop-include=config-only", 
    "invocation": {
        "module_args": {
            "allow_useg": null, 
            "ap": "Demo_3Tier_App", 
            "deploy_immediacy": null, 
            "domain": "DVS1", 
            "domain_type": "vmm", 
            "encap": null, 
            "encap_mode": null, 
            "epg": "web", 
            "host": "apic.lab", 
            "hostname": "apic.lab", 
            "method": null, 
            "netflow": null, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "primary_encap": null, 
            "protocol": "https", 
            "resolution_immediacy": "immediate", 
            "state": "present", 
            "tenant": "SDNLAB", 
            "timeout": 30, 
            "use_proxy": true, 
            "use_ssl": true, 
            "username": "ansible", 
            "validate_certs": false, 
            "vm_provider": "vmware"
        }
    }, 
    "item": {
        "domain": "DVS1", 
        "epg": "web", 
        "vm_provider": "vmware"
    }, 
    "method": "GET", 
    "proposed": {
        "fvRsDomAtt": {
            "attributes": {
                "resImedcy": "immediate"
            }
        }
    }, 
    "response": "OK (404 bytes)", 
    "status": 200, 
    "url": "https://apic.lab/api/mo/uni/tn-[SDNLAB]/ap-[Demo_3Tier_App]/epg-[web]/rsdomAtt-[uni/vmmp-VMware/dom-DVS1].json"
}

```
