### PR TITLE
fixed 'typing' for deprecated get_config

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -45,10 +45,8 @@ def get_config(parser, section, key, env_var, default_value, value_type=None, ex
             pass
     if value is None:
         value = default_value
-    try:
-        value = config.ensure_type(value, value_type)
-    except:
-        pass
+
+    value = ensure_type(value, value_type)
 
     return value
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
moved method to function, but did not move the ref
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
config
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```

