### PR TITLE
fix git wrapper

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -374,7 +374,7 @@ def set_git_ssh(ssh_wrapper, key_file, ssh_opts):
     # git_ssh_command will override git_ssh, so only older git needs it
     os.environ["GIT_SSH"] = ssh_wrapper
     # using shell to avoid 'noexec' issues if module temp dir is located in such a mount
-    os.environ["GIT_SSH_COMMAND"] = ' '.join([os.environ.get('SHELL', '/bin/sh'), ssh_wrapper])
+    os.environ["GIT_SSH_COMMAND"] = '%s %s' % (os.environ.get('SHELL', '/bin/sh'), ssh_wrapper)
 
     if os.environ.get("GIT_KEY"):
         del os.environ["GIT_KEY"]

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -374,7 +374,7 @@ def set_git_ssh(ssh_wrapper, key_file, ssh_opts):
     # git_ssh_command will override git_ssh, so only older git needs it
     os.environ["GIT_SSH"] = ssh_wrapper
     # using shell to avoid 'noexec' issues if module temp dir is located in such a mount
-    os.environ["GIT_SSH_COMMAND"] = ' '.join([os.environ['SHELL'], ssh_wrapper])
+    os.environ["GIT_SSH_COMMAND"] = ' '.join([os.environ.get('SHELL', '/bin/sh'), ssh_wrapper])
 
     if os.environ.get("GIT_KEY"):
         del os.environ["GIT_KEY"]

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -371,9 +371,10 @@ fi
 
 def set_git_ssh(ssh_wrapper, key_file, ssh_opts):
 
-    if os.environ.get("GIT_SSH"):
-        del os.environ["GIT_SSH"]
+    # git_ssh_command will override git_ssh, so only older git needs it
     os.environ["GIT_SSH"] = ssh_wrapper
+    # using shell to avoid 'noexec' issues if module temp dir is located in such a mount
+    os.environ["GIT_SSH_COMMAND"] = ' '.join([os.environ['SHELL'], ssh_wrapper])
 
     if os.environ.get("GIT_KEY"):
         del os.environ["GIT_KEY"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes issue with git on noexec when forced to use the ssh wrapper it can write on demand.
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
git
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```
