### PR TITLE
Add simple integration test for openssl_certificate

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -480,6 +480,8 @@ class AssertOnlyCertificate(Certificate):
                 setattr(self, param, [to_bytes(item) for item in attr])
             elif isinstance(attr, tuple):
                 setattr(self, param, dict((to_bytes(k), to_bytes(v)) for (k, v) in attr.items()))
+            elif isinstance(attr, dict):
+                setattr(self, param, dict((to_bytes(k), to_bytes(v)) for (k, v) in attr.items()))
             elif isinstance(attr, str):
                 setattr(self, param, to_bytes(attr))
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -26,7 +26,7 @@ description:
        Note: At least one of commonName or subjectAltName must be specified.
        This module uses file common arguments to specify generated file permissions."
 requirements:
-    - "python-pyOpenSSL"
+    - "python-pyOpenSSL >= 0.15"
 options:
     state:
         required: false
@@ -426,6 +426,11 @@ def main():
 
     if not pyopenssl_found:
         module.fail_json(msg='the python pyOpenSSL module is required')
+
+    try:
+        getattr(crypto.X509Req, 'get_extensions')
+    except AttributeError:
+        module.fail_json(msg='You need to have PyOpenSSL>=0.15 to generate CSRs')
 
     base_dir = os.path.dirname(module.params['path'])
     if not os.path.isdir(base_dir):

--- a/test/integration/targets/openssl_certificate/aliases
+++ b/test/integration/targets/openssl_certificate/aliases
@@ -1,0 +1,2 @@
+posix/ci/group1
+destructive

--- a/test/integration/targets/openssl_certificate/meta/main.yml
+++ b/test/integration/targets/openssl_certificate/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - setup_openssl

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -1,30 +1,33 @@
-- name: Generate privatekey
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey.pem'
+- block:
+  - name: Generate privatekey
+    openssl_privatekey:
+      path: '{{ output_dir }}/privatekey.pem'
 
-- name: Generate CSR
-  openssl_csr:
-    path: '{{ output_dir }}/csr.csr'
-    privatekey_path: '{{ output_dir }}/privatekey.pem'
-    commonName: 'www.ansible.com'
+  - name: Generate CSR
+    openssl_csr:
+      path: '{{ output_dir }}/csr.csr'
+      privatekey_path: '{{ output_dir }}/privatekey.pem'
+      commonName: 'www.ansible.com'
 
-- name: Generate selfsigned certificate
-  openssl_certificate:
-    path: '{{ output_dir }}/cert.pem'
-    csr_path: '{{ output_dir }}/csr.csr'
-    privatekey_path: '{{ output_dir }}/privatekey.pem'
-    provider: selfsigned
-    selfsigned_digest: sha256
+  - name: Generate selfsigned certificate
+    openssl_certificate:
+      path: '{{ output_dir }}/cert.pem'
+      csr_path: '{{ output_dir }}/csr.csr'
+      privatekey_path: '{{ output_dir }}/privatekey.pem'
+      provider: selfsigned
+      selfsigned_digest: sha256
 
-- name: Check selfsigned certificate
-  openssl_certificate:
-    path: '{{ output_dir }}/cert.pem'
-    privatekey_path: '{{ output_dir }}/privatekey.pem'
-    provider: assertonly
-    has_expired: False
-    version: 3
-    signature_algorithms:
-      - sha256WithRSAEncryption
-      - sha256WithECDSAEncryption
+  - name: Check selfsigned certificate
+    openssl_certificate:
+      path: '{{ output_dir }}/cert.pem'
+      privatekey_path: '{{ output_dir }}/privatekey.pem'
+      provider: assertonly
+      has_expired: False
+      version: 3
+      signature_algorithms:
+        - sha256WithRSAEncryption
+        - sha256WithECDSAEncryption
 
-- import_tasks: ../tests/validate.yml
+  - import_tasks: ../tests/validate.yml
+
+when: pyopenssl_version.stdout|version_compare('16.0.0', '>=')

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -1,33 +1,33 @@
 - block:
