### PR TITLE
Don't ask for password confirm on 'ansible-vault edit'

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -196,7 +196,8 @@ class CLI(with_metaclass(ABCMeta, object)):
 
     @staticmethod
     def build_vault_ids(vault_ids, vault_password_files=None,
-                        ask_vault_pass=None, create_new_password=None):
+                        ask_vault_pass=None, create_new_password=None,
+                        auto_prompt=True):
         vault_password_files = vault_password_files or []
         vault_ids = vault_ids or []
 
@@ -211,7 +212,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # if an action needs an encrypt password (create_new_password=True) and we dont
         # have other secrets setup, then automatically add a password prompt as well.
-        if ask_vault_pass or (create_new_password and not vault_ids):
+        if ask_vault_pass or (auto_prompt and not vault_ids):
             id_slug = u'%s@%s' % (C.DEFAULT_VAULT_IDENTITY, u'prompt_ask_vault_pass')
             vault_ids.append(id_slug)
 
@@ -220,7 +221,8 @@ class CLI(with_metaclass(ABCMeta, object)):
     # TODO: remove the now unused args
     @staticmethod
     def setup_vault_secrets(loader, vault_ids, vault_password_files=None,
-                            ask_vault_pass=None, create_new_password=False):
+                            ask_vault_pass=None, create_new_password=False,
+                            auto_prompt=True):
         # list of tuples
         vault_secrets = []
 
@@ -250,7 +252,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         vault_ids = CLI.build_vault_ids(vault_ids,
                                         vault_password_files,
                                         ask_vault_pass,
-                                        create_new_password)
+                                        create_new_password,
+                                        auto_prompt=auto_prompt)
 
         for vault_id_slug in vault_ids:
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
@@ -777,7 +780,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         vault_secrets = CLI.setup_vault_secrets(loader,
                                                 vault_ids=vault_ids,
                                                 vault_password_files=options.vault_password_files,
-                                                ask_vault_pass=options.ask_vault_pass)
+                                                ask_vault_pass=options.ask_vault_pass,
+                                                auto_prompt=False)
         loader.set_vault_secrets(vault_secrets)
 
         # create the inventory, and filter it based on the subset specified (if any)

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -165,7 +165,7 @@ class VaultCLI(CLI):
 
         # TODO: instead of prompting for these before, we could let VaultEditor
         #       call a callback when it needs it.
-        if self.action in ['decrypt', 'view', 'rekey']:
+        if self.action in ['decrypt', 'view', 'rekey', 'edit']:
             vault_secrets = self.setup_vault_secrets(loader,
                                                      vault_ids=vault_ids,
                                                      vault_password_files=self.options.vault_password_files,
@@ -173,7 +173,7 @@ class VaultCLI(CLI):
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
-        if self.action in ['encrypt', 'encrypt_string', 'create', 'edit']:
+        if self.action in ['encrypt', 'encrypt_string', 'create']:
             if len(vault_ids) > 1:
                 raise AnsibleOptionsError("Only one --vault-id can be used for encryption")
 

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -54,6 +54,32 @@ class TestCliBuildVaultIds(unittest.TestCase):
         res = cli.CLI.build_vault_ids([], create_new_password=True)
         self.assertEqual(res, ['default@prompt_ask_vault_pass'])
 
+    def test_create_new_password_no_vault_id_no_auto_prompt(self):
+        res = cli.CLI.build_vault_ids([], auto_prompt=False, create_new_password=True)
+        self.assertEqual(res, [])
+
+    def test_no_vault_id_no_auto_prompt(self):
+        # similate 'ansible-playbook site.yml' with out --ask-vault-pass, should not prompt
+        res = cli.CLI.build_vault_ids([], auto_prompt=False)
+        self.assertEqual(res, [])
+
+    def test_no_vault_ids_auto_prompt(self):
+        # create_new_password=False
+        # simulate 'ansible-vault edit encrypted.yml'
+        res = cli.CLI.build_vault_ids([], auto_prompt=True)
+        self.assertEqual(res, ['default@prompt_ask_vault_pass'])
+
+    def test_no_vault_ids_auto_prompt_ask_vault_pass(self):
+        # create_new_password=False
+        # simulate 'ansible-vault edit --ask-vault-pass encrypted.yml'
+        res = cli.CLI.build_vault_ids([], auto_prompt=True, ask_vault_pass=True)
+        self.assertEqual(res, ['default@prompt_ask_vault_pass'])
+
+    def test_create_new_password_auto_prompt(self):
+        # simulate 'ansible-vault encrypt somefile.yml'
+        res = cli.CLI.build_vault_ids([], auto_prompt=True, create_new_password=True)
+        self.assertEqual(res, ['default@prompt_ask_vault_pass'])
+
     def test_create_new_password_no_vault_id_ask_vault_pass(self):
         res = cli.CLI.build_vault_ids([], ask_vault_pass=True,
                                       create_new_password=True)
@@ -135,7 +161,6 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
                                           vault_ids=['prompt1@prompt'],
                                           ask_vault_pass=True)
 
