### PR TITLE
BUGFIX: GCE instance_templates: allow the setting of the service account

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -290,6 +290,7 @@ def create_instance_template(module, gce):
     external_ip = module.params.get('external_ip')
     service_account_permissions = module.params.get(
         'service_account_permissions')
+    service_account_email = module.params.get('service_account_email')
     on_host_maintenance = module.params.get('on_host_maintenance')
     automatic_restart = module.params.get('automatic_restart')
     preemptible = module.params.get('preemptible')

--- a/lib/ansible/modules/cloud/google/gce_instance_template.py
+++ b/lib/ansible/modules/cloud/google/gce_instance_template.py
@@ -369,7 +369,10 @@ def create_instance_template(module, gce):
                 bad_perms.append(perm)
         if len(bad_perms) > 0:
             module.fail_json(msg='bad permissions: %s' % str(bad_perms))
-        ex_sa_perms.append({'email': "default"})
+        if service_account_email is not None:
+            ex_sa_perms.append({'email': str(service_account_email)})
+        else:
+            ex_sa_perms.append({'email': "default"})
         ex_sa_perms[0]['scopes'] = service_account_permissions
     gce_args['service_accounts'] = ex_sa_perms
 


### PR DESCRIPTION
##### SUMMARY
Currently, the gce_instance_template module says it supports the service_account_email setting, but it actually doesnt. This fixes that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
gce_instance_template

##### ANSIBLE VERSION
```ansible 2.3.2.0
  config file = /Users/evan.carter/code/devops/ansible-cloud/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
##### ADDITIONAL INFORMATION
Also have a patch out for libcloud to fix their side.
https://github.com/apache/libcloud/pull/1108