### PR TITLE
Remove redundant check for group membership in add_host (#30530)

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -204,7 +204,7 @@ class InventoryData(object):
         else:
             h = self.hosts[host]
 
-        if g and h not in g.get_hosts():
+        if g:
             g.add_host(h)
             self._groups_dict_cache = {}
             display.debug("Added host %s to group %s" % (host, group))


### PR DESCRIPTION
(cherry picked from commit 5aebcd4f7f4973936d351b615b25fe2aa19ff824)

##### SUMMARY
backport

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.1
```

