### PR TITLE
Error on encrypt if configured ansible_password_file and --ask-vault-pass are used.

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -184,6 +184,10 @@ class VaultCLI(CLI):
                                          vault_password_files=self.options.vault_password_files,
                                          ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
+
+            if len(vault_secrets) > 1:
+                raise AnsibleOptionsError("Only one --vault-id can be used for encryption. This includes passwords from configuration and cli.")
+
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 


### PR DESCRIPTION
##### SUMMARY
   Check number of vault secrets after setup.
    
    This is to catch vault secrets from config and
    cli. Previously vault_password_file in config was
    missed since it was added by setup_vault_secrets,
    so check after setup_vault_secrets.

  Fixes the issue mentioned in https://github.com/ansible/ansible/pull/30514#pullrequestreview-63395903

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (error_on_too_many_secrets_post_vault eb29fd8885) last updated 2017/09/18 12:10:28 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
