### PR TITLE
Don't add 'iam_role' when returning module parameters

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -288,7 +288,7 @@ def create_or_update_role(connection, module):
     role = get_role(connection, module, params['RoleName'])
 
     role['attached_policies'] = get_attached_policy_list(connection, module, params['RoleName'])
-    module.exit_json(changed=changed, **camel_dict_to_snake_dict(role))
+    module.exit_json(changed=changed, role=camel_dict_to_snake_dict(role), **camel_dict_to_snake_dict(role))
 
 
 def destroy_role(connection, module):

--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -288,7 +288,7 @@ def create_or_update_role(connection, module):
     role = get_role(connection, module, params['RoleName'])
 
     role['attached_policies'] = get_attached_policy_list(connection, module, params['RoleName'])
-    module.exit_json(changed=changed, iam_role=camel_dict_to_snake_dict(role))
+    module.exit_json(changed=changed, **camel_dict_to_snake_dict(role))
 
 
 def destroy_role(connection, module):

--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -288,7 +288,7 @@ def create_or_update_role(connection, module):
     role = get_role(connection, module, params['RoleName'])
 
     role['attached_policies'] = get_attached_policy_list(connection, module, params['RoleName'])
-    module.exit_json(changed=changed, role=camel_dict_to_snake_dict(role), **camel_dict_to_snake_dict(role))
+    module.exit_json(changed=changed, iam_role=camel_dict_to_snake_dict(role), **camel_dict_to_snake_dict(role))
 
 
 def destroy_role(connection, module):


### PR DESCRIPTION
##### SUMMARY
The module should not return with `iam_role={}` it should just return with the parameters at the top.

E.g.
```
iam_role:
  name: bla
  state: present
register: iam_role
```

Currently you have to access parameters with `iam_role.iam_role.role_name`.  It should just be `iam_role.role_name` as the RETURN doc states

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
iam_role

##### ANSIBLE VERSION
```
2.4
```


##### ADDITIONAL INFORMATION

