### PR TITLE
[cluster][doc]: Fix description of OC module

### DIFF
--- a/lib/ansible/modules/clustering/oc.py
+++ b/lib/ansible/modules/clustering/oc.py
@@ -18,14 +18,14 @@ DOCUMENTATION = """
 author:
   - "Kenneth D. Evensen (@kevensen)"
 description:
-      "This module allows management of resources in an OpenShift cluster. The
-      inventory host can be any host with network connectivity to the OpenShift
-      cluster; the default port being 8443/TCP. This module relies on a token
-      to authenticate to OpenShift. This can either be a user or a service
-      account. For example:
+  - "This module allows management of resources in an OpenShift cluster. The
+    inventory host can be any host with network connectivity to the OpenShift
+    cluster; the default port being 8443/TCP. This module relies on a token
+    to authenticate to OpenShift. This can either be a user or a service
+    account. For example:
 
-      $ oc create serviceaccount ansible-sa
-      $ oadm policy add-cluster-role-to-user cluster-admin system:serviceaccount:default:ansible-sa"
+    $ oc create serviceaccount ansible-sa
+    $ oadm policy add-cluster-role-to-user cluster-admin system:serviceaccount:default:ansible-sa"
 module: oc
 options:
   host:


### PR DESCRIPTION
The description field expect list of strings, not a string.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The description field expect list of strings, not a string.
It caused the description to be rendered as one character per each item, like

* T
* h
* i
* s
*
* m

....

See screen shoot: ![oc-module](https://user-images.githubusercontent.com/1505684/30581808-bdfc1cea-9d21-11e7-836d-ce25443e7514.png)


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
oc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/lbednar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/E/lib/python2.7/site-packages/ansible
  executable location = /tmp/E/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
