### PR TITLE
Specify default delay (DOCUMENTATION only change)

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -48,13 +48,13 @@ options:
       - List of interfaces that should be associated to the VLAN.
   delay:
     description:
-      - Delay the play should wait to check for declaratie intent params values.
+      - Delay the play should wait to check for declarative intent params values.
     default: 10
   aggregate:
-    description: List of VLANs definitions
+    description: List of VLANs definitions.
   purge:
     description:
-      - Purge VLANs not defined in the aggregates parameter.
+      - Purge VLANs not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/eos/eos_vrf.py
+++ b/lib/ansible/modules/network/eos/eos_vrf.py
@@ -51,8 +51,13 @@ options:
     description: List of VRFs definitions
   purge:
     description:
-      - Purge VRFs not defined in the aggregates parameter.
+      - Purge VRFs not defined in the I(aggregate) parameter.
     default: no
+  delay:
+    description:
+      - Time in seconds to wait before checking for the operational state on remote
+        device. This wait is applicable for operational state arguments.
+    default: 10
   state:
     description:
       - State of the VRF configuration.

--- a/lib/ansible/modules/network/interface/net_interface.py
+++ b/lib/ansible/modules/network/interface/net_interface.py
@@ -46,15 +46,16 @@ options:
     choices: ['full', 'half', 'auto']
   tx_rate:
     description:
-      - Transmit rate.
+      - Transmit rate in bits per second (bps).
   rx_rate:
     description:
-      - Receiver rate.
+      - Receiver rate in bits per second (bps).
   delay:
     description:
       - Time in seconds to wait before checking for the operational state on remote
         device. This wait is applicable for operational state argument which are
         I(state) with values C(up)/C(down), I(tx_rate) and I(rx_rate).
+    default: 10
   aggregate:
     description: List of Interfaces definitions.
   purge:

--- a/lib/ansible/modules/network/interface/net_linkagg.py
+++ b/lib/ansible/modules/network/interface/net_linkagg.py
@@ -48,7 +48,7 @@ options:
     description: List of link aggregation definitions.
   purge:
     description:
-      - Purge link aggregation groups not defined in the aggregates parameter.
+      - Purge link aggregation groups not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/ios/ios_interface.py
+++ b/lib/ansible/modules/network/ios/ios_interface.py
@@ -70,6 +70,7 @@ options:
       - Time in seconds to wait before checking for the operational state on remote
         device. This wait is applicable for operational state argument which are
         I(state) with values C(up)/C(down), I(tx_rate) and I(rx_rate).
+    default: 10
   state:
     description:
       - State of the Interface configuration, C(up) means present and

--- a/lib/ansible/modules/network/ios/ios_static_route.py
+++ b/lib/ansible/modules/network/ios/ios_static_route.py
@@ -50,7 +50,7 @@ options:
       - Admin distance of the static route.
     default: 1
   aggregate:
-    description: List of static route definitions
+    description: List of static route definitions.
   state:
     description:
       - State of the static route configuration.

--- a/lib/ansible/modules/network/ios/ios_vrf.py
+++ b/lib/ansible/modules/network/ios/ios_vrf.py
@@ -69,6 +69,7 @@ options:
       - Time in seconds to wait before checking for the operational state on remote
         device.
     version_added: "2.4"
+    default: 10
   purge:
     description:
       - Instructs the module to consider the

--- a/lib/ansible/modules/network/iosxr/iosxr_interface.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_interface.py
@@ -58,6 +58,7 @@ options:
       - Time in seconds to wait before checking for the operational state on remote
         device. This wait is applicable for operational state argument which are
         I(state) with values C(up)/C(down), I(tx_rate) and I(rx_rate).
+    default: 10
   state:
     description:
       - State of the Interface configuration, C(up) means present and

--- a/lib/ansible/modules/network/junos/junos_interface.py
+++ b/lib/ansible/modules/network/junos/junos_interface.py
@@ -66,6 +66,7 @@ options:
       - Time in seconds to wait before checking for the operational state on remote
         device. This wait is applicable for operational state argument which are
         I(state) with values C(up)/C(down), I(tx_rate) and I(rx_rate).
+    default: 10
   aggregate:
     description: List of Interfaces definitions.
   state:

--- a/lib/ansible/modules/network/layer2/net_vlan.py
+++ b/lib/ansible/modules/network/layer2/net_vlan.py
@@ -36,7 +36,7 @@ options:
     description: List of VLANs definitions.
   purge:
     description:
-      - Purge VLANs not defined in the aggregates parameter.
+      - Purge VLANs not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/layer3/net_l3_interface.py
+++ b/lib/ansible/modules/network/layer3/net_l3_interface.py
@@ -36,7 +36,7 @@ options:
     description: List of L3 interfaces definitions
   purge:
     description:
-      - Purge L3 interfaces not defined in the aggregates parameter.
+      - Purge L3 interfaces not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/layer3/net_vrf.py
+++ b/lib/ansible/modules/network/layer3/net_vrf.py
@@ -33,7 +33,7 @@ options:
     description: List of VRFs definitions
   purge:
     description:
-      - Purge VRFs not defined in the aggregates parameter.
+      - Purge VRFs not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/routing/net_static_route.py
+++ b/lib/ansible/modules/network/routing/net_static_route.py
@@ -42,7 +42,7 @@ options:
     description: List of static route definitions
   purge:
     description:
-      - Purge static routes not defined in the aggregates parameter.
+      - Purge static routes not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/system/net_logging.py
+++ b/lib/ansible/modules/network/system/net_logging.py
@@ -41,7 +41,7 @@ options:
     description: List of logging definitions.
   purge:
     description:
-      - Purge logging not defined in the aggregates parameter.
+      - Purge logging not defined in the I(aggregate) parameter.
     default: no
   state:
     description:

--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -57,6 +57,12 @@ options:
       - Interface link status.
     default: auto
     choices: ['full', 'half', 'auto']
+  delay:
+    description:
+      - Time in seconds to wait before checking for the operational state on remote
+        device. This wait is applicable for operational state argument which are
+        I(state) with values C(up)/C(down) and I(neighbors).
+    default: 10
   neighbors:
     description:
       - Check the operational state of given interface C(name) for LLDP neighbor.


### PR DESCRIPTION
##### SUMMARY

* Default `delay:` wasn't in DOCUMENTATION
* Clarify that tx_rate is in bps
* Formatting for `aggregate`

##### ISSUE TYPE
 - Docs Pull Request

