### PR TITLE
lxc_container: open files as text, fixes #30571

### DIFF
--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -570,7 +570,7 @@ def create_script(command):
     """
 
     (fd, script_file) = tempfile.mkstemp(prefix='lxc-attach-script')
-    f = os.fdopen(fd, 'wb')
+    f = os.fdopen(fd, 'w')
     try:
         f.write(ATTACH_TEMPLATE % {'container_command': command})
         f.flush()
@@ -721,7 +721,7 @@ class LxcContainerManagement(object):
             return False
 
         container_config_file = self.container.config_file_name
-        with open(container_config_file, 'rb') as f:
+        with open(container_config_file, 'r') as f:
             container_config = f.readlines()
 
         # Note used ast literal_eval because AnsibleModule does not provide for
@@ -762,7 +762,7 @@ class LxcContainerManagement(object):
             if container_state != 'stopped':
                 self.container.stop()
 
-            with open(container_config_file, 'wb') as f:
+            with open(container_config_file, 'w') as f:
                 f.writelines(container_config)
 
             self.state_change = True

--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -573,7 +573,7 @@ def create_script(command):
     (fd, script_file) = tempfile.mkstemp(prefix='lxc-attach-script')
     f = os.fdopen(fd, 'wb')
     try:
-        f.write(to_bytes(ATTACH_TEMPLATE % {'container_command': command}))
+        f.write(to_bytes(ATTACH_TEMPLATE % {'container_command': command}, errors='surrogate_or_strict'))
         f.flush()
     finally:
         f.close()
@@ -764,7 +764,7 @@ class LxcContainerManagement(object):
                 self.container.stop()
 
             with open(container_config_file, 'wb') as f:
-                f.writelines([to_bytes(line) for line in container_config])
+                f.writelines([to_bytes(line, errors='surrogate_or_strict') for line in container_config])
 
             self.state_change = True
             if container_state == 'running':

--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -723,7 +723,7 @@ class LxcContainerManagement(object):
 
         container_config_file = self.container.config_file_name
         with open(container_config_file, 'rb') as f:
-            container_config = [to_text(line, errors='surrogate_or_strict') for line in f.readlines()]
+            container_config = to_text(f.read(), errors='surrogate_or_strict').splitlines()
 
         # Note used ast literal_eval because AnsibleModule does not provide for
         # adequate dictionary parsing.


### PR DESCRIPTION
##### SUMMARY

fix python3 support

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

modules/cloud/lxc/lxc_container.py

##### ANSIBLE VERSION

```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/j/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/j/.local/lib/python3.5/site-packages/ansible-2.5.0-py3.5.egg/ansible
  executable location = /home/j/.local/bin/ansible
  python version = 3.5.4 (default, Sep  5 2017, 18:32:10) [GCC 7.2.0]
```
