### PR TITLE
Update removed_in_version to 2.9 for network module top level cred args

### DIFF
--- a/docs/docsite/rst/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guide_2.5.rst
@@ -63,5 +63,40 @@ No notable changes.
 Networking
 ==========
 
-No notable changes.
+
+Change in deprecation notice of top-level connection arguments
+--------------------------------------------------------------
+.. code-block:: yaml
+
+    - name: example of using top-level options for connection properties
+      ios_command:
+        commands: show version
+        host: "{{ inventory_hostname }}"
+        username: cisco
+        password: cisco
+        authorize: yes
+        auth_pass: cisco
+
+**OLD** In Ansible 2.4:
+
+Will result in:
+
+.. code-block:: yaml
+
+   [WARNING]: argument username has been deprecated and will be removed in a future version
+   [WARNING]: argument host has been deprecated and will be removed in a future version
+   [WARNING]: argument password has been deprecated and will be removed in a future version
+
+
+**NEW** In Ansible 2.5:
+
+
+.. code-block:: yaml
+
+   [DEPRECATION WARNING]: Param 'username' is deprecated. See the module docs for more information. This feature will be removed in version
+   2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
+   [DEPRECATION WARNING]: Param 'password' is deprecated. See the module docs for more information. This feature will be removed in version
+   2.9. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
+   [DEPRECATION WARNING]: Param 'host' is deprecated. See the module docs for more information. This feature will be removed in version 2.9.
+   Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
 

--- a/lib/ansible/module_utils/aireos.py
+++ b/lib/ansible/module_utils/aireos.py
@@ -45,12 +45,12 @@ aireos_argument_spec = {
 }
 
 aireos_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 aireos_argument_spec.update(aireos_top_spec)
 

--- a/lib/ansible/module_utils/aruba.py
+++ b/lib/ansible/module_utils/aruba.py
@@ -45,12 +45,12 @@ aruba_argument_spec = {
 }
 
 aruba_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 
 aruba_argument_spec.update(aruba_top_spec)

--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -51,14 +51,14 @@ asa_argument_spec = {
 }
 
 asa_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
     'authorize': dict(type='bool'),
-    'auth_pass': dict(removed_in_version=2.3, no_log=True),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'timeout': dict(removed_in_version=2.9, type='int'),
     'context': dict(),
     'passwords': dict()
 }

--- a/lib/ansible/module_utils/ce.py
+++ b/lib/ansible/module_utils/ce.py
@@ -61,20 +61,20 @@ ce_provider_spec = {
     'use_ssl': dict(type='bool'),
     'validate_certs': dict(type='bool'),
     'timeout': dict(type='int'),
-    'transport': dict(choices=['cli']),
+    'transport': dict(default='cli', choices=['cli']),
 }
 ce_argument_spec = {
     'provider': dict(type='dict', options=ce_provider_spec),
 }
 ce_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'use_ssl': dict(removed_in_version=2.3, type='bool'),
