### PR TITLE
openssl_certificate: compare bytes with bytes on python3

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -540,7 +540,7 @@ class AssertOnlyCertificate(Certificate):
                     if extension.get_short_name() == b'keyUsage':
                         keyUsage = [OpenSSL._util.lib.OBJ_txt2nid(keyUsage) for keyUsage in self.keyUsage]
                         current_ku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in
-                            to_bytes(extension, errors='surrogate_or_strict').split(b',')]
+                                      to_bytes(extension, errors='surrogate_or_strict').split(b',')]
                         if (not self.keyUsage_strict and not all(x in current_ku for x in keyUsage)) or \
                            (self.keyUsage_strict and not set(keyUsage) == set(current_ku)):
                             self.message.append(
@@ -554,7 +554,7 @@ class AssertOnlyCertificate(Certificate):
                     if extension.get_short_name() == b'extendedKeyUsage':
                         extKeyUsage = [OpenSSL._util.lib.OBJ_txt2nid(keyUsage) for keyUsage in self.extendedKeyUsage]
                         current_xku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in
-                            to_bytes(extension, errors='surrogate_or_strict').split(b',')]
+                                       to_bytes(extension, errors='surrogate_or_strict').split(b',')]
                         if (not self.extendedKeyUsage_strict and not all(x in current_xku for x in extKeyUsage)) or \
                            (self.extendedKeyUsage_strict and not set(extKeyUsage) == set(current_xku)):
                             self.message.append(
@@ -568,7 +568,7 @@ class AssertOnlyCertificate(Certificate):
                     extension = self.cert.get_extension(extension_idx)
                     if extension.get_short_name() == b'subjectAltName':
                         l_altnames = [altname.replace(b'IP Address', b'IP') for altname in
-                            to_bytes(extension, errors='surrogate_or_strict').split(b', ')]
+                                      to_bytes(extension, errors='surrogate_or_strict').split(b', ')]
                         if (not self.subjectAltName_strict and not all(x in l_altnames for x in self.subjectAltName)) or \
                            (self.subjectAltName_strict and not set(self.subjectAltName) == set(l_altnames)):
                             self.message.append(

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -539,7 +539,8 @@ class AssertOnlyCertificate(Certificate):
                     extension = self.cert.get_extension(extension_idx)
                     if extension.get_short_name() == b'keyUsage':
                         keyUsage = [OpenSSL._util.lib.OBJ_txt2nid(keyUsage) for keyUsage in self.keyUsage]
-                        current_ku = [OpenSSL._util.lib.OBJ_txt2nid(to_bytes(usage.strip())) for usage in str(extension).split(',')]
+                        current_ku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in
+                            to_bytes(extension, errors='surrogate_or_strict').split(b',')]
                         if (not self.keyUsage_strict and not all(x in current_ku for x in keyUsage)) or \
                            (self.keyUsage_strict and not set(keyUsage) == set(current_ku)):
                             self.message.append(
@@ -552,7 +553,8 @@ class AssertOnlyCertificate(Certificate):
                     extension = self.cert.get_extension(extension_idx)
                     if extension.get_short_name() == b'extendedKeyUsage':
                         extKeyUsage = [OpenSSL._util.lib.OBJ_txt2nid(keyUsage) for keyUsage in self.extendedKeyUsage]
-                        current_xku = [OpenSSL._util.lib.OBJ_txt2nid(to_bytes(usage.strip())) for usage in str(extension).split(',')]
+                        current_xku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in
+                            to_bytes(extension, errors='surrogate_or_strict').split(b',')]
                         if (not self.extendedKeyUsage_strict and not all(x in current_xku for x in extKeyUsage)) or \
                            (self.extendedKeyUsage_strict and not set(extKeyUsage) == set(current_xku)):
                             self.message.append(
@@ -565,7 +567,8 @@ class AssertOnlyCertificate(Certificate):
                 for extension_idx in range(0, self.cert.get_extension_count()):
                     extension = self.cert.get_extension(extension_idx)
                     if extension.get_short_name() == b'subjectAltName':
-                        l_altnames = [to_bytes(altname.replace('IP Address', 'IP')) for altname in str(extension).split(', ')]
+                        l_altnames = [altname.replace(b'IP Address', b'IP') for altname in
+                            to_bytes(extension, errors='surrogate_or_strict').split(b', ')]
                         if (not self.subjectAltName_strict and not all(x in l_altnames for x in self.subjectAltName)) or \
                            (self.subjectAltName_strict and not set(self.subjectAltName) == set(l_altnames)):
                             self.message.append(

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -556,7 +556,8 @@ class AssertOnlyCertificate(Certificate):
                         if (not self.extendedKeyUsage_strict and not all(x in current_xku for x in extKeyUsage)) or \
                            (self.extendedKeyUsage_strict and not set(extKeyUsage) == set(current_xku)):
                             self.message.append(
-                                'Invalid extendedKeyUsage component (got %s, expected all of %s to be present)' % (str(extension).split(', '), self.extendedKeyUsage)
+                                'Invalid extendedKeyUsage component (got %s, expected all of %s to be present)' % (str(extension).split(', '),
+                                                                                                                   self.extendedKeyUsage)
                             )
 
         def _validate_subjectAltName():

--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -537,34 +537,34 @@ class AssertOnlyCertificate(Certificate):
             if self.keyUsage:
                 for extension_idx in range(0, self.cert.get_extension_count()):
                     extension = self.cert.get_extension(extension_idx)
-                    if extension.get_short_name() == 'keyUsage':
+                    if extension.get_short_name() == b'keyUsage':
                         keyUsage = [OpenSSL._util.lib.OBJ_txt2nid(keyUsage) for keyUsage in self.keyUsage]
-                        current_ku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in str(extension).split(',')]
+                        current_ku = [OpenSSL._util.lib.OBJ_txt2nid(to_bytes(usage.strip())) for usage in str(extension).split(',')]
                         if (not self.keyUsage_strict and not all(x in current_ku for x in keyUsage)) or \
                            (self.keyUsage_strict and not set(keyUsage) == set(current_ku)):
                             self.message.append(
-                                'Invalid keyUsage component (got %s, expected all of %s to be present)' % (str(extension).split(', '), keyUsage)
+                                'Invalid keyUsage component (got %s, expected all of %s to be present)' % (str(extension).split(', '), self.keyUsage)
                             )
 
         def _validate_extendedKeyUsage():
             if self.extendedKeyUsage:
                 for extension_idx in range(0, self.cert.get_extension_count()):
                     extension = self.cert.get_extension(extension_idx)
-                    if extension.get_short_name() == 'extendedKeyUsage':
+                    if extension.get_short_name() == b'extendedKeyUsage':
                         extKeyUsage = [OpenSSL._util.lib.OBJ_txt2nid(keyUsage) for keyUsage in self.extendedKeyUsage]
-                        current_xku = [OpenSSL._util.lib.OBJ_txt2nid(usage.strip()) for usage in str(extension).split(',')]
+                        current_xku = [OpenSSL._util.lib.OBJ_txt2nid(to_bytes(usage.strip())) for usage in str(extension).split(',')]
                         if (not self.extendedKeyUsage_strict and not all(x in current_xku for x in extKeyUsage)) or \
                            (self.extendedKeyUsage_strict and not set(extKeyUsage) == set(current_xku)):
                             self.message.append(
-                                'Invalid extendedKeyUsage component (got %s, expected all of %s to be present)' % (str(extension).split(', '), extKeyUsage)
+                                'Invalid extendedKeyUsage component (got %s, expected all of %s to be present)' % (str(extension).split(', '), self.extendedKeyUsage)
                             )
 
         def _validate_subjectAltName():
             if self.subjectAltName:
                 for extension_idx in range(0, self.cert.get_extension_count()):
                     extension = self.cert.get_extension(extension_idx)
-                    if extension.get_short_name() == 'subjectAltName':
-                        l_altnames = [altname.replace('IP Address', 'IP') for altname in str(extension).split(', ')]
+                    if extension.get_short_name() == b'subjectAltName':
+                        l_altnames = [to_bytes(altname.replace('IP Address', 'IP')) for altname in str(extension).split(', ')]
                         if (not self.subjectAltName_strict and not all(x in l_altnames for x in self.subjectAltName)) or \
                            (self.subjectAltName_strict and not set(self.subjectAltName) == set(l_altnames)):
                             self.message.append(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The key_usage, extended_key_usage and subject_alt_name parameters were silently ignored on Python3.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openssl_certificate

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Please backport to 2.4.1 too, this is a pure bug fix for Python3.
<!--- Paste verbatim command output below, e.g. before and after your change -->

