### PR TITLE
[fix] issue #29886 - docker_container module : take care about oom_killer (missed in host_config_params)

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -855,7 +855,7 @@ class TaskParameters(DockerBaseClass):
             mem_limit='memory',
             mem_reservation='mem_reservation',
             memswap_limit='memory_swap',
-            kernel_memory='kernel_memory'
+            kernel_memory='kernel_memory',
         )
         result = dict()
         for key, value in update_parameters.items():
@@ -966,6 +966,7 @@ class TaskParameters(DockerBaseClass):
             memswap_limit='memory_swap',
             mem_swappiness='memory_swappiness',
             oom_score_adj='oom_score_adj',
+            oom_kill_disable='oom_killer',
             shm_size='shm_size',
             group_add='groups',
             devices='devices',
@@ -1437,6 +1438,7 @@ class Container(DockerBaseClass):
             memory_reservation=host_config.get('MemoryReservation'),
             memory_swap=host_config.get('MemorySwap'),
             oom_score_adj=host_config.get('OomScoreAdj'),
+            oom_killer=host_config.get('OomKillDisable'),
         )
 
         differences = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
[fix] issue #29886 - it misses oom_killer in host_config_params
so it was never passed to docker API.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix_issue_#29886_docker_oomkiller 86ab721629) last updated 2017/09/21 18:41:43 (GMT +200)
```