### PR TITLE
include and import need to get documented in the porting guide

### DIFF
--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -20,6 +20,36 @@ Python version
 
 Ansible will not support Python 2.4 nor 2.5 on the target hosts anymore. Going forward, Python 2.6+ will be required on targets, as already is the case on the controller.
 
+Playbook
+========
+
+`import_` and `include_` split
+------------------------------
+
+
+**OLD** In Ansible 2.3:
+
+.. code-block:: yaml
+
+    - name: old foo
+
+Will result in:
+
+.. code-block:: yaml
+
+   [WARNING]: deprecation message 1
+   [WARNING]: deprecation message 2
+   [WARNING]: deprecation message 3
+
+
+**NEW** In Ansible 2.4:
+
+
+.. code-block:: yaml
+
+   - name: foo
+
+
 Deprecated
 ==========
 


### PR DESCRIPTION
##### SUMMARY
There was one item that needed to be added to the porting guide that wasn't added.  Documentation on how to switch from ``include_*`` to ``import_*``.  This PR is to remind us to add that in time for 2.4.1.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docsite/rst/porting_guide_2.4.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4 devel
```


##### ADDITIONAL INFORMATION

@jimi-c I think you're the one that understands this change.