### PR TITLE
Windows: Introduce Set-AnsibleFact and set reboot_pending

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Facts.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Facts.psm1
@@ -1,0 +1,47 @@
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+
+# Copyright: (c) 2017, Dag Wieers <dag@wieers.com>
+# All rights reserved.
+
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = "Stop"
+
+# Helper function to set facts
+# Example: Set-AnsibleFact $result "fact_name" "fact_value"
+Function Set-AnsibleFact($obj, $name, $value) {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute("PSUseShouldProcessForStateChangingFunctions", "", Justification="Silly rule just because we use verb Set in function")]
+
+    if (-not $obj.ContainsKey("ansible_facts")) {
+        $obj.ansible_facts = @{}
+    } elseif ($obj.ansible_facts -isnot [hashtable]) {
+        throw "Add-Warning: ansible_facts attribute is not a hash table"
+    }
+
+    $obj.ansible_facts.Add($name, $value)
+}
+
+# this line must stay at the bottom to ensure all defined module parts are exported
+Export-ModuleMember -Alias * -Function * -Cmdlet *

--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -1,21 +1,10 @@
 #!powershell
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# Copyright: (c) 2017, Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Facts
+#Requires -Module Ansible.ModuleUtils.Legacy
 
 Set-StrictMode -Version 2
 $ErrorActionPreference = "Stop"
@@ -84,6 +73,7 @@ If(-not $forest) {
         $iaf = Install-ADDSForest @install_forest_args
 
         $result.reboot_required = $iaf.RebootRequired
+        Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
     }
 }
 

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -4,6 +4,7 @@
 # Copyright: (c) 2017, Red Hat, Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+#Requires -Module Ansible.ModuleUtils.Facts
 #Requires -Module Ansible.ModuleUtils.Legacy
 
 Set-StrictMode -Version 2
@@ -42,7 +43,7 @@ Function Get-MissingFeatures {
     }
 
     $missing_features = @($features | Where-Object InstallState -ne Installed)
-    
+
     return ,$missing_features # no, the comma's not a typo- allows us to return an empty array
 }
 
@@ -190,6 +191,7 @@ Try {
                 }
 
                 $result.reboot_required = $true
+                Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
 
                 $safe_mode_secure = $safe_mode_password | ConvertTo-SecureString -AsPlainText -Force
                 Write-DebugLog "Installing domain controller..."
@@ -235,6 +237,7 @@ Try {
             }
 
             $result.reboot_required = $true
+            Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
 
             $local_admin_secure = $local_admin_password | ConvertTo-SecureString -AsPlainText -Force
 

--- a/lib/ansible/modules/windows/win_domain_membership.ps1
+++ b/lib/ansible/modules/windows/win_domain_membership.ps1
@@ -1,24 +1,10 @@
 #!powershell
 
-# (c) 2017, Red Hat, Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# WANT_JSON
-# POWERSHELL_COMMON
+#Requires -Module Ansible.ModuleUtils.Facts
+#Requires -Module Ansible.ModuleUtils.Legacy
 
 Set-StrictMode -Version 2
 
@@ -254,6 +240,7 @@ Try {
 
                     # this change requires a reboot
                     $result.reboot_required = $true
+                    Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
                 }
                 ElseIf(-not $hostname_match) { # domain matches but hostname doesn't, just do a rename
                     Write-DebugLog ("domain matches, setting hostname to {0}" -f $hostname)
@@ -269,6 +256,7 @@ Try {
 
                     # this change requires a reboot
                     $result.reboot_required = $true
+                    Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
                 } Else {
                     # no change is needed
                 }
@@ -292,6 +280,7 @@ Try {
 
                     # this change requires a reboot
                     $result.reboot_required = $true
+                    Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
                 }
                 If(-not $hostname_match) {
                     Write-DebugLog ("setting hostname to {0}" -f $hostname)
@@ -299,6 +288,7 @@ Try {
 
                     # this change requires a reboot
                     $result.reboot_required = $true
+                    Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
                 }
             }
         }

--- a/lib/ansible/modules/windows/win_dsc.ps1
+++ b/lib/ansible/modules/windows/win_dsc.ps1
@@ -1,10 +1,11 @@
 #!powershell
 # This file is part of Ansible
 
-# (c) 2015, Trond Hindenes <trond@hindenes.com>, and others
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2015, Trond Hindenes <trond@hindenes.com>, and others
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+#Requires -Module Ansible.ModuleUtils.Facts
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Version 5
 
@@ -158,7 +159,7 @@ if ($Attributes.Count -eq 0)
 }
 
 #Always return some basic info
-$result["reboot_required"] = $false
+$result.reboot_required = $false
 
 $Config = @{
    Name = ($resourcename)
@@ -248,7 +249,7 @@ foreach ($attribute in $Attributes.GetEnumerator())
         {
             $keyValue = Parse-DscProperty -name $key -value $value -resourceProp $prop
         }
-        
+
         $config.Property.Add($key, $keyValue)
     }
 }
@@ -272,7 +273,8 @@ try
                 #If SetError was filled, throw to exit out of the try/catch loop
                 throw $SetError
             }
-            $result["reboot_required"] = $SetResult.RebootRequired
+            $result.reboot_required = $SetResult.RebootRequired
+            Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
         }
         $result["changed"] = $true
         if ($SetError)

--- a/lib/ansible/modules/windows/win_feature.ps1
+++ b/lib/ansible/modules/windows/win_feature.ps1
@@ -1,23 +1,10 @@
 #!powershell
-# This file is part of Ansible.
-#
-# Copyright 2014, Paul Durivage <paul.durivage@rackspace.com>
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# Copyright: (c) 2014, Paul Durivage <paul.durivage@rackspace.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Facts
+#Requires -Module Ansible.ModuleUtils.Legacy
 
 Import-Module Servermanager
 
@@ -153,6 +140,7 @@ $result.feature_result = $installed_features
 $result.success = ($featureresult.Success.ToString() | ConvertTo-Bool)
 $result.exitcode = $featureresult.ExitCode.ToString()
 $result.reboot_required = ($featureresult.RestartNeeded.ToString() | ConvertTo-Bool)
+Set-AnsibleFact -obj $result -name "ansible_reboot_pending" -value $result.reboot_required
 
 # DEPRECATED 2.4, potential removal in 2.6+ (standardize naming to "reboot_required")
 $result.restart_needed = $result.reboot_required


### PR DESCRIPTION
##### SUMMARY
This is the first implementation to allow modules to update generic system facts. We implement a new library function **Set-AnsibleFact** that can set/update system facts, regardless if other facts were already set or not.

This PR also includes all needed changes to update the **ansible_reboot_pending** system fact from all modules that return **reboot_required**.

After this, I would also like to update other Windows modules to update the system facts after making the change (at least if these changes don't need a reboot to be effective).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
powershell/

##### ANSIBLE VERSION
2.5