### PR TITLE
Rename SuSE distribution helper function to SUSE

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -64,8 +64,8 @@ class DistributionFiles:
         {'path': '/etc/system-release', 'name': 'Amazon'},
         {'path': '/etc/alpine-release', 'name': 'Alpine'},
         {'path': '/etc/arch-release', 'name': 'Archlinux', 'allowempty': True},
-        {'path': '/etc/os-release', 'name': 'SuSE'},
-        {'path': '/etc/SuSE-release', 'name': 'SuSE'},
+        {'path': '/etc/os-release', 'name': 'SUSE'},
+        {'path': '/etc/SuSE-release', 'name': 'SUSE'},
         {'path': '/etc/gentoo-release', 'name': 'Gentoo'},
         {'path': '/etc/os-release', 'name': 'Debian'},
         {'path': '/etc/lsb-release', 'name': 'Mandriva'},
@@ -228,7 +228,7 @@ class DistributionFiles:
         alpine_facts['distribution_version'] = data
         return True, alpine_facts
 
-    def parse_distribution_file_SuSE(self, name, data, path, collected_facts):
+    def parse_distribution_file_SUSE(self, name, data, path, collected_facts):
         suse_facts = {}
         if 'suse' not in data.lower():
             return False, suse_facts  # TODO: remove if tested without this
@@ -370,8 +370,8 @@ class Distribution(object):
         {'path': '/etc/system-release', 'name': 'Amazon'},
         {'path': '/etc/alpine-release', 'name': 'Alpine'},
         {'path': '/etc/arch-release', 'name': 'Archlinux', 'allowempty': True},
-        {'path': '/etc/os-release', 'name': 'SuSE'},
-        {'path': '/etc/SuSE-release', 'name': 'SuSE'},
+        {'path': '/etc/os-release', 'name': 'SUSE'},
+        {'path': '/etc/SuSE-release', 'name': 'SUSE'},
         {'path': '/etc/gentoo-release', 'name': 'Gentoo'},
         {'path': '/etc/os-release', 'name': 'Debian'},
         {'path': '/etc/lsb-release', 'name': 'Mandriva'},


### PR DESCRIPTION
This is a noop change, but the company renamed itself from SuSE to
SUSE round about 15 years ago. See

https://www.suse.com/brandcentral/suse/identity.php

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
