### PR TITLE
New filter getmountfrompath to retrieve a mountpoint from a given path.

### DIFF
--- a/lib/ansible/plugins/filter/filesystem.py
+++ b/lib/ansible/plugins/filter/filesystem.py
@@ -1,0 +1,41 @@
+# (c) 2017, Yannig Perre <yannig.perre@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+def getmountfrompath(path, mounts):
+    '''return the closest corresponding mount for a given path'''
+    current_string_length = 0
+    current_mount = None
+    for mount in mounts:
+        if mount['mount'].startswith('/'):
+            if current_string_length < len(mount['mount']) and path.startswith(mount['mount']):
+                current_string_length = len(mount['mount'])
+                current_mount = mount
+    return current_mount
+
+
+class FilterModule(object):
+    ''' Ansible filesystem jinja2 filters '''
+
+    def filters(self):
+        return {
+            'getmountfrompath': getmountfrompath,
+        }

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -107,6 +107,22 @@
   assert:
     that: "{{_human_bytes_test.failed}}"
 
+
+- block:
+    - name: Get corresponding mountpoint from a given path
+      set_fact:
+        mount_test: "{{'/tmp/test'|getmountfrompath(ansible_mounts)}}"
+
+    - name: Give information about mount_test value
+      debug:
+        var: mount_test
+
+    - name: check size available greater than 0
+      assert:
+        that: mount_test.size_available > 0
+      when: mount_test.size_available is defined
+  when: ansible_mounts is defined
+
 - name: Test extract
   assert:
     that:


### PR DESCRIPTION
##### SUMMARY

New filter getmountfrompath: help retrieve a mount point from a path using ansible_mounts variable (Ansible facts).

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py
test/integration/test_space_available.yml

##### ANSIBLE VERSION
2.3

##### ADDITIONAL INFORMATION

This PR replace https://github.com/ansible/ansible/pull/12066

Retrieve corresponding path:

``` yaml
    - name: "Get corresponding mountpoint from a given path"
      set_fact:
        mount1:            "{{file1|getmountfrompath(ansible_mounts)}}"
        mount2:            "{{file2|getmountfrompath(ansible_mounts)}}"
    - debug: var=mount1
    - debug: var=mount2
```

Result in following result:

``` yaml
TASK [Get corresponding mountpoint from a given path] **************************
ok: [localhost]

TASK [debug var=mount1] ********************************************************
ok: [localhost] => {
    "changed": false, 
    "mount1": {
        "device": "/dev/sda1", 
        "fstype": "ext4", 
        "mount": "/", 
        "options": "rw,noatime,errors=remount-ro", 
        "size_available": 100358303744, 
        "size_total": 118014083072, 
        "uuid": "6d776313-2c09-4e73-97b3-34ab8debccf8"
    }
}

TASK [debug var=mount2] ********************************************************
ok: [localhost] => {
    "changed": false, 
    "mount2": {
        "device": "/dev/sdb7", 
        "fstype": "ext4", 
        "mount": "/home", 
        "options": "rw", 
        "size_available": 367142432768, 
        "size_total": 1897002360832, 
        "uuid": "1e803f4c-f551-4e7b-9c2e-021b539fbf75"
    }
}
```
Check that there's more than 1 % of space available:

``` yaml
    - set_fact: size_available_pc="{{mount1.size_available|int / mount1.size_total|int * 100}}"
    - name: "check 1% of free space available for first file"
      assert:
        that: size_available_pc > 1
      ignore_errors: yes
```

Result in following output:

``` yaml
TASK [set_fact size_available_pc={{mount1.size_available|int / mount1.size_total|int * 100}}] ***
ok: [localhost]

TASK [check 1% of free space available for first file] *************************
ok: [localhost]
```

Check that there's more than 1K available:

``` yaml
    - name: "check 1K available for second file"
      assert:
        that: mount2.size_available > 1024
      ignore_errors: yes
```

Expected result:

``` yaml
TASK [check 1K available for second file] **************************************
ok: [localhost]
```
