### PR TITLE
Fix handling of config vars with eval expression

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -108,6 +108,6 @@ for setting in config.data.get_settings():
         except:
             value = setting.value
 
-    set_constant(setting.name, setting.value)
+    set_constant(setting.name, value or setting.value)
 
 


### PR DESCRIPTION
The config variables defined with eval, like INVENTORY_IGNORE_EXTS,
are not stored properly once the eval is processed.
This causes references to the constant to still have the eval in the
value.