### PR TITLE
nxos_install_os incorrect options

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -189,7 +189,6 @@ def main():
     warnings = list()
     check_args(module, warnings)
 
-    install_state = module.params['install_state']
     system_image_file = module.params['system_image_file']
     kickstart_image_file = module.params['kickstart_image_file']
 
@@ -203,6 +202,7 @@ def main():
                        kickstart_image_file):
         changed = True
 
+    install_state = current_boot_options
     if not module.check_mode and changed is True:
         set_boot_options(module,
                          system_image_file,
@@ -213,8 +213,6 @@ def main():
                            kickstart_image_file):
             module.fail_json(msg='Install not successful',
                              install_state=install_state)
-    else:
-        install_state = current_boot_options
 
     module.exit_json(changed=changed, install_state=install_state, warnings=warnings)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
`install_state` is not in module.params, nor should it be.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_install_os

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```