### PR TITLE
Interpret '-' as stdout in utils.path.unfrackpath()

### DIFF
--- a/lib/ansible/utils/path.py
+++ b/lib/ansible/utils/path.py
@@ -43,6 +43,9 @@ def unfrackpath(path, follow=True):
         '$HOME/../../var/mail' becomes '/var/spool/mail'
     '''
 
+    if path == '-':
+        return path
+
     if follow:
         final_path = os.path.normpath(os.path.realpath(os.path.expanduser(os.path.expandvars(to_bytes(path, errors='surrogate_or_strict')))))
     else:

--- a/test/units/utils/test_path.py
+++ b/test/units/utils/test_path.py
@@ -1,0 +1,28 @@
+# (c) 2017, Jerome Leclanche <jerome@leclan.ch>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+
+from ansible.utils.path import unfrackpath
+
+
+class TestPath(unittest.TestCase):
+
+    def test_unfrackpath_dash(self):
+        self.assertEqual(unfrackpath("-"), "-")
+        self.assertEqual(unfrackpath("./-"), os.path.join(os.getcwd(), "-"))


### PR DESCRIPTION
Fixes #30550

##### SUMMARY
This addresses a regression in Ansible 2.4.0 which prevents `--output -` from working correctly (details in #30550).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
utils

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/adys/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```