### PR TITLE
Allow zabbix_host to change proxy to no proxy. Fixes #24735 and idempotency of this module

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -300,7 +300,7 @@ class Host(object):
                 self._module.exit_json(changed=True)
             parameters = {'hostid': host_id, 'groups': group_ids, 'status': status, 'tls_connect': tls_connect,
                           'tls_accept': tls_accept}
-            if proxy_id:
+            if proxy_id >= 0:
                 parameters['proxy_hostid'] = proxy_id
             if visible_name:
                 parameters['name'] = visible_name
@@ -448,7 +448,7 @@ class Host(object):
         if set(list(template_ids)) != set(exist_template_ids):
             return True
 
-        if host['proxy_hostid'] != proxy_id:
+        if int(host['proxy_hostid']) != int(proxy_id):
             return True
 
         if host['name'] != visible_name:
@@ -602,7 +602,7 @@ def main():
         if proxy:
             proxy_id = host.get_proxyid_by_proxy_name(proxy)
         else:
-            proxy_id = None
+            proxy_id = 0
 
         # get host id by host name
         zabbix_host_obj = host.get_host_by_host_name(host_name)


### PR DESCRIPTION
##### SUMMARY
User is not able to change proxy to '(no proxy)' if there is already proxy configured on the host. The change is possible only by manual action or custom script. This commit fixes the issue and allows user to remove proxy from the host in conjunction with `force: yes` (which is default). 

Fixes #24735 
Alternative fix for #24407 by making consecutive runs idempotent

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Mar 13 2017, 20:56:15) [GCC 5.4.0]
```