### PR TITLE
Adds manageiq_user as an action_plugin

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -96,6 +96,14 @@ EXAMPLES = '''
       token: 'sometoken'
       verify_ssl: False
 
+- name: Create a new user in ManageIQ from within a native Service
+  manageiq_user:
+    userid: 'jdoe'
+    name: 'Jane Doe'
+    password: 'VerySecret'
+    group: 'EvmGroup-user'
+    email: 'jdoe@example.com'
+
 - name: Delete a user in ManageIQ
   manageiq_user:
     state: 'absent'
@@ -105,6 +113,11 @@ EXAMPLES = '''
       username: 'admin'
       password: 'smartvm'
       verify_ssl: False
+
+- name: Delete a user in ManageIQ from within a native Service
+  manageiq_user:
+    state: 'absent'
+    userid: 'jdoe'
 
 - name: Delete a user in ManageIQ using a token
   manageiq_user:
@@ -124,6 +137,11 @@ EXAMPLES = '''
       username: 'admin'
       password: 'smartvm'
       verify_ssl: False
+
+- name: Update email of user in ManageIQ from within a native Service
+  manageiq_user:
+    userid: 'jdoe'
+    email: 'jaustine@example.com'
 
 - name: Update email of user in ManageIQ using a token
   manageiq_user:

--- a/lib/ansible/plugins/action/manageiq_user.py
+++ b/lib/ansible/plugins/action/manageiq_user.py
@@ -1,0 +1,45 @@
+# (c) 2017, Drew Bomhof <dbomhof@redhat.com>
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+from ansible.utils.vars import merge_hash
+from ansible.module_utils.manageiq import manageiq_extra_vars
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        results = super(ActionModule, self).run(tmp, task_vars or dict())
+
+        module_vars = manageiq_extra_vars(self._task.args.copy(), task_vars)
+
+        results = merge_hash(
+            results,
+            self._execute_module(module_args=module_vars, task_vars=task_vars),
+        )
+
+        return results


### PR DESCRIPTION

##### SUMMARY
Manageiq modules need the functionality to receive `url`, `token` and future attributes as `extra_vars` which are then passed through to the module.  This change modifies `manageiq_user` into  an action_plugin which allows the above requirement to work as expected.


##### ISSUE TYPE
 - New Plugin Pull Request

##### COMPONENT NAME
Action Plugin: manageiq_user

##### ANSIBLE VERSION
```
ansible 2.4.0 (convert_manageiq_user_to_plugin b06f8c5c59) last updated 2017/09/07 16:07:36 (GMT -400)
  config file = /Users/dbomhof/syncrou/playbooks/ansible.cfg
  configured module search path = [u'/Users/dbomhof/syncrou/ansible/lib/ansible/modules']
  ansible python module location = /Users/dbomhof/syncrou/ansible/lib/ansible
  executable location = /Users/dbomhof/syncrou/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
[ManageIQ](http://manageiq.org) allows for the creation of Ansible based services.  Essentially a clickable button that allows for a playbook to execute.  These Ansible services pass manageiq specific `api_url`, `api_token` information to the playbook via `extra_vars`.  

This change allows those specific connection based attributes to be passed through as a `module_var`  directly to the `manageiq_user` module.  This allows playbooks run from inside ManageIQ to gain authentication behavior while also simplifying the arguments required to make them run.

##### EXAMPLE COMMAND
```
ansible-playbook example_playbook.yml --extra-vars "{'manageiq':{'api_url':'http://localhost:3000', 'api_token':'sometoken'}}" -vvv
```