### PR TITLE
docker_service build command respects the "pull: no" parameter (#30296).

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -895,7 +895,7 @@ class ContainerManager(DockerBaseClass):
 
                     # build the image
                     try:
-                        new_image_id = service.build(pull=True, no_cache=self.nocache)
+                        new_image_id = service.build(pull=self.pull, no_cache=self.nocache)
                     except Exception as exc:
                         self.client.fail("Error: build failed with %s" % str(exc))
 


### PR DESCRIPTION
##### SUMMARY
docker_service build command respects the "pull: no" paramater in task description.

docker_service fails when building service images that use local images in the "FROM" instruction in their Dockerfiles, because pull was unconditionally set to True.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_service

##### ANSIBLE VERSION
```
ansible 2.3.1.0
configured module search path = Default w/o overrides
python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```