### PR TITLE
Support pyrax.auth_with_token in rackspace modules

### DIFF
--- a/lib/ansible/plugins/doc_fragments/rackspace.py
+++ b/lib/ansible/plugins/doc_fragments/rackspace.py
@@ -65,6 +65,11 @@ options:
       - The URI of the authentication service.
     default: https://identity.api.rackspacecloud.com/v2.0/
     version_added: '1.5'
+  auth_token:
+    description:
+      - A pre-generated authentication token (requires I(tenant_name) or C(OS_PROJECT_NAME))
+        see U(https://developer.rackspace.com/docs/cloud-identity/v2/api-reference/token-operations/).
+    version_added: '2.8.0'
   credentials:
     description:
       - File to find the Rackspace credentials in. Ignored if I(api_key) and
@@ -110,4 +115,7 @@ notes:
     appropriate for pyrax. See U(https://github.com/rackspace/pyrax/blob/master/docs/getting_started.md#authenticating)
   - C(RAX_USERNAME) and C(RAX_API_KEY) obviate the use of a credentials file
   - C(RAX_REGION) defines a Rackspace Public Cloud region (DFW, ORD, LON, ...)
+  - C(RAX_TOKEN) contains a pre-generated Rackspace authentication token.
+    See U(https://developer.rackspace.com/docs/cloud-identity/v2/api-reference/token-operations/)
+  - C(RAX_TENANT_NAME) defines the default value for I(tenant_name).
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When automating ansible or running in a less than fully trusted
environment it's desirable to use the [scoped and short-lived
auth token](https://developer.rackspace.com/docs/cloud-servers/v2/getting-started/authenticate/)
that rackspace supports. For this we should optionally be able to use `pyrax.auth_with_token` instead of the credentials file.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
rax

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (rax_auth_token 52daaa08db) last updated 2017/09/11 12:16:40 (GMT +300)
  config file = None
  configured module search path = [u'/Users/kouk/code/ansible/library']
  ansible python module location = /Users/kouk/code/ansible/lib/ansible
  executable location = /Users/kouk/code/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This pr adds support for retrieving the auth token either from the
rax modules arguments or from the environment. It also uses the tenant
name since it is required when authenticating via auth token.
