### PR TITLE
Added project_id/tenant_id filter

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -117,7 +117,9 @@ def main():
 
     try:
         cloud = shade.openstack_cloud(**module.params)
-        secgroup = cloud.get_security_group(name)
+        project_id = cloud.current_project_id
+        tenant_filter = "[? tenant_id == \'%s\']" % project_id
+        secgroup = cloud.get_security_group(name, filters = tenant_filter)
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, secgroup))

--- a/lib/ansible/modules/cloud/openstack/os_security_group.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group.py
@@ -119,7 +119,7 @@ def main():
         cloud = shade.openstack_cloud(**module.params)
         project_id = cloud.current_project_id
         tenant_filter = "[? tenant_id == \'%s\']" % project_id
-        secgroup = cloud.get_security_group(name, filters = tenant_filter)
+        secgroup = cloud.get_security_group(name, filters=tenant_filter)
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, secgroup))

--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -312,7 +312,9 @@ def main():
 
     try:
         cloud = shade.openstack_cloud(**module.params)
-        secgroup = cloud.get_security_group(security_group)
+        project_id = cloud.current_project_id
+        tenant_filter = "[? tenant_id == \'%s\']" % project_id
+        secgroup = cloud.get_security_group(security_group, filters=tenant_filter)
 
         if remote_group:
             remotegroup = cloud.get_security_group(remote_group)


### PR DESCRIPTION
##### ISSUE TYPE
Bug Report

##### COMPONENT NAME
os_security_group

##### SUMMARY
When there is security group with the same name in different project and you are logged as admin you are modifying security group in that project - Similar problem with os_security_group_role
##### STEPS TO REPRODUCE
1. Create security group with name 'foo' in first project
2. Use os_security_group to create security group in you project and authenticate with admin privilege. 
##### ANSIBLE VERSION
2.4
##### EXPECTED RESULTS
Creating security group in second project.
##### ACTUAL RESULTS
Updating security group in first project