### PR TITLE
Add support for replacing an existing openstack keypair

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_keypair.py
+++ b/lib/ansible/modules/cloud/openstack/os_keypair.py
@@ -51,8 +51,10 @@ options:
     default: None
   state:
     description:
-      - Should the resource be present or absent.
-    choices: [present, absent]
+      - Should the resource be present or absent. If state is replace and
+        the key exists but has different content, delete it and recreate it
+        with the new content.
+    choices: [present, absent, replace]
     default: present
   availability_zone:
     description:
@@ -118,7 +120,7 @@ def main():
         public_key      = dict(default=None),
         public_key_file = dict(default=None),
         state           = dict(default='present',
-                               choices=['absent', 'present']),
+                               choices=['absent', 'present', 'replace']),
     )
 
     module_kwargs = openstack_module_kwargs(
@@ -146,13 +148,18 @@ def main():
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, keypair))
 
-        if state == 'present':
+        if state in ('present', 'replace'):
             if keypair and keypair['name'] == name:
                 if public_key and (public_key != keypair['public_key']):
-                    module.fail_json(
-                        msg="Key name %s present but key hash not the same"
-                            " as offered. Delete key first." % name
-                    )
+                    if state == 'present'
+                        module.fail_json(
+                            msg="Key name %s present but key hash not the same"
+                                " as offered. Delete key first." % name
+                        )
+                    else:
+                        cloud.delete_keypair(name)
+                        keypair = cloud.create_keypair(name, public_key)
+                        changed = True
                 else:
                     changed = False
             else:


### PR DESCRIPTION
##### SUMMARY
Nova doesn't allow updating keypairs, so one must delete and recreate. Add a 'replace' state to allow
replacing a keypair with new content if necessary.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
os_keypair