-  - name: Generate privatekey
-    openssl_privatekey:
-      path: '{{ output_dir }}/privatekey.pem'
+    - name: Generate privatekey
+      openssl_privatekey:
+        path: '{{ output_dir }}/privatekey.pem'
 
-  - name: Generate CSR
-    openssl_csr:
-      path: '{{ output_dir }}/csr.csr'
-      privatekey_path: '{{ output_dir }}/privatekey.pem'
-      commonName: 'www.ansible.com'
+    - name: Generate CSR
+      openssl_csr:
+        path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        commonName: 'www.ansible.com'
 
-  - name: Generate selfsigned certificate
-    openssl_certificate:
-      path: '{{ output_dir }}/cert.pem'
-      csr_path: '{{ output_dir }}/csr.csr'
-      privatekey_path: '{{ output_dir }}/privatekey.pem'
-      provider: selfsigned
-      selfsigned_digest: sha256
+    - name: Generate selfsigned certificate
+      openssl_certificate:
+        path: '{{ output_dir }}/cert.pem'
+        csr_path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        provider: selfsigned
+        selfsigned_digest: sha256
 
-  - name: Check selfsigned certificate
-    openssl_certificate:
-      path: '{{ output_dir }}/cert.pem'
-      privatekey_path: '{{ output_dir }}/privatekey.pem'
-      provider: assertonly
-      has_expired: False
-      version: 3
-      signature_algorithms:
-        - sha256WithRSAEncryption
-        - sha256WithECDSAEncryption
+    - name: Check selfsigned certificate
+      openssl_certificate:
+        path: '{{ output_dir }}/cert.pem'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        provider: assertonly
+        has_expired: False
+        version: 3
+        signature_algorithms:
+          - sha256WithRSAEncryption
+          - sha256WithECDSAEncryption
 
-  - import_tasks: ../tests/validate.yml
+    - import_tasks: ../tests/validate.yml
 
-when: pyopenssl_version.stdout|version_compare('16.0.0', '>=')
+  when: pyopenssl_version.stdout|version_compare('15.0.0', '>=')

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -28,6 +28,47 @@
           - sha256WithRSAEncryption
           - sha256WithECDSAEncryption
 
+    - name: Generate privatekey2
+      openssl_privatekey:
+        path: '{{ output_dir }}/privatekey2.pem'
+
+    - name: Generate CSR2
+      openssl_csr:
+        C: US
+        ST: California
+        L: Los Angeles
+        O: ACME Inc.
+        OU: Roadrunner pest control
+        path: '{{ output_dir }}/csr2.csr'
+        privatekey_path: '{{ output_dir }}/privatekey2.pem'
+        CN: 'www.example.com'
+
+    - name: Generate selfsigned certificate2
+      openssl_certificate:
+        path: '{{ output_dir }}/cert2.pem'
+        csr_path: '{{ output_dir }}/csr2.csr'
+        privatekey_path: '{{ output_dir }}/privatekey2.pem'
+        provider: selfsigned
+        selfsigned_digest: sha256
+
+    - name: Check selfsigned certificate2
+      openssl_certificate:
+        path: '{{ output_dir }}/cert2.pem'
+        privatekey_path: '{{ output_dir }}/privatekey2.pem'
+        provider: assertonly
+        has_expired: False
+        version: 3
+        signature_algorithms:
+          - sha256WithRSAEncryption
+          - sha256WithECDSAEncryption
+        subject:
+          CN: www.example.com
+          C: US
+          ST: California
+          L: Los Angeles
+          O: ACME Inc.
+          OU: Roadrunner pest control
+
     - import_tasks: ../tests/validate.yml
 
   when: pyopenssl_version.stdout|version_compare('15.0.0', '>=')

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -71,4 +71,4 @@
 
     - import_tasks: ../tests/validate.yml
 
