### PR TITLE
nxos: 32 bits AS in as-dot format not recognized by regexp asn_regex

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp.py
@@ -461,7 +461,7 @@ def get_existing(module, args, warnings):
     existing = {}
     netcfg = CustomNetworkConfig(indent=2, contents=get_config(module, flags=['bgp all']))
 
-    asn_re = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+).*', re.S)
+    asn_re = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+(\.\d+)?).*', re.S)
     asn_match = asn_re.match(str(netcfg))
 
     if asn_match:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_af.py
@@ -449,7 +449,7 @@ def get_existing(module, args, warnings):
     existing = {}
     netcfg = CustomNetworkConfig(indent=2, contents=get_config(module))
 
-    asn_regex = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+).*', re.DOTALL)
+    asn_regex = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+(\.\d+)?).*', re.DOTALL)
     match_asn = asn_regex.match(str(netcfg))
 
     if match_asn:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor.py
@@ -308,7 +308,7 @@ def get_existing(module, args, warnings):
     existing = {}
     netcfg = CustomNetworkConfig(indent=2, contents=get_config(module))
 
-    asn_regex = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+).*', re.S)
+    asn_regex = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+(\.\d+)?).*', re.S)
     match_asn = asn_regex.match(str(netcfg))
 
     if match_asn:

--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -446,7 +446,7 @@ def get_existing(module, args, warnings):
     existing = {}
     netcfg = CustomNetworkConfig(indent=2, contents=get_config(module))
 
-    asn_regex = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+).*', re.S)
+    asn_regex = re.compile(r'.*router\sbgp\s(?P<existing_asn>\d+(\.\d+)?).*', re.S)
     match_asn = asn_regex.match(str(netcfg))
 
     if match_asn:

--- a/test/units/modules/network/nxos/fixtures/nxos_bgp/config_32_bits_as.cfg
+++ b/test/units/modules/network/nxos/fixtures/nxos_bgp/config_32_bits_as.cfg
@@ -1,0 +1,6 @@
+feature bgp
+
+router bgp 65535.65535
+  router-id 192.168.1.1
+  vrf test
+    address-family ipv4 unicast

--- a/test/units/modules/network/nxos/test_nxos_bgp.py
+++ b/test/units/modules/network/nxos/test_nxos_bgp.py
@@ -96,3 +96,39 @@ class TestNxosBgpModule(TestNxosModule):
             changed=True,
             commands=['router bgp 65535', 'graceful-restart restart-time 120']
         )
+
+class TestNxosBgp32BitsAS(TestNxosModule):
+
+    module = nxos_bgp
+
+    def setUp(self):
+        super(TestNxosBgp32BitsAS, self).setUp()
+
+        self.mock_load_config = patch('ansible.modules.network.nxos.nxos_bgp.load_config')
+        self.load_config = self.mock_load_config.start()
+
+        self.mock_get_config = patch('ansible.modules.network.nxos.nxos_bgp.get_config')
+        self.get_config = self.mock_get_config.start()
+
+    def tearDown(self):
+        super(TestNxosBgp32BitsAS, self).tearDown()
+        self.mock_load_config.stop()
+        self.mock_get_config.stop()
+
+    def load_fixtures(self, commands=None, device=''):
+        self.get_config.return_value = load_fixture('nxos_bgp', 'config_32_bits_as.cfg')
+        self.load_config.return_value = []
+
+    def test_nxos_bgp_change_nothing(self):
+        set_module_args(dict(asn='65535.65535', router_id='192.168.1.1'))
+        self.execute_module(changed=False)
+
+    def test_nxos_bgp_wrong_asn(self):
+        set_module_args(dict(asn='65535.10', router_id='192.168.1.1'))
+        result = self.execute_module(failed=True)
+        self.assertEqual(result['msg'], 'Another BGP ASN already exists.')
+
+    def test_nxos_bgp_remove(self):
+        set_module_args(dict(asn='65535.65535', state='absent'))
+        self.execute_module(changed=True, commands=['no router bgp 65535.65535'])
+

--- a/test/units/modules/network/nxos/test_nxos_bgp.py
+++ b/test/units/modules/network/nxos/test_nxos_bgp.py
@@ -97,6 +97,7 @@ class TestNxosBgpModule(TestNxosModule):
             commands=['router bgp 65535', 'graceful-restart restart-time 120']
         )
 
+
 class TestNxosBgp32BitsAS(TestNxosModule):
 
     module = nxos_bgp
@@ -131,4 +132,3 @@ class TestNxosBgp32BitsAS(TestNxosModule):
     def test_nxos_bgp_remove(self):
         set_module_args(dict(asn='65535.65535', state='absent'))
         self.execute_module(changed=True, commands=['no router bgp 65535.65535'])
-


### PR DESCRIPTION
##### SUMMARY
asn_regexp doesn't match 32 bits AS in the as-dot format (xxx.yyy) in the existing configuration. When a 32 bit AS in as-dot format is in the configuration, only the first part is matched (xxx).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/nxos/nxos_bgp
modules/network/nxos/nxos_bgp_af
modules/network/nxos/nxos_bgp_neighbor
modules/network/nxos/nxos_bgp_neighbor_af

##### ANSIBLE VERSION
ansible 2.5.0
  config file = None
  configured module search path = ['/home/alt/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible-2.5.0-py3.6.egg/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.2 (default, Jul 20 2017, 03:52:27) [GCC 7.1.1 20170630]
