### PR TITLE
module_utils/avi.py: fix broken import

### DIFF
--- a/lib/ansible/module_utils/avi.py
+++ b/lib/ansible/module_utils/avi.py
@@ -33,13 +33,13 @@
 
 from __future__ import absolute_import
 import os
-from pkg_resources import parse_version
+from distutils.version import LooseVersion
 
 HAS_AVI = True
 try:
     import avi.sdk
     sdk_version = getattr(avi.sdk, '__version__', None)
-    if ((sdk_version is None) or (sdk_version and (parse_version(sdk_version) < parse_version('17.1')))):
+    if ((sdk_version is None) or (sdk_version and (LooseVersion(sdk_version) < LooseVersion('17.1')))):
         # It allows the __version__ to be '' as that value is used in development builds
         raise ImportError
     from avi.sdk.utils.ansible_utils import avi_ansible_api

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,5 +1,4 @@
 lib/ansible/module_utils/ansible_tower.py
-lib/ansible/module_utils/avi.py
 lib/ansible/modules/cloud/amazon/cloudtrail.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py


### PR DESCRIPTION
##### SUMMARY
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `module_utils/avi.py`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/avi.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible-playbook 2.5.0 (devel c9f2b931db) last updated 2017/09/07 17:22:11 (GMT +200)
```