### PR TITLE
Fixes #30281 eos_banner integration test failure

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -92,7 +92,9 @@ session_name:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.eos import load_config, run_commands
 from ansible.module_utils.eos import eos_argument_spec, check_args
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_text
+
 
 def map_obj_to_commands(updates, module):
     commands = list()
@@ -106,7 +108,7 @@ def map_obj_to_commands(updates, module):
             commands.append({'cmd': 'no banner %s' % module.params['banner']})
 
     elif state == 'present':
-        if isinstance(have['text'], str):
+        if isinstance(have['text'], string_types):
             if want['text'] != have['text']:
                 commands.append('banner %s' % module.params['banner'])
                 commands.extend(want['text'].strip().split('\n'))
@@ -121,7 +123,6 @@ def map_obj_to_commands(updates, module):
                 # key/values for the banner
                 commands.append({'cmd': 'banner %s' % module.params['banner'],
                                  'input': want['text'].strip('\n')})
-
 
     return commands
 
@@ -139,7 +140,7 @@ def map_config_to_obj(module):
             else:
                 banner_response_key = 'motd'
             if isinstance(output[0], dict) and banner_response_key in output[0].keys():
-                obj['text'] = output[0][banner_response_key].strip('\n')
+                obj['text'] = output[0]
         obj['state'] = 'present'
     return obj
 

--- a/test/units/modules/network/eos/eos_module.py
+++ b/test/units/modules/network/eos/eos_module.py
@@ -64,7 +64,7 @@ class AnsibleFailJson(Exception):
 
 class TestEosModule(unittest.TestCase):
 
-    def execute_module(self, failed=False, changed=False, commands=None, sort=True, defaults=False, transport='cli'):
+    def execute_module(self, failed=False, changed=False, commands=None, inputs=None, sort=True, defaults=False, transport='cli'):
 
         self.load_fixtures(commands, transport=transport)
 
@@ -76,10 +76,25 @@ class TestEosModule(unittest.TestCase):
             self.assertEqual(result['changed'], changed, result)
 
         if commands is not None:
-            if sort:
-                self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
+            if transport == 'eapi':
+                cmd = []
+                value = []
+                for item in result['commands']:
+                    cmd.append(item['cmd'])
+                    if 'input' in item:
+                        value.append(item['input'])
+                if sort:
+                    self.assertEqual(sorted(commands), sorted(cmd), cmd)
+                else:
+                    self.assertEqual(commands, cmd, cmd)
+                if inputs:
+                    self.assertEqual(inputs, value, value)
             else:
-                self.assertEqual(commands, result['commands'], result['commands'])
+                if sort:
+                    self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
+                else:
+                    self.assertEqual(commands, result['commands'], result['commands'])
+
 
         return result
 

--- a/test/units/modules/network/eos/eos_module.py
+++ b/test/units/modules/network/eos/eos_module.py
@@ -95,7 +95,6 @@ class TestEosModule(unittest.TestCase):
                 else:
                     self.assertEqual(commands, result['commands'], result['commands'])
 
-
         return result
 
     def failed(self):

--- a/test/units/modules/network/eos/test_eos_banner.py
+++ b/test/units/modules/network/eos/test_eos_banner.py
@@ -58,6 +58,13 @@ class TestEosBannerModule(TestEosModule):
         commands = ['no banner login']
         self.execute_module(changed=True, commands=commands)
 
+    def test_eos_banner_create_with_eapi_transport(self):
+        set_module_args(dict(banner='login', text='test\nbanner\nstring',
+                             transport='eapi'))
+        commands = ['banner login']
+        inputs = ['test\nbanner\nstring']
+        self.execute_module(changed=True, commands=commands, inputs=inputs, transport='eapi')
+
     def test_eos_banner_remove_with_eapi_transport(self):
         set_module_args(dict(banner='login', state='absent', transport='eapi'))
         commands = ['no banner login']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30281
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible__CH5Gb/ansible_module_eos_banner.py", line 197, in <module>
    main()
  File "/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible__CH5Gb/ansible_module_eos_banner.py", line 183, in main
    commands = map_obj_to_commands((want, have), module)
  File "/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible__CH5Gb/ansible_module_eos_banner.py", line 115, in map_obj_to_commands
    have_text = have['text'].get('loginBanner') or have['text'].get('motd')
AttributeError: 'unicode' object has no attribute 'get'

fatal: [veos01]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible__CH5Gb/ansible_module_eos_banner.py\", line 197, in <module>\n    main()\n  File \"/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible__CH5Gb/ansible_module_eos_banner.py\", line 183, in main\n    commands = map_obj_to_commands((want, have), module)\n  File \"/var/folders/bp/pf3l672j2s79st6d4ps6q7200000gn/T/ansible__CH5Gb/ansible_module_eos_banner.py\", line 115, in map_obj_to_commands\n    have_text = have['text'].get('loginBanner') or have['text'].get('motd')\nAttributeError: 'unicode' object has no attribute 'get'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 0
}


```
After:
```
changed: [veos01] => {
    "changed": true,
    "commands": [
        "no banner login"
    ],
    "diff": {
        "prepared": "\n"
    },
    "failed": false,
    "invocation": {
        "module_args": {
            "after": null,
            "auth_pass": null,
            "authorize": true,
            "backup": false,
            "before": null,
            "defaults": false,
            "diff_against": "session",
            "diff_ignore_lines": null,
            "force": false,
            "host": "veos01",
            "intended_config": null,
            "lines": [
                "no banner login"
            ],
            "match": "line",
            "parents": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 80,
            "provider": {
                "auth_pass": null,
                "authorize": true,
                "host": "veos01",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "port": 80,
                "ssh_keyfile": null,
                "timeout": 50,
                "transport": "eapi",
                "use_ssl": false,
                "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "validate_certs": true
            },
            "replace": "line",
            "running_config": null,
            "save": false,
            "save_when": "never",
            "src": null,
            "ssh_keyfile": null,
            "timeout": 50,
            "transport": "eapi",
            "url_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "url_username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "use_ssl": false,
            "username": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": true
        }
    },
    "session": "ansible_1505314855",
    "updates": [
        "no banner login"
    ]
}
```
