### PR TITLE
become flags are primary

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -400,7 +400,7 @@ DEFAULT_BECOME_EXE:
   - {key: become_exe, section: privilege_escalation}
 DEFAULT_BECOME_FLAGS:
   name: Set 'become' executable options
-  default: ~
+  default: ''
   description: Flags to pass to the privilege escalation executable.
   env: [{name: ANSIBLE_BECOME_FLAGS}]
   ini:
@@ -1001,7 +1001,7 @@ DEFAULT_SU_EXE:
   - {key: su_exe, section: defaults}
 DEFAULT_SU_FLAGS:
   name: su flags
-  default: ~
+  default: ''
   deprecated:
     why: In favor of become which is a generic framework
     version: "2.8"

--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -528,19 +528,13 @@ class PlayContext(Base):
                 command = success_cmd
 
             # set executable to use for the privilege escalation method, with various overrides
-            exe = self.become_method
-            for myexe in (getattr(self, '%s_exe' % self.become_method, None), self.become_exe):
-                if myexe:
-                    exe = myexe
-                    break
+            exe = self.become_exe or getattr(self, '%s_exe' % self.become_method, self.become_method)
 
             # set flags to use for the privilege escalation method, with various overrides
-            flags = ''
-            for myflag in (getattr(self, '%s_flags' % self.become_method, None), self.become_flags):
-                if myflag is not None:
-                    flags = myflag
-                    break
+            flags = self.become_flags or getattr(self, '%s_flags' % self.become_method, '')
 
+            print(exe)
+            print(flags)
             if self.become_method == 'sudo':
                 # If we have a password, we run sudo with a randomly-generated
                 # prompt set using -p. Otherwise we run it with default -n, which makes


### PR DESCRIPTION
##### SUMMARY

with new configuration the sudo flags are always set and become cannot override,
switching to simple 'or' will result in become_flags working.

also sudo_flags are deprecated.

fixes #30629

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
become

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```

