### PR TITLE
Fix crypttab python3 compatibility issue

### DIFF
--- a/lib/ansible/modules/system/crypttab.py
+++ b/lib/ansible/modules/system/crypttab.py
@@ -89,7 +89,7 @@ import os
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_bytes, to_native
 
 def main():
 
@@ -169,7 +169,7 @@ def main():
     if changed and not module.check_mode:
         try:
             f = open(path, 'wb')
-            f.write(str(crypttab))
+            f.write(to_bytes(crypttab, errors='surrogate_or_strict'))
         finally:
             f.close()
 


### PR DESCRIPTION
##### SUMMARY
The crypttab module doesn't work with Python3.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
crypttab

##### ANSIBLE VERSION
```
ansible 2.5.0 (crypttab_python3_compatibility_fix 8c4532203c) last updated 2017/09/16 14:27:26 (GMT +200)
  config file = None
  configured module search path = [u'/home/john/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/john/workspace/ansible/lib/ansible
  executable location = /home/john/workspace/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Here is how to reproduce:
Python2 working case:
```
./hacking/test-module -I 'ansible_python_interpreter=/usr/bin/python2' -m lib/ansible/modules/system/crypttab.py -a '{"name":"foo","backing_device":"/dev/bar","state":"present","path":"/tmp/crypttab"}'
* including generated source, if any, saving to: /home/john/.ansible_module_generated
* ansiballz module detected; extracted module source to: /home/john/debug_dir
***********************************
RAW OUTPUT

{"group": "john", "name": "foo", "backing_device": "/dev/bar", "warnings": ["Module did not set no_log for password"], "changed": true, "invocation": {"module_args": {"name": "foo", "backing_device": "/dev/bar", "state": "present", "path": "/tmp/crypttab", "password": null, "opts": null}}, "state": "file", "gid": 1000, "mode": "0664", "msg": "added line", "owner": "john", "path": "/tmp/crypttab", "password": null, "uid": 1000, "opts": null, "size": 13}


***********************************
PARSED OUTPUT
{
    "backing_device": "/dev/bar", 
    "changed": true, 
    "gid": 1000, 
    "group": "john", 
    "invocation": {
        "module_args": {
            "backing_device": "/dev/bar", 
            "name": "foo", 
            "opts": null, 
            "password": null, 
            "path": "/tmp/crypttab", 
            "state": "present"
        }
    }, 
    "mode": "0664", 
    "msg": "added line", 
    "name": "foo", 
    "opts": null, 
    "owner": "john", 
    "password": null, 
    "path": "/tmp/crypttab", 
    "size": 13, 
    "state": "file", 
    "uid": 1000, 
    "warnings": [
        "Module did not set no_log for password"
    ]
}
```
Python3 not working case:
```
./hacking/test-module -I 'ansible_python_interpreter=/usr/bin/python3' -m lib/ansible/modules/system/crypttab.py -a '{"name":"foo","backing_device":"/dev/bar","state":"present","path":"/tmp/crypttab"}'
* including generated source, if any, saving to: /home/john/.ansible_module_generated
* ansiballz module detected; extracted module source to: /home/john/debug_dir
***********************************
RAW OUTPUT

Traceback (most recent call last):
  File "/home/john/debug_dir/ansible_module_crypttab.py", line 372, in <module>
    main()
  File "/home/john/debug_dir/ansible_module_crypttab.py", line 172, in main
    f.write(str(crypttab))
TypeError: a bytes-like object is required, not 'str'

***********************************
INVALID OUTPUT FORMAT

Traceback (most recent call last):
  File "./hacking/test-module", line 220, in runtest
    results = json.loads(out)
  File "/usr/lib/python2.7/json/__init__.py", line 339, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 364, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 382, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
```
