### PR TITLE
Rename monit status function to prevent override in runtime

### DIFF
--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -100,7 +100,7 @@ def main():
         else:
             return ''
 
-    def status():
+    def get_status():
         """Return the status of the process in monit, or the empty string if not present."""
         rc, out, err = module.run_command('%s %s' % (MONIT, SUMMARY_COMMAND), check_rc=True)
         for line in out.split('\n'):
@@ -116,14 +116,14 @@ def main():
     def run_command(command):
         """Runs a monit command, and returns the new status."""
         module.run_command('%s %s %s' % (MONIT, command, name), check_rc=True)
-        return status()
+        return get_status()
 
     def wait_for_monit_to_stop_pending():
         """Fails this run if there is no status or it's pending/initializing for timeout"""
         timeout_time = time.time() + timeout
         sleep_time = 5
 
-        running_status = status()
+        running_status = get_status()
         while running_status == '' or 'pending' in running_status or 'initializing' in running_status:
             if time.time() >= timeout_time:
                 module.fail_json(
@@ -134,7 +134,7 @@ def main():
                 )
 
             time.sleep(sleep_time)
-            running_status = status()
+            running_status = get_status()
 
     MONIT_MAJOR_VERSION, MONIT_MINOR_VERSION = monit_version()
 
@@ -149,7 +149,7 @@ def main():
         wait_for_monit_to_stop_pending()
         module.exit_json(changed=True, name=name, state=state)
 
-    present = status() != ''
+    present = get_status() != ''
 
     if not present and not state == 'present':
         module.fail_json(msg='%s process not presently configured with monit' % name, name=name, state=state)
@@ -165,7 +165,7 @@ def main():
         module.exit_json(changed=False, name=name, state=state)
 
     wait_for_monit_to_stop_pending()
-    running = 'running' in status()
+    running = 'running' in get_status()
 
     if running and state in ['started', 'monitored']:
         module.exit_json(changed=False, name=name, state=state)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Rename`status` to `get_status` to prevent override in runtime
Fixes #30637
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/monitoring/monit.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = ['/home/louie/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/louie/dev/ansible/.venv/lib/python3.6/site-packages/ansible-2.5.0-py3.6.egg/ansible
  executable location = /home/louie/dev/ansible/.venv/bin/ansible
  python version = 3.6.2 (default, Jul 20 2017, 03:52:27) [GCC 7.1.1 20170630]
```