### PR TITLE
ansible-vault edit: prompt for existing instead of new password (#30491)

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -165,7 +165,7 @@ class VaultCLI(CLI):
 
         # TODO: instead of prompting for these before, we could let VaultEditor
         #       call a callback when it needs it.
-        if self.action in ['decrypt', 'view', 'rekey']:
+        if self.action in ['decrypt', 'view', 'rekey', 'edit']:
             vault_secrets = self.setup_vault_secrets(loader,
                                                      vault_ids=vault_ids,
                                                      vault_password_files=self.options.vault_password_files,
@@ -173,7 +173,7 @@ class VaultCLI(CLI):
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
-        if self.action in ['encrypt', 'encrypt_string', 'create', 'edit']:
+        if self.action in ['encrypt', 'encrypt_string', 'create']:
             if len(vault_ids) > 1:
                 raise AnsibleOptionsError("Only one --vault-id can be used for encryption")
 


### PR DESCRIPTION
##### SUMMARY
ansible-vault edit: prompt for existing instead of new password (#30491)

Currently the `ansible-vault edit` command is prompting for a new password after one has been set. The purpose of the edit command is to edit an already encrypted file. New encryptions should be done using the `encrypt` or `create` commands. See issue for more info.

Need to backport this to 2.4 per @abadger .

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (issue/30491 139f3e7bbd) last updated 2017/09/17 22:49:04 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/reid/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/reid/git/ansible/lib/ansible
  executable location = /home/reid/git/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
BEFORE:
```
[reid@laptop ~/git]$ ansible-vault edit dummy.txt --ask-vault-pass
New Vault password: 
Confirm New Vault password: 
```

AFTER:
```
[reid@laptop ~/git]$ ansible-vault edit dummy.txt --ask-vault-pass
Vault password: 
```