### PR TITLE
azure_rm_networkinterface: load balancer backend pool address and vnet resource group support

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -59,6 +59,12 @@ options:
             - virtual_network
         required: true
         default: null
+    virtual_network_resource_group:
+        description:
+            - The resource group name in which the virtual network exists. Defaults to the value of the
+              resource group argument.
+        required: false
+        default: resource_group
     subnet_name:
         description:
             - Name of an existing subnet within the specified virtual network. Required when creating a network
@@ -128,6 +134,11 @@ options:
             - When a default security group is created for a Linux host a rule will be added allowing inbound TCP
               connections to the default SSH port 22, and for a Windows host rules will be added allowing inbound
               access to RDP ports 3389 and 5986. Override the default ports by providing a list of open ports.
+        required: false
+        default: null
+    backend_address_pool_name:
+        description:
+            - Name of an existing load-balancer backend address pool to associate with the network interface.
         required: false
         default: null
 extends_documentation_fragment:
@@ -203,7 +214,8 @@ state:
                 "id": "/subscriptions/XXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXX/resourceGroups/Testing/providers/Microsoft.Network/publicIPAddresses/publicip001",
                 "name": "publicip001"
             },
-            "subnet": {}
+            "subnet": {},
+            "backend_address_pool": {}
         },
         "location": "eastus2",
         "mac_address": null,
@@ -239,6 +251,7 @@ def nic_to_dict(nic):
             private_ip_allocation_method=nic.ip_configurations[0].private_ip_allocation_method,
             subnet=dict(),
             public_ip_address=dict(),
+            backend_address_pool=dict(),
         ),
         dns_settings=dict(
             dns_servers=nic.dns_settings.dns_servers,
@@ -262,6 +275,7 @@ def nic_to_dict(nic):
         result['ip_configuration']['subnet']['id'] = \
             nic.ip_configurations[0].subnet.id
         id_keys = azure_id_to_dict(nic.ip_configurations[0].subnet.id)
+        result['ip_configuration']['subnet']['virtual_network_resource_group'] = id_keys['resourceGroups']
         result['ip_configuration']['subnet']['virtual_network_name'] = id_keys['virtualNetworks']
         result['ip_configuration']['subnet']['name'] = id_keys['subnets']
 
@@ -270,6 +284,12 @@ def nic_to_dict(nic):
             nic.ip_configurations[0].public_ip_address.id
         id_keys = azure_id_to_dict(nic.ip_configurations[0].public_ip_address.id)
         result['ip_configuration']['public_ip_address']['name'] = id_keys['publicIPAddresses']
+
+    if nic.ip_configurations[0].load_balancer_backend_address_pools:
+        id_keys = azure_id_to_dict(nic.ip_configurations[0].load_balancer_backend_address_pools[0].id)
+        result['ip_configuration']['backend_address_pool']['name'] = id_keys['backendAddressPools']
+        result['ip_configuration']['backend_address_pool']['id'] = \
+            nic.ip_configurations[0].load_balancer_backend_address_pools[0].id
 
     return result
 
@@ -290,9 +310,11 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             public_ip=dict(type='bool', default=True),
             subnet_name=dict(type='str', aliases=['subnet']),
             virtual_network_name=dict(type='str', aliases=['virtual_network']),
+            virtual_network_resource_group=dict(type='str'),
             os_type=dict(type='str', choices=['Windows', 'Linux'], default='Linux'),
             open_ports=dict(type='list'),
             public_ip_allocation_method=dict(type='str', choices=['Dynamic', 'Static'], default='Dynamic'),
+            backend_address_pool_name=dict(type='str'),
         )
 
         self.resource_group = None
@@ -306,11 +328,13 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         self.subnet_name = None
         self.tags = None
         self.virtual_network_name = None
+        self.virtual_network_resource_group = None
         self.security_group_name = None
         self.os_type = None
         self.open_ports = None
         self.public_ip_allocation_method = None
         self.public_ip = None
