### PR TITLE
postgresql_db: Document that name and db are aliases

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -25,6 +25,7 @@ options:
       - name of the database to add or remove
     required: true
     default: null
+    aliases: [ db ]
   owner:
     description:
       - Name of the role to set as owner of the database


### PR DESCRIPTION
##### SUMMARY
Let the documentation match the code.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
postgresql_db module

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel ab7c850360) last updated 2017/09/10 15:11:34 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/lab/ansible/devel/lib/ansible
  executable location = /home/andreas/lab/ansible/devel/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```