### PR TITLE
Print deprecation warnings for hostfile/ANSIBLE_HOSTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ Ansible Changes By Release
 
 
 ### Minor Changes
-* Removed previously deprecated config option `hostfile` and env var `ANSIBLE_HOSTS`
+* Ensure deprecated config option `hostfile` and env var `ANSIBLE_HOSTS` print deprecation warnings for removal in 2.6
 * Removed unused and deprecated config option `pattern`
 * Updated the copy of six bundled for modules to use from 1.4.1 to 1.10.0
 * The `include_dir` var is not a global anymore, as we now allow multiple inventory sources, it is now host dependant.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -598,7 +598,7 @@ DEFAULT_HASH_BEHAVIOUR:
   - {key: hash_behaviour, section: defaults}
   yaml: {key: defaults.hash_behaviour}
 DEFAULT_HOST_LIST:
-  default: /etc/ansible/hosts
+  default: eval(DEPRECATED_HOST_LIST)
   description: Location of the Ansible inventory source.
   env: [{name: ANSIBLE_INVENTORY}]
   expand_relative_paths: True
@@ -1083,6 +1083,19 @@ DEFAULT_VERBOSITY:
   - {key: verbosity, section: defaults}
   type: integer
   yaml: {key: defaults.verbosity}
+DEPRECATED_HOST_LIST:
+  default: /etc/ansible/hosts
+  description: Location of the Ansible inventory source.
+  env: [{name: ANSIBLE_HOSTS}]
+  expand_relative_paths: True
+  ini:
+  - {key: hostfile, section: defaults}
+  type: path
+  yaml: {key: defaults.hostfile}
+  deprecated:
+    why: Use inventory instead of hostfile in ansible.cfg, and ANSIBLE_INVENTORY instead of ANSIBLE_HOSTS
+    version: "2.6"
+    alternatives: inventory in defaults section
 DEPRECATION_WARNINGS:
   default: True
   description: "Toggle to control the showing of deprecation warnings"


### PR DESCRIPTION
##### SUMMARY
Revert the removal of the hostfile configuration setting,
and ensure a deprecation warning is printed instead.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible configuration

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel e71cddc026) last updated 2017/09/08 12:44:20 (GMT -700)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
This must be backported onto 2.4 as well.