### PR TITLE
Fix up some yaml+jinja examples to not give sphinx lex errors

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_modules_general.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general.rst
@@ -53,7 +53,7 @@ working on a whole new file. Here is an example:
 -  Create your new module file: ``$ touch my_new_test_module.py``
 -  Paste this example code into the new module file: (explanation in comments)
 
-.. code:: python
+.. code-block:: python
 
     #!/usr/bin/python
 

--- a/docs/docsite/rst/dev_guide/developing_python3.rst
+++ b/docs/docsite/rst/dev_guide/developing_python3.rst
@@ -295,7 +295,7 @@ new exception-catching syntax which uses the ``as`` keyword:
 Do **not** use the following syntax as it will fail on every version of Python-3:
 
 .. This code block won't highlight because python2 isn't recognized. This is necessary to pass tests under python 3.
-.. code-block:: python2
+.. code-block:: none
 
     try:
         a = 2/0

--- a/docs/docsite/rst/network_debug_troubleshooting.rst
+++ b/docs/docsite/rst/network_debug_troubleshooting.rst
@@ -185,7 +185,7 @@ Indicates that the remote host you are trying to connect to can not be reached
 
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    2017-04-04 11:39:48,147 p=15299 u=fred |  control socket path is /home/fred/.ansible/pc/ca5960d27a
    2017-04-04 11:39:48,147 p=15299 u=fred |  current working directory is /home/fred/git/ansible-inc/stable-2.3/test/integration
@@ -214,7 +214,7 @@ Occurs if the credentials (username, passwords, or ssh keys) passed to ``ansible
 
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    <ios01> ESTABLISH CONNECTION FOR USER: cisco on PORT 22 TO ios01
    <ios01> Authentication failed.
@@ -224,7 +224,7 @@ Suggestions to resolve:
 
 If you are specifying credentials via ``password:`` (either directly or via ``provider:``) or the environment variable :envvar:`ANSIBLE_NET_PASSWORD` it is possible that ``paramiko`` (the Python SSH library that Ansible uses) is using ssh keys, and therefore the credentials you are specifying are being ignored. To find out if this is the case, disable "look for keys". This can be done like this:
 
-.. code-block:: yaml
+.. code-block:: bash
 
    export ANSIBLE_PARAMIKO_LOOK_FOR_KEYS=False
 
@@ -245,7 +245,7 @@ When using persistent connections with Paramiko, the connection runs in a backgr
 
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    2017-04-04 12:06:03,486 p=17981 u=fred |  using connection plugin network_cli
    2017-04-04 12:06:04,680 p=17981 u=fred |  connecting to host veos01 returned an error
@@ -292,7 +292,7 @@ Error: "No authentication methods available"
 
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  creating new control socket for host veos01:None as user admin
    2017-04-04 12:19:05,670 p=18591 u=fred |  control socket path is /home/fred/.ansible/pc/ca5960d27a
@@ -331,14 +331,14 @@ Persistent connection idle timeout:
 
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  persistent connection idle timeout triggered, timeout value is 30 secs
 
 Suggestions to resolve:
 
 Increase value of presistent connection idle timeout.
-.. code-block:: yaml
+.. code-block:: shell
 
    export ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=60
 
@@ -352,7 +352,7 @@ To make this a permanent change, add the following to your ``ansible.cfg`` file:
 Command timeout:
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    2017-04-04 12:19:05,670 p=18591 u=fred |  command timeout triggered, timeout value is 10 secs
 
@@ -362,7 +362,7 @@ Options 1:
 Increase value of command timeout in configuration file or by setting environment variable.
 Note: This value should be less than persistent connection idle timeout ie. connect_timeout
 
-.. code-block:: yaml
+.. code-block:: shell
 
    export ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=30
 
@@ -385,7 +385,7 @@ For example:
 
 Suggestions to resolve:
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
     - name: save running-config
       ios_command:
@@ -403,7 +403,7 @@ Note: This value should be less than persistent connection idle timeout ie. conn
 Persistent socket connect timeout:
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
    2017-04-04 12:19:35,708 p=18591 u=fred |  connect retry timeout expired, unable to connect to control socket
    2017-04-04 12:19:35,709 p=18591 u=fred |  persistent_connect_retry_timeout is 15 secs
