### PR TITLE
Only get rules if listener has been identified in compare_rules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -1002,6 +1002,9 @@ def main():
                 if key not in ['Protocol', 'Port', 'SslPolicy', 'Certificates', 'DefaultActions', 'Rules']:
                     module.fail_json(msg="listeners parameter contains invalid dict keys. Should be one of 'Protocol', "
                                          "'Port', 'SslPolicy', 'Certificates', 'DefaultActions', 'Rules'.")
+                # Make sure Port is always an integer
+                elif key == 'Port':
+                    listener[key] = int(listener[key])
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')

--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -619,6 +619,8 @@ def compare_listeners(connection, module, current_listeners, new_listeners, purg
     Compare listeners and return listeners to add, listeners to modify and listeners to remove
     Listeners are compared based on port
 
+    :param connection: ELBv2 boto3 connection
+    :param module: Ansible module object
     :param current_listeners:
     :param new_listeners:
     :param purge_listeners:
@@ -659,10 +661,10 @@ def compare_rules(connection, module, current_listeners, listener):
     Compare rules and return rules to add, rules to modify and rules to remove
     Rules are compared based on priority
 
-    :param connection:
-    :param module:
-    :param current_listeners:
-    :param listener:
+    :param connection: ELBv2 boto3 connection
+    :param module: Ansible module object
+    :param current_listeners: list of listeners currently associated with the ELB
+    :param listener: dict object of a listener passed by the user
     :return:
     """
 
@@ -672,8 +674,11 @@ def compare_rules(connection, module, current_listeners, listener):
             listener['ListenerArn'] = current_listener['ListenerArn']
             break
 
-    # Get rules for the listener
-    current_rules = get_listener_rules(connection, module, listener['ListenerArn'])
+    # If the listener exists (i.e. has an ARN) get rules for the listener
+    if 'ListenerArn' in listener:
+        current_rules = get_listener_rules(connection, module, listener['ListenerArn'])
+    else:
+        current_rules = []
 
     rules_to_modify = []
     rules_to_delete = []


### PR DESCRIPTION
##### SUMMARY
Fixes #30578 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
```
2.4
```


##### ADDITIONAL INFORMATION
We should only try and get rules for existing listeners.  I'm a little unsure as to why this hasn't come up earlier because it's quite a common scenario.

None the less, this fix checks for the Arn key before getting the rules.  If no Arn exists then rules set to empty list.