### PR TITLE
aws_kms: handle updated policy format+cleanup

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -182,7 +182,7 @@ def do_grant(kms, keyarn, role_arn, granttypes, mode='grant', dry_run=True, clea
                         statement['Principal']['AWS'].append(role_arn)
                 elif role_arn in statement['Principal']['AWS']: # not one the places the role should be
                     changes_needed[granttype] = 'remove'
-                        statement['Principal']['AWS'].remove(role_arn)
+                    statement['Principal']['AWS'].remove(role_arn)
 
             elif mode == 'deny' and statement['Sid'] == statement_label[granttype] and role_arn in statement['Principal']['AWS']:
                 # we don't selectively deny. that's a grant with a

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -161,7 +161,7 @@ def do_grant(kms, keyarn, role_arn, granttypes, mode='grant', dry_run=True, clea
 
             if 'AWS' in statement['Principal'] and isinstance(statement['Principal']['AWS'], str):
                 # convert to list
-                statement['Principal']['AWS'] = list([statement['Principal']['AWS']])
+                statement['Principal']['AWS'] = list(statement['Principal']['AWS'])
             if not isinstance(statement['Principal'].get('AWS'), list):
                 statement['Principal']['AWS'] = list()
 

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -105,6 +105,7 @@ statement_label = {
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import boto_exception
+from ansible.module_utils.six import string_types
 
 # import a class, we'll use a fully qualified path
 import ansible.module_utils.ec2
@@ -159,9 +160,9 @@ def do_grant(kms, keyarn, role_arn, granttypes, mode='grant', dry_run=True, clea
             if not isinstance(statement.get('Principal'), dict):
                 statement['Principal'] = dict()
 
-            if 'AWS' in statement['Principal'] and isinstance(statement['Principal']['AWS'], str):
+            if 'AWS' in statement['Principal'] and isinstance(statement['Principal']['AWS'], string_types):
                 # convert to list
-                statement['Principal']['AWS'] = list(statement['Principal']['AWS'])
+                statement['Principal']['AWS'] = [statement['Principal']['AWS']]
             if not isinstance(statement['Principal'].get('AWS'), list):
                 statement['Principal']['AWS'] = list()
 

--- a/lib/ansible/modules/cloud/amazon/aws_kms.py
+++ b/lib/ansible/modules/cloud/amazon/aws_kms.py
@@ -170,11 +170,11 @@ def do_grant(kms, keyarn, role_arn, granttypes, mode='grant', dry_run=True, clea
                 # we're granting and we recognize this statement ID.
 
                 if granttype in granttypes:
-                    invalid_entries = list(filter(lambda x: not x.startswith('arn:aws:iam::'), statement['Principal']['AWS']))
+                    invalid_entries = [item for item in statement['Principal']['AWS'] if not item.startswith('arn:aws:iam::')]
                     if clean_invalid_entries and invalid_entries:
                         # we have bad/invalid entries. These are roles that were deleted.
                         # prune the list.
-                        valid_entries = filter(lambda x: x.startswith('arn:aws:iam::'), statement['Principal']['AWS'])
+                        valid_entries = [item for item in statement['Principal']['AWS'] if item.startswith('arn:aws:iam::')]
                         statement['Principal']['AWS'] = valid_entries
                         had_invalid_entries = True
 


### PR DESCRIPTION
##### SUMMARY
- create slightly updated policy in that handles lists instead of a single string; the previous version's policy was being rejected if the key was new enough to have the updated base policy.
- removed `dry_run` conditionals, not committing the policy anyhow.
- return the policy in the return data. Leaving undocumented for now.
- update exception handling: don't rethrow in `do_grant`, don't pass anything to `format_exc`.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`aws_kms` module.

##### ANSIBLE VERSION
`devel`

##### ADDITIONAL INFORMATION
Ping me here and I can hop on IRC.
