### PR TITLE
Improve ansible-test HttpClient error handling.

### DIFF
--- a/test/runner/lib/http.py
+++ b/test/runner/lib/http.py
@@ -103,7 +103,7 @@ class HttpClient(object):
                 break
             except SubprocessError as ex:
                 if ex.status in retry_on_status and attempts < max_attempts:
-                    display.warning(ex.message)
+                    display.warning(u'%s' % ex)
                     time.sleep(sleep_seconds)
                     continue
 

--- a/test/runner/shippable.py
+++ b/test/runner/shippable.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, print_function
 # noinspection PyCompatibility
 import argparse
 import errno
+import json
 import os
 import sys
 
@@ -43,6 +44,9 @@ def main():
         client = HttpClient(args)
         response = client.get('https://api.shippable.com/jobs?runIds=%s' % run_id)
         jobs = response.json()
+
+        if not isinstance(jobs, list):
+            raise ApplicationError(json.dumps(jobs, indent=4, sort_keys=True))
 
         if len(jobs) == 1:
             raise ApplicationError('Shippable run %s has only one job. Did you use the "Rebuild with SSH" option?' % run_id)


### PR DESCRIPTION
##### SUMMARY

Improve ansible-test HttpClient error handling:

- Automatic retries on DNS lookup failures.
- Handle API errors in shippable.py.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-error-handling 8df47b2115) last updated 2017/09/13 10:54:22 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
