### PR TITLE
Allow multiple values per key in name fields in openssl_certificate/csr

### DIFF
--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -96,6 +96,19 @@ def load_certificate_request(path):
         raise OpenSSLObjectError(exc)
 
 
+def parse_name_field(input_dict):
+    """Take a dict with key: value or key: list_of_values mappings and return a list of tuples"""
+
+    result = []
+    for key in input_dict:
+        if isinstance(input_dict[key], basestring):
+            for entry in input_dict[key]:
+                result.append((key, entry))
+        else:
+            result.append((key, input_dict[key]))
+    return result
+
+
 @six.add_metaclass(abc.ABCMeta)
 class OpenSSLObject(object):
 

--- a/lib/ansible/module_utils/crypto.py
+++ b/lib/ansible/module_utils/crypto.py
@@ -101,7 +101,7 @@ def parse_name_field(input_dict):
 
     result = []
     for key in input_dict:
-        if isinstance(input_dict[key], basestring):
+        if isinstance(input_dict[key], list):
             for entry in input_dict[key]:
                 result.append((key, entry))
         else:

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -109,11 +109,13 @@ options:
 
     issuer:
         description:
-            - Key/value pairs that must be present in the issuer name field of the certificate
+            - Key/value pairs that must be present in the issuer name field of the certificate.
+              If you need to specify more than one value with the same key, use a list as value.
 
     subject:
         description:
-            - Key/value pairs that must be present in the subject name field of the certificate
+            - Key/value pairs that must be present in the subject name field of the certificate.
+              If you need to specify more than one value with the same key, use a list as value.
 
     has_expired:
         default: False
@@ -501,7 +503,7 @@ class AssertOnlyCertificate(Certificate):
 
         def _validate_subject():
             if self.subject:
-                cert_subject = self.cert.get_subject().get_components()
+                cert_subject = crypto_utils.parse_name_field(self.cert.get_subject())
                 diff = [item for item in self.subject.items() if item not in cert_subject]
                 if diff:
                     self.message.append(
@@ -510,7 +512,7 @@ class AssertOnlyCertificate(Certificate):
 
         def _validate_issuer():
             if self.issuer:
-                cert_issuer = self.cert.get_issuer().get_components()
+                cert_issuer = crypto_utils.parse_name_field(self.cert.get_issuer())
                 diff = [item for item in self.issuer.items() if item not in cert_issuer]
                 if diff:
                     self.message.append(

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -489,7 +489,7 @@ class AssertOnlyCertificate(Certificate):
                       'notAfter', 'valid_at', 'invalid_at']:
 
             attr = getattr(self, param)
-            if isinstance(attr, list):
+            if isinstance(attr, list) and attr:
                 if isinstance(attr[0], str):
                     setattr(self, param, [to_bytes(item) for item in attr])
                 elif isinstance(attr[0], tuple):

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -512,7 +512,7 @@ class AssertOnlyCertificate(Certificate):
         def _validate_subject():
             if self.subject:
                 subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in self.subject]
-                current_subject = self.cert.get_subject().get_components()
+                current_subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in self.cert.get_subject().get_components()]
                 if (not self.subject_strict and not all(x in current_subject for x in subject)) or \
                    (self.subject_strict and not set(subject) == set(current_subject)):
                     diff = [item for item in self.subject if item not in current_subject]
@@ -523,7 +523,7 @@ class AssertOnlyCertificate(Certificate):
         def _validate_issuer():
             if self.issuer:
                 issuer = [(OpenSSL._util.lib.OBJ_txt2nid(iss[0]), iss[1]) for iss in self.issuer]
-                current_issuer = self.cert.get_issuer().get_components()
+                current_issuer = [(OpenSSL._util.lib.OBJ_txt2nid(iss[0]), iss[1]) for iss in self.cert.get_issuer().get_components()]
                 if (not self.issuer_strict and not all(x in current_issuer for x in issuer)) or \
                    (self.issuer_strict and not set(issuer) == set(current_issuer)):
                     diff = [item for item in self.issuer if item not in current_issuer]

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -455,9 +455,15 @@ class AssertOnlyCertificate(Certificate):
     def __init__(self, module):
         super(AssertOnlyCertificate, self).__init__(module)
         self.signature_algorithms = module.params['signature_algorithms']
