### PR TITLE
better handling of Linux ip addresses

### DIFF
--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -187,11 +187,15 @@ class LinuxNetwork(Network):
                         # NOTE: interfaces is also ref to outside scope
                         if iface != device:
                             interfaces[iface] = {}
-                        if not secondary and "ipv4" not in interfaces[iface]:
-                            interfaces[iface]['ipv4'] = {'address': address,
-                                                         'broadcast': broadcast,
-                                                         'netmask': netmask,
-                                                         'network': network}
+                        if not secondary:
+                            if "ipv4" not in interfaces[iface]:
+                                interfaces[iface]['ipv4'] = []
+                            interfaces[iface]['ipv4'].append({
+                                'address': address,
+                                'broadcast': broadcast,
+                                'netmask': netmask,
+                                'network': network,
+                            })
                         else:
                             if "ipv4_secondaries" not in interfaces[iface]:
                                 interfaces[iface]["ipv4_secondaries"] = []

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -205,17 +205,16 @@ class LinuxNetwork(Network):
                                 'netmask': netmask,
                                 'network': network,
                             })
-
-                        # add this secondary IP to the main device
-                        if secondary:
-                            if "ipv4_secondaries" not in interfaces[device]:
-                                interfaces[device]["ipv4_secondaries"] = []
-                            interfaces[device]["ipv4_secondaries"].append({
-                                'address': address,
-                                'broadcast': broadcast,
-                                'netmask': netmask,
-                                'network': network,
-                            })
+                            # add this secondary IP to the main device
+                            if iface!=device:
+                                if "ipv4_secondaries" not in interfaces[device]:
+                                    interfaces[device]["ipv4_secondaries"] = []
+                                interfaces[device]["ipv4_secondaries"].append({
+                                    'address': address,
+                                    'broadcast': broadcast,
+                                    'netmask': netmask,
+                                    'network': network,
+                                })
 
                         # NOTE: default_ipv4 is ref to outside scope
                         # If this is the default address, update default_ipv4

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -206,7 +206,7 @@ class LinuxNetwork(Network):
                                 'network': network,
                             })
                             # add this secondary IP to the main device
-                            if iface!=device:
+                            if iface != device:
                                 if "ipv4_secondaries" not in interfaces[device]:
                                     interfaces[device]["ipv4_secondaries"] = []
                                 interfaces[device]["ipv4_secondaries"].append({


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This has multiple fixes, it puts primary ip addreses in a list under ansible_ifname:ipv4, prevents double entries of secondary ip addresses under ansible_ifname:ipv4_secondaries, also (mostly by accident) makes the fact format consistent with generic_bsd facts, where ansible_ifname:ipv4 is a list, unlike current linux where it's a dictionary.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (devel ab7c850360) last updated 2017/09/10 21:11:37 (GMT +200)
  config file = None
  configured module search path = [u'/home/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ansible/development/ansible-upstream/ansible/lib/ansible
  executable location = /home/ansible/development/ansible-upstream/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The logic behind the module is wrong. At line [190](https://github.com/ansible/ansible/blob/ab7c850360e6369308fc94ec82022542871cadd1/lib/ansible/module_utils/facts/network/linux.py#L190) it checks whether the ip is secondary *and* if no ipv4 is present, so that can activate only once. After that at line [195](https://github.com/ansible/ansible/blob/ab7c850360e6369308fc94ec82022542871cadd1/lib/ansible/module_utils/facts/network/linux.py#L195) it doesn't check whether the ip is secondary.
The second bug is result of code after line [206](https://github.com/ansible/ansible/blob/ab7c850360e6369308fc94ec82022542871cadd1/lib/ansible/module_utils/facts/network/linux.py#L206), where there is no check if interface is same as device, and in that case the address is added second time if secondary.
<!--- Paste verbatim command output below, e.g. before and after your change -->
With interface configured as follows:
```
2: ens192: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
    link/ether 00:0c:29:dc:f2:12 brd ff:ff:ff:ff:ff:ff
    inet 192.168.0.151/24 brd 192.168.0.255 scope global ens192
       valid_lft forever preferred_lft forever
    inet 10.0.0.5/24 brd 10.0.0.255 scope global ens192
       valid_lft forever preferred_lft forever
    inet 10.0.0.8/24 scope global secondary ens192
       valid_lft forever preferred_lft forever
    inet6 fe80::375c:5c45:ba87:25c/64 scope link
       valid_lft forever preferred_lft forever
```
The result is:
Before:
```
        "ansible_ens192": {
            ...
            "ipv4": {
                "address": "192.168.0.151",
                "broadcast": "192.168.0.255",
                "netmask": "255.255.255.0",
                "network": "192.168.0.0"
            },
            "ipv4_secondaries": [
                {
                    "address": "10.0.0.5",
                    "broadcast": "10.0.0.255",
                    "netmask": "255.255.255.0",
                    "network": "10.0.0.0"
                },
                {
                    "address": "10.0.0.8",
                    "broadcast": "global",
                    "netmask": "255.255.255.0",
                    "network": "10.0.0.0"
                },
                {
                    "address": "10.0.0.8",
                    "broadcast": "global",
                    "netmask": "255.255.255.0",
                    "network": "10.0.0.0"
                }
            ],
            ...
        },
```
After:
```
        "ansible_ens192": {
            ...
            "ipv4": [
                {
                    "address": "192.168.0.151",
                    "broadcast": "192.168.0.255",
                    "netmask": "255.255.255.0",
                    "network": "192.168.0.0"
                },
                {
                    "address": "10.0.0.5",
                    "broadcast": "10.0.0.255",
                    "netmask": "255.255.255.0",
                    "network": "10.0.0.0"
                }
            ],
            "ipv4_secondaries": [
                {
                    "address": "10.0.0.8",
                    "broadcast": "global",
                    "netmask": "255.255.255.0",
                    "network": "10.0.0.0"
                }
            ],
            ...
        },
```