### PR TITLE
Miscellaneous pylint fixes.

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -46,7 +46,7 @@ from ansible.module_utils._text import to_text
 ########################################
 # OUTPUT OF LAST RESORT
 class LastResort(object):
-    def display(self, msg):
+    def display(self, msg, log_only=None):
         print(msg, file=sys.stderr)
 
     def error(self, msg, wrap_text=None):

--- a/contrib/inventory/rax.py
+++ b/contrib/inventory/rax.py
@@ -233,13 +233,17 @@ def _list_into_cache(regions):
                               'RAX_ACCESS_NETWORK', 'public', value_type='list')
     except TypeError:
         # Ansible 2.2.x and below
+        # pylint: disable=unexpected-keyword-arg
         networks = get_config(p, 'rax', 'access_network',
                               'RAX_ACCESS_NETWORK', 'public', islist=True)
     try:
         try:
+            # Ansible 2.3+
             ip_versions = map(int, get_config(p, 'rax', 'access_ip_version',
                                               'RAX_ACCESS_IP_VERSION', 4, value_type='list'))
         except TypeError:
+            # Ansible 2.2.x and below
+            # pylint: disable=unexpected-keyword-arg
             ip_versions = map(int, get_config(p, 'rax', 'access_ip_version',
                                               'RAX_ACCESS_IP_VERSION', 4, islist=True))
     except:
@@ -438,6 +442,7 @@ def setup():
                                      value_type='list')
         except TypeError:
             # Ansible 2.2.x and below
+            # pylint: disable=unexpected-keyword-arg
             region_list = get_config(p, 'rax', 'regions', 'RAX_REGION', 'all',
                                      islist=True)
 

--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -109,6 +109,7 @@ class ConfigCLI(CLI):
         '''
         raise AnsibleError("Option not implemented yet")
 
+        # pylint: disable=unreachable
         if self.options.setting is None:
             raise AnsibleOptionsError("update option requries a setting to update")
 
@@ -141,6 +142,8 @@ class ConfigCLI(CLI):
         Opens ansible.cfg in the default EDITOR
         '''
         raise AnsibleError("Option not implemented yet")
+
+        # pylint: disable=unreachable
         try:
             editor = shlex.split(os.environ.get('EDITOR','vi'))
             editor.append(self.config_file)

--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -643,7 +643,6 @@ class GalaxyCLI(CLI):
 
         if len(self.args) < 4:
             raise AnsibleError("Missing one or more arguments. Expecting: source github_user github_repo secret")
-            return 0
 
         secret = self.args.pop()
         github_repo = self.args.pop()

--- a/lib/ansible/config/data.py
+++ b/lib/ansible/config/data.py
@@ -42,4 +42,3 @@ class ConfigData(object):
             if plugin.name not in self._plugins[plugin.type]:
                 self._plugins[plugin.type][plugin.name] = {}
             self._plugins[plugin.type][plugin.name][setting.name] = setting
-

