### PR TITLE
ansible_tower: fix broken import, reuse tower_argument_spec and documentation fragment

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -28,9 +28,14 @@
 
 import os
 
-import tower_cli.utils.exceptions as exc
-from tower_cli.utils import parser
-from tower_cli.api import client
+try:
+    import tower_cli.utils.exceptions as exc
+    from tower_cli.utils import parser
+    from tower_cli.api import client
+
+    HAS_TOWER_CLI = True
+except ImportError:
+    HAS_TOWER_CLI = False
 
 
 def tower_auth_config(module):

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -190,17 +190,17 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+import os
+
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
-    import os
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -138,45 +138,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.2"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -192,7 +154,7 @@ EXAMPLES = '''
 
 import os
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -204,42 +166,38 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            user=dict(),
-            team=dict(),
-            kind=dict(required=True,
-                      choices=["ssh", "net", "scm", "aws", "rax", "vmware", "satellite6",
-                               "cloudforms", "gce", "azure", "azure_rm", "openstack"]),
-            host=dict(),
-            username=dict(),
-            password=dict(no_log=True),
-            ssh_key_data=dict(no_log=True),
-            ssh_key_unlock=dict(no_log=True),
-            authorize=dict(type='bool', default=False),
-            authorize_password=dict(no_log=True),
-            client=dict(),
-            secret=dict(),
-            tenant=dict(),
-            subscription=dict(),
-            domain=dict(),
-            become_method=dict(),
-            become_username=dict(),
-            become_password=dict(no_log=True),
-            vault_password=dict(no_log=True),
-            description=dict(),
-            organization=dict(required=True),
-            project=dict(),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        user=dict(),
+        team=dict(),
+        kind=dict(required=True,
+                  choices=["ssh", "net", "scm", "aws", "rax", "vmware", "satellite6",
+                           "cloudforms", "gce", "azure", "azure_rm", "openstack"]),
+        host=dict(),
+        username=dict(),
+        password=dict(no_log=True),
+        ssh_key_data=dict(no_log=True),
+        ssh_key_unlock=dict(no_log=True),
+        authorize=dict(type='bool', default=False),
+        authorize_password=dict(no_log=True),
+        client=dict(),
+        secret=dict(),
+        tenant=dict(),
+        subscription=dict(),
+        domain=dict(),
+        become_method=dict(),
+        become_username=dict(),
+        become_password=dict(no_log=True),
+        vault_password=dict(no_log=True),
+        description=dict(),
+        organization=dict(required=True),
+        project=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -98,45 +98,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.2"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -152,7 +114,7 @@ EXAMPLES = '''
 
 import os
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -164,33 +126,28 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            description=dict(),
-            inventory=dict(required=True),
-            variables=dict(),
-            credential=dict(),
-            source=dict(choices=["manual", "file", "ec2", "rax", "vmware",
-                                 "gce", "azure", "azure_rm", "openstack",
-                                 "satellite6", "cloudforms", "custom"], default="manual"),
-            source_regions=dict(),
-            source_vars=dict(),
-            instance_filters=dict(),
-            group_by=dict(),
-            source_script=dict(),
-            overwrite=dict(type='bool', default=False),
-            overwrite_vars=dict(),
-            update_on_launch=dict(type='bool', default=False),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        description=dict(),
+        inventory=dict(required=True),
+        variables=dict(),
+        credential=dict(),
+        source=dict(choices=["manual", "file", "ec2", "rax", "vmware",
+                             "gce", "azure", "azure_rm", "openstack",
+                             "satellite6", "cloudforms", "custom"], default="manual"),
+        source_regions=dict(),
+        source_vars=dict(),
+        instance_filters=dict(),
+        group_by=dict(),
+        source_script=dict(),
+        overwrite=dict(type='bool', default=False),
+        overwrite_vars=dict(),
+        update_on_launch=dict(type='bool', default=False),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -150,18 +150,17 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+import os
+
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
-    import os
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
@@ -50,45 +50,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -105,7 +67,7 @@ EXAMPLES = '''
 
 import os
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -117,22 +79,16 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            description=dict(),
-            inventory=dict(required=True),
-            enabled=dict(type='bool', default=True),
-            variables=dict(),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        description=dict(),
+        inventory=dict(required=True),
+        enabled=dict(type='bool', default=True),
+        variables=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_host.py
@@ -103,17 +103,17 @@ EXAMPLES = '''
 '''
 
 
+import os
+
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
-    import os
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -47,45 +47,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -100,7 +62,7 @@ EXAMPLES = '''
 '''
 
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -112,21 +74,16 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            description=dict(),
-            organization=dict(required=True),
-            variables=dict(),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        description=dict(),
+        organization=dict(required=True),
+        variables=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_inventory.py
@@ -100,16 +100,15 @@ EXAMPLES = '''
 '''
 
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_cancel.py
@@ -56,20 +56,15 @@ status:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import (
-        tower_auth_config,
-        tower_check_mode,
-        tower_argument_spec,
-    )
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_launch.py
@@ -90,20 +90,15 @@ status:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import (
-        tower_auth_config,
-        tower_check_mode,
-        tower_argument_spec,
-    )
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_list.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_list.py
@@ -82,20 +82,15 @@ results:
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import (
-        tower_auth_config,
-        tower_check_mode,
-        tower_argument_spec,
-    )
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -192,16 +192,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def update_fields(p):

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -137,45 +137,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -192,7 +154,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -251,40 +213,35 @@ def update_resources(module, p):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            description=dict(),
-            job_type=dict(choices=['run', 'check', 'scan'], required=True),
-            inventory=dict(),
-            project=dict(required=True),
-            playbook=dict(required=True),
-            machine_credential=dict(),
-            cloud_credential=dict(),
-            network_credential=dict(),
-            forks=dict(type='int'),
-            limit=dict(),
-            verbosity=dict(choices=['verbose', 'debug']),
-            job_tags=dict(),
-            skip_tags=dict(),
-            host_config_key=dict(),
-            extra_vars_path=dict(type='path', required=False),
-            ask_extra_vars=dict(type='bool', default=False),
-            ask_limit=dict(type='bool', default=False),
-            ask_tags=dict(type='bool', default=False),
-            ask_job_type=dict(type='bool', default=False),
-            ask_inventory=dict(type='bool', default=False),
-            ask_credential=dict(type='bool', default=False),
-            become_enabled=dict(type='bool', default=False),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        description=dict(),
+        job_type=dict(choices=['run', 'check', 'scan'], required=True),
+        inventory=dict(),
+        project=dict(required=True),
+        playbook=dict(required=True),
+        machine_credential=dict(),
+        cloud_credential=dict(),
+        network_credential=dict(),
+        forks=dict(type='int'),
+        limit=dict(),
+        verbosity=dict(choices=['verbose', 'debug']),
+        job_tags=dict(),
+        skip_tags=dict(),
+        host_config_key=dict(),
+        extra_vars_path=dict(type='path', required=False),
+        ask_extra_vars=dict(type='bool', default=False),
+        ask_limit=dict(type='bool', default=False),
+        ask_tags=dict(type='bool', default=False),
+        ask_job_type=dict(type='bool', default=False),
+        ask_inventory=dict(type='bool', default=False),
+        ask_credential=dict(type='bool', default=False),
+        become_enabled=dict(type='bool', default=False),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
@@ -82,14 +82,10 @@ status:
 '''
 
 
