### PR TITLE
[fix] pylint errors on modules packaging language

### DIFF
--- a/lib/ansible/modules/packaging/language/bower.py
+++ b/lib/ansible/modules/packaging/language/bower.py
@@ -217,12 +217,12 @@ def main():
     changed = False
     if state == 'present':
         installed, missing, outdated = bower.list()
-        if len(missing):
+        if missing:
             changed = True
             bower.install()
     elif state == 'latest':
         installed, missing, outdated = bower.list()
-        if len(missing) or len(outdated):
+        if missing or outdated:
             changed = True
             bower.update()
     else:  # Absent

--- a/lib/ansible/modules/packaging/language/bundler.py
+++ b/lib/ansible/modules/packaging/language/bundler.py
@@ -135,9 +135,10 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def get_bundler_executable(module):
-    result = [module.get_bin_path('bundle', True)]
     if module.params.get('executable'):
         result = module.params.get('executable').split(' ')
+    else:
+        result = [module.get_bin_path('bundle', True)]
     return result
 
 

--- a/lib/ansible/modules/packaging/language/bundler.py
+++ b/lib/ansible/modules/packaging/language/bundler.py
@@ -135,10 +135,10 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def get_bundler_executable(module):
+    result = [module.get_bin_path('bundle', True)]
     if module.params.get('executable'):
-        return module.params.get('executable').split(' ')
-    else:
-        return [ module.get_bin_path('bundle', True) ]
+        result = module.params.get('executable').split(' ')
+    return result
 
 
 def main():

--- a/lib/ansible/modules/packaging/language/cpanm.py
+++ b/lib/ansible/modules/packaging/language/cpanm.py
@@ -171,9 +171,10 @@ def _build_cmd_line(name, from_path, notest, locallib, mirror, mirror_only, inst
 
 
 def _get_cpanm_path(module):
-    result = module.get_bin_path('cpanm', True)
     if module.params['executable']:
         result = module.params['executable']
+    else:
+        result = module.get_bin_path('cpanm', True)
     return result
 
 

--- a/lib/ansible/modules/packaging/language/cpanm.py
+++ b/lib/ansible/modules/packaging/language/cpanm.py
@@ -139,10 +139,7 @@ def _is_package_installed(module, name, locallib, cpanm, version):
     else:
         cmd = "%s;'" % cmd
     res, stdout, stderr = module.run_command(cmd, check_rc=False)
-    if res == 0:
-        return True
-    else:
-        return False
+    return res == 0
 
 def _build_cmd_line(name, from_path, notest, locallib, mirror, mirror_only, installdeps, cpanm, use_sudo):
     # this code should use "%s" like everything else and just return early but not fixing all of it now.
@@ -174,10 +171,10 @@ def _build_cmd_line(name, from_path, notest, locallib, mirror, mirror_only, inst
 
 
 def _get_cpanm_path(module):
+    result = module.get_bin_path('cpanm', True)
     if module.params['executable']:
-        return module.params['executable']
-    else:
-        return module.get_bin_path('cpanm', True)
+        result = module.params['executable']
+    return result
 
 
 def main():

--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -115,10 +115,10 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def get_rubygems_path(module):
+    result = [module.get_bin_path('gem', True)]
     if module.params['executable']:
-        return module.params['executable'].split(' ')
-    else:
-        return [ module.get_bin_path('gem', True) ]
+        result = module.params['executable'].split(' ')
+    return result
 
 def get_rubygems_version(module):
     cmd = get_rubygems_path(module) + [ '--version' ]

--- a/lib/ansible/modules/packaging/language/gem.py
+++ b/lib/ansible/modules/packaging/language/gem.py
@@ -115,9 +115,10 @@ from ansible.module_utils.basic import AnsibleModule
 
 
 def get_rubygems_path(module):
-    result = [module.get_bin_path('gem', True)]
     if module.params['executable']:
         result = module.params['executable'].split(' ')
+    else:
+        result = [module.get_bin_path('gem', True)]
     return result
 
 def get_rubygems_version(module):

--- a/lib/ansible/modules/packaging/language/npm.py
+++ b/lib/ansible/modules/packaging/language/npm.py
@@ -264,16 +264,16 @@ def main():
     changed = False
     if state == 'present':
         installed, missing = npm.list()
-        if len(missing):
+        if missing:
             changed = True
             npm.install()
     elif state == 'latest':
         installed, missing = npm.list()
         outdated = npm.list_outdated()
-        if len(missing):
+        if missing:
             changed = True
             npm.install()
-        if len(outdated):
+        if outdated:
             changed = True
             npm.update()
     else:  # absent

--- a/lib/ansible/modules/packaging/language/pear.py
+++ b/lib/ansible/modules/packaging/language/pear.py
@@ -84,9 +84,10 @@ def get_local_version(pear_output):
     return None
 
 def _get_pear_path(module):
-    result = module.get_bin_path('pear', True, [module.params['executable']])
     if module.params['executable'] and os.path.isfile(module.params['executable']):
         result = module.params['executable']
+    else:
+        result = module.get_bin_path('pear', True, [module.params['executable']])
     return result
 
 def get_repository_version(pear_output):

--- a/lib/ansible/modules/packaging/language/pear.py
+++ b/lib/ansible/modules/packaging/language/pear.py
@@ -84,10 +84,10 @@ def get_local_version(pear_output):
     return None
 
 def _get_pear_path(module):
+    result = module.get_bin_path('pear', True, [module.params['executable']])
     if module.params['executable'] and os.path.isfile(module.params['executable']):
-        return module.params['executable']
-    else:
-        return module.get_bin_path('pear', True, [module.params['executable']])
+        result = module.params['executable']
+    return result
 
 def get_repository_version(pear_output):
     """Take pear remote-info output and get the latest version"""


### PR DESCRIPTION
##### SUMMARY
fix pylint errors  on modules packaging language files

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/packaging/language/*.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (pep8/language 01b2454984) last updated 2017/09/22 14:06:02 (GMT +200)
  config file = None
  configured module search path = ['/home/herve/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/herve/dev/ansible/lib/ansible
  executable location = /home/herve/dev/ansible/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before changes
```
Sanity check using pylint
ERROR: Found 54 pylint issue(s) which need to be resolved:
ERROR: lib/ansible/modules/packaging/language/bower.py:220:11: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/bower.py:225:11: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/bower.py:225:27: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/bundler.py:138:4: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/cpanm.py:142:4: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/cpanm.py:177:4: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/gem.py:118:4: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:192:7: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:222:8: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:228:8: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:241:8: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:296:88: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:297:86: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:345:8: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:347:12: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/maven_artifact.py:386:8: no-else-return Unnecessary "else" after "return"
ERROR: lib/ansible/modules/packaging/language/npm.py:267:11: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/npm.py:273:11: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/npm.py:276:11: len-as-condition Do not use `len(SEQUENCE)` as condition value
ERROR: lib/ansible/modules/packaging/language/pear.py:87:4: no-else-return Unnecessary "else" after "return"
```

```
Sanity check using no-wildcard-import
Sanity check using pep8
Sanity check using pylint
Sanity check using pylint-ansible-test
```
