### PR TITLE
vyos util - minor typo on deprecation warning

### DIFF
--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -66,7 +66,7 @@ def check_args(module, warnings):
     for key in vyos_argument_spec:
         if module._name == 'vyos_user':
             if key not in ['password', 'provider'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be in a future version' % key)
+                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
         else:
             if key != 'provider' and module.params[key]:
                 warnings.append('argument %s has been deprecated and will be removed in a future version' % key)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Deprecation warning is missing 'removed' confusing the meaning of the warning
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vyos utility
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