@@ -415,7 +415,7 @@ Note: This value should be greater than SSH timeout ie. timeout value under defa
 section in configuration file and less than the value of the persistent
 connection idle timeout (connect_timeout)
 
-.. code-block:: yaml
+.. code-block:: shell
 
    export ANSIBLE_PERSISTENT_CONNECT_RETRY_TIMEOUT=30
 
@@ -442,7 +442,7 @@ Network modules require that the connection is set to ``local``.  Any other
 connection setting will cause the playbook to fail.  Ansible will now detect
 this condition and return an error message:
 
-.. code-block:: yaml
+.. code-block:: none
 
     fatal: [nxos01]: FAILED! => {
         "changed": false,
@@ -467,7 +467,7 @@ This occurs when you attempt to run a task that requires privileged mode in a us
 
 For example:
 
-.. code-block:: yaml
+.. code-block:: none
 
   TASK [ios_system : configure name_servers] *****************************************************************************
   task path:
@@ -495,7 +495,7 @@ If the user requires a password to go into privileged mode, this can be specifie
 
 Add `authorize: yes` to the task. For example:
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
   - name: configure hostname
     ios_system:
@@ -529,7 +529,7 @@ Add `authorize: yes` to the task. For example:
 
    This information is available when :ref:`DEFAULT_LOG_PATH` is set see (FIXMELINKTOSECTION):
 
-   .. code-block:: yaml
+   .. code-block:: none
 
      less $ANSIBLE_LOG_PATH
      2017-03-10 15:32:06,173 p=19677 u=fred |  connect retry timeout expired, unable to connect to control socket
@@ -540,6 +540,6 @@ Add `authorize: yes` to the task. For example:
 
    Do stuff For example:
 
-   .. code-block:: yaml
+   .. code-block:: none
 
    	Example stuff

--- a/docs/docsite/rst/playbooks_async.rst
+++ b/docs/docsite/rst/playbooks_async.rst
@@ -13,7 +13,9 @@ operations that might be subject to timeout.
 
 To launch a task asynchronously, specify its maximum runtime
 and how frequently you would like to poll for status.  The default
-poll value is 10 seconds if you do not specify a value for `poll`::
+poll value is 10 seconds if you do not specify a value for `poll`:
+
+.. code-block:: yaml+jinja
 
     ---
 
@@ -33,9 +35,9 @@ poll value is 10 seconds if you do not specify a value for `poll`::
    default.
 
 Alternatively, if you do not need to wait on the task to complete, you may
-"fire and forget" by specifying a poll value of 0::
+"fire and forget" by specifying a poll value of 0:
 
-    ---
+.. code-block:: yaml+jinja
 
     - hosts: all
       remote_user: root
@@ -56,35 +58,35 @@ Alternatively, if you do not need to wait on the task to complete, you may
    Using a higher value for ``--forks`` will result in kicking off asynchronous
    tasks even faster.  This also increases the efficiency of polling.
 
-If you would like to perform a variation of the "fire and forget" where you 
-"fire and forget, check on it later" you can perform a task similar to the 
-following::
+If you would like to perform a variation of the "fire and forget" where you
+"fire and forget, check on it later" you can perform a task similar to the
+following:
 
-      --- 
-      # Requires ansible 1.8+
-      - name: 'YUM - fire and forget task'
-        yum: name=docker-io state=installed
-        async: 1000
-        poll: 0
-        register: yum_sleeper
+.. code-block:: yaml+jinja
 
-      - name: 'YUM - check on fire and forget task'
-        async_status: jid={{ yum_sleeper.ansible_job_id }}
-        register: job_result
-        until: job_result.finished
-        retries: 30
+    # Requires ansible 1.8+
+    - name: 'YUM - fire and forget task'
+      yum: name=docker-io state=installed
+      async: 1000
+      poll: 0
+      register: yum_sleeper
+
+    - name: 'YUM - check on fire and forget task'
+      async_status: jid={{ yum_sleeper.ansible_job_id }}
+      register: job_result
+      until: job_result.finished
+      retries: 30
 
 .. note::
-   If the value of ``async:`` is not high enough, this will cause the 
+   If the value of ``async:`` is not high enough, this will cause the
    "check on it later" task to fail because the temporary status file that
-   the ``async_status:`` is looking for will not have been written or no longer exist 
+   the ``async_status:`` is looking for will not have been written or no longer exist
 
 If you would like to run multiple asynchronous tasks while limiting the amount
-of tasks running concurrently, you can do it this way::
+of tasks running concurrently, you can do it this way:
 
-    #####################
-    # main.yml
-    #####################
+.. code-block:: yaml+jinja
+
     - name: Run items asynchronously in batch of two items
       vars:
         sleep_durations:
@@ -95,12 +97,8 @@ of tasks running concurrently, you can do it this way::
           - 5
         durations: "{{ item }}"
       include: execute_batch.yml
-      with_items:
-        - "{{ sleep_durations | batch(2) | list }}"
+      with_items: "{{ sleep_durations|batch(2)|list }}"
 
-    #####################
-    # execute_batch.yml
-    #####################
     - name: Async sleeping for batched_items
       command: sleep {{ async_item }}
       async: 45
@@ -119,6 +117,7 @@ of tasks running concurrently, you can do it this way::
       register: async_poll_results
       until: async_poll_results.finished
       retries: 30
+
 
 .. seealso::
 

--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -345,7 +345,9 @@ how to parse the CLI output.
 
 The spec file should be valid formatted YAML.  It defines how to parse the CLI
 output and return JSON data.  Below is an example of a valid spec file that
-will parse the output from the ``show vlan`` command.::
+will parse the output from the ``show vlan`` command.:
+
+.. code-block:: yaml
 
     ---
     vars:
@@ -368,7 +370,9 @@ with the parsed VLAN information.
 
 The same command could be parsed into a hash by using the key and values
 directives.  Here is an example of how to parse the output into a hash
-value using the same ``show vlan`` command.::
+value using the same ``show vlan`` command.:
+
+.. code-block:: yaml
 
     ---
     vars:
@@ -390,7 +394,9 @@ value using the same ``show vlan`` command.::
 
 Another common use case for parsing CLI commands is to break a large command
 into blocks that can parsed.  This can be done using the ``start_block`` and
-``end_block`` directives to break the command into blocks that can be parsed.::
+``end_block`` directives to break the command into blocks that can be parsed.:
+
+.. code-block:: yaml+jinja
 
     ---
     vars:

--- a/docs/docsite/rst/porting_guide_2.3.rst
+++ b/docs/docsite/rst/porting_guide_2.3.rst
@@ -43,7 +43,7 @@ The `ansible_distribution_release` and `ansible_distribution_version` facts on O
 **OLD** In Ansible 2.2 (and earlier)
 
 
-.. code-block:: yaml
+.. code-block:: none
 
     "ansible_distribution": "OpenBSD"
     "ansible_distribution_release": "6.0",
@@ -52,7 +52,7 @@ The `ansible_distribution_release` and `ansible_distribution_version` facts on O
 **NEW** In Ansible 2.3:
 
 
-.. code-block:: yaml
+.. code-block:: none
 
     "ansible_distribution": "OpenBSD",
     "ansible_distribution_release": "release",
@@ -189,7 +189,7 @@ Deprecation of top-level connection arguments
 
 Will result in:
 
-.. code-block:: yaml
+.. code-block:: none
 
    [WARNING]: argument username has been deprecated and will be removed in a future version
    [WARNING]: argument host has been deprecated and will be removed in a future version


### PR DESCRIPTION
#### SUMMARY
Gets rid of some docs build warnings like:

WARNING: Could not lex literal_block as "yaml". Highlighting skipped.

Also improves some of the code block rendering.

use 'none' lexer instead of 'python2' that doesnt exist

remove some unneeded 'yaml' highlighting that warns

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docsite/rst/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (rst_yaml_jinja_lex_warning 3867afb172) last updated 2017/09/12 17:42:27 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
