### PR TITLE
Specify version of pyapi-gitlab in documentation

### DIFF
--- a/lib/ansible/modules/source_control/gitlab_group.py
+++ b/lib/ansible/modules/source_control/gitlab_group.py
@@ -21,7 +21,7 @@ description:
 version_added: "2.1"
 author: "Werner Dijkerman (@dj-wasabi)"
 requirements:
-    - pyapi-gitlab python module
+    - pyapi-gitlab python module (version: 7.5.x)
 options:
     server_url:
         description:

--- a/lib/ansible/modules/source_control/gitlab_project.py
+++ b/lib/ansible/modules/source_control/gitlab_project.py
@@ -22,7 +22,7 @@ description:
 version_added: "2.1"
 author: "Werner Dijkerman (@dj-wasabi)"
 requirements:
-    - pyapi-gitlab python module
+    - pyapi-gitlab python module (version: 7.5.x)
 options:
     server_url:
         description:

--- a/lib/ansible/modules/source_control/gitlab_user.py
+++ b/lib/ansible/modules/source_control/gitlab_user.py
@@ -22,7 +22,7 @@ description:
 version_added: "2.1"
 author: "Werner Dijkerman (@dj-wasabi)"
 requirements:
-    - pyapi-gitlab python module
+    - pyapi-gitlab python module (version: 7.5.x)
     - administrator rights on the Gitlab server
 options:
     server_url:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Module source_control (gitlab_project, gitlab_user and gitlab_group) works only with library pyapi-gitlab version 7.5.x
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
source_control

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.3
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
