### PR TITLE
standardize params across pg modules

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -358,7 +358,7 @@ def do_with_password(module, cmd, password):
 def main():
     argument_spec = pgutils.postgres_common_argument_spec()
     argument_spec.update(dict(
-        db=dict(required=True, aliases=['name']),
+        db=dict(required=True, aliases=['name', 'database']),
         owner=dict(default=""),
         template=dict(default=""),
         encoding=dict(default=""),

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -126,7 +126,7 @@ def main():
             login_password=dict(default="", no_log=True),
             login_host=dict(default=""),
             port=dict(default="5432"),
-            db=dict(required=True),
+            db=dict(required=True, aliases=['database']),
             ext=dict(required=True, aliases=['name']),
             state=dict(default="present", choices=["absent", "present"]),
         ),

--- a/lib/ansible/modules/database/postgresql/postgresql_lang.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_lang.py
@@ -203,7 +203,7 @@ def main():
             login_user=dict(default="postgres"),
             login_password=dict(default="", no_log=True),
             login_host=dict(default=""),
-            db=dict(required=True),
+            db=dict(required=True, aliases=['database']),
             port=dict(default='5432'),
             lang=dict(required=True),
             state=dict(default="present", choices=["absent", "present"]),

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -105,6 +105,7 @@ except ImportError:
 else:
     postgresqldb_found = True
 
+import ansible.module_utils.postgres as pgutils
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.database import SQLParseError, pg_quote_identifier
 from ansible.module_utils._text import to_native
@@ -177,19 +178,16 @@ def schema_matches(cursor, schema, owner):
 #
 
 def main():
+    argument_spec = pgutils.postgres_common_argument_spec()
+    argument_spec.update(dict(
+        schema=dict(required=True, aliases=['name']),
+        owner=dict(default=""),
+        database=dict(default="postgres"),
+        state=dict(default="present", choices=["absent", "present"]),
+    ))
     module = AnsibleModule(
-        argument_spec=dict(
-            login_user=dict(default="postgres"),
-            login_password=dict(default="", no_log=True),
-            login_host=dict(default=""),
-            login_unix_socket=dict(default=""),
-            port=dict(default="5432"),
-            schema=dict(required=True, aliases=['name']),
-            owner=dict(default=""),
-            database=dict(default="postgres"),
-            state=dict(default="present", choices=["absent", "present"]),
-        ),
-        supports_check_mode = True
+      argument_spec = argument_spec,
+      supports_check_mode = True
     )
 
     if not postgresqldb_found:
@@ -208,7 +206,9 @@ def main():
         "login_host":"host",
         "login_user":"user",
         "login_password":"password",
-        "port":"port"
+        "port":"port",
+        "ssl_mode":"sslmode",
+        "ssl_rootcert":"sslrootcert"
     }
     kw = dict( (params_map[k], v) for (k, v) in module.params.items()
               if k in params_map and v != '' )
@@ -219,6 +219,7 @@ def main():
         kw["host"] = module.params["login_unix_socket"]
 
     try:
+        pgutils.ensure_libs(sslrootcert=module.params.get('ssl_rootcert'))
         db_connection = psycopg2.connect(database=database, **kw)
         # Enable autocommit so we can create databases
         if psycopg2.__version__ >= '2.4.2':

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -186,8 +186,8 @@ def main():
         state=dict(default="present", choices=["absent", "present"]),
     ))
     module = AnsibleModule(
-      argument_spec = argument_spec,
-      supports_check_mode = True
+        argument_spec = argument_spec,
+        supports_check_mode = True
     )
 
     if not postgresqldb_found:

--- a/lib/ansible/modules/database/postgresql/postgresql_schema.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_schema.py
@@ -73,6 +73,8 @@ notes:
      using this module.
 requirements: [ psycopg2 ]
 author: "Flavien Chantelot <contact@flavien.io>"
+extends_documentation_fragment:
+- postgres
 '''
 
 EXAMPLES = '''
@@ -182,7 +184,7 @@ def main():
     argument_spec.update(dict(
         schema=dict(required=True, aliases=['name']),
         owner=dict(default=""),
-        database=dict(default="postgres"),
+        database=dict(default="postgres", aliases=['db']),
         state=dict(default="present", choices=["absent", "present"]),
     ))
     module = AnsibleModule(

--- a/lib/ansible/modules/database/postgresql/postgresql_user.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_user.py
@@ -716,7 +716,7 @@ def main():
             password=dict(default=None, no_log=True),
             state=dict(default="present", choices=["absent", "present"]),
             priv=dict(default=None),
-            db=dict(default=''),
+            db=dict(default='', aliases=['database']),
             port=dict(default='5432'),
             fail_on_user=dict(type='bool', default='yes'),
             role_attr_flags=dict(default=''),


### PR DESCRIPTION
##### SUMMARY
- 'db' vs 'database' - now if they take one, they take both.
- in `postgresql_schema`, completely refactor the params to use pgutils. Needed this to add SSL support.

Not feeling ambitious enough to standardize params-via-pgutils everywhere, this is a smaller change to avoid rocking the boat too much.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules: `postgres_*`

##### ANSIBLE VERSION
`devel`


##### ADDITIONAL INFORMATION
Ping me here and I can hop on IRC.
