### PR TITLE
Use 'hostname switch' on setup/teardown tasks for nxos_config non_idempotent

### DIFF
--- a/test/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/nxos_config/tests/common/toplevel_nonidempotent.yaml
@@ -3,7 +3,7 @@
 
 - name: setup
   nxos_config:
-    lines: hostname {{ inventory_hostname_short }}
+    lines: hostname switch
     provider: "{{ connection }}"
     match: none
 
@@ -32,7 +32,7 @@
 
 - name: teardown
   nxos_config:
-    lines: hostname {{ inventory_hostname_short }}
+    lines: hostname switch
     provider: "{{ connection }}"
     match: none
 


### PR DESCRIPTION
inventory_hostname breaks CI due to too long string.