### PR TITLE
UTF-8 paths CLI patch

### DIFF
--- a/lib/ansible/cli/config.py
+++ b/lib/ansible/cli/config.py
@@ -174,7 +174,7 @@ class ConfigCLI(CLI):
                     color = 'green'
                 else:
                     color = 'yellow'
-                msg = "%s(%s) = %s" % (setting, defaults[setting].origin, defaults[setting].value)
+                msg = "%s(%s) = %s" % (setting, defaults[setting].origin.decode(sys.getfilesystemencoding()), defaults[setting].value)
             else:
                 color = 'green'
                 msg = "%s(%s) = %s" % (setting, 'default', defaults[setting].get('default'))

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 import fnmatch
 import os
+import sys
 import re
 import itertools
 
@@ -281,7 +282,7 @@ class InventoryManager(object):
                             display.vvv(fail['exc'].tb)
 
         if not parsed:
-            display.warning("Unable to parse %s as an inventory source" % to_native(source))
+            display.warning(u"Unable to parse %s as an inventory source" % to_native(source).decode(sys.getfilesystemencoding()))
 
         # clear up, jic
         self._inventory.current_source = None


### PR DESCRIPTION
##### SUMMARY
Tries to fix #30592 

As documented in [utils/display.py](https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/display.py#L106) calls to `display.warning` or calls to [stringc](https://github.com/ansible/ansible/blob/devel/lib/ansible/utils/color.py#L88) needs to be done with unicode strings.  I've spotted at least 2 different places where it was not the case and I provide a fix for it.  There probably are other occurrences.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
CLI warnings.

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /Users/antoine/Jobs/GÉANT/Code/github/distribution/debian/build-machine/ansible.cfg
  configured module search path = [u'/Users/antoine/Jobs/GE\u0301ANT/Code/github/distribution/debian/build-machine/ansible/library', u'/Users/antoine/Library/Application Support/debops/debops-playbooks/playbooks/library', u'/usr/share/ansible/library']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
Still outputs  UnicodeDecodeError when in a UTF-8 path and run like
```
$ LC_ALL=C ansible-playbook ping.yml
$ LC_ALL=C ansible-config dump --only-changed
```
I'm not sure how to fix that.