### PR TITLE
Fixes #30769 - nxos_vtp_version errors out on N1 images.

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vtp_domain.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_domain.py
@@ -149,10 +149,13 @@ def get_vtp_config(module):
 def get_vtp_password(module):
     command = 'show vtp password'
     body = execute_show_command(command, module)[0]
-    password = body['passwd']
-    if password:
-        return str(password)
-    else:
+    try:
+        password = body['passwd']
+        if password:
+            return str(password)
+        else:
+            return ""
+    except TypeError:
         return ""
 
 

--- a/lib/ansible/modules/network/nxos/nxos_vtp_password.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_password.py
@@ -180,10 +180,13 @@ def get_vtp_config(module):
 def get_vtp_password(module):
     command = 'show vtp password'
     body = execute_show_command(command, module)[0]
-    password = body['passwd']
-    if password:
-        return str(password)
-    else:
+    try:
+        password = body['passwd']
+        if password:
+            return str(password)
+        else:
+            return ""
+    except TypeError:
         return ""
 
 

--- a/lib/ansible/modules/network/nxos/nxos_vtp_version.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_version.py
@@ -147,10 +147,13 @@ def get_vtp_config(module):
 def get_vtp_password(module):
     command = 'show vtp password'
     body = execute_show_command(command, module)[0]
-    password = body['passwd']
-    if password:
-        return str(password)
-    else:
+    try:
+        password = body['passwd']
+        if password:
+            return str(password)
+        else:
+            return ""
+    except TypeError:
         return ""
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30769. Handle case where vtp password is not configured on N1 images and returns a string.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_vtp_version

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0 (detached HEAD d14467b029) last updated 2017/09/21 15:17:44 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```