### PR TITLE
Add esxi_hostname as argument in vmware_vswitch

### DIFF
--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -126,3 +126,31 @@
 #- assert:
 #    that:
 #    - remove_nic_again_run.changed == false
+
+
+- name: get a list of Host Systems from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=H' }}"
+  register: host_systems
+
+- name: get a host system
+  set_fact: hs1="{{ host_systems['json'][0] | basename }}"
+
+- debug: var=hs1
+
+- name: Add vswitch to a specific host system
+  vmware_vswitch:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    switch: vmswitch_0002
+    nics: vnic_1
+    esxi_hostname: hs1
+  register: add_vswitch_with_host_system
+
+- debug: var=add_vswitch_with_host_system
+
+- assert:
+    that:
+    - add_vswitch_with_host_system.changed == true


### PR DESCRIPTION
##### SUMMARY
Fix adds esxi_hostname as Ansible module argument for user
to define ESXi hostname to deploy VMware vSwitch.

Fixes: #24647

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
test/integration/targets/vmware_vswitch/tasks/main.yml
lib/ansible/modules/cloud/vmware/vmware_vswitch.py

##### ANSIBLE VERSION
```
2.5devel
```