### PR TITLE
Added ecs_taskdefinition_facts module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -304,27 +304,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_conn, ec2_argument_spec, get_aws_connection_info
 
 
-class EcsTaskManager:
-    """Handles ECS Tasks"""
-
-    def __init__(self, module):
-        self.module = module
-
-        try:
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            if not region:
-                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
-            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto3.exception.NoAuthHandlerFound as e:
-            self.module.fail_json(msg="Can't authorize connection - %s" % str(e))
-
-    def describe_task_definitions(self, family):
-        # Return the full descriptions of the task definition
-        return camel_dict_to_snake_dict(self.ecs.describe_task_definition(taskDefinition=family)['taskDefinition'])
-
-
 def main():
-
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
         task_definition=dict(required=True, type='str')
@@ -335,8 +315,15 @@ def main():
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')
 
-    task_mgr = EcsTaskManager(module)
-    ecs_td_facts = task_mgr.describe_task_definitions(module.params['task_definition'])
+    try:
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+        ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except botocore.exceptions.ProfileNotFound as e:
+        module.fail_json(msg="AWS profile not found - %s" % str(e))
+
+    ecs_td_facts = camel_dict_to_snake_dict(ecs.describe_task_definition(taskDefinition=module.params['task_definition'])['taskDefinition'])
 
     ecs_td_facts_result = dict(changed=False, ansible_facts=ecs_td_facts)
     module.exit_json(**ecs_td_facts_result)

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -118,11 +118,13 @@ class EcsTaskManager:
     def describe_task_definitions(self, family):
         # Return the full descriptions of the task definition
         return self.ecs.describe_task_definition(taskDefinition=family)['taskDefinition']
+
+
 def main():
 
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        task_definition=dict(required=True, type='str' )
+        task_definition=dict(required=True, type='str')
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -74,12 +74,15 @@ containerDefinitions:
             contains:
                 containerPort:
                     description: The port number on the container.
+                    returned: when present
                     type: int
                 hostPort
                     description: The port number on the container instance to reserve for your container.
+                    returned: when present
                     type: int
                 protocol:
                     description: The protocol used for the port mapping.
+                    returned: when present
                     type: string
         essential:
             description: Whether this is an essential container or not.
@@ -129,7 +132,7 @@ containerDefinitions:
             type: complex
             contains:
                 sourceContainer:
-                description: The name of another container within the same task definition to mount volumes from.
+                    description: The name of another container within the same task definition to mount volumes from.
                     returned: when present
                     type: string
                 readOnly:

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -333,7 +333,7 @@ def main():
     ecs_td_snake = {}
     for k, v in ecs_td.items():
         ecs_td_snake[_camel_to_snake(k)] = v
-    
+
     ecs_td_facts_result = dict(changed=False, ansible_facts=ecs_td_snake)
     module.exit_json(**ecs_td_facts_result)
 

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -46,6 +46,174 @@ containerDefinitions:
     description: Returns a list of complex objects representing the containers
     returned: success
     type: complex
