### PR TITLE
[fix] py3 compatibility

### DIFF
--- a/docs/bin/generate_man.py
+++ b/docs/bin/generate_man.py
@@ -31,14 +31,19 @@ def trim_docstring(docstring):
     # and split into a list of lines:
     lines = docstring.expandtabs().splitlines()
     # Determine minimum indentation (first line doesn't count):
-    indent = sys.maxsize
+    try:
+        indent = sys.maxint
+        limit = sys.maxint
+    except AttributeError:
+        indent = sys.maxsize
+        limit = sys.maxsize
     for line in lines[1:]:
         stripped = line.lstrip()
         if stripped:
             indent = min(indent, len(line) - len(stripped))
     # Remove indentation (first line is special):
     trimmed = [lines[0].strip()]
-    if indent < sys.maxsize:
+    if indent < limit:
         for line in lines[1:]:
             trimmed.append(line[indent:].rstrip())
     # Strip off trailing and leading blank lines:


### PR DESCRIPTION
##### SUMMARY
fix python3 error on documentation generation ```make docs``` with python3.5.
Using sys.maxsize instead of sys.maxint

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docs/bin/generate_man.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (bugfix/docs_py3_compatibility 567b236ebf) last updated 2017/09/21 17:59:14 (GMT +200)
  config file = None
  configured module search path = ['/home/herve/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/herve/dev/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before changes
```
make docs
mkdir -p ./docs/man/man1/ ; \
PYTHONPATH=./lib docs/bin/generate_man.py --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
Traceback (most recent call last):
  File "docs/bin/generate_man.py", line 253, in <module>
    allvars[cli_name] = opts_docs(cli_class_name, cli_name)
  File "docs/bin/generate_man.py", line 119, in opts_docs
    'long_desc': trim_docstring(cli.__doc__),
  File "docs/bin/generate_man.py", line 34, in trim_docstring
    indent = sys.maxint
AttributeError: module 'sys' has no attribute 'maxint'
Makefile:347 : la recette pour la cible « generate_asciidoc » a échouée
make: *** [generate_asciidoc] Erreur 1
```

after changes
```
make docs
mkdir -p ./docs/man/man1/ ; \
PYTHONPATH=./lib docs/bin/generate_man.py --template-file=docs/templates/man.j2 --output-dir=docs/man/man1/ --output-format man lib/ansible/cli/*.py
Wrote doc to /home/herve/dev/ansible/docs/man/man1/ansible-config.1.asciidoc.in
Wrote doc to /home/herve/dev/ansible/docs/man/man1/ansible-pull.1.asciidoc.in
Wrote doc to /home/herve/dev/ansible/docs/man/man1/ansible.1.asciidoc.in
Wrote doc to /home/herve/dev/ansible/docs/man/man1/ansible-inventory.1.asciidoc.in
Wrote doc to /home/herve/dev/ansible/docs/man/man1/ansible-console.1.asciidoc.in
Wrote doc to /home/herve/dev/ansible/docs/man/man1/ansible-doc.1.asciidoc.in
```