### PR TITLE
Change ansible-doc usage to show -a is for internal use

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -147,7 +147,7 @@ class DocCLI(CLI):
                     doc, plainexamples, returndocs, metadata = plugin_docs.get_docstring(filename, verbose=(self.options.verbosity > 0))
                 except:
                     display.vvv(traceback.format_exc())
-                    display.warning("%s %s has a documentation error formatting or is missing documentation." % (plugin_type, plugin))
+                    display.error("%s %s has a documentation error formatting or is missing documentation." % (plugin_type, plugin))
                     continue
 
                 if doc is not None:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -54,7 +54,7 @@ class DocCLI(CLI):
     def parse(self):
 
         self.parser = CLI.base_parser(
-            usage='usage: %prog [-l|-s|-a] [options] [-t <plugin type] [plugin]',
+            usage='usage: %prog [-l|-s] [options] [-t <plugin type] [plugin]',
             module_opts=True,
             desc="plugin documentation tool",
             epilog="See man pages for Ansible CLI options or website for tutorials https://docs.ansible.com"
@@ -65,7 +65,7 @@ class DocCLI(CLI):
         self.parser.add_option("-s", "--snippet", action="store_true", default=False, dest='show_snippet',
                                help='Show playbook snippet for specified plugin(s)')
         self.parser.add_option("-a", "--all", action="store_true", default=False, dest='all_plugins',
-                               help='Show documentation for all plugins')
+                               help='**For internal testing only** Show documentation for all plugins.')
         self.parser.add_option("-t", "--type", action="store", default='module', dest='type', type='choice',
                                help='Choose which plugin type (defaults to "module")',
                                choices=['cache', 'callback', 'connection', 'inventory', 'lookup', 'module', 'strategy', 'vars'])
@@ -73,7 +73,7 @@ class DocCLI(CLI):
         super(DocCLI, self).parse()
 
         if [self.options.all_plugins, self.options.list_dir, self.options.show_snippet].count(True) > 1:
-            raise AnsibleOptionsError("Only one of -l, -a or -s can be used at the same time.")
+            raise AnsibleOptionsError("Only one of -l, -s or -a can be used at the same time.")
 
         display.verbosity = self.options.verbosity
 
@@ -147,7 +147,7 @@ class DocCLI(CLI):
                     doc, plainexamples, returndocs, metadata = plugin_docs.get_docstring(filename, verbose=(self.options.verbosity > 0))
                 except:
                     display.vvv(traceback.format_exc())
-                    display.error("%s %s has a documentation error formatting or is missing documentation." % (plugin_type, plugin))
+                    display.warning("%s %s has a documentation error formatting or is missing documentation." % (plugin_type, plugin))
                     continue
 
                 if doc is not None:


### PR DESCRIPTION
ansible-doc -a is for testing that documentation is sane.  It should not
be used by normal users in production.  The main reason for this is that
it is designed to fail if there are any undocumented modules or plugins.
This is good for testing that all plugins we ship are documented.  It is
not good for end users who may have undocumented third-party plugins.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
cli/doc.py
ansible-doc

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.4
```