### PR TITLE
Fix 'distribution' fact for ArchLinux

### DIFF
--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -815,6 +815,48 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
             "distribution_version": "NA"
         }
     },
+
+    # ArchLinux with an empty /etc/arch-release and a /etc/os-releae with NAME=Arch Linux
+    {
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/os-release": "NAME=\"Arch Linux\"\nPRETTY_NAME=\"Arch Linux\"\nID=arch\nID_LIKE=archlinux\nANSI_COLOR=\"0;36\"\nHOME_URL=\"https://www.archlinux.org/\"\nSUPPORT_URL=\"https://bbs.archlinux.org/\"\nBUG_REPORT_URL=\"https://bugs.archlinux.org/\"\n\n",  # noqa
+            "/etc/arch-release": "",
+        },
+        "name": "Arch Linux NA",
+        "result": {
+            "distribution_release": "NA",
+            "distribution": "Archlinux",
+            "distribution_major_version": "NA",
+            "os_family": "Archlinux",
+            "distribution_version": "NA"
+        }
+    },
+
+    # ArchLinux with no /etc/arch-release and a /etc/os-release with NAME=Arch Linux
+    # The fact needs to map 'Arch Linux' to 'Archlinux' for compat
+    {
+        "platform.dist": [
+            "",
+            "",
+            ""
+        ],
+        "input": {
+            "/etc/os-release": "NAME=\"Arch Linux\"\nPRETTY_NAME=\"Arch Linux\"\nID=arch\nID_LIKE=archlinux\nANSI_COLOR=\"0;36\"\nHOME_URL=\"https://www.archlinux.org/\"\nSUPPORT_URL=\"https://bbs.archlinux.org/\"\nBUG_REPORT_URL=\"https://bugs.archlinux.org/\"\n\n",  # noqa
+        },
+        "name": "Arch Linux no arch-release NA",
+        "result": {
+            "distribution_release": "NA",
+            "distribution": "Archlinux",
+            "distribution_major_version": "NA",
+            "os_family": "Archlinux",
+            "distribution_version": "NA"
+        }
+    }
 ]
 
 
@@ -892,10 +934,12 @@ def _test_one_distribution(module, testcase):
         res = distro_collector.collect(module)
         return res
 
+    #print(testcase)
     generated_facts = get_facts(testcase)
 
     # testcase['result'] has a list of variables and values it expects Facts() to set
     for key, val in testcase['result'].items():
+        #print('Key: %s' % key)
         assert key in generated_facts
         msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
             (key, testcase['name'], val, generated_facts[key])

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -816,7 +816,7 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         }
     },
 
-    # ArchLinux with an empty /etc/arch-release and a /etc/os-releae with NAME=Arch Linux
+    # ArchLinux with an empty /etc/arch-release and a /etc/os-release with "NAME=Arch Linux"
     {
         "platform.dist": [
             "",
@@ -837,8 +837,8 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         }
     },
 
-    # ArchLinux with no /etc/arch-release and a /etc/os-release with NAME=Arch Linux
-    # The fact needs to map 'Arch Linux' to 'Archlinux' for compat
+    # ArchLinux with no /etc/arch-release but with a /etc/os-release with NAME=Arch Linux
+    # The fact needs to map 'Arch Linux' to 'Archlinux' for compat with 2.3 and earlier facts
     {
         "platform.dist": [
             "",
@@ -934,12 +934,10 @@ def _test_one_distribution(module, testcase):
         res = distro_collector.collect(module)
         return res
 
-    #print(testcase)
     generated_facts = get_facts(testcase)
 
     # testcase['result'] has a list of variables and values it expects Facts() to set
     for key, val in testcase['result'].items():
-        #print('Key: %s' % key)
         assert key in generated_facts
         msg = 'Comparing value of %s on %s, should: %s, is: %s' %\
             (key, testcase['name'], val, generated_facts[key])


### PR DESCRIPTION
Allow empty wasn't breaking out of the process_dist_files
loop, so a empty /etc/arch-release would continue searching
and eventually try /etc/os-release. The os-release parsing
works, but the distro name there is 'Arch Linux' which does
not match the 2.3 behavior of 'Archlinux'

Add a OS_RELEASE_ALIAS map for the cases where we need to get
the distro name from os-release but use an alias.

We can't include 'Archlinux' in SEARCH_STRING because a name match on its keys
but without a match on the content causes a fallback to using the first
whitespace seperated item from the file content as the name.
For os-release, that is in form 'NAME=Arch Linux'

With os-release returning the right name, this also supports the
case where there is no /etc/arch-release, but there is a /etc/os-release

Fixes #30600

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts/system/distribution.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (facts_arch_linux_30600 1de792b99a) last updated 2017/09/21 16:35:12 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Not the prettiest fix, but it is relatively small for cherrypicking to 2.4

A better fix should probably separate the methods for parsing random dist files and
those that parse /etc/os-release.
```
