### PR TITLE
Remove all cli provider options from nxos tests

### DIFF
--- a/test/integration/targets/nxos_acl/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_acl/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_acl_interface/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_banner/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_banner/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_af/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_bgp_neighbor_af/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_command/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_command/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_command/tests/cli/bad_operator.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/bad_operator.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state foo up"
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_command/tests/cli/contains.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/contains.yaml
@@ -9,7 +9,6 @@
     wait_for:
       - "result[0] contains NX-OS"
       - "result[1].TABLE_interface.ROW_interface.interface contains mgmt"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/equal.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/equal.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state eq up"
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +21,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state == up"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/greaterthan.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/greaterthan.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask gt 0"
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +21,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask > 0"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/greaterthanorequal.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/greaterthanorequal.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask ge 0"
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +21,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask >= 0"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/invalid.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/invalid.yaml
@@ -4,7 +4,6 @@
 - name: run invalid command
   nxos_command:
     commands: ['show foo']
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 
@@ -17,7 +16,6 @@
     commands:
       - show version
       - show foo
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_command/tests/cli/lessthan.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/lessthan.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask lt 33"
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +21,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask lt 33"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/lessthanorequal.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/lessthanorequal.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask le 32"
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +21,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.eth_ip_mask <= 32"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/notequal.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/notequal.yaml
@@ -8,7 +8,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state neq down"
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -23,7 +22,6 @@
       - show interface mgmt0 | json
     wait_for:
       - "result[1].TABLE_interface.ROW_interface.state != down"
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/output.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/output.yaml
@@ -4,7 +4,6 @@
 - name: get output for single command
   nxos_command:
     commands: ['show version']
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -16,7 +15,6 @@
     commands:
       - show version
       - show interface
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/nxos_command/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/sanity.yaml
@@ -5,14 +5,12 @@
   nxos_feature:
     feature: bgp
     state: disabled
-    provider: "{{ cli }}"
 
 - block:
   - name: "Run show running-config bgp - should fail"
     nxos_command:
       commands:
         - sh running-config bgp
-      provider: "{{ cli }}"
     ignore_errors: yes
     register: result
 
@@ -25,14 +23,12 @@
     nxos_feature:
       feature: bgp
       state: enabled
-      provider: "{{ cli }}"
 
   - name: "Configure BGP defaults"
     nxos_bgp: &configure_default
       asn: 65535
       router_id: 1.1.1.1
       state: present
-      provider: "{{ cli }}"
     register: result
 
   - assert: &true
@@ -43,7 +39,6 @@
     nxos_command:
       commands:
         - sh running-config bgp
-      provider: "{{ cli }}"
     register: result
 
   - assert:
@@ -55,7 +50,6 @@
     nxos_command:
       commands:
         - show interface bief
-      provider: "{{ cli }}"
     ignore_errors: yes
     register: result
 
@@ -69,6 +63,5 @@
     nxos_feature:
       feature: bgp
       state: disabled
-      provider: "{{ cli }}"
 
   - debug: msg="END TRANSPORT:CLI nxos_command sanity test"

--- a/test/integration/targets/nxos_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/nxos_command/tests/cli/timeout.yaml
@@ -7,7 +7,6 @@
       - show version
     wait_for:
       - "result[0] contains bad_value_string"
-    provider: "{{ cli }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_config/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_config/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_config/tests/cli/multilevel.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/multilevel.yaml
@@ -4,19 +4,16 @@
 - name: get config
   nxos_command:
     commands: show running-config
-    provider: "{{ cli }}"
   register: config
 
 - name: enable feature bgp
   nxos_config:
     lines: feature bgp
-    provider: "{{ cli }}"
   when: "'feature bgp' not in config.stdout[0]"
 
 - name: remove bgp
   nxos_config:
     lines: no router bgp 1
-    provider: "{{ cli }}"
   when: "'router bgp 1' in config.stdout[0]"
 
 - name: configure multi level command
@@ -25,7 +22,6 @@
     parents:
       - router bgp 1
       - address-family ipv4 unicast
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -41,7 +37,6 @@
     parents:
       - router bgp 1
       - address-family ipv4 unicast
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -53,6 +48,5 @@
     lines:
       - no feature bgp
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/mulitlevel.yaml"

