### PR TITLE
Also render variables in task name for step mode confirmations.

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -236,14 +236,6 @@ class StrategyModule(StrategyBase):
                         if task.args.get('_raw_params', None) != 'noop':
                             run_once = True
                     else:
-                        # handle step if needed, skip meta actions as they are used internally
-                        if self._step and choose_step:
-                            if self._take_step(task):
-                                choose_step = False
-                            else:
-                                skip_rest = True
-                                break
-
                         display.debug("getting variables")
                         task_vars = self._variable_manager.get_vars(play=iterator._play, host=host, task=task)
                         self.add_tqm_variables(task_vars, play=iterator._play)
@@ -255,23 +247,33 @@ class StrategyModule(StrategyBase):
                         if (task.any_errors_fatal or run_once) and not task.ignore_errors:
                             any_errors_fatal = True
 
+                        display.debug("sending task start callback, copying the task so we can template it temporarily")
+                        saved_name = task.name
+                        display.debug("done copying, going to template now")
+                        try:
+                            task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
+                            display.debug("done templating")
+                        except:
+                            # just ignore any errors during task name templating,
+                            # we don't care if it just shows the raw name
+                            display.debug("templating failed for some reason")
+                            pass
+                        display.debug("here goes the callback...")
+
+                        # handle step if needed, skip meta actions as they are used internally
+                        if self._step and choose_step:
+                            if self._take_step(task):
+                                choose_step = False
+                            else:
+                                skip_rest = True
+                                break
+
                         if not callback_sent:
-                            display.debug("sending task start callback, copying the task so we can template it temporarily")
-                            saved_name = task.name
-                            display.debug("done copying, going to template now")
-                            try:
-                                task.name = to_text(templar.template(task.name, fail_on_undefined=False), nonstring='empty')
-                                display.debug("done templating")
-                            except:
-                                # just ignore any errors during task name templating,
-                                # we don't care if it just shows the raw name
-                                display.debug("templating failed for some reason")
-                                pass
-                            display.debug("here goes the callback...")
                             self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
-                            task.name = saved_name
                             callback_sent = True
                             display.debug("sending task start callback")
+
+                        task.name = saved_name
 
                         self._blocked_hosts[host.get_name()] = True
                         self._queue_task(host, task, task_vars, play_context)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When running in step mode and using variables in task names, they do not get rendered. This can confuse users since they expect their variable to exist and have a decent value.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/strategy/linear.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (devel 52f2edf19d) last updated 2017/09/07 22:03:17 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before:
```
PLAY [Test] ******************************************************************************************************************************
Perform task: TASK: {{ avar }} is readable in task bar (N)o/(y)es/(c)ontinue: y

Perform task: TASK: {{ avar }} is readable in task bar (N)o/(y)es/(c)ontinue: ************************************************************

TASK [avalue is readable in task bar] ****************************************************************************************************
ok: [localhost] => {
    "msg": "see up and verify"
}

PLAY RECAP *******************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```

after:
```
PLAY [Test] ******************************************************************************************************************************
Perform task: TASK: avalue is readable in task bar (N)o/(y)es/(c)ontinue: y

Perform task: TASK: avalue is readable in task bar (N)o/(y)es/(c)ontinue: ****************************************************************

TASK [avalue is readable in task bar] ****************************************************************************************************
ok: [localhost] => {
    "msg": "see up and verify"
}

PLAY RECAP *******************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```