### PR TITLE
CamelConversion: fix to not convert string values

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CamelConversion.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.CamelConversion.psm1
@@ -30,8 +30,6 @@ Function Convert-ListToSnakeCase($list) {
             $new_value = Convert-DictToSnakeCase -dict $value
         } elseif ($value -is [Array]) {
             $new_value = Convert-ListToSnakeCase -list $value
-        } elseif ($value -is [String]) {
-            $new_value = Convert-StringToSnakeCase -string $value
         } else {
             $new_value = $value
         }
@@ -55,8 +53,6 @@ Function Convert-DictToSnakeCase($dict) {
             $snake_dict.$snake_key = Convert-DictToSnakeCase -dict $value          
         } elseif ($value -is [Array]) {
             $snake_dict.$snake_key = Convert-ListToSnakeCase -list $value
-        } elseif ($value -is [String]) {
-            $snake_dict.$snake_key = Convert-StringToSnakeCase -string $value
         } else {
             $snake_dict.$snake_key = $value
         }

--- a/test/integration/targets/win_module_utils/library/camel_conversion_test.ps1
+++ b/test/integration/targets/win_module_utils/library/camel_conversion_test.ps1
@@ -51,7 +51,8 @@ foreach ($entry in $output_dict.GetEnumerator()) {
                     Assert-Equals -actual $inner_list_hash.Name -expected $inner_list_hash.Value
                 }
             } elseif ($inner_list -is [String]) {
-                Assert-Equals -actual $inner_list -expected "string_two"
+                # this is not a string key so we need to keep it the same
+                Assert-Equals -actual $inner_list -expected "stringTwo"
             } else {
                 Assert-Equals -actual $inner_list -expected 0
             }


### PR DESCRIPTION
##### SUMMARY
Current module util converts values that are string to snake_case. This should only touch key's of dicts and not the values themselves.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.CamelConversion.psm1

##### ANSIBLE VERSION
```
2.5
```