### PR TITLE
modules/system/user.py: Replace deprecated platform.dist() call

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -247,7 +247,6 @@ EXAMPLES = '''
 import os
 import pwd
 import grp
-import platform
 import socket
 import time
 import shutil
@@ -385,9 +384,12 @@ class User(object):
             # errors from useradd trying to create a group when
             # USERGROUPS_ENAB is set in /etc/login.defs.
             if os.path.exists('/etc/redhat-release'):
-                dist = platform.dist()
-                major_release = int(dist[1].split('.')[0])
-                if major_release <= 5:
+                major_release = None
+                with open('/etc/redhat-release', 'r') as f:
+                    firstline = f.readline()
+                    os_release = firstline.split()[7]
+                    major_release = int(os_release.split('.')[0])
+                if major_release and major_release <= 5:
                     cmd.append('-n')
                 else:
                     cmd.append('-N')


### PR DESCRIPTION
##### SUMMARY
modules/system/user.py: Replace deprecated platform.dist() call

`platform.dist()` and `platform.linux_distribution()` are deprecated and expected to be removed in Py3.7 (https://bugs.python.org/issue1322). There was discussion that due to cross-platform reliability issues it should not be included in the standard library. I don't see much in the way of what should replace it, except a module called `distro` (https://github.com/nir0s/distro#distro---a-linux-os-platform-information-api). `distro` is not part of the standard distribution of Python and currently needs to be installed separately. We probably need to re-evaluate how `module_utils/basic.py` gets distribution info as well.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/system/user.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (issue/30179_3 16b8d24dfd) last updated 2017/09/17 17:01:10 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

##### ADDITIONAL INFORMATION
N/A