### PR TITLE
Return None for DC in case of detached storage domain

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -334,9 +334,9 @@ class StorageDomainModule(BaseModule):
         # Serach the data_center name, if it does not exists, try to search by guid.
         dc = search_by_name(dcs_service, self._module.params['data_center'])
         if dc is None:
-            dc = dcs_service.service(self._module.params['data_center']).get()
+            dc = get_entity(dcs_service.service(self._module.params['data_center']))
             if dc is None:
-                return
+                return None
 
         dc_service = dcs_service.data_center_service(dc.id)
         return dc_service.storage_domains_service()


### PR DESCRIPTION
##### SUMMARY
The following patch fixes a regression when trying to remove a detached
storage domain.
As part of the remove process the ovirt_storage_domains module first
tries to move the domain to maintenance and detach it.
In case of removing a detached storage domain with no DC attached to it
The maintenace process will fail with 404 (not exists) exception when
trying to fetch the DC using empty Guid.
The fix proposes a solution to return None value in case of a detached
storage domain.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py

##### ANSIBLE VERSION
master

##### REVIEWERS
@machacekondra 