### PR TITLE
Feature/refactor opkg add unit test to opkg

### DIFF
--- a/lib/ansible/modules/packaging/os/opkg.py
+++ b/lib/ansible/modules/packaging/os/opkg.py
@@ -120,8 +120,8 @@ def is_installed(module, package, state="present"):
     """ Returns whether a package is installed or not. """
     present = False
     if state != "present":
-        command = get_opkg_path(module)
         return present
+    command = get_opkg_path(module)
     rc, _, _ = module.run_command("%s list-installed | grep -q \"^%s \"" % (
         pipes.quote(command),
         pipes.quote(package)),

--- a/lib/ansible/modules/packaging/os/opkg.py
+++ b/lib/ansible/modules/packaging/os/opkg.py
@@ -120,9 +120,10 @@ def is_installed(module, package, state="present"):
     """ Returns whether a package is installed or not. """
     present = False
     if state != "present":
+        command = get_opkg_path(module)
         return present
     rc, _, _ = module.run_command("%s list-installed | grep -q \"^%s \"" % (
-        pipes.quote(get_opkg_path(module)),
+        pipes.quote(command),
         pipes.quote(package)),
         use_unsafe_shell=True
     )

--- a/test/units/modules/packaging/os/test_opkg.py
+++ b/test/units/modules/packaging/os/test_opkg.py
@@ -1,0 +1,28 @@
+from ansible.compat.tests import mock
+from ansible.compat.tests import unittest
+from ansible.modules.packaging.os import opkg
+
+
+class TestOpkgInstall(unittest.TestCase):
+
+    def setUp(self):
+        self.module_names = [
+            'bash',
+            'g++',
+        ]
+
+    @mock.patch('ansible.modules.packaging.os.opkg.AnsibleModule')
+    def test_already_installed(self, mock_module):
+        for module_name in self.module_names:
+            command_output = module_name + '-2.0.0-r1 < 3.0.0-r2 '
+            mock_module.run_command.return_value = (0, command_output, None)
+            command_result = opkg.is_installed(mock_module, module_name)
+            self.assertTrue(command_result)
+
+    @mock.patch('ansible.modules.packaging.os.opkg.AnsibleModule')
+    def test_get_opkg_path(self, mock_module):
+        for module_name in self.module_names:
+            mock_module.run_command.return_value = (0, "", None)
+            mock_module.get_bin_path.return_value = "/bin/opkg"
+            command_result = opkg.is_installed(mock_module, module_name)
+            self.assertTrue(command_result)

--- a/test/units/modules/packaging/os/test_opkg.py
+++ b/test/units/modules/packaging/os/test_opkg.py
@@ -16,6 +16,7 @@ class TestOpkgInstall(unittest.TestCase):
         for module_name in self.module_names:
             command_output = module_name + '-2.0.0-r1 < 3.0.0-r2 '
             mock_module.run_command.return_value = (0, command_output, None)
+            mock_module.get_bin_path.return_value = "/bin/opkg"
             command_result = opkg.is_installed(mock_module, module_name)
             self.assertTrue(command_result)
 


### PR DESCRIPTION
##### SUMMARY
Implement unittest for opkg package manager and refactor this

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/os/opkg.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/rector_opkg f05db96763) last updated 2017/09/17 23:23:58 (GMT +200)
  config file = None
  configured module search path = ['/home/herve/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/herve/dev/ansible/lib/ansible
  executable location = /home/herve/dev/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION

After adding unittest
```
Unit test with Python 2.7
============================================================= test session starts =============================================================
platform linux2 -- Python 2.7.12, pytest-3.2.2, py-1.4.34, pluggy-0.4.0
rootdir: /home/herve/dev/ansible, inifile:
plugins: xdist-1.20.0, mock-1.6.2, forked-0.2, f5-sdk-2.3.3
collected 2 items                                                                                                                              

test/units/modules/packaging/os/test_opkg.py ..

----------------------------- generated xml file: /home/herve/dev/ansible/test/results/junit/python2.7-units.xml ------------------------------
========================================================== 2 passed in 0.04 seconds ===========================================================
___________________________________________________________________ summary ___________________________________________________________________
  py27: commands succeeded
  congratulations :)

```
