### PR TITLE
Remove provider lines from iosxr tests

### DIFF
--- a/test/integration/targets/iosxr_banner/tests/cli/basic-login.yaml
+++ b/test/integration/targets/iosxr_banner/tests/cli/basic-login.yaml
@@ -3,7 +3,6 @@
   iosxr_banner:
     banner: login
     state: absent
-    provider: "{{ cli }}"
 
 - name: Set login
   iosxr_banner:
@@ -13,7 +12,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -33,7 +31,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/iosxr_banner/tests/cli/basic-motd.yaml
@@ -3,7 +3,6 @@
   iosxr_banner:
     banner: motd
     state: absent
-    provider: "{{ cli }}"
 
 - name: Set motd
   iosxr_banner:
@@ -13,7 +12,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -33,7 +31,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_banner/tests/cli/basic-no-login.yaml
+++ b/test/integration/targets/iosxr_banner/tests/cli/basic-no-login.yaml
@@ -6,13 +6,11 @@
       Junk login banner
       over multiple lines
     state: present
-    provider: "{{ cli }}"
 
 - name: remove login
   iosxr_banner:
     banner: login
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -27,7 +25,6 @@
   iosxr_banner:
     banner: login
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_interface/tests/cli/basic.yaml
@@ -5,7 +5,6 @@
   iosxr_interface:
     name: GigabitEthernet0/0/0/2
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 
@@ -14,7 +13,6 @@
     name: GigabitEthernet0/0/0/2
     description: test-interface-initial
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -27,7 +25,6 @@
     name: GigabitEthernet0/0/0/2
     description: test-interface-initial
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -42,7 +39,6 @@
     duplex: half
     mtu: 512
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -61,7 +57,6 @@
     duplex: full
     mtu: 256
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -80,7 +75,6 @@
     duplex: full
     mtu: 256
     state: present
-    provider: "{{ cli }}"
   register: result
 - assert:
     that:
@@ -90,7 +84,6 @@
   iosxr_interface:
     name: GigabitEthernet0/0/0/2
     enabled: False
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -102,7 +95,6 @@
   iosxr_interface:
     name: GigabitEthernet0/0/0/2
     enabled: True
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -115,7 +107,6 @@
     name: GigabitEthernet0/0/0/3
     description: test-interface-initial
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -138,7 +129,6 @@
     speed: 100
     duplex: full
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -162,7 +152,6 @@
     speed: 100
     duplex: full
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -176,7 +165,6 @@
     - name: GigabitEthernet0/0/0/2
     enabled: False
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -192,7 +180,6 @@
     - name: GigabitEthernet0/0/0/2
     enabled: True
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -207,7 +194,6 @@
     - name: GigabitEthernet0/0/0/4
     - name: GigabitEthernet0/0/0/5
     description: test-interface-initial
-    provider: "{{ cli }}"
   register: result
 
 - name: Create interface aggregate
@@ -218,7 +204,6 @@
     - name: GigabitEthernet0/0/0/5
       description: test_interface_2
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -233,7 +218,6 @@
     - name: GigabitEthernet0/0/0/4
     - name: GigabitEthernet0/0/0/5
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -248,7 +232,6 @@
     - name: GigabitEthernet0/0/0/4
     - name: GigabitEthernet0/0/0/5
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/iosxr_interface/tests/cli/intent.yaml
@@ -7,7 +7,6 @@
     description: test_interface_5
     enabled: True
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - name: Check intent arguments
@@ -15,7 +14,6 @@
     name: GigabitEthernet0/0/0/5
     state: up
     delay: 20
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +24,6 @@
   iosxr_interface:
     name: GigabitEthernet0/0/0/5
     state: down
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -41,7 +38,6 @@
     enabled: False
     state: down
     delay: 20
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -53,7 +49,6 @@
     name: GigabitEthernet0/0/0/5
     enabled: False
     state: up
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -69,7 +64,6 @@
       enabled: True
       state: up
       delay: 20
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 

--- a/test/integration/targets/iosxr_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_logging/tests/cli/basic.yaml
@@ -5,14 +5,12 @@
     dest: hostnameprefix
     name: 172.16.0.1
     state: absent
-    provider: "{{ cli }}"
 
 - name: Remove console logging
   iosxr_logging:
     dest: console
     level: warning
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - name: Remove buffer
@@ -20,7 +18,6 @@
     dest: buffered
     size: 4800000
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 # Start tests
@@ -29,7 +26,6 @@
     dest: hostnameprefix
     name: 172.16.0.1
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -43,7 +39,6 @@
     dest: hostnameprefix
     name: 172.16.0.1
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -55,7 +50,6 @@
     dest: hostnameprefix
     name: 172.16.0.1
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -68,7 +62,6 @@
     dest: hostnameprefix
     name: 172.16.0.1
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -80,7 +73,6 @@
     dest: console
     level: warning
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -92,7 +84,6 @@
   iosxr_logging:
     dest: buffered
     size: 4800000
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -105,7 +96,6 @@
     aggregate:
       - { dest: console, level: notifications }
       - { dest: buffered, size: 4700000 }
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -120,7 +110,6 @@
       - { dest: console, level: notifications }
       - { dest: buffered, size: 4700000 }
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_domain_list.yaml
@@ -7,14 +7,12 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_search
   iosxr_system:
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,7 +26,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,7 +36,6 @@
   iosxr_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -51,7 +47,6 @@
   iosxr_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -63,7 +58,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -76,7 +70,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -88,7 +81,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -103,7 +95,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -117,6 +108,5 @@
       - no domain list redhat.com
       - no domain list eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_search.yaml"

