### PR TITLE
Updated Display.do_var_prompt to use to_native on prompt ( Fixes #30265 )

### DIFF
--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -35,7 +35,7 @@ from termios import TIOCGWINSZ
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_bytes, to_text, to_native
 from ansible.utils.color import stringc
 
 
@@ -297,6 +297,7 @@ class Display:
             else:
                 msg = 'input for %s: ' % varname
 
+            msg = to_native(msg)
             if confirm:
                 while True:
                     result = do_prompt(msg, private)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -35,7 +35,7 @@ from termios import TIOCGWINSZ
 
 from ansible import constants as C
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.utils.color import stringc
 
 
@@ -279,7 +279,7 @@ class Display:
             prompt_string = to_text(prompt_string)
 
         if private:
-            return getpass.getpass(msg)
+            return getpass.getpass(prompt_string)
         else:
             return input(prompt_string)
 
@@ -297,7 +297,6 @@ class Display:
             else:
                 msg = 'input for %s: ' % varname
 
-            msg = to_native(msg)
             if confirm:
                 while True:
                     result = do_prompt(msg, private)


### PR DESCRIPTION
##### SUMMARY
The prompt string was not being correctly set to `string`/`bytes`, which causes it to fail in cases similar to #30265 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/utils/display.py`

##### ANSIBLE VERSION
```
ansible 2.5.0 (30265_fix_prompt_encoding 891631a0e8) last updated 2017/09/13 16:25:10 (GMT +100)
  config file = /Users/shaps/.ansible.cfg
  configured module search path = [u'/Users/shaps/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shaps/PycharmProjects/ansible/lib/ansible
  executable location = /Users/shaps/PycharmProjects/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
N/A