### PR TITLE
win_iis_webapppool: handle recycling.periodicRestart.schedule

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -178,6 +178,19 @@ if ($state -eq "absent") {
             }
             $result.changed = $true
         }
+        
+        # periodic restart schedule needs special handling, as it's an array
+        if ($attribute_key -eq "recycling.periodicRestart.schedule") {
+            $schedule=$new_raw_value
+
+            # Set restart times for the pool
+            Clear-ItemProperty -Path IIS:\AppPools\$name -Name Recycling.periodicRestart.schedule
+            if ((-not $schedule -eq "")) {
+                foreach ($restartTime in $schedule) {
+                    New-ItemProperty -Path IIS:\AppPools\$name -Name Recycling.periodicRestart.schedule -Value @{value=$restartTime}
+                }
+            }
+        }
     }
 
     # Set the state of the pool


### PR DESCRIPTION
##### SUMMARY
Added possibility to change recycling.periodicRestart.schedule.

Sample Usage in a playbook (called with: ansible-playbook create_application_pool.yml --extra-vars "hosts=websrv name=MyPool"):

```yaml
- name: Create IIS Application Pool
  hosts: "{{ hosts }}"
  gather_facts: false
  tasks:
    - name: create a new application pool
      win_iis_webapppool:
        name: "{{ name }}"
        state: started
        attributes:
          managedRuntimeVersion: v4.0
          # Timespan with full string "day:hour:minute:second.millisecond"
          recycling.periodicRestart.time: "0"
          recycling.periodicRestart.schedule: "04:58"
          # Shortened timespan "hour:minute:second"
          processModel.pingResponseTime: "00:00:30"
```

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
win_iis_webapppool

##### ANSIBLE VERSION
?