### PR TITLE
Show -M values in version info at -vv or higher

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -90,8 +90,9 @@ class SortedOptParser(optparse.OptionParser):
         return optparse.OptionParser.format_help(self, formatter=None)
 
     def get_version(self):
-        # if args have been parsed, update module path based on cli options
-        return _version(self.get_prog_name(), module_path=self.values.module_path)
+        # if args have been parsed and cli, update module path based on cli options
+        return _version(self.get_prog_name(),
+                        module_path=getattr(self.values, 'module_path', None))
 
 
 # Note: Inherit from SortedOptParser so that we get our format_help method

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -36,6 +36,12 @@ class TestCliVersion(unittest.TestCase):
         self.assertIn('ansible-cli-test', ver)
         self.assertIn('python version', ver)
 
+    def test_version_with_module_path(self):
+        ver = cli._version('ansible-cli-test', module_path=['/dev/null/module_path'])
+        self.assertIn('ansible-cli-test', ver)
+        self.assertIn('python version', ver)
+        self.assertIn('/dev/null/module_path', ver)
+
     def test_version_info(self):
         version_info = cli.CLI.version_info()
         self.assertEqual(version_info['string'], __version__)

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -37,7 +37,7 @@ class TestCliVersion(unittest.TestCase):
         self.assertIn('python version', ver)
 
     def test_version_with_module_path(self):
-        ver = cli._version('ansible-cli-test', module_path=['/dev/null/module_path'])
+        ver = cli.CLI.version('ansible-cli-test', module_path=['/dev/null/module_path'])
         self.assertIn('ansible-cli-test', ver)
         self.assertIn('python version', ver)
         self.assertIn('/dev/null/module_path', ver)


### PR DESCRIPTION
##### SUMMARY

If cli -M or --module-path was use, the ansible 'version' info shown at -vv or higher did
not reflect the cli options.  The version info was being created before the option parser was
constructed, so it missed any cli info. Instead of using a static version arg to OptionParser(),
we override get_version to do it dynamically.

Move the version() method to module scope, and add
a module_path arg to it.

Override OptionParser.get_version() to use module scope
version method to update the version info including the
module path provided via cli.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (module_path_in_version_info 66cda6ef2d) last updated 2018/01/05 16:45:46 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
