### PR TITLE
Remove unnecessary pre_ci section.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -69,8 +69,6 @@ branches:
     - "revert-*-*"
 
 build:
-  pre_ci:
-    - docker images drydock/u16pytall
   pre_ci_boot:
     image_name: drydock/u16pytall
     image_tag: master


### PR DESCRIPTION
##### SUMMARY

Remove unnecessary pre_ci section. This should remove the redundant git_sync on Shippable.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.4.0 (devel 08bdb6198e) last updated 2017/09/05 20:54:37 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
