### PR TITLE
run banner exec test only for NXOS7K

### DIFF
--- a/test/integration/targets/nxos_banner/tests/common/basic-exec.yaml
+++ b/test/integration/targets/nxos_banner/tests/common/basic-exec.yaml
@@ -1,34 +1,41 @@
 ---
-- name: setup - remove exec
-  nxos_banner:
-    banner: exec
-    state: absent
-    provider: "{{ connection }}"
+- debug: msg="START nxos_banner exec test"
 
-- name: Set exec
-  nxos_banner: &exec
-    banner: exec
-    text: |
-      this is my exec banner
-      that has a multiline
-      string
-    state: present
-    provider: "{{ connection }}"
-  register: result
+- block:
+    - name: setup - remove exec
+      nxos_banner:
+        banner: exec
+        state: absent
+        provider: "{{ connection }}"
 
-- assert:
-    that:
-      - "result.changed == true"
-      - "'banner exec @\nthis is my exec banner\nthat has a multiline\nstring\n@' in result.commands"
+    - name: Set exec
+      nxos_banner: &exec
+        banner: exec
+        text: |
+          this is my exec banner
+          that has a multiline
+          string
+        state: present
+        provider: "{{ connection }}"
+      register: result
 
-- name: Set exec again (idempotent)
-  nxos_banner: *exec
-  register: result
+    - assert:
+        that:
+          - "result.changed == true"
+          - "'banner exec @\nthis is my exec banner\nthat has a multiline\nstring\n@' in result.commands"
 
-- assert:
-    that:
-      - "result.changed == false"
-      - "result.commands | length == 0"
+    - name: Set exec again (idempotent)
+      nxos_banner: *exec
+      register: result
+
+    - assert:
+        that:
+          - "result.changed == false"
+          - "result.commands | length == 0"
+
+  when: platform | match("N7K")
+
+- debug: msg="END nxos_banner exec test"
 
 # FIXME add in tests for everything defined in docs
 # FIXME Test state:absent + test:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
NXOS9K doesn't support banner exec. So running the exec test only for NXOS7K.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/nxos_banner/tests/common/basic-exec.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```