### PR TITLE
Fixes #26793: convert insert regex to_bytes before searching

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -253,9 +253,9 @@ def main():
         insertafter = 'EOF'
 
     if insertafter not in (None, 'EOF'):
-        insertre = re.compile(insertafter)
+        insertre = re.compile(to_bytes(insertafter, errors='surrogate_or_strict'))
     elif insertbefore not in (None, 'BOF'):
-        insertre = re.compile(insertbefore)
+        insertre = re.compile(to_bytes(insertbefore, errors='surrogate_or_strict'))
     else:
         insertre = None
 


### PR DESCRIPTION
##### SUMMARY

Text regexes can't be used for searching in bytes in python 3. This change converts insert regexes `to_bytes` before compiling them in a way it is done in a similar [`lineinfile`](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/files/lineinfile.py#L253) module.

Fixes #26793

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`blockinfile` module

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
And current `devel`.


##### ADDITIONAL INFORMATION

Without the change it would crash if target host uses python 3 with:
```
fatal: [ansible-vagrant]: FAILED! => {"changed": false, "failed": true, "module_stderr": "mesg: ttyname failed: Inappropriate ioctl for device\nTraceback (most recent call last):\n  File \"/tmp/ansible_sycgkdbv/ansible_module_blockinfile.py\", line 334, in <module>\n    main()\n  File \"/tmp/ansible_sycgkdbv/ansible_module_blockinfile.py\", line 284, in main\n    if insertre.search(line):\nTypeError: cannot use a string pattern on a bytes-like object\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 1}
```

On this branch everything works as expected.
