### PR TITLE
Remove references to obsolete PR Mover.

### DIFF
--- a/docs/docsite/rst/dev_guide/repomerge.rst
+++ b/docs/docsite/rst/dev_guide/repomerge.rst
@@ -27,19 +27,3 @@ As part of this move, we will be introducing module metadata, which will contain
 
 
 The documentation pages for modules will be updated to reflect the above information as well, so that users can evaluate the status of a module before committing to using it in playbooks and roles.
-
-
-.. _PRMover:
-
-Move Issues and PRs to new Repo
--------------------------------
-A tool has been developed to move a PR from the old repos to `ansible/ansible` this can be found at `prmover tool <https://prmover.pythonanywhere.com/>`_ 
-
-Before using prmover please ensure you have a fork of the Ansible repo.
-
-To move issues please use `GitHub Issue Mover <https://github-issue-mover.appspot.com/>`_
-
-If you have *any* issues with updating your PR please ask for support in `#ansible-devel`
-
-For support please use `#ansible-devel` on Freenode IRC
-


### PR DESCRIPTION
##### SUMMARY

Remove references to obsolete PR Mover.

##### ISSUE TYPE

Docs Pull Request

##### COMPONENT NAME

Dev Guide

##### ANSIBLE VERSION

```
ansible 2.5.0 (no-prmover 981869546d) last updated 2017/09/13 10:10:17 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
