### PR TITLE
[2.3] Fixes verify_ssl option when False in ansible_tower module util (#30308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ Ansible Changes By Release
 * Fix cloudtrail module to allow AWS profiles other than the default
 * Fix an encoding issue with secret (password) vars_prompts
 * Fix for Windows become to show the stdout and stderr strings on a failure 
+* Fix the issue SSL verification can not be disabled for Tower modules
 
 <a id="2.3.2"></a>
 

--- a/lib/ansible/module_utils/ansible_tower.py
+++ b/lib/ansible/module_utils/ansible_tower.py
@@ -62,7 +62,7 @@ def tower_auth_config(module):
         if password:
             auth_config['password'] = password
         verify_ssl = module.params.get('tower_verify_ssl')
-        if verify_ssl:
+        if verify_ssl is not None:
             auth_config['verify_ssl'] = verify_ssl
         return auth_config
 


### PR DESCRIPTION
##### SUMMARY
Fixes verify_ssl option when False in ansible_tower module util

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
