### PR TITLE
modules/system/user.py: Change createhome to create_home (#30179)

### DIFF
--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -58,7 +58,7 @@
   user:
       name: "{{ user_names.stdout_lines|random }}"
       state: present
-      createhome: no
+      create_home: no
   with_sequence: start=1 end=5
   register: user_test1
 - debug: var=user_test1


### PR DESCRIPTION
##### SUMMARY
modules/system/user.py: Change createhome to create_home (#30179)

This is done to maintain consistency with other parameters that replace a hyphen with an underscore. I've maintained `createhome` as an alias to `create_home` to avoid breaking existing plays. Documentation and integration tests have been updated to reflect new preferred name.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/system/user.py

##### ANSIBLE VERSION
```
[reid@laptop ~/git]$ ansible --version
ansible 2.5.0 (issue/30179 a47eb840a6) last updated 2017/09/17 12:46:43 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
N/A
