### PR TITLE
AIX distribution consistency with Linux

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -456,8 +456,9 @@ class Distribution(object):
         aix_facts = {}
         rc, out, err = self.module.run_command("/usr/bin/oslevel")
         data = out.split('.')
-        aix_facts['distribution_version'] = data[0]
-        aix_facts['distribution_release'] = data[1]
+        aix_facts['distribution_version'] = out.strip()
+        aix_facts['distribution_major_version'] = data[0]
+        aix_facts['distribution_minor_version'] = data[1]
         return aix_facts
 
     def get_distribution_HPUX(self):

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -459,6 +459,7 @@ class Distribution(object):
         aix_facts['distribution_version'] = out.strip()
         aix_facts['distribution_major_version'] = data[0]
         aix_facts['distribution_minor_version'] = data[1]
+        aix_facts['distribution_release'] = ''
         return aix_facts
 
     def get_distribution_HPUX(self):

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -1,17 +1,4 @@
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -456,10 +443,10 @@ class Distribution(object):
         aix_facts = {}
         rc, out, err = self.module.run_command("/usr/bin/oslevel")
         data = out.split('.')
-        aix_facts['distribution_version'] = out.strip()
+        aix_facts['distribution_version'] = data[0]
         aix_facts['distribution_major_version'] = data[0]
         aix_facts['distribution_minor_version'] = data[1]
-        aix_facts['distribution_release'] = ''
+        aix_facts['distribution_release'] = data[1]
         return aix_facts
 
     def get_distribution_HPUX(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make AIX distribution facts more consistent with Linux, putting major and minor version into their respective facts, and putting complete version in distribution_version.
Also set distribution_release to empty string since i'm not avare of any release naming convention for AIX.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
fixes #29079

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (devel 167cd89d50) last updated 2017/09/08 11:07:29 (GMT +100)
  config file = None
  configured module search path = [u'/home/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/ansible/lib/ansible
  executable location = /home/ansible/ansible/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Results in facts similar to this:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
        "ansible_distribution": "AIX",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_minor_version": "1",
        "ansible_distribution_release": "",
        "ansible_distribution_version": "7.1.0.0",
```
