### PR TITLE
Ensure region is set in ec2_vpc_subnet_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
@@ -235,10 +235,13 @@ def main():
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
-    try:
-        connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-    except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound) as e:
-        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    if region:
+        try:
+            connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
+        except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound) as e:
+            module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    else:
+        module.fail_json(msg="Region must be specified")
 
     describe_subnets(connection, module)
 


### PR DESCRIPTION
##### SUMMARY
Catches unset region that should have been part of #30370

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_subnet_facts

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 4ec91491e2) last updated 2017/09/15 13:56:33 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
