### PR TITLE
openssl_certificate: make subject-alt-name identifier consistent with openssl_csr

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -542,11 +542,11 @@ class AssertOnlyCertificate(Certificate):
                 for extension_idx in range(0, self.cert.get_extension_count()):
                     extension = self.cert.get_extension(extension_idx)
                     if extension.get_short_name() == 'subjectAltName':
-                        l_subjectAltName = [altname.replace('IP', 'IP Address') for altname in self.subjectAltName]
-                        if (not self.subjectAltName_strict and not all(x in str(extension).split(', ') for x in l_subjectAltName)) or \
-                           (self.subjectAltName_strict and not set(l_subjectAltName) == set(str(extension).split(', '))):
+                        l_altnames = [altname.replace('IP Address', 'IP') for altname in str(extension).split(', ')]
+                        if (not self.subjectAltName_strict and not all(x in l_altnames for x in self.subjectAltName)) or \
+                           (self.subjectAltName_strict and not set(self.subjectAltName) == set(l_altnames)):
                             self.message.append(
-                                'Invalid subjectAltName component (got %s, expected all of %s to be present)' % (str(extension).split(', '), l_subjectAltName)
+                                'Invalid subjectAltName component (got %s, expected all of %s to be present)' % (l_altnames, self.subjectAltName)
                             )
 
         def _validate_notBefore():


### PR DESCRIPTION
Unfortunately OpenSSL is inconsistent when it comes to the identifiers for the subjectAltName extension. When generating CSR's it wants `IP:<address>` but when printing a CSR or Certificate it will use
 `IP Address:<address>` ([Bug in OpenSSL](https://github.com/openssl/openssl/issues/4004)).

The `openssl_csr` module fixes this by replacing `IP Address` from OpenSSL output with `IP` before comparing it with the module arguments.
The fix in this module worked the other way round (replacing the `IP` with `IP Address` in the modules arguments before comparing). For most cases this doesn't matter but if the user would use `IP Address` as identifier the workaround would replace that with `IP Address Address` which must fail.
Also `openssl_certificate` will print a misleading message when the check fails.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
openssl_certificate

##### ANSIBLE VERSION
```
2.4
```

##### ADDITIONAL INFORMATION

Please backport this to stable-2.4 branch as well.
