### PR TITLE
Remove check_args for vyos modules

### DIFF
--- a/lib/ansible/module_utils/vyos.py
+++ b/lib/ansible/module_utils/vyos.py
@@ -62,16 +62,6 @@ def get_provider_argspec():
     return vyos_provider_spec
 
 
-def check_args(module, warnings):
-    for key in vyos_argument_spec:
-        if module._name == 'vyos_user':
-            if key not in ['password', 'provider'] and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-        else:
-            if key != 'provider' and module.params[key]:
-                warnings.append('argument %s has been deprecated and will be removed in a future version' % key)
-
-
 def get_config(module, target='commands'):
     cmd = ' '.join(['show configuration', target])
 

--- a/lib/ansible/modules/network/vyos/vyos_banner.py
+++ b/lib/ansible/modules/network/vyos/vyos_banner.py
@@ -88,7 +88,7 @@ import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vyos import get_config, load_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def spec_to_commands(updates, module):
@@ -156,7 +156,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -140,7 +140,7 @@ from ansible.module_utils.netcli import Conditional
 from ansible.module_utils.network_common import ComplexList
 from ansible.module_utils.six import string_types
 from ansible.module_utils.vyos import run_commands
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 def to_lines(stdout):
     for item in stdout:
@@ -184,7 +184,6 @@ def main():
     module = AnsibleModule(argument_spec=spec, supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     commands = parse_commands(module, warnings)
 

--- a/lib/ansible/modules/network/vyos/vyos_config.py
+++ b/lib/ansible/modules/network/vyos/vyos_config.py
@@ -129,7 +129,7 @@ import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.netcfg import NetworkConfig
 from ansible.module_utils.vyos import load_config, get_config, run_commands
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 DEFAULT_COMMENT = 'configured by vyos_config'
@@ -260,7 +260,6 @@ def main():
     )
 
     warnings = list()
-    check_args(module, warnings)
 
     result = dict(changed=False, warnings=warnings)
 

--- a/lib/ansible/modules/network/vyos/vyos_facts.py
+++ b/lib/ansible/modules/network/vyos/vyos_facts.py
@@ -101,7 +101,7 @@ import re
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import iteritems
 from ansible.module_utils.vyos import run_commands
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 class FactsBase(object):
@@ -262,7 +262,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     gather_subset = module.params['gather_subset']
 

--- a/lib/ansible/modules/network/vyos/vyos_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_interface.py
@@ -169,7 +169,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network_common import conditional, remove_default_spec
 from ansible.module_utils.vyos import load_config, get_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def search_obj_in_list(name, lst):
@@ -402,7 +402,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/vyos/vyos_l3_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_l3_interface.py
@@ -92,7 +92,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network_common import remove_default_spec
 from ansible.module_utils.vyos import load_config, run_commands
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def search_obj_in_list(name, lst):
@@ -218,7 +218,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/vyos/vyos_linkagg.py
+++ b/lib/ansible/modules/network/vyos/vyos_linkagg.py
@@ -100,7 +100,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network_common import remove_default_spec
 from ansible.module_utils.vyos import load_config, run_commands
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def search_obj_in_list(name, lst):
@@ -240,7 +240,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/vyos/vyos_lldp.py
+++ b/lib/ansible/modules/network/vyos/vyos_lldp.py
@@ -63,7 +63,7 @@ commands:
 """
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vyos import get_config, load_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def has_lldp(module):
@@ -91,7 +91,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/vyos/vyos_lldp_interface.py
+++ b/lib/ansible/modules/network/vyos/vyos_lldp_interface.py
@@ -93,7 +93,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network_common import remove_default_spec
 from ansible.module_utils.vyos import get_config, load_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def search_obj_in_list(name, lst):
@@ -203,7 +203,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
 

--- a/lib/ansible/modules/network/vyos/vyos_logging.py
+++ b/lib/ansible/modules/network/vyos/vyos_logging.py
@@ -110,7 +110,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network_common import remove_default_spec
 from ansible.module_utils.vyos import get_config, load_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def spec_to_commands(updates, module):
@@ -240,7 +240,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/vyos/vyos_static_route.py
+++ b/lib/ansible/modules/network/vyos/vyos_static_route.py
@@ -108,7 +108,7 @@ from copy import deepcopy
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network_common import remove_default_spec
 from ansible.module_utils.vyos import get_config, load_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def spec_to_commands(updates, module):
@@ -242,7 +242,6 @@ def main():
                            supports_check_mode=True)
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:

--- a/lib/ansible/modules/network/vyos/vyos_system.py
+++ b/lib/ansible/modules/network/vyos/vyos_system.py
@@ -94,7 +94,7 @@ EXAMPLES = """
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.vyos import get_config, load_config
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def spec_key_to_device_key(key):
@@ -190,7 +190,6 @@ def main():
     )
 
     warnings = list()
-    check_args(module, warnings)
 
     result = {'changed': False, 'warnings': warnings}
 

--- a/lib/ansible/modules/network/vyos/vyos_user.py
+++ b/lib/ansible/modules/network/vyos/vyos_user.py
@@ -136,7 +136,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network_common import remove_default_spec
 from ansible.module_utils.vyos import get_config, load_config
 from ansible.module_utils.six import iteritems
-from ansible.module_utils.vyos import vyos_argument_spec, check_args
+from ansible.module_utils.vyos import vyos_argument_spec
 
 
 def validate_level(value, module):
@@ -308,8 +308,6 @@ def main():
             'The "password" argument is used to authenticate the current connection. ' +
             'To set a user password use "configured_password" instead.'
         )
-
-    check_args(module, warnings)
 
     result = {'changed': False}
     if warnings:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  With addition of provider sub option validation check_args()
   is no longer required.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/vyos.py
vyos_banner
vyos_command
vyos_config
vyos_facts
vyos_interface
vyos_l3_interface
vyos_linkagg
vyos_lldp
vyos_lldp_interface
vyos_logging
vyos_static_route
vyos_system
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
