### PR TITLE
Fix import test handling of multi-line messages.

### DIFF
--- a/test/runner/importer.py
+++ b/test/runner/importer.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, print_function
 
 import imp
 import os
+import re
 import sys
 import traceback
 
@@ -50,6 +51,7 @@ def main():
                     # Hack to remove the filename and line number from the message, if present.
                     message = message.replace(' (%s, line %d)' % (os.path.basename(path), line), '')
 
+            message = re.sub(r'\n *', ': ', message)
             error = '%s:%d:%d: %s: %s' % (source, line, offset, exc_type.__name__, message)
 
             if error not in messages:


### PR DESCRIPTION
##### SUMMARY

Fix import test handling of multi-line messages.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-importer-fix 583fd38db3) last updated 2017/09/14 09:01:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
