### PR TITLE
module_utils/ovirt.py: add maintainers

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -951,6 +951,8 @@ files:
   $module_utils/ordnance.py:
     maintainers: alexanderturner djh00t
     labels: networking
+  $module_utils/ovirt.py:
+    maintainers: joshainglis karmab machacekondra
   $module_utils/sros.py:
     maintainers: $team_networking
     labels: networking


### PR DESCRIPTION
##### SUMMARY
Following https://github.com/ansible/ansible/pull/29107#issuecomment-328552732, add maintainers for `module_utils/ovirt.py`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0 (devel 07f5a186fb) last updated 2017/09/20 14:26:04 (GMT +200)
```