### PR TITLE
Fix nxos provider transport warning issue

### DIFF
--- a/lib/ansible/module_utils/nxos.py
+++ b/lib/ansible/module_utils/nxos.py
@@ -49,6 +49,7 @@ nxos_provider_spec = {
 
     'use_ssl': dict(type='bool'),
     'validate_certs': dict(type='bool'),
+
     'timeout': dict(type='int'),
 
     'transport': dict(default='cli', choices=['cli', 'nxapi'])
@@ -68,7 +69,7 @@ nxos_top_spec = {
     'validate_certs': dict(removed_in_version=2.9, type='bool'),
     'timeout': dict(removed_in_version=2.9, type='int'),
 
-    'transport': dict(removed_in_version=2.9, default='cli', choices=['cli', 'nxapi'])
+    'transport': dict(removed_in_version=2.9, choices=['cli', 'nxapi'])
 }
 nxos_argument_spec.update(nxos_top_spec)
 
@@ -84,7 +85,7 @@ def check_args(module, warnings):
 def load_params(module):
     provider = module.params.get('provider') or dict()
     for key, value in iteritems(provider):
-        if key in nxos_argument_spec:
+        if key in nxos_provider_spec:
             if module.params.get(key) is None and value is not None:
                 module.params[key] = value
 

--- a/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
+++ b/lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
@@ -161,12 +161,13 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         if 'show run' not in command:
             command += ' | json'
         cmds = [command]
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         cmds = {'command': command, 'output': 'text'}
         body = run_commands(module, cmds)
 

--- a/lib/ansible/modules/network/nxos/nxos_gir.py
+++ b/lib/ansible/modules/network/nxos/nxos_gir.py
@@ -170,9 +170,10 @@ from ansible.module_utils.basic import AnsibleModule
 
 def execute_show_command(command, module, command_type='cli_show_ascii'):
     cmds = [command]
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         body = run_commands(module, cmds)
 
     return body

--- a/lib/ansible/modules/network/nxos/nxos_hsrp.py
+++ b/lib/ansible/modules/network/nxos/nxos_hsrp.py
@@ -129,11 +129,12 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def execute_show_command(command, module):
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         command += ' | json'
         cmds = [command]
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         cmds = [command]
         body = run_commands(module, cmds)
 
@@ -394,7 +395,7 @@ def main():
     auth_type = module.params['auth_type']
     auth_string = module.params['auth_string']
 
-    transport = module.params['transport']
+    transport = module.params['provider']['transport']
 
     if state == 'present' and not vip:
         module.fail_json(msg='the "vip" param is required when state=present')

--- a/lib/ansible/modules/network/nxos/nxos_ip_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_ip_interface.py
@@ -425,7 +425,7 @@ def validate_params(addr, interface, mask, tag, allow_secondary, version, state,
             module.fail_json(msg="IPv6 address and mask must be provided when "
                                  "state=absent.")
 
-    if intf_type != "ethernet" and module.params["transport"] == "cli":
+    if intf_type != "ethernet" and module.params["provider"]["transport"] == "cli":
         if is_default(interface, module) == "DNE":
             module.fail_json(msg="That interface does not exist yet. Create "
                                  "it first.", interface=interface)

--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -131,10 +131,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 
 def check_args(module, warnings):
-    transport = module.params['transport']
-    provider_transport = (module.params['provider'] or {}).get('transport')
-    if 'nxapi' in (transport, provider_transport):
-        module.fail_json(msg='transport=nxapi is not supporting when configuring nxapi')
+    provider = module.params['provider']
+    if provider['transport'] == 'nxapi':
+        module.fail_json(msg='module not supported over nxapi transport')
 
     nxos_check_args(module, warnings)
 
@@ -148,9 +147,6 @@ def check_args(module, warnings):
         module.params['state'] = 'absent'
         warnings.append('state=stopped is deprecated and will be removed in a '
                         'a future release.  Please use state=absent instead')
-
-    if module.params['transport'] == 'nxapi':
-        module.fail_json(msg='module not supported over nxapi transport')
 
     for key in ['config']:
         if module.params[key]:

--- a/lib/ansible/modules/network/nxos/nxos_portchannel.py
+++ b/lib/ansible/modules/network/nxos/nxos_portchannel.py
@@ -142,12 +142,13 @@ def get_custom_value(arg, config, module):
 
 
 def execute_show_command(command, module):
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         if 'show port-channel summary' in command:
             command += ' | json'
         cmds = [command]
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         cmds = [command]
         body = run_commands(module, cmds)
 

--- a/lib/ansible/modules/network/nxos/nxos_switchport.py
+++ b/lib/ansible/modules/network/nxos/nxos_switchport.py
@@ -434,11 +434,12 @@ def apply_value_map(value_map, resource):
 
 
 def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         command += ' | json'
         cmds = [command]
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         cmds = [command]
         body = run_commands(module, cmds)
 

--- a/lib/ansible/modules/network/nxos/nxos_udld.py
+++ b/lib/ansible/modules/network/nxos/nxos_udld.py
@@ -121,12 +121,13 @@ import re
 
 
 def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         if 'show run' not in command:
             command += ' | json'
         cmds = [command]
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         cmds = [command]
         body = run_commands(module, cmds)
 

--- a/lib/ansible/modules/network/nxos/nxos_udld_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_udld_interface.py
@@ -116,12 +116,13 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def execute_show_command(command, module, command_type='cli_show'):
-    if module.params['transport'] == 'cli':
+    provider = module.params['provider']
+    if provider['transport'] == 'cli':
         if 'show run' not in command:
             command += ' | json'
         cmds = [command]
         body = run_commands(module, cmds)
-    elif module.params['transport'] == 'nxapi':
+    elif provider['transport'] == 'nxapi':
         cmds = [command]
         body = run_commands(module, cmds)
 

--- a/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vrf_interface.py
@@ -204,7 +204,7 @@ def main():
                         "Use nxos_vrf to fix this.")
 
     intf_type = get_interface_type(interface)
-    if (intf_type != 'ethernet' and module.params['transport'] == 'cli'):
+    if (intf_type != 'ethernet' and module.params['provider']['transport'] == 'cli'):
         if is_default(interface, module) == 'DNE':
             module.fail_json(msg="interface does not exist on switch. Verify "
                                  "switch platform or create it first with "

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -107,8 +107,5 @@ class ActionModule(_ActionModule):
 
             self._task.args['provider'] = provider
 
-        # make sure a transport value is set in args
-        self._task.args['transport'] = transport
-
         result = super(ActionModule, self).run(tmp, task_vars)
         return result

--- a/test/units/modules/network/nxos/nxos_module.py
+++ b/test/units/modules/network/nxos/nxos_module.py
@@ -29,6 +29,9 @@ from ansible.module_utils._text import to_bytes
 
 
 def set_module_args(args):
+    if 'provider' not in args:
+        args['provider'] = {'transport': args.get('transport') or 'cli'}
+
     args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
     basic._ANSIBLE_ARGS = to_bytes(args)
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Add default value of transport arg in provider spec
*  Remove default value if transport arg in top level spec
   This ensure deprecation warning is seen only in case transport
   is given as a top level arg in task
*  Refactor nxos modules to reference transport value from provider
   spec
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/nxos.py
nxos_aaa_server_host
nxos_gir
nxos_hsrp
nxos_ip_interface
nxos_nxapi
nxos_portchannel
nxos_switchport
nxos_udld
nxos_udld_interface
nxos_vrf_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
