### PR TITLE
Add missing support for lldp neighbor argument in ios_interface

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/intent.yaml
@@ -61,6 +61,37 @@
       - "result.failed == true"
       - "'state eq(up)' in result.failed_conditions"
 
+- name: Check neighbors intent arguments
+  ios_interface:
+    name: Gi0/0
+    neighbors:
+    - port: eth0
+      host: netdev
+    authorize: yes
+    provider: "{{ cli }}"
+  register: result
+
+- assert:
+    that:
+      - "result.failed == false"
+
+- name: Check neighbors intent arguments (failed condition)
+  ios_interface:
+    name: Gi0/0
+    neighbors:
+    - port: dummy_port
+      host: dummy_host
+    authorize: yes
+    provider: "{{ cli }}"
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'host dummy_host' in result.failed_conditions"
+      - "'port dummy_port' in result.failed_conditions"
+
 - name: Aggregate config + intent (pass)
   ios_interface:
     aggregate:
@@ -75,3 +106,39 @@
 - assert:
     that:
       - "result.failed == false"
+
+- name: Aggregate neighbors intent (pass)
+  ios_interface:
+    aggregate:
+    - name: Gi0/0
+      neighbors:
+      - port: eth0
+        host: netdev
+    authorize: yes
+    provider: "{{ cli }}"
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result.failed == false"
+
+- name: Aggregate neighbors intent (fail)
+  ios_interface:
+    aggregate:
+    - name: Gi0/0
+      neighbors:
+      - port: eth0
+        host: netdev
+      - port: dummy_port
+        host: dummy_host
+    authorize: yes
+    provider: "{{ cli }}"
+  ignore_errors: yes
+  register: result
+
+- assert:
+    that:
+      - "result.failed == true"
+      - "'host dummy_host' in result.failed_conditions"
+      - "'port dummy_port' in result.failed_conditions"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add missing lldp neighbor intent argument for ios_interface
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
