### PR TITLE
Fixes ipv4 fact gathering

### DIFF
--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -203,7 +203,7 @@ class LinuxNetwork(Network):
                             })
 
                         # add this secondary IP to the main device
-                        if secondary:
+                        if secondary and iface != device:
                             if "ipv4_secondaries" not in interfaces[device]:
                                 interfaces[device]["ipv4_secondaries"] = []
                             interfaces[device]["ipv4_secondaries"].append({


### PR DESCRIPTION


##### SUMMARY
Fixes #29547 and #22257
This ensures that secondary ip's aren't added twice to the ipv4_secondaries fact. I guess this was originally introduced in case one is using subinterfaces, instead of adding the seconary ip's to the main interface. So we are simply checking if iface and device is the same before adding it again. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/module_utils/facts.py

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
