### PR TITLE
documentation for vmware_guest module uuid usecase

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -51,6 +51,7 @@ options:
     description:
     - UUID of the instance to manage if known, this is VMware's unique identifier.
     - This is required if name is not supplied.
+    - This is required if you want to destroy VM (from state 'present' to 'absent')
   template:
     description:
     - Template used to create VM.


### PR DESCRIPTION
##### SUMMARY
When you want to destroy a VM, you have to change its state from 'present' to 'absent'. You need to provide the UUID of the virtual machine for this action to work.
It is not mentionned clearly in the module documentation.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
module/cloud/vmware/vmware_guest

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/opt/ansible/ansible_library']
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION

