### PR TITLE
Fixes #27336 - nxos_gir_profile_management issue while creating profile

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
@@ -69,7 +69,7 @@ options:
 
 EXAMPLES = '''
 # Create a maintenance-mode profile
-- nxos_gir_profile:
+- nxos_gir_profile_management:
     mode: maintenance
     commands:
       - router eigrp 11
@@ -78,7 +78,7 @@ EXAMPLES = '''
     username: "{{ un }}"
     password: "{{ pwd }}"
 # Remove the maintenance-mode profile
-- nxos_gir_profile:
+- nxos_gir_profile_management:
     mode: maintenance
     state: absent
     host: "{{ inventory_hostname }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #27336. Also correcting documentation errors.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_gir_profile_management

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (nxos_gir_profile_management 7095cdee38) last updated 2017/09/08 15:33:22 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```