### PR TITLE
fix nxos_file_copy and provider getting set to None when transport is cli

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -61,9 +61,8 @@ options:
 EXAMPLES = '''
 - nxos_file_copy:
     local_file: "./test_file.txt"
-    username: "{{ un }}"
-    password: "{{ pwd }}"
-    host: "{{ inventory_hostname }}"
+    remote_file: "test_file.txt"
+    provider: "{{ cli }}"
 '''
 
 RETURN = '''
@@ -144,9 +143,9 @@ def transfer_file(module, dest):
     if not enough_space(module):
         module.fail_json(msg='Could not transfer file. Not enough space on device.')
 
-    hostname = module.params['host']
-    username = module.params['username']
-    password = module.params['password']
+    hostname = module.params['provider']['host']
+    username = module.params['provider']['username']
+    password = module.params['provider']['password']
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -143,9 +143,11 @@ def transfer_file(module, dest):
     if not enough_space(module):
         module.fail_json(msg='Could not transfer file. Not enough space on device.')
 
-    hostname = module.params['provider']['host']
-    username = module.params['provider']['username']
-    password = module.params['provider']['password']
+    provider = module.params['provider']
+
+    hostname = module.params.get('host') or provider.get('host')
+    username = module.params.get('username') or provider.get('username')
+    password = module.params.get('password') or provider.get('password')
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -59,13 +59,6 @@ class ActionModule(_ActionModule):
             pc.password = provider['password'] or self._play_context.password
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
             pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
-            self._task.args['provider'] = provider.update(
-                host=pc.remote_addr,
-                port=pc.port,
-                username=pc.remote_user,
-                password=pc.password,
-                ssh_keyfile=pc.private_key_file
-            )
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes #28796 
- nxos_file_copy fix
- provider gets set to None on module level when transport is cli 

This should be cherry-picked to 2.4
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_file_copy
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel and 2.4
```