### PR TITLE
Exit early if vmware object has no name attribute.

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -234,6 +234,8 @@ def compile_folder_path_for_object(vobj):
     thisobj = vobj
     while hasattr(thisobj, 'parent'):
         thisobj = thisobj.parent
+        if not hasattr(thisobj, 'name'):
+            break
         if thisobj.name == 'Datacenters':
             break
         if isinstance(thisobj, vim.Folder):


### PR DESCRIPTION
##### SUMMARY
Addresses #29043

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
