### PR TITLE
2.4 bugfix - fixes #19666 Correct AMI information output by ec2_ami module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -401,7 +401,9 @@ def get_ami_info(image):
         root_device_name=image.root_device_name,
         root_device_type=image.root_device_type,
         tags=image.tags,
-        virtualization_type=image.virtualization_type
+        virtualization_type=image.virtualization_type,
+        name=image.name,
+        platform=image.platform
     )
 
 


### PR DESCRIPTION
##### SUMMARY

Add AMI name and platform to outputs on AMI creation as is documented.
Fixes #19666 Correct AMI information output by ec2_ami module (merged in devel in #27021)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_ami.py

##### ANSIBLE VERSION
```
2.4.0.0
```
