### PR TITLE
fix os_image so it works when id is None

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_image.py
+++ b/lib/ansible/modules/cloud/openstack/os_image.py
@@ -164,9 +164,11 @@ def main():
 
         if module.params['state'] == 'present':
             if not image:
+                kwargs={}
+                if module.params['id'] is not None:
+                    kwargs['id'] = module.params['id']
                 image = cloud.create_image(
                     name=module.params['name'],
-                    id=module.params['id'],
                     filename=module.params['filename'],
                     disk_format=module.params['disk_format'],
                     container_format=module.params['container_format'],
@@ -174,7 +176,8 @@ def main():
                     timeout=module.params['timeout'],
                     is_public=module.params['is_public'],
                     min_disk=module.params['min_disk'],
-                    min_ram=module.params['min_ram']
+                    min_ram=module.params['min_ram'],
+                    **kwargs
                 )
                 changed = True
                 if not module.params['wait']:


### PR DESCRIPTION
##### SUMMARY
Adds protection to the handling of the `id` module parameter to the `os_image` module so that when it is `None`  (which is the default) it is not passed as a keyword argument to shade's `create_image` function. 

Fixes #29145

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
os_image

##### ANSIBLE VERSION
```
ansible 2.4.0
  config file = None
  configured module search path = ['/nfs/users/nfs_j/jr17/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /software/hgi/pkglocal/ansible-git-20170906-8f4c8844-hgiextras-992e571d167746f79b7bae07a0db5835/lib/python3.6/site-packages/ansible
  executable location = /software/hgi/pkglocal/ansible-git-20170906-8f4c8844-hgiextras-992e571d167746f79b7bae07a0db5835/bin/ansible
  python version = 3.6.1 (default, May 17 2017, 13:38:25) [GCC 4.9.1]
```


