### PR TITLE
Fix OS version check in win_power_plan

### DIFF
--- a/lib/ansible/modules/windows/win_power_plan.ps1
+++ b/lib/ansible/modules/windows/win_power_plan.ps1
@@ -33,7 +33,7 @@ If ([System.Environment]::OSVersion.Version -lt '6.1')
         power_plan_enabled = $null
         all_available_plans = $null
     }
-    Fail-Json $result "The win_power_plan Ansible module is only available on Server 2008R2 (6.1) and newer"
+    Fail-Json $result "The win_power_plan Ansible module is only available on Server 2008r2 (6.1) and newer"
 }
 
 $result = @{


### PR DESCRIPTION
##### SUMMARY
Fixes OS version check in `win_power_plan` (new module in Ansible 2.4.0.0). Minor PS styling and readability changes (aliases replaced etc.).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_power_plan

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]
```

##### ADDITIONAL INFORMATION
OS: Windows 10, Windows Server 2016

Error:
```
FAILED! => {"all_available_plans": null, "changed": false, "failed": true, "msg": "The win_power_plan Ansible module is only available on Server 2008r2 (6.1) and newer", "power_plan_enabled": null, "power_plan_name": "High performance"}
```
The offending line:
```
PS C:\> (gcim Win32_OperatingSystem).version -lt 6.1
True

PS C:\> (gcim Win32_OperatingSystem).version
10.0.15063
```
The fix:
```
PS C:\> [System.Environment]::OSVersion.Version -lt '6.1'
False

PS C:\> [System.Environment]::OSVersion.Version

Major  Minor  Build  Revision
-----  -----  -----  --------
10     0      15063  0
```
