### PR TITLE
nxos_banner CI fix

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -96,7 +96,7 @@ def map_obj_to_commands(want, have, module):
     commands = list()
     state = module.params['state']
 
-    if state == 'absent' and have.get('text'):
+    if (state == 'absent' and (have.get('text') and have.get('text') != 'User Access Verification')):
         commands.append('no banner %s' % module.params['banner'])
 
     elif state == 'present' and want.get('text') != have.get('text'):

--- a/test/integration/targets/nxos_banner/tests/common/basic-no-exec.yaml
+++ b/test/integration/targets/nxos_banner/tests/common/basic-no-exec.yaml
@@ -1,16 +1,16 @@
 ---
 - name: Setup
   nxos_banner:
-    banner: exec
+    banner: motd
     text: |
-      Junk exec banner
+      Junk motd banner
       over multiple lines
     state: present
     provider: "{{ connection }}"
 
-- name: remove exec
-  nxos_banner: &rm-exec
-    banner: exec
+- name: remove motd
+  nxos_banner: &rm-motd
+    banner: motd
     state: absent
     provider: "{{ connection }}"
   register: result
@@ -18,10 +18,10 @@
 - assert:
     that:
       - "result.changed == true"
-      - "'no banner exec' in result.commands"
+      - "'no banner motd' in result.commands"
 
-- name: remove exec (idempotent)
-  nxos_banner: *rm-exec
+- name: remove motd (idempotent)
+  nxos_banner: *rm-motd
   register: result
 
 - assert:


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Adding `basic_no-motd` test instead of `basic_no_exec` test since all other NXOS version supports banner motd.
- Fix idempotence on removing banner. NXOS adds `User Access Verification` string to text by default after removing the banner.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_banner.py
test/integration/targets/nxos_banner/common/
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4 devel
```