### PR TITLE
Remove git:// urls from docsite and from packaging

### DIFF
--- a/docs/docsite/rst/intro_adhoc.rst
+++ b/docs/docsite/rst/intro_adhoc.rst
@@ -193,7 +193,7 @@ Deploying From Source Control
 
 Deploy your webapp straight from git::
 
-    $ ansible webservers -m git -a "repo=git://foo.example.org/repo.git dest=/srv/myapp version=HEAD"
+    $ ansible webservers -m git -a "repo=https://foo.example.org/repo.git dest=/srv/myapp version=HEAD"
 
 Since Ansible modules can notify change handlers it is possible to
 tell Ansible to run specific tasks when the code is updated, such as

--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -124,7 +124,7 @@ You can also build an RPM yourself.  From the root of a checkout or tarball, use
 
 .. code-block:: bash
 
-    $ git clone git://github.com/ansible/ansible.git
+    $ git clone https://github.com/ansible/ansible.git
     $ cd ./ansible
     $ make rpm
     $ sudo rpm -Uvh ./rpm-build/ansible-*.noarch.rpm
@@ -263,7 +263,7 @@ Then install Ansible with [1]_::
 
 Or if you are looking for the latest development version::
 
-    pip install git+git://github.com/ansible/ansible.git@devel
+    pip install git+https://github.com/ansible/ansible.git@devel
 
 If you are installing on OS X Mavericks, you may encounter some noise from your compiler.  A workaround is to do the following::
 
@@ -305,7 +305,7 @@ To install from source, clone the Ansible git repository:
 
 .. code-block:: bash
 
-    $ git clone git://github.com/ansible/ansible.git --recursive
+    $ git clone https://github.com/ansible/ansible.git --recursive
     $ cd ./ansible
 
 Once git has cloned the Ansible repository, setup the Ansible environment:

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -24,7 +24,7 @@ optdepends=('python2-pyasn1: needed for accelerated mode'
 conflicts=('ansible')
 provides=('ansible')
 backup=('etc/ansible/ansible.cfg')
-source=($pkgname::git://github.com/ansible/ansible.git)
+source=($pkgname::git+https://github.com/ansible/ansible.git)
 md5sums=('SKIP')
 
 pkgver() {

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -7,7 +7,7 @@ __Note__: You must run this target as root or set `PBUILDER_BIN='sudo pbuilder'`
 
 ```
 apt-get install asciidoc cdbs debootstrap devscripts make pbuilder python-setuptools
-git clone git://github.com/ansible/ansible.git
+git clone https://github.com/ansible/ansible.git
 cd ansible
 git submodule update --init
 DEB_DIST='xenial trusty precise' make deb
@@ -16,7 +16,7 @@ DEB_DIST='xenial trusty precise' make deb
 Building in Docker:
 
 ```
-git clone git://github.com/ansible/ansible.git
+git clone https://github.com/ansible/ansible.git
 cd ansible
 git submodule update --init
 docker build -t ansible-deb-builder -f packaging/debian/Dockerfile .


### PR DESCRIPTION
##### SUMMARY
It's almost always preferable to clone by way of https:// rather than
using the bare git:// protocol. Not only does https:// provide
stronger guarantees it also plays nicer with corporate proxies, etc.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
documentation

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 785e604c57) last updated 2017/09/16 13:25:40 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/lab/ansible/devel/lib/ansible
  executable location = /home/andreas/lab/ansible/devel/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```