### PR TITLE
windows facts: better way to get machine SID

### DIFF
--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -49,8 +49,7 @@ Function Get-MachineSid {
     
     $machine_sid = $null
     if ($users -ne $null) {
-        $administrator_sid = $users.Sid.Value
-        $machine_sid = $administrator_sid.Substring(0, $administrator_sid.Length - 4)
+        $machine_sid = $users.Sid.AccountDomainSid.Value
     }
     return $machine_sid
 }

--- a/lib/ansible/modules/windows/setup.ps1
+++ b/lib/ansible/modules/windows/setup.ps1
@@ -36,6 +36,25 @@ Function Get-CustomFacts {
   }
 }
 
+Function Get-MachineSid {
+    # The Machine SID is stored in HKLM:\SECURITY\SAM\Domains\Account and is
+    # only accessible by the Local System account. This method get's the local
+    # admin account (ends with -500) and lops it off to get the machine sid.
+
+    Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+    $principal_context = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalContext([System.DirectoryServices.AccountManagement.ContextType]::Machine)
+    $user_principal = New-Object -TypeName System.DirectoryServices.AccountManagement.UserPrincipal($principal_context)
+    $searcher = New-Object -TypeName System.DirectoryServices.AccountManagement.PrincipalSearcher($user_principal)
+    $users = $searcher.FindAll() | Where-Object { $_.Sid -like "*-500" }
+    
+    $machine_sid = $null
+    if ($users -ne $null) {
+        $administrator_sid = $users.Sid.Value
+        $machine_sid = $administrator_sid.Substring(0, $administrator_sid.Length - 4)
+    }
+    return $machine_sid
+}
+
 $result = @{
     ansible_facts = @{ }
     changed = $false
@@ -147,7 +166,7 @@ $ansible_facts = @{
     ansible_ip_addresses = $ips
     ansible_kernel = $osversion.Version.ToString()
     ansible_lastboot = $win32_os.lastbootuptime.ToString("u")
-    ansible_machine_id = $user.User.AccountDomainSid.Value
+    ansible_machine_id = Get-MachineSid
     ansible_nodename = ($ip_props.HostName + "." + $ip_props.DomainName)
     ansible_os_family = "Windows"
     ansible_os_name = ($win32_os.Name.Split('|')[0]).Trim()


### PR DESCRIPTION
##### SUMMARY
Currently the Windows facts get's the machine id (SID) by getting the account domain security identifier from the current user. This would result in an incorrect value if the current user is not a local user. It also fails if it is running under an NT Authority account as they do not have this property set.

This change changes this process by first trying to find the local Administrator account and getting the machine SID through that. If it fails during this lookup for whatever reason it will just return null.

This would superceed https://github.com/ansible/ansible/pull/22621 and https://github.com/ansible/ansible/issues/29524.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup.ps1

##### ANSIBLE VERSION
```
ansible 2.5.0 (win-facts-machine-sid 45e9719bd9) last updated 2017/09/12 11:05:52 (GMT +1000)
  config file = /Users/jborean/dev/module-tester/ansible.cfg
  configured module search path = ['/Users/jborean/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jborean/dev/ansible/lib/ansible
  executable location = /Users/jborean/dev/ansible/bin/ansible
  python version = 3.6.2 (default, Sep  6 2017, 15:32:21) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
