### PR TITLE
Add region to ansible-test AWS cloud config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,8 @@ Vagrantfile
 .vagrant
 ansible.egg-info/
 /shippable/
-/test/integration/cloud-config-azure.yml
+/test/integration/cloud-config-*.*
+!/test/integration/cloud-config-*.*.template
 # Release directory
 packaging/release/ansible_release
 /.cache/

--- a/test/integration/cloud-config-aws.yml.template
+++ b/test/integration/cloud-config-aws.yml.template
@@ -14,6 +14,8 @@
 aws_access_key: @ACCESS_KEY
 aws_secret_key: @SECRET_KEY
 security_token: @SECURITY_TOKEN
+aws_region: @REGION
 # aliases for backwards compatibility with older integration test playbooks
 ec2_access_key: '{{ aws_access_key }}'
 ec2_secret_key: '{{ aws_secret_key }}'
+ec2_region: '{{ aws_region }}'

--- a/test/runner/lib/cloud/aws.py
+++ b/test/runner/lib/cloud/aws.py
@@ -68,6 +68,7 @@ class AwsCloudProvider(CloudProvider):
                 ACCESS_KEY=credentials['access_key'],
                 SECRET_KEY=credentials['secret_key'],
                 SECURITY_TOKEN=credentials['session_token'],
+                REGION='us-east-1',
             )
 
             config = self._populate_config_template(config, values)


### PR DESCRIPTION
##### SUMMARY

Add region to ansible-test AWS cloud config.

Also fix .gitignore for ansible-test cloud config.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-aws-region d3eb930596) last updated 2017/09/21 23:55:14 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
