### PR TITLE
[cloud] Fix ec2_vpc_subnet tags

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -102,7 +102,7 @@ def get_subnet_info(subnet):
         subnet = camel_dict_to_snake_dict(subnet)
 
     if 'tags' in subnet:
-        subnet['tags'] = boto3_tag_list_to_ansible_dict(subnet['tags'])
+        subnet['tags'] = boto3_tag_list_to_ansible_dict(subnet['tags'], 'key', 'value')
     else:
         subnet['tags'] = dict()
 


### PR DESCRIPTION
##### SUMMARY

Tags for VPC subnets were not working, capitalization issue with `camel_dict_to_snake_dict()`. Tested manually, no unit test since I found no other unit tests for `ec2_vpc_subnet`.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py

##### ANSIBLE VERSION

```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/weisslj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/weisslj/.local/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /home/weisslj/.local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```