-from ansible.module_utils.basic import AnsibleModule
-
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from StringIO import StringIO
-
 from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves import cStringIO as StringIO
+
 
 try:
     import tower_cli

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py
@@ -89,20 +89,15 @@ try:
 except ImportError:
     from StringIO import StringIO
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, tower_argument_spec, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import (
-        tower_auth_config,
-        tower_check_mode,
-        tower_argument_spec,
-    )
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
@@ -90,16 +90,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_label.py
@@ -39,45 +39,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -90,7 +52,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -102,19 +64,14 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            organization=dict(required=True),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        organization=dict(required=True),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
@@ -89,16 +89,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_organization.py
@@ -38,45 +38,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(tower_config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(tower_config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -89,7 +51,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -101,19 +63,14 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            description=dict(),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        description=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -85,45 +85,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -137,7 +99,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -149,29 +111,24 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(),
-            description=dict(),
-            organization=dict(),
-            scm_type=dict(choices=['manual', 'git', 'hg', 'svn'], default='manual'),
-            scm_url=dict(),
-            scm_branch=dict(),
-            scm_credential=dict(),
-            scm_clean=dict(type='bool', default=False),
-            scm_delete_on_update=dict(type='bool', default=False),
-            scm_update_on_launch=dict(type='bool', default=False),
-            local_path=dict(),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(),
+        description=dict(),
+        organization=dict(),
+        scm_type=dict(choices=['manual', 'git', 'hg', 'svn'], default='manual'),
+        scm_url=dict(),
+        scm_branch=dict(),
+        scm_credential=dict(),
+        scm_clean=dict(type='bool', default=False),
+        scm_delete_on_update=dict(type='bool', default=False),
+        scm_update_on_launch=dict(type='bool', default=False),
+        local_path=dict(),
 
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_project.py
@@ -137,16 +137,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -74,45 +74,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -126,7 +88,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -164,26 +126,22 @@ def update_resources(module, p):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            user=dict(),
-            team=dict(),
-            role=dict(choices=["admin", "read", "member", "execute", "adhoc", "update", "use", "auditor"]),
-            target_team=dict(),
-            inventory=dict(),
-            job_template=dict(),
-            credential=dict(),
-            organization=dict(),
-            project=dict(),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        user=dict(),
+        team=dict(),
+        role=dict(choices=["admin", "read", "member", "execute", "adhoc", "update", "use", "auditor"]),
+        target_team=dict(),
+        inventory=dict(),
+        job_template=dict(),
+        credential=dict(),
+        organization=dict(),
+        project=dict(),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_role.py
@@ -126,16 +126,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def update_resources(module, p):

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py
@@ -91,16 +91,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_team.py
@@ -39,45 +39,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -91,7 +53,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -103,20 +65,16 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            name=dict(required=True),
-            description=dict(),
-            organization=dict(required=True),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True),
+        description=dict(),
+        organization=dict(required=True),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -116,16 +116,15 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
+from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+
 try:
     import tower_cli
     import tower_cli.utils.exceptions as exc
 
     from tower_cli.conf import settings
-    from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode
-
-    HAS_TOWER_CLI = True
 except ImportError:
-    HAS_TOWER_CLI = False
+    pass
 
 
 def main():

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_user.py
@@ -62,45 +62,7 @@ options:
       required: False
       default: "present"
       choices: ["present", "absent"]
-    tower_host:
-      description:
-        - URL to your Tower instance.
-      required: False
-      default: null
-    tower_username:
-        description:
-          - Username for your Tower instance.
-        required: False
-        default: null
-    tower_password:
-        description:
-          - Password for your Tower instance.
-        required: False
-        default: null
-    tower_verify_ssl:
-        description:
-          - Dis/allow insecure connections to Tower. If C(no), SSL certificates will not be validated.
-            This should only be used on personally controlled sites using self-signed certificates.
-        required: False
-        default: True
-    tower_config_file:
-      description:
-        - Path to the Tower config file. See notes.
-      required: False
-      default: null
-
-
-requirements:
-  - "python >= 2.6"
-  - "ansible-tower-cli >= 3.0.3"
-
-notes:
-  - If no I(config_file) is provided we will attempt to use the tower-cli library
-    defaults to find your Tower host information.
-  - I(config_file) should contain Tower configuration in the following format
-      host=hostname
-      username=username
-      password=password
+extends_documentation_fragment: tower
 '''
 
 
@@ -116,7 +78,7 @@ EXAMPLES = '''
     tower_config_file: "~/tower_cli.cfg"
 '''
 
-from ansible.module_utils.ansible_tower import tower_auth_config, tower_check_mode, HAS_TOWER_CLI
+from ansible.module_utils.ansible_tower import tower_argument_spec, tower_auth_config, tower_check_mode, HAS_TOWER_CLI
 
 try:
     import tower_cli
@@ -128,24 +90,19 @@ except ImportError:
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            username=dict(required=True),
-            first_name=dict(),
-            last_name=dict(),
-            password=dict(no_log=True),
-            email=dict(required=True),
-            superuser=dict(type='bool', default=False),
-            auditor=dict(type='bool', default=False),
-            tower_host=dict(),
-            tower_username=dict(),
-            tower_password=dict(no_log=True),
-            tower_verify_ssl=dict(type='bool', default=True),
-            tower_config_file=dict(type='path'),
-            state=dict(choices=['present', 'absent'], default='present'),
-        ),
-        supports_check_mode=True
-    )
+    argument_spec = tower_argument_spec()
+    argument_spec.update(dict(
+        username=dict(required=True),
+        first_name=dict(),
+        last_name=dict(),
+        password=dict(no_log=True),
+        email=dict(required=True),
+        superuser=dict(type='bool', default=False),
+        auditor=dict(type='bool', default=False),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_TOWER_CLI:
         module.fail_json(msg='ansible-tower-cli required for this module')

--- a/lib/ansible/utils/module_docs_fragments/tower.py
+++ b/lib/ansible/utils/module_docs_fragments/tower.py
@@ -51,7 +51,6 @@ options:
 
 
 requirements:
-  - "python >= 2.6"
   - "ansible-tower-cli >= 3.0.2"
 
 notes:

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,4 +1,3 @@
-lib/ansible/module_utils/ansible_tower.py
 lib/ansible/modules/cloud/amazon/cloudtrail.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -55,4 +55,3 @@ lib/ansible/modules/network/lenovo/cnos_vlag.py
 lib/ansible/modules/network/lenovo/cnos_vlan.py
 lib/ansible/modules/network/nxos/nxos_file_copy.py
 lib/ansible/modules/packaging/language/maven_artifact.py
-lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_wait.py


### PR DESCRIPTION
##### SUMMARY
- Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `module_utils/tower.py` and `web_infrastructure/ansible_tower/tower_job_wait.py`
- reuse `tower_argument_spec` and tower documentation fragment
- remove Python 2.6 from requirements

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0 (devel c9f2b931db) last updated 2017/09/07 17:22:11 (GMT +200)
```