### PR TITLE
ovirt_vms: Raise proper error when template isn't found

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -599,8 +599,14 @@ class VmsModule(BaseModule):
                     t for t in templates
                     if t.version.version_number == self.param('template_version')
                 ]
-            if templates:
-                template = templates[0]
+            if not templates:
+                raise ValueError(
+                    "Template with name '%s' and version '%s' was not found'" % (
+                        self.param('template'),
+                        self.param('template_version')
+                    )
+                )
+            template = templates[0]
 
         return template
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Print nice error when template or specific template version isn't found.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
    - name: Create vm from template
      ovirt_vms:
        auth: "{{ ovirt_auth }}"
        cluster: Default
        state: absent
        name: myvmads
        template: nonexstingtemplate
```

Output:
```bash
PLAY [localhost] **************************************************************************************************************************************************************************************************

TASK [Obtain SSO token] *******************************************************************************************************************************************************************************************
ok: [localhost]

TASK [Create vm from template] ************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: Template with name 'cirrossaddsadsa' and version 'None' was not found'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Template with name 'cirrossaddsadsa' and version 'None' was not found'"}

PLAY RECAP ********************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1   
```