### PR TITLE
aws_s3: fix backwards incompatibility for modes put and get with object syntax - fixes #30576

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -585,6 +585,10 @@ def main():
 
     if module.params.get('object'):
         obj = module.params['object']
+        # If there is a top level object, do nothing - if the object starts with /
+        # remove the leading character to maintain compatibility with Ansible versions < 2.4
+        if obj.startswith('/'):
+            obj = obj[1:]
 
     # Bucket deletion does not require obj.  Prevents ambiguity with delobj.
     if obj and mode == "delete":


### PR DESCRIPTION
##### SUMMARY
previously to use the modes put or get the object had to be specified with a leading /. Since the boto call doesn't take an object like that this was overlooked and removed. Added a check to remove that leading character. Fixes #30576.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_s3.py

##### ANSIBLE VERSION
```
2.5.0
```
