### PR TITLE
Fix Dell OS network module timeout

### DIFF
--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -52,6 +52,7 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
         pc.network_os = 'dellos10'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
         pc.port = int(provider['port'] or self._play_context.port or 22)
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -48,6 +48,7 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
         pc.network_os = 'dellos6'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
         pc.port = int(provider['port'] or self._play_context.port or 22)
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -52,6 +52,7 @@ class ActionModule(_ActionModule):
         pc = copy.deepcopy(self._play_context)
         pc.connection = 'network_cli'
         pc.network_os = 'dellos9'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
         pc.port = int(provider['port'] or self._play_context.port or 22)
         pc.remote_user = provider['username'] or self._play_context.connection_user
         pc.password = provider['password'] or self._play_context.password


### PR DESCRIPTION
##### SUMMARY
This change fixes issue #30350. The dellos action plugins should add the remote address of the switch provider to the play context. This was fixed in issue #23589 in an almost identical manner for the eos, ios, iosxr, and vyos action plugins.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Dell action plugins: dellos6, dellos9, dellos10.

##### ANSIBLE VERSION
Tested for dellos6 and dellos9 against devel @ 524c5dcfefb06f2cd931b8028fee7d101e9983d1.

```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/stack/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/alaska/alt-1/kayobe/kayobe-venv/lib/python2.7/site-packages/ansible
  executable location = /opt/alaska/alt-1/kayobe/kayobe-venv/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```