### PR TITLE
nmcli fix for not specified `dns4` option

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -556,7 +556,7 @@ class Nmcli(object):
         self.type = module.params['type']
         self.ip4 = module.params['ip4']
         self.gw4 = module.params['gw4']
-        self.dns4 = ' '.join(module.params['dns4'])
+        self.dns4 = ' '.join(module.params['dns4']) if module.params.get('dns4') else None
         self.ip6 = module.params['ip6']
         self.gw6 = module.params['gw6']
         self.dns6 = module.params['dns6']

--- a/test/units/modules/net_tools/test_nmcli.py
+++ b/test/units/modules/net_tools/test_nmcli.py
@@ -1,0 +1,44 @@
+# Copyright: (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+import json
+
+from ansible.modules.net_tools import nmcli
+
+pytestmark = pytest.mark.usefixtures('patch_ansible_module')
+
+TESTCASE = [
+    {
+        'type': 'ethernet',
+        'conn_name': 'non_existent_nw_device',
+        'state': 'absent',
+        '_ansible_check_mode': True,
+    }
+]
+
+
+@pytest.fixture
+def mocked_connection_exists(mocker):
+    mocker.patch('ansible.modules.net_tools.nmcli.HAVE_DBUS', True)
+    mocker.patch('ansible.modules.net_tools.nmcli.HAVE_NM_CLIENT', True)
+
+    get_bin_path = mocker.patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    get_bin_path.return_value = '/usr/bin/nmcli'
+
+    connection = mocker.patch.object(nmcli.Nmcli, 'connection_exists')
+    connection.return_value = True
+    return connection
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE, indirect=['patch_ansible_module'])
+def test_dns4_none(mocked_connection_exists, capfd):
+    """
+    Test if DNS4 param is None
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert results['changed']


### PR DESCRIPTION
##### SUMMARY
Fixes cases when settings for nmcli need to be specified without actually specifying `dns4` servers option.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION

Previously this code hadn't worked
```
- name: Do not use DNS Resolver from DHCP
  nmcli:
    conn_name: "System eth0"
    ignore_auto_dns: yes
    state: present
    type: ethernet
```

Due to the TypeError conversion of module.params['dns4'] None value 

```
File \"/tmp/ansible_3yuCcC/ansible_module_nmcli.py\", line 565, in __init__\n    self.dns4=' '.join(module.params['dns4'])\nTypeError\n
```

