### PR TITLE
update miq compare_user group comparison

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -185,7 +185,7 @@ class ManageIQUser(object):
             (name and user['name'] != name) or
             (password is not None) or
             (email and user['email'] != email) or
-            (group_id and user['group']['id'] != group_id)
+            (group_id and user['current_group_id'] != group_id)
         )
 
         return not found_difference


### PR DESCRIPTION
##### SUMMARY
When calling manageiq_user to an already existing user (but leaving out the password so that it doesn't automatically 're-create' the user), the module fails with:

fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 127.0.0.1 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 324, in <module>\r\n    main()\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 315, in main\r\n    res_args = manageiq_user.edit_user(user, name, group, password, email)\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 229, in edit_user\r\n    if self.compare_user(user, name, group_id, password, email):\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 189, in compare_user\r\n    (group_id and user['group']['id'] != group_id)\r\nKeyError: 'group'\r\n", "msg": "MODULE FAILURE", "rc": 0}

The 'group' field turns out to be 'current_group_id' (at least with ManageIQ 4.6). Update the comparison accordingly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
manageiq_user

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 31d2eb0828) last updated 2017/09/06 15:15:51 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jdiaz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jdiaz/tmp/ansible/lib/ansible
  executable location = /home/jdiaz/tmp/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Here are the two calls I was making to manageiq_user to repo the failure:
```
    - name: create new user
      manageiq_user:
        state: present
        userid: testuser
        password: secretpassword
        name: Test user
        email: testuser@example.com
        group: EvmGroup-user
        manageiq_connection: "{{ miq_connection }}"

    - name: present user (no password)
      manageiq_user:
        state: present
        userid: testuser
        #password: secretpassword
        name: Test user
        email: testuser@example.com
        group: EvmGroup-user
        manageiq_connection: "{{ miq_connection }}"
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 127.0.0.1 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 324, in <module>\r\n    main()\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 315, in main\r\n    res_args = manageiq_user.edit_user(user, name, group, password, email)\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 229, in edit_user\r\n    if self.compare_user(user, name, group_id, password, email):\r\n  File \"/tmp/ansible_Fr7Nt3/ansible_module_manageiq_user.py\", line 189, in compare_user\r\n    (group_id and user['group']['id'] != group_id)\r\nKeyError: 'group'\r\n", "msg": "MODULE FAILURE", "rc": 0}

After:
ok: [127.0.0.1] => {"changed": false, "failed": false, "msg": "user testuser is not changed."}

```
