### PR TITLE
ec2_asg: document that boto3 and botocore are module requirements

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -27,6 +27,7 @@ description:
   - Works with the ec2_lc module to manage Launch Configurations
 version_added: "1.6"
 author: "Gareth Rushgrove (@garethr)"
+requirements: [ "boto3", "botocore" ]
 options:
   state:
     description:


### PR DESCRIPTION
##### SUMMARY
As of 2.4, the module requires boto3 and botocore.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_asg.py

##### ANSIBLE VERSION
```
2.5.0
```
