### PR TITLE
Use safe_load to load yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ Ansible Changes By Release
 * Fix an encoding issue with secret (password) vars_prompts
 * Fix for Windows become to show the stdout and stderr strings on a failure 
 * Fix the issue SSL verification can not be disabled for Tower modules
+* Use safe_load instead on load to read a yaml document
+
 
 <a id="2.3.2"></a>
 

--- a/lib/ansible/modules/network/aos/aos_blueprint_param.py
+++ b/lib/ansible/modules/network/aos/aos_blueprint_param.py
@@ -201,7 +201,7 @@ def get_collection_from_param_map(module, aos):
             module.fail_json(msg="Python library Yaml is mandatory to use 'param_map'")
 
         try:
-            param_map = yaml.load(param_map_json)
+            param_map = yaml.safe_load(param_map_json)
         except:
             module.fail_json(msg="Unable to parse param_map information")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Replace `yaml.load` with `yaml.safe_load`

(cherry picked from commit 8c3bf20a13a185e7c5c4bd0dee1bbe0b1ec2eab3)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aos_blueprint_param

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