+    contains:
+        name:
+            description: The name of a container.
+            returned: always
+            type: string
+        image:
+            description: The image used to start a container.
+            returned: always
+            type: string
+        cpu:
+            description: The number of cpu units reserved for the container.
+            returned: always
+            type: int
+        memoryReservation:
+            description: The soft limit (in MiB) of memory to reserve for the container.
+            returned: when present
+            type: int
+        links:
+            description: Links to other containers.
+            returned: when present
+            type: string
+        portMappings:
+            description: The list of port mappings for the container.
+            returned: always
+            type: complex
+            contains:
+                containerPort:
+                    description: The port number on the container.
+                    type: int
+                hostPort
+                    description: The port number on the container instance to reserve for your container.
+                    type: int
+                protocol:
+                    description: The protocol used for the port mapping.
+                    type: string
+        essential:
+            description: Whether this is an essential container or not.
+            returned: always
+            type: bool
+        entryPoint:
+            description: The entry point that is passed to the container.
+            returned: when present
+            type: string
+        command:
+            description: The command that is passed to the container.
+            returned: when present
+            type: string
+        environment:
+            description: The environment variables to pass to a container.
+            returned: always
+            type: complex
+            contains:
+                name:
+                    description: The name of the environment variable.
+                    returned: when present
+                    type: string
+                value:
+                    description: The value of the environment variable.
+                    returned: when present
+                    type: string
+        mountPoints:
+            description: The mount points for data volumes in your container.
+            returned: always
+            type: complex
+            contains:
+                sourceVolume:
+                    description: The name of the volume to mount.
+                    returned: when present
+                    type: string
+                containerPath:
+                    description: The path on the container to mount the host volume at.
+                    returned: when present
+                    type: string
+                readOnly:
+                    description: If this value is true , the container has read-only access to the volume. If this value is false , then the container can write to the volume.
+                    returned: when present
+                    type: bool
+        volumesFrom:
+            description: Data volumes to mount from another container.
+            returned: always
+            type: complex
+            contains:
+                sourceContainer:
+                description: The name of another container within the same task definition to mount volumes from.
+                    returned: when present
+                    type: string
+                readOnly:
+                    description: If this value is true , the container has read-only access to the volume. If this value is false , then the container can write to the volume.
+                    returned: when present
+                    type: bool
+        hostname:
+            description: The hostname to use for your container.
+            returned: when present
+            type: string
+        user:
+            description: The user name to use inside the container.
+            returned: when present
+            type: string
+        workingDirectory:
+            description: The working directory in which to run commands inside the container.
+            returned: when present
+            type: string
+        disableNetworking:
+            description: When this parameter is true, networking is disabled within the container.
+            returned: when present
+            type: bool
+        privileged:
+            description: When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user).
+            returned: when present
+            type: bool
+        readonlyRootFilesystem:
+            description: When this parameter is true, the container is given read-only access to its root file system.
+            returned: when present
+            type: bool
+        dnsServers:
+            description: A list of DNS servers that are presented to the container.
+            returned: when present
+            type: string
+        dnsSearchDomains:
+            description: A list of DNS search domains that are presented to the container.
+            returned: when present
+            type: string
+        extraHosts:
+            description: A list of hostnames and IP address mappings to append to the /etc/hosts file on the container.
+            returned: when present
+            type: complex
+            contains:
+                hostname:
+                    description: The hostname to use in the /etc/hosts entry.
+                    returned: when present
+                    type: string
+                ipAddress:
+                    description: The IP address to use in the /etc/hosts entry.
+                    returned: when present
+                    type: string
+        dockerSecurityOptions:
+            description: A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems.
+            returned: when present
+            type: string
+        dockerLabels:
+            description: A key/value map of labels to add to the container.
+            returned: when present
+            type: string
+        ulimits:
+            description: A list of ulimits to set in the container.
+            returned: when present
+            type: complex
+            contains:
+                name:
+                    description: The type of the ulimit .
+                    returned: when present
+                    type: string
+                softLimit:
+                    description: The soft limit for the ulimit type.
+                    returned: when present
+                    type: int
+                hardLimit:
+                    description: The hard limit for the ulimit type.
+                    returned: when present
+                    type: int
+        logConfiguration:
+            description: The log configuration specification for the container.
+            returned: when present
+            type: string
+        options:
+            description: The configuration options to send to the log driver.
+            returned: when present
+            type: string
 family:
     description: The family of your task definition, used as the definition name
     returned: always
@@ -70,6 +238,19 @@ volumes:
     description: The list of volumes in a task
     returned: always
     type: complex
+    contains:
+        name:
+            description: The name of the volume.
+            returned: when present
+            type: string
+        host:
+            description: The contents of the host parameter determine whether your data volume persists on the host container instance and where it is stored.
+            returned: when present
+            type: bool
+        sourcePath:
+            description: The path on the host container instance that is presented to the container.
+            returned: when present
+            type: string
 status:
     description: The status of the task definition
     returned: always
@@ -78,18 +259,37 @@ requiresAttributes:
     description: The container instance attributes required by your task
     returned: when present
     type: complex
+    contains:
+        name:
+            description: The name of the attribute.
+            returned: when present
+            type: string
+        value:
+            description: The value of the attribute.
+            returned: when present
+            type: string
+        targetType:
+            description: The type of the target with which to attach the attribute.
+            returned: when present
+            type: string
+        targetId:
+            description: The ID of the target.
+            returned: when present
+            type: string
 placementConstraints:
     description: A list of placement constraint objects to use for tasks
     returned: always
     type: complex