+        self.backend_address_pool_name = None
 
         self.results = dict(
             changed=False,
@@ -331,11 +355,16 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         subnet = None
         nsg = None
         pip = None
+        beap = None
 
         resource_group = self.get_resource_group(self.resource_group)
         if not self.location:
             # Set default location
             self.location = resource_group.location
+
+        if not self.virtual_network_resource_group:
+            # Set default virtual network resource group
+            self.virtual_network_resource_group = self.resource_group
 
         if self.state == 'present':
             if self.virtual_network_name and not self.subnet_name:
@@ -345,13 +374,17 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                 self.fail("Parameter error: virtual_network_name is required when passing a subnet value.")
 
             if self.virtual_network_name and self.subnet_name:
-                subnet = self.get_subnet(self.virtual_network_name, self.subnet_name)
+                subnet = self.get_subnet(self.virtual_network_resource_group,
+                                         self.virtual_network_name, self.subnet_name)
 
             if self.public_ip_address_name:
                 pip = self.get_public_ip_address(self.public_ip_address_name)
 
             if self.security_group_name:
                 nsg = self.get_security_group(self.security_group_name)
+
+            if self.backend_address_pool_name:
+                beap = self.get_backend_pool(self.backend_address_pool_name)
 
         try:
             self.log('Fetching network interface {0}'.format(self.name))
@@ -402,7 +435,17 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         self.log("CHANGED: network interface {0} subnet".format(self.name))
                         results['ip_configuration']['subnet']['id'] = subnet.id
                         results['ip_configuration']['subnet']['name'] = subnet.name
+                        results['ip_configuration']['subnet']['virtual_network_resource_group'] = \
+                            self.virtual_network_resource_group
                         results['ip_configuration']['subnet']['virtual_network_name'] = self.virtual_network_name
+
+                if self.backend_address_pool_name:
+                    if results['ip_configuration']['backend_address_pool'].get('name') != \
+                            self.backend_address_pool_name:
+                        changed = True
+                        self.log("CHANGED: network interface {0} backend address pool".format(self.name))
+                        results['ip_configuration']['backend_address_pool']['name'] = self.backend_address_pool_name
+                        results['ip_configuration']['backend_address_pool']['id'] = beap.id
 
             elif self.state == 'absent':
                 self.log("CHANGED: network interface {0} exists but requested state is 'absent'".format(self.name))
@@ -448,6 +491,7 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         ip_configurations=[
                             self.network_models.NetworkInterfaceIPConfiguration(
                                 private_ip_allocation_method=self.private_ip_allocation_method,
+                                load_balancer_backend_address_pools=[beap]
                             )
                         ]
                     )
@@ -473,11 +517,13 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
                         tags=results['tags'],
                         ip_configurations=[
                             self.network_models.NetworkInterfaceIPConfiguration(
-                                private_ip_allocation_method=results['ip_configuration']['private_ip_allocation_method']
+                                private_ip_allocation_method=results['ip_configuration']['private_ip_allocation_method'],
+                                load_balancer_backend_address_pools=[beap]
                             )
                         ]
                     )
