### PR TITLE
Fix python3 and nonascii handling in inventory plugins

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -60,18 +60,18 @@ class BaseInventoryPlugin(object):
     def verify_file(self, path):
         ''' Verify if file is usable by this plugin, base does minimal accessability check '''
 
-        b_path = to_bytes(path)
+        b_path = to_bytes(path, errors='surrogate_or_strict')
         return (os.path.exists(b_path) and os.access(b_path, os.R_OK))
 
     def get_cache_prefix(self, path):
         ''' create predictable unique prefix for plugin/inventory '''
 
         m = hashlib.sha1()
-        m.update(to_bytes(self.NAME))
+        m.update(to_bytes(self.NAME, errors='surrogate_or_strict'))
         d1 = m.hexdigest()
 
         n = hashlib.sha1()
-        n.update(to_bytes(path))
+        n.update(to_bytes(path, errors='surrogate_or_strict'))
         d2 = n.hexdigest()
 
         return 's_'.join([d1[:5], d2[:5]])

--- a/lib/ansible/plugins/inventory/advanced_host_list.py
+++ b/lib/ansible/plugins/inventory/advanced_host_list.py
@@ -36,9 +36,9 @@ class InventoryModule(BaseInventoryPlugin):
     def verify_file(self, host_list):
 
         valid = False
-        b_path = to_bytes(host_list)
+        b_path = to_bytes(host_list, errors='surrogate_or_strict')
         if not os.path.exists(b_path) and ',' in host_list:
-                valid = True
+            valid = True
         return valid
 
     def parse(self, inventory, loader, host_list, cache=True):
@@ -61,7 +61,7 @@ class InventoryModule(BaseInventoryPlugin):
                         if host not in self.inventory.hosts:
                             self.inventory.add_host(host, group='ungrouped', port=port)
         except Exception as e:
-            raise AnsibleParserError("Invalid data from string, could not parse: %s" % str(e))
+            raise AnsibleParserError("Invalid data from string, could not parse: %s" % to_native(e))
 
     def _expand_hostpattern(self, hostpattern):
         '''

--- a/lib/ansible/plugins/inventory/host_list.py
+++ b/lib/ansible/plugins/inventory/host_list.py
@@ -27,8 +27,7 @@ EXAMPLES = r'''
 import os
 
 from ansible.errors import AnsibleError, AnsibleParserError
-from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_bytes, to_text, to_native
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.parsing.utils.addresses import parse_address
 from ansible.plugins.inventory import BaseInventoryPlugin
 
@@ -40,9 +39,9 @@ class InventoryModule(BaseInventoryPlugin):
     def verify_file(self, host_list):
 
         valid = False
-        b_path = to_bytes(host_list)
+        b_path = to_bytes(host_list, errors='surrogate_or_strict')
         if not os.path.exists(b_path) and ',' in host_list:
-                valid = True
+            valid = True
         return valid
 
     def parse(self, inventory, loader, host_list, cache=True):
@@ -64,4 +63,4 @@ class InventoryModule(BaseInventoryPlugin):
                     if host not in self.inventory.hosts:
                         self.inventory.add_host(host, group='ungrouped', port=port)
         except Exception as e:
-            raise AnsibleParserError("Invalid data from string, could not parse: %s" % str(e))
+            raise AnsibleParserError("Invalid data from string, could not parse: %s" % to_native(e))

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -105,7 +105,7 @@ class InventoryModule(BaseFileInventoryPlugin):
             if self.loader:
                 (b_data, private) = self.loader._get_file_contents(path)
             else:
-                b_path = to_bytes(path)
+                b_path = to_bytes(path, errors='surrogate_or_strict')
                 with open(b_path, 'rb') as fh:
                     b_data = fh.read()
 
@@ -366,14 +366,14 @@ class InventoryModule(BaseFileInventoryPlugin):
         # [naughty:children] # only get coal in their stockings
 
         self.patterns['section'] = re.compile(
-            r'''^\[
+            to_text(r'''^\[
                     ([^:\]\s]+)             # group name (see groupname below)
                     (?::(\w+))?             # optional : and tag name
                 \]
                 \s*                         # ignore trailing whitespace
                 (?:\#.*)?                   # and/or a comment till the
                 $                           # end of the line
-            ''', re.X
+            ''', errors='surrogate_or_strict'), re.X
         )
 
         # FIXME: What are the real restrictions on group names, or rather, what
@@ -382,10 +382,10 @@ class InventoryModule(BaseFileInventoryPlugin):
         # precise rules in order to support better diagnostics.
 
         self.patterns['groupname'] = re.compile(
-            r'''^
+            to_text(r'''^
                 ([^:\]\s]+)
                 \s*                         # ignore trailing whitespace
                 (?:\#.*)?                   # and/or a comment till the
                 $                           # end of the line
-            ''', re.X
+            ''', errors='surrogate_or_strict'), re.X
         )


### PR DESCRIPTION
Fixes #30663

##### SUMMARY

* Fixes one known problem fixed where we compared a byte string with text strings (which is always false on python3).
* Also fixes places that would likely fail on python2 with nonascii strings
* Fixes some unreported problems comparing byte strings with text strings.
* Fixes loading the virtualbox cache with a mangled entry.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

various inventory plugins

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```
