### PR TITLE
Bugfix for vmware_guest module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -301,8 +301,8 @@ instance:
     sample: None
 '''
 
-import time
 import posixpath
+import time
 
 HAS_PYVMOMI = False
 try:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -537,7 +537,7 @@ class PyVmomiHelper(object):
             self.params['folder'] = '/%(folder)s' % self.params
         self.params['folder'] = self.params['folder'].rstrip('/')
 
-        dcpath = compile_folder_path_for_object(datacenter)
+        dcpath = compile_folder_path_for_object(datacenter) + '/'
 
         # Check for full path first in case it was already supplied
         if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -537,7 +537,9 @@ class PyVmomiHelper(object):
             self.params['folder'] = '/%(folder)s' % self.params
         self.params['folder'] = self.params['folder'].rstrip('/')
 
-        dcpath = compile_folder_path_for_object(datacenter) + '/'
+        dcpath = compile_folder_path_for_object(datacenter)
+        if not dcpath.endswith('/'):
+            dcpath = dcpath + '/'
 
         # Check for full path first in case it was already supplied
         if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -591,8 +591,8 @@ class PyVmomiHelper(object):
                 else:
                     result['changed'] = True
 
-        # need to get new metadata if changed
-        if result['changed']:
+        # need to get new metadata if not failed
+        if not result['failed']:
             newvm = self.getvm(uuid=vm.config.uuid)
             facts = self.gather_facts(newvm)
             result['instance'] = facts
@@ -1488,11 +1488,7 @@ def main():
             result = pyv.reconfigure_vm()
         elif module.params['state'] in ['poweredon', 'poweredoff', 'restarted', 'suspended', 'shutdownguest', 'rebootguest']:
             # set powerstate
-            tmp_result = pyv.set_powerstate(vm, module.params['state'], module.params['force'])
-            if tmp_result['changed']:
-                result["changed"] = True
-            if not tmp_result["failed"]:
-                result["failed"] = False
+            result = pyv.set_powerstate(vm, module.params['state'], module.params['force'])
         else:
             # This should not happen
             assert False

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -302,6 +302,7 @@ instance:
 '''
 
 import time
+import posixpath
 
 HAS_PYVMOMI = False
 try:
@@ -532,24 +533,21 @@ class PyVmomiHelper(object):
         return datacenter
 
     def get_folder_path(self, datacenter):
-        # Prepend / if it was missing from the folder path, also strip trailing slashes
-        if not self.params['folder'].startswith('/'):
-            self.params['folder'] = '/%(folder)s' % self.params
-        self.params['folder'] = self.params['folder'].rstrip('/')
+        # Ensure we have a starting slash and no trailing slash
+        self.params['folder'] = posixpath.join('/', self.params['folder']).rstrip('/')
 
-        dcpath = compile_folder_path_for_object(datacenter)
-        if not dcpath.endswith('/'):
-            dcpath = dcpath + '/'
+        toppath = compile_folder_path_for_object(datacenter)
+        dcpath = posixpath.join(toppath, self.params['datacenter'])
 
         # Check for full path first in case it was already supplied
-        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):
+        if (self.params['folder'].startswith(dcpath + '/vm/') or self.params['folder'] == dcpath + '/vm'):
             fullpath = self.params['folder']
         elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
-            fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+            fullpath = "%s%s" % (dcpath, self.params['folder'])
         elif (self.params['folder'].startswith('/')):
-            fullpath = "%s%s/vm%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+            fullpath = "%s/vm%s" % (dcpath, self.params['folder'])
         else:
-            fullpath = "%s%s/vm/%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+            fullpath = "%s/vm/%s" % (dcpath, self.params['folder'])
 
         return fullpath
 


### PR DESCRIPTION
##### SUMMARY
- The vm metadata should be returned also when setting powerstate isn't failed even if nothing has been changed.
- The existing vm will not be found just via `module.params['folder']`, the full path of it should be correct.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/vmware/vmware_guest

##### ANSIBLE VERSION
```
[DEPRECATED] [defaults]hostfile: The key is misleading as it can also be a list of hosts, a directory or a list of paths. It will be removed in 2.8. As alternative use one of [inventory]
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```


##### ADDITIONAL INFORMATION
Nothing here!
