### PR TITLE
ec2_vpc_route_table: backport fix, reflect tags correctly in results from route table creation - fixes #29257

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -589,6 +589,7 @@ def ensure_route_table_present(connection, module):
     if not tags_valid and tags is not None:
         result = ensure_tags(connection, route_table.id, tags,
                              add_only=True, check_mode=module.check_mode)
+        route_table.tags = result['tags']
         changed = changed or result['changed']
 
     if subnets:


### PR DESCRIPTION
##### SUMMARY
Backport bugfix. Merged to devel in https://github.com/ansible/ansible/pull/23136 for 2.4. Fixes #29257

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.2.0 (vpc_route_table_tags a91e8f16b6) last updated 2017/09/12 09:18:39 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```