### PR TITLE
Support Adding And Removing Digital Ocean Domain Records

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -20,7 +20,9 @@ short_description: Create/delete a DNS record in DigitalOcean
 description:
      - Create/delete a DNS record in DigitalOcean.
 version_added: "1.6"
-author: "Michael Gregson (@mgregson)"
+author:
+  - "Michael Gregson (@mgregson)"
+  - "Spencer McIntyre (@zeroSteiner)"
 options:
   state:
     description:
@@ -39,7 +41,17 @@ options:
      - String, this is the name of the droplet - must be formatted by hostname rules, or the name of a SSH key, or the name of a domain.
   ip:
     description:
-     - The IP address to point a domain at.
+     - The IP address to point a domain or record at.
+  type:
+    description:
+      - The type of operation, None (default) to create or remove a domain otherwise the type of record to create or remove.
+    default: None
+    choices: ['A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'SRV', 'TXT']
+    version_added: "2.4.1"
+  data:
+    description:
+      - The data to use when creating or removing a record. When the record is being removed, this string is treated as a regular expression.
+    version_added: "2.4.1"
 
 notes:
   - Two environment variables can be used, DO_API_KEY and DO_API_TOKEN. They both refer to the v2 token.
@@ -77,6 +89,13 @@ EXAMPLES = '''
     name: "{{ test_droplet.droplet.name }}.my.domain"
     ip: "{{ test_droplet.droplet.ip_address }}"
 
+# Remove an existing SPF record for a domain
+
+- digital_ocean_domain:
+    state: absent
+    name: "my.domain"
+    data: "v\\=spf1\\ .*"
+    type: txt
 '''
 
 import os

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -254,7 +254,9 @@ def record_absent(module):
     record_data = None
     if "ip" in module.params:
         record_data = module.params["ip"]
-    if not record_data:
+    if record_data:
+        record_data = re.escape(record_data)
+    else:
         record_data = get_key_or_die(module, "data")
 
     record_type = module.params["type"].upper()

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -47,11 +47,11 @@ options:
       - The type of operation, None (default) to create or remove a domain otherwise the type of record to create or remove.
     default: None
     choices: ['A', 'AAAA', 'CAA', 'CNAME', 'MX', 'NS', 'SRV', 'TXT']
-    version_added: "2.4.1"
+    version_added: "2.5"
   data:
     description:
       - The data to use when creating or removing a record. When the record is being removed, this string is treated as a regular expression.
-    version_added: "2.4.1"
+    version_added: "2.5"
 
 notes:
   - Two environment variables can be used, DO_API_KEY and DO_API_TOKEN. They both refer to the v2 token.
@@ -93,8 +93,8 @@ EXAMPLES = '''
 
 - digital_ocean_domain:
     state: absent
-    name: "my.domain"
-    data: "v\\=spf1\\ .*"
+    name: my.domain
+    data: v\=spf1\ .*
     type: txt
 '''
 
@@ -209,7 +209,8 @@ def get_record_info_or_die(module):
     record_name = '@'
     record_domain = get_key_or_die(module, "name").strip()
     json_domains = Domain.manager.all_domains()
-    domain_find = lambda name: next((Domain(jd) for jd in json_domains if jd['name'] == name), False)
+    def domain_find(name):
+        return next((Domain(jd) for jd in json_domains if jd['name'] == name), False)
 
     if record_domain.startswith('@.'):
         record_domain = record_domain[2:]

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_domain.py
@@ -209,6 +209,7 @@ def get_record_info_or_die(module):
     record_name = '@'
     record_domain = get_key_or_die(module, "name").strip()
     json_domains = Domain.manager.all_domains()
+
     def domain_find(name):
         return next((Domain(jd) for jd in json_domains if jd['name'] == name), False)
 


### PR DESCRIPTION
##### SUMMARY
This PR updates the `digital_ocean_domain` module to allow it to not only add and remove domains but also records for those domains.

The module is backwards compatible as the new `type` option defaults to None and when it is None, the module operates on domains. Alternatively the `type` option can be one of the record types supported by Digital Ocean such as A, AAAA, CNAME, TXT etc. and these records can be added or removed.

The new `data` option specifies the data to use when creating a new record, or a regex that can be used to match a record for removal. This allows removing records when the current value is not entirely known.

When operating on records (because `type` is set), the `name` field is first checked to see if it an existing domain, if it is the special name of `@` is used. If the `name` field is not an existing domain, the hostname field is removed from the domain and the API is checked again to see if the domain exists. I hope this is intuitive for users.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`digital_ocean_domain`

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.2.0
  config file = /home/steiner/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.6.2 (default, Aug 11 2017, 11:59:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
**Before the patch:**
```
ansible localhost -m digital_ocean_domain -a "api_token=API_KEY state=absent name=zerosteiner.com data='v\=spf1\ .*' type=txt" 
 [WARNING]: Found both group and host with same name: zerosteiner.com

localhost | FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Unsupported parameters for (digital_ocean_domain) module: data,type. Supported parameters include: api_token,id,ip,name,state"
}
```

**With the patch: (Example is removing an SPF record)**
```
ansible localhost -m digital_ocean_domain -a "api_token=API_KEY state=absent name=zerosteiner.com data='v\=spf1\ .*' type=txt"
[DEPRECATED] DEFAULT_SUDO_FLAGS: In favor of become which is a generic framework. It will be removed in 2.8. As alternative use one of [become]
[DEPRECATED] [defaults]hostfile: The key is misleading as it can also be a list of hosts, a directory or a list of paths. It will be removed in 2.8. As alternative use one of [inventory]
[DEPRECATION WARNING]: DEFAULT_SUDO_FLAGS option, In favor of become which is a generic framework . This feature will be removed in version 2.8. Deprecation warnings can be disabled by setting 
deprecation_warnings=False in ansible.cfg.
[DEPRECATION WARNING]: [defaults]hostfile option, The key is misleading as it can also be a list of hosts, a directory or a list of paths . This feature will be removed in version 2.8. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
 [WARNING]: Found both group and host with same name: zerosteiner.com

localhost | SUCCESS => {
    "changed": true, 
    "domain": {
        "name": "zerosteiner.com", 
        "ttl": 1800, 
        "zone_file": "$ORIGIN zerosteiner.com.\n$TTL 1800\nzerosteiner.com. IN SOA ns1.digitalocean.com. hostmaster.zerosteiner.com. 1505238748 10800 3600 604800 1800\nzerosteiner.com. 1800 IN NS ns1.digitalocean.com.\nzerosteiner.com. 1800 IN NS ns2.digitalocean.com.\nzerosteiner.com. 1800 IN NS ns3.digitalocean.com.\nzerosteiner.com. 1800 IN A 104.131.39.224\nhome.zerosteiner.com. 3600 IN CNAME zerosteiner.mynetgear.com.\nbandit.zerosteiner.com. 1800 IN A 104.131.96.203\nzerosteiner.com. 3600 IN TXT keybase-site-verification=226qlUWaG6tkQt-UwUUo3RjfjvQ2gtxrBMcV3Cu0pmw\nzerosteiner.com. 1800 IN TXT v=spf1 a mx -all\nworker.zerosteiner.com. 1800 IN A 45.55.93.8\n"
    }, 
    "failed": false, 
    "record": {
        "data": "v=spf1 a mx -all", 
        "domain_id": "zerosteiner.com", 
        "flags": null, 
        "id": 28429588, 
        "name": "@", 
        "port": null, 
        "priority": null, 
        "tag": null, 
        "ttl": 1800, 
        "type": "TXT", 
        "weight": null
    }
}
```