### PR TITLE
win_domain_membership: added better error handling and basic tests

### DIFF
--- a/test/integration/targets/win_domain_membership/aliases
+++ b/test/integration/targets/win_domain_membership/aliases
@@ -1,0 +1,1 @@
+windows/ci/group2

--- a/test/integration/targets/win_domain_membership/tasks/main.yml
+++ b/test/integration/targets/win_domain_membership/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: get current workgroup
+  win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
+  register: workgroup
+
+- name: fail if workgroup result is empty (means test host is in a domain)
+  fail:
+    msg: Cannot run tests for win_domain_membership when host is a member of a domain
+  when: workgroup.stdout == ""
+
+- block:
+  - include_tasks: tests.yml
+
+  always:
+  - name: revert workgroup back to original before tests
+    win_domain_membership:
+      workgroup_name: '{{workgroup.stdout_lines[0]}}'
+      state: workgroup
+      domain_admin_user: fake user
+      domain_admin_password: fake password

--- a/test/integration/targets/win_domain_membership/tasks/tests.yml
+++ b/test/integration/targets/win_domain_membership/tasks/tests.yml
@@ -1,0 +1,59 @@
+---
+- name: change workgroup (check mode)
+  win_domain_membership:
+    workgroup_name: ANSIBLETEST
+    state: workgroup
+    domain_admin_user: fake user
+    domain_admin_password: fake password
+  register: change_workgroup_check
+  check_mode: yes
+
+- name: get result of change workgroup (check mode)
+  win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
+  register: change_workgroup_result_check
+
+- name: assert result of change workgroup (check mode)
+  assert:
+    that:
+    - change_workgroup_check|changed
+    - change_workgroup_result_check.stdout == workgroup.stdout
+
+- name: change workgroup
+  win_domain_membership:
+    workgroup_name: ANSIBLETEST
+    state: workgroup
+    domain_admin_user: fake user
+    domain_admin_password: fake password
+  register: change_workgroup
+
+- name: get result of change workgroup
+  win_shell: (Get-WmiObject Win32_ComputerSystem).Workgroup
+  register: change_workgroup_result
+
+- name: assert result of change workgroup
+  assert:
+    that:
+    - change_workgroup|changed
+    - change_workgroup_result.stdout_lines[0] == "ANSIBLETEST"
+
+- name: change workgroup (idempotent)
+  win_domain_membership:
+    workgroup_name: ANSIBLETEST
+    state: workgroup
+    domain_admin_user: fake user
+    domain_admin_password: fake password
+  register: change_workgroup_again
+
+- name: assert result of change workgroup (idempotent)
+  assert:
+    that:
+    - not change_workgroup_again|changed
+
+- name: change workgroup fail invalid name
+  win_domain_membership:
+    workgroup_name: ANSIBLELONGNAMEFAILURE
+    state: workgroup
+    domain_admin_user: fake user
+    domain_admin_password: fake password
+  register: fail_change_workgroup
+  failed_when: "fail_change_workgroup.msg != 'failed to set workgroup through WMI, return value: 2695'"


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/30555, basically adds better error handling on certain tasks so that it gives a user a better indication where it failed and why.

Also adds in some very basic tests that test out changing the hosts's workgroup name.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_domain_membership

##### ANSIBLE VERSION
```
2.5
```