--- a/test/integration/targets/nxos_config/tests/cli/sublevel.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/sublevel.yaml
@@ -4,14 +4,12 @@
 - name: setup
   nxos_config:
     lines: no ip access-list test
-    provider: "{{ cli }}"
     match: none
 
 - name: configure sub level command
   nxos_config:
     lines: 10 permit ip any any log
     parents: ip access-list test
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -24,7 +22,6 @@
   nxos_config:
     lines: 10 permit ip any any log
     parents: ip access-list test
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -34,7 +31,6 @@
 - name: teardown
   nxos_config:
     lines: no ip access-list test
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg='END cli/sublevel.yaml'

--- a/test/integration/targets/nxos_config/tests/cli/sublevel_exact.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/sublevel_exact.yaml
@@ -11,7 +11,6 @@
       - 50 permit ip 5.5.5.5/32 any log
     parents: ip access-list test
     before: no ip access-list test
-    provider: "{{ cli }}"
     match: none
 
 - name: configure sub level command using exact match
@@ -23,7 +22,6 @@
       - 40 permit ip 4.4.4.4/32 any log
     parents: ip access-list test
     match: exact
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -46,7 +44,6 @@
       - 50 permit ip 5.5.5.5/32 any log
     parents: ip access-list test
     match: exact
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -56,7 +53,6 @@
 - name: teardown
   nxos_config:
     lines: no ip access-list test
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg='END cli/sublevel_exact.yaml'

--- a/test/integration/targets/nxos_config/tests/cli/sublevel_strict.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/sublevel_strict.yaml
@@ -11,7 +11,6 @@
       - 50 permit ip 5.5.5.5/32 any log
     parents: ip access-list test
     before: no ip access-list test
-    provider: "{{ cli }}"
     match: none
 
 - name: configure sub level command using strict match
@@ -25,7 +24,6 @@
     before: no ip access-list test
     match: strict
     replace: block
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -47,7 +45,6 @@
       - 40 permit ip 4.4.4.4/32 any log
     parents: ip access-list test
     match: strict
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -57,7 +54,6 @@
 - name: teardown
   nxos_config:
     commands: no ip access-list test
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg='END cli/sublevel_strict.yaml'

--- a/test/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/toplevel_after.yaml
@@ -6,14 +6,12 @@
     lines:
       - "snmp-server contact ansible"
       - "hostname switch"
-    provider: "{{ cli }}"
     match: none
 
 - name: configure top level command with before
   nxos_config:
     lines: hostname foo
     after: snmp-server contact bar
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +24,6 @@
   nxos_config:
     lines: hostname foo
     after: snmp-server contact foo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -38,7 +35,6 @@
     lines:
       - "no snmp-server contact"
       - "hostname switch"
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg='END cli/toplevel_after.yaml'

--- a/test/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/nxos_config/tests/cli/toplevel_before.yaml
@@ -6,14 +6,12 @@
     lines:
       - "snmp-server contact ansible"
       - "hostname switch"
-    provider: "{{ cli }}"
     match: none
 
 - name: configure top level command with before
   nxos_config:
     lines: hostname foo
     before: snmp-server contact bar
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -26,7 +24,6 @@
   nxos_config:
     lines: hostname foo
     before: snmp-server contact foo
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -38,7 +35,6 @@
     lines:
       - "no snmp-server contact"
       - "hostname switch"
-    provider: "{{ cli }}"
     match: none
 
 - debug: msg='END cli/toplevel_before.yaml'

--- a/test/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_evpn_global/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_evpn_vni/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_facts/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_facts/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_feature/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_feature/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_igmp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_igmp/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_interface/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_interface_ospf/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ip_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ip_interface/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ip_interface/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_ip_interface/tests/cli/sanity.yaml
@@ -8,14 +8,12 @@
   nxos_config: &intdefault1
     lines:
       - "default interface {{ testint1 }}"
-    provider: "{{ cli }}"
   ignore_errors: yes
 
 - name: "Put interface {{testint2}} into default state"
   nxos_config: &intdefault2
     lines:
       - "default interface {{ testint2 }}"
