### PR TITLE
Fix ansible-test unicode and sanity tests.

### DIFF
--- a/test/runner/import/lib/ansible/__init__.py
+++ b/test/runner/import/lib/ansible/__init__.py
@@ -1,0 +1,1 @@
+"""Empty placeholder for import sanity test."""

--- a/test/runner/lib/sanity/__init__.py
+++ b/test/runner/lib/sanity/__init__.py
@@ -169,7 +169,7 @@ class SanityFailure(TestFailure):
         :type test: str
         :type python_version: str
         :type messages: list[SanityMessage]
-        :type summary: str
+        :type summary: unicode
         """
         super(SanityFailure, self).__init__(COMMAND, test, python_version, messages, summary)
 
@@ -227,7 +227,7 @@ class SanityCodeSmellTest(SanityTest):
             status = ex.status
 
         if stderr or status:
-            summary = str(SubprocessError(cmd=cmd, status=status, stderr=stderr, stdout=stdout))
+            summary = u'%s' % SubprocessError(cmd=cmd, status=status, stderr=stderr, stdout=stdout)
             return SanityFailure(self.name, summary=summary)
 
         return SanitySuccess(self.name)

--- a/test/runner/lib/sanity/ansible_doc.py
+++ b/test/runner/lib/sanity/ansible_doc.py
@@ -57,14 +57,14 @@ class AnsibleDocTest(SanityMultipleVersion):
             status = ex.status
 
         if status:
-            summary = str(SubprocessError(cmd=cmd, status=status, stderr=stderr))
+            summary = u'%s' % SubprocessError(cmd=cmd, status=status, stderr=stderr)
             return SanityFailure(self.name, summary=summary, python_version=python_version)
 
         if stdout:
             display.info(stdout.strip(), verbosity=3)
 
         if stderr:
-            summary = 'Output on stderr from ansible-doc is considered an error.\n\n%s' % SubprocessError(cmd, stderr=stderr)
+            summary = u'Output on stderr from ansible-doc is considered an error.\n\n%s' % SubprocessError(cmd, stderr=stderr)
             return SanityFailure(self.name, summary=summary, python_version=python_version)
 
         return SanitySuccess(self.name, python_version=python_version)

--- a/test/runner/lib/sanity/pylint.py
+++ b/test/runner/lib/sanity/pylint.py
@@ -9,11 +9,13 @@ from lib.sanity import (
     SanityMessage,
     SanityFailure,
     SanitySuccess,
+    SanitySkipped,
 )
 
 from lib.util import (
     SubprocessError,
     run_command,
+    display,
 )
 
 from lib.ansible_util import (
@@ -30,6 +32,10 @@ from lib.test import (
 
 PYLINT_SKIP_PATH = 'test/sanity/pylint/skip.txt'
 
+UNSUPPORTED_PYTHON_VERSIONS = (
+    '2.6',
+)
+
 
 class PylintTest(SanitySingleVersion):
     """Sanity test using pylint."""
@@ -39,6 +45,10 @@ class PylintTest(SanitySingleVersion):
         :type targets: SanityTargets
         :rtype: SanityResult
         """
+        if args.python_version in UNSUPPORTED_PYTHON_VERSIONS:
+            display.warning('Skipping pylint on unsupported Python version %s.' % args.python_version)
+            return SanitySkipped(self.name)
+
         with open(PYLINT_SKIP_PATH, 'r') as skip_fd:
             skip_paths = skip_fd.read().splitlines()
 

--- a/test/runner/lib/test.py
+++ b/test/runner/lib/test.py
@@ -194,7 +194,7 @@ class TestFailure(TestResult):
         :type test: str
         :type python_version: str | None
         :type messages: list[TestMessage] | None
-        :type summary: str | None
+        :type summary: unicode | None
         """
         super(TestFailure, self).__init__(command, test, python_version)
 

--- a/test/runner/tox.ini
+++ b/test/runner/tox.ini
@@ -5,7 +5,7 @@ minversion = 2.5.0
 [testenv]
 changedir = {toxinidir}/../../
 commands = {posargs}
-passenv = HOME SHIPPABLE*
+passenv = HOME LC_ALL SHIPPABLE*
 args_are_paths = False
 deps = setuptools == 35.0.2
     wheel < 0.30.0 ; python_version < '2.7'

--- a/test/sanity/pylint/disable.txt
+++ b/test/sanity/pylint/disable.txt
@@ -18,6 +18,7 @@ cell-var-from-loop
 consider-iterating-dictionary
 consider-using-enumerate
 dangerous-default-value
+deprecated-lambda
 deprecated-method
 deprecated-module
 duplicate-key
@@ -32,6 +33,7 @@ global-variable-not-assigned
 global-variable-undefined
 import-error
 import-self
+invalid-encoded-data
 invalid-name
 line-too-long
 locally-disabled
@@ -41,6 +43,7 @@ lost-exception
 method-hidden
 misplaced-comparison-constant
 missing-docstring
+no-init
 no-member
 no-name-in-module
 no-self-use
@@ -49,6 +52,7 @@ non-iterator-returned
 not-a-mapping
 not-an-iterable
 not-callable
+old-style-class
 pointless-statement
 pointless-string-statement
 protected-access
@@ -58,6 +62,7 @@ redefined-outer-name
 redefined-variable-type
 redundant-unittest-assert
 reimported
+relative-import
 signature-differs
 simplifiable-if-statement
 super-init-not-called


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test unicode and sanity tests:

- Show warning when using pylint on Python 2.6.
- Add pylint disable entries for Python 2.
- Fix unicode handling in ansible-test.
- Add missing documentation.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-fixes 8dd24ebf78) last updated 2017/09/11 15:14:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
