### PR TITLE
Allow delegate_to if transport is not cli

### DIFF
--- a/docs/docsite/rst/porting_guide_2.3.rst
+++ b/docs/docsite/rst/porting_guide_2.3.rst
@@ -213,10 +213,10 @@ Will result in:
 delegate_to vs ProxyCommand
 ---------------------------
 
-The new connection framework for Network Modules in Ansible 2.3 no longer supports the use of the
-``delegate_to`` directive.  In order to use a bastion or intermediate jump host
-to connect to network devices, network modules now support the use of
-``ProxyCommand``.
+The new connection framework for Network Modules in Ansible 2.3 that uses ``cli`` transport
+no longer supports the use of the ``delegate_to`` directive.
+In order to use a bastion or intermediate jump host to connect to network devices over ``cli``
+transport, network modules now support the use of ``ProxyCommand``.
 
 To use ``ProxyCommand`` configure the proxy settings in the Ansible inventory
 file to specify the proxy host.

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -37,15 +37,15 @@ except ImportError:
 class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):
-        if self._play_context.connection != 'local':
+        provider = load_provider(eos_provider_spec, self._task.args)
+        transport = provider['transport'] or 'cli'
+
+        if self._play_context.connection != 'local' and transport == 'cli':
             return dict(
                 failed=True,
                 msg='invalid connection specified, expected connection=local, '
                     'got %s' % self._play_context.connection
             )
-
-        provider = load_provider(eos_provider_spec, self._task.args)
-        transport = provider['transport'] or 'cli'
 
         display.vvvv('connection transport is %s' % transport, self._play_context.remote_addr)
 

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -37,15 +37,15 @@ except ImportError:
 class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):
-        if self._play_context.connection != 'local':
+        provider = load_provider(nxos_provider_spec, self._task.args)
+        transport = provider['transport'] or 'cli'
+
+        if self._play_context.connection != 'local' and transport == 'cli':
             return dict(
                 failed=True,
                 msg='invalid connection specified, expected connection=local, '
                     'got %s' % self._play_context.connection
             )
-
-        provider = load_provider(nxos_provider_spec, self._task.args)
-        transport = provider['transport'] or 'cli'
 
         display.vvvv('connection transport is %s' % transport, self._play_context.remote_addr)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #29060

Allow delegate_to if transport is either nxapi or eapi.

Persistent connection uses `cli` transport and create
a local socket on the control node. Hence delegate_to is not allowed
for `cli` transport.

However, as `nxapi` and `eapi` transport does not use persistent connection
it is possible to use delegate_to in this case.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
action/eos.py
action/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
