### PR TITLE
add ios_pmtud network module

### DIFF
--- a/lib/ansible/modules/network/ios/ios_pmtud.py
+++ b/lib/ansible/modules/network/ios/ios_pmtud.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import print_function
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: ios_pmtud
+short_description: Perform path MTU discovery on Cisco IOS devices.
+description:
+    - Perform path MTU discovery on Cisco IOS devices.
+author:
+    - Martin Komon (@mkomon)
+version_added: '2.5'
+extends_documentation_fragment: ios
+options:
+    dest:
+        description:
+            - IP to ping, should respond to 1500 B packets from Internet
+        required: true
+    vrf:
+        description:
+            - VRF name
+        required: false
+    source:
+        description:
+            - Source interface name or IP address
+        required: false
+    max_size:
+        description:
+            - Start and max size for path MTU discovery.
+        default: 1500
+        required: false
+    max_range:
+        description:
+            - Max range of path MTU discovery. Must be 2^n.
+        default: 512
+        required: false
+
+'''
+
+EXAMPLES = '''
+---
+- cli:
+    host: "{{ inventory_hostname }}"
+    username: cisco
+    password: cisco
+
+# Run path MTU discovery
+- name: MTU check
+  ios_pmtud:
+    ip: 169.254.169.254
+    provider: "{{ cli }}"
+
+
+# Run path MTU discovery with source interface and VRF
+- name: Test with a message and changed output
+  ios_pmtud:
+    ip: 169.254.169.254
+    src_if: Lo0
+    vrf: MGMT
+    provider: "{{ cli }}"
+
+# Run a quicker path MTU discovery in smaller range
+- name: Test failure of the module
+  ios_pmtud:
+    ip: 8.8.8.8
+    vrf: internet
+    max_range: 64
+    provider: "{{ cli }}"
+
+# fail the module
+- name: Test failure of the module
+  ios_pmtud:
+    ip: 333.333.333.333
+    provider: "{{ cli }}"
+
+'''
+
+RETURN = '''
+mtu:
+  description: Path MTU size in bytes
+  returned: always
+  type: int
+dest:
+  description: Destination IP tested
+  returned: always
+  type: int
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ios import run_commands
+from ansible.module_utils.ios import ios_argument_spec, check_args
+
+
+def run_module():
+    module_args = dict(
+        dest=dict(type='str', required=True),
+        vrf=dict(type='str', required=False, default=None),
+        source=dict(type='str', required=False, default=None),
+        max_size=dict(type='int', required=False, default=1500),
+        max_range=dict(type='int', required=False, default=512),
+    )
+    module_args.update(ios_argument_spec)
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    results = dict(
+        changed=False,
+        mtu=0,
+        dest=module.params['dest']
+    )
+
+    dest = module.params['dest']
+    source = module.params['source']
+    vrf = module.params['vrf']
+    max_size = module.params['max_size']
+    max_range = module.params['max_range']
+
+    warnings = list()
+    check_args(module, warnings)
+
+    if module.check_mode:
+        return results
+
+    test_size = max_size
+    step = max_range
+
+    def ping_str(dest, vrf, source, test_size):
+        return 'ping {0}{1} df-bit {2}repeat 3 size {3}'.format(
+            'vrf {0} '.format(vrf) if vrf else '',
+            dest,
+            'source {0} '.format(source) if source else '',
+            test_size)
+
+    # Check if ICMP passes at all
+    ping_results = run_commands(module, commands=ping_str(dest, vrf, source, 64))[0]
+    if 'Success rate is 0 percent' in ping_results:
+        module.fail_json(msg='Unknown error, PMTUD cannot run.', **results)
+
+    while True:
+        step = step / 2 if step >= 2 else 0
+        ping_results = run_commands(module, commands=ping_str(dest, vrf, source, test_size))[0]
+        if 'Success rate is 0 percent' not in ping_results and test_size == max_size:
+            # ping success with max test size, save and break
+            results['mtu'] = test_size
+            break
+        if 'Success rate is 0 percent' not in ping_results:
+            # ping success, increase test size
+            results['mtu'] = test_size
+            test_size += step
+        else:
+            # ping fail, lower size
+            test_size -= step
+        if step < 1:
+            break
+
+    if not results['mtu']:
+        module.fail_json(msg='MTU too low, increase max_range.', **results)
+
+    module.exit_json(**results)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/ios/ios_pmtud.py
+++ b/lib/ansible/modules/network/ios/ios_pmtud.py
@@ -97,6 +97,7 @@ dest:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ios import run_commands
 from ansible.module_utils.ios import ios_argument_spec, check_args
