### PR TITLE
Reuse eip

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_eip.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eip.py
@@ -403,14 +403,17 @@ def main():
         if device_id:
             address = find_address(ec2, public_ip, device_id, isinstance=is_instance)
         else:
-            address = False
+            address = find_address(ec2, public_ip, None)
 
         if state == 'present':
             if device_id:
                 result = ensure_present(ec2, module, domain, address, private_ip_address, device_id,
                                     reuse_existing_ip_allowed, module.check_mode, isinstance=is_instance)
             else:
-                address, changed = allocate_address(ec2, domain, reuse_existing_ip_allowed)
+                if address:
+                    changed = False
+                else:
+                    address, changed = allocate_address(ec2, domain, reuse_existing_ip_allowed)
                 result = {'changed': changed, 'public_ip': address.public_ip, 'allocation_id': address.allocation_id}
         else:
             if device_id:
@@ -422,7 +425,6 @@ def main():
                 else:
                     result = {'changed': disassociated['changed'], 'disassociated': disassociated, 'released': {'changed': False}}
             else:
-                address = find_address(ec2, public_ip, None)
                 released = release_address(ec2, address, module.check_mode)
                 result = {'changed': released['changed'], 'disassociated': {'changed': False}, 'released': released}
 


### PR DESCRIPTION
##### SUMMARY

Fix ec2_eip module so that it allocates an existing EIP if one is available and, more importantly, returns an existing public_ip if not.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_eip

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel d0867edbc3) last updated 2017/09/14 12:09:32 (GMT +1000)
  config file = None
  configured module search path = [u'/Users/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/will/src/ansible/lib/ansible
  executable location = /Users/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
