### PR TITLE
docker_container: remove unwilling author from maintainers (BOTMETA)

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -181,7 +181,9 @@ files:
   $modules/cloud/digital_ocean/digital_ocean_sshkey.py: alukovenko mgregson
   $modules/cloud/digital_ocean/digital_ocean_tag.py: kontrafiktion
   $modules/cloud/dimensiondata/dimensiondata_network.py: aimonb tintoy
-  $modules/cloud/docker/docker_container.py: ThomasSteinbach $team_ansible cove dusdanig jctanner kassiansun softzilla zfil
+  $modules/cloud/docker/docker_container.py:
+    ignored: ThomasSteinbach
+    maintainers: $team_ansible cove dusdanig jctanner kassiansun softzilla zfil
   $modules/cloud/docker/docker_image.py: $team_ansible jctanner softzilla
   $modules/cloud/docker/docker_image_facts.py: $team_ansible jctanner
   $modules/cloud/docker/docker_login.py: jctanner olsaki


### PR DESCRIPTION
##### SUMMARY
@ThomasSteinbach is a `docker_container` author but he is not willing to be a maintainer.
See https://github.com/ansible/ansible/issues/30455#issuecomment-329963756.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0 (devel 32d6b1d0e0) last updated 2017/09/20 00:19:59 (GMT +200)
```