### PR TITLE
ovirt_vms: Fix the logout condition

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -1339,7 +1339,7 @@ def main():
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())
     finally:
-        connection.close(logout='token' not in module.params['auth'])
+        connection.close(logout=auth.get('token') is None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Since we remove `auth` dictionary from module, we need to compare the logout condition to that popped dictionary instead of `module.params['auth']`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.3.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
---
- hosts: localhost
  connection: local
  gather_facts: false
  vars_files:
    - ../vars.yml

  tasks:
    - name: Create vm from template
      ovirt_vms:
        auth:
          url: "{{ url }}"
          username: "{{ username }}"
          password: "{{ password }}"
          insecure: "{{ insecure }}"
        cluster: Default
        name: myvmads
        template: nonexsting
```

Now running such playbook will generate such logs in oVirt, we can see proper logout:

```
2017-09-15 10:50:21,585+02 INFO  [org.ovirt.engine.core.sso.utils.AuthenticationUtils] (default task-6) [] User admin@internal successfully logged in with scopes: ovirt-app-api ovirt-ext=token-info:authz-search ovirt-ext=token-info:public-authz-search ovirt-ext=token-info:validate ovirt-ext=token:password-access
2017-09-15 10:50:22,129+02 INFO  [org.ovirt.engine.core.sso.utils.AuthenticationUtils] (default task-64) [] User admin@internal successfully logged in with scopes: ovirt-app-api ovirt-ext=token-info:authz-search ovirt-ext=token-info:public-authz-search ovirt-ext=token-info:validate ovirt-ext=token:password-access
2017-09-15 10:50:22,189+02 INFO  [org.ovirt.engine.core.bll.aaa.CreateUserSessionCommand] (default task-9) [47058499] Running command: CreateUserSessionCommand internal: false.
2017-09-15 10:50:22,200+02 INFO  [org.ovirt.engine.core.dal.dbbroker.auditloghandling.AuditLogDirector] (default task-9) [47058499] EVENT_ID: USER_VDC_LOGIN(30), User admin@internal-authz logged in.
2017-09-15 10:50:22,413+02 INFO  [org.ovirt.engine.core.sso.servlets.OAuthRevokeServlet] (default task-15) [] User admin@internal successfully logged out
2017-09-15 10:50:22,460+02 INFO  [org.ovirt.engine.core.bll.aaa.TerminateSessionsForTokenCommand] (default task-17) [9cce570] Running command: TerminateSessionsForTokenCommand internal: true.
```