### PR TITLE
Fix ios_system lookup enable issue

### DIFF
--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -146,7 +146,7 @@ def map_obj_to_commands(want, have, module):
     commands = list()
     state = module.params['state']
 
-    needs_update = lambda x: want.get(x) and (want.get(x) != have.get(x))
+    needs_update = lambda x: want.get(x) is not None and (want.get(x) != have.get(x))
 
     if state == 'absent':
         if have['hostname'] != 'Router':

--- a/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
@@ -33,6 +33,30 @@
     that:
       - result.changed == false
 
+- name: Disable lookup_source
+  ios_system:
+    lookup_enabled: False
+    provider: "{{ cli }}"
+    authorize: yes
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - "'no ip domain lookup' in result.commands"
+
+- name: Disable lookup_source
+  ios_system:
+    lookup_enabled: True
+    provider: "{{ cli }}"
+    authorize: yes
+  register: result
+
+- assert:
+    that:
+      - result.changed == true
+      - "'ip domain lookup' in result.commands"
+
 #- name: change to vrf
 #  ios_system:
 #    lookup_source:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #29974

Add `None` check while comparing module parameter values (want) with the actual
configuration present on device (have).
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_system

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
