### PR TITLE
add config groups to foreman inventories

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -145,6 +145,9 @@ want_facts = True
 # the script for stand-alone Foreman.
 want_hostcollections = False
 
+# Whether to create Ansible groups for config groups.
+want_configgroups = False
+
 # Whether to interpret global parameters value as JSON (if possible, else
 # take as is). Only tested with Katello (Red Hat Satellite).
 # This allows to define lists and dictionaries (and more complicated structures)


### PR DESCRIPTION
##### SUMMARY
This is my first pull request. Hopefully I didn't miss anything.

Adding Ansible groups to match config groups in Foreman's inventory.
The data was already available and was pulled via the API in the existing script. It just wasn't used.
Config groups can be used essentially like tags in Foreman to group inventory items in Ansible. Unlike the existing host collections functionality config groups are in the core of Foreman and don't require a plugin.

Basically all the code is a copy of the 'hostcollections' bits with the exception of the 'ungrouped' config group. (The else clause on the new line 344).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py
contrib/inventory/foreman.ini

##### ANSIBLE VERSION
Tested with latest devel
```
ansible 2.5.0 (ysk_devel 13ec86b796) last updated 2017/09/14 16:42:36 (GMT -500)
  config file = /home/ykuksenko/data/code/ykuksenko_ansible/ansible.cfg
  configured module search path = [u'/home/ykuksenko/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible/lib/ansible
  executable location = /tmp/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
and
```
ansible 2.2.1.0
  config file = /home/ykuksenko/data/code/ykuksenko_ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### ADDITIONAL INFORMATION
none?