### PR TITLE
Set hostname to 'switch' on nxos_system teardown

### DIFF
--- a/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
+++ b/test/integration/targets/nxos_system/tests/common/set_hostname.yaml
@@ -29,7 +29,7 @@
 
 - name: teardown
   nxos_config:
-    lines: "hostname {{ inventory_hostname }}"
+    lines: hostname switch
     match: none
     provider: "{{ connection }}"
 


### PR DESCRIPTION
On setup we set it to 'switch', so teardown should be 'switch'.
Also, using inventory_hostname breaks the test, since in our CI
it's a long UUID string, which exceeds the 32 chars maximum for setting
a hostname on NXOS.