### PR TITLE
add 'update_password' param to manageiq_user

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -190,7 +190,7 @@ class ManageIQUser(object):
         """
         found_difference = (
             (name and user['name'] != name) or
-            (password is not None and self.module.params['update_password'] == 'always') or
+            (password is not None) or
             (email and user['email'] != email) or
             (group_id and user['group']['id'] != group_id)
         )
@@ -226,10 +226,15 @@ class ManageIQUser(object):
             resource['group'] = dict(id=group_id)
         if name is not None:
             resource['name'] = name
-        if password is not None:
-            resource['password'] = password
         if email is not None:
             resource['email'] = email
+
+        # if there is a password param, but 'update_password' is 'on_create'
+        # then discard the password (since we're editing an existing user)
+        if self.module.params['update_password'] == 'on_create':
+            password = None
+        if password is not None:
+            resource['password'] = password
 
         # check if we need to update ( compare_user is true is no difference found )
         if self.compare_user(user, name, group_id, password, email):
@@ -289,7 +294,7 @@ def main():
             email=dict(),
             state=dict(choices=['absent', 'present'], default='present'),
             update_password=dict(choices=['always', 'on_create'],
-                                 default='always')
+                                 default='always'),
         ),
     )
 

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -68,6 +68,13 @@ options:
       - The users' E-mail address.
     required: false
     default: null
+  update_password:
+    required: false
+    default: always
+    choices: ['always', 'on_create']
+    description:
+      - C(always) will update passwords unconditionally.  C(on_create) will only set the password for a newly created user.
+    version_added: '2.5'
 '''
 
 EXAMPLES = '''
@@ -183,7 +190,7 @@ class ManageIQUser(object):
         """
         found_difference = (
             (name and user['name'] != name) or
-            (password is not None) or
+            (password is not None and self.module.params['update_password'] == 'always') or
             (email and user['email'] != email) or
             (group_id and user['group']['id'] != group_id)
         )
@@ -280,7 +287,9 @@ def main():
             password=dict(no_log=True),
             group=dict(),
             email=dict(),
-            state=dict(choices=['absent', 'present'], default='present')
+            state=dict(choices=['absent', 'present'], default='present'),
+            update_password=dict(choices=['always', 'on_create'],
+                                 default='always')
         ),
     )
 


### PR DESCRIPTION
##### SUMMARY
Currently with the manageiq_user module, if you call it repeatedly while passing the 'password' parameter, it will always run the task and mark it as 'changed'.

Following the pattern of the AWS IAM module, add an 'update_password' parameter that takes 'always' (default) or 'on_create'. This will let you set an initial password when creating a user, but allow the user to modify their password and not stomp over their password changes if you re-run the playbook/task that created the user.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
manageiq_user

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 31d2eb0828) last updated 2017/09/06 15:15:51 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jdiaz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jdiaz/tmp/ansible/lib/ansible
  executable location = /home/jdiaz/tmp/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
    - name: create user
      manageiq_user:
        state: present
        userid: testuser
        password: supersecret
        name: Test User
        email: testuser@testing123.com
        group: EvmGroup-user
        manageiq_connection: "{{ miq_connection }}"

Before if you called the above task twice the second run would return 'changed':
changed: [127.0.0.1] => {"changed": true, "failed": false, "msg": "successfully updated the user testuser: {u'name': u'Test User', u'settings': {}, u'userid': u'testuser', u'current_group_id': u'4', u'id': u'38', u'created_on': u'2017-09-07T15:37:12Z', u'href': u'https://REDACTED/api/users/38', u'updated_on': u'2017-09-07T15:37:22Z', u'email': u'testuser@testing123.com'}"}

After the change (and adding the 'update_password' param set to 'on_create') running the task twice will show no changes on the second call:

ok: [127.0.0.1] => {"changed": false, "failed": false, "msg": "user testuser is not changed."}
```
