### PR TITLE
remove dupe deprecation on config

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -168,7 +168,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         else:
             display.v(u"No config file found; using defaults")
 
-        # warn about deprecated options
+        # warn about deprecated config options
         for deprecated in C.config.DEPRECATED:
             name = deprecated[0]
             why = deprecated[1]['why']
@@ -178,6 +178,10 @@ class CLI(with_metaclass(ABCMeta, object)):
                 alt = ''
             ver = deprecated[1]['version']
             display.deprecated("%s option, %s %s" % (name, why, alt), version=ver)
+
+        # warn about typing issues with configuration entries
+        for unable in  C.config.UNABLE:
+            display.warning("Unable to set correct type for configuration entry: %s" % unable)
 
     @staticmethod
     def split_vault_id(vault_id):

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -180,7 +180,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             display.deprecated("%s option, %s %s" % (name, why, alt), version=ver)
 
         # warn about typing issues with configuration entries
-        for unable in  C.config.UNABLE:
+        for unable in C.config.UNABLE:
             display.warning("Unable to set correct type for configuration entry: %s" % unable)
 
     @staticmethod

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -698,7 +698,7 @@ DEFAULT_HOST_LIST:
       deprecated:
         why: The key is misleading as it can also be a list of hosts, a directory or a list of paths
         version: "2.8"
-        alternatives: inventory
+        alternatives: "[defaults]\ninventory=/path/to/file|dir"
     - key: inventory
       section: defaults
   type: pathlist

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -374,10 +374,3 @@ class ConfigManager(object):
             # set the constant
             self.data.update_setting(Setting(config, value, origin, defs[config].get('type', 'string')))
 
-        # FIXME: find better way to do this by passing back to where display is available
-        if self.UNABLE:
-            sys.stderr.write("Unable to set correct type for:\n\t%s\n" % '\n\t'.join(self.UNABLE))
-        if self.DEPRECATED:
-            for k, reason in self.DEPRECATED:
-                sys.stderr.write("[DEPRECATED] %(k)s: %(why)s. It will be removed in %(version)s. As alternative use one of [%(alternatives)s]\n"
-                                 % dict(k=k, **reason))

--- a/lib/ansible/config/manager.py
+++ b/lib/ansible/config/manager.py
@@ -373,4 +373,3 @@ class ConfigManager(object):
 
             # set the constant
             self.data.update_setting(Setting(config, value, origin, defs[config].get('type', 'string')))
-


### PR DESCRIPTION
##### SUMMARY
also move failed typing to same place to use 'standard' display vs hack.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
config

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

#### ADITIONAL INFO
we go from 
```
[DEPRECATED] [defaults]hostfile: The key is misleading as it can also be a list of hosts, a directory or a list of paths. It will be removed in 2.8. As alternative use one of [inventory]
[DEPRECATION WARNING]: [defaults]hostfile option, The key is misleading as it can also be a list of hosts, a directory or a list of paths . This feature will be
 removed in version 2.8. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```
 to the expected:
```
[DEPRECATION WARNING]: [defaults]hostfile option, The key is misleading as it can also be a list of hosts, a directory or a list of paths . This feature will be
 removed in version 2.8. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```