### PR TITLE
Fix nxos_mtu nxapi failure - module errors out.

### DIFF
--- a/lib/ansible/modules/network/nxos/_nxos_mtu.py
+++ b/lib/ansible/modules/network/nxos/_nxos_mtu.py
@@ -125,15 +125,17 @@ from ansible.module_utils.nxos import load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
-def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
-        if 'show run' not in command:
-            command += ' | json'
-        cmds = [command]
-        body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
-        cmds = [command]
-        body = run_commands(module, cmds)
+def execute_show_command(command, module):
+    if 'show run' not in command:
+        output = 'json'
+    else:
+        output = 'text'
+    cmds = [{
+        'command': command,
+        'output': output,
+    }]
+
+    body = run_commands(module, cmds)
     return body
 
 
@@ -169,7 +171,7 @@ def get_system_mtu(module):
     command = 'show run all | inc jumbomtu'
     sysmtu = ''
 
-    body = execute_show_command(command, module, command_type='cli_show_ascii')
+    body = execute_show_command(command, module)
 
     if body:
         sysmtu = str(body[0].split(' ')[-1])
@@ -237,8 +239,7 @@ def is_default(interface, module):
     command = 'show run interface {0}'.format(interface)
 
     try:
-        body = execute_show_command(
-            command, module, command_type='cli_show_ascii')[0]
+        body = execute_show_command(command, module)[0]
         if body == 'DNE':
             return 'DNE'
         else:

--- a/test/integration/targets/nxos_mtu/tests/common/set_mtu.yaml
+++ b/test/integration/targets/nxos_mtu/tests/common/set_mtu.yaml
@@ -1,18 +1,20 @@
 ---
 - debug: msg="START {{ connection.transport }}/set_mtu.yaml"
 
+- set_fact: testint="{{ nxos_int1 }}"
+
 - name: setup
   nxos_config:
     lines:
       - no switchport
       - no mtu
-    parents: interface Ethernet3/1
+    parents: "interface {{ testint }}"
     match: none
     provider: "{{ connection }}"
 
 - name: configure interface mtu
   nxos_mtu:
-    interface: Ethernet3/1
+    interface: "{{ testint }}"
     mtu: 2000
     provider: "{{ connection }}"
   register: result
@@ -23,7 +25,7 @@
 
 - name: verify interface mtu
   nxos_mtu:
-    interface: Ethernet3/1
+    interface: "{{ testint }}"
     mtu: 2000
     provider: "{{ connection }}"
   register: result
@@ -34,7 +36,7 @@
 
 - name: configure invalid (odd) interface mtu
   nxos_mtu:
-    interface: Ethernet3/1
+    interface: "{{ testint }}"
     mtu: 2001
     provider: "{{ connection }}"
   register: result
@@ -46,7 +48,7 @@
 
 - name: configure invalid (large) mtu setting
   nxos_mtu:
-    interface: Ethernet3/1
+    interface: "{{ testint }}"
     mtu: 100000
     provider: "{{ connection }}"
   register: result
@@ -59,7 +61,7 @@
 - name: teardown
   nxos_config:
     lines: no mtu
-    parents: interface Ethernet3/1
+    parents: "interface {{ testint }}"
     match: none
     provider: "{{ connection }}"
 


### PR DESCRIPTION
##### SUMMARY
**NOTE:** This fix is a must have for 2.4

The nxos_mtu modules errors out for transport nxapi

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_mtu
##### ANSIBLE VERSION
```
ansible 2.5.0 (rel240/fix_nxos_mtu 8fe6d73b94) last updated 2017/09/12 13:02:46 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]

```


##### ADDITIONAL INFORMATION
The following playbook can be used to demonstrate the problem for nxapi
```yaml
---
- debug: msg="START {{ connection.transport }}/set_mtu.yaml"

- set_fact: testint="{{ nxos_int1 }}"

- name: setup
  nxos_config:
    lines:
      - no switchport
      - no mtu
    parents: "interface {{ testint }}"
    match: none
    provider: "{{ connection }}"

- name: configure interface mtu
  nxos_mtu:
    interface: "{{ testint }}"
    mtu: 2000
    provider: "{{ connection }}"
  register: result

- assert:
    that:
      - "result.changed == true"

- name: verify interface mtu
  nxos_mtu:
    interface: "{{ testint }}"
    mtu: 2000
    provider: "{{ connection }}"
  register: result

- assert:
    that:
      - "result.changed == false"

- name: configure invalid (odd) interface mtu
  nxos_mtu:
    interface: "{{ testint }}"
    mtu: 2001
    provider: "{{ connection }}"
  register: result
  ignore_errors: yes

- assert:
    that:
      - "result.failed == true"

- name: configure invalid (large) mtu setting
  nxos_mtu:
    interface: "{{ testint }}"
    mtu: 100000
    provider: "{{ connection }}"
  register: result
  ignore_errors: yes

- assert:
    that:
      - "result.failed == true"

- name: teardown
  nxos_config:
    lines: no mtu
    parents: "interface {{ testint }}"
    match: none
    provider: "{{ connection }}"

- debug: msg="END {{ connection.transport }}/set_mtu.yaml"

```
```shell
TASK [nxos_mtu : configure interface mtu] **************************************************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_mtu/tests/common/set_mtu.yaml:15
<n9k.example.com> connection transport is nxapi
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/_nxos_mtu.py
<n9k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865 `" && echo ansible-tmp-1505233998.87-16738052561865="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmpQzJP0Y TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865/_nxos_mtu.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865/_nxos_mtu.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865/_nxos_mtu.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1505233998.87-16738052561865/" > /dev/null 2>&1 && sleep 0'
fatal: [n9k.example.com]: FAILED! => {
    "changed": false, 
    "clierror": "", 
    "code": "501", 
    "failed": true, 
    "input": "show run all | inc jumbomtu", 
    "invocation": {
        "module_args": {
            "host": "n9k.example.com", 
            "interface": "Ethernet1/1", 
            "mtu": "2000", 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "port": 80, 
            "provider": {
                "host": "n9k.example.com", 
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "port": 80, 
                "ssh_keyfile": null, 
                "timeout": 10, 
                "transport": "nxapi", 
                "use_ssl": false, 
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
                "validate_certs": true
            }, 
            "ssh_keyfile": null, 
            "state": "present", 
            "sysmtu": null, 
            "timeout": 10, 
            "transport": "nxapi", 
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "url_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "use_ssl": false, 
            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "validate_certs": true
        }
    }, 
    "msg": "Pipe is not allowed for this message type", 
    "output": {
        "clierror": "", 
        "code": "501", 
        "input": "show run all | inc jumbomtu", 
        "msg": "Pipe is not allowed for this message type"
    }, 
    "url": "http://n9k.example.com:80/ins"
}
	to retry, use: --limit @/Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/nxos.retry

PLAY RECAP *********************************************************************************************************************************************************************************************************************************
n9k.example.com          : ok=53   changed=10   unreachable=0    failed=1   
```
