### PR TITLE
Replace rst extension with html in message for makdocs htmlsingle

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -73,4 +73,4 @@ epub:
 
 htmlsingle: assertrst
 	sphinx-build -j $(CPUS) -b html -d _build/doctrees ./rst _build/html rst/$(rst)
-	@echo "Output is in _build/html/$(rst)"
+	@echo "Output is in _build/html/$(rst:.rst=.html)"


### PR DESCRIPTION
##### SUMMARY
Currently the output of `make htmlsingle rst=playbooks_blocks.rst` is:

```
Output is in _build/html/playbooks_blocks.rst
```

This is incorrect since the generated file name has an `html` extension. This PR fixes the output message so it displays the correct generated filename:

```
Output is in _build/html/playbooks_blocks.html
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`docs/docsite/make htmlsingle`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
