### PR TITLE
Increase socket connect retry timeout for integration test

### DIFF
--- a/test/integration/network-integration.cfg
+++ b/test/integration/network-integration.cfg
@@ -10,3 +10,5 @@ ssh_args = '-o UserKnownHostsFile=/dev/null'
 
 [persistent_connection]
 command_timeout = 60
+connect_timeout = 60
+connect_retry_timeout = 60


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Increase persistent connection local socket
   retry timeout to fix intermittent failure in
   network integration test
(cherry picked from commit 869cd6f72953b72b15fd996ce8d510e896fcc73c)

*  This should ensure green CI for Network integration tests in DCI.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
