### PR TITLE
Fixes #27138 - nxos_facts not reporting ansible_net_version and ansible_net_image on 9K and 3K

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -209,7 +209,7 @@ class FactsBase(object):
 
 class Default(FactsBase):
 
-    VERSION_MAP = frozenset([
+    VERSION_MAP_7K = frozenset([
         ('sys_ver_str', 'version'),
         ('proc_board_id', 'serialnum'),
         ('chassis_id', 'model'),
@@ -217,10 +217,21 @@ class Default(FactsBase):
         ('host_name', 'hostname')
     ])
 
+    VERSION_MAP = frozenset([
+        ('kickstart_ver_str', 'version'),
+        ('proc_board_id', 'serialnum'),
+        ('chassis_id', 'model'),
+        ('kick_file_name', 'image'),
+        ('host_name', 'hostname')
+    ])
+
     def populate(self):
         data = self.run('show version', 'json')
         if data:
-            self.facts.update(self.transform_dict(data, self.VERSION_MAP))
+            if data.get('sys_ver_str'):
+                self.facts.update(self.transform_dict(data, self.VERSION_MAP_7K))
+            else:
+                self.facts.update(self.transform_dict(data, self.VERSION_MAP))
 
 
 class Config(FactsBase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
'show version | json' output differs between 7K and other platforms.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxos_facts 865bc1f4b7) last updated 2017/09/06 16:02:05 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```
