### PR TITLE
Fix nxos_user tests

### DIFF
--- a/test/integration/targets/nxos_user/tests/common/auth.yaml
+++ b/test/integration/targets/nxos_user/tests/common/auth.yaml
@@ -10,13 +10,13 @@
 
   - name: test login
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
         (?i)password: "pass123"
 
   - name: test login with invalid password (should fail)
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes


### PR DESCRIPTION
On our CI we use SSH port 8022, so parameterized the test passing
-p {{ ansible_ssh_port }}.
Also, force user/pass auth.