### PR TITLE
Fixing two bugs with import_role

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -297,7 +297,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                 if 'import_role' in task_ds:
                     is_static = True
 
-                if ir.static is not None:
+                elif ir.static is not None:
                     display.deprecated("The use of 'static' for 'include_role' has been deprecated. "
                                        "Use 'import_role' for static inclusion, or 'include_role' for dynamic inclusion")
                     is_static = ir.static
@@ -320,6 +320,12 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                     display.debug('Determined that if include_role static is %s' % str(is_static))
 
                 if is_static:
+                    if ir.loop is not None:
+                        if 'import_tasks' in task_ds:
+                            raise AnsibleParserError("You cannot use loops on 'import_role' statements. You should use 'include_role' instead.", obj=task_ds)
+                        else:
+                            raise AnsibleParserError("You cannot use 'static' on an include_role with a loop", obj=task_ds)
+
                     # we set a flag to indicate this include was static
                     ir.statically_loaded = True
 


### PR DESCRIPTION
1) import_role was never resulting in a static inclusion of the role
   tasks due to a logic error.
2) no error was raised when import_role tried to use a with loop, resulting
   in a strange error down the execution path.