-  when: pyopenssl_version.stdout|version_compare('15.0.0', '>=')
+  when: pyopenssl_version.stdout|version_compare('0.15', '>=')

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -1,0 +1,30 @@
+- name: Generate privatekey
+  openssl_privatekey:
+    path: '{{ output_dir }}/privatekey.pem'
+
+- name: Generate CSR
+  openssl_csr:
+    path: '{{ output_dir }}/csr.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    commonName: 'www.ansible.com'
+
+- name: Generate selfsigned certificate
+  openssl_certificate:
+    path: '{{ output_dir }}/cert.pem'
+    csr_path: '{{ output_dir }}/csr.csr'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    provider: selfsigned
+    selfsigned_digest: sha256
+
+- name: Check selfsigned certificate
+  openssl_certificate:
+    path: '{{ output_dir }}/cert.pem'
+    privatekey_path: '{{ output_dir }}/privatekey.pem'
+    provider: assertonly
+    has_expired: False
+    version: 3
+    signature_algorithms:
+      - sha256WithRSAEncryption
+      - sha256WithECDSAEncryption
+
+- import_tasks: ../tests/validate.yml

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -6,18 +6,7 @@
   shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert.pem | openssl md5'
   register: cert_modulus
 
-- name: Validate certificate (test - subject)
-  shell: "openssl x509 -noout -subject -in {{ output_dir }}/cert.pem -nameopt oneline,-space_eq"
-  register: cert_subject
-
-- name: Validate certificate (test - issuer)
-  shell: "openssl x509 -noout -issuer -in {{ output_dir }}/cert.pem -nameopt oneline,-space_eq"
-  register: cert_issuer
-
-
 - name: Validate certificate (assert)
   assert:
     that:
-      # Certificate is selfsigned: subject == issuer)
-      - cert_subject.stdout == cert_issuer.stdout
       - cert_modulus.stdout == privatekey_modulus.stdout

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -10,3 +10,16 @@
   assert:
     that:
       - cert_modulus.stdout == privatekey_modulus.stdout
+
+- name: Validate certificate2 (test - privatekey modulus)
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey2.pem | openssl md5'
+  register: privatekey2_modulus
+
+- name: Validate certificate2 (test - certificate modulus)
+  shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert2.pem | openssl md5'
+  register: cert2_modulus
+
+- name: Validate certificate2 (assert)
+  assert:
+    that:
+      - cert2_modulus.stdout == privatekey2_modulus.stdout

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -1,0 +1,23 @@
+- name: Validate certificate (test - privatekey modulus)
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
+  register: privatekey_modulus
+
+- name: Validate certificate (test - certificate modulus)
+  shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert.pem | openssl md5'
+  register: cert_modulus
+
+- name: Validate certificate (test - subject)
+  shell: "openssl x509 -noout -subject -in {{ output_dir }}/cert.pem -nameopt oneline,-space_eq"
+  register: cert_subject
+
+- name: Validate certificate (test - issuer)
+  shell: "openssl x509 -noout -issuer -in {{ output_dir }}/cert.pem -nameopt oneline,-space_eq"
+  register: cert_issuer
+
+
+- name: Validate certificate (assert)
+  assert:
+    that:
+      # Certificate is selfsigned: subject == issuer)
+      - cert_subject.stdout == cert_issuer.stdout
+      - cert_modulus.stdout == privatekey_modulus.stdout

--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -1,11 +1,14 @@
-- name: Generate privatekey
-  openssl_privatekey:
-    path: '{{ output_dir }}/privatekey.pem'
+- block:
+    - name: Generate privatekey
+      openssl_privatekey:
+        path: '{{ output_dir }}/privatekey.pem'
 
-- name: Generate CSR
-  openssl_csr:
-    path: '{{ output_dir }}/csr.csr'
-    privatekey_path: '{{ output_dir }}/privatekey.pem'
-    commonName: 'www.ansible.com'
+    - name: Generate CSR
+      openssl_csr:
+        path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        commonName: 'www.ansible.com'
 
-- import_tasks: ../tests/validate.yml
+    - import_tasks: ../tests/validate.yml
+
+  when: pyopenssl_version.stdout|version_compare('0.15', '>=')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a simple integration test for the openssl_certificate module.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
* crypto/openssl_certificate
* test/integration
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Not a lot of functionality yet, but it is a start. The design is modeled after the openssl_csr integration test.
<!--- Paste verbatim command output below, e.g. before and after your change -->

