### PR TITLE
Bug Fixes for Vlan Name not assigned and Switch Error

### DIFF
--- a/lib/ansible/module_utils/cnos.py
+++ b/lib/ansible/module_utils/cnos.py
@@ -2178,7 +2178,8 @@ def checkVlanNameNotAssigned(
     retVal = waitForDeviceResponse(command, prompt, timeout, obj)
     if(retVal.find(vlanName) != -1):
         return "Nok"
-    return retVal
+    else:
+        return "ok"
 # EOM
 
 
@@ -3175,7 +3176,7 @@ def checkOutputForError(output):
         index = output.lower().find("invalid")
         startIndex = index + 8
         if(index == -1):
-            index = output.lower().find("Cannot be enabled in L2 Interface")
+            index = output.lower().find("cannot be enabled in l2 interface")
             startIndex = index + 34
             if(index == -1):
                 index = output.lower().find("incorrect")


### PR DESCRIPTION
##### SUMMARY
There were two bugs reported by QA team of lenovo. 
1. Vlan Name was not getting set on the device
2. Errors like "cannot be enabled in l2 interface" etc are not getting reported.

These are getting fixed

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/cnos.py

##### ANSIBLE VERSION
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.4.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
Bugs are 
1. Try to set/change vlan name on the switch . And it was not happening
3. Do bfd changes for a portchannel and errors associated with it are no reflecting while running playbook