--- a/test/integration/targets/iosxr_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_domain_name.yaml
@@ -5,12 +5,10 @@
   iosxr_config:
     lines: no domain name
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_name
   iosxr_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +18,6 @@
 - name: verify domain_name
   iosxr_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +28,5 @@
   iosxr_config:
     lines: no domain name
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_name.yaml"

--- a/test/integration/targets/iosxr_system/tests/cli/set_hostname.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_hostname.yaml
@@ -5,12 +5,10 @@
   iosxr_config:
     lines: hostname switch
     match: none
-    provider: "{{ cli }}"
 
 - name: configure hostname
   iosxr_system:
     hostname: foo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +18,6 @@
 - name: verify hostname
   iosxr_system:
     hostname: foo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +28,5 @@
   iosxr_config:
     lines: "hostname {{ inventory_hostname }}"
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_hostname.yaml"

--- a/test/integration/targets/iosxr_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_lookup_source.yaml
@@ -7,12 +7,10 @@
       - no domain lookup source-interface Loopback10
 #      - vrf ansible
     match: none
-    provider: "{{ cli }}"
 
 - name: configure lookup_source
   iosxr_system:
     lookup_source: Loopback10
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -23,7 +21,6 @@
 - name: verify lookup_source
   iosxr_system:
     lookup_source: Loopback10
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,7 +32,6 @@
 #    lookup_source:
 #      - interface: Loopback10
 #        vrf: ansible
-#    provider: "{{ cli }}"
 #  register: result
 #
 #- assert:
@@ -50,7 +46,6 @@
 #    lookup_source:
 #      - interface: Management1
 #        vrf: ansible
-#    provider: "{{ cli }}"
 #  register: result
 #
 #- assert:
@@ -63,6 +58,5 @@
       - no domain lookup source-interface Loopback10
       - no vrf ansible
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_lookup_source.yaml"

--- a/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/iosxr_system/tests/cli/set_name_servers.yaml
@@ -8,7 +8,6 @@
       - no ip name-server 2.2.2.2
       - no ip name-server 3.3.3.3
     match: none
-    provider: "{{ cli }}"
 
 - name: configure name_servers
   iosxr_system:
@@ -16,7 +15,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -33,7 +31,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -46,7 +43,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
 #  register: result
 
 #- assert:
@@ -62,7 +58,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
 #  register: result
 #
 #- assert:
@@ -74,7 +69,6 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/iosxr_user/tests/cli/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/auth.yaml
@@ -4,7 +4,6 @@
     iosxr_user:
       name: auth_user
       state: present
-      provider: "{{ cli }}"
       configured_password: pass123
 
   - name: test login
@@ -31,5 +30,4 @@
     iosxr_user:
       name: auth_user
       state: absent
-      provider: "{{ cli }}"
     register: result

--- a/test/integration/targets/iosxr_user/tests/cli/basic.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/basic.yaml
@@ -5,14 +5,12 @@
       - no username ansibletest1
       - no username ansibletest2
       - no username ansibletest3
-    provider: "{{ cli }}"
 
 - name: Create user (SetUp)
   iosxr_user:
     name: ansibletest1
     configured_password: test
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -27,7 +25,6 @@
     configured_password: test
     update_password: always
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -42,7 +39,6 @@
     configured_password: test
     update_password: on_create
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -57,7 +53,6 @@
     update_password: on_create
     group: sysadmin
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -73,7 +68,6 @@
     update_password: on_create
     group: sysadmin
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -89,7 +83,6 @@
     configured_password: test
     state: present
     group: sysadmin
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -110,7 +103,6 @@
     configured_password: test
     state: present
     group: sysadmin
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -130,7 +122,6 @@
     update_password: on_create
     state: present
     group: sysadmin
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -145,7 +136,6 @@
       - name: ansibletest2
       - name: ansibletest3
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -160,7 +150,6 @@
       - name: ansibletest2
       - name: ansibletest3
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_iosxr_tests/tasks/main.yml
@@ -3,8 +3,6 @@
 - name: Ensure we have loopback 888 for testing
   iosxr_config:
     src: config.j2
-    provider: "{{ cli }}"
-
 
 # Some AWS hostnames can be longer than those allowed by the system we are testing
 # Truncate the hostname


### PR DESCRIPTION
We don't use authorize on iosxr nor we use a special transport,
so no need to use iosxr for CLI at all.