### PR TITLE
Fix wheel dependency on python 2.6.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -2,6 +2,7 @@ coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 
 pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance
 pylint >= 1.5.3, < 1.7.0 # 1.4.1 adds JSON output, but 1.5.3 fixes bugs related to JSON output
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
+wheel < 0.30.0 ; python_version < '2.7' # wheel 0.30.0 and later require python 2.7 or later
 yamllint != 1.8.0 ; python_version < '2.7' # yamllint 1.8.0 requires python 2.7+ while earlier/later versions do not
 isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previously passing pylint tests
 pycrypto >= 2.6 # Need features found in 2.6 and greater

--- a/test/runner/tox.ini
+++ b/test/runner/tox.ini
@@ -8,3 +8,4 @@ commands = {posargs}
 passenv = HOME SHIPPABLE*
 args_are_paths = False
 deps = setuptools == 35.0.2
+    wheel < 0.30.0 ; python_version < '2.7'


### PR DESCRIPTION
##### SUMMARY

Fix wheel dependency on python 2.6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Test Requirements

##### ANSIBLE VERSION

```
ansible 2.5.0 (wheel-fix 60dad457e5) last updated 2017/09/10 20:54:15 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
