### PR TITLE
cloudtrail: import botocore.exceptions in a try/except

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -245,7 +245,11 @@ trail:
 
 import traceback
 
-from botocore.exceptions import ClientError
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    # Handled in main() by imported HAS_BOTO3
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_connection_info,


### PR DESCRIPTION
##### SUMMARY
In #28821 it was noticed that not having botocore installed was causing a traceback. Fixes that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudtrail.py

##### ANSIBLE VERSION
```
2.4.0
```

