### PR TITLE
Reduce deprecation warnings for hostfile

### DIFF
--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -287,7 +287,7 @@ class ConfigManager(object):
                         for ini_entry in defs[config]['ini']:
                             value = get_ini_config_value(self._parser, ini_entry)
                             origin = cfile
-                            if 'deprecated' in ini_entry:
+                            if 'deprecated' in ini_entry and value:
                                 self.DEPRECATED.append(('[%s]%s' % (ini_entry['section'], ini_entry['key']), ini_entry['deprecated']))
                     except Exception as e:
                         sys.stderr.write("Error while loading ini config %s: %s" % (cfile, to_native(e)))


### PR DESCRIPTION
##### SUMMARY

Deprecation warnings for hostfile should only occur
if hostfile is actually in the configuration file
(this is likely more general but happening most
obviously for hostfile)


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
configuration

##### ANSIBLE VERSION
```
[DEPRECATED] [defaults]hostfile: The key is misleading as it can also be a list of hosts, a directory or a list of paths. It will be removed in 2.8. As alternative use one of [inventory]
ansible 2.5.0 (devel 0c291ece1a) last updated 2017/09/11 10:16:27 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
As can be seen above, `ansible --version` shows a deprecation warning. This is in spite of the fact that my ansible.cfg file has no hostfile configuration. With the proposed change, only configuration with `hostfile` set will see the deprecation warning