### PR TITLE
Command module bug fix, tests and cleanup.

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -144,7 +144,7 @@ def main():
         module.warn("As of Ansible 2.4, the parameter 'executable' is no longer supported with the 'command' module. Not using '%s'." % executable)
         executable = None
 
-    if args.strip() == '':
+    if not args or args.strip() == '':
         module.fail_json(rc=256, msg="no command given")
 
     if chdir:

--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -187,11 +187,6 @@ def main():
     endd = datetime.datetime.now()
     delta = endd - startd
 
-    if out is None:
-        out = b''
-    if err is None:
-        err = b''
-
     result = dict(
         cmd=args,
         stdout=out.rstrip(b"\r\n"),

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -206,8 +206,6 @@
       this line is the last line
   register: command_result6
 
-- debug: var=command_result6
-
 - name: assert the multiline input was passed correctly
   assert:
     that:
@@ -285,8 +283,6 @@
     | cut -f1 -d ' '
     echo "this is a second line"
   register: shell_result5
-
-- debug: var=shell_result5
 
 - name: assert the multiline shell command ran as expected
   assert:

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -16,6 +16,69 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: use command to execute sudo
+  command: sudo -h
+  register: become
+
+- name: assert become warning was reported
+  assert:
+    that:
+      - "become.warnings | length() == 1"
+      - "'Consider using' in become.warnings[0]"
+
+- name: use command to execute sudo without warnings
+  command: sudo -h warn=no
+  register: become
+
+- name: assert become warning was not reported
+  assert:
+    that:
+      - "'warnings' not in become"
+
+- name: use command to execute tar
+  command: tar -h
+  register: tar
+
+- name: assert tar warning was reported
+  assert:
+    that:
+      - "tar.warnings | length() == 1"
+      - "'Consider using unarchive module rather than running tar' in tar.warnings[0]"
+
+- name: use command to execute chown
+  command: chown -h
+  register: chown
+  ignore_errors: true
+
+- name: assert chown warning was reported
+  assert:
+    that:
+      - "chown.warnings | length() == 1"
+      - "'Consider using file module with owner rather than running chown' in chown.warnings[0]"
+
+- name: use command with unsupported executable arg
+  command: ls /dev/null executable=/bogus
+  register: executable
+
+- name: assert executable warning was reported
+  assert:
+    that:
+      - "executable.stdout == '/dev/null'"
+      - "executable.warnings | length() == 1"
+      - "'no longer supported' in executable.warnings[0]"
+
+- name: use command with no command
+  command: chdir=/
+  register: no_command
+  ignore_errors: true
+
+- name: assert executable fails with no command
+  assert:
+    that:
+      - "no_command.failed == true"
+      - "no_command.msg == 'no command given'"
+      - "no_command.rc == 256"
+
 - set_fact: output_dir_test={{output_dir}}/test_command_shell
 
 - name: make sure our testing sub-directory does not exist

--- a/test/integration/targets/command_shell/tasks/main.yml
+++ b/test/integration/targets/command_shell/tasks/main.yml
@@ -36,7 +36,7 @@
       - "'warnings' not in become"
 
 - name: use command to execute tar
-  command: tar -h
+  command: tar --help
   register: tar
 
 - name: assert tar warning was reported


### PR DESCRIPTION
##### SUMMARY

Command module bug fix, tests and cleanup:

- Add more command integration tests.
- Remove unnecessary command test debug tasks.
- Fix traceback in command module for empty args.
- Remove unreachable code.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

command module

##### ANSIBLE VERSION

```
ansible 2.5.0 (command-module 99485d9073) last updated 2017/09/15 11:15:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
