### PR TITLE
fix user module error when generating ssh keys w/o a home

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -641,13 +641,13 @@ class User(object):
         if os.path.isabs(self.ssh_file):
             ssh_key_file = self.ssh_file
         else:
+            if not os.path.exists(info[5]) and not self.module.check_mode:
+                return (1, '', 'User %s home directory does not exist' % self.name)
             ssh_key_file = os.path.join(info[5], self.ssh_file)
         return ssh_key_file
 
     def ssh_key_gen(self):
         info = self.user_info()
-        if not os.path.exists(info[5]) and not self.module.check_mode:
-            return (1, '', 'User %s home directory does not exist' % self.name)
         ssh_key_file = self.get_ssh_key_path()
         ssh_dir = os.path.dirname(ssh_key_file)
         if not os.path.exists(ssh_dir):

--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -642,13 +642,17 @@ class User(object):
             ssh_key_file = self.ssh_file
         else:
             if not os.path.exists(info[5]) and not self.module.check_mode:
-                return (1, '', 'User %s home directory does not exist' % self.name)
+                raise Exception('User %s home directory does not exist' % self.name)
             ssh_key_file = os.path.join(info[5], self.ssh_file)
         return ssh_key_file
 
     def ssh_key_gen(self):
         info = self.user_info()
-        ssh_key_file = self.get_ssh_key_path()
+        try:
+            ssh_key_file = self.get_ssh_key_path()
+        except Exception:
+            e = get_exception()
+            return (1, '', str(e))
         ssh_dir = os.path.dirname(ssh_key_file)
         if not os.path.exists(ssh_dir):
             if self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY

When creating a user with `createhome: no` but `generate_ssh_key: yes`, the code will fail here:

https://github.com/ansible/ansible/blob/d548c477c027441d12c10a83aed72424279da8c7/lib/ansible/modules/system/user.py#L650

If the `ssh_file` is specified as an absolute filepath, this check is unnecessary. 

This PR moves the check into `get_ssh_key_path`, before line 644

fixes #29028 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
user module