+import math
 
 
 def run_module():
@@ -128,6 +129,14 @@ def run_module():
 
     warnings = list()
     check_args(module, warnings)
+
+    # check if max_range is a power of 2
+    log_max_range = math.log(max_range) / math.log(2)
+    if math.floor(log_max_range) != log_max_range:
+        max_range = module_args['max_range']['default']
+        warnings.append('Max_range must be a power of 2 between 2 and 1024; '
+                        'ignoring value {0} and using default {1}.'
+                        ''.format(module.params['max_range'], max_range))
 
     if module.check_mode:
         return results
@@ -167,6 +176,7 @@ def run_module():
     if not results['mtu']:
         module.fail_json(msg='MTU too low, increase max_range.', **results)
 
+    results['warnings'] = warnings
     module.exit_json(**results)
 
 

--- a/test/integration/ios.yaml
+++ b/test/integration/ios.yaml
@@ -103,6 +103,16 @@
             failed_modules: "{{ failed_modules }} + [ 'ios_ping' ]"
             test_failed: true
 
+    - block:
+      - include_role:
+          name: ios_pmtud
+        when: "limit_to in ['*', 'ios_pmtud']"
+      rescue:
+        - set_fact:
+            failed_modules: "{{ failed_modules }} + [ 'ios_pmtud' ]"
+            test_failed: true
+
+
 ###########
     - debug: var=failed_modules
       when: test_failed

--- a/test/integration/targets/ios_pmtud/defaults/main.yaml
+++ b/test/integration/targets/ios_pmtud/defaults/main.yaml
@@ -1,0 +1,3 @@
+---
+testcase: "*"
+test_items: []

--- a/test/integration/targets/ios_pmtud/meta/main.yaml
+++ b/test/integration/targets/ios_pmtud/meta/main.yaml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_ios_tests

--- a/test/integration/targets/ios_pmtud/tasks/cli.yaml
+++ b/test/integration/targets/ios_pmtud/tasks/cli.yaml
@@ -1,0 +1,16 @@
+---
+- name: collect all cli test cases
+  find:
+    paths: "{{ role_path }}/tests/cli"
+    patterns: "{{ testcase }}.yaml"
+  register: test_cases
+  delegate_to: localhost
+
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case
+  include: "{{ test_case_to_run }}"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run

--- a/test/integration/targets/ios_pmtud/tasks/main.yaml
+++ b/test/integration/targets/ios_pmtud/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- { include: cli.yaml, tags: ['cli'] }

--- a/test/integration/targets/ios_pmtud/tests/cli/pmtud.yaml
+++ b/test/integration/targets/ios_pmtud/tests/cli/pmtud.yaml
@@ -1,0 +1,25 @@
+---
+- debug: msg="START cli/pmtud.yaml"
+
+- name: expected successful pmtud
+  ios_pmtud: &valid_ip
+    dest: '8.8.8.8'
+  register: test1
+  
+- name: expected unknown error (unreachable dest IP)
+  ios_pmtud: &invalid_ip
+    dest: '1.1.1.1'
+  register: test2
+
+- name: expected MTU too low
+  ios_pmtud: &valid_ip
+    dest: '8.8.8.8'
+    max_size: 9999
+    max_range: 2
+  register: test3
+
+- name: assert
+  assert:
+    that:
+    - test1.failed == false
+    - test2.failed == test3.failed == true

