### PR TITLE
Fixes #20443 - Adjust version checking regex to account fo no comma in IOS-XE

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -184,7 +184,7 @@ class Default(FactsBase):
             self.facts['hostname'] = self.parse_hostname(data)
 
     def parse_version(self, data):
-        match = re.search(r'Version (\S+)(?:,|\S)', data)
+        match = re.search(r'Version (\S+?)(?:,\s|\s)', data)
         if match:
             return match.group(1)
 

--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -184,7 +184,7 @@ class Default(FactsBase):
             self.facts['hostname'] = self.parse_hostname(data)
 
     def parse_version(self, data):
-        match = re.search(r'Version (\S+),', data)
+        match = re.search(r'Version (\S+)(?:,|\S)', data)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #20443. IOS-XE doesn't have a comma after the version number. Standard IOS does. This regex allows for either. Example text can be seen here: [https://regex101.com/r/WCVPWb/2](https://regex101.com/r/WCVPWb/2)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_facts

##### ANSIBLE VERSION
```
15:45 $ ansible --version
ansible 2.5.0
  config file = /home/jkarras/netcom-network-ansible/ansible.cfg
  configured module search path = ['/home/jkarras/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Bug affects back to version 2.2 per the attached issue.