### PR TITLE
dont validate group names in yaml plugin

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -68,9 +68,6 @@ class InventoryModule(BaseFileInventoryPlugin):
     def __init__(self):
 
         super(InventoryModule, self).__init__()
-        self.patterns = {}
-
-        self._compile_patterns()
 
     def verify_file(self, path):
 
@@ -104,31 +101,27 @@ class InventoryModule(BaseFileInventoryPlugin):
 
     def _parse_group(self, group, group_data):
 
-        if self.patterns['groupname'].match(group):
+        self.inventory.add_group(group)
 
-            self.inventory.add_group(group)
+        if isinstance(group_data, MutableMapping):
+            # make sure they are dicts
+            for section in ['vars', 'children', 'hosts']:
+                if section in group_data and isinstance(group_data[section], string_types):
+                    group_data[section] = {group_data[section]: None}
 
-            if isinstance(group_data, MutableMapping):
-                # make sure they are dicts
-                for section in ['vars', 'children', 'hosts']:
-                    if section in group_data and isinstance(group_data[section], string_types):
-                        group_data[section] = {group_data[section]: None}
+            if group_data.get('vars', False):
+                for var in group_data['vars']:
+                    self.inventory.set_variable(group, var, group_data['vars'][var])
 
-                if group_data.get('vars', False):
-                    for var in group_data['vars']:
-                        self.inventory.set_variable(group, var, group_data['vars'][var])
+            if group_data.get('children', False):
+                for subgroup in group_data['children']:
+                    self._parse_group(subgroup, group_data['children'][subgroup])
+                    self.inventory.add_child(group, subgroup)
 
-                if group_data.get('children', False):
-                    for subgroup in group_data['children']:
-                        self._parse_group(subgroup, group_data['children'][subgroup])
-                        self.inventory.add_child(group, subgroup)
-
-                if group_data.get('hosts', False):
-                    for host_pattern in group_data['hosts']:
-                        hosts, port = self._parse_host(host_pattern)
-                        self.populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
-        else:
-            self.display.warning("Skipping '%s' as this is not a valid group name" % group)
+            if group_data.get('hosts', False):
+                for host_pattern in group_data['hosts']:
+                    hosts, port = self._parse_host(host_pattern)
+                    self.populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
 
     def _parse_host(self, host_pattern):
         '''
@@ -162,9 +155,3 @@ class InventoryModule(BaseFileInventoryPlugin):
             hostnames = [pattern]
 
         return (hostnames, port)
-
-    def _compile_patterns(self):
-        '''
-        Compiles the regular expressions required to parse the inventory and stores them in self.patterns.
-        '''
-        self.patterns['groupname'] = re.compile(u'''^[A-Za-z_][A-Za-z0-9_]*$''')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove group name restriction for YAML inventory
fixes #30624

previously YAML inventory did have 'group name validation' regex but was never in use,
which was 'fixed' once moved to an inventory plugin, but that breaks existing setups.

Removed for now but will eventually need to reintroduce group/hostname validation and/or 'sanitation'.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/inventory/yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/.2.5
```