### PR TITLE
fix typo in new jsonquery filter example that uses backticks

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -291,7 +291,7 @@ Or, alternatively::
     - name: "Display all server names from cluster1"
       debug:
         var: item
-      with_items: "{{domain_definition|json_query('domain.server[?cluster=`cluster`].port')}}"
+      with_items: "{{domain_definition|json_query('domain.server[?cluster=`cluster1`].port')}}"
 
 .. note:: Here, quoting literals using backticks avoids escaping quotes and maintains readability.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
https://github.com/ansible/ansible/commit/0d69b63c01e71ef4b5193d865ab237ab55f4226a added a new json query filter example using backticks. This just fixes a typo in it.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
json query filter
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (jsonquery_typofix b2cb500e22) last updated 2017/09/07 10:42:32 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
self explanatory, filter now matches its description.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
