### PR TITLE
fix nxos_command nxapi test output

### DIFF
--- a/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/nxapi/sanity.yaml
@@ -41,8 +41,9 @@
 
   - name: "Run show running-config bgp - should pass"
     nxos_command:
-      commands:
-        - sh running-config bgp
+      commands: 
+        - command: sh running-config bgp
+          output: text
       provider: "{{ nxapi }}"
     register: result
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix nxos_command nxapi test output
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/tests/nxos_command/tests/nxapi/sanity.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel and 2.4
```