### PR TITLE
module_utils/basic: attributes may be an empty string - fixes #30613

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1251,7 +1251,7 @@ class AnsibleModule(object):
 
     def set_attributes_if_different(self, path, attributes, changed, diff=None, expand=True):
 
-        if not attributes:
+        if attributes is None:
             return changed
 
         b_path = to_bytes(path, errors='surrogate_or_strict')
@@ -2396,7 +2396,7 @@ class AnsibleModule(object):
         # Set the attributes
         current_attribs = self.get_file_attributes(src)
         current_attribs = current_attribs.get('attr_flags', [])
-        current_attribs = ''.join(current_attribs)
+        current_attribs = ''.join(current_attribs) or None
         self.set_attributes_if_different(dest, current_attribs, True)
 
     def atomic_move(self, src, dest, unsafe_writes=False):

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1251,7 +1251,7 @@ class AnsibleModule(object):
 
     def set_attributes_if_different(self, path, attributes, changed, diff=None, expand=True):
 
-        if attributes is None:
+        if not attributes:
             return changed
 
         b_path = to_bytes(path, errors='surrogate_or_strict')


### PR DESCRIPTION
##### SUMMARY
Attributes is an empty string rather than None so the check to return early doesn't work. Fixes #30613.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
```
2.5.0
```
