### PR TITLE
systemd: ignore unknown unit states

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -448,8 +448,8 @@ def main():
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
             else:
-                # this should not happen?
-                module.fail_json(msg="Service is in unknown state", status=result['status'])
+                # this can happen when we're running in a chroot, in which case systemd supports only enable/disable operations
+                module.warn('Service is in unknown state')
 
 
     module.exit_json(**result)


### PR DESCRIPTION
##### SUMMARY
This PR makes the systemd module not fail if it encounters a unit with an unknown state (i.e. with no `ActiveState` property). This can happen when systemctl is run in a chroot, which is legal (and useful, e.g. when provisioning OS images in a chroot into a loopback-mounted filesystem).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
systemd module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (systemd-ignore-unknown-state f350cbc8bf) last updated 2017/09/13 14:49:19 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
