### PR TITLE
Update Windows CI groups from 2 to 3.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -24,6 +24,7 @@ matrix:
 
     - env: TEST=windows/1
     - env: TEST=windows/2
+    - env: TEST=windows/3
 
     - env: TEST=network
 

--- a/test/integration/targets/win_hotfix/aliases
+++ b/test/integration/targets/win_hotfix/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group2

--- a/test/integration/targets/win_iis_webapppool/aliases
+++ b/test/integration/targets/win_iis_webapppool/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group2

--- a/test/integration/targets/win_lineinfile/aliases
+++ b/test/integration/targets/win_lineinfile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group1

--- a/test/integration/targets/win_power_plan/aliases
+++ b/test/integration/targets/win_power_plan/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_rabbitmq_plugin/aliases
+++ b/test/integration/targets/win_rabbitmq_plugin/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_region/aliases
+++ b/test/integration/targets/win_region/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_regmerge/aliases
+++ b/test/integration/targets/win_regmerge/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_route/aliases
+++ b/test/integration/targets/win_route/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_say/aliases
+++ b/test/integration/targets/win_say/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_scheduled_task/aliases
+++ b/test/integration/targets/win_scheduled_task/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_security_policy/aliases
+++ b/test/integration/targets/win_security_policy/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_setup/aliases
+++ b/test/integration/targets/win_setup/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_share/aliases
+++ b/test/integration/targets/win_share/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_shortcut/aliases
+++ b/test/integration/targets/win_shortcut/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_slurp/aliases
+++ b/test/integration/targets/win_slurp/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_stat/aliases
+++ b/test/integration/targets/win_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_tempfile/aliases
+++ b/test/integration/targets/win_tempfile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_timezone/aliases
+++ b/test/integration/targets/win_timezone/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_toast/aliases
+++ b/test/integration/targets/win_toast/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_unzip/aliases
+++ b/test/integration/targets/win_unzip/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group1

--- a/test/integration/targets/win_user/aliases
+++ b/test/integration/targets/win_user/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group1

--- a/test/integration/targets/win_user_right/aliases
+++ b/test/integration/targets/win_user_right/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_wakeonlan/aliases
+++ b/test/integration/targets/win_wakeonlan/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3


### PR DESCRIPTION
##### SUMMARY

WIP - Experiment with 3 Windows CI groups

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.5.0 (windows-groups 80e8e44b1f) last updated 2017/09/14 13:27:01 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
