### PR TITLE
kinesis stream server side encryption - fixes #30269

### DIFF
--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -27,7 +27,7 @@ description:
     - Update the retention period of a Kinesis Stream.
     - Update Tags on a Kinesis Stream.
     - Enable/disable server side encryption on a Kinesis Stream.
-version_added: "2.2.1"
+version_added: "2.5"
 author: Allen Sanabria (@linuxdynasty)
 options:
   name:

--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -678,9 +678,8 @@ def stream_action(client, stream_name, shard_count=1, action='create',
     return success, err_msg
 
 
-
-def stream_encryption_action(client, stream_name, action='start_encryption',encryption_type='',key_id='',
-                  timeout=300, check_mode=False):
+def stream_encryption_action(client, stream_name, action='start_encryption', encryption_type='', key_id='',
+                             timeout=300, check_mode=False):
     """Create, Encrypt or Delete an Amazon Kinesis Stream.
     Args:
         client (botocore.client.EC2): Boto3 client.
@@ -775,16 +774,14 @@ def retention_action(client, stream_name, retention_period=24,
                 client.increase_stream_retention_period(**params)
                 success = True
                 err_msg = (
-                    'Retention Period increased successfully to {0}'
-                        .format(retention_period)
+                    'Retention Period increased successfully to {0}'.format(retention_period)
                 )
             elif action == 'decrease':
                 params['RetentionPeriodHours'] = retention_period
                 client.decrease_stream_retention_period(**params)
                 success = True
                 err_msg = (
-                    'Retention Period decreased successfully to {0}'
-                        .format(retention_period)
+                    'Retention Period decreased successfully to {0}'.format(retention_period)
                 )
             else:
                 err_msg = 'Invalid action {0}'.format(action)
@@ -1204,8 +1201,9 @@ def delete_stream(client, stream_name, wait=False, wait_timeout=300,
 
     return success, changed, err_msg, results
 
+
 def start_stream_encryption(client, stream_name, encryption_type='',key_id='',
-                            wait=False, wait_timeout=300,check_mode=False):
+                            wait=False, wait_timeout=300, check_mode=False):
     """Start encryption on an Amazon Kinesis Stream.
     Args:
         client (botocore.client.EC2): Boto3 client.
@@ -1238,7 +1236,6 @@ def start_stream_encryption(client, stream_name, encryption_type='',key_id='',
         'StreamName': stream_name
     }
 
-
     results = dict()
     stream_found, stream_msg, current_stream = (
         find_stream(client, stream_name, check_mode=check_mode)
@@ -1263,8 +1260,7 @@ def start_stream_encryption(client, stream_name, encryption_type='',key_id='',
                     return success, True, err_msg, results
             else:
                 err_msg = (
-                    'Kinesis Stream {0} is in the process of starting encryption.'
-                        .format(stream_name)
+                    'Kinesis Stream {0} is in the process of starting encryption.'.format(stream_name)
                 )
     else:
         success = True
@@ -1273,8 +1269,9 @@ def start_stream_encryption(client, stream_name, encryption_type='',key_id='',
 
     return success, changed, err_msg, results
 
+
 def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
-                            wait=True, wait_timeout=300,check_mode=False):
+                           wait=True, wait_timeout=300, check_mode=False):
     """Stop encryption on an Amazon Kinesis Stream.
     Args:
         client (botocore.client.EC2): Boto3 client.
@@ -1305,7 +1302,6 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
         'StreamName': stream_name
     }
 
-
     results = dict()
     stream_found, stream_msg, current_stream = (
         find_stream(client, stream_name, check_mode=check_mode)
@@ -1314,7 +1310,7 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
         if current_stream.get('EncryptionType') == 'KMS':
             success, err_msg = (
                 stream_encryption_action(
-                    client, stream_name, action='stop_encryption',key_id=key_id, encryption_type=encryption_type, check_mode=check_mode
+                    client, stream_name, action='stop_encryption', key_id=key_id, encryption_type=encryption_type, check_mode=check_mode
                 )
             )
         elif current_stream.get('EncryptionType') == 'NONE':
@@ -1334,8 +1330,7 @@ def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
                     return success, True, err_msg, results
             else:
                 err_msg = (
-                    'Stream {0} is in the process of stopping encryption.'
-                        .format(stream_name)
+                    'Stream {0} is in the process of stopping encryption.'.format(stream_name)
                 )
     else:
         success = True

--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -1205,7 +1205,7 @@ def delete_stream(client, stream_name, wait=False, wait_timeout=300,
     return success, changed, err_msg, results
 
 
-def start_stream_encryption(client, stream_name, encryption_type='',key_id='',
+def start_stream_encryption(client, stream_name, encryption_type='', key_id='',
                             wait=False, wait_timeout=300, check_mode=False):
     """Start encryption on an Amazon Kinesis Stream.
     Args:

--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -26,7 +26,8 @@ description:
     - Create or Delete a Kinesis Stream.
     - Update the retention period of a Kinesis Stream.
     - Update Tags on a Kinesis Stream.
-version_added: "2.2"
+    - Enable/disable server side encryption on a Kinesis Stream.
+version_added: "2.2.1"
 author: Allen Sanabria (@linuxdynasty)
 options:
   name:
@@ -69,6 +70,21 @@ options:
     required: false
     default: null
     aliases: [ "resource_tags" ]
+  encryption_state:
+    description:
+      - "Enable or Disable encryption on the Kinesis Stream."
+    required: false
+    choices: [ 'enabled', 'disabled' ]
+  encryption_type:
+    description:
+      - "The type of encryption."
+    required: false
+    default: KMS
+  key_id:
+    description:
+      - "The GUID or alias for the KMS key."
+    required: false
+    default: None
 extends_documentation_fragment:
     - aws
     - ec2
@@ -114,6 +130,30 @@ EXAMPLES = '''
   kinesis_stream:
     name: test-stream
     state: absent
+    wait: yes
+    wait_timeout: 600
+  register: test_stream
+
+# Basic enable encryption example:
+- name: Encrypt Kinesis Stream test-stream.
+  kinesis_stream:
+    name: test-stream
+    state: present
+    encryption_state: enabled
+    encryption_type: KMS
+    key_id: alias/aws/kinesis
+    wait: yes
+    wait_timeout: 600
+  register: test_stream
+
+# Basic disable encryption example:
+- name: Encrypt Kinesis Stream test-stream.
+  kinesis_stream:
+    name: test-stream
+    state: present
+    encryption_state: disabled
+    encryption_type: KMS
+    key_id: alias/aws/kinesis
     wait: yes
     wait_timeout: 600
   register: test_stream
@@ -346,7 +386,8 @@ def find_stream(client, stream_name, check_mode=False):
                 'RetentionPeriodHours': 24,
                 'StreamName': stream_name,
                 'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/{0}'.format(stream_name),
-                'StreamStatus': 'ACTIVE'
+                'StreamStatus': 'ACTIVE',
+                'EncryptionType': 'NONE'
             }
         success = True
     except botocore.exceptions.ClientError as e:
@@ -637,6 +678,66 @@ def stream_action(client, stream_name, shard_count=1, action='create',
     return success, err_msg
 
 
+
+def stream_encryption_action(client, stream_name, action='start_encryption',encryption_type='BLAH',key_id='',
+                  timeout=300, check_mode=False):
+    """Create, Encrypt or Delete an Amazon Kinesis Stream.
+    Args:
+        client (botocore.client.EC2): Boto3 client.
+        stream_name (str): The name of the kinesis stream.
+
+    Kwargs:
+        shard_count (int): Number of shards this stream will use.
+        action (str): The action to perform.
+            valid actions == create and delete
+            default=create
+        encryption_type (str): NONE or KMS
+        key_id (str): The GUID or alias for the KMS key
+        check_mode (bool): This will pass DryRun as one of the parameters to the aws api.
+            default=False
+
+    Basic Usage:
+        >>> client = boto3.client('kinesis')
+        >>> stream_name = 'test-stream'
+        >>> shard_count = 20
+        >>> stream_action(client, stream_name, shard_count, action='create', encryption_type='KMS',key_id='alias/aws')
+
+    Returns:
+        List (bool, str)
+    """
+    success = False
+    err_msg = ''
+    params = {
+        'StreamName': stream_name
+    }
+    try:
+        if not check_mode:
+            if action == 'start_encryption':
+                params['EncryptionType'] = encryption_type
+                params['KeyId'] = key_id
+                client.start_stream_encryption(**params)
+                success = True
+            elif action == 'stop_encryption':
+                params['EncryptionType'] = encryption_type
+                params['KeyId'] = key_id
+                client.stop_stream_encryption(**params)
+                success = True
+            else:
+                err_msg = 'Invalid encryption action {0}'.format(action)
+        else:
+            if action == 'start_encryption':
+                success = True
+            elif action == 'stop_encryption':
+                success = True
+            else:
+                err_msg = 'Invalid encryption action {0}'.format(action)
+
+    except botocore.exceptions.ClientError as e:
+        err_msg = to_native(e)
+
+    return success, err_msg
+
+
 def retention_action(client, stream_name, retention_period=24,
                      action='increase', check_mode=False):
     """Increase or Decrease the retention of messages in the Kinesis stream.
@@ -675,7 +776,7 @@ def retention_action(client, stream_name, retention_period=24,
                 success = True
                 err_msg = (
                     'Retention Period increased successfully to {0}'
-                    .format(retention_period)
+                        .format(retention_period)
                 )
             elif action == 'decrease':
                 params['RetentionPeriodHours'] = retention_period
@@ -683,7 +784,7 @@ def retention_action(client, stream_name, retention_period=24,
                 success = True
                 err_msg = (
                     'Retention Period decreased successfully to {0}'
-                    .format(retention_period)
+                        .format(retention_period)
                 )
             else:
                 err_msg = 'Invalid action {0}'.format(action)
@@ -1103,6 +1204,146 @@ def delete_stream(client, stream_name, wait=False, wait_timeout=300,
 
     return success, changed, err_msg, results
 
+def start_stream_encryption(client, stream_name, encryption_type='',key_id='',
+                            wait=False, wait_timeout=300,check_mode=False):
+    """Start encryption on an Amazon Kinesis Stream.
+    Args:
+        client (botocore.client.EC2): Boto3 client.
+        stream_name (str): The name of the kinesis stream.
+
+    Kwargs:
+        encryption_type (str): KMS or NONE
+        key_id (str): KMS key GUID or alias
+        wait (bool): Wait until Stream is ACTIVE.
+            default=False
+        wait_timeout (int): How long to wait until this operation is considered failed.
+            default=300
+        check_mode (bool): This will pass DryRun as one of the parameters to the aws api.
+            default=False
+
+    Basic Usage:
+        >>> client = boto3.client('kinesis')
+        >>> stream_name = 'test-stream'
+        >>> key_id = 'alias/aws'
+        >>> encryption_type = 'KMS'
+        >>> start_stream_encryption(client, stream_name,encryption_type,key_id)
+
+    Returns:
+        Tuple (bool, bool, str, dict)
+    """
+    success = False
+    changed = False
+    err_msg = ''
+    params = {
+        'StreamName': stream_name
+    }
+
+
+    results = dict()
+    stream_found, stream_msg, current_stream = (
+        find_stream(client, stream_name, check_mode=check_mode)
+    )
+    if stream_found:
+        success, err_msg = (
+            stream_encryption_action(
+                client, stream_name, action='start_encryption', encryption_type=encryption_type, key_id=key_id, check_mode=check_mode
+            )
+        )
+        if success:
+            changed = True
+            if wait:
+                success, err_msg, results = (
+                    wait_for_status(
+                        client, stream_name, 'ACTIVE', wait_timeout,
+                        check_mode=check_mode
+                    )
+                )
+                err_msg = 'Kinesis Stream {0} encryption started successfully.'.format(stream_name)
+                if not success:
+                    return success, True, err_msg, results
+            else:
+                err_msg = (
+                    'Kinesis Stream {0} is in the process of starting encryption.'
+                        .format(stream_name)
+                )
+    else:
+        success = True
+        changed = False
+        err_msg = 'Kinesis Stream {0} does not exist'.format(stream_name)
+
+    return success, changed, err_msg, results
+
+def stop_stream_encryption(client, stream_name, encryption_type='', key_id='',
+                            wait=True, wait_timeout=300,check_mode=False):
+    """Stop encryption on an Amazon Kinesis Stream.
+    Args:
+        client (botocore.client.EC2): Boto3 client.
+        stream_name (str): The name of the kinesis stream.
+
+    Kwargs:
+        encryption_type (str): KMS or NONE
+        key_id (str): KMS key GUID or alias
+        wait (bool): Wait until Stream is ACTIVE.
+            default=False
+        wait_timeout (int): How long to wait until this operation is considered failed.
+            default=300
+        check_mode (bool): This will pass DryRun as one of the parameters to the aws api.
+            default=False
+
+    Basic Usage:
+        >>> client = boto3.client('kinesis')
+        >>> stream_name = 'test-stream'
+        >>> start_stream_encryption(client, stream_name,encryption_type, key_id)
+
+    Returns:
+        Tuple (bool, bool, str, dict)
+    """
+    success = False
+    changed = False
+    err_msg = ''
+    params = {
+        'StreamName': stream_name
+    }
+
+
+    results = dict()
+    stream_found, stream_msg, current_stream = (
+        find_stream(client, stream_name, check_mode=check_mode)
+    )
+    if stream_found:
+        if current_stream.get('EncryptionType') == 'KMS':
+            success, err_msg = (
+                stream_encryption_action(
+                    client, stream_name, action='stop_encryption',key_id=key_id, encryption_type=encryption_type, check_mode=check_mode
+                )
+            )
+        elif current_stream.get('EncryptionType') == 'NONE':
+            success = True
+
+        if success:
+            changed = True
+            if wait:
+                success, err_msg, results = (
+                    wait_for_status(
+                        client, stream_name, 'ACTIVE', wait_timeout,
+                        check_mode=check_mode
+                    )
+                )
+                err_msg = 'Kinesis Stream {0} encryption stopped successfully.'.format(stream_name)
+                if not success:
+                    return success, True, err_msg, results
+            else:
+                err_msg = (
+                    'Stream {0} is in the process of stopping encryption.'
+                        .format(stream_name)
+                )
+    else:
+        success = True
+        changed = False
+        err_msg = 'Stream {0} does not exist.'.format(stream_name)
+
+    return success, changed, err_msg, results
+
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -1115,6 +1356,9 @@ def main():
             wait=dict(default=True, required=False, type='bool'),
             wait_timeout=dict(default=300, required=False, type='int'),
             state=dict(default='present', choices=['present', 'absent']),
+            encryption_type=dict(required=False, choices=['NONE', 'KMS']),
+            key_id=dict(required=False, type='str'),
+            encryption_state=dict(required=False, choices=['enabled', 'disabled']),
         )
     )
     module = AnsibleModule(
@@ -1129,6 +1373,9 @@ def main():
     tags = module.params.get('tags')
     wait = module.params.get('wait')
     wait_timeout = module.params.get('wait_timeout')
+    encryption_type = module.params.get('encryption_type')
+    key_id = module.params.get('key_id')
+    encryption_state = module.params.get('encryption_state')
 
     if state == 'present' and not shards:
         module.fail_json(msg='Shards is required when state == present.')
@@ -1164,6 +1411,18 @@ def main():
                 wait, wait_timeout, check_mode
             )
         )
+        if encryption_state == 'enabled':
+            success, changed, err_msg, results = (
+                start_stream_encryption(
+                    client, stream_name, encryption_type, key_id, wait, wait_timeout, check_mode
+                )
+            )
+        elif encryption_state == 'disabled':
+            success, changed, err_msg, results = (
+                stop_stream_encryption(
+                    client, stream_name, encryption_type, key_id, wait, wait_timeout, check_mode
+                )
+            )
     elif state == 'absent':
         success, changed, err_msg, results = (
             delete_stream(client, stream_name, wait, wait_timeout, check_mode)

--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -27,7 +27,7 @@ description:
     - Update the retention period of a Kinesis Stream.
     - Update Tags on a Kinesis Stream.
     - Enable/disable server side encryption on a Kinesis Stream.
-version_added: "2.5"
+version_added: "2.2"
 author: Allen Sanabria (@linuxdynasty)
 options:
   name:
@@ -75,16 +75,19 @@ options:
       - "Enable or Disable encryption on the Kinesis Stream."
     required: false
     choices: [ 'enabled', 'disabled' ]
+    version_added: "2.5"
   encryption_type:
     description:
       - "The type of encryption."
     required: false
     default: KMS
+    version_added: "2.5"
   key_id:
     description:
       - "The GUID or alias for the KMS key."
     required: false
     default: None
+    version_added: "2.5"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/lib/ansible/modules/cloud/amazon/kinesis_stream.py
+++ b/lib/ansible/modules/cloud/amazon/kinesis_stream.py
@@ -679,7 +679,7 @@ def stream_action(client, stream_name, shard_count=1, action='create',
 
 
 
-def stream_encryption_action(client, stream_name, action='start_encryption',encryption_type='BLAH',key_id='',
+def stream_encryption_action(client, stream_name, action='start_encryption',encryption_type='',key_id='',
                   timeout=300, check_mode=False):
     """Create, Encrypt or Delete an Amazon Kinesis Stream.
     Args:

--- a/test/units/modules/cloud/amazon/test_kinesis_stream.py
+++ b/test/units/modules/cloud/amazon/test_kinesis_stream.py
@@ -105,7 +105,8 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             'RetentionPeriodHours': 24,
             'StreamName': 'test',
             'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/test',
-            'StreamStatus': 'ACTIVE'
+            'StreamStatus': 'ACTIVE',
+            'EncryptionType': 'NONE'
         }
         self.assertTrue(success)
         self.assertEqual(stream, should_return)
@@ -125,7 +126,8 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             'RetentionPeriodHours': 24,
             'StreamName': 'test',
             'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/test',
-            'StreamStatus': 'ACTIVE'
+            'StreamStatus': 'ACTIVE',
+            'EncryptionType': 'NONE'
         }
         self.assertTrue(success)
         self.assertEqual(stream, should_return)
@@ -255,7 +257,8 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             'RetentionPeriodHours': 24,
             'StreamName': 'test',
             'StreamARN': 'arn:aws:kinesis:east-side:123456789:stream/test',
-            'StreamStatus': 'ACTIVE'
+            'StreamStatus': 'ACTIVE',
+            'EncryptionType': 'NONE'
         }
         tags = {
             'env': 'development',
@@ -292,9 +295,32 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
             'stream_name': 'test',
             'stream_arn': 'arn:aws:kinesis:east-side:123456789:stream/test',
             'stream_status': 'ACTIVE',
+            'encryption_type': 'NONE',
             'tags': tags,
         }
         self.assertTrue(success)
         self.assertTrue(changed)
         self.assertEqual(results, should_return)
         self.assertEqual(err_msg, 'Kinesis Stream test updated successfully.')
+
+    def test_enable_stream_encription(self):
+        client = boto3.client('kinesis', region_name=aws_region)
+        success, changed, err_msg, results = (
+            kinesis_stream.start_stream_encryption(
+                client, 'test', encryption_type='KMS', key_id='', wait=True,wait_timeout=60,  check_mode=True
+            )
+        )
+        self.assertTrue(success)
+        self.assertTrue(changed)
+        self.assertEqual(err_msg, 'Kinesis Stream test encryption started successfully.')
+
+    def test_dsbale_stream_encryption(self):
+        client = boto3.client('kinesis', region_name=aws_region)
+        success, changed, err_msg, results = (
+            kinesis_stream.stop_stream_encryption(
+                client, 'test', encryption_type='KMS', key_id='', wait=True,wait_timeout=60,  check_mode=True
+            )
+        )
+        self.assertTrue(success)
+        self.assertTrue(changed)
+        self.assertEqual(err_msg, 'Kinesis Stream test encryption stopped successfully.')

--- a/test/units/modules/cloud/amazon/test_kinesis_stream.py
+++ b/test/units/modules/cloud/amazon/test_kinesis_stream.py
@@ -307,7 +307,7 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
         client = boto3.client('kinesis', region_name=aws_region)
         success, changed, err_msg, results = (
             kinesis_stream.start_stream_encryption(
-                client, 'test', encryption_type='KMS', key_id='', wait=True,wait_timeout=60,  check_mode=True
+                client, 'test', encryption_type='KMS', key_id='', wait=True, wait_timeout=60, check_mode=True
             )
         )
         self.assertTrue(success)
@@ -318,7 +318,7 @@ class AnsibleKinesisStreamFunctions(unittest.TestCase):
         client = boto3.client('kinesis', region_name=aws_region)
         success, changed, err_msg, results = (
             kinesis_stream.stop_stream_encryption(
-                client, 'test', encryption_type='KMS', key_id='', wait=True,wait_timeout=60,  check_mode=True
+                client, 'test', encryption_type='KMS', key_id='', wait=True, wait_timeout=60, check_mode=True
             )
         )
         self.assertTrue(success)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To manage the server side encryption on a Kinesis stream I have added an encryption action to enable or disable the encryption service feature. Fixes #30269.

The new arguments are:
```
    encryption_state: 'enabled'/'disabled'
    encryption_type: 'KMS'/'NONE'
    key_id: 'GUID or alias/aws/kinesis'
```
It handles encryption use cases where:
1. Create new stream with encryption - it will be created and encryption enabled
2. Enable encryption on an existing stream with encryption disabled - encryption will be enabled
3. Disable encryption on an existing stream with encryption enabled - encryption will be disabled

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (30269_kinesis_stream_server_side_encryption 619c49e9c6) last updated 2017/09/21 12:09:48 (GMT +100)
  config file = None
  configured module search path = ['/Users/sclark/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sclark/IdeaProjects/ansible/lib/ansible
  executable location = /Users/sclark/IdeaProjects/ansible/bin/ansible
  python version = 3.6.2 (default, Jul 17 2017, 16:44:45) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
### Example playbook
```
- name: Setup Kinesis Stream with encryption enabled
  connection: local
  hosts: localhost
  tasks:
  # Basic creation example:
  - name: Set up Kinesis Stream with 1 shard and enable encryption, wait for the stream to become ACTIVE
    kinesis_stream:
      name: test-stream
      shards: 1
      wait: yes
      wait_timeout: 600
      state: present
      encryption_state: enabled
      key_id: alias/aws/kinesis
      encryption_type: KMS
    register: testout
  - name: dump test output
    debug:
      msg: '{{ testout }}'
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
