### PR TITLE
Fix docker_service python3 incompatibility

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_service.py
+++ b/lib/ansible/modules/cloud/docker/docker_service.py
@@ -520,7 +520,7 @@ def get_redirected_output(path_name):
     with open(path_name, 'r') as fd:
         for line in fd:
             # strip terminal format/color chars
-            new_line = re.sub(r'\x1b\[.+m', '', line.encode('ascii'))
+            new_line = re.sub(r'\x1b\[.+m', '', line)
             output.append(new_line)
     fd.close()
     os.remove(path_name)


### PR DESCRIPTION
Looks like this is supposed to operate on native strings so there's no
need to encode or decode at all here

Fixes #30354


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_service.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```
