### PR TITLE
fixed issue with default callback inheritance

### DIFF
--- a/lib/ansible/plugins/callback/actionable.py
+++ b/lib/ansible/plugins/callback/actionable.py
@@ -14,6 +14,8 @@ DOCUMENTATION = '''
       - Use this callback when you dont care about OK nor Skipped.
       - This callback suppreses any non Failed or Changed status.
     version_added: "2.1"
+    extends_documentation_fragment:
+      - default_callback
     requirements:
       - set as stdout callback in configuration
 '''

--- a/lib/ansible/plugins/callback/debug.py
+++ b/lib/ansible/plugins/callback/debug.py
@@ -11,6 +11,8 @@ DOCUMENTATION = '''
     description:
       - Use this callback to sort though extensive debug output
     version_added: "2.4"
+    extends_documentation_fragment:
+      - default_callback
     requirements:
       - set as stdout in configuration
 '''

--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -9,6 +9,8 @@ DOCUMENTATION = '''
     callback: dense
     type: stdout
     short_description: minimal stdout output
+    extends_documentation_fragment:
+      - default_callback
     description:
       - When in verbose mode it will act the same as the default callback
     version_added: "2.3"

--- a/lib/ansible/plugins/callback/full_skip.py
+++ b/lib/ansible/plugins/callback/full_skip.py
@@ -13,6 +13,8 @@ DOCUMENTATION = '''
     description:
       - Use this plugin when you dont care about any output for tasks that were completly skipped
     version_added: "2.4"
+    extends_documentation_fragment:
+      - default_callback
     requirements:
       - set as stdout in configuation
 '''

--- a/lib/ansible/plugins/callback/skippy.py
+++ b/lib/ansible/plugins/callback/skippy.py
@@ -13,6 +13,8 @@ DOCUMENTATION = '''
       - set as main display callback
     short_description: Ansible screen output that ignores skipped status
     version_added: "2.0"
+    extends_documentation_fragment:
+      - default_callback
     description:
         - This callback does the same as the default except it does not output skipped host/task/item status
 '''

--- a/lib/ansible/plugins/callback/stderr.py
+++ b/lib/ansible/plugins/callback/stderr.py
@@ -13,6 +13,8 @@ DOCUMENTATION = '''
       - set as main display callback
     short_description: Splits output, sending failed tasks to stderr
     version_added: "2.4"
+    extends_documentation_fragment:
+      - default_callback
     description:
         - This is the stderr callback plugin, it behaves like the default callback plugin but sends error output to stderr.
         - Also it does not output skipped host/task/item status

--- a/lib/ansible/utils/module_docs_fragments/default_callback.py
+++ b/lib/ansible/utils/module_docs_fragments/default_callback.py
@@ -1,0 +1,28 @@
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+class ModuleDocFragment(object):
+
+    DOCUMENTATION = """
+    options:
+      show_skipped_hosts:
+        name: Show skipped hosts
+        description: "Toggle to control displaying skipped task/host results in a task"
+        default: True
+        env:
+          - name: DISPLAY_SKIPPED_HOSTS
+        ini:
+          - key: display_skipped_hosts
+            section: defaults
+        type: boolean
+      show_custom_stats:
+        name: Show custom stats
+        description: 'This adds the custom stats set via the set_stats plugin to the play recap'
+        default: False
+        env:
+          - name: ANSIBLE_SHOW_CUSTOM_STATS
+        ini:
+          - key: show_custom_stats
+            section: defaults
+        type: bool
+"""

--- a/lib/ansible/utils/module_docs_fragments/default_callback.py
+++ b/lib/ansible/utils/module_docs_fragments/default_callback.py
@@ -1,6 +1,7 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+
 class ModuleDocFragment(object):
 
     DOCUMENTATION = """


### PR DESCRIPTION
##### SUMMARY

 - callbacks need to document same options as callbacks they inherit from to get them configured
 - since default is also used by many 3rd party callbacks for inheritance, making the code 'tolerate' the missing docs and fallback to using the direct constant to configure it's options.
 
Also fixed CLI options display .. wrongly changed into plugin_options

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
callbacks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


