### PR TITLE
Add additional volume settings to na_cdot_volume

### DIFF
--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -69,6 +69,7 @@ options:
     - Name of the export policy to use.
     required: false
     default: None
+    version_added: '2.5'
 
   vserver:
     description:
@@ -322,9 +323,7 @@ class NetAppCDOTVolume(object):
                                   exception=traceback.format_exc())
     def change_export(self):
         """
-        Change export policy of Volume.
-
-       
+        Change export policy of the volume.
         """
 
         volume_change = netapp_utils.zapi.NaElement('volume-modify-iter')
@@ -342,7 +341,7 @@ class NetAppCDOTVolume(object):
         query.add_child_elem(volume_attributes)
 
         attributes = netapp_utils.zapi.NaElement('attributes')
-        attributes.add_child_elem(change_attributes) 
+        attributes.add_child_elem(change_attributes)
 
         volume_change.add_child_elem(query)
         volume_change.add_child_elem(attributes)

--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -230,7 +230,8 @@ class NetAppCDOTVolume(object):
         volume_create = netapp_utils.zapi.NaElement.create_node_with_children(
             'volume-create', **{'volume': self.name,
                                 'containing-aggr-name': self.aggregate_name,
-                                'size': str(self.size)})
+                                'size': str(self.size),
+                                'junction-path': '/%s' % (self.name)})
 
         try:
             self.server.invoke_successfully(volume_create,

--- a/lib/ansible/modules/storage/netapp/na_cdot_volume.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_volume.py
@@ -342,7 +342,7 @@ class NetAppCDOTVolume(object):
     def change_volume(self):
         """
         Change volume settings.
-        
+
         Currently implemented options that can be changed:
 
         - export-policy


### PR DESCRIPTION
##### SUMMARY
This adds the following things to the na_cdot_volume module:

auto mounts the volume at junction path /volume-name
adds the option to specify an export-policy for a volume
adds the option to specify a space reserve for a volume

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
na_cdot_volume

##### ANSIBLE VERSION
2.3.1

##### ADDITIONAL INFORMATION
I was missing the option for exporting newly created volumes (without which they are pretty useless in an interconnected world), so I added the code for specifying an export-policy.

Also, per default volumes are created with a space reserve of 'volume' which means no thin provisioning. I added the option for specifying the space reserve, so thin provisioning state of the volume can be controlled.