### PR TITLE
backport fix for cloudtrail module to allow for AWS profiles other than the default - fixes #28821

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -119,7 +119,7 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import connect_to_aws, ec2_argument_spec, get_ec2_creds
+from ansible.module_utils.ec2 import connect_to_aws, ec2_argument_spec, get_aws_connection_info
 
 
 class CloudTrailManager:
@@ -186,9 +186,7 @@ def main():
     if not HAS_BOTO:
         module.fail_json(msg='boto is required.')
 
-    ec2_url, access_key, secret_key, region = get_ec2_creds(module)
-    aws_connect_params = dict(aws_access_key_id=access_key,
-                              aws_secret_access_key=secret_key)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
 
     if not region:
         module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")


### PR DESCRIPTION
##### SUMMARY
This has been fixed for 2.4 when the module was ported to boto3. This is a backport bugfix. Currently the profile option is ignored for the cloudtrail module in stable 2.3. Fixes #28821.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudtrail.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0 (cloudtrail_boto_profile_bug_on_2.3 356c762557) last updated 2017/09/08 11:06:19 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
