### PR TITLE
Revert "Temporarily disable failing opensuse test jobs."

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -31,6 +31,8 @@ matrix:
     - env: TEST=linux/centos7/1
     - env: TEST=linux/fedora24/1
     - env: TEST=linux/fedora25/1
+    - env: TEST=linux/opensuse42.2/1
+    - env: TEST=linux/opensuse42.3/1
     - env: TEST=linux/ubuntu1404/1
     - env: TEST=linux/ubuntu1604/1
     - env: TEST=linux/ubuntu1604py3/1
@@ -39,6 +41,8 @@ matrix:
     - env: TEST=linux/centos7/2
     - env: TEST=linux/fedora24/2
     - env: TEST=linux/fedora25/2
+    - env: TEST=linux/opensuse42.2/2
+    - env: TEST=linux/opensuse42.3/2
     - env: TEST=linux/ubuntu1404/2
     - env: TEST=linux/ubuntu1604/2
     - env: TEST=linux/ubuntu1604py3/2


### PR DESCRIPTION
##### SUMMARY

This reverts commit 31d2eb082890b91c0bb1a003ba47f19b4a188e55.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.5.0 (opensuse 01ae40338a) last updated 2017/09/06 16:53:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
