### PR TITLE
Correctly validate module name for modules with aliases

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -802,7 +802,14 @@ class ModuleValidator(Validator):
                             msg='Module deprecated, but DOCUMENTATION.deprecated is missing'
                         )
 
-                self._validate_docs_schema(doc, doc_schema(self.object_name.split('.')[0]), 'DOCUMENTATION', 305)
+                if os.path.islink(self.object_path):
+                  # This module has an alias, which we can tell as it's a symlink
+                  # Rather than checking for `module: $filename` we need to check against the true filename
+                  self._validate_docs_schema(doc, doc_schema(os.readlink(self.object_path).split('.')[0]), 'DOCUMENTATION', 305)
+                else:
+                  # This is the normal case
+                  self._validate_docs_schema(doc, doc_schema(self.object_name.split('.')[0]), 'DOCUMENTATION', 305)
+
                 self._check_version_added(doc)
                 self._check_for_new_args(doc)
 

--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -803,12 +803,12 @@ class ModuleValidator(Validator):
                         )
 
                 if os.path.islink(self.object_path):
-                  # This module has an alias, which we can tell as it's a symlink
-                  # Rather than checking for `module: $filename` we need to check against the true filename
-                  self._validate_docs_schema(doc, doc_schema(os.readlink(self.object_path).split('.')[0]), 'DOCUMENTATION', 305)
+                    # This module has an alias, which we can tell as it's a symlink
+                    # Rather than checking for `module: $filename` we need to check against the true filename
+                    self._validate_docs_schema(doc, doc_schema(os.readlink(self.object_path).split('.')[0]), 'DOCUMENTATION', 305)
                 else:
-                  # This is the normal case
-                  self._validate_docs_schema(doc, doc_schema(self.object_name.split('.')[0]), 'DOCUMENTATION', 305)
+                    # This is the normal case
+                    self._validate_docs_schema(doc, doc_schema(self.object_name.split('.')[0]), 'DOCUMENTATION', 305)
 
                 self._check_version_added(doc)
                 self._check_for_new_args(doc)


### PR DESCRIPTION
##### SUMMARY

If a module has an alias (ie is a symlink) then we need to ensure that
DOCUMENTATION.module is set to the main name, not the aliased name

Caused by https://github.com/ansible/ansible/pull/29747 though not exposed by CI as we only ran `validate-modules` against the single module, not the whole repo.


##### ISSUE TYPE
 - Bugfix Pull Request

