### PR TITLE
add htmlsingle target

### DIFF
--- a/docs/docsite/Makefile
+++ b/docs/docsite/Makefile
@@ -20,9 +20,13 @@ all: docs
 
 docs: clean htmldocs
 
-htmldocs: testing keywords modules staticmin cli config
+generate_rst: testing keywords modules staticmin cli config
 
+htmldocs: generate_rst
 	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx html
+
+singlehtmldocs: generate_rst
+	CPUS=$(CPUS) $(MAKE) -f Makefile.sphinx singlehtml
 
 webdocs: docs
 


### PR DESCRIPTION
For whatever reason, building the 'singlehtml' version of
the docs is much much faster than building the normal html
version.

To use:

cd docs/docsite
make singlehtmldocs



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docssite/Makefile

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (docsite_singlehtml_make d776fd3b01) last updated 2017/09/13 12:00:26 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