-    provider: "{{ cli }}"
   ignore_errors: yes
 
 - name: "Make {{testint1}} a layer3 interface"
@@ -25,7 +23,6 @@
     description: 'Configured by Ansible - Layer3'
     admin_state: 'up'
     state: present
-    provider: "{{ cli }}"
 
 - name: "Make {{testint2}} a layer3 interface"
   nxos_interface: &l3int2
@@ -34,7 +31,6 @@
     description: 'Configured by Ansible - Layer3'
     admin_state: 'up'
     state: present
-    provider: "{{ cli }}"
 
 # For titanium
 - name: Clear interface v4
@@ -44,7 +40,6 @@
     state: absent
     addr: 20.20.20.20
     mask: 24
-    provider: "{{ cli }}"
 
 # For titanium
 - name: Clear interface v6
@@ -54,7 +49,6 @@
     state: absent
     addr: 'fd56:31f7:e4ad:5585::1'
     mask: 64
-    provider: "{{ cli }}"
 
 - name: Ensure ipv4 address is configured
   nxos_ip_interface: &ipv4
@@ -63,7 +57,6 @@
     state: present
     addr: 20.20.20.20
     mask: 24
-    provider: "{{ cli }}"
   register: result
 
 - assert: &true
@@ -85,7 +78,6 @@
     state: present
     addr: 'fd56:31f7:e4ad:5585::1'
     mask: 64
-    provider: "{{ cli }}"
   register: result
 
 - assert: *true

--- a/test/integration/targets/nxos_logging/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_logging/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_mtu/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_mtu/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ntp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ntp/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_nxapi/tasks/cli.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/cli.yaml
@@ -18,4 +18,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_nxapi/tests/cli/badtransport.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/badtransport.yaml
@@ -6,7 +6,6 @@
     enable_http: no
     enable_sandbox: no
     https_port: 9443
-    provider: "{{ nxapi }}"
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/nxos_nxapi/tests/cli/config.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/config.yaml
@@ -6,20 +6,17 @@
   nxos_config:
     lines: no feature nxapi
     match: none
-    provider: "{{ cli }}"
   connection: local
 
 - name: Get running-config
   nxos_command:
     commands: show running-config
-    provider: "{{ cli }}"
   register: config
   connection: local
 
 - name: Set config
   nxos_nxapi:
     config: "{{ config.stdout[0] }}"
-    provider: "{{ cli }}"
   register: config
   connection: local
 
@@ -40,14 +37,12 @@
 - name: Get running-config again
   nxos_command:
     commands: show running-config
-    provider: "{{ cli }}"
   register: runningconfig
   connection: local
 
 - name: Set config
   nxos_nxapi:
     config: "{{ runningconfig.stdout[0] }}"
-    provider: "{{ cli }}"
   register: config
   connection: local
 
@@ -65,7 +60,6 @@
 - name: Set config - FIXME, shouldn't need this
   nxos_nxapi:
     config: "{{ runningconfig.stdout[0] }}"
-    provider: "{{ cli }}"
   register: config
   connection: local
 

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -7,7 +7,6 @@
 - name: Setup - put NXAPI in stopped state
   nxos_nxapi:
     state: absent
-    provider: "{{ cli }}"
 
 - name: Configure NXAPI
   nxos_nxapi:
@@ -15,13 +14,11 @@
     enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
     enable_https: yes
     https_port: 9443
-    provider: "{{ cli }}"
   register: result
 
 - nxos_command:
     commands:
       - show nxapi | json
-    provider: "{{ cli }}"
   register: result
 
 - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
@@ -36,7 +33,6 @@
     enable_sandbox: "{{nxapi_sandbox_option|default(omit)}}"
     enable_https: yes
     https_port: 9443
-    provider: "{{ cli }}"
   register: result
 
 - name: Assert configuration is idempotent

--- a/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
@@ -4,7 +4,6 @@
 - name: Disable NXAPI
   nxos_nxapi:
     state: absent
-    provider: "{{ cli }}"
   register: result
   # delegate_to: "{{ delegate_to }}"
 
@@ -15,7 +14,6 @@
   nxos_command:
     commands:
       - show feature | grep nxapi
