### PR TITLE
cloud: ovirt_datacenter.py: Add 'force' parameter for removing dc

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_datacenter.py
@@ -65,6 +65,15 @@ options:
             - "IMPORTANT: This option is deprecated in oVirt/RHV 4.1. You should
                use C(mac_pool) in C(ovirt_clusters) module, as MAC pools are
                set per cluster since 4.1."
+    force:
+        description:
+            - "This parameter can be used only when removing a data center.
+              If I(True) data center will be forcibly removed, even though it
+              contains some clusters. Default value is I(False), which means
+              that only empty data center can be removed."
+        version_added: "2.5"
+        default: False
+
 extends_documentation_fragment: ovirt
 '''
 
@@ -188,6 +197,7 @@ def main():
         quota_mode=dict(choices=['disabled', 'audit', 'enabled']),
         comment=dict(default=None),
         mac_pool=dict(default=None),
+        force=dict(default=None, type='bool'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -214,7 +224,7 @@ def main():
         if state == 'present':
             ret = clusters_module.create()
         elif state == 'absent':
-            ret = clusters_module.remove()
+            ret = clusters_module.remove(force=module.params['force'])
 
         module.exit_json(**ret)
     except Exception as e:


### PR DESCRIPTION
##### SUMMARY
Add option to force remove datacenter

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
ovirt

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
I tried to remove forcibly with this parameter a DC which has no hosts attached.
The parameter is passed fine to the module fine but it fails to remove it anyway.

Error: Fault reason is "Operation Failed". Fault detail is "[Cannot remove Data Center. There is no 
active Host in the Data Center.]

Bellow follows the traceback. Maybe you have any idea what is going wrong?

```code 
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Djw1k2/ansible_module_ovirt_datacenter.py", line 223, in main
    ret = clusters_module.remove()
  File "/tmp/ansible_Djw1k2/ansible_modlib.zip/ansible/module_utils/ovirt.py", line 652, in remove
    entity_service.remove(**kwargs)
  File "/home/kkoukiou/sandbox/ansible/lib/python2.7/site-packages/ovirtsdk4/services.py", line 3925, in remove
    self._internal_remove(headers, query, wait)
  File "/home/kkoukiou/sandbox/ansible/lib/python2.7/site-packages/ovirtsdk4/service.py", line 262, in _internal_remove
    return future.wait() if wait else future
  File "/home/kkoukiou/sandbox/ansible/lib/python2.7/site-packages/ovirtsdk4/service.py", line 53, in wait
    return self._code(response)
  File "/home/kkoukiou/sandbox/ansible/lib/python2.7/site-packages/ovirtsdk4/service.py", line 259, in callback
    self._check_fault(response)
  File "/home/kkoukiou/sandbox/ansible/lib/python2.7/site-packages/ovirtsdk4/service.py", line 123, in _check_fault
    self._raise_error(response, body)
  File "/home/kkoukiou/sandbox/ansible/lib/python2.7/site-packages/ovirtsdk4/service.py", line 109, in _raise_error
    raise error
Error: Fault reason is "Operation Failed". Fault detail is "[Cannot remove Data Center. There is no active Host in the Data Center.]". HTTP response code is 409.

failed: [localhost] (item={u'status': u'maintenance', u'qoss': [], u'supported_versions': [{u'major': 4, u'minor': 2}], u'name': u'golden_env_mixed', u'quota_mode': u'disabled', u'networks': [{u'id': [u'b3f6de6a-7d0b-4b86-bda2-1c5d2975e5b8']}], u'storage_domains': [{u'id': [u'b41e1ffb-351c-4e31-b30a-408b6c94cd83']}], u'quotas': [{u'id': [u'460ff4ce-6188-4738-9bac-aba4b859007a']}], u'href': u'/ovirt-engine/api/datacenters/cb185fd3-ca64-4ab9-9a6c-e2d2d4888304', u'version': {u'major': 4, u'minor': 2}, u'id': u'cb185fd3-ca64-4ab9-9a6c-e2d2d4888304', u'clusters': [], u'permissions': [{u'id': [u'58ca605c-010d-0307-0224-0000000001a9']}, {u'id': [u'59a7c26b-01be-01ab-00e1-0000000000e0']}], u'iscsi_bonds': [], u'local': False, u'storage_format': u'v4', u'description': u'golden_env_mixed'}) => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "comment": null, 
            "compatibility_version": null, 
            "description": null, 
            "fetch_nested": false, 
            "force": true, 
            "local": null, 
            "mac_pool": null, 
            "name": "golden_env_mixed", 
            "nested_attributes": [], 
            "poll_interval": 3, 
            "quota_mode": null, 
            "state": "absent", 
            "timeout": 180, 
            "wait": true
        }
    }, 
    "msg": "Fault reason is \"Operation Failed\". Fault detail is \"[Cannot remove Data Center. There is no active Host in the Data Center.]\". HTTP response code is 409.", 
...
```
