### PR TITLE
Do switch to apt if aptitude is not installed

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -912,8 +912,8 @@ def main():
 
     use_apt_get = p['force_apt_get']
 
-    if not use_apt_get and not APTITUDE_CMD and p.get('upgrade', None) in ['full', 'safe', 'yes']:
-        module.warn("Could not find aptitude. Using apt-get instead.")
+    if not use_apt_get and not APTITUDE_CMD:
+        module.warn("Could not find aptitude. Using apt-get instead")
         use_apt_get = True
 
     updated_cache = False


### PR DESCRIPTION
Trying to use the apt module on a freshly install 16.04 Ubuntu VM with
"ansible -m apt -a 'name=* state=latest' all" fail with this backtrace:

```  Traceback (most recent call last):
    File \"/tmp/ansible_2inxygge/ansible_module_apt.py\", line 1055, in <module>
      main()
    File \"/tmp/ansible_2inxygge/ansible_module_apt.py\", line 998, in main
      upgrade(module, 'yes', force_yes, p['default_release'], use_apt_get, dpkg_options)
    File \"/tmp/ansible_2inxygge/ansible_module_apt.py\", line 759, in upgrade
      apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
    File \"/tmp/ansible_2inxygge/ansible_modlib.zip/ansible/module_utils/basic.py\", line 2182, in get_bin_path
    File \"/usr/lib/python3.5/posixpath.py\", line 89, in join
      genericpath._check_arg_types('join', a, *p)
    File \"/usr/lib/python3.5/genericpath.py\", line 143, in _check_arg_types
      (funcname, s.__class__.__name__)) from None
    TypeError: join() argument must be str or bytes, not 'NoneType'
```
It seems that since aptitude is not installed on Xenial, so APTITUDE_CMD is None
and we later hit the bug in the upgrade function since it assume APTITUDE_CMD
is set.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
apt