--- a/test/units/modules/network/ios/test_ios_pmtud.py
+++ b/test/units/modules/network/ios/test_ios_pmtud.py
@@ -42,7 +42,27 @@ class TestIosPmtudModule(TestIosModule):
         set_module_args(dict(dest="8.8.8.8"))
         self.execute_module()
 
-    def test_ios_pmtud_expected_failure(self):
-        ''' Test path MTU discovery when destination should not be reachable '''
-        set_module_args(dict(dest="1.1.1.1"))
+    def test_ios_pmtud_expected_success2(self):
+        ''' Test path MTU discovery with a valid max_range '''
+        set_module_args(dict(dest="8.8.8.8", max_range=2))
+        self.execute_module()
+
+    def test_ios_pmtud_expected_success3(self):
+        ''' Test path MTU discovery with a valid max_range '''
+        set_module_args(dict(dest="8.8.8.8", max_range=512))
+        self.execute_module()
+
+    def test_ios_pmtud_expected_success4(self):
+        ''' Test path MTU discovery with a valid max_range '''
+        set_module_args(dict(dest="8.8.8.8", max_range=1024))
+        self.execute_module()
+
+    def test_ios_pmtud_expected_success5(self):
+        ''' Test path MTU discovery with invalid max_range '''
+        set_module_args(dict(dest="8.8.8.8", max_range=100))
+        self.execute_module()
+
+    def test_ios_pmtud_expected_success6(self):
+        ''' Test path MTU discovery with invalid max_range '''
+        set_module_args(dict(dest="8.8.8.8", max_range=1042))
         self.execute_module()

--- a/test/units/modules/network/ios/test_ios_pmtud.py
+++ b/test/units/modules/network/ios/test_ios_pmtud.py
@@ -1,0 +1,48 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.ios import ios_pmtud
+from .ios_module import TestIosModule, load_fixture, set_module_args
+
+
+class TestIosPmtudModule(TestIosModule):
+    ''' Class used for Unit Tests against ios_pmtud module '''
+    module = ios_pmtud
+
+    def setUp(self):
+        self.mock_run_commands = patch('ansible.modules.network.ios.ios_pmtud.run_commands')
+        self.run_commands = self.mock_run_commands.start()
+
+    def tearDown(self):
+        self.mock_run_commands.stop()
+
+    def load_fixtures(self, commands=None):
+        # path MTU discovery is interactive
+        pass
+
+    def test_ios_pmtud_expected_success(self):
+        ''' Test path MTU discovery when destination should be reachable '''
+        set_module_args(dict(dest="8.8.8.8"))
+        self.execute_module()
+
+    def test_ios_pmtud_expected_failure(self):
+        ''' Test path MTU discovery when destination should not be reachable '''
+        set_module_args(dict(dest="1.1.1.1"))
+        self.execute_module()


### PR DESCRIPTION
##### SUMMARY
Add ios_pmtud module to perform path MTU discovery on Cisco IOS devices.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
ios_pmtud

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 6e7cfb5add) last updated 2017/09/17 18:42:39 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules', u'/Users/mkomon/ansible-ios-pmtud', u'/Users/mkomon/Documents/github/ansible-junos-stdlib/library']
  ansible python module location = /Users/mkomon/Documents/github/ansible/lib/ansible
  executable location = /Users/mkomon/Documents/github/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
Finds path MTU to destination IP, with optional VRF and source IP/interface specification. With defaults it finds MTU in range 989-1500 B in exactly 9 steps (always log2(max_range) steps). Tolerates any packet loss lower than 100 pct.

Tested on
- 15.5(3)S3
- 15.4(3)S4

Example invocation:
```
  - name: Check Internet circuit MTU
      ios_pmtud:
        dest: 8.8.8.8
        provider: "{{ cli }}"
        vrf: internet
        max_range: 256
      register: mtu
```

edit: updated Ansible version