### PR TITLE
Increase pause time in junos integration test

### DIFF
--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -31,7 +31,7 @@
 
 - name: wait for persistent socket to timeout, this ensures new socket creation with connection type netconf
   pause:
-    seconds: 30
+    seconds: 120
 
 - name: Ensure we can communicate over 22
   junos_command:
@@ -55,7 +55,7 @@
 
 - name: wait for persistent socket to timeout, this ensures new socket creation with connection type netconf
   pause:
-    seconds: 30
+    seconds: 120
 
 - name: Set back netconf to default port
   junos_netconf:

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -45,7 +45,7 @@
 
 - name: wait for persistent socket to timeout
   pause:
-    seconds: 30
+    seconds: 120
 
 - name: Ensure we can NOT talk via netconf
   junos_command:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Increase pause time to a value greater
   than persistent connection timeout to clean
   out socket path.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
