### PR TITLE
Don't expect (postgres) SERVER_VERSION to be M.N

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -207,7 +207,6 @@ EXAMPLES = '''
 import itertools
 import re
 import traceback
-from distutils.version import StrictVersion
 from hashlib import md5
 
 try:
@@ -225,7 +224,7 @@ from ansible.module_utils.six import iteritems
 
 
 FLAGS = ('SUPERUSER', 'CREATEROLE', 'CREATEUSER', 'CREATEDB', 'INHERIT', 'LOGIN', 'REPLICATION')
-FLAGS_BY_VERSION = {'BYPASSRLS': '9.5.0'}
+FLAGS_BY_VERSION = {'BYPASSRLS': 90500}
 
 VALID_PRIVS = dict(table=frozenset(('SELECT', 'INSERT', 'UPDATE', 'DELETE', 'TRUNCATE', 'REFERENCES', 'TRIGGER', 'ALL')),
                    database=frozenset(
@@ -687,33 +686,17 @@ def parse_privs(privs, db):
     return o_privs
 
 
-def get_pg_server_version(cursor):
-    """
-    Queries Postgres for its server version.
-
-    server_version should be just the server version itself:
-
-    postgres=# SHOW SERVER_VERSION;
-    server_version
-    ----------------
-     9.6.2
-    (1 row)
-    """
-    cursor.execute("SHOW SERVER_VERSION")
-    return cursor.fetchone()['server_version']
-
-
 def get_valid_flags_by_version(cursor):
     """
     Some role attributes were introduced after certain versions. We want to
     compile a list of valid flags against the current Postgres version.
     """
-    current_version = StrictVersion(get_pg_server_version(cursor))
+    current_version = cursor.connection.server_version
 
     return [
         flag
         for flag, version_introduced in FLAGS_BY_VERSION.items()
-        if current_version >= StrictVersion(version_introduced)
+        if current_version >= version_introduced
     ]
 
 


### PR DESCRIPTION
##### SUMMARY

Don't expect (postgres) SERVER_VERSION to be M.N

It could be something like '10beta4', which StrictVersion() would
reject. When Postgres 10 is released, it will be '10', which
StrictVersion() would STILL reject.

Fortunately, psycopg2 has a 'server_version' connection attribute that
is guaranteed to be an integer like 90605 for version 9.6.5, or 100000
for version 10. We can safely use this for version-specific code.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
``postgresql_user`` module

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel@a6c8978b74
```

##### ADDITIONAL INFORMATION
N/A