### PR TITLE
Feature to Specify AZURE blob storage type

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -561,10 +561,8 @@ class AzureRMModuleBase(object):
             self.log('Create blob service')
             if storage_blob_type == 'page':
                 return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_page_blob_service()
-            elif storage_blob_type == 'block':
-                return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_block_blob_service()
             else:
-                raise Exception("Invalid storage blob type")
+                return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_block_blob_service()
         except Exception as exc:
             self.fail("Error creating blob service client for storage account {0} - {1}".format(storage_account_name,
                                                                                                 str(exc)))

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -561,8 +561,10 @@ class AzureRMModuleBase(object):
             self.log('Create blob service')
             if storage_blob_type == 'page':
                 return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_page_blob_service()
-            else:
+            elif storage_blob_type == 'block':
                 return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_block_blob_service()
+            else:
+                raise Exception("Invalid storage blob type defined.")
         except Exception as exc:
             self.fail("Error creating blob service client for storage account {0} - {1}".format(storage_account_name,
                                                                                                 str(exc)))

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -548,7 +548,7 @@ class AzureRMModuleBase(object):
                 self.fail("Error {0} has a provisioning state of {1}. Expecting state to be {2}.".format(
                     azure_object.name, azure_object.provisioning_state, AZURE_SUCCESS_STATE))
 
-    def get_blob_client(self, resource_group_name, storage_account_name):
+    def get_blob_client(self, resource_group_name, storage_account_name, storage_blob_type='block'):
         keys = dict()
         try:
             # Get keys from the storage account
@@ -559,7 +559,10 @@ class AzureRMModuleBase(object):
 
         try:
             self.log('Create blob service')
-            return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_block_blob_service()
+            if storage_blob_type == 'page':
+                return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_page_blob_service()
+            else:
+                return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_block_blob_service()
         except Exception as exc:
             self.fail("Error creating blob service client for storage account {0} - {1}".format(storage_account_name,
                                                                                                 str(exc)))

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -561,8 +561,10 @@ class AzureRMModuleBase(object):
             self.log('Create blob service')
             if storage_blob_type == 'page':
                 return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_page_blob_service()
-            else:
+            elif storage_blob_type == 'block':
                 return CloudStorageAccount(storage_account_name, account_keys.keys[0].value).create_block_blob_service()
+            else:
+                raise Exception("Invalid storage blob type")
         except Exception as exc:
             self.fail("Error creating blob service client for storage account {0} - {1}".format(storage_account_name,
                                                                                                 str(exc)))

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -45,6 +45,7 @@ options:
         choices:
             - block
             - page
+        version_added: "2.5"
     container:
         description:
             - Name of a blob container within the storage account.

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -37,6 +37,14 @@ options:
         default: null
         aliases:
             - blob_name
+    blob_type:
+        description:
+            - Type of Blob Object.
+        required: false
+        default: block
+        choices:
+            - block
+            - page
     container:
         description:
             - Name of a blob container within the storage account.
@@ -212,6 +220,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
         self.module_arg_spec = dict(
             storage_account_name=dict(required=True, type='str', aliases=['account_name', 'storage_account']),
             blob=dict(type='str', aliases=['blob_name']),
+            blob_type=dict(type='str', default='block', choices=['block','page']),
             container=dict(required=True, type='str', aliases=['container_name']),
             dest=dict(type='str'),
             force=dict(type='bool', default=False),
@@ -234,6 +243,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
         self.storage_account_name = None
         self.blob = None
         self.blob_obj = None
+        self.blob_type = None
         self.container = None
         self.container_obj = None
         self.dest = None
@@ -264,7 +274,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
 
         # add file path validation
 
-        self.blob_client = self.get_blob_client(self.resource_group, self.storage_account_name)
+        self.blob_client = self.get_blob_client(self.resource_group, self.storage_account_name, self.blob_type)
         self.container_obj = self.get_container()
 
         if self.blob is not None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Support for the feature to specify blob type while doing an operation on Azure storage blob object.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_storageblob

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
