### PR TITLE
Add one-versus-many-matches logic to network filter plugin

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -56,7 +56,10 @@ def re_matchall(regex, value):
         obj = {}
         if regex.groupindex:
             for name, index in iteritems(regex.groupindex):
-                obj[name] = match[index - 1]
+		if len(regex.groupindex) == 1:
+		    obj[name] = match
+		else:
+                    obj[name] = match[index - 1]
             objects.append(obj)
     return objects
 

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -56,9 +56,9 @@ def re_matchall(regex, value):
         obj = {}
         if regex.groupindex:
             for name, index in iteritems(regex.groupindex):
-		if len(regex.groupindex) == 1:
-		    obj[name] = match
-		else:
+                if len(regex.groupindex) == 1:
+                    obj[name] = match
+                else:
                     obj[name] = match[index - 1]
             objects.append(obj)
     return objects


### PR DESCRIPTION
##### SUMMARY
*findall* function used in *re_matchall* returns a list of strings (when there's a single group in the pattern) or a list of lists of strings (when there's more than one group in the pattern).

*re_matchall* did not work correctly for the first case as it always treated the result as a list of lists of strings.

Fixes #30509 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
parse_cli filter

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (fix_30509 6011dfc105) last updated 2017/09/18 13:00:13 (GMT +000)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
See #30509
