### PR TITLE
module and vault fixes

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -385,13 +385,15 @@ class CLI(with_metaclass(ABCMeta, object)):
     @staticmethod
     def unfrack_paths(option, opt, value, parser):
         paths = getattr(parser.values, option.dest)
-        if isinstance(value, string_types):
-            paths[:0] = [unfrackpath(x) for x in value.split(os.pathsep)]
-        elif isinstance(value, list):
-            paths[:0] = [unfrackpath(x) for x in value]
-        else:
-            pass  # FIXME: should we raise options error?
-        setattr(parser.values, option.dest, paths)
+        if paths is None and value:
+            paths = []
+            if isinstance(value, string_types):
+                paths[:0] = [unfrackpath(x) for x in value.split(os.pathsep) if x]
+            elif isinstance(value, list):
+                paths[:0] = [unfrackpath(x) for x in value if x]
+            else:
+                pass  # FIXME: should we raise options error?
+            setattr(parser.values, option.dest, paths)
 
     @staticmethod
     def unfrack_path(option, opt, value, parser):
@@ -419,8 +421,8 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         if module_opts:
             parser.add_option('-M', '--module-path', dest='module_path', default=None,
-                              help="prepend path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
-                              action="callback", callback=CLI.unfrack_path, type='str')
+                              help="prepend coloon separated path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
+                              action="callback", callback=CLI.unfrack_paths, type='str')
         if runtask_opts:
             parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",
                               help="set additional variables as key=value or YAML/JSON, if filename prepend with @", default=[])
@@ -436,9 +438,6 @@ class CLI(with_metaclass(ABCMeta, object)):
                               help="vault password file", action="callback", callback=CLI.unfrack_paths, type='string')
             parser.add_option('--new-vault-password-file', default=[], dest='new_vault_password_files',
                               help="new vault password file for rekey", action="callback", callback=CLI.unfrack_paths, type='string')
-            parser.add_option('--output', default=None, dest='output_file',
-                              help='output file name for encrypt or decrypt; use - for stdout',
-                              action="callback", callback=CLI.unfrack_path, type='string'),
             parser.add_option('--vault-id', default=[], dest='vault_ids', action='append', type='string',
                               help='the vault identity to use')
             parser.add_option('--new-vault-id', default=None, dest='new_vault_id', type='string',

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -423,7 +423,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         if module_opts:
             parser.add_option('-M', '--module-path', dest='module_path', default=None,
-                              help="prepend coloon separated path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
+                              help="prepend colon-separated path(s) to module library (default=%s)" % C.DEFAULT_MODULE_PATH,
                               action="callback", callback=CLI.unfrack_paths, type='str')
         if runtask_opts:
             parser.add_option('-e', '--extra-vars', dest="extra_vars", action="append",

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -385,15 +385,17 @@ class CLI(with_metaclass(ABCMeta, object)):
     @staticmethod
     def unfrack_paths(option, opt, value, parser):
         paths = getattr(parser.values, option.dest)
-        if paths is None and value:
+        if paths is None:
             paths = []
-            if isinstance(value, string_types):
-                paths[:0] = [unfrackpath(x) for x in value.split(os.pathsep) if x]
-            elif isinstance(value, list):
-                paths[:0] = [unfrackpath(x) for x in value if x]
-            else:
-                pass  # FIXME: should we raise options error?
-            setattr(parser.values, option.dest, paths)
+
+        if isinstance(value, string_types):
+            paths[:0] = [unfrackpath(x) for x in value.split(os.pathsep) if x]
+        elif isinstance(value, list):
+            paths[:0] = [unfrackpath(x) for x in value if x]
+        else:
+            pass  # FIXME: should we raise options error?
+
+        setattr(parser.values, option.dest, paths)
 
     @staticmethod
     def unfrack_path(option, opt, value, parser):

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -84,9 +84,9 @@ class TaskQueueManager:
         self._start_at_done = False
 
         # make sure any module paths (if specified) are added to the module_loader
-        if isinstance(options.module_path, list):
+        if options.module_path:
             for path in options.module_path:
-                if path is not None:
+                if path:
                     module_loader.add_directory(path)
 
         # a special flag to help us exit cleanly

--- a/lib/ansible/plugins/loader.py
+++ b/lib/ansible/plugins/loader.py
@@ -226,6 +226,7 @@ class PluginLoader:
                 # append the directory and invalidate the path cache
                 self._extra_dirs.append(directory)
                 self._paths = None
+                display.debug('Added %s to loader search path' % (directory))
 
     def find_plugin(self, name, mod_type='', ignore_deprecated=False, check_aliases=False):
         ''' Find a plugin named name '''


### PR DESCRIPTION
##### SUMMARY
- fix module_path cli option and usage, which fixes #29653
- move --output to be in subset of vault cli, no need for all vault enabled cli to use it
- added debug to loader to see directories added

<!--- Describe the change, including rationale and design decisions -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```