### PR TITLE
Fix tags in ec2_instance_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
@@ -500,8 +500,11 @@ def list_ec2_instances(connection, module):
 
     # Turn the boto3 result in to ansible friendly tag dictionary
     for instance in snaked_instances:
-        if 'tags' in instance:
-            instance['tags'] = boto3_tag_list_to_ansible_dict(instance['tags'])
+        if 'tags' in instance and len(instance['tags']) > 0:
+            if 'key' in instance['tags'][0]:
+                instance['tags'] = boto3_tag_list_to_ansible_dict(instance['tags'], 'key', 'value')
+            else:
+                instance['tags'] = boto3_tag_list_to_ansible_dict(instance['tags'])
 
     module.exit_json(instances=snaked_instances)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
@@ -500,11 +500,7 @@ def list_ec2_instances(connection, module):
 
     # Turn the boto3 result in to ansible friendly tag dictionary
     for instance in snaked_instances:
-        if 'tags' in instance and len(instance['tags']) > 0:
-            if 'key' in instance['tags'][0]:
-                instance['tags'] = boto3_tag_list_to_ansible_dict(instance['tags'], 'key', 'value')
-            else:
-                instance['tags'] = boto3_tag_list_to_ansible_dict(instance['tags'])
+        instance['tags'] = boto3_tag_list_to_ansible_dict(instance.get('tags', []), 'key', 'value')
 
     module.exit_json(instances=snaked_instances)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The method boto3_tag_list_to_ansible_dict in module_utils/ec2.py changed
and does no longer check whether the returned result of boto3 uses
"key" or "Key" as the tag key identifier.
This fixes ec2_instance_facts to make this check in its own, since boto3
may return "key" instead of "Key"
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_instance_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
