### PR TITLE
[cloud] Add support for rule description in ec2_group

### DIFF
--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -8,6 +8,10 @@
 
 # - include: ../../setup_ec2/tasks/common.yml module_name: ec2_group
 
+- name: register botocore version
+  command: python -c 'import botocore; print(botocore.__version__)'
+  register: botocore_version
+
 - block:
 
     # ============================================================
@@ -250,6 +254,64 @@
         that:
            - 'result.changed'
            - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test rule description (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ip: "1.1.1.1/32"
+          description: a
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ipv6: "64:ff9b::/96"
+          description: b
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          group_name: "{{ec2_group_name}}"
+          description: c
+        rules_egress:
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ip: "1.1.1.1/32"
+          description: d
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ipv6: "64:ff9b::/96"
+          description: e
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          group_name: "{{ec2_group_name}}"
+          description: f
+      register: result
+      when: botocore_version.stdout|version_compare('1.7.2', '>=')
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+           - 'result.ip_permissions[0].ip_ranges[0]["description"] == "a"'
+           - 'result.ip_permissions[0].ipv6_ranges[0]["description"] == "b"'
+           - 'result.ip_permissions[0].user_id_group_pairs[0]["description"] == "c"'
+           - 'result.ip_permissions_egress[0].ip_ranges[0]["description"] == "d"'
+           - 'result.ip_permissions_egress[0].ipv6_ranges[0]["description"] == "e"'
+           - 'result.ip_permissions_egress[0].user_id_group_pairs[0]["description"] == "f"'
+      when: botocore_version.stdout|version_compare('1.7.2', '>=')
 
     # ============================================================
     - name: test rules_egress state=present for ipv6 (expected changed=true)


### PR DESCRIPTION
##### SUMMARY

Add support for rule description in ec2_group. Descriptions for security group rules were announced on Aug 31, 2017: https://aws.amazon.com/blogs/aws/new-descriptions-for-security-group-rules/

This requires botocore >= 1.7.2. If an older version is used
- and the user tries to use rule descriptions in the YAML file, an error is printed
- and the rule descriptions are not used, everything works like before this change (i.e. rule descriptions entered via web console are not touched)

Fixes #29040 and #30260.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION

```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/weisslj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/weisslj/.local/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /home/weisslj/.local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```