-        self.subject = crypto_utils.parse_name_field(module.params['subject'])
+        if module.params['subject']:
+            self.subject = crypto_utils.parse_name_field(module.params['subject'])
+        else:
+            self.subject = []
         self.subject_strict = False
-        self.issuer = crypto_utils.parse_name_field(module.params['issuer'])
+        if module.params['issuer']:
+            self.issuer = crypto_utils.parse_name_field(module.params['issuer'])
+        else:
+            self.issuer = []
         self.issuer_strict = False
         self.has_expired = module.params['has_expired']
         self.version = module.params['version']

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -503,8 +503,8 @@ class AssertOnlyCertificate(Certificate):
 
         def _validate_subject():
             if self.subject:
-                cert_subject = crypto_utils.parse_name_field(self.cert.get_subject())
-                diff = [item for item in self.subject.items() if item not in cert_subject]
+                cert_subject = self.cert.get_subject().get_components()
+                diff = [item for item in crypto_utils.parse_name_field(self.subject) if item not in cert_subject]
                 if diff:
                     self.message.append(
                         'Invalid subject component (got %s, expected all of %s to be present)' % (cert_subject, self.subject.items())
@@ -512,8 +512,8 @@ class AssertOnlyCertificate(Certificate):
 
         def _validate_issuer():
             if self.issuer:
-                cert_issuer = crypto_utils.parse_name_field(self.cert.get_issuer())
-                diff = [item for item in self.issuer.items() if item not in cert_issuer]
+                cert_issuer = self.cert.get_issuer().get_components()
+                diff = [item for item in crypto_utils.parse_name_field(self.issuer) if item not in cert_issuer]
                 if diff:
                     self.message.append(
                         'Invalid issuer component (got %s, expected all of %s to be present)' % (cert_issuer, self.issuer.items())

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -312,9 +312,9 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             req = crypto.X509Req()
             req.set_version(self.version - 1)
             subject = req.get_subject()
-            for (key, value) in self.subject.items():
-                if value is not None:
-                    setattr(subject, key, value)
+            for entry in self.subject:
+                if entry[1] is not None:
+                    setattr(subject, entry[0], entry[1])
 
             altnames = ', '.join(self.subjectAltName)
             extensions = [crypto.X509Extension(b"subjectAltName", self.subjectAltName_critical, altnames.encode('ascii'))]

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -299,7 +299,7 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
         ]
 
         self.subject = self.subject + crypto_utils.parse_name_field(module.params['subject'])
-        self.subject = [(k, v) for k, v in self.subject.items() if v]
+        self.subject = [(entry[0], entry[1]) for entry in self.subject if entry[1]]
 
         if not self.subjectAltName:
             self.subjectAltName = ['DNS:%s' % module.params['commonName']]

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -23,7 +23,7 @@ description:
     - "This module allows one to (re)generate OpenSSL certificate signing requests.
        It uses the pyOpenSSL python library to interact with openssl. This module supports
        the subjectAltName as well as the keyUsage and extendedKeyUsage extensions.
-       Note: At least one of common_name or subject_alt_name must be specified."
+       Note: At least one of subject, common_name or subject_alt_name must be specified."
 requirements:
     - "python-pyOpenSSL >= 0.15"
 options:
@@ -464,7 +464,7 @@ def main():
         ),
         add_file_common_args=True,
         supports_check_mode=True,
-        required_one_of=[['commonName', 'subjectAltName']],
+        required_one_of=[['commonName', 'subjectAltName', 'subject']],
     )
 
     if not pyopenssl_found:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -298,7 +298,8 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             ('emailAddress', module.params['emailAddress']),
         ]
 
-        self.subject = self.subject + crypto_utils.parse_name_field(module.params['subject'])
+        if module.params['subject']:
+            self.subject = self.subject + crypto_utils.parse_name_field(module.params['subject'])
         self.subject = [(entry[0], entry[1]) for entry in self.subject if entry[1]]
 
         if not self.subjectAltName:

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -305,7 +305,7 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
 
         if not self.subjectAltName:
             for sub in self.subject:
-                if OpenSSL._util.lib.OBJ_txt2nid(sub[0]) == 13:  # 13 is the NID for "commonName"
+                if OpenSSL._util.lib.OBJ_txt2nid(to_bytes(sub[0])) == 13:  # 13 is the NID for "commonName"
                     self.subjectAltName = ['DNS:%s' % sub[1]]
                     break
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -359,7 +359,7 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
 
         def _check_subject(csr):
             subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in self.subject]
