### PR TITLE
Adding support for tags and instance attributes for destination variable.

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -111,7 +111,6 @@ be used instead.
 'my_instance': {
     'region': 'us-east-1',             # attribute
     'availability_zone': 'us-east-1a', # attribute
-    'availability_zone': 'us-east-1a', # attribute
     'private_dns_name': '172.31.0.1',  # attribute
     'ec2_tag_deployment': 'blue',      # tag
     'ec2_tag_clusterid': 'ansible',    # tag

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -101,6 +101,32 @@ variable named:
 
 Security groups are comma-separated in 'ec2_security_group_ids' and
 'ec2_security_group_names'.
+
+When destination_format and destination_format_tags are specified
+the destination_format can be built from the instance tags and attributes.
+The behavior will first check the user defined tags, then proceed to
+check instance attributes, and finally if neither are found 'nil' will
+be used instead.
+
+'my_instance': {
+    'region': 'us-east-1',             # attribute
+    'availability_zone': 'us-east-1a', # attribute
+    'availability_zone': 'us-east-1a', # attribute
+    'private_dns_name': '172.31.0.1',  # attribute
+    'ec2_tag_deployment': 'blue',      # tag
+    'ec2_tag_clusterid': 'ansible',    # tag
+    'ec2_tag_Name': 'webserver',       # tag
+    ...
+}
+
+Inside of the ec2.ini file the following settings are specified:
+...
+destination_format: {0}-{1}-{2}-{3}
+destination_format_tags: Name,clusterid,deployment,private_dns_name
+...
+
+These settings would produce a destination_format as the following:
+'webserver-ansible-blue-172.31.0.1'
 '''
 
 # (c) 2012, Peter Sankauskas
@@ -858,8 +884,22 @@ class Ec2Inventory(object):
             return
 
         # Select the best destination address
+        # When destination_format and destination_format_tags are specified
+        # the following code will attempt to find the instance tags first,
+        # then the instance attributes next, and finally if neither are found
+        # assign nil for the desired destination format attribute.
         if self.destination_format and self.destination_format_tags:
-            dest = self.destination_format.format(*[getattr(instance, 'tags').get(tag, '') for tag in self.destination_format_tags])
+            dest_vars = []
+            inst_tags = getattr(instance, 'tags')
+            for tag in self.destination_format_tags:
+                if tag in inst_tags:
+                    dest_vars.append(inst_tags[tag])
+                elif hasattr(instance, tag):
+                    dest_vars.append(getattr(instance, tag))
+                else:
+                    dest_vars.append('nil')
+
+            dest = self.destination_format.format(*dest_vars)
         elif instance.subnet_id:
             dest = getattr(instance, self.vpc_destination_variable, None)
             if dest is None:


### PR DESCRIPTION
##### SUMMARY
I wanted the `destination_format` to support more than just instance tags.  This patch adds support for the `destination_format_tags` to include tags and instance attributes.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
https://github.com/ansible/ansible/blob/devel/contrib/inventory/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
The new destination_format variable will support a composition of tags and attributes.
```ini
destination_format_tags = clusterid,host-type,sub-host-type,private_dns_name
destination_format = {0}-{1}-{2}-{3}
```
In the following example, clusterid, host-type, and sub-host-type are instance tags.  private_dns_name is an instance attribute.

When tag or attribute is missing, the string 'nil' is supplied which is the old behavior.