-    'validate_certs': dict(removed_in_version=2.3, type='bool'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
-    'transport': dict(choices=['cli']),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'use_ssl': dict(removed_in_version=2.9, type='bool'),
+    'validate_certs': dict(removed_in_version=2.9, type='bool'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
+    'transport': dict(removed_in_version=2.9, choices=['cli']),
 }
 ce_argument_spec.update(ce_top_spec)
 

--- a/lib/ansible/module_utils/dellos10.py
+++ b/lib/ansible/module_utils/dellos10.py
@@ -59,14 +59,14 @@ dellos10_argument_spec = {
     'provider': dict(type='dict', options=dellos10_provider_spec),
 }
 dellos10_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'authorize': dict(removed_in_version=2.3, type='bool'),
-    'auth_pass': dict(removed_in_version=2.3, no_log=True),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'authorize': dict(removed_in_version=2.9, type='bool'),
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 dellos10_argument_spec.update(dellos10_top_spec)
 

--- a/lib/ansible/module_utils/dellos6.py
+++ b/lib/ansible/module_utils/dellos6.py
@@ -58,14 +58,14 @@ dellos6_argument_spec = {
     'provider': dict(type='dict', options=dellos6_provider_spec),
 }
 dellos6_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'authorize': dict(removed_in_version=2.3, type='bool'),
-    'auth_pass': dict(removed_in_version=2.3, no_log=True),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'authorize': dict(removed_in_version=2.9, type='bool'),
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 dellos6_argument_spec.update(dellos6_top_spec)
 

--- a/lib/ansible/module_utils/dellos9.py
+++ b/lib/ansible/module_utils/dellos9.py
@@ -59,14 +59,14 @@ dellos9_argument_spec = {
     'provider': dict(type='dict', options=dellos9_provider_spec),
 }
 dellos9_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'authorize': dict(removed_in_version=2.3, type='bool'),
-    'auth_pass': dict(removed_in_version=2.3, no_log=True),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'authorize': dict(removed_in_version=2.9, type='bool'),
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 dellos9_argument_spec.update(dellos9_top_spec)
 

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -59,20 +59,20 @@ eos_argument_spec = {
     'provider': dict(type='dict', options=eos_provider_spec),
 }
 eos_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
 
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(no_log=True, removed_in_version=2.3),
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
 
-    'use_ssl': dict(removed_in_version=2.3, type='bool'),
-    'validate_certs': dict(removed_in_version=2.3, type='bool'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'use_ssl': dict(removed_in_version=2.9, type='bool'),
+    'validate_certs': dict(removed_in_version=2.9, type='bool'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 
-    'transport': dict(removed_in_version=2.3, choices=['cli', 'eapi'])
+    'transport': dict(removed_in_version=2.9, choices=['cli', 'eapi'])
 }
 eos_argument_spec.update(eos_top_spec)
 

--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -47,14 +47,14 @@ ios_argument_spec = {
 }
 
 ios_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
-    'auth_pass': dict(removed_in_version=2.3, no_log=True),
-    'timeout': dict(removed_in_version=2.3, type='int')
+    'auth_pass': dict(removed_in_version=2.9, no_log=True),
+    'timeout': dict(removed_in_version=2.9, type='int')
 }
 ios_argument_spec.update(ios_top_spec)
 

--- a/lib/ansible/module_utils/iosxr.py
+++ b/lib/ansible/module_utils/iosxr.py
@@ -45,12 +45,12 @@ iosxr_argument_spec = {
     'provider': dict(type='dict', options=iosxr_provider_spec)
 }
 iosxr_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 iosxr_argument_spec.update(iosxr_top_spec)
 

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -51,13 +51,13 @@ junos_argument_spec = {
     'provider': dict(type='dict', options=junos_provider_spec),
 }
 junos_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
-    'transport': dict(removed_in_version=2.3)
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
+    'transport': dict(removed_in_version=2.9)
 }
 junos_argument_spec.update(junos_top_spec)
 

--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -57,18 +57,18 @@ nxos_argument_spec = {
     'provider': dict(type='dict', options=nxos_provider_spec),
 }
 nxos_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
 
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9),
 
-    'use_ssl': dict(removed_in_version=2.3, type='bool'),
-    'validate_certs': dict(removed_in_version=2.3, type='bool'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'use_ssl': dict(removed_in_version=2.9, type='bool'),
+    'validate_certs': dict(removed_in_version=2.9, type='bool'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 
-    'transport': dict(default='cli', choices=['cli', 'nxapi'])
+    'transport': dict(removed_in_version=2.9, default='cli', choices=['cli', 'nxapi'])
 }
 nxos_argument_spec.update(nxos_top_spec)
 

--- a/lib/ansible/module_utils/sros.py
+++ b/lib/ansible/module_utils/sros.py
@@ -50,12 +50,12 @@ sros_argument_spec = {
     'provider': dict(type='dict', options=sros_provider_spec),
 }
 sros_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 sros_argument_spec.update(sros_top_spec)
 

--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -46,14 +46,14 @@ vyos_argument_spec = {
     'provider': dict(type='dict', options=vyos_provider_spec),
 }
 vyos_top_spec = {
-    'host': dict(removed_in_version=2.3),
-    'port': dict(removed_in_version=2.3, type='int'),
+    'host': dict(removed_in_version=2.9),
+    'port': dict(removed_in_version=2.9, type='int'),
 
-    'username': dict(removed_in_version=2.3),
-    'password': dict(removed_in_version=2.3, no_log=True),
-    'ssh_keyfile': dict(removed_in_version=2.3, type='path'),
+    'username': dict(removed_in_version=2.9),
+    'password': dict(removed_in_version=2.9, no_log=True),
+    'ssh_keyfile': dict(removed_in_version=2.9, type='path'),
 
-    'timeout': dict(removed_in_version=2.3, type='int'),
+    'timeout': dict(removed_in_version=2.9, type='int'),
 }
 vyos_argument_spec.update(vyos_top_spec)
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update removed_in_version to 2.9 for network module top level cred args
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/aireos.py
module_utils/aruba.py
module_utils/asa.py
module_utils/ce.py
module_utils/dellos10.py
module_utils/dellos6.py
module_utils/dellos9.py
module_utils/eos.py
module_utils/ios.py
module_utils/iosxr.py
module_utils/junos.py
module_utils/nxos.py
module_utils/sros.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