-            current_subject = csr.get_subject()
+            current_subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in csr.get_subject()]
             if not set(subject) == set(current_subject):
                 return False
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -318,8 +318,9 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
             subject = req.get_subject()
             for entry in self.subject:
                 if entry[1] is not None:
-                    nid = OpenSSL._util.lib.OBJ_txt2nid(entry[0])
-                    OpenSSL._util.lib.X509_NAME_add_entry_by_NID(subject._name, nid, OpenSSL._util.lib.MBSTRING_UTF8, entry[1], -1, -1, 0)
+                    # Workaround for https://github.com/pyca/pyopenssl/issues/165
+                    nid = OpenSSL._util.lib.OBJ_txt2nid(to_bytes(entry[0]))
+                    OpenSSL._util.lib.X509_NAME_add_entry_by_NID(subject._name, nid, OpenSSL._util.lib.MBSTRING_UTF8, to_bytes(entry[1]), -1, -1, 0)
 
             altnames = ', '.join(self.subjectAltName)
             extensions = [crypto.X509Extension(b"subjectAltName", self.subjectAltName_critical, altnames.encode('ascii'))]
@@ -362,8 +363,8 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
         self.privatekey = crypto_utils.load_privatekey(self.privatekey_path, self.privatekey_passphrase)
 
         def _check_subject(csr):
-            subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in self.subject]
-            current_subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in csr.get_subject().get_components()]
+            subject = [(OpenSSL._util.lib.OBJ_txt2nid(to_bytes(sub[0])), to_bytes(sub[1])) for sub in self.subject]
+            current_subject = [(OpenSSL._util.lib.OBJ_txt2nid(to_bytes(sub[0])), to_bytes(sub[1])) for sub in csr.get_subject().get_components()]
             if not set(subject) == set(current_subject):
                 return False
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -358,10 +358,10 @@ class CertificateSigningRequest(crypto_utils.OpenSSLObject):
         self.privatekey = crypto_utils.load_privatekey(self.privatekey_path, self.privatekey_passphrase)
 
         def _check_subject(csr):
-            subject = csr.get_subject()
-            for entry in self.subject:
-                if getattr(subject, entry[0], None) != entry[1]:
-                    return False
+            subject = [(OpenSSL._util.lib.OBJ_txt2nid(sub[0]), sub[1]) for sub in self.subject]
+            current_subject = csr.get_subject()
+            if not set(subject) == set(current_subject):
+                return False
 
             return True
 

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -65,7 +65,8 @@ options:
         required: false
         description:
             - Key/value pairs that will be present in the subject name field of the certificate signing request.
-              If you need to specify more than one value with the same key, use a list as value.
+            - If you need to specify more than one value with the same key, use a list as value.
+        version_added: '2.5'
     country_name:
         required: false
         aliases: [ 'C', 'countryName' ]
@@ -222,7 +223,7 @@ subject:
     description: A list of the subject tuples attached to the CSR
     returned: changed or success
     type: list
-    sample: [('CN', 'www.ansible.com'), ('O', 'Ansible')]
+    sample: `[ ('CN', 'www.ansible.com'), ('O', 'Ansible') ]`
 subjectAltName:
     description: The alternative names this CSR is valid for
     returned: changed or success

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -223,7 +223,7 @@ subject:
     description: A list of the subject tuples attached to the CSR
     returned: changed or success
     type: list
-    sample: `[ ('CN', 'www.ansible.com'), ('O', 'Ansible') ]`
+    sample: "[('CN', 'www.ansible.com'), ('O', 'Ansible')]"
 subjectAltName:
     description: The alternative names this CSR is valid for
     returned: changed or success

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -43,14 +43,16 @@
 
     - name: Generate CSR2
       openssl_csr:
-        C: US
-        ST: California
-        L: Los Angeles
-        O: ACME Inc.
-        OU: Roadrunner pest control
+        subject:
+          CN: 'www.example.com'
+          C: US
+          ST: California
+          L: Los Angeles
+          O: ACME Inc.
+          OU: Roadrunner pest control
+          OU: Pyrotechnics
         path: '{{ output_dir }}/csr2.csr'
         privatekey_path: '{{ output_dir }}/privatekey2.pem'
