### PR TITLE
fix(tasks: synchronize): wrap in sshpass if ssh password was provided

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2681,7 +2681,7 @@ class AnsibleModule(object):
 
     def run_command(self, args, check_rc=False, close_fds=True, executable=None, data=None, binary_data=False, path_prefix=None, cwd=None,
                     use_unsafe_shell=False, prompt_regex=None, environ_update=None, umask=None, encoding='utf-8', errors='surrogate_or_strict',
-                    expand_user_and_vars=True):
+                    expand_user_and_vars=True, pass_fds=None, before_communicate_callback=None):
         '''
         Execute a command, returns rc, stdout, and stderr.
 
@@ -2724,6 +2724,13 @@ class AnsibleModule(object):
             are expanded before running the command. When ``True`` a string such as
             ``$SHELL`` will be expanded regardless of escaping. When ``False`` and
             ``use_unsafe_shell=False`` no path or variable expansion will be done.
+        :kw pass_fds: When running on python3 this argument
+            dictates which file descriptors should be passed
+            to an underlying ``Popen`` constructor.
+        :kw before_communicate_callback: This function will be called
+            after ``Popen`` object will be created
+            but before communicating to the process.
+            (``Popen`` object will be passed to callback as a first argument)
         :returns: A 3-tuple of return code (integer), stdout (native string),
             and stderr (native string).  On python2, stdout and stderr are both
             byte strings.  On python3, stdout and stderr are text strings converted
@@ -2824,6 +2831,8 @@ class AnsibleModule(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
+        if PY3:
+            kwargs["pass_fds"] = pass_fds
 
         # store the pwd
         prev_dir = os.getcwd()
@@ -2846,6 +2855,8 @@ class AnsibleModule(object):
             if self._debug:
                 self.log('Executing: ' + self._clean_args(args))
             cmd = subprocess.Popen(args, **kwargs)
+            if before_communicate_callback:
+                before_communicate_callback(cmd)
 
             # the communication logic here is essentially taken from that
             # of the _communicate() function in ssh.py

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2831,7 +2831,7 @@ class AnsibleModule(object):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
-        if PY3:
+        if PY3 and pass_fds:
             kwargs["pass_fds"] = pass_fds
 
         # store the pwd

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -307,7 +307,7 @@ EXAMPLES = '''
 import os
 import errno
 
-from ansible.module_utils.basic import AnsibleModule, to_bytes, PY3
+from ansible.module_utils.basic import AnsibleModule, to_bytes
 from ansible.module_utils.six.moves import shlex_quote
 
 

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -351,6 +351,7 @@ def main():
             private_key=dict(type='path'),
             rsync_path=dict(type='str'),
             _local_rsync_path=dict(type='path', default='rsync'),
+            _local_rsync_password=dict(default=None, no_log=True),
             _substitute_controller=dict(type='bool', default=False),
             archive=dict(type='bool', default=True),
             checksum=dict(type='bool', default=False),
@@ -390,6 +391,7 @@ def main():
     private_key = module.params['private_key']
     rsync_path = module.params['rsync_path']
     rsync = module.params.get('_local_rsync_path', 'rsync')
+    rsync_password = module.params.get('_local_rsync_password')
     rsync_timeout = module.params.get('rsync_timeout', 'rsync_timeout')
     archive = module.params['archive']
     checksum = module.params['checksum']
@@ -414,6 +416,8 @@ def main():
         rsync = module.get_bin_path(rsync, required=True)
 
     cmd = [rsync, '--delay-updates', '-F']
+    if rsync_password:
+        cmd = ['sshpass', '-p', rsync_password] + cmd
     if compress:
         cmd.append('--compress')
     if rsync_timeout:

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -310,7 +310,6 @@ import errno
 
 from ansible.module_utils.basic import AnsibleModule, to_bytes, PY3
 from ansible.module_utils.six.moves import shlex_quote
-from ansible.errors import AnsibleError
 
 
 client_addr = None
@@ -427,8 +426,8 @@ def main():
             )
             proc.communicate()
         except OSError:
-            raise AnsibleError(
-                "to use rsync connection with passwords, you must install the sshpass program"
+            module.fail_json(
+                msg="to use rsync connection with passwords, you must install the sshpass program"
             )
         _sshpass_pipe = os.pipe()
         cmd = ['sshpass', '-d' + _sshpass_pipe[0]] + cmd

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -538,16 +538,18 @@ def main():
     cmd.append(dest)
     cmdstr = ' '.join(cmd)
 
-    if not (PY3 and rsync_password):
-        proc = subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-    # If we are using password authentication, write the password into the pipe
-    else:
+    # On python3 we need to pass file descriptors explicitly
+    if PY3 and rsync_password:
         # pylint: disable=unexpected-keyword-arg
         proc = subprocess.Popen(
             cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, pass_fds=_sshpass_pipe
         )
+    else:
+        proc = subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+    # If we are using password authentication, write the password into the pipe
+    if rsync_password:
         os.close(_sshpass_pipe[0])
         try:
             os.write(_sshpass_pipe[1], to_bytes(rsync_password) + b'\n')

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -205,6 +205,7 @@ class ActionModule(ActionBase):
 
         # Parameter name needed by the ansible module
         _tmp_args['_local_rsync_path'] = task_vars.get('ansible_rsync_path') or 'rsync'
+        _tmp_args['_local_rsync_password'] = task_vars.get('ansible_ssh_pass') or task_vars.get('ansible_password')
 
         # rsync thinks that one end of the connection is localhost and the
         # other is the host we're running the task for  (Note: We use


### PR DESCRIPTION
##### SUMMARY

> The action plugin detects the inventory data and connection type then juggles the connection to local and sets the remote host args for rsync. If the remote host required a password for auth and the user gave a password via the available methods, we would wrap ssh calls with sshpass. However, we completely ignore that in the action plugin for synchronize where we would probably know that a password is needed based on contexts. We should look into detecting that situation and wrapping rsync with sshpass.
> sshpass somewhere in the the exec arguments and sending the password when the prompt occurs.
> 

Fixes #16616

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize

##### ANSIBLE VERSION
(could be easily backported to older versions if needed)
```
$ ansible --version
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/sbin/ansible
  python version = 2.7.13 (default, Jul 21 2017, 03:24:34) [GCC 7.1.1 20170630]
```

