### PR TITLE
Remove redundant check for group membership in add_host

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -204,7 +204,7 @@ class InventoryData(object):
         else:
             h = self.hosts[host]
 
-        if g and h not in g.get_hosts():
+        if g:
             g.add_host(h)
             self._groups_dict_cache = {}
             display.debug("Added host %s to group %s" % (host, group))


### PR DESCRIPTION
##### SUMMARY
Inventory performance enhancement.

The Group class's add_host add_host method does a check for membership prior to adding the host ...

```
114     def add_host(self, host):                                                    
115         if host in self.hosts:                                                   
116             return                                                               
117         self.hosts.append(host)                                                  
118         host.add_group(self)                                                     
119         self.clear_hosts_cache()                                                 
```

So it is redundant and kills performance to also check for membership in data.py:add_host

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.5
```

