### PR TITLE
fix for make webdocs

### DIFF
--- a/docs/bin/plugin_formatter.py
+++ b/docs/bin/plugin_formatter.py
@@ -123,7 +123,7 @@ def write_data(text, output_dir, outputname, module=None):
             outputname = outputname % module
 
         if not os.path.exists(output_dir):
-            os.mkdir(output_dir)
+            os.makedirs(output_dir)
         fname = os.path.join(output_dir, outputname)
         fname = fname.replace(".py", "")
         with open(fname, 'wb') as f:


### PR DESCRIPTION
##### SUMMARY
After https://github.com/ansible/ansible/commit/da15cf1f54779b10e2186b3e6da6d609b4aebba7 `make webdocs` fails because it cannot create a folder where the parent does not exist. Changing a line so it does not case and will create the parent directory.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
2.5
```

cc @alikins feel free to create your own PR if you wish to go a different route to fix this.