### PR TITLE
Fix command argument typo in telnet module docs

### DIFF
--- a/lib/ansible/modules/commands/telnet.py
+++ b/lib/ansible/modules/commands/telnet.py
@@ -18,7 +18,7 @@ description:
      - Executes a low-down and dirty telnet command, not going through the module subsystem.
      - This is mostly to be used for enabling ssh on devices that only have telnet enabled by default.
 options:
-  commands:
+  command:
     description:
       - List of commands to be executed in the telnet session.
     required: True
@@ -67,7 +67,7 @@ EXAMPLES = '''
     login_prompt: "Username: "
     prompts:
       - "[>|#]"
-    commands:
+    command:
       - terminal length 0
       - configure terminal
       - hostname ios01
@@ -79,8 +79,9 @@ EXAMPLES = '''
     login_prompt: "Username: "
     prompts:
       - "[>|#]"
-    commands:
+    command:
       - terminal length 0
+      - show version
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
telnet

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
