### PR TITLE
Fix ec2_snapshot_facts for python3

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_snapshot_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_snapshot_facts.py
@@ -185,8 +185,8 @@ from ansible.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
 def list_ec2_snapshots(connection, module):
 
     snapshot_ids = module.params.get("snapshot_ids")
-    owner_ids = map(str, module.params.get("owner_ids"))
-    restorable_by_user_ids = module.params.get("restorable_by_user_ids")
+    owner_ids = [str(owner_id) for owner_id in module.params.get("owner_ids")]
+    restorable_by_user_ids = [str(user_id) for user_id in module.params.get("restorable_by_user_ids")]
     filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
 
     try:

--- a/test/integration/targets/ec2_ami/tasks/main.yml
+++ b/test/integration/targets/ec2_ami/tasks/main.yml
@@ -346,21 +346,20 @@
           - "result.changed"
           - "'image_id' not in result"
 
-# FIXME: in ec2_snapshot_facts OwnerIds is cast to a map, causing traceback (needs to be a list or tuple)
-#    - name: ensure the snapshot still exists
-#      ec2_snapshot_facts:
-#        snapshot_ids:
-#          - '{{ ec2_ami_snapshot }}'
-#        ec2_region: '{{ec2_region}}'
-#        ec2_access_key: '{{ec2_access_key}}'
-#        ec2_secret_key: '{{ec2_secret_key}}'
-#        security_token: '{{security_token}}'
-#      register: snapshot_result
+    - name: ensure the snapshot still exists
+      ec2_snapshot_facts:
+        snapshot_ids:
+          - '{{ ec2_ami_snapshot }}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+      register: snapshot_result
 
-#    - name: assert the snapshot wasn't deleted
-#      assert:
-#        that:
-#          - "snapshot_result.snapshots[0].snapshot_id == ec2_ami_snapshot"
+    - name: assert the snapshot wasn't deleted
+      assert:
+        that:
+          - "snapshot_result.snapshots[0].snapshot_id == ec2_ami_snapshot"
 
     - name: delete ami for a second time
       ec2_ami:


### PR DESCRIPTION
##### SUMMARY

Avoid the following seen when running ec2_ami tests on python3,
presumably because the return type of `map` is different between
python2 and python3.

```
Traceback (most recent call last):
  File "/tmp/ansible_e44v27uj/ansible_module_ec2_snapshot_facts.py", line 242, in <module>
    main()
  File "/tmp/ansible_e44v27uj/ansible_module_ec2_snapshot_facts.py", line 238, in main
    list_ec2_snapshots(connection, module)
  File "/tmp/ansible_e44v27uj/ansible_module_ec2_snapshot_facts.py", line 193, in list_ec2_snapshots
    snapshots = connection.describe_snapshots(SnapshotIds=snapshot_ids, OwnerIds=owner_ids, RestorableByUserIds=restorable_by_user_ids, Filters=filters)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 312, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 575, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/usr/local/lib/python3.5/dist-packages/botocore/client.py", line 630, in _convert_to_request_dict
    api_params, operation_model)
  File "/usr/local/lib/python3.5/dist-packages/botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter OwnerIds, value: <map object at 0x7ff577511048>, type: <class 'map'>, valid types: <class 'list'>, <class 'tuple'>
```

https://github.com/ansible/ansible/pull/30435#issuecomment-330750498


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_snapshot_facts

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 37736ee87e) last updated 2017/09/20 16:37:19 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
