### PR TITLE
Fix nxos_smu error

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_smu.py
+++ b/lib/ansible/modules/network/nxos/nxos_smu.py
@@ -115,8 +115,7 @@ def get_commands(module, pkg, file_system):
         commands.append('install activate {0}{1} force'.format(
             file_system, pkg))
     command = 'show install committed'
-    install_body = execute_show_command(command, module,
-                                                command_type='cli_show_ascii')
+    install_body = execute_show_command(command, module)
     if fixed_pkg not in install_body[0]:
         commands.append('install commit {0}{1}'.format(file_system, pkg))
 


### PR DESCRIPTION
##### SUMMARY
**NOTE:** This is a must have for 2.4

The `execute_show_command` function was modified to remove the `command_type` argument but not all uses of the function were updated to reflect the change causing the module to error out.

**NOTE 2:** I am not including tests for this because it requires a custom patch for each image version.  We have tests in a private repository for this and they pass with this fix.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_smu

##### ANSIBLE VERSION
```
ansible 2.5.0 (rel240/fix_nxos_smu d906c615a5) last updated 2017/09/12 13:37:00 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]

```


##### ADDITIONAL INFORMATION
Error without the fix

```shell
TASK [nxos_smu : Test SMUs] ***********************************************************************************************************************************************************************************************************************
task path: /Users/mwiebe/Projects/nxos_ansible/fix_ansible/test/integration/targets/nxos_smu/tests/common/sanity.yaml:4
<n9k.example.com> connection transport is cli
<n9k.example.com> using connection plugin network_cli
<n9k.example.com> socket_path: /Users/mwiebe/.ansible/pc/34de4e5bd3
Using module file /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible/modules/network/nxos/nxos_smu.py
<n9k.example.com> ESTABLISH LOCAL CONNECTION FOR USER: mwiebe
<n9k.example.com> EXEC /bin/sh -c 'echo ~ && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978 `" && echo ansible-tmp-1505237171.97-239865943233978="` echo /Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978 `" ) && sleep 0'
<n9k.example.com> PUT /var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/tmpJG8ceX TO /Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978/nxos_smu.py
<n9k.example.com> EXEC /bin/sh -c 'chmod u+x /Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978/ /Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978/nxos_smu.py && sleep 0'
<n9k.example.com> EXEC /bin/sh -c '/Users/mwiebe/Virtualenvs/py2-ansible/bin/python /Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978/nxos_smu.py; rm -rf "/Users/mwiebe/.ansible/tmp/ansible-tmp-1505237171.97-239865943233978/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_3KmNsE/ansible_module_nxos_smu.py", line 164, in <module>
    main()
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_3KmNsE/ansible_module_nxos_smu.py", line 151, in main
    commands = get_commands(module, pkg, file_system)
  File "/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_3KmNsE/ansible_module_nxos_smu.py", line 119, in get_commands
    command_type='cli_show_ascii')
TypeError: execute_show_command() got an unexpected keyword argument 'command_type'

fatal: [n9k.example.com]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_3KmNsE/ansible_module_nxos_smu.py\", line 164, in <module>\n    main()\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_3KmNsE/ansible_module_nxos_smu.py\", line 151, in main\n    commands = get_commands(module, pkg, file_system)\n  File \"/var/folders/ww/538d42ys18l5tjyz0l1yk1rc0000gn/T/ansible_3KmNsE/ansible_module_nxos_smu.py\", line 119, in get_commands\n    command_type='cli_show_ascii')\nTypeError: execute_show_command() got an unexpected keyword argument 'command_type'\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 0
}

```