-        CN: 'www.example.com'
         keyUsage:
           - digitalSignature
         extendedKeyUsage:
@@ -82,6 +84,7 @@
           L: Los Angeles
           O: ACME Inc.
           OU: Roadrunner pest control
+          OU: Pyrotechnics
         keyUsage:
           - digitalSignature
         extendedKeyUsage:

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -7,7 +7,8 @@
       openssl_csr:
         path: '{{ output_dir }}/csr.csr'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
-        commonName: 'www.ansible.com'
+        subject:
+          commonName: www.example.com
 
     - name: Generate selfsigned certificate
       openssl_certificate:
@@ -27,6 +28,8 @@
         signature_algorithms:
           - sha256WithRSAEncryption
           - sha256WithECDSAEncryption
+        subject:
+          commonName: www.example.com
 
     - name: Generate selfsigned v2 certificate
       openssl_certificate:
@@ -44,13 +47,14 @@
     - name: Generate CSR2
       openssl_csr:
         subject:
-          CN: 'www.example.com'
+          CN: www.example.com
           C: US
           ST: California
           L: Los Angeles
           O: ACME Inc.
-          OU: Roadrunner pest control
-          OU: Pyrotechnics
+          OU:
+            - Roadrunner pest control
+            - Pyrotechnics
         path: '{{ output_dir }}/csr2.csr'
         privatekey_path: '{{ output_dir }}/privatekey2.pem'
         keyUsage:
@@ -83,8 +87,9 @@
           ST: California
           L: Los Angeles
           O: ACME Inc.
-          OU: Roadrunner pest control
-          OU: Pyrotechnics
+          OU:
+            - Roadrunner pest control
+            - Pyrotechnics
         keyUsage:
           - digitalSignature
         extendedKeyUsage:

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -82,7 +82,7 @@
           - sha256WithRSAEncryption
           - sha256WithECDSAEncryption
         subject:
-          CN: www.example.com
+          commonName: www.example.com
           C: US
           ST: California
           L: Los Angeles

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -1,9 +1,9 @@
 - name: Validate certificate (test - privatekey modulus)
-  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey_modulus
 
 - name: Validate certificate (test - certificate modulus)
-  shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert.pem | openssl md5'
+  shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert.pem'
   register: cert_modulus
 
 - name: Validate certificate (test - certficate version == default == 3)
@@ -26,11 +26,11 @@
       - cert_v2_version.stdout == '2'
 
 - name: Validate certificate2 (test - privatekey modulus)
-  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey2.pem | openssl md5'
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey2.pem'
   register: privatekey2_modulus
 
 - name: Validate certificate2 (test - certificate modulus)
-  shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert2.pem | openssl md5'
+  shell: 'openssl x509 -noout -modulus -in {{ output_dir }}/cert2.pem'
   register: cert2_modulus
 
 - name: Validate certificate2 (assert)

--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -7,7 +7,8 @@
       openssl_csr:
         path: '{{ output_dir }}/csr.csr'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
-        commonName: 'www.ansible.com'
+        subject:
+          commonName: www.ansible.com
 
     # keyUsage longname and shortname should be able to be used
     # interchangeably. Hence the long name is specified here
@@ -17,7 +18,8 @@
       openssl_csr:
         path: '{{ output_dir }}/csr_ku_xku.csr'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
-        commonName: 'www.ansible.com'
+        subject:
+          CN: www.ansible.com
         keyUsage:
           - digitalSignature
           - keyAgreement
@@ -31,7 +33,8 @@
       openssl_csr:
         path: '{{ output_dir }}/csr_ku_xku.csr'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
-        commonName: 'www.ansible.com'
+        subject:
+          commonName: 'www.ansible.com'
         keyUsage:
           - digitalSignature
           - keyAgreement

--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -45,6 +45,12 @@
           - Biometric Info
       register: csr_ku_xku
 
+    - name: Generate CSR with old API
+      openssl_csr:
+        path: '{{ output_dir }}/csr_oldapi.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        commonName: www.ansible.com
+
     - import_tasks: ../tests/validate.yml
 
   when: pyopenssl_version.stdout is version('0.15', '>=')

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -22,15 +22,15 @@
       - csr_ku_xku.changed == False
 
 - name: Validate old_API CSR (test - Common Name)
