### PR TITLE
fixes #27066 - nxos_acl errors when there are 0 or 1 access lists configured

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -245,7 +245,7 @@ def get_acl(module, acl_name, seq_number):
         # no access-lists configured on the device
         return {}, []
 
-    if type(all_acl_body) == type({}):
+    if isinstance(all_acl_body, dict):
         # Only 1 ACL configured.
         if all_acl_body.get('acl_name') == acl_name:
             acl_body = all_acl_body

--- a/lib/ansible/modules/network/nxos/nxos_acl.py
+++ b/lib/ansible/modules/network/nxos/nxos_acl.py
@@ -239,11 +239,20 @@ def get_acl(module, acl_name, seq_number):
     acl_body = {}
 
     body = execute_show_command(command, module)[0]
-    all_acl_body = body['TABLE_ip_ipv6_mac']['ROW_ip_ipv6_mac']
+    if body:
+        all_acl_body = body['TABLE_ip_ipv6_mac']['ROW_ip_ipv6_mac']
+    else:
+        # no access-lists configured on the device
+        return {}, []
 
-    for acl in all_acl_body:
-        if acl.get('acl_name') == acl_name:
-            acl_body = acl
+    if type(all_acl_body) == type({}):
+        # Only 1 ACL configured.
+        if all_acl_body.get('acl_name') == acl_name:
+            acl_body = all_acl_body
+    else:
+        for acl in all_acl_body:
+            if acl.get('acl_name') == acl_name:
+                acl_body = acl
 
     try:
         acl_entries = acl_body['TABLE_seqno']['ROW_seqno']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added checks for when access-lists are absent and when there is only 1 access list (type is dictionary in that case)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
fixes https://github.com/ansible/ansible/issues/27066
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_acl

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0 (nxos_facts 865bc1f4b7) last updated 2017/09/06 16:02:05 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```
