### PR TITLE
manageiq_provider add default role of 'prometheus_alerts' for alerts

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -239,6 +239,7 @@ def supported_providers():
             authtype='bearer',
             default_role='default',
             metrics_role='prometheus',
+            alerts_role='prometheus_alerts',
         ),
         Amazon=dict(
             class_name='ManageIQ::Providers::Amazon::CloudManager',


### PR DESCRIPTION
##### SUMMARY

Currently, MIQ only supports an alert type of 'prometheus', so rather than have the caller of manageiq_provider pass this info, just set it as the default.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
manageiq_provider

##### ANSIBLE VERSION
```
ansible 2.4.0 (devel 31d2eb0828) last updated 2017/09/06 15:15:51 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jdiaz/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jdiaz/tmp/ansible/lib/ansible
  executable location = /home/jdiaz/tmp/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
Before this change a caller to manageiq_provider that included an 'alerts' section would look like:
```
    - name: create provider
      manageiq_provider:
        name: "{{ miq_provider['name'] }}"
        type: "{{ miq_provider['type'] }}"
        provider: "{{ miq_provider['provider'] }}"
        metrics: "{{ miq_provider['metrics'] }}"
        alerts:
          hostname: my-alerts.cluster.example.com
          port: 443
          role: prometheus_alerts
        manageiq_connection: "{{ miq_connection }}"
```
With this change, you can now call the module without needing to specify anything for alerts.role.