-        print('res: %s' % res)
         self.assertIsInstance(res, list)
         self.assertEqual(len(res), 0)
         matches = vault.match_secrets(res, ['prompt1'])

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -74,7 +74,8 @@ class TestCliBuildVaultIds(unittest.TestCase):
                                       vault_password_files=['yet-another-password-file',
                                                             'one-more-password-file'],
                                       ask_vault_pass=True,
-                                      create_new_password=True)
+                                      create_new_password=True,
+                                      auto_prompt=False)
         self.assertEqual(set(res), set(['blip@prompt', 'baz@prompt_ask_vault_pass',
                                         'default@prompt_ask_vault_pass',
                                         'some-password-file', 'qux@another-password-file',
@@ -92,7 +93,7 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
         self.tty_patcher.stop()
 
     def test(self):
-        res = cli.CLI.setup_vault_secrets(None, None)
+        res = cli.CLI.setup_vault_secrets(None, None, auto_prompt=False)
         self.assertIsInstance(res, list)
 
     @patch('ansible.cli.get_file_vault_secret')


### PR DESCRIPTION
This is to match the 2.3 behavior on:

        ansible-vault edit encrypted_file.yml

Previously, the above command would consider that a 'new password'
scenario and prompt accordingly, ie:

        $ ansible-vault edit encrypted_file.yml
        New Password:
        Confirm New Password:

The bug was cause by 'create_new_password' being used for
'edit' action. This also causes the previous implicit 'auto prompt'
to get triggered and prompt the user.

Fix is to make auto prompt explicit in the calling code to handle
the 'edit' case where we want to auto prompt but we do not want
to request a password confirm.

Fixes #30491

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (vault_edit_30491 c5c5de41b0) last updated 2017/09/18 10:19:40 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

output of test case in #30491 after fix
```
[newswoop:F25:ansible (vault_edit_30491 %)]$ echo "this is a test" > foobar.yml
[newswoop:F25:ansible (vault_edit_30491 %)]$ cat foobar.yml 
this is a test
[newswoop:F25:ansible (vault_edit_30491 %)]$ ansible-vault encrypt foobar.yml
New Vault password: 
Confirm New Vault password: 
Encryption successful
[newswoop:F25:ansible (vault_edit_30491 %)]$ cat foobar.yml 
$ANSIBLE_VAULT;1.1;AES256
36613865393032643635646631633830333333373835613361323631613034656235376366643239
3138386136393961303230333139313535316536396134300a316238316266643330656461386238
30303362336630383838323935386436383230333264366136373666316564373335656165626432
6339643738323436370a356534313963623039646132643736316536313239306637376431666335
6661
[newswoop:F25:ansible (vault_edit_30491 %)]$ ansible-vault edit foobar.yml 
Vault password: 
[newswoop:F25:ansible (vault_edit_30491 %)]$ cat foobar.yml 
$ANSIBLE_VAULT;1.1;AES256
33303662343039613166633238613837316232656637306263653237336232383436316662653533
3830366438316565326430663435306438316233636439340a343836633933303164383230313762
35366633316563656435333463633363323439333131323433356637626463373630313538353766
6132623765386266310a316133363665393135643134306233666634396333383130643562353434
34616435643230363866323436623362663137396264343137303132653031643535
[newswoop:F25:ansible (vault_edit_30491 %)]$ ansible-vault view foobar.yml 
Vault password: 
bbthis is a test

```
