### PR TITLE
Fix broken LimitExceeded check in iam_managed_policy

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
@@ -188,7 +188,7 @@ def get_or_create_policy_version(module, iam, policy, policy_document):
         version = iam.create_policy_version(PolicyArn=policy['Arn'], PolicyDocument=policy_document)['PolicyVersion']
         return version, True
     except botocore.exceptions.ClientError as e:
-        if e['Error']['Code'] == 'LimitExceeded':
+        if e.response['Error']['Code'] == 'LimitExceeded':
             delete_oldest_non_default_version(module, iam, policy)
             try:
                 version = iam.create_policy_version(PolicyArn=policy['Arn'], PolicyDocument=policy_document)['PolicyVersion']


### PR DESCRIPTION
##### SUMMARY

When policy versions exceed 5, we hit LimitExceeded. However,
the exception checking should use `e.response['Error']['Code']`


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
iam_managed_policy

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 5aebcd4f7f) last updated 2017/09/19 12:22:40 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```


##### ADDITIONAL INFORMATION
Please backport to stable-2.4