### PR TITLE
Fix crypttab module adding extra newlines

### DIFF
--- a/lib/ansible/modules/system/crypttab.py
+++ b/lib/ansible/modules/system/crypttab.py
@@ -194,7 +194,7 @@ class Crypttab(object):
     def __str__(self):
         lines = []
         for line in self._lines:
-            lines.append(str(line))
+            lines.append(str(line).splitlines()[0])
         crypttab = '\n'.join(lines)
         if len(crypttab) == 0:
             crypttab += '\n'


### PR DESCRIPTION
##### SUMMARY
Crypttab adds unwanted newlines after each unrelevant line (e.g comments, empty lines, ...).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
crypttab

##### ANSIBLE VERSION
```
ansible 2.5.0 (crypttab_carriage_return_fix a8409cc39f) last updated 2017/09/17 10:09:33 (GMT +200)
  config file = None
  configured module search path = [u'/home/john/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/john/workspace/ansible/lib/ansible
  executable location = /home/john/workspace/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Here is how to reproduce:
```
echo -e "#comment1\n#comment2" > /tmp/crypttab
./hacking/test-module -m lib/ansible/modules/system/crypttab.py -a '{"name":"foo","backing_device":"/dev/bar","state":"present","path":"/tmp/crypttab"}'
cat /tmp/crypttab
```
will output:
```
#comment1

#comment2

foo /dev/bar
```
while the expected result is:
```
#comment1
#comment2
foo /dev/bar
```
