### PR TITLE
Remove provider cli for vyos tests

### DIFF
--- a/test/integration/targets/vyos_banner/tests/cli/basic-no-login.yaml
+++ b/test/integration/targets/vyos_banner/tests/cli/basic-no-login.yaml
@@ -6,13 +6,11 @@
       Junk pre-login banner
       over multiple lines
     state: present
-    provider: "{{ cli }}"
 
 - name: remove pre-login
   vyos_banner:
     banner: pre-login
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -27,7 +25,6 @@
   vyos_banner:
     banner: pre-login
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_banner/tests/cli/basic-post-login.yaml
+++ b/test/integration/targets/vyos_banner/tests/cli/basic-post-login.yaml
@@ -3,7 +3,6 @@
   vyos_banner:
     banner: post-login
     state: absent
-    provider: "{{ cli }}"
 
 - name: Set post-login
   vyos_banner:
@@ -13,7 +12,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -33,7 +31,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_banner/tests/cli/basic-pre-login.yaml
+++ b/test/integration/targets/vyos_banner/tests/cli/basic-pre-login.yaml
@@ -3,7 +3,6 @@
   vyos_banner:
     banner: pre-login
     state: absent
-    provider: "{{ cli }}"
 
 - name: Set pre-login
   vyos_banner:
@@ -13,7 +12,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -33,7 +31,6 @@
       that has a multiline
       string
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_command/tests/cli/bad_operator.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/bad_operator.yaml
@@ -8,7 +8,6 @@
       - show interfaces
     wait_for:
       - result[0] is 'VyOS'
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/vyos_command/tests/cli/contains.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/contains.yaml
@@ -9,7 +9,6 @@
     wait_for:
       - result[0] contains VyOS
       - result[1] contains eth0
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_command/tests/cli/invalid.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/invalid.yaml
@@ -4,7 +4,6 @@
 - name: run invalid command
   vyos_command:
     commands: show foo
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 
@@ -15,7 +14,6 @@
     commands:
       - show version
       - show foo
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/vyos_command/tests/cli/output.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/output.yaml
@@ -4,7 +4,6 @@
 - name: get output for single command
   vyos_command:
     commands: show version
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -18,7 +17,6 @@
     commands:
       - show version
       - show interfaces
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,7 +33,6 @@
       - show hardware cpu detail
       - show hardware mem
       - show license
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/vyos_command/tests/cli/timeout.yaml
@@ -7,7 +7,6 @@
       - show version
     wait_for:
       - result[0] contains bad_value_string
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/vyos_config/tests/cli/check_config.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/check_config.yaml
@@ -4,12 +4,10 @@
 - name: setup
   vyos_config:
     lines: set interfaces loopback lo description test
-    provider: "{{ cli }}"
 
 - name: configure config_check config command
   vyos_config:
     lines: delete interfaces loopback lo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -19,7 +17,6 @@
 - name: check config_check config command idempontent
   vyos_config:
     lines: delete interfaces loopback lo
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_config/tests/cli/comment.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/comment.yaml
@@ -4,14 +4,12 @@
 - name: setup
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}
-    provider: "{{ cli }}"
     match: none
 
 - name: configure using comment
   vyos_config:
     lines: set system host-name foo
     comment: this is a test
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +20,6 @@
 - name: collect system commits
   vyos_command:
     commands: show system commit
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -32,7 +29,6 @@
 - name: teardown
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/comment.yaml"

--- a/test/integration/targets/vyos_config/tests/cli/save.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/save.yaml
@@ -4,13 +4,11 @@
 - name: setup
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}
-    provider: "{{ cli }}"
     match: none
 
 - name: configure hostaname and save
   vyos_config:
     lines: set system host-name foo
-    provider: "{{ cli }}"
     save: true
   register: result
 
@@ -22,7 +20,6 @@
 - name: configure hostaname and don't save
   vyos_config:
     lines: set system host-name bar
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -33,7 +30,6 @@
 - name: save config
   vyos_config:
     save: true
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -43,7 +39,6 @@
 - name: save config again
   vyos_config:
     save: true
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -53,7 +48,6 @@
 - name: teardown
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}
-    provider: "{{ cli }}"
     match: none
     save: true
 

--- a/test/integration/targets/vyos_config/tests/cli/simple.yaml
+++ b/test/integration/targets/vyos_config/tests/cli/simple.yaml
@@ -4,13 +4,11 @@
 - name: setup
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}
-    provider: "{{ cli }}"
     match: none
 
 - name: configure simple config command
   vyos_config:
     lines: set system host-name foo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -21,7 +19,6 @@
 - name: check simple config command idempontent
   vyos_config:
     lines: set system host-name foo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,7 +28,6 @@
 - name: teardown
   vyos_config:
     lines: set system host-name {{ inventory_hostname_short }}
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg="END cli/simple.yaml"

