### PR TITLE
activationkey argument validation for redhat_subscription module

### DIFF
--- a/lib/ansible/modules/packaging/os/redhat_subscription.py
+++ b/lib/ansible/modules/packaging/os/redhat_subscription.py
@@ -381,9 +381,11 @@ class Rhsm(RegistrationBase):
         if server_hostname:
             args.extend(['--serverurl', server_hostname])
 
+        if org_id:
+            args.extend(['--org', org_id])
+
         if activationkey:
             args.extend(['--activationkey', activationkey])
-            args.extend(['--org', org_id])
         else:
             if autosubscribe:
                 args.append('--autosubscribe')
@@ -701,9 +703,17 @@ def main():
                                        required=False,
                                        no_log=True),
         ),
-        required_together=[['username', 'password'], ['activationkey', 'org_id'],
-                           ['server_proxy_hostname', 'server_proxy_port'], ['server_proxy_user', 'server_proxy_password']],
-        mutually_exclusive=[['username', 'activationkey'], ['pool', 'pool_ids']],
+        required_together=[['username', 'password'],
+                           ['server_proxy_hostname', 'server_proxy_port'],
+                           ['server_proxy_user', 'server_proxy_password']],
+
+        mutually_exclusive=[['activationkey', 'username'],
+                            ['activationkey', 'consumer_id'],
+                            ['activationkey', 'environment'],
+                            ['activationkey', 'autosubscribe'],
+                            ['force', 'consumer_id'],
+                            ['pool', 'pool_ids']],
+
         required_if=[['state', 'present', ['username', 'activationkey'], True]],
     )
 
@@ -717,6 +727,8 @@ def main():
     autosubscribe = module.params['autosubscribe']
     activationkey = module.params['activationkey']
     org_id = module.params['org_id']
+    if activationkey and not org_id:
+        module.fail_json(msg='org_id is required when using activationkey')
     environment = module.params['environment']
     pool = module.params['pool']
     pool_ids = {}


### PR DESCRIPTION
##### SUMMARY
updating argument validation for activation keys to match subscription-manager command line, fixes #27283

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module: redhat_subscription

##### ANSIBLE VERSION
```
❯❯❯ ./bin/ansible --version
```
```
ansible 2.5.0 (issue/27283 d68443f7b9) last updated 2017/09/12 15:38:09 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/jmolet/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jmolet/Projects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 3.5.4 (default, Aug 23 2017, 18:32:05) [GCC 6.4.1 20170727 (Red Hat 6.4.1-1)]
```


##### ADDITIONAL INFORMATION
The validation logic for `subscription-manager register` has drifted apart from the ansible module.  In this case org_id is valid in all register cases and not just when activation keys are supplied.   This fixes that issue and updates some of the other argument logic.  (reference: https://github.com/candlepin/subscription-manager/blob/d0f8a86ecec1f10bca21b54713ce746457adab0f/src/subscription_manager/managercli.py#L1003 )
