### PR TITLE
Fix logic error in nxos get_config.

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -115,7 +115,7 @@ class Cli:
     def get_config(self, flags=None):
         """Retrieves the current config from the device or cache
         """
-        flags = [] if flags is None else []
+        flags = [] if flags is None else flags
 
         cmd = 'show running-config '
         cmd += ' '.join(flags)


### PR DESCRIPTION
##### SUMMARY

Fix logic error in nxos get_config.

Fixes https://github.com/ansible/ansible/issues/30310

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

nxos.py

##### ANSIBLE VERSION

```
ansible 2.5.0 (fix-typo c198e75f99) last updated 2017/09/13 22:35:24 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
