### PR TITLE
openssl_certificate: Correctly set the version

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -71,6 +71,12 @@ options:
         description:
             - The passphrase for the I(privatekey_path).
 
+    selfsigned_version:
+        default: 3
+        description:
+            - Version of the C(selfsigned) certificate. Nowadays it should almost always be C(3).
+        version_added: "2.5"
+
     selfsigned_digest:
         default: "sha256"
         description:
@@ -374,6 +380,7 @@ class SelfSignedCertificate(Certificate):
         self.notBefore = module.params['selfsigned_notBefore']
         self.notAfter = module.params['selfsigned_notAfter']
         self.digest = module.params['selfsigned_digest']
+        self.version = module.params['selfsigned_version']
         self.csr = crypto_utils.load_certificate_request(self.csr_path)
         self.privatekey = crypto_utils.load_privatekey(
             self.privatekey_path, self.privatekey_passphrase
@@ -406,7 +413,7 @@ class SelfSignedCertificate(Certificate):
                 # 10 years. 315360000 is 10 years in seconds.
                 cert.gmtime_adj_notAfter(315360000)
             cert.set_subject(self.csr.get_subject())
-            cert.set_version(self.csr.get_version() - 1)
+            cert.set_version(self.version - 1)
             cert.set_pubkey(self.csr.get_pubkey())
             cert.add_extensions(self.csr.get_extensions())
 
@@ -740,6 +747,7 @@ def main():
             valid_in=dict(type='int'),
 
             # provider: selfsigned
+            selfsigned_version=dict(type='int', default='3'),
             selfsigned_digest=dict(type='str', default='sha256'),
             selfsigned_notBefore=dict(type='str', aliases=['selfsigned_not_before']),
             selfsigned_notAfter=dict(type='str', aliases=['selfsigned_not_after']),

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -49,7 +49,7 @@ options:
             - The passphrase for the privatekey.
     version:
         required: false
-        default: 3
+        default: 1
         description:
             - Version of the certificate signing request
     force:
@@ -283,7 +283,7 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
 
         if not self.check(module, perms_required=False) or self.force:
             req = crypto.X509Req()
-            req.set_version(self.version)
+            req.set_version(self.version - 1)
             subject = req.get_subject()
             for (key, value) in self.subject.items():
                 if value is not None:
@@ -405,7 +405,7 @@ def main():
             digest=dict(default='sha256', type='str'),
             privatekey_path=dict(require=True, type='path'),
             privatekey_passphrase=dict(type='str', no_log=True),
-            version=dict(default='3', type='int'),
+            version=dict(default='1', type='int'),
             force=dict(default=False, type='bool'),
             path=dict(required=True, type='path'),
             countryName=dict(aliases=['C', 'country_name'], type='str'),

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -28,6 +28,15 @@
           - sha256WithRSAEncryption
           - sha256WithECDSAEncryption
 
+    - name: Generate selfsigned v2 certificate
+      openssl_certificate:
+        path: '{{ output_dir }}/cert_v2.pem'
+        csr_path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        provider: selfsigned
+        selfsigned_digest: sha256
+        selfsigned_version: 2
+
     - name: Generate privatekey2
       openssl_privatekey:
         path: '{{ output_dir }}/privatekey2.pem'

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -6,10 +6,24 @@
   shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert.pem | openssl md5'
   register: cert_modulus
 
+- name: Validate certificate (test - certficate version == default == 3)
+  shell: 'openssl x509 -noout  -in {{ output_dir}}/cert.pem -text | grep "Version" | sed "s/.*: \(.*\) .*/\1/g"'
+  register: cert_version
+
 - name: Validate certificate (assert)
   assert:
     that:
       - cert_modulus.stdout == privatekey_modulus.stdout
+      - cert_version.stdout == '3'
+
+- name: Validate certificate v2 (test - certificate version == 2)
+  shell: 'openssl x509 -noout  -in {{ output_dir}}/cert_v2.pem -text | grep "Version" | sed "s/.*: \(.*\) .*/\1/g"'
+  register: cert_v2_version
+
+- name: Validate certificate version 2 (assert)
+  assert:
+    that:
+      - cert_v2_version.stdout == '2'
 
 - name: Validate certificate2 (test - privatekey modulus)
   shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey2.pem | openssl md5'


### PR DESCRIPTION
##### SUMMARY

Current `openssl_certificate` is mistakenly taking its derivating its
version number from the csr version number.

Thos two fields are completely unrelated and hence the version number of
the certificate should be able to be directly specified (via
`selfsigned_version` parameter).

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

  * crypto/openssl_certificate.py
  * crypto/openssl_csr.py

##### ANSIBLE VERSION

  * devel