### PR TITLE
[cloud] Add CAA record type to route53

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -49,7 +49,7 @@ options:
     description:
       - The type of DNS record to create
     required: true
-    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS', 'SOA' ]
+    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA' ]
   alias:
     description:
       - Indicates if this is an alias record.
@@ -292,6 +292,17 @@ EXAMPLES = '''
       weight: 100
       health_check: "d994b780-3150-49fd-9205-356abdd42e75"
 
+# Add a CAA record (RFC 6844):
+- route53:
+      state: present
+      zone: example.com
+      record: example.com
+      type: CAA
+      value:
+        - 0 issue "ca.example.net"
+        - 0 issuewild ";"
+        - 0 iodef "mailto:security@example.com"
+
 '''
 
 import time
@@ -398,7 +409,7 @@ def main():
         hosted_zone_id=dict(required=False, default=None),
         record=dict(required=True),
         ttl=dict(required=False, type='int', default=3600),
-        type=dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS', 'SOA'], required=True),
+        type=dict(choices=['A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS', 'SOA'], required=True),
         alias=dict(required=False, type='bool'),
         alias_hosted_zone_id=dict(required=False),
         alias_evaluate_target_health=dict(required=False, type='bool', default=False),

--- a/lib/ansible/modules/cloud/amazon/route53_facts.py
+++ b/lib/ansible/modules/cloud/amazon/route53_facts.py
@@ -66,7 +66,7 @@ options:
     description:
       - The type of DNS record
     required: false
-    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS' ]
+    choices: [ 'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS' ]
   dns_name:
     description:
       - The first name in the lexicographic ordering of domain names that you want
@@ -388,7 +388,7 @@ def main():
         delegation_set_id=dict(),
         start_record_name=dict(),
         type=dict(choices=[
-            'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'NS'
+            'A', 'CNAME', 'MX', 'AAAA', 'TXT', 'PTR', 'SRV', 'SPF', 'CAA', 'NS'
         ]),
         dns_name=dict(),
         resource_id=dict(type='list', aliases=['resource_ids']),


### PR DESCRIPTION
##### SUMMARY

Add CAA record type to route53. The CAA record type is supported in Amazon Route 53 since Aug 21, 2017. Tested manually.

- https://aws.amazon.com/about-aws/whats-new/2017/08/amazon-route-53-now-supports-caa-records/
- http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#CAAFormat
- https://tools.ietf.org/html/rfc6844

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/route53.py

##### ANSIBLE VERSION

```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/weisslj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/weisslj/.local/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /home/weisslj/.local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION