### PR TITLE
Add underscore and period to regex for hostname prompt

### DIFF
--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -28,8 +28,8 @@ from ansible.errors import AnsibleConnectionFailure
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-]*[>|#|%](?:\s*)$'),
-        re.compile(br'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-]*\(.+\)#(?:\s*)$')
+        re.compile(br'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-_.]*[>|#|%](?:\s*)$'),
+        re.compile(br'[\r\n]?[a-zA-Z]{1}[a-zA-Z0-9-_.]*\(.+\)#(?:\s*)$')
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
Adding underscore and period to the nxos regex for determining the prompt for hostnames with underscores and periods in the hostname.

##### SUMMARY
The nxos.py terminal plugin file has a different regex than the ios.py terminal plugin file. The nxos regex does not include any underscores or periods.

When you are connecting to a NXOS device and there is either an underscore or period in the hostname, all CLI commands fail as the terminal receive function never completes. Adding the underscore and period to the regex allows for this method to pass and continue.

This fixes issue #30383 
Reference issue #18974 for deriving toward this issue and testing we've done.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
plugin/terminal/nxos.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```
