### PR TITLE
Document boolean default value treatment

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -223,6 +223,8 @@ The following fields can be used and are all required unless specified otherwise
     * If `required` is false/missing, `default` may be specified (assumed 'null' if missing).
     * Ensure that the default parameter in the docs matches the default parameter in the code.
     * The default option must not be listed as part of the description.
+    * If the option is a boolean value, you can use any of the boolean values recognized by Ansible:
+      (true/false, yes/no, etc).  Choose the one that reads better in the context of the option.
   :choices:
     List of option values. Should be absent if empty.
   :type:

--- a/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_documenting.rst
@@ -224,7 +224,7 @@ The following fields can be used and are all required unless specified otherwise
     * Ensure that the default parameter in the docs matches the default parameter in the code.
     * The default option must not be listed as part of the description.
     * If the option is a boolean value, you can use any of the boolean values recognized by Ansible:
-      (true/false, yes/no, etc).  Choose the one that reads better in the context of the option.
+      (such as true/false or yes/no).  Choose the one that reads better in the context of the option.
   :choices:
     List of option values. Should be absent if empty.
   :type:

--- a/lib/ansible/utils/module_docs_fragments/decrypt.py
+++ b/lib/ansible/utils/module_docs_fragments/decrypt.py
@@ -25,7 +25,7 @@ options:
     description:
       - This option controls the autodecryption of source files using vault.
     required: false
-    choices: ['Yes', 'No']
+    type: 'bool'
     default: 'Yes'
     version_added: "2.4"
 """

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -69,6 +69,7 @@ options:
          they cannot be updated atomically and can only be done in an unsafe manner.
       -  This boolean option allows ansible to fall back to unsafe methods of updating files for those cases in which you do
          not have any other choice. Be aware that this is subject to race conditions and can lead to data corruption.
+    type: bool
     required: false
     default: false
     version_added: "2.2"


### PR DESCRIPTION
##### SUMMARY

* Document that default values of booleans can use whichever Ansible recognized boolean reads better.
* Make doc fragments used by the copy module conform to the documentation guidelines (type: bool and do not use choices).

##### ISSUE TYPE
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel
```

this can be backported to 2.4 and 2.3 but it's not a big deal either way.