+    contains:
+        type:
+            description: The type of constraint.
+            returned: when present
+            type: string
+        expression:
+            description: A cluster query language expression to apply to the constraint.
+            returned: when present
+            type: string
 '''  # NOQA
-
-try:
-    import boto
-    import botocore
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
 
 try:
     import boto3

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -1,0 +1,144 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: ecs_taskdefinition_facts
+short_description: describe a task definition in ecs
+notes:
+    - for details of the parameters and returns see U(http://boto3.readthedocs.io/en/latest/reference/services/ecs.html#ECS.Client.describe_task_definition)
+description:
+    - Describes a task definition in ecs.
+version_added: "2.5"
+author:
+    - Gustavo Maia(@gurumaia)
+    - Mark Chance(@Java1Guy)
+    - Darek Kaczynski (@kaczynskid)
+requirements: [ json, boto, botocore, boto3 ]
+options:
+    task_definition:
+        description:
+            - The name of the task definition to get details for
+        required: true
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
+- ecs_taskdefinition_facts:
+    task_definition: test-td
+'''
+
+RETURN = '''
+containerDefinitions:
+    description: Returns a list of complex objects representing the containers
+    returned: success
+    type: complex
+family:
+    description: The family of your task definition, used as the definition name
+    returned: always
+    type: string
+taskDefinitionArn:
+    description: ARN of the task definition
+    returned: always
+    type: string
+taskRoleArn:
+    description: The ARN of the IAM role that containers in this task can assume
+    returned: when role is set
+    type: string
+networkMode:
+    description: Network mode for the containers
+    returned: always
+    type: string
+revision:
+    description: Revision number that was queried
+    returned: always
+    type: int
+volumes:
+    description: The list of volumes in a task
+    returned: always
+    type: complex
+status:
+    description: The status of the task definition
+    returned: always
+    type: string
+requiresAttributes:
+    description: The container instance attributes required by your task
+    returned: when present
+    type: complex
+placementConstraints:
+    description: A list of placement constraint objects to use for tasks
+    returned: always
+    type: complex
+'''  # NOQA
+
+try:
+    import boto
+    import botocore
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+try:
+    import boto3
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+
+
+class EcsTaskManager:
+    """Handles ECS Tasks"""
+
+    def __init__(self, module):
+        self.module = module
+
+        try:
+            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+            if not region:
+                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+        except boto.exception.NoAuthHandlerFound as e:
+            self.module.fail_json(msg="Can't authorize connection - %s" % str(e))
+
+    def describe_task_definitions(self, family):
+        # Return the full descriptions of the task definition
+        return self.ecs.describe_task_definition(taskDefinition=family)['taskDefinition']
+def main():
+
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        task_definition=dict(required=True, type='str' )
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    if not HAS_BOTO:
+        module.fail_json(msg='boto is required.')
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 is required.')
+
+    task_mgr = EcsTaskManager(module)
+    ecs_td_facts = task_mgr.describe_task_definitions(module.params['task_definition'])
+
+    ecs_td_facts_result = dict(changed=False, ansible_facts=ecs_td_facts)
+    module.exit_json(**ecs_td_facts_result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -76,7 +76,7 @@ containerDefinitions:
                     description: The port number on the container.
                     returned: when present
                     type: int
-                hostPort
+                hostPort:
                     description: The port number on the container instance to reserve for your container.
                     returned: when present
                     type: int

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -23,7 +23,7 @@ author:
     - Gustavo Maia(@gurumaia)
     - Mark Chance(@Java1Guy)
     - Darek Kaczynski (@kaczynskid)
-requirements: [ json, boto, botocore, boto3 ]
+requirements: [ json, botocore, boto3 ]
 options:
     task_definition:
         description:
@@ -312,7 +312,7 @@ class EcsTaskManager:
             if not region:
                 module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
             self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto.exception.NoAuthHandlerFound as e:
+        except boto3.exception.NoAuthHandlerFound as e:
             self.module.fail_json(msg="Can't authorize connection - %s" % str(e))
 
     def describe_task_definitions(self, family):
@@ -328,9 +328,6 @@ def main():
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required.')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -303,7 +303,10 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_conn, ec2_argument_spec, get_aws_connection_info
 
-from botocore.exceptions import ProfileNotFound
+try:
+    import botocore
+except ImportError:
+    pass  # will be detected by imported HAS_BOTO3
 
 
 def main():
@@ -322,8 +325,8 @@ def main():
         if not region:
             module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except ProfileNotFound as e:
-        module.fail_json(msg="AWS profile not found - %s" % str(e))
+    except botocore.exceptions.ProfileNotFound as e:
+        module.fail_json(msg=str(e))
 
     ecs_td_facts = camel_dict_to_snake_dict(ecs.describe_task_definition(taskDefinition=module.params['task_definition'])['taskDefinition'])
 

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -333,15 +333,7 @@ def main():
     ecs_td_snake = {}
     for k, v in ecs_td.items():
         ecs_td_snake[_camel_to_snake(k)] = v
-
-    # ecs_td = ecs.describe_task_definition(taskDefinition=module.params['task_definition'])['taskDefinition']
-    # ecs_td_container_definitions = ecs_td['containerDefinitions']
-    # del ecs_td['containerDefinitions']
-    #
-    # ecs_td_facts = camel_dict_to_snake_dict(ecs_td)
-    # ecs_td_facts['container_definitions'] = ecs_td_container_definitions
-
-
+    
     ecs_td_facts_result = dict(changed=False, ansible_facts=ecs_td_snake)
     module.exit_json(**ecs_td_facts_result)
 

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -42,7 +42,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-containerDefinitions:
+container_definitions:
     description: Returns a list of complex objects representing the containers
     returned: success
     type: complex
@@ -59,24 +59,24 @@ containerDefinitions:
             description: The number of cpu units reserved for the container.
             returned: always
             type: int
-        memoryReservation:
-            description: The soft limit (in MiB) of memory to reserve for the container.
+        memory_reservation:
+            description: The soft limit (in Mi_b) of memory to reserve for the container.
             returned: when present
             type: int
         links:
             description: Links to other containers.
             returned: when present
             type: string
-        portMappings:
+        port_mappings:
             description: The list of port mappings for the container.
             returned: always
             type: complex
             contains:
-                containerPort:
+                container_port:
                     description: The port number on the container.
                     returned: when present
                     type: int
-                hostPort:
+                host_port:
                     description: The port number on the container instance to reserve for your container.
                     returned: when present
                     type: int
@@ -88,7 +88,7 @@ containerDefinitions:
             description: Whether this is an essential container or not.
             returned: always
             type: bool
-        entryPoint:
+        entry_point:
             description: The entry point that is passed to the container.
             returned: when present
             type: string
@@ -109,33 +109,33 @@ containerDefinitions:
                     description: The value of the environment variable.
                     returned: when present
                     type: string
-        mountPoints:
+        mount_points:
             description: The mount points for data volumes in your container.
             returned: always
             type: complex
             contains:
-                sourceVolume:
+                source_volume:
                     description: The name of the volume to mount.
                     returned: when present
                     type: string
-                containerPath:
+                container_path:
                     description: The path on the container to mount the host volume at.
                     returned: when present
                     type: string
-                readOnly:
+                read_only:
                     description: If this value is true , the container has read-only access to the volume. If this value is false , then the container can write to the volume.
                     returned: when present
                     type: bool
-        volumesFrom:
+        volumes_from:
             description: Data volumes to mount from another container.
             returned: always
             type: complex
             contains:
-                sourceContainer:
+                source_container:
                     description: The name of another container within the same task definition to mount volumes from.
                     returned: when present
                     type: string
-                readOnly:
+                read_only:
                     description: If this value is true , the container has read-only access to the volume. If this value is false , then the container can write to the volume.
                     returned: when present
                     type: bool
@@ -147,11 +147,11 @@ containerDefinitions:
             description: The user name to use inside the container.
             returned: when present
             type: string
-        workingDirectory:
+        working_directory:
             description: The working directory in which to run commands inside the container.
             returned: when present
             type: string
-        disableNetworking:
+        disable_networking:
             description: When this parameter is true, networking is disabled within the container.
             returned: when present
             type: bool
@@ -159,19 +159,19 @@ containerDefinitions:
             description: When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user).
             returned: when present
             type: bool
