### PR TITLE
oc module- Fixing description & removing example command

### DIFF
--- a/lib/ansible/modules/clustering/oc.py
+++ b/lib/ansible/modules/clustering/oc.py
@@ -18,14 +18,11 @@ DOCUMENTATION = """
 author:
   - "Kenneth D. Evensen (@kevensen)"
 description:
-      "This module allows management of resources in an OpenShift cluster. The
-      inventory host can be any host with network connectivity to the OpenShift
-      cluster; the default port being 8443/TCP. This module relies on a token
-      to authenticate to OpenShift. This can either be a user or a service
-      account. For example:
-
-      $ oc create serviceaccount ansible-sa
-      $ oadm policy add-cluster-role-to-user cluster-admin system:serviceaccount:default:ansible-sa"
+  - This module allows management of resources in an OpenShift cluster. The
+    inventory host can be any host with network connectivity to the OpenShift
+    cluster; the default port being 8443/TCP. 
+  - This module relies on a token to authenticate to OpenShift. This can either
+    be a user or a service account. 
 module: oc
 options:
   host:

--- a/lib/ansible/modules/clustering/oc.py
+++ b/lib/ansible/modules/clustering/oc.py
@@ -20,9 +20,9 @@ author:
 description:
   - This module allows management of resources in an OpenShift cluster. The
     inventory host can be any host with network connectivity to the OpenShift
-    cluster; the default port being 8443/TCP. 
+    cluster; the default port being 8443/TCP.
   - This module relies on a token to authenticate to OpenShift. This can either
-    be a user or a service account. 
+    be a user or a service account.
 module: oc
 options:
   host:


### PR DESCRIPTION
Noticed formatting errors on http://docs.ansible.com/ansible/latest/oc_module.html -- also removing oc/oadm command examples

##### SUMMARY
Fixing docstring in oc module - also removing example openshift commands for creating cluster-admin service account.



##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cluster/oc

##### ANSIBLE VERSION

```
latest
```


##### ADDITIONAL INFORMATION
see http://docs.ansible.com/ansible/latest/oc_module.html