--- a/test/integration/targets/vyos_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/vyos_interface/tests/cli/intent.yaml
@@ -12,14 +12,12 @@
     name: eth1
     enabled: True
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - name: Check intent arguments
   vyos_interface:
     name: eth1
     state: up
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,7 +29,6 @@
     name: eth0
     neighbors:
     - port: eth0
-    provider: "{{ cli }}"
   when: "'virtio_net' not in lsmod_out.stdout[0]"
   register: result
 
@@ -44,7 +41,6 @@
   vyos_interface:
     name: eth1
     state: down
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -59,7 +55,6 @@
     neighbors:
     - port: dummy_port
       host: dummy_host
-    provider: "{{ cli }}"
   ignore_errors: yes
   when: "'virtio_net' not in lsmod_out.stdout[0]"
   register: result
@@ -76,7 +71,6 @@
     name: eth1
     enabled: False
     state: down
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -88,7 +82,6 @@
     name: eth1
     enabled: False
     state: up
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -103,7 +96,6 @@
     - name: eth1
       enabled: True
       state: up
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -117,7 +109,6 @@
     - name: eth0
       neighbors:
       - port: eth0
-    provider: "{{ cli }}"
   when: "'virtio_net' not in lsmod_out.stdout[0]"
   register: result
 
@@ -134,7 +125,6 @@
       - port: eth0
       - port: dummy_port
         host: dummy_host
-    provider: "{{ cli }}"
   ignore_errors: yes
   when: "'virtio_net' not in lsmod_out.stdout[0]"
   register: result

--- a/test/integration/targets/vyos_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_logging/tests/cli/basic.yaml
@@ -5,7 +5,6 @@
     facility: all
     level: info
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -19,7 +18,6 @@
     facility: all
     level: info
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -33,7 +31,6 @@
     facility: all
     level: notice
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -48,7 +45,6 @@
     facility: all
     level: notice
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -62,7 +58,6 @@
     facility: all
     level: notice
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -77,7 +72,6 @@
     facility: all
     level: notice
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -90,7 +84,6 @@
       - { dest: file, name: test1, facility: all, level: info }
       - { dest: file, name: test2, facility: news, level: debug }
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -106,7 +99,6 @@
       - { dest: file, name: test1, facility: all, level: info, state: absent }
       - { dest: console, facility: daemon, level: warning }
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -122,7 +114,6 @@
       - { dest: console, facility: daemon, level: warning }
       - { dest: file, name: test2, facility: news, level: debug }
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_static_route/tests/cli/basic.yaml
@@ -4,7 +4,6 @@
     prefix: 172.24.0.0/24
     next_hop: 192.168.42.64
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -18,7 +17,6 @@
     mask: 24
     next_hop: 192.168.42.64
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,7 +29,6 @@
     next_hop: 192.168.42.64
     admin_distance: 1
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -46,7 +43,6 @@
     next_hop: 192.168.42.64
     admin_distance: 1
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -59,7 +55,6 @@
     next_hop: 192.168.42.64
     admin_distance: 1
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -73,7 +68,6 @@
     next_hop: 192.168.42.64
     admin_distance: 1
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -86,7 +80,6 @@
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.2.0, mask: 24, next_hop: 192.168.42.64 }
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -102,7 +95,6 @@
       - { prefix: 172.24.2.0/24, next_hop: 192.168.42.64, state: absent }
       - { prefix: 172.24.3.0/24, next_hop: 192.168.42.64 }
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -117,7 +109,6 @@
       - { prefix: 172.24.1.0/24, next_hop: 192.168.42.64 }
       - { prefix: 172.24.3.0/24, next_hop: 192.168.42.64 }
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/vyos_user/tests/cli/auth.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/auth.yaml
@@ -5,7 +5,6 @@
       name: auth_user
       role: admin
       state: present
-      provider: "{{ cli }}"
       configured_password: pass123
 
   - name: test login
@@ -32,5 +31,4 @@
     vyos_user:
       name: auth_user
       state: absent
-      provider: "{{ cli }}"
     register: result

--- a/test/integration/targets/vyos_user/tests/cli/basic.yaml
+++ b/test/integration/targets/vyos_user/tests/cli/basic.yaml
@@ -5,14 +5,12 @@
       - delete system login user ansibletest1
       - delete system login user ansibletest2
       - delete system login user ansibletest3
-    provider: "{{ cli }}"
 
 - name: Create user
   vyos_user:
     name: ansibletest1
     configured_password: test
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,7 +26,6 @@
       - name: ansibletest3
     level: operator
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -42,7 +39,6 @@
     configured_password: test
     state: present
     update_password: on_create
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -57,7 +53,6 @@
       - name: ansibletest3
     level: operator
     state: present
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -72,7 +67,6 @@
       - name: ansibletest2
       - name: ansibletest3
     state: absent
-    provider: "{{ cli }}"
   register: result
 
 - assert:


### PR DESCRIPTION
Transport is cli by default, and we set user/passwords on group_vars.