### PR TITLE
Improve test reliability for win_chocolatey.

### DIFF
--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -20,42 +20,42 @@
   win_chocolatey:
     name: sysinternals
     state: present
-  register: install_sysinternals
+  register: install
 
 - name: verify install sysinternals
   assert:
     that:
-    - 'install_sysinternals.changed == true'
+    - 'install.changed == true'
 
 - name: install sysinternals again
   win_chocolatey:
     name: sysinternals
     state: present
-  register: install_sysinternals_again
+  register: install_again
 
 - name: verify install sysinternals again
   assert:
     that:
-    - 'install_sysinternals_again.changed == false'
+    - 'install_again.changed == false'
 
 - name: remove sysinternals
   win_chocolatey:
     name: sysinternals
     state: absent
-  register: remove_sysinternals
+  register: remove
 
 - name: verify remove sysinternals
   assert:
     that:
-    - 'remove_sysinternals.changed == true'
+    - 'remove.changed == true'
 
 - name: remove sysinternals again
   win_chocolatey:
     name: sysinternals
     state: absent
-  register: remove_sysinternals_again
+  register: remove_again
 
 - name: verify remove sysinternals again
   assert:
     that:
-    - 'remove_sysinternals_again.changed == false'
+    - 'remove_again.changed == false'

--- a/test/integration/targets/win_chocolatey/tasks/main.yml
+++ b/test/integration/targets/win_chocolatey/tasks/main.yml
@@ -16,46 +16,46 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: install sysinternals
+- name: install chocolatey-core.extension
   win_chocolatey:
-    name: sysinternals
+    name: chocolatey-core.extension
     state: present
   register: install
 
-- name: verify install sysinternals
+- name: verify install chocolatey-core.extension
   assert:
     that:
     - 'install.changed == true'
 
-- name: install sysinternals again
+- name: install chocolatey-core.extension again
   win_chocolatey:
-    name: sysinternals
+    name: chocolatey-core.extension
     state: present
   register: install_again
 
-- name: verify install sysinternals again
+- name: verify install chocolatey-core.extension again
   assert:
     that:
     - 'install_again.changed == false'
 
-- name: remove sysinternals
+- name: remove chocolatey-core.extension
   win_chocolatey:
-    name: sysinternals
+    name: chocolatey-core.extension
     state: absent
   register: remove
 
-- name: verify remove sysinternals
+- name: verify remove chocolatey-core.extension
   assert:
     that:
     - 'remove.changed == true'
 
-- name: remove sysinternals again
+- name: remove chocolatey-core.extension again
   win_chocolatey:
-    name: sysinternals
+    name: chocolatey-core.extension
     state: absent
   register: remove_again
 
-- name: verify remove sysinternals again
+- name: verify remove chocolatey-core.extension again
   assert:
     that:
     - 'remove_again.changed == false'


### PR DESCRIPTION
##### SUMMARY

Improve test reliability for win_chocolatey.

Hopefully installation of `chocolatey-core.extension` will be more reliable than `sysinternals`. The download for `sysinternals` occasionally fails during CI runs.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_chocolatey integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-chocolatey 737b09a3be) last updated 2017/09/15 12:44:01 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
