### PR TITLE
Fix build on Python 3.x by correctly handling sys.maxint.

### DIFF
--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -31,14 +31,14 @@ def trim_docstring(docstring):
     # and split into a list of lines:
     lines = docstring.expandtabs().splitlines()
     # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxint
+    indent = sys.maxsize
     for line in lines[1:]:
         stripped = line.lstrip()
         if stripped:
             indent = min(indent, len(line) - len(stripped))
     # Remove indentation (first line is special):
     trimmed = [lines[0].strip()]
-    if indent < sys.maxint:
+    if indent < sys.maxsize:
         for line in lines[1:]:
             trimmed.append(line[indent:].rstrip())
     # Strip off trailing and leading blank lines:


### PR DESCRIPTION
##### SUMMARY
As outlined in https://docs.python.org/3.1/whatsnew/3.0.html#integers, sys.maxint doesn't exist anymore in Python 3.x because there is no maximum value for integers in Python 3.x.  However, really old Python versions don't have sys.maxsize, but do have sys.maxint.  Instead of explicitly using one or the other, check the version and use sys.maxsize if it's 3.x, or sys.maxint if it's 2.x.  This allows operation on both major versions, and still behaves as it needs to.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Build system.

##### ADDITIONAL INFORMATION
Fixes the following build error when trying to build with Python 3.x
```
make -j1 docs 
mkdir -p ./docs/man/man1/ ; \
PYTHONPATH=./lib docs/bin/generate_man.py --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
Traceback (most recent call last):
  File "docs/bin/generate_man.py", line 253, in <module>
    allvars[cli_name] = opts_docs(cli_class_name, cli_name)
  File "docs/bin/generate_man.py", line 119, in opts_docs
    'long_desc': trim_docstring(cli.__doc__),
  File "docs/bin/generate_man.py", line 34, in trim_docstring
    indent = sys.maxint
AttributeError: module 'sys' has no attribute 'maxint'
make: *** [Makefile:347: generate_asciidoc] Error 1
```

Tested with Python 2.7 and Python 3.6.

This results in no actual change in value for CPython 2.7 on any platform I know of.