### PR TITLE
windows: fix for checking locked system files

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -1,0 +1,41 @@
+# Copyright (c) 2017 Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+<#
+Test-Path/Get-Item cannot find/return info on files that are locked like
+C:\pagefile.sys. These 2 functions are designed to work with these files and
+provide similar functionality with the normal cmdlets with as minimal overhead
+as possible. They work by using Get-ChildItem with a filter and return the
+result from that.
+#>
+
+Function Test-FilePath($path) {
+    # Basic replacement for Test-Path that tests if the file/folder exists at the path
+    $directory = Split-Path -Path $path -Parent
+    $filename = Split-Path -Path $path -Leaf
+
+    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
+    if ($file -ne $null) {
+        if ($file -is [Array] -and $file.Count -gt 1) {
+            throw "found multiple files at path '$path', make sure no wildcards are set in the path"
+        }
+        return $true
+    } else {
+        return $false
+    }
+}
+
+Function Get-FileItem($path) {
+    # Replacement for Get-Item
+    $directory = Split-Path -Path $path -Parent
+    $filename = Split-Path -Path $path -Leaf
+
+    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
+    if ($file -is [Array] -and $file.Count -gt 1) {
+        throw "found multiple files at path '$path', make sure no wildcards are set in the path"
+    }
+
+    return $file
+}
+
+Export-ModuleMember -Function Test-FilePath, Get-FileItem

--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -6,6 +6,7 @@
 
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.CommandUtil
+#Requires -Module Ansible.ModuleUtils.FileUtil
 
 # TODO: add check mode support
 
@@ -25,24 +26,6 @@ $raw_command_line = $raw_command_line.Trim()
 $result = @{
     changed = $true
     cmd = $raw_command_line
-}
-
-Function Test-FilePath($path) {
-    # Test-Path/Get-Item fails on files that are locked like C:\pagefile.sys
-    # Get-ChildItem -Path -Filter works fine without any performance
-    # degredations so use that instead
-    $directory = Split-Path -Path $path -Parent
-    $filename = Split-Path -Path $path -Leaf
-
-    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
-    if ($file -ne $null) {
-        if ($file -is [Array] -and $file.Count -gt 1) {
-            Fail-Json -obj $result -message "found multiple files at path '$path', make sure no wildcards are set in the path"
-        }
-        return $true
-    } else {
-        return $false
-    }
 }
 
 if ($creates -and $(Test-FilePath -path $creates)) {

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -6,6 +6,7 @@
 
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.CommandUtil
+#Requires -Module Ansible.ModuleUtils.FileUtil
 
 # TODO: add check mode support
 
@@ -36,24 +37,6 @@ Function Cleanse-Stderr($raw_stderr) {
     }
     Catch {
         "***EXCEPTION PARSING CLIXML: $_***" + $raw_stderr
-    }
-}
-
-Function Test-FilePath($path) {
-    # Test-Path/Get-Item fails on files that are locked like C:\pagefile.sys
-    # Get-ChildItem -Path -Filter works fine without any performance
-    # degredations so use that instead
-    $directory = Split-Path -Path $path -Parent
-    $filename = Split-Path -Path $path -Leaf
-
-    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
-    if ($file -ne $null) {
-        if ($file -is [Array] -and $file.Count -gt 1) {
-            Fail-Json -obj $result -message "found multiple files at path '$path', make sure no wildcards are set in the path"
-        }
-        return $true
-    } else {
-        return $false
     }
 }
 

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -39,6 +39,24 @@ Function Cleanse-Stderr($raw_stderr) {
     }
 }
 
+Function Test-FilePath($path) {
+    # Test-Path/Get-Item fails on files that are locked like C:\pagefile.sys
+    # Get-ChildItem -Path -Filter works fine without any performance
+    # degredations so use that instead
+    $directory = Split-Path -Path $path -Parent
+    $filename = Split-Path -Path $path -Leaf
+
+    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
+    if ($file -ne $null) {
+        if ($file -is [Array] -and $file.Count -gt 1) {
+            Fail-Json -obj $result -message "found multiple files at path '$path', make sure no wildcards are set in the path"
+        }
+        return $true
+    } else {
+        return $false
+    }
+}
+
 $params = Parse-Args $args -supports_check_mode $false
 
 $raw_command_line = Get-AnsibleParam -obj $params -name "_raw_params" -type "str" -failifempty $true
