### PR TITLE
Fix folder search path in vmware_guest_facts

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -48,11 +48,11 @@ options:
             - This is required if name is supplied.
             - The 'root' virtual machine folder is always '<name_of_datacenter>/vm'
             - ESX/ESXi's datacenter name is 'ha-datacenter'
-            - 'Examples:'
-            - '   folder: folder2' would search 'ha-datacenter/vm/folder2' on ESX
-            - '   folder: level1/level2/level3'
-            - '   folder: /DC2/vm/testfolder' would exactly search within that path
-            -                                 although "datacenter" might contain something else.
+            - Examples:
+            - "   'folder: folder2' would search 'ha-datacenter/vm/folder2' on ESX"
+            - "   'folder: level1/level2/level3'"
+            - "   'folder: /DC2/vm/testfolder' would exactly search within that path"
+            - "                                although 'datacenter' might contain something else."
    datacenter:
         description:
             - Destination datacenter for the deploy operation


### PR DESCRIPTION
Use relativ paths to search for the guest vm. The 'root' virtual machine
folder is always '<name_of_datacenter>/vm'. So append given folder path to
this 'root' path if folder does NOT match the default '/vm' path.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - vmware_guest_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.12 (default, Jun 29 2016, 08:57:23) [GCC 5.3.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Trying to gather facts from a vm in the default 'root' folder does not succeed. The virtual machine is not found.

Using a simple playbook like

```
---

- hosts: vctest
  gather_facts: false
  connection: local

  tasks:
  - name: Gather facts from a vm
    vmware_guest_facts:
      hostname: vctest
      username: administrator@vpshere.local
      password: password
      name: test1
      datacenter: TEST
      validate_certs: false
```
results in

```
fatal: [vctest]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "datacenter": "TEST",
            "folder": "/vm",
            "hostname": "vctest",
            "name": "test1",
            "name_match": "first",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "administrator@vspher.local",
            "uuid": null,
            "validate_certs": false
        }
    },
    "msg": "Unable to gather facts for non-existing VM test1"
}
```
This is because the search path is wrong. We need to prepend the "folder" path with "<name_of_datacenter>/vm" This is the 'root' path. Using this, the facts can be retrieved

After code change...

```
ok: [vctest] => {
    ...
    ...
    "invocation": {
        "module_args": {
            "datacenter": "TEST",
            "folder": "TEST/vm",
            "hostname": "vctest",
            "name": "test1",
            "name_match": "first",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "username": "administrator@vsphere.local",
            "uuid": null,
            "validate_certs": false
        }
    }
}
```

Tested on the VCSA 6.5