### PR TITLE
Azure Private IP Addresses In Dynamic Inventory

### DIFF
--- a/contrib/inventory/azure_rm.ini
+++ b/contrib/inventory/azure_rm.ini
@@ -15,6 +15,9 @@
 # Include powerstate. If you don't need powerstate information, turning it off improves runtime performance.
 include_powerstate=yes
 
+# Return private ip addresses instead of public that is set by default
+#include_private_ip=yes
+
 # Control grouping with the following boolean flags. Valid values: yes, no, true, false, True, False, 0, 1.
 group_by_resource_group=yes
 group_by_location=yes

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -472,6 +472,7 @@ class AzureInventory(object):
         self.group_by_security_group = True
         self.group_by_tag = True
         self.include_powerstate = True
+        self.include_private_ip = False
 
         self._inventory = dict(
             _meta=dict(
@@ -646,11 +647,15 @@ class AzureInventory(object):
                     for ip_config in network_interface.ip_configurations:
                         host_vars['private_ip'] = ip_config.private_ip_address
                         host_vars['private_ip_alloc_method'] = ip_config.private_ip_allocation_method
+                        if self.include_private_ip:
+                            host_vars['ansible_host'] = ip_config.private_ip_address
                         if ip_config.public_ip_address:
                             public_ip_reference = self._parse_ref_id(ip_config.public_ip_address.id)
                             public_ip_address = self._network_client.public_ip_addresses.get(
                                 public_ip_reference['resourceGroups'],
                                 public_ip_reference['publicIPAddresses'])
+                            if not self.include_private_ip:
+                                host_vars['ansible_host'] = public_ip_address.ip_address
                             host_vars['ansible_host'] = public_ip_address.ip_address
                             host_vars['public_ip'] = public_ip_address.ip_address
                             host_vars['public_ip_name'] = public_ip_address.name


### PR DESCRIPTION
##### SUMMARY
Includes options for returning private ip addresses in dynamic inventory script for Azure

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
/contrib/inventory/azure_rm.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION
Tested before cloud changes to inventory script. Haven't seen those. Should not effect it, but would like a second set of eyes on it. Thanks! 👍 
