### PR TITLE
Fix nxos_interface error for nxapi and idempotence problem

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface.py
@@ -214,22 +214,21 @@ def get_manual_interface_attributes(interface, module):
     """
 
     if get_interface_type(interface) == 'svi':
-        command = 'show interface {0}'.format(interface)
+        command = 'show run interface {0} all'.format(interface)
         try:
-            body = run_commands(module, [command])[0]
+            # body = run_commands(module, [command])[0]
+            body = execute_show_command(command, module)[0]
         except IndexError:
             return None
-
         if body:
             command_list = body.split('\n')
             desc = None
-            admin_state = 'up'
+            admin_state = 'down'
             for each in command_list:
-                if 'Description:' in each:
-                    line = each.split('Description:')
-                    desc = line[1].strip().split('MTU')[0].strip()
-                elif 'Administratively down' in each:
-                    admin_state = 'down'
+                if 'description' in each:
+                    desc = each.lstrip().split("description")[1].lstrip()
+                elif 'no shutdown' in each:
+                    admin_state = 'up'
 
             return dict(description=desc, admin_state=admin_state)
     else:

--- a/test/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -1,0 +1,131 @@
+---
+- debug: msg="START TRANSPORT:{{ connection.transport }} nxos_interface sanity test"
+
+- set_fact: testint="{{ nxos_int1 }}"
+
+- name: "Setup: Enable feature interface-vlan"
+  nxos_feature:
+    feature: interface-vlan
+    state: enabled
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
+- name: "Setup: Put interface {{ testint }} into a default state"
+  nxos_config: &intcleanup
+    lines:
+      - "default interface {{ testint }}"
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
+- name: "Setup: Remove possibly existing vlan interfaces"
+  nxos_config: &vlanintcleanup
+    lines:
+      - "no interface vlan 2"
+      - "no interface vlan 710"
+      - "no interface vlan 711"
+      - "no interface vlan 712"
+    provider: "{{ connection }}"
+  ignore_errors: yes
+
+- block:
+  - name: "Configure layer3 params"
+    nxos_interface: &l3config
+      interface: "{{ testint }}"
+      mode: layer3
+      description: 'Configured by Ansible - Layer3'
+      admin_state: 'up'
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: &true
+      that:
+        - "result.changed == true"
+
+  - name: "Check Idempotence"
+    nxos_interface: *l3config
+    register: result
+
+  - assert: &false
+      that:
+        - "result.changed == false"
+
+  - name: "Configure layer2 params"
+    nxos_interface: &l2config
+      interface: "{{ testint }}"
+      mode: layer2
+      description: 'Configured by Ansible - Layer2'
+      admin_state: 'down'
+      state: present
+      provider: "{{ connection }}"
+    register: result
+
+  - assert: *true
+
+  - name: "Check Idempotence"
+    nxos_interface: *l2config
+    register: result
+
+  - assert: *false
+
+  - name: Create VLAN Interfaces
+    nxos_interface: &createvlans
+      interface: "{{ item.os_svi_int }}"
+      description: "{{ item.os_svi_desc }}"
+      provider: "{{ connection }}"
+    with_items: &vlanitems
+      - {os_svi_int: vlan2 , os_svi_desc: SVI_VLAN2}
+      - {os_svi_int: vlan710 , os_svi_desc: SVI_VLAN710}
+      - {os_svi_int: vlan711 , os_svi_desc: SVI_VLAN711}
+      - {os_svi_int: vlan712 , os_svi_desc: SVI_VLAN712}
+    register: result
+
+  - assert: *true
+
+  - name: Configure Required SVI
+    nxos_ip_interface: &addips
+      interface: "{{ item.os_svi_int }}"
+      addr: "{{ item.ipv4_addr }}"
+      mask: "{{ item.ipv4_mask }}"
+      version: "{{ item.ipv4_ver }}"
+      provider: "{{ connection }}"
+    with_items: &vlanips
+      - {os_svi_int: vlan2 , ipv4_addr: 192.168.2.1 , ipv4_mask: 24 , ipv4_ver: v4}
+      - {os_svi_int: vlan710 , ipv4_addr: 192.168.3.1 , ipv4_mask: 24 , ipv4_ver: v4}
+      - {os_svi_int: vlan711 , ipv4_addr: 192.168.4.1 , ipv4_mask: 24 , ipv4_ver: v4}
+      - {os_svi_int: vlan712 , ipv4_addr: 192.168.5.1 , ipv4_mask: 24 , ipv4_ver: v4}
+    register: result
+
+  - assert: *true
+
+  - name: Create VLAN Interfaces Idempotence Check
+    nxos_interface: *createvlans
+    with_items: *vlanitems
+    register: result
+
+  - assert: *false
+
+  - name: Configure Required SVI Idempotence Check
+    nxos_ip_interface: *addips
+    with_items: *vlanips
+    register: result
+
+  - assert: *false
+
+  rescue:
+  - name: "Set interface back to default"
+    nxos_config: *intcleanup
+    ignore_errors: yes
+
+  - name: "Remove vlan interfaces"
+    nxos_config: *vlanintcleanup
+
+  - name: "Setup: Disable feature interface-vlan"
+    nxos_feature:
+      feature: interface-vlan
+      state: disabled
+      provider: "{{ connection }}"
+    ignore_errors: yes
+
+  always:
+  - debug: msg="END TRANSPORT:{{ connection.transport }} nxos_interface sanity test"

--- a/test/integration/targets/nxos_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_interface/tests/common/sanity.yaml
@@ -74,10 +74,10 @@
       description: "{{ item.os_svi_desc }}"
       provider: "{{ connection }}"
     with_items: &vlanitems
-      - {os_svi_int: vlan2 , os_svi_desc: SVI_VLAN2}
-      - {os_svi_int: vlan710 , os_svi_desc: SVI_VLAN710}
-      - {os_svi_int: vlan711 , os_svi_desc: SVI_VLAN711}
-      - {os_svi_int: vlan712 , os_svi_desc: SVI_VLAN712}
+      - {os_svi_int: vlan2, os_svi_desc: SVI_VLAN2}
+      - {os_svi_int: vlan710, os_svi_desc: SVI_VLAN710}
+      - {os_svi_int: vlan711, os_svi_desc: SVI_VLAN711}
+      - {os_svi_int: vlan712, os_svi_desc: SVI_VLAN712}
     register: result
 
   - assert: *true
@@ -90,10 +90,10 @@
       version: "{{ item.ipv4_ver }}"
       provider: "{{ connection }}"
     with_items: &vlanips
-      - {os_svi_int: vlan2 , ipv4_addr: 192.168.2.1 , ipv4_mask: 24 , ipv4_ver: v4}
-      - {os_svi_int: vlan710 , ipv4_addr: 192.168.3.1 , ipv4_mask: 24 , ipv4_ver: v4}
-      - {os_svi_int: vlan711 , ipv4_addr: 192.168.4.1 , ipv4_mask: 24 , ipv4_ver: v4}
-      - {os_svi_int: vlan712 , ipv4_addr: 192.168.5.1 , ipv4_mask: 24 , ipv4_ver: v4}
+      - {os_svi_int: vlan2, ipv4_addr: 192.168.2.1, ipv4_mask: 24, ipv4_ver: v4}
+      - {os_svi_int: vlan710, ipv4_addr: 192.168.3.1, ipv4_mask: 24, ipv4_ver: v4}
+      - {os_svi_int: vlan711, ipv4_addr: 192.168.4.1, ipv4_mask: 24, ipv4_ver: v4}
+      - {os_svi_int: vlan712, ipv4_addr: 192.168.5.1, ipv4_mask: 24, ipv4_ver: v4}
     register: result
 
   - assert: *true


### PR DESCRIPTION
##### SUMMARY
**NOTE:** This fix is a must have for 2.4

The nxos_interface module has two issues when using it to create and configure vlan interfaces.
  * Creating vlan interface and setting the `description` filed errors out for transport `nxapi`.
  * Configuring the `description` field it not idempotent for vlan interfaces.

This fix uses the far more reliable `show run interface vlan x all` command to get admin_state and description information instead of `show interface vlan x` which is less structured and prone to errors.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_interface 

##### ANSIBLE VERSION
```
ansible 2.5.0 (rel240/nxos_interface_idempotence f7505a74d0) last updated 2017/09/08 11:00:17 (GMT -400)
  config file = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/ansible.cfg
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
The following playbook that is part of this PR is used to demonstrate the two problems without the fix.

```yaml
---
- debug: msg="START TRANSPORT:{{ connection.transport }} nxos_interface sanity test"

- set_fact: testint="{{ nxos_int1 }}"

- name: "Setup: Enable feature interface-vlan"
  nxos_feature:
    feature: interface-vlan
    state: enabled
    provider: "{{ connection }}"
  ignore_errors: yes

- name: "Setup: Put interface {{ testint }} into a default state"
  nxos_config: &intcleanup
    lines:
      - "default interface {{ testint }}"
    provider: "{{ connection }}"
  ignore_errors: yes

- name: "Setup: Remove possibly existing vlan interfaces"
  nxos_config: &vlanintcleanup
    lines:
      - "no interface vlan 2"
      - "no interface vlan 710"
      - "no interface vlan 711"
      - "no interface vlan 712"
    provider: "{{ connection }}"
  ignore_errors: yes

- block:
  - name: "Configure layer3 params"
    nxos_interface: &l3config
      interface: "{{ testint }}"
      mode: layer3
      description: 'Configured by Ansible - Layer3'
      admin_state: 'up'
      state: present
      provider: "{{ connection }}"
    register: result

  - assert: &true
      that:
        - "result.changed == true"

  - name: "Check Idempotence"
    nxos_interface: *l3config
    register: result

  - assert: &false
      that:
        - "result.changed == false"

  - name: "Configure layer2 params"
    nxos_interface: &l2config
      interface: "{{ testint }}"
      mode: layer2
      description: 'Configured by Ansible - Layer2'
      admin_state: 'down'
      state: present
      provider: "{{ connection }}"
    register: result

  - assert: *true

  - name: "Check Idempotence"
    nxos_interface: *l2config
    register: result

  - assert: *false

  - name: Create VLAN Interfaces
    nxos_interface: &createvlans
      interface: "{{ item.os_svi_int }}"
      description: "{{ item.os_svi_desc }}"
      provider: "{{ connection }}"
    with_items: &vlanitems
      - {os_svi_int: vlan2 , os_svi_desc: SVI_VLAN2}
      - {os_svi_int: vlan710 , os_svi_desc: SVI_VLAN710}
      - {os_svi_int: vlan711 , os_svi_desc: SVI_VLAN711}
      - {os_svi_int: vlan712 , os_svi_desc: SVI_VLAN712}
    register: result

  - assert: *true

  - name: Configure Required SVI
    nxos_ip_interface: &addips
      interface: "{{ item.os_svi_int }}"
      addr: "{{ item.ipv4_addr }}"
      mask: "{{ item.ipv4_mask }}"
      version: "{{ item.ipv4_ver }}"
      provider: "{{ connection }}"
    with_items: &vlanips
      - {os_svi_int: vlan2 , ipv4_addr: 192.168.2.1 , ipv4_mask: 24 , ipv4_ver: v4}
      - {os_svi_int: vlan710 , ipv4_addr: 192.168.3.1 , ipv4_mask: 24 , ipv4_ver: v4}
      - {os_svi_int: vlan711 , ipv4_addr: 192.168.4.1 , ipv4_mask: 24 , ipv4_ver: v4}
      - {os_svi_int: vlan712 , ipv4_addr: 192.168.5.1 , ipv4_mask: 24 , ipv4_ver: v4}
    register: result

  - assert: *true

  - name: Create VLAN Interfaces Idempotence Check
    nxos_interface: *createvlans
    with_items: *vlanitems
    register: result

  - assert: *false

  - name: Configure Required SVI Idempotence Check
    nxos_ip_interface: *addips
    with_items: *vlanips
    register: result

  - assert: *false

  rescue:
  - name: "Set interface back to default"
    nxos_config: *intcleanup
    ignore_errors: yes

  - name: "Remove vlan interfaces"
    nxos_config: *vlanintcleanup

  - name: "Setup: Disable feature interface-vlan"
    nxos_feature:
      feature: interface-vlan
      state: disabled
      provider: "{{ connection }}"
    ignore_errors: yes

  always:
  - debug: msg="END TRANSPORT:{{ connection.transport }} nxos_interface sanity test"
```
###### Transport nxapi error when setting description on vlan interfaces.
```shell
TASK [nxos_interface : Create VLAN Interfaces] ************************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_interface/tests/common/sanity.yaml:71
<n9k.example.com> connection transport is nxapi
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_interface.py
<n9k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663 `" && echo ansible-tmp-1504884078.03-170119267405663="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmp7OGO1u TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663/nxos_interface.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663/nxos_interface.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1504884078.03-170119267405663/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py", line 713, in <module>
    main()
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py", line 702, in main
    normalized_interface)
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py", line 535, in smart_existing
    existing = get_interface(normalized_interface, module)
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py", line 301, in get_interface
    attributes = get_manual_interface_attributes(intf, module)
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py", line 224, in get_manual_interface_attributes
    command_list = body.split('\n')
AttributeError: 'dict' object has no attribute 'split'

failed: [n9k.example.com] (item={u'os_svi_desc': u'SVI_VLAN2', u'os_svi_int': u'vlan2'}) => {
    "changed": false, 
    "failed": true, 
    "item": {
        "os_svi_desc": "SVI_VLAN2", 
        "os_svi_int": "vlan2"
    }, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py\", line 713, in <module>\n    main()\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py\", line 702, in main\n    normalized_interface)\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py\", line 535, in smart_existing\n    existing = get_interface(normalized_interface, module)\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py\", line 301, in get_interface\n    attributes = get_manual_interface_attributes(intf, module)\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_hr7scQ/ansible_module_nxos_interface.py\", line 224, in get_manual_interface_attributes\n    command_list = body.split('\\n')\nAttributeError: 'dict' object has no attribute 'split'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}

```
###### Description field not idempotent for vlan interfaces.
```shell
TASK [nxos_interface : Create VLAN Interfaces Idempotence Check] ******************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_interface/tests/common/sanity.yaml:101
<n9k.example.com> connection transport is cli
<n9k.example.com> using connection plugin network_cli
<n9k.example.com> socket_path: /Users/mwiebe/.ansible/pc/34de4e5bd3
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_interface.py
<n9k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457 `" && echo ansible-tmp-1504883975.28-124882059728457="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmpMY8qTF TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457/nxos_interface.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457/nxos_interface.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1504883975.28-124882059728457/" > /dev/null 2>&1 && sleep 0'
changed: [n9k.example.com] => (item={u'os_svi_desc': u'SVI_VLAN2', u'os_svi_int': u'vlan2'}) => {
    "changed": true, 
    "commands": [
        "interface Vlan2", 
        "description SVI_VLAN2"
    ], 
    "failed": false, 
    "invocation": {
        "module_args": {
            "admin_state": "up", 
            "description": "SVI_VLAN2", 
            "fabric_forwarding_anycast_gateway": null, 
            "host": null, 
            "interface": "vlan2", 
            "interface_type": null, 
            "ip_forward": null, 
            "mode": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": null, 
            "transport": "cli", 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null
        }
    }, 
    "item": {
        "os_svi_desc": "SVI_VLAN2", 
        "os_svi_int": "vlan2"
    }
}
<n9k.example.com> connection transport is cli
<n9k.example.com> using connection plugin network_cli
<n9k.example.com> socket_path: /Users/mwiebe/.ansible/pc/34de4e5bd3
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983 `" && echo ansible-tmp-1504883981.83-105606701773983="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmp8cqsZP TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983/nxos_interface.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983/nxos_interface.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1504883981.83-105606701773983/" > /dev/null 2>&1 && sleep 0'
changed: [n9k.example.com] => (item={u'os_svi_desc': u'SVI_VLAN710', u'os_svi_int': u'vlan710'}) => {
    "changed": true, 
    "commands": [
        "interface Vlan710", 
        "description SVI_VLAN710"
    ], 
    "failed": false, 
    "invocation": {
        "module_args": {
            "admin_state": "up", 
            "description": "SVI_VLAN710", 
            "fabric_forwarding_anycast_gateway": null, 
            "host": null, 
            "interface": "vlan710", 
            "interface_type": null, 
            "ip_forward": null, 
            "mode": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": null, 
            "transport": "cli", 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null
        }
    }, 
    "item": {
        "os_svi_desc": "SVI_VLAN710", 
        "os_svi_int": "vlan710"
    }
}
<n9k.example.com> connection transport is cli
<n9k.example.com> using connection plugin network_cli
<n9k.example.com> socket_path: /Users/mwiebe/.ansible/pc/34de4e5bd3
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432 `" && echo ansible-tmp-1504883988.6-95691312491432="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmpRiP05c TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432/nxos_interface.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432/nxos_interface.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1504883988.6-95691312491432/" > /dev/null 2>&1 && sleep 0'
changed: [n9k.example.com] => (item={u'os_svi_desc': u'SVI_VLAN711', u'os_svi_int': u'vlan711'}) => {
    "changed": true, 
    "commands": [
        "interface Vlan711", 
        "description SVI_VLAN711"
    ], 
    "failed": false, 
    "invocation": {
        "module_args": {
            "admin_state": "up", 
            "description": "SVI_VLAN711", 
            "fabric_forwarding_anycast_gateway": null, 
            "host": null, 
            "interface": "vlan711", 
            "interface_type": null, 
            "ip_forward": null, 
            "mode": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": null, 
            "transport": "cli", 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null
        }
    }, 
    "item": {
        "os_svi_desc": "SVI_VLAN711", 
        "os_svi_int": "vlan711"
    }
}
<n9k.example.com> connection transport is cli
<n9k.example.com> using connection plugin network_cli
<n9k.example.com> socket_path: /Users/mwiebe/.ansible/pc/34de4e5bd3
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727 `" && echo ansible-tmp-1504883995.27-89755518484727="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmpz3QVcB TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727/nxos_interface.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727/nxos_interface.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727/nxos_interface.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1504883995.27-89755518484727/" > /dev/null 2>&1 && sleep 0'
changed: [n9k.example.com] => (item={u'os_svi_desc': u'SVI_VLAN712', u'os_svi_int': u'vlan712'}) => {
    "changed": true, 
    "commands": [
        "interface Vlan712", 
        "description SVI_VLAN712"
    ], 
    "failed": false, 
    "invocation": {
        "module_args": {
            "admin_state": "up", 
            "description": "SVI_VLAN712", 
            "fabric_forwarding_anycast_gateway": null, 
            "host": null, 
            "interface": "vlan712", 
            "interface_type": null, 
            "ip_forward": null, 
            "mode": null, 
            "password": null, 
            "port": null, 
            "provider": null, 
            "ssh_keyfile": null, 
            "state": "present", 
            "timeout": null, 
            "transport": "cli", 
            "use_ssl": null, 
            "username": null, 
            "validate_certs": null
        }
    }, 
    "item": {
        "os_svi_desc": "SVI_VLAN712", 
        "os_svi_int": "vlan712"
    }
}

TASK [nxos_interface : assert] ****************************************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_interface/tests/common/sanity.yaml:106
fatal: [n9k.example.com]: FAILED! => {
    "assertion": "result.changed == false", 
    "changed": false, 
    "evaluated_to": false, 
    "failed": true
}
```
