### PR TITLE
Avoid KeyError when subnet['Tags'] doesn't exist

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
@@ -215,7 +215,7 @@ def describe_subnets(connection, module):
         subnet['id'] = subnet['SubnetId']
         subnet_info.append(camel_dict_to_snake_dict(subnet))
         # convert tag list to ansible dict
-        subnet_info[-1]['tags'] = boto3_tag_list_to_ansible_dict(subnet['Tags'])
+        subnet_info[-1]['tags'] = boto3_tag_list_to_ansible_dict(subnet.get('Tags', []))
 
     module.exit_json(subnets=subnet_info)
 


### PR DESCRIPTION
The problem was introduced in 2cdf31d3.

##### SUMMARY
``subnet['Tags']`` broke with a KeyError there were no tags.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_subnet_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel@4c9ad00c
```


##### ADDITIONAL INFORMATION
Before: KeyError
After: no KeyError