### PR TITLE
Add runasusercategory and runasgroupcategory parameters for ipa_sudo_rule module

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -56,10 +56,12 @@ options:
     description:
     - RunAs User category the rule applies to.
     choices: ['all']
+    version_added: "2.5"
   runasgroupcategory:
     description:
       - RunAs Group category the rule applies to.
     choices: ['all']
+    version_added: "2.5"
   user:
     description:
     - List of users assigned to the rule.

--- a/lib/ansible/modules/identity/ipa/ipa_sudorule.py
+++ b/lib/ansible/modules/identity/ipa/ipa_sudorule.py
@@ -326,20 +326,20 @@ def ensure(module, client):
 
 def main():
     argument_spec = ipa_argument_spec()
-    argument_spec.update(cmd=dict(type='list', required=False),
-                         cmdcategory=dict(type='str', required=False, choices=['all']),
+    argument_spec.update(cmd=dict(type='list'),
+                         cmdcategory=dict(type='str', choices=['all']),
                          cn=dict(type='str', required=True, aliases=['name']),
-                         description=dict(type='str', required=False),
-                         host=dict(type='list', required=False),
-                         hostcategory=dict(type='str', required=False, choices=['all']),
-                         hostgroup=dict(type='list', required=False),
-                         runasusercategory=dict(type='str', required=False, choices=['all']),
-                         runasgroupcategory=dict(type='str', required=False, choices=['all']),
-                         sudoopt=dict(type='list', required=False),
-                         state=dict(type='str', required=False, default='present', choices=['present', 'absent', 'enabled', 'disabled']),
-                         user=dict(type='list', required=False),
-                         usercategory=dict(type='str', required=False, choices=['all']),
-                         usergroup=dict(type='list', required=False))
+                         description=dict(type='str'),
+                         host=dict(type='list'),
+                         hostcategory=dict(type='str', choices=['all']),
+                         hostgroup=dict(type='list'),
+                         runasusercategory=dict(type='str', choices=['all']),
+                         runasgroupcategory=dict(type='str', choices=['all']),
+                         sudoopt=dict(type='list'),
+                         state=dict(type='str', default='present', choices=['present', 'absent', 'enabled', 'disabled']),
+                         user=dict(type='list'),
+                         usercategory=dict(type='str', choices=['all']),
+                         usergroup=dict(type='list'))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=[['cmdcategory', 'cmd'],


### PR DESCRIPTION
##### SUMMARY
Adds support for parameters runasusercategory and runasgroupcategory when creating sudo rule.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
module: ipa_sudorule

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.5.0
```

