### PR TITLE
nicer error on bad ansible config

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -40,17 +40,15 @@ import traceback
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_text
 
-########################################
-# OUTPUT OF LAST RESORT
+
 class LastResort(object):
+    # OUTPUT OF LAST RESORT
     def display(self, msg, log_only=None):
         print(msg, file=sys.stderr)
 
     def error(self, msg, wrap_text=None):
         print(msg, file=sys.stderr)
 
-
-########################################
 
 if __name__ == '__main__':
 

--- a/bin/ansible
+++ b/bin/ansible
@@ -37,11 +37,8 @@ import shutil
 import sys
 import traceback
 
-import ansible.constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
-from ansible.utils.display import Display
 from ansible.module_utils._text import to_text
-
 
 ########################################
 # OUTPUT OF LAST RESORT
@@ -58,6 +55,14 @@ class LastResort(object):
 if __name__ == '__main__':
 
     display = LastResort()
+
+    try:  # bad ANSIBLE_CONFIG or config options can force ugly stacktrace
+        import ansible.constants as C
+        from ansible.utils.display import Display
+    except AnsibleOptionsError as e:
+        display.error(to_text(e), wrap_text=False)
+        sys.exit(5)
+
     cli = None
     me = os.path.basename(sys.argv[0])
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

`ANSIBLE_CONFIG=/etc/hosts ansible -m debug localhost` results in nasty traceback, this fix makes sure the msg is not clouded by it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
config
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.5/2.4
```