### PR TITLE
move --host and --port option for mysql_db db_import method

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -196,15 +196,15 @@ def db_import(module, host, user, password, db_name, target, all_databases, port
         cmd.append("--password=%s" % pipes.quote(password))
     if socket is not None:
         cmd.append("--socket=%s" % pipes.quote(socket))
+    else:
+        cmd.append("--host=%s" % pipes.quote(host))
+        cmd.append("--port=%i" % port)
     if ssl_cert is not None:
         cmd.append("--ssl-cert=%s" % pipes.quote(ssl_cert))
     if ssl_key is not None:
         cmd.append("--ssl-key=%s" % pipes.quote(ssl_key))
     if ssl_cert is not None:
         cmd.append("--ssl-ca=%s" % pipes.quote(ssl_ca))
-    else:
-        cmd.append("--host=%s" % pipes.quote(host))
-        cmd.append("--port=%i" % port)
     if not all_databases:
         cmd.append("-D")
         cmd.append(pipes.quote(db_name))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix condition for mysql_db db_import method.
Move --host and --port option condition.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #30500 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
mysql_db

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
