### PR TITLE
windows: fix list type in legacy module utils

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -201,7 +201,9 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
 
     # If $value -eq $null, the parameter was unspecified by the user (deliberately or not)
     # Please leave $null-values intact, modules need to know if a parameter was specified
-    if ($value -ne $null) {
+    # When $value is already an array, we cannot rely on the null check, as an empty list
+    # is seen as null in the check below
+    if ($value -ne $null -or $value -is [array]) {
         if ($type -eq "path") {
             # Expand environment variables on path-type
             $value = Expand-Environment($value)

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -240,10 +240,12 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
             } else {
                 Fail-Json -obj $resultobj -message "Get-AnsibleParam: Parameter '$name' is not a YAML list."
             }
+            # , is not a typo, forces it to return as a list when it is empty or only has 1 entry
+            return ,$value
         }
     }
 
-    return ,$value
+    return $value
 }
 
 #Alias Get-attr-->Get-AnsibleParam for backwards compat. Only add when needed to ease debugging of scripts

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.Legacy.psm1
@@ -243,7 +243,7 @@ Function Get-AnsibleParam($obj, $name, $default = $null, $resultobj = @{}, $fail
         }
     }
 
-    return $value
+    return ,$value
 }
 
 #Alias Get-attr-->Get-AnsibleParam for backwards compat. Only add when needed to ease debugging of scripts

--- a/test/integration/targets/win_module_utils_legacy/library/testlist.ps1
+++ b/test/integration/targets/win_module_utils_legacy/library/testlist.ps1
@@ -1,0 +1,12 @@
+#powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+
+$params = Parse-Args $args
+$value = Get-AnsibleParam -Obj $params -Name value -Type list
+
+if ($value -isnot [array]) {
+    Fail-Json -obj @{} -message "value was not a list but was $($value.GetType().FullName)"
+}
+
+Exit-Json @{ count = $value.Count }

--- a/test/integration/targets/win_module_utils_legacy/tasks/main.yml
+++ b/test/integration/targets/win_module_utils_legacy/tasks/main.yml
@@ -21,3 +21,21 @@
   - path: '{{ bogus_driveletter.stdout_lines[0] }}:\goodpath'
   - path: '{{ bogus_driveletter.stdout_lines[0] }}:\badpath*%@:\blar'
     should_fail: true
+
+- name: test list parameters
+  testlist:
+    value: '{{item.value}}'
+  register: list_tests
+  failed_when: list_tests|failed or list_tests.count != item.count
+  with_items:
+  - value: []
+    count: 0
+  - value:
+    - 1
+    - 2
+    count: 2
+  - value:
+    - 1
+    count: 1
+  - value: "1, 2"
+    count: 2


### PR DESCRIPTION
##### SUMMARY
The legacy module utils does not return a list when the param is empty or only has 1 entry.

Fixes https://github.com/ansible/ansible/issues/30480

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.Legacy.psm1

##### ANSIBLE VERSION
```
2.5
```