### PR TITLE
Correct sl_vm documentation

### DIFF
--- a/lib/ansible/modules/cloud/softlayer/sl_vm.py
+++ b/lib/ansible/modules/cloud/softlayer/sl_vm.py
@@ -124,7 +124,7 @@ options:
       - Flag used to wait for active status before returning
     required: false
     default: true
-  wait_timeout:
+  wait_time:
     description:
       - time in seconds before wait returns
     required: false


### PR DESCRIPTION
##### SUMMARY
Fix corrects sl_vm documentation from wait_timeout to wait_time

Fixes: #29395

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/softlayer/sl_vm.py

##### ANSIBLE VERSION
```
2.5devel
```