### PR TITLE
[2.4.1] Fixes verify_ssl option when False in ansible_tower module util (#30308)

### DIFF
--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -62,7 +62,7 @@ def tower_auth_config(module):
         if password:
             auth_config['password'] = password
         verify_ssl = module.params.get('tower_verify_ssl')
-        if verify_ssl:
+        if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl
         return auth_config
 


### PR DESCRIPTION
* Fixes verify_ssl option when False in ansible_tower module util

* fixed comparison to None per PEP-8 standards

(cherry picked from commit 4980ebf06477b5e9db9718aba5c9bcf9736fc715)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/tower

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

targeted for 2.4.1
/cc @abadger 