### PR TITLE
Expand Windows test matrix on Shippable.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -17,10 +17,23 @@ matrix:
     - env: T=units/3.6
     - env: T=units/3.7
 
-    - env: T=windows/1
-    - env: T=windows/2
-    - env: T=windows/3
-    - env: T=windows/4
+    - env: T=windows/2008/1
+    - env: T=windows/2008-R2/1
+    - env: T=windows/2012/1
+    - env: T=windows/2012-R2/1
+    - env: T=windows/2016/1
+
+    - env: T=windows/2008/2
+    - env: T=windows/2008-R2/2
+    - env: T=windows/2012/2
+    - env: T=windows/2012-R2/2
+    - env: T=windows/2016/2
+
+    - env: T=windows/2008/3
+    - env: T=windows/2008-R2/3
+    - env: T=windows/2012/3
+    - env: T=windows/2012-R2/3
+    - env: T=windows/2016/3
 
     - env: T=network
 

--- a/test/integration/targets/wait_for_connection/aliases
+++ b/test/integration/targets/wait_for_connection/aliases
@@ -1,2 +1,2 @@
 posix/ci/group1
-windows/ci/group4
+windows/ci/group1

--- a/test/integration/targets/win_acl_inheritance/aliases
+++ b/test/integration/targets/win_acl_inheritance/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_audit_policy_system/aliases
+++ b/test/integration/targets/win_audit_policy_system/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group2

--- a/test/integration/targets/win_audit_rule/aliases
+++ b/test/integration/targets/win_audit_rule/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_certificate_store/aliases
+++ b/test/integration/targets/win_certificate_store/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group2

--- a/test/integration/targets/win_command/aliases
+++ b/test/integration/targets/win_command/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group1

--- a/test/integration/targets/win_copy/aliases
+++ b/test/integration/targets/win_copy/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_disk_facts/aliases
+++ b/test/integration/targets/win_disk_facts/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group2

--- a/test/integration/targets/win_domain_membership/aliases
+++ b/test/integration/targets/win_domain_membership/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group2

--- a/test/integration/targets/win_dotnet_ngen/aliases
+++ b/test/integration/targets/win_dotnet_ngen/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group2

--- a/test/integration/targets/win_dsc/aliases
+++ b/test/integration/targets/win_dsc/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group1

--- a/test/integration/targets/win_environment/aliases
+++ b/test/integration/targets/win_environment/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_eventlog_entry/aliases
+++ b/test/integration/targets/win_eventlog_entry/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group1

--- a/test/integration/targets/win_exec_wrapper/aliases
+++ b/test/integration/targets/win_exec_wrapper/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group2

--- a/test/integration/targets/win_firewall/aliases
+++ b/test/integration/targets/win_firewall/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group2

--- a/test/integration/targets/win_group_membership/aliases
+++ b/test/integration/targets/win_group_membership/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group1

--- a/test/integration/targets/win_iis_webbinding/aliases
+++ b/test/integration/targets/win_iis_webbinding/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_mapped_drive/aliases
+++ b/test/integration/targets/win_mapped_drive/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group1

--- a/test/integration/targets/win_msi/aliases
+++ b/test/integration/targets/win_msi/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group1

--- a/test/integration/targets/win_package/aliases
+++ b/test/integration/targets/win_package/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_pagefile/aliases
+++ b/test/integration/targets/win_pagefile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_psmodule/aliases
+++ b/test/integration/targets/win_psmodule/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group2

--- a/test/integration/targets/win_reg_stat/aliases
+++ b/test/integration/targets/win_reg_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group1

--- a/test/integration/targets/win_regedit/aliases
+++ b/test/integration/targets/win_regedit/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group2

--- a/test/integration/targets/win_region/aliases
+++ b/test/integration/targets/win_region/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group1

--- a/test/integration/targets/win_route/aliases
+++ b/test/integration/targets/win_route/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group3

--- a/test/integration/targets/win_say/aliases
+++ b/test/integration/targets/win_say/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group1

--- a/test/integration/targets/win_scheduled_task_stat/aliases
+++ b/test/integration/targets/win_scheduled_task_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group1

--- a/test/integration/targets/win_setup/aliases
+++ b/test/integration/targets/win_setup/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_share/aliases
+++ b/test/integration/targets/win_share/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_slurp/aliases
+++ b/test/integration/targets/win_slurp/aliases
@@ -1,1 +1,1 @@
-windows/ci/group3
+windows/ci/group2

--- a/test/integration/targets/win_stat/aliases
+++ b/test/integration/targets/win_stat/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group1

--- a/test/integration/targets/win_tempfile/aliases
+++ b/test/integration/targets/win_tempfile/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group2

--- a/test/integration/targets/win_timezone/aliases
+++ b/test/integration/targets/win_timezone/aliases
@@ -1,1 +1,1 @@
-windows/ci/group2
+windows/ci/group3

--- a/test/integration/targets/win_unzip/aliases
+++ b/test/integration/targets/win_unzip/aliases
@@ -1,1 +1,1 @@
-windows/ci/group1
+windows/ci/group2

--- a/test/integration/targets/win_uri/aliases
+++ b/test/integration/targets/win_uri/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_wakeonlan/aliases
+++ b/test/integration/targets/win_wakeonlan/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/integration/targets/win_whoami/aliases
+++ b/test/integration/targets/win_whoami/aliases
@@ -1,1 +1,1 @@
-windows/ci/group4
+windows/ci/group3

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -5,7 +5,8 @@ set -o pipefail
 declare -a args
 IFS='/:' read -ra args <<< "$1"
 
-target="windows/ci/group${args[1]}/"
+version="${args[1]}"
+target="windows/ci/group${args[2]}/"
 
 stage="${S:-prod}"
 provider="${P:-default}"
@@ -19,6 +20,9 @@ python_versions=(
     2.7
 )
 
+# version to test when only testing a single version
+single_version=2012-R2
+
 # shellcheck disable=SC2086
 ansible-test windows-integration "${target}" --explain ${CHANGED:+"$CHANGED"} 2>&1 | { grep ' windows-integration: .* (targeted)$' || true; } > /tmp/windows.txt
 
@@ -29,18 +33,19 @@ if [ -s /tmp/windows.txt ] || [ "${CHANGED:+$CHANGED}" == "" ]; then
     echo "Running Windows integration tests for multiple versions concurrently."
 
     platforms=(
-        --windows 2008
-        --windows 2008-R2
-        --windows 2012
-        --windows 2012-R2
-        --windows 2016
+        --windows "${version}"
     )
 else
     echo "No changes requiring integration tests specific to Windows were detected."
-    echo "Running Windows integration tests for a single version only."
+    echo "Running Windows integration tests for a single version only: ${single_version}"
+
+    if [ "${version}" != "${single_version}" ]; then
+        echo "Skipping this job since it is for: ${version}"
+        exit 0
+    fi
 
     platforms=(
-        --windows 2012-R2
+        --windows "${version}"
     )
 fi
 


### PR DESCRIPTION
##### SUMMARY

Expand Windows test matrix on Shippable.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.5.0 (windows-test-matrix fa8a3cbdd2) last updated 2017/09/15 09:43:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
