### PR TITLE
Use hostgroup_find(all=True) returns member hosts of all hostgroups i…

### DIFF
--- a/contrib/inventory/freeipa.py
+++ b/contrib/inventory/freeipa.py
@@ -5,7 +5,6 @@
 import argparse
 from ipalib import api
 import json
-from distutils.version import StrictVersion
 
 
 def initialize():
@@ -35,15 +34,11 @@ def list_groups(api):
     inventory = {}
     hostvars = {}
 
-    ipa_version = api.Command.env()['result']['version']
-    result = api.Command.hostgroup_find()['result']
+    result = api.Command.hostgroup_find(all=True)['result']
 
     for hostgroup in result:
         # Get direct and indirect members (nested hostgroups) of hostgroup
         members = []
-        if StrictVersion(ipa_version) >= StrictVersion('4.0.0'):
-            hostgroup_name = hostgroup['cn'][0]
-            hostgroup = api.Command.hostgroup_show(hostgroup_name)['result']
 
         if 'member_host' in hostgroup:
             members = [host for host in hostgroup['member_host']]


### PR DESCRIPTION
…n a single call

##### SUMMARY
Improve performance of freeipa inventory by getting all hostgroup members in a single call. Default behavior of hostgroup_find() was changed after FreeIPA4.2 to not return a list of members. Adding the all=True parameter fixes this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
freeipa.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (ipa_hostgroup_list_fix 41d54df7c3) last updated 2017/09/07 09:08:14 (GMT -600)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/rgroten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rgroten/git/ansible-rgroten/lib/ansible
  executable location = /home/rgroten/git/ansible-rgroten/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```

##### ADDITIONAL INFORMATION
Tested on FreeIPA Version 4.2 and 4.4