-                    subnet = self.get_subnet(results['ip_configuration']['subnet']['virtual_network_name'],
+                    subnet = self.get_subnet(results['ip_configuration']['subnet']['virtual_network_resource_group'],
+                                             results['ip_configuration']['subnet']['virtual_network_name'],
                                              results['ip_configuration']['subnet']['name'])
                     nic.ip_configurations[0].subnet = self.network_models.Subnet(id=subnet.id)
                     nic.ip_configurations[0].name = results['ip_configuration']['name']
@@ -540,14 +586,14 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
             self.fail("Error: fetching public ip address {0} - {1}".format(self.name, str(exc)))
         return public_ip
 
-    def get_subnet(self, vnet_name, subnet_name):
-        self.log("Fetching subnet {0} in virtual network {1}".format(subnet_name, vnet_name))
+    def get_subnet(self, vnet_rg, vnet_name, subnet_name):
+        self.log("Fetching subnet {0} in virtual network {1} in resource group {2}"
+                 .format(subnet_name, vnet_name, vnet_rg))
         try:
-            subnet = self.network_client.subnets.get(self.resource_group, vnet_name, subnet_name)
+            subnet = self.network_client.subnets.get(vnet_rg, vnet_name, subnet_name)
         except Exception as exc:
-            self.fail("Error: fetching subnet {0} in virtual network {1} - {2}".format(subnet_name,
-                                                                                       vnet_name,
-                                                                                       str(exc)))
+            self.fail("Error: fetching subnet {0} in virtual network {1} in resource group {2} - {3}"
+                      .format(subnet_name, vnet_name, vnet_rg, str(exc)))
         return subnet
 
     def get_security_group(self, name):
@@ -557,6 +603,18 @@ class AzureRMNetworkInterface(AzureRMModuleBase):
         except Exception as exc:
             self.fail("Error: fetching network security group {0} - {1}.".format(name, str(exc)))
         return nsg
+
+    def get_backend_pool(self, pool_name):
+        self.log("Fetching backend address pool {0}".format(pool_name))
+        try:
+            lbs = self.network_client.load_balancers.list(self.resource_group)
+        except Exception as exc:
+            self.fail("Error: fetching load balancers in resource group {0} - {1}."
+                      .format(self.resource_group, str(exc)))
+        pools = [pool for lb in lbs for pool in lb.backend_address_pools if pool.name == pool_name]
+        if not pools:
+            self.fail("Error: no pool {0} found".format(pool_name))
+        return pools[0]
 
 
 def main():

--- a/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
@@ -65,6 +65,7 @@ options:
               resource group argument.
         required: false
         default: resource_group
+        version_added: "2.5"
     subnet_name:
         description:
             - Name of an existing subnet within the specified virtual network. Required when creating a network
@@ -141,6 +142,7 @@ options:
             - Name of an existing load-balancer backend address pool to associate with the network interface.
         required: false
         default: null
+        version_added: "2.5"
 extends_documentation_fragment:
     - azure
     - azure_tags


### PR DESCRIPTION
##### SUMMARY
This PR adds two features to the `azure_rm_networkinterface` module:
* Support for providing an optional load-balancer backend pool address name to assign to the interface
* Support for providing an optional virtual network resource group for when a virtual network resides in a different resource group to the network interface

Both changes are option and respect current behaviour hence they are backwards compatible.

*Load-balancer backend pool address name*
This change adds an optional load-balancer backend pool name. Since Azure Load-Balancer support [was recently added to Ansible](https://github.com/ansible/ansible/pull/26099) changes are needed to this module to allow network interfaces to use the load-balancers.

This configuration in optional and is ignored if not provided. It will place the network interface into the named backend pool that resides within the resource group. The name is a good identifier as it is [unique within a resource group](https://docs.microsoft.com/en-gb/rest/api/load-balancer/LoadBalancers/CreateOrUpdate).

*Virtual network resource group*
This small changes allows an optional virtual network resource group name to be provided. This allows Ansible to create and update network interfaces that use a virtual network in a different resource group. If this parameter is not given it defaults to the `resource_group` parameter which matches the current behaviour.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_networkinterface

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = /home/vmadmin/cluster_build/ansible.cfg
  configured module search path = [u'/home/vmadmin/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vmadmin/.local/lib/python2.7/site-packages/ansible
  executable location = /home/vmadmin/.local/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]

```

##### ADDITIONAL INFORMATION
*Before:* 
No load-balancer and vnet in another resource group support.

*After:*
When adding multiple NICs into the same pool, the task below shows the case where one is already in the pool and does not change (first in output) and where one is not in the pool and is added (second in output). Both NICs are using a Virtual Network that is not in the same resource group as the NIC:

Task (the contents of item is shown below):
```
- name: Update NI to add the backend pool
  azure_rm_networkinterface_fix:
    name: "{{ item.id | regex_replace('^.*/([^/]+)$', '\\1') }}"
    resource_group: "{{ azure_resource_group }}"
    backend_address_pool_name: "{{ beap.name }}"
    subscription_id: "{{ azure_subscriptionId }}"
    client_id: "{{ azure_clientId }}"
    tenant: "{{ azure_tenantId }}"
    secret: "{{ azure_clientSecret }}"
  with_items: "{{ interfaces.ansible_facts.azure_networkinterfaces }}"
```

Output:
```
ok: [localhost] => (item={u'location': u'westeurope', u'etag': u'W/"84ba2d17-155e-4916-9d9e-eb7eaea26558"', u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/networkInterfaces/6f6c1b4dqwyvjoevnic', u'tags': {u'cluster': u'cluster-name', u'role': u'worker', u'group': u'worker'}, u'properties': {u'macAddress': u'00-0D-3A-2A-F3-47', u'virtualMachine': {u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Compute/virtualMachines/pref-6f6c1b4d-fbc7-4f90-9af2-2b4123f358ce'}, u'enableAcceleratedNetworking': False, u'primary': True, u'networkSecurityGroup': {u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/networkSecurityGroups/nsg-name'}, u'dnsSettings': {u'internalDomainNameSuffix': u'a1vrhvet5oiezdezfvtmaim00a.ax.internal.cloudapp.net', u'dnsServers': [], u'appliedDnsServers': []}, u'resourceGuid': u'e0c52807-4ee0-4117-bf14-d1bd1be9bcb8', u'enableIPForwarding': False, u'ipConfigurations': [{u'etag': u'W/"84ba2d17-155e-4916-9d9e-eb7eaea26558"', u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/networkInterfaces/6f6c1b4dqwyvjoevnic/ipConfigurations/6f6c1b4dqwyvjoevipconfig', u'name': u'6f6c1b4dqwyvjoevipconfig', u'properties': {u'subnet': {u'id': u'/subscriptions/********/resourceGroups/VnetRG/providers/Microsoft.Network/virtualNetworks/vnet-name/subnets/subnet-name'}, u'primary': True, u'privateIPAddressVersion': u'IPv4', u'privateIPAllocationMethod': u'Dynamic', u'loadBalancerBackendAddressPools': [{u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/loadBalancers/lb-name/backendAddressPools/pool-name'}], u'privateIPAddress': u'x.x.x.x', u'provisioningState': u'Succeeded'}}], u'provisioningState': u'Succeeded'}})
changed: [localhost] => (item={u'location': u'westeurope', u'etag': u'W/"49c91658-86db-441c-a6cd-60e90abe56ba"', u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/networkInterfaces/913e74b9jhhfwqxtnic', u'tags': {u'cluster': u'cluster-name', u'role': u'worker', u'group': u'worker'}, u'properties': {u'macAddress': u'00-0D-3A-2A-FD-64', u'virtualMachine': {u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Compute/virtualMachines/pref-913e74b9-3fba-4a67-93c0-a9452ab16542'}, u'enableAcceleratedNetworking': False, u'primary': True, u'networkSecurityGroup': {u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/networkSecurityGroups/nsg-name'}, u'dnsSettings': {u'internalDomainNameSuffix': u'a1vrhvet5oiezdezfvtmaim00a.ax.internal.cloudapp.net', u'dnsServers': [], u'appliedDnsServers': []}, u'resourceGuid': u'e33bdbcb-8122-45ef-bfe9-eaabc2434396', u'enableIPForwarding': False, u'ipConfigurations': [{u'etag': u'W/"49c91658-86db-441c-a6cd-60e90abe56ba"', u'id': u'/subscriptions/********/resourceGroups/InterfaceRG/providers/Microsoft.Network/networkInterfaces/913e74b9jhhfwqxtnic/ipConfigurations/913e74b9jhhfwqxtipconfig', u'name': u'913e74b9jhhfwqxtipconfig', u'properties': {u'subnet': {u'id': u'/subscriptions/********/resourceGroups/VnetRG/providers/Microsoft.Network/virtualNetworks/vnet-name/subnets/subnet-name'}, u'primary': True, u'privateIPAddressVersion': u'IPv4', u'privateIPAllocationMethod': u'Dynamic', u'privateIPAddress': u'x.x.x.x', u'provisioningState': u'Succeeded'}}], u'provisioningState': u'Succeeded'}})
```

@tstringer Hi Thomas, I have tagged you since I believe you have recently done the development for the load balancer module. Hope that's okay.