-        readonlyRootFilesystem:
+        readonly_root_filesystem:
             description: When this parameter is true, the container is given read-only access to its root file system.
             returned: when present
             type: bool
-        dnsServers:
+        dns_servers:
             description: A list of DNS servers that are presented to the container.
             returned: when present
             type: string
-        dnsSearchDomains:
+        dns_search_domains:
             description: A list of DNS search domains that are presented to the container.
             returned: when present
             type: string
-        extraHosts:
+        extra_hosts:
             description: A list of hostnames and IP address mappings to append to the /etc/hosts file on the container.
             returned: when present
             type: complex
@@ -180,15 +180,15 @@ containerDefinitions:
                     description: The hostname to use in the /etc/hosts entry.
                     returned: when present
                     type: string
-                ipAddress:
+                ip_address:
                     description: The IP address to use in the /etc/hosts entry.
                     returned: when present
                     type: string
-        dockerSecurityOptions:
-            description: A list of strings to provide custom labels for SELinux and AppArmor multi-level security systems.
+        docker_security_options:
+            description: A list of strings to provide custom labels for SELinux and App_armor multi-level security systems.
             returned: when present
             type: string
-        dockerLabels:
+        docker_labels:
             description: A key/value map of labels to add to the container.
             returned: when present
             type: string
