### PR TITLE
Make clear the file must not contain .repo (fixes #30644)

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['stableinterface'],
-                    'supported_by': 'core'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['stableinterface'],
+    'supported_by': 'core'
+}
 
 DOCUMENTATION = '''
 ---
@@ -112,7 +114,8 @@ options:
     required: false
     default: null
     description:
-      - File to use to save the repo in. Defaults to the value of I(name).
+      - File name without the C(.repo) extension to save the repo in. Defaults
+        to the value of I(name).
   gpgcakey:
     required: false
     default: null


### PR DESCRIPTION
##### SUMMARY

This PR is fixing issue #30644. It just makes sure the documentation is clear about the `file` parameter of the `yum_repository`.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
`yum_repository`

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/_/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```


##### ADDITIONAL INFORMATION

None