### PR TITLE
config: use pathlist for default inventory in config

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -596,9 +596,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 self.options.inventory = [unfrackpath(opt) if ',' not in opt else opt for opt in self.options.inventory]
 
             else:
-                # set default if it exists
-                if os.path.exists(C.DEFAULT_HOST_LIST):
-                    self.options.inventory = [C.DEFAULT_HOST_LIST]
+                self.options.inventory = C.DEFAULT_HOST_LIST
 
     @staticmethod
     def version(prog):

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -604,7 +604,7 @@ DEFAULT_HOST_LIST:
   expand_relative_paths: True
   ini:
   - {key: inventory, section: defaults}
-  type: path
+  type: pathlist
   yaml: {key: defaults.inventory}
 DEFAULT_INTERNAL_POLL_INTERVAL:
   default: 0.001


### PR DESCRIPTION
##### SUMMARY

This allows to use a pathlist in the ansible.cfg

  [default]
  inventory = path/inventory:other_path/inventory

Since ansible allows to use --inventory on CLI more then once, we should
also support a pathlist in the config.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
/cc @bcoca