### PR TITLE
[fix] no-unicode-literals sanity error on ansible.egg-info

### DIFF
--- a/test/sanity/code-smell/no-unicode-literals.sh
+++ b/test/sanity/code-smell/no-unicode-literals.sh
@@ -3,6 +3,7 @@
 UNICODE_LITERALS_USERS=$(grep -r unicode_literals . \
     --exclude-dir .git \
     --exclude-dir .tox \
+    --exclude SOURCES.txt \
     --exclude no-unicode-literals.sh \
     --exclude no-unicode-literals.rst |
     grep -v ./test/results \

--- a/test/sanity/code-smell/no-unicode-literals.sh
+++ b/test/sanity/code-smell/no-unicode-literals.sh
@@ -6,7 +6,7 @@ UNICODE_LITERALS_USERS=$(grep -r unicode_literals . \
     --exclude no-unicode-literals.sh \
     --exclude no-unicode-literals.rst |
     grep -v ./test/results | \
-    grep -v ansible.egg-info/SOURCES.txt | \
+    grep -v ansible.egg-info/SOURCES.txt \
     )
 
 if [ "${UNICODE_LITERALS_USERS}" ]; then

--- a/test/sanity/code-smell/no-unicode-literals.sh
+++ b/test/sanity/code-smell/no-unicode-literals.sh
@@ -3,10 +3,10 @@
 UNICODE_LITERALS_USERS=$(grep -r unicode_literals . \
     --exclude-dir .git \
     --exclude-dir .tox \
-    --exclude SOURCES.txt \
     --exclude no-unicode-literals.sh \
     --exclude no-unicode-literals.rst |
-    grep -v ./test/results \
+    grep -v ./test/results | \
+    grep -v ansible.egg-info/SOURCES.txt | \
     )
 
 if [ "${UNICODE_LITERALS_USERS}" ]; then


### PR DESCRIPTION
##### SUMMARY
When we source hacking environment with ```source hacking/env-setup``` a python egg folder was created in lib/ so when we run the command ```ansible-test sanity --python 2.7``` an error occure because the grep command doesn't ignore the egg folder.
My fix modify the grep command used in the no-unicode-literals sanity check for ignoring matching results inside the egg folder.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
./test/sanity/code-smell/no-unicode-literals.sh

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
This is not systematical a bug I think it's depends on when the development environment was sourced and when the ansible.egg-info directory was generated.

before changes
```
Sanity check using no-get-exception
Sanity check using no-unicode-literals
ERROR: Command "test/sanity/code-smell/no-unicode-literals.sh" returned exit status 1.
>>> Standard Output
./lib/ansible.egg-info/SOURCES.txt:test/runner/.tox/py27/lib/python2.7/site-packages/pylint/test/functional/future_unicode_literals.py
./lib/ansible.egg-info/SOURCES.txt:test/runner/.tox/py27/lib/python2.7/site-packages/pylint/test/functional/future_unicode_literals.rc
./lib/ansible.egg-info/SOURCES.txt:test/runner/.tox/py27/lib/python2.7/site-packages/pylint/test/functional/future_unicode_literals.txt
./lib/ansible.egg-info/SOURCES.txt:test/runner/.tox/py27/local/lib/python2.7/site-packages/pylint/test/functional/future_unicode_literals.py
./lib/ansible.egg-info/SOURCES.txt:test/runner/.tox/py27/local/lib/python2.7/site-packages/pylint/test/functional/future_unicode_literals.rc
./lib/ansible.egg-info/SOURCES.txt:test/runner/.tox/py27/local/lib/python2.7/site-packages/pylint/test/functional/future_unicode_literals.txt
Sanity check using no-wildcard-import
Sanity check using pep8
```

after changes
```
Sanity check using no-basestring
Sanity check using no-dict-iteritems
Sanity check using no-dict-iterkeys
Sanity check using no-dict-itervalues
Sanity check using no-get-exception
Sanity check using no-unicode-literals
Sanity check using no-wildcard-import
Sanity check using pep8
```