### PR TITLE
Set hostname to 'switch' on nxos_config toplevel setup/teardown tasks

### DIFF
--- a/test/integration/targets/nxos_config/tests/common/toplevel.yaml
+++ b/test/integration/targets/nxos_config/tests/common/toplevel.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname_short }}
+    lines: hostname switch
     provider: "{{ connection }}"
     match: none
 
@@ -30,7 +30,7 @@
 
 - name: teardown
   nxos_config:
-    lines: hostname {{ inventory_hostname_short }}
+    lines: hostname switch
     provider: "{{ connection }}"
     match: none
 


### PR DESCRIPTION
Using inventory_hostname breaks in our CI, as the inventory_hostname
translates to a long UUID, exceeding the maximum length for a NXOS
hostname.