### PR TITLE
Avoid RuntimeError: dictionary changed size

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group_facts.py
@@ -184,11 +184,8 @@ def get_target_group_attributes(connection, module, target_group_arn):
         module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     # Replace '.' with '_' in attribute key names to make it more Ansibley
-    for k, v in target_group_attributes.items():
-        target_group_attributes[k.replace('.', '_')] = v
-        del target_group_attributes[k]
-
-    return target_group_attributes
+    return dict((k.replace('.', '_'), v)
+                for (k, v) in target_group_attributes.items())
 
 
 def get_target_group_tags(connection, module, target_group_arn):


### PR DESCRIPTION
##### SUMMARY

Don't update the target_group_attributes dict
while iterating over it.

Fixes #30190


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_target_group_facts

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 779e365639) last updated 2017/09/13 10:11:58 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
Should be backported to stable-2.4