### PR TITLE
win_unzip: added support for Server core by using .net zip functions

### DIFF
--- a/test/integration/targets/win_unzip/tasks/tests.yml
+++ b/test/integration/targets/win_unzip/tasks/tests.yml
@@ -4,12 +4,26 @@
     dest: C:\Program Files\sysinternals
   register: unzip_archive
 
-- name: Test unzip_archive
+- name: get stat of an extracted file
+  win_stat:
+    path: C:\Program Files\sysinternals\procexp.exe
+  register: unzip_archive_file
+
+- name: Test unzip_archive (check-mode)
   assert:
     that:
     - unzip_archive|changed == true
     - unzip_archive.removed == false
+    - unzip_archive_file.stat.exists == false
+  when: in_check_mode
 
+- name: Test unzip_archive (normal mode)
+  assert:
+    that:
+    - unzip_archive|changed == true
+    - unzip_archive.removed == false
+    - unzip_archive_file.stat.exists == true
+  when: not in_check_mode
 
 - name: Unarchive sysinternals archive again, use creates
   win_unzip:


### PR DESCRIPTION
##### SUMMARY
Currently win_unzip using the COM object `Shell.Application` to unzip files if the PSCX extensions are not installed. This will not work with Server Core installations as this COM object is not available. This PR changes the code so that it will use the newer dotnet ZipFile classes if dotnet 4.5 is available and will revert to the older code if it isn't.

This fixes https://github.com/ansible/ansible/issues/16708

Before:
```
fatal: [Server2012R2]: FAILED! => {"changed": false, "dest": "C:\\Program Files\\sysinternals", "failed": true, "msg": "Error unzipping 'C:\\Windows\\Temp\\SysinternalsSuite.zip' to 'C:\\Program Files\\sysinternals'!. Method: COM Shell.Application, Exception: Exception calling \"NameSpace\" with \"1\" argument(s): \"Unspecified error (Exception from HRESULT: 0x80004005 (E_FAIL))\"", "removed": false, "src": "C:\\Windows\\Temp\\SysinternalsSuite.zip"}
```

After:
```
changed: [Server2012R2] => {"changed": true, "dest": "C:\\Program Files\\sysinternals", "failed": false, "removed": false, "src": "C:\\Windows\\Temp\\SysinternalsSuite.zip"}
```

It also includes some minor changes where it will give a better error message when trying to delete the archive and an additional test to ensure a file was actually extracted.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_unzip

##### ANSIBLE VERSION
```
ansible 2.5.0 (win_unzip-dotnet 4d8b648d05) last updated 2017/09/11 09:02:33 (GMT +1000)
  config file = None
  configured module search path = ['/Users/jborean/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jborean/dev/ansible/lib/ansible
  executable location = /Users/jborean/dev/ansible/bin/ansible
  python version = 3.6.2 (default, Sep  6 2017, 15:32:21) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```