@@ -55,11 +73,11 @@ $result = @{
     cmd = $raw_command_line
 }
 
-If($creates -and $(Test-Path $creates)) {
+if ($creates -and $(Test-FilePath -path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }
 
-If($removes -and -not $(Test-Path $removes)) {
+if ($removes -and -not $(Test-FilePath -path $removes)) {
     Exit-Json @{msg="skipped, since $removes does not exist";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }
 

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -1,21 +1,11 @@
 #!powershell
 # This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.FileUtil
 
 # C# code to determine link target, copied from http://chrisbensen.blogspot.com.au/2010/06/getfinalpathnamebyhandle.html
 $symlink_util = @"
@@ -69,21 +59,6 @@ function Date_To_Timestamp($start_date, $end_date)
     }
 }
 
-Function Get-File($path) {
-    # Test-Path/Get-Item fails on files that are locked like C:\pagefile.sys
-    # Get-ChildItem -Path -Filter works fine without any performance
-    # degredations so use that instead
-    $directory = Split-Path -Path $path -Parent
-    $filename = Split-Path -Path $path -Leaf
-
-    $file = Get-ChildItem -Path $directory -Filter $filename -Force -ErrorAction SilentlyContinue
-    if ($file -is [Array] -and $file.Count -gt 1) {
-        Fail-Json -obj $result -message "found multiple files at path '$path', make sure no wildcards are set in the path"
-    }
-
-    return $file
-}
-
 $params = Parse-Args $args -supports_check_mode $true
 
 $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true -aliases "dest","name"
@@ -103,7 +78,7 @@ if ($get_md5 -eq $true -and (Get-Member -inputobject $params -name "get_md5") ) 
     Add-DeprecationWarning -obj $result -message "The parameter 'get_md5' is being replaced with 'checksum_algorithm: md5'" -version 2.7
 }
 
-$info = Get-File -path $path
+$info = Get-FileItem -path $path
 If ($info -ne $null)
 {
     $result.stat.exists = $true

--- a/lib/ansible/modules/windows/win_stat.py
+++ b/lib/ansible/modules/windows/win_stat.py
@@ -44,6 +44,7 @@ options:
               use specified algorithm.
             - This option is deprecated in Ansible 2.3 and is replaced with
               C(checksum_algorithm=md5).
+            - This option will be removed in Ansible 2.7
         required: no
         default: True
     get_checksum:
@@ -199,7 +200,7 @@ stat:
             type: string
             sample: C:\temp
         md5:
-            description: The MD5 checksum of a file (Between Ansible 1.9 and 2.2 this was returned as a SHA1 hash)
+            description: The MD5 checksum of a file (Between Ansible 1.9 and 2.2 this was returned as a SHA1 hash), will be removed in 2.7
             returned: success, path exist, path is a file, get_md5 == True, md5 is supported
             type: string
             sample: 09cb79e8fc7453c84a07f644e441fd81623b7f98

--- a/test/integration/targets/win_command/tasks/main.yml
+++ b/test/integration/targets/win_command/tasks/main.yml
@@ -77,6 +77,18 @@
     - cmdout|skipped
     - cmdout.msg is search('exists')
 
+- name: test creates with hidden system file, should skip
+  win_command: echo no
+  args:
+    creates: C:\pagefile.sys
+  register: cmdout
+
+- name: validate result
+  assert:
+    that:
+    - cmdout|skipped
+    - cmdout.msg is search('exists')
+
 - name: ensure testfile is still present
   win_stat:
     path: c:\testfile.txt

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -1,0 +1,59 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.FileUtil
+
+Function Assert-Equals($actual, $expected) {
+    if ($actual -cne $expected) {
+        Fail-Json @{} "actual != expected`nActual: $actual`nExpected: $expected"
+    }
+}
+
+# Test-FilePath Hidden system file
+$actual = Test-FilePath -path C:\pagefile.sys
+Assert-Equals -actual $actual -expected $true
+
+# Test-FilePath File that doesn't exist
+$actual = Test-FilePath -path C:\fakefile
+Assert-Equals -actual $actual -expected $false
+
+# Test-FilePath Normal directory
+$actual = Test-FilePath -path C:\Windows
+Assert-Equals -actual $actual -expected $true
+
+# Test-FilePath Normal file
+$actual = Test-FilePath -path C:\Windows\System32\kernel32.dll
+
+# Test-FilePath fails with wildcard
+try {
+    Test-FilePath -Path C:\Windows\*.exe
+    Fail-Json @{} "exception was not thrown with wildcard search for Test-FilePath"
+} catch {
+    Assert-Equals -actual $_.Exception.Message -expected "found multiple files at path 'C:\Windows\*.exe', make sure no wildcards are set in the path"
+}
+
+# Get-FileItem file
+$actual = Get-FileItem -path C:\pagefile.sys
+Assert-Equals -actual $actual.FullName -expected C:\pagefile.sys
+Assert-Equals -actual $actual.PSIsContainer -expected $false
+Assert-Equals -actual $actual.Exists -expected $true
+
+# Get-FileItem directory
+$actual = Get-FileItem -path C:\Windows
+Assert-Equals -actual $actual.FullName -expected C:\Windows
+Assert-Equals -actual $actual.PSIsContainer -expected $true
+Assert-Equals -actual $actual.Exists -expected $true
+
+# Get-FileItem doesn't exists
+$actual = Get-FileItem -path C:\fakefile
+Assert-Equals -actual $actual -expected $null
+
+# Get-FileItem fails with wildcard
+try {
+    Get-FileItem -Path C:\Windows\*.exe
+    Fail-Json @{} "exception was not thrown with wildcard search for Get-FileItem"
+} catch {
+    Assert-Equals -actual $_.Exception.Message -expected "found multiple files at path 'C:\Windows\*.exe', make sure no wildcards are set in the path"
+}
+
+Exit-Json @{ data = 'success' }

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -80,3 +80,11 @@
   win_file:
     path: C:\ansible testing
     state: absent
+
+- name: call module with FileUtil tests
+  file_util_test:
+  register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -105,6 +105,18 @@
     - shellout|skipped
     - shellout.msg is search('exists')
 
+- name: test creates with hidden system file, should skip
+  win_shell: echo test
+  args:
+    creates: C:\pagefile.sys
+  register: shellout
+
+- name: validate result
+  assert:
+    that:
+    - shellout|skipped
+    - shellout.msg is search('exists')
+
 - name: ensure testfile is still present
   win_stat:
     path: c:\testfile.txt

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -295,6 +295,9 @@
     - stat_readonly.stat.size == 3
 
 # Requires more work once modular powershell utils are in
+- name: weird issue, need to access the file in anyway to get the correct date stats
+  win_command: powershell.exe Test-Path {{win_output_dir}}\win_stat\nested\hard-link.ps1
+
 - name: test win_stat on hard link file
   win_stat:
     path: "{{win_output_dir}}\\win_stat\\nested\\hard-link.ps1"
@@ -541,3 +544,13 @@
   win_file:
     path: "{{win_output_dir}}\\win_stat"
     state: absent
+
+- name: get stat of pagefile
+  win_stat:
+    path: C:\pagefile.sys
+  register: pagefile_stat
+
+- name: assert get stat of pagefile
+  assert:
+    that:
+    - pagefile_stat.stat.exists == True

--- a/test/integration/targets/windows-paths/tasks/main.yml
+++ b/test/integration/targets/windows-paths/tasks/main.yml
@@ -82,7 +82,7 @@
     - trailing_result|success
     - trailing_result.stat.attributes == 'Directory'
     - trailing_result.stat.exists == true
-    - trailing_result.stat.path == trailing
+    - trailing_result.stat.path == no_quotes_single  # path is without the trailing \
 
 - name: Set variables in key=value syntax
   set_fact:
@@ -178,7 +178,7 @@
     - trailing_result|success
     - trailing_result.stat.attributes == 'Directory'
     - trailing_result.stat.exists == true
-    - trailing_result.stat.path == trailing
+    - trailing_result.stat.path == no_quotes_single  # path is without the trailing \
 
 - name: Test tab path {{ tab }}
   win_stat:


### PR DESCRIPTION
##### SUMMARY
When using `Test-Path` or `Get-Item` on a file that is a hidden system file and is locked (like `C:\pagefile.sys`) they will return `$false` and `$null` respectively even when it does exist. This workaround uses the `Get-ChildItem -Path -Filter` to get a file and return that for modules where this would be useful.

While there are other modules that may be affected by this, I don't believe they would usually touch a file like `pagefile.sys` so I don't believe it is necessary to complicate things there.

This also includes some minor doc fixes to actually set the version `get_md5` for `win_stat` will be deprecated and set the version on the warning message.

This fixes #30258

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_command
win_stat
win_shell
win_wait_for

##### ANSIBLE VERSION
```
2.5
```

##### ADDITIONAL INFORMATION
I've done some basic performance tests to see if `Get-ChildItem` with a filter is slower than `Get-Item` or `Test-Path`. In these tests the folder `C:\temp\test` contains just a bit less than 1 million empty files.

##### Test-Path comparison

File Exists
```
PS C:\Users\Administrator.JORDAN> $path = "C:\temp\test\file-123456"
PS C:\Users\Administrator.JORDAN> Measure-Command { Test-Path -Path $path }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 4
Ticks             : 49522
TotalDays         : 5.73171296296296E-08
TotalHours        : 1.37561111111111E-06
TotalMinutes      : 8.25366666666667E-05
TotalSeconds      : 0.0049522
TotalMilliseconds : 4.9522

PS C:\Users\Administrator.JORDAN> Measure-Command { Test-FilePath -path $path }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 4
Ticks             : 49555
TotalDays         : 5.73553240740741E-08
TotalHours        : 1.37652777777778E-06
TotalMinutes      : 8.25916666666667E-05
TotalSeconds      : 0.0049555
TotalMilliseconds : 4.9555
```

File Missing
```
PS C:\Users\Administrator.JORDAN> $path = "C:\temp\test\missing"
PS C:\Users\Administrator.JORDAN> Measure-Command { Test-Path -Path $path }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 1
Ticks             : 15792
TotalDays         : 1.82777777777778E-08
TotalHours        : 4.38666666666667E-07
TotalMinutes      : 2.632E-05
TotalSeconds      : 0.0015792
TotalMilliseconds : 1.5792

PS C:\Users\Administrator.JORDAN> Measure-Command { Test-FilePath -path $path }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 1
Ticks             : 18936
TotalDays         : 2.19166666666667E-08
TotalHours        : 5.26E-07
TotalMinutes      : 3.156E-05
TotalSeconds      : 0.0018936
TotalMilliseconds : 1.8936
```

##### Get-Item comparison

File Exists
```
PS C:\Users\Administrator.JORDAN> $path = "C:\temp\test\file-123456"
PS C:\Users\Administrator.JORDAN> Measure-Command { Get-Item -Path $path -Force }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 1
Ticks             : 16944
TotalDays         : 1.96111111111111E-08
TotalHours        : 4.70666666666667E-07
TotalMinutes      : 2.824E-05
TotalSeconds      : 0.0016944
TotalMilliseconds : 1.6944

PS C:\Users\Administrator.JORDAN> Measure-Command { Get-File -path $path }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 8
Ticks             : 85995
TotalDays         : 9.953125E-08
TotalHours        : 2.38875E-06
TotalMinutes      : 0.000143325
TotalSeconds      : 0.0085995
TotalMilliseconds : 8.5995
```

File Missing
```
PS C:\Users\Administrator.JORDAN> $path = "C:\temp\test\missing"
PS C:\Users\Administrator.JORDAN> Measure-Command { Get-Item -Path $path -Force -ErrorAction SilentlyContinue }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 5
Ticks             : 59818
TotalDays         : 6.92337962962963E-08
TotalHours        : 1.66161111111111E-06
TotalMinutes      : 9.96966666666667E-05
TotalSeconds      : 0.0059818
TotalMilliseconds : 5.9818

PS C:\Users\Administrator.JORDAN> Measure-Command { Get-File -path $path }

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 3
Ticks             : 39557
TotalDays         : 4.57835648148148E-08
TotalHours        : 1.09880555555556E-06
TotalMinutes      : 6.59283333333333E-05
TotalSeconds      : 0.0039557
TotalMilliseconds : 3.9557
```
