### PR TITLE
made callbacks backwards compatible

### DIFF
--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -180,7 +180,8 @@ class TaskQueueManager:
                     self._stdout_callback.set_options(C.config.get_plugin_options('callback', self._stdout_callback._load_name))
                 except AttributeError:
                     display.deprecated("%s stdout callback, does not support setting 'options', it will work for now, "
-                                       " but this will be required in the future and should be updated.." % self._stdout_callback._load_name, version="2.9")
+                                       " but this will be required in the future and should be updated,"
+                                       " see the 2.4 porting guide for details." % self._stdout_callback._load_name, version="2.9")
                 stdout_callback_loaded = True
         else:
             raise AnsibleError("callback must be an instance of CallbackBase or the name of a callback plugin")
@@ -208,7 +209,8 @@ class TaskQueueManager:
                 callback_obj .set_options(C.config.get_plugin_options('callback', callback_plugin._load_name))
             except AttributeError:
                     display.deprecated("%s callback, does not support setting 'options', it will work for now, "
-                                       " but this will be required in the future and should be updated.." % self._stdout_callback._load_name, version="2.9")
+                                       " but this will be required in the future and should be updated, "
+                                       " see the 2.4 porting guide for details." % self._stdout_callback._load_name, version="2.9")
             self._callback_plugins.append(callback_obj)
 
         self._callbacks_loaded = True

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -176,7 +176,11 @@ class TaskQueueManager:
                 raise AnsibleError("Invalid callback for stdout specified: %s" % self._stdout_callback)
             else:
                 self._stdout_callback = callback_loader.get(self._stdout_callback)
-                self._stdout_callback.set_options(C.config.get_plugin_options('callback', self._stdout_callback._load_name))
+                try:
+                    self._stdout_callback.set_options(C.config.get_plugin_options('callback', self._stdout_callback._load_name))
+                except AttributeError:
+                    display.deprecated("%s stdout callback, does not support setting 'options', it will work for now, "
+                                       " but this will be required in the future and should be updated.." % self._stdout_callback._load_name, version="2.9")
                 stdout_callback_loaded = True
         else:
             raise AnsibleError("callback must be an instance of CallbackBase or the name of a callback plugin")
@@ -200,7 +204,11 @@ class TaskQueueManager:
                     continue
 
             callback_obj = callback_plugin()
-            callback_obj .set_options(C.config.get_plugin_options('callback', callback_plugin._load_name))
+            try:
+                callback_obj .set_options(C.config.get_plugin_options('callback', callback_plugin._load_name))
+            except AttributeError:
+                    display.deprecated("%s callback, does not support setting 'options', it will work for now, "
+                                       " but this will be required in the future and should be updated.." % self._stdout_callback._load_name, version="2.9")
             self._callback_plugins.append(callback_obj)
 
         self._callbacks_loaded = True


### PR DESCRIPTION
##### SUMMARY

This fixes #30597 for those that were not inheriting from base.

Added deprecation notice so those callbacks get updated.

Callback must either inherit from base (directly or indirectly),
which already implements this or implement set_options themselves.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
callbacks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```