### PR TITLE
Improve coverage of expect integration tests.

### DIFF
--- a/test/integration/targets/expect/files/test_command.py
+++ b/test/integration/targets/expect/files/test_command.py
@@ -1,3 +1,10 @@
+import sys
+
 from ansible.module_utils.six.moves import input
-user_input = input('foo')
-print(user_input)
+
+
+prompts = sys.argv[1:] or ['foo']
+
+for prompt in prompts:
+    user_input = input(prompt)
+    print(user_input)

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -48,7 +48,7 @@
 
 - name: test creates option
   expect:
-    command: "echo"
+    command: "echo output"
     responses:
       foo: bar
     creates: "{{output_file}}"
@@ -58,6 +58,49 @@
   assert:
     that:
     - "creates_result.changed == false"
+    - "'skipped' in creates_result.stdout"
+
+- name: test creates option (missing)
+  expect:
+    command: "echo output"
+    responses:
+      foo: bar
+    creates: "{{output_file}}.does.not.exist"
+  register: creates_result
+
+- name: assert when missing creates is provided command is run
+  assert:
+    that:
+    - "creates_result.changed == true"
+    - "creates_result.stdout == 'output'"
+
+- name: test removes option
+  expect:
+    command: "echo output"
+    responses:
+      foo: bar
+    removes: "{{output_file}}"
+  register: removes_result
+
+- name: assert when removes is provided command is run
+  assert:
+    that:
+    - "removes_result.changed == true"
+    - "removes_result.stdout == 'output'"
+
+- name: test removes option (missing)
+  expect:
+    command: "echo output"
+    responses:
+      foo: bar
+    removes: "{{output_file}}.does.not.exist"
+  register: removes_result
+
+- name: assert when missing removes is provided command is not run
+  assert:
+    that:
+    - "removes_result.changed == false"
+    - "'skipped' in removes_result.stdout"
 
 - name: test chdir
   expect:
@@ -97,4 +140,66 @@
 - name: assert echo works
   assert:
     that:
-    - "'bar' in echo_result.stdout_lines"
+    - "echo_result.stdout_lines|length == 2"
+    - "echo_result.stdout_lines[0] == 'foobar'"
+    - "echo_result.stdout_lines[1] == 'bar'"
+
+- name: test response list
+  expect:
+    command: "{{ansible_python_interpreter}} {{test_command_file}} foo foo"
+    responses:
+      foo:
+      - bar
+      - baz
+  register: list_result
+
+- name: assert list response works
+  assert:
+    that:
+    - "list_result.stdout_lines|length == 2"
+    - "list_result.stdout_lines[0] == 'foobar'"
+    - "list_result.stdout_lines[1] == 'foobaz'"
+
+- name: test no remaining responses
+  expect:
+    command: "{{ansible_python_interpreter}} {{test_command_file}} foo foo"
+    responses:
+      foo:
+      - bar
+  register: list_result
+  ignore_errors: yes
+
+- name: assert no remaining responses
+  assert:
+    that:
+    - "list_result.failed"
+    - "'No remaining responses' in list_result.msg"
+
+- name: test no command
+  expect:
+    command: ""
+    responses:
+      foo: bar
+  register: no_command_result
+  ignore_errors: yes
+
+- name: assert no command
+  assert:
+    that:
+    - "no_command_result.failed"
+    - "no_command_result.msg == 'no command given'"
+    - "no_command_result.rc == 256"
+
+- name: test non-zero return code
+  expect:
+    command: "ls /does-not-exist"
+    responses:
+      foo: bar
+  register: non_zero_result
+  ignore_errors: yes
+
+- name: assert non-zero return code
+  assert:
+    that:
+    - "non_zero_result.failed"
+    - "non_zero_result.msg == 'non-zero return code'"

--- a/test/integration/targets/expect/tasks/main.yml
+++ b/test/integration/targets/expect/tasks/main.yml
@@ -48,7 +48,7 @@
 
 - name: test creates option
   expect:
-    command: "echo output"
+    command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
       foo: bar
     creates: "{{output_file}}"
@@ -62,7 +62,7 @@
 
 - name: test creates option (missing)
   expect:
-    command: "echo output"
+    command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
       foo: bar
     creates: "{{output_file}}.does.not.exist"
@@ -72,11 +72,11 @@
   assert:
     that:
     - "creates_result.changed == true"
-    - "creates_result.stdout == 'output'"
+    - "creates_result.stdout == 'foobar'"
 
 - name: test removes option
   expect:
-    command: "echo output"
+    command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
       foo: bar
     removes: "{{output_file}}"
@@ -86,11 +86,11 @@
   assert:
     that:
     - "removes_result.changed == true"
-    - "removes_result.stdout == 'output'"
+    - "removes_result.stdout == 'foobar'"
 
 - name: test removes option (missing)
   expect:
-    command: "echo output"
+    command: "{{ansible_python_interpreter}} {{test_command_file}}"
     responses:
       foo: bar
     removes: "{{output_file}}.does.not.exist"


### PR DESCRIPTION
##### SUMMARY

Improve coverage of expect integration tests.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

expect integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (expect a13986408b) last updated 2017/09/20 00:14:40 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
