### PR TITLE
Fixes verify_ssl option when False in ansible_tower module util

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -62,7 +62,7 @@ def tower_auth_config(module):
         if password:
             auth_config['password'] = password
         verify_ssl = module.params.get('tower_verify_ssl')
-        if verify_ssl:
+        if verify_ssl != None:
             auth_config['verify_ssl'] = verify_ssl
         return auth_config
 

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -62,7 +62,7 @@ def tower_auth_config(module):
         if password:
             auth_config['password'] = password
         verify_ssl = module.params.get('tower_verify_ssl')
-        if verify_ssl != None:
+        if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl
         return auth_config
 


### PR DESCRIPTION
##### SUMMARY
Fixes the verify_ssl option in ansible_tower module util when setting the option to False. Current implementation doesn't include verify_ssl in the auth_config hash if the parameter is non-truthy. Since the Tower API defaults to verify_ssl as True, this makes it impossible to set as False. The fix checks that verify_ssl isn't None, passing along the provided value regardless of truthiness.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/ansible_tower.py

##### ANSIBLE VERSION
4f682e889689d7f2093d80532be542f3fa5e10dd

##### ADDITIONAL INFORMATION

