### PR TITLE
swapped out key-value pairs for multi-line YML

### DIFF
--- a/docs/docsite/rst/playbooks_intro.rst
+++ b/docs/docsite/rst/playbooks_intro.rst
@@ -114,18 +114,26 @@ the web servers, and then the database servers. For example::
 
       tasks:
       - name: ensure apache is at the latest version
-        yum: name=httpd state=latest
+        yum:
+          name: httpd
+          state: latest
       - name: write the apache config file
-        template: src=/srv/httpd.j2 dest=/etc/httpd.conf
+        template:
+          src: /srv/httpd.j2
+          dest: /etc/httpd.conf
 
     - hosts: databases
       remote_user: root
 
       tasks:
       - name: ensure postgresql is at the latest version
-        yum: name=postgresql state=latest
+        yum:
+          name: postgresql
+          state: latest
       - name: ensure that postgresql is started
-        service: name=postgresql state=started
+        service:
+          name: postgresql
+          state: started
 
 You can use this method to switch between the host group you're targeting,
 the username logging into the remote servers, whether to sudo or not, and so
@@ -187,7 +195,9 @@ You can also use become on a particular task instead of the whole play::
     - hosts: webservers
       remote_user: yourname
       tasks:
-        - service: name=nginx state=started
+        - service: 
+            name: nginx
+            state: started
           become: yes
           become_method: sudo
 
@@ -302,7 +312,9 @@ the service module takes ``key=value`` arguments::
 
    tasks:
      - name: make sure apache is running
-       service: name=httpd state=started
+       service:
+         name: httpd
+         state: started
 
 The **command** and **shell** modules are the only modules that just take a list
 of arguments and don't use the ``key=value`` form.  This makes
@@ -340,7 +352,9 @@ a variable called ``vhost`` in the ``vars`` section, you could do this::
 
    tasks:
      - name: create a virtual host file for {{ vhost }}
-       template: src=somefile.j2 dest=/etc/httpd/conf.d/{{ vhost }}
+       template:
+         src: somefile.j2
+         dest: /etc/httpd/conf.d/{{ vhost }}
 
 Those same variables are usable in templates, which we'll get to later.
 
@@ -384,7 +398,9 @@ Here's an example of restarting two services when the contents of a file
 change, but only if the file changes::
 
    - name: template configuration file
-     template: src=template.j2 dest=/etc/foo.conf
+     template:
+       src: template.j2
+       dest: /etc/foo.conf
      notify:
         - restart memcached
         - restart apache
@@ -402,18 +418,26 @@ Here's an example handlers section::
 
     handlers:
         - name: restart memcached
-          service: name=memcached state=restarted
+          service:
+            name: memcached
+            state: restarted
         - name: restart apache
-          service: name=apache state=restarted
+          service:
+            name: apache
+            state: restarted
 
 As of Ansible 2.2, handlers can also "listen" to generic topics, and tasks can notify those topics as follows::
 
     handlers:
         - name: restart memcached
-          service: name=memcached state=restarted
+          service:
+            name: memcached
+            state: restarted
           listen: "restart web services"
         - name: restart apache
-          service: name=apache state=restarted
+          service:
+            name: apache
+            state:restarted
           listen: "restart web services"
 
     tasks:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Per a recent Ansible blog, YML syntax is preferred, and I though to help update the docs where reasonable.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /home/adj/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Key value pairs aren't as easy to read as multi-line expanded YML syntax.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
