### PR TITLE
Set default value for provider transport

### DIFF
--- a/lib/ansible/module_utils/ce.py
+++ b/lib/ansible/module_utils/ce.py
@@ -61,7 +61,7 @@ ce_provider_spec = {
     'use_ssl': dict(type='bool'),
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
-    'transport': dict(choices=['cli']),
+    'transport': dict(default='cli', choices=['cli']),
 }
 ce_argument_spec = {
     'provider': dict(type='dict', options=ce_provider_spec),

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -53,7 +53,7 @@ eos_provider_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'transport': dict(choices=['cli', 'eapi'])
+    'transport': dict(default='cli', choices=['cli', 'eapi'])
 }
 eos_argument_spec = {
     'provider': dict(type='dict', options=eos_provider_spec),
@@ -79,7 +79,7 @@ def check_args(module, warnings):
                     module.params[key]):
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
         else:
-            if key not in ['provider', 'authorize'] and module.params[key]:
+            if key not in ['provider', 'transport', 'authorize'] and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
 
     # set argument's default value if not provided in input

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -51,7 +51,7 @@ nxos_provider_spec = {
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
 
-    'transport': dict(choices=['cli', 'nxapi'])
+    'transport': dict(default='cli', choices=['cli', 'nxapi'])
 }
 nxos_argument_spec = {
     'provider': dict(type='dict', options=nxos_provider_spec),

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -100,6 +100,8 @@ class ActionModule(_ActionModule):
                     provider[key] = self._task.args[key]
                 elif 'fallback' in value:
                     provider[key] = self._fallback(value['fallback'])
+                elif 'default' in value:
+                    provider[key] = value['default']
                 elif key not in provider:
                     provider[key] = None
         return provider

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -124,6 +124,8 @@ class ActionModule(_ActionModule):
                     provider[key] = self._task.args[key]
                 elif 'fallback' in value:
                     provider[key] = self._fallback(value['fallback'])
+                elif 'default' in value:
+                    provider[key] = value['default']
                 elif key not in provider:
                     provider[key] = None
         return provider

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -122,6 +122,8 @@ class ActionModule(_ActionModule):
                     provider[key] = self._task.args[key]
                 elif 'fallback' in value:
                     provider[key] = self._fallback(value['fallback'])
+                elif 'default' in value:
+                    provider[key] = value['default']
                 elif key not in provider:
                     provider[key] = None
         return provider


### PR DESCRIPTION
    Fixes #30331
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

```
Set default value of transport param within provider spec to avoid behavior change before 
and after provider spec validation which was added as part of PR #28894 
```
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_*
nxos_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook:
```
- name: Enable Ethernet1 interface and disable switchport
  eos_config:
    lines:
      - no shutdown
      - no switchport
    parents: int Ethernet1
    authorize: yes
    provider:
      authorize: yes
```
Before
```
{
"changed": false, 
"failed": true, 
"msg": "value of transport must be one of: cli,eapi, got: None found in provider"
}
```
After:
```
changed: [veos01] => {
    "changed": true,
    "commands": [
        "int Ethernet1",
        "no shutdown",
        "no switchport"
    ],
    "failed": false,
    "invocation": {
        "module_args": {
            "after": null,
            "auth_pass": null,
            "authorize": true,
            "backup": false,
            "before": null,
            "defaults": false,
            "diff_against": "session",
            "diff_ignore_lines": null,
            "force": false,
            "host": null,
            "intended_config": null,
            "lines": [
                "no shutdown",
                "no switchport"
            ],
            "match": "line",
            "parents": [
                "int Ethernet1"
            ],
            "password": null,
            "port": null,
            "provider": {
                "auth_pass": null,
                "authorize": true,
                "host": null,
                "password": null,
                "port": null,
                "ssh_keyfile": null,
                "timeout": null,
                "transport": "cli",
                "use_ssl": null,
                "username": null,
                "validate_certs": null
            },
            "replace": "line",
            "running_config": null,
            "save": false,
            "save_when": "never",
            "src": null,
            "ssh_keyfile": null,
            "timeout": null,
            "transport": "cli",
            "use_ssl": true,
            "username": null,
            "validate_certs": true
        }
    },
    "session": "ansible_1505374127",
    "updates": [
        "int Ethernet1",
        "no shutdown",
        "no switchport"
    ]
}
```