### PR TITLE
document the required variables for using Windows certificates

### DIFF
--- a/docs/docsite/rst/intro_windows.rst
+++ b/docs/docsite/rst/intro_windows.rst
@@ -94,9 +94,9 @@ You can specify which authentication option you wish to use by setting it to the
 Certificate
 +++++++++++
 
-Certificate authentication is similar to SSH because it uses both a public and private key. This removes the need for using a password.
+Certificate authentication is similar to SSH because it uses both a public and private key to access a local Windows user account. This removes the need for using a password.
 
-This requires two variables that specify the path to both the PEM file containing the certificate and the related private key file.
+This requires two variables that specify the path to both the PEM file containing the certificate (cert_pem) and the related private key file (cert_key_pem).
 
     ansible_winrm_cert_pem:
     ansible_winrm_cert_key_pem:

--- a/docs/docsite/rst/intro_windows.rst
+++ b/docs/docsite/rst/intro_windows.rst
@@ -94,8 +94,12 @@ You can specify which authentication option you wish to use by setting it to the
 Certificate
 +++++++++++
 
-Certificate authentication is similar to SSH where a certificate is assigned to a local user and instead of using a password to authenticate a certificate is used instead.
+Certificate authentication is similar to SSH because it uses both a public and private key. This removes the need for using a password.
 
+This requires two variables that specify the path to both the PEM file containing the certificate and the related private key file.
+
+    ansible_winrm_cert_pem:
+    ansible_winrm_cert_key_pem:
 
 Kerberos
 ++++++++


### PR DESCRIPTION
##### SUMMARY

As originally stated in [this issue](https://github.com/ansible/ansible/issues/16243), there is no documentation on the variables to use when authenticating to Windows via WinRM using certificates.

There is also a long run-on sentence that I simplified.

Fixes #16243


##### ISSUE TYPE
 - Docs Pull Request


##### COMPONENT NAME
intro_windows documentation


##### ANSIBLE VERSION
2.4