### PR TITLE
Fixes #28493 - nxos_ntp_options fails with stratum and master required message

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_ntp_options.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp_options.py
@@ -105,7 +105,7 @@ def get_current(module):
         master = False
         stratum = None
 
-    logging = 'Enabled' in output[1]
+    logging = 'enabled' in output[1].lower()
 
     return {'master': master, 'stratum': stratum, 'logging': logging}
 
@@ -113,17 +113,14 @@ def get_current(module):
 def main():
     argument_spec = dict(
         master=dict(required=False, type='bool'),
-        stratum=dict(type='str'),
+        stratum=dict(required=False, type='str', default='8'),
         logging=dict(required=False, type='bool'),
         state=dict(choices=['absent', 'present'], default='present'),
     )
 
     argument_spec.update(nxos_argument_spec)
 
-    required_together = [('master', 'stratum')]
-
     module = AnsibleModule(argument_spec=argument_spec,
-                           required_together=required_together,
                            supports_check_mode=True)
 
     warnings = list()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Documentation state that the stratum has a default value of '8' and is hence not a required together property. Even default behavior on CLI is that if no stratum is provided, stratum=8. Also, fixed an idempotence issue with ntp logging. 'enabled' is lower case in the output on the N9K, but have generalized the output by using lower().

fixes #28493
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_ntp_options

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (devel 31d2eb0828) last updated 2017/09/06 13:15:52 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```