### PR TITLE
Changed 'plugins/json_query.py' to use jebabin's solution to issue #27299

### DIFF
--- a/lib/ansible/plugins/filter/json_query.py
+++ b/lib/ansible/plugins/filter/json_query.py
@@ -47,6 +47,7 @@ def json_query(data, expr):
         # For older jmespath, we can get ValueError and TypeError without much info.
         raise AnsibleFilterError('Error in jmespath.search in json_query filter plugin:\n%s' % e)
 
+
 class FilterModule(object):
     ''' Query filter '''
 

--- a/lib/ansible/plugins/filter/json_query.py
+++ b/lib/ansible/plugins/filter/json_query.py
@@ -19,6 +19,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.errors import AnsibleError, AnsibleFilterError
+import ast
 
 try:
     import jmespath
@@ -27,13 +28,17 @@ except ImportError:
     HAS_LIB = False
 
 
+
 def json_query(data, expr):
     '''Query data using jmespath query language ( http://jmespath.org ). Example:
     - debug: msg="{{ instance | json_query(tagged_instances[*].block_device_mapping.*.volume_id') }}"
     '''
+
     if not HAS_LIB:
         raise AnsibleError('You need to install "jmespath" prior to running '
                            'json_query filter')
+
+    data = ast.literal_eval(str(data))
 
     try:
         return jmespath.search(expr, data)
@@ -42,7 +47,6 @@ def json_query(data, expr):
     except Exception as e:
         # For older jmespath, we can get ValueError and TypeError without much info.
         raise AnsibleFilterError('Error in jmespath.search in json_query filter plugin:\n%s' % e)
-
 
 class FilterModule(object):
     ''' Query filter '''

--- a/lib/ansible/plugins/filter/json_query.py
+++ b/lib/ansible/plugins/filter/json_query.py
@@ -28,7 +28,6 @@ except ImportError:
     HAS_LIB = False
 
 
-
 def json_query(data, expr):
     '''Query data using jmespath query language ( http://jmespath.org ). Example:
     - debug: msg="{{ instance | json_query(tagged_instances[*].block_device_mapping.*.volume_id') }}"


### PR DESCRIPTION
##### SUMMARY
Submitting this PR as a solution for Issue #27299 .

This change uses the python library `ast` to resolve some issues that arise from using certain query strings including `starts_with`, `contains`, and others.

This solution was from @jebabin . I'm submitting the PR because even though I don't understand the fix completely, it seems a simple enough of a fix to include future releases of Ansible (possibly even back-porting to other releases of Ansible 2.4).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
json_query

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.5.0 (devel 140ea7f5ff) last updated 2017/09/20 13:14:52 (GMT -600)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/my_modules']
  ansible python module location = /home/bl839s/ansible/lib/ansible
  executable location = /home/bl839s/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
See Issue #27299 for details.

Before:
```
PLAY [json_query testing] ****************************************************************************

TASK [debug] *****************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "JMESPathError in json_query filter plugin:\nIn function contains(), invalid type for value: irb.1111, expected one of: ['array', 'string'], received: \"unknown\""}

PLAY RECAP *******************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1
```

After:
```
PLAY [json_query testing] ****************************************************************************

TASK [debug] *****************************************************************************************
ok: [localhost] => (item={u'interface': u'irb.1111', u'address': u'10.0.1.1/29'}) => {
    "item": {
        "address": "10.0.1.1/29",
        "interface": "irb.1111"
    }
}
ok: [localhost] => (item={u'interface': u'irb.1114', u'address': u'10.0.2.1/29'}) => {
    "item": {
        "address": "10.0.2.1/29",
        "interface": "irb.1114"
    }
}
ok: [localhost] => (item={u'interface': u'irb.1114', u'address': u'fe80::b/112'}) => {
    "item": {
        "address": "fe80::b/112",
        "interface": "irb.1114"
    }
}

PLAY RECAP *******************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0
```