-    provider: "{{ cli }}"
   register: result
   # delegate_to: "{{ delegate_to }}"
 
@@ -31,7 +29,6 @@
   nxos_nxapi:
     state:
       absent
-    provider: "{{ cli }}"
   register: result
   # delegate_to: "{{ delegate_to }}"
 

--- a/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -4,20 +4,17 @@
 - name: Setup - put NXAPI in stopped state
   nxos_nxapi:
       state: absent
-      provider: "{{ cli }}"
   register: result
 
 - name: Enable NXAPI
   nxos_nxapi:
       state: present
-      provider: "{{ cli }}"
   register: result
 
 - name: Check NXAPI state
   nxos_command:
       commands:
           - show feature | grep nxapi
-      provider: "{{ cli }}"
   register: result
 
 - name: Assert NXAPI is enabled
@@ -26,7 +23,6 @@
 
 - name: Enable NXAPI again
   nxos_nxapi:
-      provider: "{{ cli }}"
   register: result
 
 - name: Assert idempotence

--- a/test/integration/targets/nxos_ospf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ospf/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_ospf_vrf/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_overlay_global/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_portchannel/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_portchannel/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_rollback/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_rollback/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_switchport/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_switchport/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_system/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_system/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/set_domain_list.yaml
@@ -7,14 +7,12 @@
       - no ip domain-list ansible.com
       - no ip domain-list redhat.com
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_list
   nxos_system:
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -28,7 +26,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -39,7 +36,6 @@
   nxos_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -51,7 +47,6 @@
   nxos_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -63,7 +58,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -76,7 +70,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -88,7 +81,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -103,7 +95,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -117,6 +108,5 @@
       - no ip domain-list redhat.com
       - no ip domain-list eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_search.yaml"

--- a/test/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/set_domain_name.yaml
@@ -5,12 +5,10 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - name: configure domain_name
   nxos_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -20,7 +18,6 @@
 - name: verify domain_name
   nxos_system:
     domain_name: eng.ansible.com
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -31,6 +28,5 @@
   nxos_config:
     lines: no ip domain-name eng.ansible.com
     match: none
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_name.yaml"

--- a/test/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/nxos_system/tests/cli/set_name_servers.yaml
@@ -8,7 +8,6 @@
       - no ip name-server 2.2.2.2
       - no ip name-server 3.3.3.3
     match: none
-    provider: "{{ cli }}"
 
 - name: configure name_servers
   nxos_system:
@@ -16,7 +15,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -32,7 +30,6 @@
       - 1.1.1.1
       - 2.2.2.2
       - 3.3.3.3
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -45,7 +42,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
 #  register: result
 
 #- assert:
@@ -61,7 +57,6 @@
 #      - 1.1.1.1
 #      - { server: 2.2.2.2, vrf: ansible }
 #      - 3.3.3.3
-#    provider: "{{ cli }}"
 #  register: result
 #
 #- assert:
@@ -73,7 +68,6 @@
     name_servers:
       - 1.1.1.1
       - 2.2.2.2
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -87,7 +81,6 @@
     lines:
       - no ip lookup source-interface
     match: none
-    provider: "{{ cli }}"
   ignore_errors: yes
   # FIXME Copied from iosxr, not sure what we need here
 

--- a/test/integration/targets/nxos_user/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_user/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vlan/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vlan/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vpc/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vpc/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vpc_interface/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrf/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf_af/tasks/nxapi.yaml
@@ -13,7 +13,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }}"
@@ -25,4 +24,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrf_interface/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vrrp/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vrrp/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_domain/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_password/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vtp_version/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"

--- a/test/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tasks/nxapi.yaml
@@ -23,7 +23,6 @@
     lines:
       - feature nxapi
       - nxapi http port 80
-    provider: "{{ cli }}"
 
 - name: run test case
   include: "{{ test_case_to_run }} connection={{ nxapi }}"
@@ -35,4 +34,3 @@
   nxos_config:
     lines:
       - no feature nxapi
-    provider: "{{ cli }}"


### PR DESCRIPTION
##### ISSUE TYPE
Feature PullRequest

##### ANSIBLE VERSION
N/A

##### SUMMARY
Transport is by default cli, so no point in passing a provider dict
cli that just contains transport: cli