### PR TITLE
Resolving bug on CNOS Image download on multiple devices.

### DIFF
--- a/lib/ansible/module_utils/cnos.py
+++ b/lib/ansible/module_utils/cnos.py
@@ -3159,10 +3159,13 @@ def waitForDeviceResponse(command, prompt, timeout, obj):
             if(gotit != -1):
                 flag = True
         except:
-            if prompt != "(yes/no)?":
-                retVal = retVal + "\n Error-101"
-            else:
+            # debugOutput(prompt)
+            if prompt == "(yes/no)?":
                 retVal = retVal
+            elif prompt == "Password:":
+                retVal = retVal
+            else:
+                retVal = retVal + "\n Error-101"
             flag = True
     return retVal
 # EOM


### PR DESCRIPTION
##### SUMMARY
This is a fix for the failure of image download on to multiple devices. Error string are popping up on waiting for image transfer from sftp server. This errors are isolated and issue is getting mitigated

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/cnos.py

##### ANSIBLE VERSION
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.4.0.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

##### ADDITIONAL INFORMATION
If the devices are contacting a sftp server for image for the first time, it will ask for prompts to save this hosts among the known hosts, This will get saved and in next image download server wont ask it, So the logic written for first logic will wait for the prompt and time out. This will get interpreted as Error. With this fix I mitigate this