-  shell: "openssl req -noout -subject -in {{ output_dir }}/csr_olddapi.csr -nameopt oneline,-space_eq"
-  register: csr_olddapi_cn
+  shell: "openssl req -noout -subject -in {{ output_dir }}/csr_oldapi.csr -nameopt oneline,-space_eq"
+  register: csr_oldapi_cn
 
 - name: Validate old_API CSR (test - csr modulus)
-  shell: 'openssl req -noout -modulus -in {{ output_dir }}/csr_olddapi.csr'
-  register: csr_olddapi_modulus
+  shell: 'openssl req -noout -modulus -in {{ output_dir }}/csr_oldapi.csr'
+  register: csr_oldapi_modulus
 
 - name: Validate old_API CSR (assert)
   assert:
     that:
-      - csr_olddapi_cn.stdout.split('=')[-1] == 'www.ansible.com'
-      - csr_olddapi_modulus.stdout == privatekey_modulus.stdout
+      - csr_oldapi_cn.stdout.split('=')[-1] == 'www.ansible.com'
+      - csr_oldapi_modulus.stdout == privatekey_modulus.stdout

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -1,5 +1,5 @@
 - name: Validate CSR (test - privatekey modulus)
-  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey_modulus
 
 - name: Validate CSR (test - Common Name)
@@ -7,7 +7,7 @@
   register: csr_cn
 
 - name: Validate CSR (test - csr modulus)
-  shell: 'openssl req -noout -modulus -in {{ output_dir }}/csr.csr | openssl md5'
+  shell: 'openssl req -noout -modulus -in {{ output_dir }}/csr.csr'
   register: csr_modulus
 
 - name: Validate CSR (assert)

--- a/test/integration/targets/openssl_csr/tests/validate.yml
+++ b/test/integration/targets/openssl_csr/tests/validate.yml
@@ -20,3 +20,17 @@
   assert:
     that:
       - csr_ku_xku.changed == False
+
+- name: Validate old_API CSR (test - Common Name)
+  shell: "openssl req -noout -subject -in {{ output_dir }}/csr_olddapi.csr -nameopt oneline,-space_eq"
+  register: csr_olddapi_cn
+
+- name: Validate old_API CSR (test - csr modulus)
+  shell: 'openssl req -noout -modulus -in {{ output_dir }}/csr_olddapi.csr'
+  register: csr_olddapi_modulus
+
+- name: Validate old_API CSR (assert)
+  assert:
+    that:
+      - csr_olddapi_cn.stdout.split('=')[-1] == 'www.ansible.com'
+      - csr_olddapi_modulus.stdout == privatekey_modulus.stdout

--- a/test/integration/targets/openssl_publickey/tests/validate.yml
+++ b/test/integration/targets/openssl_publickey/tests/validate.yml
@@ -1,9 +1,9 @@
 - name: Validate public key (test - privatekey modulus)
-  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey_modulus
 
 - name: Validate public key (test - publickey modulus)
-  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey.pub  | openssl md5'
+  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey.pub'
   register: publickey_modulus
 
 - name: Validate public key (assert)
@@ -46,12 +46,12 @@
 
 
 - name: Validate publickey3 (test - privatekey modulus)
-  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey3.pem -passin pass:ansible | openssl md5'
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey3.pem -passin pass:ansible'
   register: privatekey3_modulus
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey3 (test - publickey modulus)
-  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey3.pub  | openssl md5'
+  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey3.pub'
   register: publickey3_modulus
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
@@ -67,12 +67,12 @@
       - publickey3_idempotence is not changed
 
 - name: Validate publickey4 (test - privatekey modulus)
-  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem'
   register: privatekey4_modulus
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey4 (test - publickey modulus)
-  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey4.pub  | openssl md5'
+  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey4.pub'
   register: publickey4_modulus
   when: openssl_version.stdout is version('0.9.8zh', '>=')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
x509 certificates can contain more than one value with the same key in the issuer and subject fields.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openssl_certificate

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
~~This is the easier part of #29946 which doesn't break existing syntax, it only extends it. The harder part will be the followup to either deprecate the current openssl_csr syntax or to offer this one as an alternative. I can't write integration tests for this until openssl_csr is done though, so marking this as WIP until that syntax change is discussed.~~

PR contains both changes to openssl_certificate and openssl_csr.