@@ -201,15 +201,15 @@ containerDefinitions:
                     description: The type of the ulimit .
                     returned: when present
                     type: string
-                softLimit:
+                soft_limit:
                     description: The soft limit for the ulimit type.
                     returned: when present
                     type: int
-                hardLimit:
+                hard_limit:
                     description: The hard limit for the ulimit type.
                     returned: when present
                     type: int
-        logConfiguration:
+        log_configuration:
             description: The log configuration specification for the container.
             returned: when present
             type: string
@@ -221,15 +221,15 @@ family:
     description: The family of your task definition, used as the definition name
     returned: always
     type: string
-taskDefinitionArn:
+task_definition_arn:
     description: ARN of the task definition
     returned: always
     type: string
-taskRoleArn:
+task_role_arn:
     description: The ARN of the IAM role that containers in this task can assume
     returned: when role is set
     type: string
-networkMode:
+network_mode:
     description: Network mode for the containers
     returned: always
     type: string
@@ -250,7 +250,7 @@ volumes:
             description: The contents of the host parameter determine whether your data volume persists on the host container instance and where it is stored.
             returned: when present
             type: bool
-        sourcePath:
+        source_path:
             description: The path on the host container instance that is presented to the container.
             returned: when present
             type: string
@@ -258,7 +258,7 @@ status:
     description: The status of the task definition
     returned: always
     type: string
-requiresAttributes:
+requires_attributes:
     description: The container instance attributes required by your task
     returned: when present
     type: complex
@@ -271,15 +271,15 @@ requiresAttributes:
             description: The value of the attribute.
             returned: when present
             type: string
-        targetType:
+        target_type:
             description: The type of the target with which to attach the attribute.
             returned: when present
             type: string
-        targetId:
+        target_id:
             description: The ID of the target.
             returned: when present
             type: string
-placementConstraints:
+placement_constraints:
     description: A list of placement constraint objects to use for tasks
     returned: always
     type: complex
@@ -301,7 +301,7 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_conn, ec2_argument_spec, get_aws_connection_info
 
 
 class EcsTaskManager:
@@ -320,7 +320,7 @@ class EcsTaskManager:
 
     def describe_task_definitions(self, family):
         # Return the full descriptions of the task definition
-        return self.ecs.describe_task_definition(taskDefinition=family)['taskDefinition']
+        return camel_dict_to_snake_dict(self.ecs.describe_task_definition(taskDefinition=family)['taskDefinition'])
 
 
 def main():

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -303,6 +303,8 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_conn, ec2_argument_spec, get_aws_connection_info
 
+from botocore.exceptions import ProfileNotFound
+
 
 def main():
     argument_spec = ec2_argument_spec()
@@ -320,7 +322,7 @@ def main():
         if not region:
             module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except botocore.exceptions.ProfileNotFound as e:
+    except ProfileNotFound as e:
         module.fail_json(msg="AWS profile not found - %s" % str(e))
 
     ecs_td_facts = camel_dict_to_snake_dict(ecs.describe_task_definition(taskDefinition=module.params['task_definition'])['taskDefinition'])


### PR DESCRIPTION
##### SUMMARY
Added a module called ecs_taskdefinition_facts that fetches facts about an AWS ECS Task Definition.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
ecs_taskdefinition_facts

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 2b09268473) last updated 2017/09/22 09:58:45 (GMT -200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/gustavo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gustavo/Documents/foss/fork/ansible/lib/ansible
  executable location = /home/gustavo/Documents/foss/fork/ansible/bin/ansible
  python version = 3.5.2 (default, Aug 18 2017, 17:48:00) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
I've referenced both @Java1Guy and @kaczynskid as authors because I basically copied their ecs_service_facts module and adapted for task definitions, so there's a bunch of their code in here.