### PR TITLE
Run all Windows tests if change detection disabled

### DIFF
--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -19,7 +19,7 @@ python_versions=(
 # shellcheck disable=SC2086
 ansible-test windows-integration "${target}" --explain ${CHANGED:+"$CHANGED"} 2>&1 | { grep ' windows-integration: .* (targeted)$' || true; } > /tmp/windows.txt
 
-if [ -s /tmp/windows.txt ]; then
+if [ -s /tmp/windows.txt ] || [ "${CHANGED:+$CHANGED}" == "" ]; then
     echo "Detected changes requiring integration tests specific to Windows:"
     cat /tmp/windows.txt
 

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -62,10 +62,8 @@ for version in "${python_versions[@]}"; do
                 changed_all_target="none"
             fi
         else
-            # only run smoketest tests for group1
-            if [ "${target}" != "windows/ci/group1/" ]; then continue; fi
-            # without change detection enabled run only smoketest tests
-            ci="windows/ci/smoketest/"
+            # without change detection enabled run entire test group
+            ci="${target}"
         fi
     else
         # only run minimal tests for group1


### PR DESCRIPTION
##### SUMMARY

This will cause all Windows tests to be run as part of the nightly coverage runs, to help avoid failing tests from going undetected for more than a day.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.5.0 (windows-all 99a5549d68) last updated 2017/09/13 18:03:04 (GMT -700)
  config file = None
  configured module search path = [u'/home/matt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/matt/code/mattclay/ansible/lib/ansible
  executable location = /home/matt/code/mattclay/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```
