### PR TITLE
azure_rm_loadbalancer_facts.py: list() takes at least 2 arguments. Fixes #29046

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
@@ -70,6 +70,10 @@ EXAMPLES = '''
     - name: Get facts for all load balancers
       azure_rm_loadbalancer_facts:
 
+    - name: Get facts for all load balancers in a specific resource group
+      azure_rm_loadbalancer_facts:
+        resource_group: TestRG
+
     - name: Get facts by tags
       azure_rm_loadbalancer_facts:
         tags:
@@ -158,10 +162,16 @@ class AzureRMLoadBalancerFacts(AzureRMModuleBase):
 
         self.log('List all load balancers')
 
-        try:
-            response = self.network_client.load_balancers.list()
-        except AzureHttpError as exc:
-            self.fail('Failed to list all items - {}'.format(str(exc)))
+        if self.resource_group:
+            try:
+                response = self.network_client.load_balancers.list(self.resource_group)
+            except AzureHttpError as exc:
+                self.fail('Failed to list items in resource group {} - {}'.format(self.resource_group, str(exc)))
+        else:
+            try:
+                response = self.network_client.load_balancers.list_all()
+            except AzureHttpError as exc:
+                self.fail('Failed to list all items - {}'.format(str(exc)))
 
         results = []
         for item in response:


### PR DESCRIPTION
##### SUMMARY
This PR fixes bug: https://github.com/ansible/ansible/issues/29046

When trying to list all load balancers within an Azure subscription or when trying to list load balancers within a resource group I get a stack trace.

There are two issues here:

Cannot list all load balancers (as the documentation mentions)
Cannot list all load balancers within an RG
In the module code you can see:
```
        try:
            response = self.network_client.load_balancers.list()
        except AzureHttpError as exc:
            self.fail('Failed to list all items - {}'.format(str(exc)))
```
However the list method is defined as:
```
    def list(
            self, resource_group_name, custom_headers=None, raw=False, **operation_config):
        """
        The List loadBalancer opertion retrieves all the loadbalancers in a
        resource group.
```

In this PR I have allowed all loadbalancers within a subscription to be listed, and all loadbalancers within a specific resource group.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_loadbalancer_facts.py

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/vmadmin/cluster_build/ansible.cfg
  configured module search path = [u'/home/vmadmin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vmadmin/.local/lib/python2.7/site-packages/ansible
  executable location = /home/vmadmin/.local/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [azure_load_balancer : Get lbs] *********************************************************************************************
task path: /home/vmadmin/cluster_build/roles/azure_load_balancer/tasks/main.yaml:15
Using module file /home/vmadmin/.local/lib/python2.7/site-packages/ansible/modules/cloud/azure/azure_rm_loadbalancer_facts.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: vmadmin
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814 `" && echo ansible-tmp-1504708358.3-41710485333814="` echo /home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814 `" ) && sleep 0'
<localhost> PUT /tmp/tmpy_CiqC TO /home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814/azure_rm_loadbalancer_facts.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814/ /home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814/azure_rm_loadbalancer_facts.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814/azure_rm_loadbalancer_facts.py; rm -rf "/home/vmadmin/.ansible/tmp/ansible-tmp-1504708358.3-41710485333814/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py", line 180, in <module>
    main()
  File "/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py", line 177, in main
    AzureRMLoadBalancerFacts()
  File "/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py", line 123, in __init__
    facts_module=True
  File "/tmp/ansible_VTaHxN/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py", line 255, in __init__
  File "/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py", line 133, in exec_module
    else self.list_items()
  File "/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py", line 162, in list_items
    response = self.network_client.load_balancers.list()
TypeError: list() takes at least 2 arguments (1 given)

fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py\", line 180, in <module>\n    main()\n  File \"/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py\", line 177, in main\n    AzureRMLoadBalancerFacts()\n  File \"/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py\", line 123, in __init__\n    facts_module=True\n  File \"/tmp/ansible_VTaHxN/ansible_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 255, in __init__\n  File \"/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py\", line 133, in exec_module\n    else self.list_items()\n  File \"/tmp/ansible_VTaHxN/ansible_module_azure_rm_loadbalancer_facts.py\", line 162, in list_items\n    response = self.network_client.load_balancers.list()\nTypeError: list() takes at least 2 arguments (1 given)\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}
```

After:
```
TASK [azure_load_balancer : Get lbs] *********************************************************************************************
task path: /home/vmadmin/cluster_build/roles/azure_load_balancer/tasks/main.yaml:15
Using module file /home/vmadmin/cluster_build/library/azure_rm_loadbalancer_facts.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: vmadmin
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381 `" && echo ansible-tmp-1504710486.23-270157734664381="` echo /home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381 `" ) && sleep 0'
<localhost> PUT /tmp/tmp7NvCNL TO /home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381/azure_rm_loadbalancer_facts.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381/ /home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381/azure_rm_loadbalancer_facts.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381/azure_rm_loadbalancer_facts.py; rm -rf "/home/vmadmin/.ansible/tmp/ansible-tmp-1504710486.23-270157734664381/" > /dev/null 2>&1 && sleep 0'
ok: [localhost] => {
    "ansible_facts": {
        "azure_loadbalancers": [
    ...
        ]
    }, 
    "changed": false, 
    "failed": false, 
    "invocation": {
        "module_args": {
            "ad_user": null, 
            "cli_default_profile": null, 
            "client_id": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "cloud_environment": null, 
            "name": null, 
            "password": null, 
            "profile": null, 
            "resource_group": "...", 
            "secret": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "subscription_id": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "tags": null, 
            "tenant": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
        }
    }
}
```