### PR TITLE
Improve vmware_vm_shell module

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -225,7 +225,7 @@ def main():
             module.fail_json(msg='VM not found')
 
         (exitcode, msg) = execute_command(content, vm, p['vm_username'], p['vm_password'],
-                                            p['vm_shell'], p['vm_shell_args'], p['vm_shell_env'], p['vm_shell_cwd'])
+                                        p['vm_shell'], p['vm_shell_args'], p['vm_shell_env'], p['vm_shell_cwd'])
 
         if exitcode != 0:
             module.fail_json(changed=False, msg=msg)

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -225,7 +225,7 @@ def main():
             module.fail_json(msg='VM not found')
 
         (exitcode, msg) = execute_command(content, vm, p['vm_username'], p['vm_password'],
-                                        p['vm_shell'], p['vm_shell_args'], p['vm_shell_env'], p['vm_shell_cwd'])
+                                          p['vm_shell'], p['vm_shell_args'], p['vm_shell_env'], p['vm_shell_cwd'])
 
         if exitcode != 0:
             module.fail_json(changed=False, msg=msg)


### PR DESCRIPTION
##### SUMMARY
- Get and return the exit code and process information of the program which was executed through VMware tools.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/vmware/vmware_vm_shell

##### ANSIBLE VERSION
```
[DEPRECATED] [defaults]hostfile: The key is misleading as it can also be a list of hosts, a directory or a list of paths. It will be removed in 2.8. As alternative use one of [inventory]        
ansible 2.4.0.0                                 
  config file = /etc/ansible/ansible.cfg        
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']                                                                                      
  ansible python module location = /usr/lib/python2.7/site-packages/ansible                      
  executable location = /usr/bin/ansible        
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```


##### ADDITIONAL INFORMATION
With this improvement, the task can be failed when the program running in guest occurred some errors.
