### PR TITLE
Fix conditional inheritance on dynamic includes (tasks and roles)

### DIFF
--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -294,11 +294,12 @@ class Block(Base, Become, Conditional, Taggable):
 
             if self._parent and (value is None or extend):
                 try:
-                    parent_value = getattr(self._parent, attr, None)
-                    if extend:
-                        value = self._extend_value(value, parent_value, prepend)
-                    else:
-                        value = parent_value
+                    if attr != 'when' or getattr(self._parent, 'statically_loaded', True):
+                        parent_value = getattr(self._parent, attr, None)
+                        if extend:
+                            value = self._extend_value(value, parent_value, prepend)
+                        else:
+                            value = parent_value
                 except AttributeError:
                     pass
             if self._role and (value is None or extend):
@@ -386,3 +387,11 @@ class Block(Base, Become, Conditional, Taggable):
             return self._parent.all_parents_static()
 
         return True
+
+    def get_first_parent_include(self):
+        from ansible.playbook.task_include import TaskInclude
+        if self._parent:
+            if isinstance(self._parent, TaskInclude):
+                return self._parent
+            return self._parent.get_first_parent_include()
+        return None

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -279,6 +279,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     else:
                         task_list.extend(included_blocks)
                 else:
+                    t.is_static = False
                     task_list.append(t)
 
             elif 'include_role' in task_ds or 'import_role' in task_ds:
@@ -319,6 +320,9 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     display.debug('Determined that if include_role static is %s' % str(is_static))
 
                 if is_static:
+                    # we set a flag to indicate this include was static
+                    ir.statically_loaded = True
+
                     # uses compiled list from object
                     blocks, _ = ir.get_block_list(variable_manager=variable_manager, loader=loader)
                     t = task_list.extend(blocks)


### PR DESCRIPTION
Per the new style of execution, for dynamic tasks conditionals are expected
to only affect the include task itself and should not be inherited by child
tasks. This patch brings the behavior inline with this expectation.

Fixes #27845 