### PR TITLE
ipv6 support for ec2_vpc_nacl_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -173,16 +173,16 @@ def nacl_entry_to_list(entry):
     else:
         elist.append(None)
 
-    if entry['protocol'] == '1':
-        elist = elist + [-1, -1]
-    else:
-        elist = elist + [None, None, None, None]
+    elist = elist + [None, None, None, None]
 
-    if 'icmp_type_code' in entry:
-        elist[4] = entry['icmp_type_code']['type']
-        elist[5] = entry['icmp_type_code']['code']
+    if entry['protocol'] in ('1', '58'):
+        elist[4] = entry.get('icmp_type_code', {}).get('type')
+        elist[5] = entry.get('icmp_type_code', {}).get('code')
 
-    if 'port_range' in entry:
+    if entry['protocol'] not in ('1', '6', '17', '58'):
+        elist[6] = 0
+        elist[7] = 65535
+    elif 'port_range' in entry:
         elist[6] = entry['port_range']['from']
         elist[7] = entry['port_range']['to']
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -148,9 +148,9 @@ def list_ec2_vpc_nacls(connection, module):
             nacl['tags'] = boto3_tag_list_to_ansible_dict(nacl['tags'], 'key', 'value')
         if 'entries' in nacl:
             nacl['egress'] = [nacl_entry_to_list(entry) for entry in nacl['entries']
-                              if entry['rule_number'] < 32766 and entry['egress']]
+                              if entry['rule_number'] < 32767 and entry['egress']]
             nacl['ingress'] = [nacl_entry_to_list(entry) for entry in nacl['entries']
-                               if entry['rule_number'] < 32766 and not entry['egress']]
+                               if entry['rule_number'] < 32767 and not entry['egress']]
             del nacl['entries']
         if 'associations' in nacl:
             nacl['subnets'] = [a['subnet_id'] for a in nacl['associations']]

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -123,8 +123,8 @@ def list_ec2_vpc_nacls(connection, module):
 
     try:
         nacls = connection.describe_network_acls(NetworkAclIds=nacl_ids, Filters=filters)
-    except (ClientError, NoCredentialsError) as e:
-        module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+    except ClientError as e:
+        module.fail_json(msg=e.message, exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
 
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_nacls = []

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -86,13 +86,19 @@ nacls:
             returned: always
             type: list of string
         ingress:
-            description: A list of NACL ingress rules.
+            description:
+              - A list of NACL ingress rules with the following format.
+              - [rule no, protocol, allow/deny, v4 or v6 cidr, icmp_type, icmp_code, port from, port to]
             returned: always
             type: list of list
+            sample: [[100, 'tcp', 'allow', '0.0.0.0/0', null, null, 22, 22]]
         egress:
-            description: A list of NACL egress rules.
+            description:
+              - A list of NACL egress rules with the following format.
+              - [rule no, protocol, allow/deny, v4 or v6 cidr, icmp_type, icmp_code, port from, port to]
             returned: always
             type: list of list
+            sample: [[100, 'all', 'allow', '0.0.0.0/0', null, null, null, null]]
 '''
 
 import traceback

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -155,9 +155,16 @@ def nacl_entry_to_list(entry):
 
     elist = [entry['rule_number'],
              PROTOCOL_NAMES[entry['protocol']],
-             entry['rule_action'],
-             entry['cidr_block']
+             entry['rule_action']
              ]
+
+    if entry.get('cidr_block'):
+        elist.append(entry['cidr_block'])
+    elif entry.get('ipv6_cidr_block'):
+        elist.append(entry['ipv6_cidr_block'])
+    else:
+        elist.append(None)
+
     if entry['protocol'] == '1':
         elist = elist + [-1, -1]
     else:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -153,10 +153,18 @@ def list_ec2_vpc_nacls(connection, module):
 
 def nacl_entry_to_list(entry):
 
-    elist = [entry['rule_number'],
-             PROTOCOL_NAMES[entry['protocol']],
-             entry['rule_action']
-             ]
+    # entry list format
+    # [ rule_num, protocol name or number, allow or deny, ipv4/6 cidr, icmp type, icmp code, port from, port to]
+    elist = []
+
+    elist.append(entry['rule_number'])
+
+    if entry.get('protocol') in PROTOCOL_NAMES:
+        elist.append(PROTOCOL_NAMES[entry['protocol']])
+    else:
+        elist.append(entry.get('protocol'))
+
+    elist.append(entry['rule_action'])
 
     if entry.get('cidr_block'):
         elist.append(entry['cidr_block'])

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-nacl:
+nacls:
     description: Returns an array of complex objects as described below.
     returned: success
     type: complex

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -118,6 +118,9 @@ def list_ec2_vpc_nacls(connection, module):
     nacl_ids = module.params.get("nacl_ids")
     filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
 
+    if nacl_ids is None:
+        nacl_ids = []
+
     try:
         nacls = connection.describe_network_acls(NetworkAclIds=nacl_ids, Filters=filters)
     except (ClientError, NoCredentialsError) as e:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -137,9 +137,9 @@ def list_ec2_vpc_nacls(connection, module):
             nacl['tags'] = boto3_tag_list_to_ansible_dict(nacl['tags'], 'key', 'value')
         if 'entries' in nacl:
             nacl['egress'] = [nacl_entry_to_list(entry) for entry in nacl['entries']
-                              if entry['rule_number'] != 32767 and entry['egress']]
+                              if entry['rule_number'] < 32766 and entry['egress']]
             nacl['ingress'] = [nacl_entry_to_list(entry) for entry in nacl['entries']
-                               if entry['rule_number'] != 32767 and not entry['egress']]
+                               if entry['rule_number'] < 32766 and not entry['egress']]
             del nacl['entries']
         if 'associations' in nacl:
             nacl['subnets'] = [a['subnet_id'] for a in nacl['associations']]

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl_facts.py
@@ -181,8 +181,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[['nacl_ids', 'filters']])
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')


### PR DESCRIPTION
##### SUMMARY
- Adding support for gathering IPv6 NACL facts. Current module throws exception when an IPv6 CIDR NACL rule is encountered.
- Fixes some errors in RETURN documentation and updates with documentation of ingress/egress rule format that is returned.
- Adds support for all non-standard Protocol numbers that are supported by AWS.
 
Details about adding IPv6 support to AWS VPC modules can be found in #27800 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_nacl_facts


##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0 (ipv6_support_for_ec2_vpc_nacl_facts e9d5c77f47) last updated 2017/09/19 17:43:56 (GMT -400)
  config file = /Users/user/.ansible.cfg
  configured module search path = [u'/Users/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/user/devel/ansible/lib/ansible
  executable location = /Users/user/devel/ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