--- a/lib/ansible/module_utils/redhat.py
+++ b/lib/ansible/module_utils/redhat.py
@@ -147,11 +147,6 @@ class Rhsm(RegistrationBase):
               * Boolean - whether the current system is currently registered to
                           RHN.
         '''
-        # Quick version...
-        if False:
-            return os.path.isfile('/etc/pki/consumer/cert.pem') and \
-                os.path.isfile('/etc/pki/consumer/key.pem')
-
         args = ['subscription-manager', 'identity']
         rc, stdout, stderr = self.module.run_command(args, check_rc=False)
         if rc == 0:

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -293,4 +293,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/cloud/openstack/os_floating_ip.py
+++ b/lib/ansible/modules/cloud/openstack/os_floating_ip.py
@@ -218,7 +218,7 @@ def main():
                     module.fail_json(msg="server {server} already has a "
                                          "floating-ip on requested "
                                          "interface but it doesn't match "
-                                         "requested network {network: {fip}"
+                                         "requested network {network}: {fip}"
                                      .format(server=server_name_or_id,
                                              network=network,
                                              fip=remove_values(f_ip,

--- a/lib/ansible/modules/cloud/openstack/os_image_facts.py
+++ b/lib/ansible/modules/cloud/openstack/os_image_facts.py
@@ -167,4 +167,3 @@ from ansible.module_utils.basic import *
 from ansible.module_utils.openstack import *
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/asa/asa_command.py
+++ b/lib/ansible/modules/network/asa/asa_command.py
@@ -199,4 +199,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/fortios/fortios_config.py
+++ b/lib/ansible/modules/network/fortios/fortios_config.py
@@ -181,4 +181,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/_nxos_mtu.py
+++ b/lib/ansible/modules/network/nxos/_nxos_mtu.py
@@ -380,4 +380,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
+++ b/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
@@ -365,4 +365,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_gir.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir.py
@@ -318,4 +318,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
@@ -225,4 +225,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
@@ -294,4 +294,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_ntp_auth.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp_auth.py
@@ -325,4 +325,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_snmp_community.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_community.py
@@ -248,4 +248,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_snmp_contact.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_contact.py
@@ -152,4 +152,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_snmp_host.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_host.py
@@ -432,4 +432,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_traps.py
@@ -289,4 +289,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_snmp_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_user.py
@@ -351,4 +351,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_udld.py
+++ b/lib/ansible/modules/network/nxos/nxos_udld.py
@@ -295,4 +295,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/nxos/nxos_udld_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_udld_interface.py
@@ -308,4 +308,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/storage/netapp/sf_account_manager.py
+++ b/lib/ansible/modules/storage/netapp/sf_account_manager.py
@@ -270,4 +270,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/storage/netapp/sf_volume_manager.py
+++ b/lib/ansible/modules/storage/netapp/sf_volume_manager.py
@@ -329,4 +329,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -532,7 +532,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             elif 'json' in errormsg or 'simplejson' in errormsg:
                 x = "5"  # json or simplejson modules needed
         finally:
-            return x
+            return x  # pylint: disable=lost-exception
 
     def _remote_expand_user(self, path, sudoable=True):
         ''' takes a remote path and performs tilde expansion on the remote host '''

--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -60,7 +60,7 @@ class Cliconf(CliconfBase):
             cmd = b'show configuration'
         else:
             cmd = b'show configuration | display %s' % format
-        return self.send_command(to_bytes(cmd), errors='surrogate_or_strict')
+        return self.send_command(to_bytes(cmd, errors='surrogate_or_strict'))
 
     def edit_config(self, command):
         for cmd in chain([b'configure'], to_list(command)):

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -589,6 +589,7 @@ class Connection(ConnectionBase):
                 # Make sure stdin is a proper pty to avoid tcgetattr errors
                 master, slave = pty.openpty()
                 if PY3 and self._play_context.password:
+                    # pylint: disable=unexpected-keyword-arg
                     p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
                 else:
                     p = subprocess.Popen(cmd, stdin=slave, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
@@ -599,6 +600,7 @@ class Connection(ConnectionBase):
 
         if not p:
             if PY3 and self._play_context.password:
+                # pylint: disable=unexpected-keyword-arg
                 p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=self.sshpass_pipe)
             else:
                 p = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/lib/ansible/plugins/lookup/etcd.py
+++ b/lib/ansible/plugins/lookup/etcd.py
@@ -139,7 +139,6 @@ class Etcd:
                 value = "ENOENT"
         except:
             raise
-            pass
 
         return value
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -114,7 +114,6 @@ lib/ansible/modules/cloud/misc/virt_pool.py
 lib/ansible/modules/cloud/misc/xenserver_facts.py
 lib/ansible/modules/cloud/openstack/os_group.py
 lib/ansible/modules/cloud/openstack/os_image.py
-lib/ansible/modules/cloud/openstack/os_image_facts.py
 lib/ansible/modules/cloud/openstack/os_ironic.py
 lib/ansible/modules/cloud/openstack/os_keypair.py
 lib/ansible/modules/cloud/openstack/os_keystone_domain.py
@@ -310,7 +309,6 @@ lib/ansible/modules/network/nxos/nxos_overlay_global.py
 lib/ansible/modules/network/nxos/nxos_ping.py
 lib/ansible/modules/network/nxos/nxos_smu.py
 lib/ansible/modules/network/nxos/nxos_snapshot.py
-lib/ansible/modules/network/nxos/nxos_snmp_community.py
 lib/ansible/modules/network/nxos/nxos_snmp_contact.py
 lib/ansible/modules/network/nxos/nxos_snmp_host.py
 lib/ansible/modules/network/nxos/nxos_snmp_traps.py
@@ -410,7 +408,6 @@ lib/ansible/modules/storage/netapp/na_cdot_qtree.py
 lib/ansible/modules/storage/netapp/na_cdot_volume.py
 lib/ansible/modules/storage/netapp/netapp_e_amg.py
 lib/ansible/modules/storage/netapp/netapp_e_storagepool.py
-lib/ansible/modules/storage/netapp/sf_account_manager.py
 lib/ansible/modules/storage/netapp/sf_snapshot_schedule_manager.py
 lib/ansible/modules/storage/netapp/sf_volume_access_group_manager.py
 lib/ansible/modules/storage/netapp/sf_volume_manager.py

--- a/test/sanity/pylint/disable.txt
+++ b/test/sanity/pylint/disable.txt
@@ -6,7 +6,6 @@ arguments-differ
 assignment-from-no-return
 attribute-defined-outside-init
 bad-continuation
-bad-format-string
 bad-indentation
 bad-mcs-classmethod-argument
 bad-open-mode
@@ -20,7 +19,6 @@ consider-using-enumerate
 deprecated-lambda
 deprecated-method
 deprecated-module
-duplicate-key
 eval-used
 exec-used
 expression-not-assigned
@@ -38,7 +36,6 @@ line-too-long
 locally-disabled
 logging-format-interpolation
 logging-not-lazy
-lost-exception
 method-hidden
 misplaced-comparison-constant
 missing-docstring
@@ -80,9 +77,7 @@ too-many-nested-blocks
 too-many-public-methods
 too-many-return-statements
 too-many-statements
-trailing-newlines
 undefined-loop-variable
-unexpected-keyword-arg
 ungrouped-imports
 unidiomatic-typecheck
 unnecessary-lambda
@@ -97,8 +92,6 @@ unused-variable
 unused-wildcard-import
 used-before-assignment
 useless-else-on-loop
-useless-suppression
-using-constant-test
 wildcard-import
 wrong-import-order
 wrong-import-position

--- a/test/units/modules/network/netscaler/test_netscaler_cs_action.py
+++ b/test/units/modules/network/netscaler/test_netscaler_cs_action.py
@@ -41,7 +41,6 @@ class TestNetscalerCSActionModule(TestModule):
         nssrc_modules_mock = {
             'nssrc.com.citrix.netscaler.nitro.resource.config.cs': m,
             'nssrc.com.citrix.netscaler.nitro.resource.config.cs.csaction': m,
-            'nssrc.com.citrix.netscaler.nitro.resource.config.cs.csaction': m,
             'nssrc.com.citrix.netscaler.nitro.resource.config.cs.csaction.csaction': cls.cs_action_mock,
         }
 

--- a/test/units/modules/system/interfaces_file/test_interfaces_file.py
+++ b/test/units/modules/system/interfaces_file/test_interfaces_file.py
@@ -33,7 +33,6 @@ class AnsibleFailJson(Exception):
 class ModuleMocked():
     def fail_json(self, msg):
         raise AnsibleFailJson(msg)
-        pass
 
 
 module = ModuleMocked()

--- a/test/units/vars/test_variable_manager.py
+++ b/test/units/vars/test_variable_manager.py
@@ -104,6 +104,7 @@ class TestVariableManager(unittest.TestCase):
         # FIXME: BCS make this work
         return
 
+        # pylint: disable=unreachable
         fake_loader = DictDataLoader({})
 
         mock_task = MagicMock()
@@ -134,6 +135,8 @@ class TestVariableManager(unittest.TestCase):
     def test_variable_manager_precedence(self):
         # FIXME: this needs to be redone as dataloader is not the automatic source of data anymore
         return
+
+        # pylint: disable=unreachable
         '''
         Tests complex variations and combinations of get_vars() with different
         objects to modify the context under which variables are merged.


### PR DESCRIPTION
##### SUMMARY

The following rules are no longer disabled:

- bad-format-string
- duplicate-key
- lost-exception
- trailing-newlines
- unexpected-keyword-arg
- useless-suppression
- using-constant-test

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Various

##### ANSIBLE VERSION

```
ansible 2.5.0 (pylint-fixes 3a5973ee0e) last updated 2017/09/13 00:17:21 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
