### PR TITLE
Fact collector ordering

### DIFF
--- a/lib/ansible/module_utils/facts/collector.py
+++ b/lib/ansible/module_utils/facts/collector.py
@@ -18,6 +18,7 @@ __metaclass__ = type
 
 from collections import defaultdict
 
+import pprint
 import platform
 
 from ansible.module_utils.facts import timeout
@@ -160,6 +161,7 @@ def get_collector_names(valid_subsets=None,
 
     additional_subsets.difference_update(exclude_subsets - explicitly_added)
 
+    # pprint.pprint(('additiona_subsets', additional_subsets))
     return additional_subsets
 
 
@@ -201,6 +203,25 @@ def build_fact_id_to_collector_map(collectors_for_platform):
             aliases_map[primary_name].add(fact_id)
 
     return fact_id_to_collector_map, aliases_map
+
+
+def select_collector_classes(collector_names, all_fact_subsets):
+    # TODO: can be a set()
+    seen_collector_classes = []
+
+    selected_collector_classes = []
+
+    for collector_name in collector_names:
+        collector_classes = all_fact_subsets.get(collector_name, [])
+
+        # TODO? log/warn if we dont find an implementation of a fact_id?
+
+        for collector_class in collector_classes:
+            if collector_class not in seen_collector_classes:
+                selected_collector_classes.append(collector_class)
+                seen_collector_classes.append(collector_class)
+
+    return selected_collector_classes
 
 
 def collector_classes_from_gather_subset(all_collector_classes=None,
@@ -248,19 +269,8 @@ def collector_classes_from_gather_subset(all_collector_classes=None,
                                           aliases_map=aliases_map,
                                           platform_info=platform_info)
 
-    # TODO: can be a set()
-    seen_collector_classes = []
-
-    selected_collector_classes = []
-
-    for collector_name in collector_names:
-        collector_classes = all_fact_subsets.get(collector_name, [])
-
-        # TODO? log/warn if we dont find an implementation of a fact_id?
-
-        for collector_class in collector_classes:
-            if collector_class not in seen_collector_classes:
-                selected_collector_classes.append(collector_class)
-                seen_collector_classes.append(collector_class)
+    # pprint.pprint(('collector_names', collector_names))
+    # pprint.pprint(('all_fact_subsets', dict(all_fact_subsets)))
+    selected_collector_classes = select_collector_classes(collector_names, all_fact_subsets)
 
     return selected_collector_classes

--- a/lib/ansible/module_utils/facts/collector.py
+++ b/lib/ansible/module_utils/facts/collector.py
@@ -160,7 +160,6 @@ def get_collector_names(valid_subsets=None,
 
     additional_subsets.difference_update(exclude_subsets - explicitly_added)
 
-    # pprint.pprint(('additiona_subsets', additional_subsets))
     return additional_subsets
 
 

--- a/lib/ansible/module_utils/facts/collector.py
+++ b/lib/ansible/module_utils/facts/collector.py
@@ -18,7 +18,6 @@ __metaclass__ = type
 
 from collections import defaultdict
 
-import pprint
 import platform
 
 from ansible.module_utils.facts import timeout
@@ -211,7 +210,6 @@ def select_collector_classes(collector_names, all_fact_subsets, all_collector_cl
 
     selected_collector_classes = []
 
-    # pprint.pprint(('all_collector_classes', all_collector_classes))
     for candidate_collector_class in all_collector_classes:
         candidate_collector_name = candidate_collector_class.name
 
@@ -225,7 +223,6 @@ def select_collector_classes(collector_names, all_fact_subsets, all_collector_cl
                 selected_collector_classes.append(collector_class)
                 seen_collector_classes.append(collector_class)
 
-    pprint.pprint(('selected_collector_classes', selected_collector_classes))
     return selected_collector_classes
 
 
@@ -274,8 +271,6 @@ def collector_classes_from_gather_subset(all_collector_classes=None,
                                           aliases_map=aliases_map,
                                           platform_info=platform_info)
 
-    # pprint.pprint(('collector_names', collector_names))
-    # pprint.pprint(('all_fact_subsets', dict(all_fact_subsets)))
     selected_collector_classes = select_collector_classes(collector_names,
                                                           all_fact_subsets,
                                                           all_collector_classes)

--- a/lib/ansible/module_utils/facts/collector.py
+++ b/lib/ansible/module_utils/facts/collector.py
@@ -205,22 +205,27 @@ def build_fact_id_to_collector_map(collectors_for_platform):
     return fact_id_to_collector_map, aliases_map
 
 
-def select_collector_classes(collector_names, all_fact_subsets):
+def select_collector_classes(collector_names, all_fact_subsets, all_collector_classes):
     # TODO: can be a set()
     seen_collector_classes = []
 
     selected_collector_classes = []
 
-    for collector_name in collector_names:
-        collector_classes = all_fact_subsets.get(collector_name, [])
+    # pprint.pprint(('all_collector_classes', all_collector_classes))
+    for candidate_collector_class in all_collector_classes:
+        candidate_collector_name = candidate_collector_class.name
 
-        # TODO? log/warn if we dont find an implementation of a fact_id?
+        if candidate_collector_name not in collector_names:
+            continue
+
+        collector_classes = all_fact_subsets.get(candidate_collector_name, [])
 
         for collector_class in collector_classes:
             if collector_class not in seen_collector_classes:
                 selected_collector_classes.append(collector_class)
                 seen_collector_classes.append(collector_class)
 
+    pprint.pprint(('selected_collector_classes', selected_collector_classes))
     return selected_collector_classes
 
 
@@ -271,6 +276,8 @@ def collector_classes_from_gather_subset(all_collector_classes=None,
 
     # pprint.pprint(('collector_names', collector_names))
     # pprint.pprint(('all_fact_subsets', dict(all_fact_subsets)))
-    selected_collector_classes = select_collector_classes(collector_names, all_fact_subsets)
+    selected_collector_classes = select_collector_classes(collector_names,
+                                                          all_fact_subsets,
+                                                          all_collector_classes)
 
     return selected_collector_classes

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -74,77 +74,82 @@ from ansible.module_utils.facts.virtual.netbsd import NetBSDVirtualCollector
 from ansible.module_utils.facts.virtual.openbsd import OpenBSDVirtualCollector
 from ansible.module_utils.facts.virtual.sunos import SunOSVirtualCollector
 
+# these should always be first due to most other facts depending on them
 _base = [
-              # these should always be first due to most other facts depending on them
-              PlatformFactCollector,
-              DistributionFactCollector,
-              LSBFactCollector]
+    PlatformFactCollector,
+    DistributionFactCollector,
+    LSBFactCollector
+]
 
+# These restrict what is possible in others
 _restrictive = [
-              # These restrict what is possible in others
-              SelinuxFactCollector,
-              ApparmorFactCollector,
-              ChrootFactCollector,
-              FipsFactCollector]
+    SelinuxFactCollector,
+    ApparmorFactCollector,
+    ChrootFactCollector,
+    FipsFactCollector
+]
 
+# general info, not required but probably useful for other facts
 _general = [
-              # general info, not required but probably useful for other facts
-              PythonFactCollector,
-              SystemCapabilitiesFactCollector,
-              PkgMgrFactCollector,
-              OpenBSDPkgMgrFactCollector,
-              ServiceMgrFactCollector,
-              CmdLineFactCollector,
-              DateTimeFactCollector,
-              EnvFactCollector,
-              SshPubKeyFactCollector,
-              UserFactCollector]
+    PythonFactCollector,
+    SystemCapabilitiesFactCollector,
+    PkgMgrFactCollector,
+    OpenBSDPkgMgrFactCollector,
+    ServiceMgrFactCollector,
+    CmdLineFactCollector,
+    DateTimeFactCollector,
+    EnvFactCollector,
+    SshPubKeyFactCollector,
+    UserFactCollector
+]
 
+# virtual, this might also limit hardware/networking
 _virtual = [
-              # virtual, this might also limit hardware/networking
-              VirtualCollector,
-              DragonFlyVirtualCollector,
-              FreeBSDVirtualCollector,
-              LinuxVirtualCollector,
-              OpenBSDVirtualCollector,
-              NetBSDVirtualCollector,
-              SunOSVirtualCollector,
-              HPUXVirtualCollector]
+    VirtualCollector,
+    DragonFlyVirtualCollector,
+    FreeBSDVirtualCollector,
+    LinuxVirtualCollector,
+    OpenBSDVirtualCollector,
+    NetBSDVirtualCollector,
+    SunOSVirtualCollector,
+    HPUXVirtualCollector
+]
 
 _hardware = [
-              # hardware
-              HardwareCollector,
-              AIXHardwareCollector,
-              DarwinHardwareCollector,
-              DragonFlyHardwareCollector,
-              FreeBSDHardwareCollector,
-              HPUXHardwareCollector,
-              HurdHardwareCollector,
-              LinuxHardwareCollector,
-              NetBSDHardwareCollector,
-              OpenBSDHardwareCollector,
-              SunOSHardwareCollector]
+    HardwareCollector,
+    AIXHardwareCollector,
+    DarwinHardwareCollector,
+    DragonFlyHardwareCollector,
+    FreeBSDHardwareCollector,
+    HPUXHardwareCollector,
+    HurdHardwareCollector,
+    LinuxHardwareCollector,
+    NetBSDHardwareCollector,
+    OpenBSDHardwareCollector,
+    SunOSHardwareCollector
+]
 
 _network = [
-              # networking
-              DnsFactCollector,
-              NetworkCollector,
-              AIXNetworkCollector,
-              DarwinNetworkCollector,
-              DragonFlyNetworkCollector,
-              FreeBSDNetworkCollector,
-              HPUXNetworkCollector,
-              HurdNetworkCollector,
-              LinuxNetworkCollector,
-              NetBSDNetworkCollector,
-              OpenBSDNetworkCollector,
-              SunOSNetworkCollector]
+    DnsFactCollector,
+    NetworkCollector,
+    AIXNetworkCollector,
+    DarwinNetworkCollector,
+    DragonFlyNetworkCollector,
+    FreeBSDNetworkCollector,
+    HPUXNetworkCollector,
+    HurdNetworkCollector,
+    LinuxNetworkCollector,
+    NetBSDNetworkCollector,
+    OpenBSDNetworkCollector,
+    SunOSNetworkCollector
+]
 
+# other fact sources
 _extra_facts = [
-              # other fact sources
-              LocalFactCollector,
-              FacterFactCollector,
-              OhaiFactCollector]
+    LocalFactCollector,
+    FacterFactCollector,
+    OhaiFactCollector
+]
 
 # TODO: make config driven
 collectors = _base + _restrictive + _general + _virtual + _hardware + _network + _extra_facts

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -78,14 +78,14 @@ _base = [
               # these should always be first due to most other facts depending on them
               PlatformFactCollector,
               DistributionFactCollector,
-              LSBFactCollector,]
+              LSBFactCollector]
 
 _restrictive = [
               # These restrict what is possible in others
               SelinuxFactCollector,
               ApparmorFactCollector,
               ChrootFactCollector,
-              FipsFactCollector,]
+              FipsFactCollector]
 
 _general = [
               # general info, not required but probably useful for other facts
@@ -98,7 +98,7 @@ _general = [
               DateTimeFactCollector,
               EnvFactCollector,
               SshPubKeyFactCollector,
-              UserFactCollector,]
+              UserFactCollector]
 
 _virtual = [
               # virtual, this might also limit hardware/networking
@@ -109,7 +109,7 @@ _virtual = [
               OpenBSDVirtualCollector,
               NetBSDVirtualCollector,
               SunOSVirtualCollector,
-              HPUXVirtualCollector,]
+              HPUXVirtualCollector]
 
 _hardware = [
               # hardware
@@ -123,7 +123,7 @@ _hardware = [
               LinuxHardwareCollector,
               NetBSDHardwareCollector,
               OpenBSDHardwareCollector,
-              SunOSHardwareCollector,]
+              SunOSHardwareCollector]
 
 _network = [
               # networking
@@ -138,7 +138,7 @@ _network = [
               LinuxNetworkCollector,
               NetBSDNetworkCollector,
               OpenBSDNetworkCollector,
-              SunOSNetworkCollector,]
+              SunOSNetworkCollector]
 
 _extra_facts = [
               # other fact sources

--- a/lib/ansible/module_utils/facts/default_collectors.py
+++ b/lib/ansible/module_utils/facts/default_collectors.py
@@ -74,16 +74,45 @@ from ansible.module_utils.facts.virtual.netbsd import NetBSDVirtualCollector
 from ansible.module_utils.facts.virtual.openbsd import OpenBSDVirtualCollector
 from ansible.module_utils.facts.virtual.sunos import SunOSVirtualCollector
 
-# TODO: make config driven
-collectors = [ApparmorFactCollector,
+_base = [
+              # these should always be first due to most other facts depending on them
+              PlatformFactCollector,
+              DistributionFactCollector,
+              LSBFactCollector,]
+
+_restrictive = [
+              # These restrict what is possible in others
+              SelinuxFactCollector,
+              ApparmorFactCollector,
               ChrootFactCollector,
+              FipsFactCollector,]
+
+_general = [
+              # general info, not required but probably useful for other facts
+              PythonFactCollector,
+              SystemCapabilitiesFactCollector,
+              PkgMgrFactCollector,
+              OpenBSDPkgMgrFactCollector,
+              ServiceMgrFactCollector,
               CmdLineFactCollector,
               DateTimeFactCollector,
-              DistributionFactCollector,
-              DnsFactCollector,
               EnvFactCollector,
-              FipsFactCollector,
+              SshPubKeyFactCollector,
+              UserFactCollector,]
 
+_virtual = [
+              # virtual, this might also limit hardware/networking
+              VirtualCollector,
+              DragonFlyVirtualCollector,
+              FreeBSDVirtualCollector,
+              LinuxVirtualCollector,
+              OpenBSDVirtualCollector,
+              NetBSDVirtualCollector,
+              SunOSVirtualCollector,
+              HPUXVirtualCollector,]
+
+_hardware = [
+              # hardware
               HardwareCollector,
               AIXHardwareCollector,
               DarwinHardwareCollector,
@@ -94,10 +123,11 @@ collectors = [ApparmorFactCollector,
               LinuxHardwareCollector,
               NetBSDHardwareCollector,
               OpenBSDHardwareCollector,
-              SunOSHardwareCollector,
-              LocalFactCollector,
-              LSBFactCollector,
+              SunOSHardwareCollector,]
 
+_network = [
+              # networking
+              DnsFactCollector,
               NetworkCollector,
               AIXNetworkCollector,
               DarwinNetworkCollector,
@@ -108,26 +138,13 @@ collectors = [ApparmorFactCollector,
               LinuxNetworkCollector,
               NetBSDNetworkCollector,
               OpenBSDNetworkCollector,
-              SunOSNetworkCollector,
+              SunOSNetworkCollector,]
 
-              PkgMgrFactCollector,
-              OpenBSDPkgMgrFactCollector,
-              PlatformFactCollector,
-              PythonFactCollector,
-              SelinuxFactCollector,
-              ServiceMgrFactCollector,
-              SshPubKeyFactCollector,
-              SystemCapabilitiesFactCollector,
-              UserFactCollector,
-
-              VirtualCollector,
-              DragonFlyVirtualCollector,
-              FreeBSDVirtualCollector,
-              LinuxVirtualCollector,
-              OpenBSDVirtualCollector,
-              NetBSDVirtualCollector,
-              SunOSVirtualCollector,
-              HPUXVirtualCollector,
-
+_extra_facts = [
+              # other fact sources
+              LocalFactCollector,
               FacterFactCollector,
               OhaiFactCollector]
+
+# TODO: make config driven
+collectors = _base + _restrictive + _general + _virtual + _hardware + _network + _extra_facts

--- a/test/integration/inventory
+++ b/test/integration/inventory
@@ -5,7 +5,7 @@ testhost2 ansible_ssh_host=127.0.0.1 ansible_connection=local
 testhost3 ansible_ssh_host=127.0.0.3
 testhost4 ansible_ssh_host=127.0.0.4
 # For testing fact gathering
-facthost[0:20] ansible_host=127.0.0.1 ansible_connection=local
+facthost[0:25] ansible_host=127.0.0.1 ansible_connection=local
 
 [binary_modules]
 testhost_binary_modules ansible_host=127.0.0.1 ansible_connection=local

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -2,4 +2,6 @@
 
 set -eux
 
+# ANSIBLE_CACHE_PLUGINS=cache_plugins/ ANSIBLE_CACHE_PLUGIN=none ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
 ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
+#ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/gathering_facts/runme.sh
+++ b/test/integration/targets/gathering_facts/runme.sh
@@ -2,6 +2,4 @@
 
 set -eux
 
-# ANSIBLE_CACHE_PLUGINS=cache_plugins/ ANSIBLE_CACHE_PLUGIN=none ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
 ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"
-#ANSIBLE_CACHE_PLUGIN=base ansible-playbook test_gathering_facts.yml -i ../../inventory -v "$@"

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -40,11 +40,14 @@
   gather_subset: "hardware"
   gather_facts: yes
   tasks:
+    - name: debug stuff
+      debug:
+        var: hostvars['facthost22']
     # we should also collect platform, but not distribution
     - name: Test that retrieving hardware facts works and gets prereqs from platform and distribution
+      when: ansible_system|default("UNDEF") == "Linux"
       assert:
         # LinuxHardwareCollector requires 'platform' facts
-        when: ansible_system|default("UNDEF") == "Linux"
         that:
           - 'ansible_memory_mb|default("UNDEF") != "UNDEF"'
           - 'ansible_default_ipv4|default("UNDEF") == "UNDEF"'

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -44,8 +44,7 @@
     - name: Test that retrieving hardware facts works and gets prereqs from platform and distribution
       assert:
         # LinuxHardwareCollector requires 'platform' facts
-        when:
-          - 'ansible_system|default("UNDEF") == "Linux"'
+        when: ansible_system|default("UNDEF") == "Linux"
         that:
           - 'ansible_memory_mb|default("UNDEF") != "UNDEF"'
           - 'ansible_default_ipv4|default("UNDEF") == "UNDEF"'

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -9,8 +9,91 @@
       setup:
        gather_subset:
            - "!hardware"
-      register: not_hardware_facts
+             # register: not_hardware_facts
 
+- name: min and network test for platform added
+  hosts: facthost21
+  tags: [ 'fact_network' ]
+  connection: local
+  gather_subset: "!all,network"
+  gather_facts: yes
+  tasks:
+    - name: debug min+network platform
+      debug:
+        var: hostvars['facthost21']
+    - name: Test that retrieving network facts works and gets prereqs from platform and distribution
+      assert:
+        that:
+          - 'ansible_default_ipv4|default("UNDEF") != "UNDEF"'
+          - 'ansible_interfaces|default("UNDEF") != "UNDEF"'
+            # these are true for linux, but maybe not for other os
+          - 'ansible_system|default("UNDEF") != "UNDEF"'
+          - 'ansible_distribution|default("UNDEF") != "UNDEF"'
+            # we dont really require these but they are in the min set
+            # - 'ansible_virtualization_role|default("UNDEF") == "UNDEF"'
+            # - 'ansible_user_id|default("UNDEF") == "UNDEF"'
+            # - 'ansible_env|default("UNDEF") == "UNDEF"'
+            # - 'ansible_selinux|default("UNDEF") == "UNDEF"'
+            # - 'ansible_pkg_mgr|default("UNDEF") == "UNDEF"'
+
+- name: min and hardware test for platform added
+  hosts: facthost22
+  tags: [ 'fact_hardware' ]
+  connection: local
+  gather_subset: "hardware"
+  gather_facts: yes
+  tasks:
+    - name: debug min+hardware platform
+      debug:
+        var: hostvars['facthost22']
+    # we should also collect platform, but not distribution
+    - name: Test that retrieving hardware facts works and gets prereqs from platform and distribution
+      assert:
+        # LinuxHardwareCollector requires 'platform' facts
+        when:
+          - 'ansible_system|default("UNDEF") == "Linux"'
+        that:
+          - 'ansible_memory_mb|default("UNDEF") != "UNDEF"'
+          - 'ansible_default_ipv4|default("UNDEF") == "UNDEF"'
+          - 'ansible_interfaces|default("UNDEF") == "UNDEF"'
+            # these are true for linux, but maybe not for other os
+            # hardware requires 'platform'
+          - 'ansible_system|default("UNDEF") != "UNDEF"'
+          - 'ansible_machine|default("UNDEF") != "UNDEF"'
+            # hardware does not require 'distribution' but it is min set
+            # - 'ansible_distribution|default("UNDEF") == "UNDEF"'
+            # we dont really require these but they are in the min set
+            # - 'ansible_virtualization_role|default("UNDEF") == "UNDEF"'
+            # - 'ansible_user_id|default("UNDEF") == "UNDEF"'
+            # - 'ansible_env|default("UNDEF") == "UNDEF"'
+            # - 'ansible_selinux|default("UNDEF") == "UNDEF"'
+            # - 'ansible_pkg_mgr|default("UNDEF") == "UNDEF"'
+
+- name: min and service_mgr test for platform added
+  hosts: facthost23
+  tags: [ 'fact_service_mgr' ]
+  connection: local
+  gather_subset: "!all,service_mgr"
+  gather_facts: yes
+  tasks:
+    - name: debug min+service_mgr platform
+      debug:
+        var: hostvars['facthost23']
+    - name: Test that retrieving service_mgr facts works and gets prereqs from platform and distribution
+      assert:
+        that:
+          - 'ansible_service_mgr|default("UNDEF") != "UNDEF"'
+          - 'ansible_default_ipv4|default("UNDEF") == "UNDEF"'
+          - 'ansible_interfaces|default("UNDEF") == "UNDEF"'
+            # these are true for linux, but maybe not for other os
+          - 'ansible_system|default("UNDEF") != "UNDEF"'
+          - 'ansible_distribution|default("UNDEF") != "UNDEF"'
+            # we dont really require these but they are in the min set
+            # - 'ansible_virtualization_role|default("UNDEF") == "UNDEF"'
+            # - 'ansible_user_id|default("UNDEF") == "UNDEF"'
+            # - 'ansible_env|default("UNDEF") == "UNDEF"'
+            # - 'ansible_selinux|default("UNDEF") == "UNDEF"'
+            # - 'ansible_pkg_mgr|default("UNDEF") == "UNDEF"'
 
 - hosts: facthost0
   tags: [ 'fact_min' ]
@@ -18,8 +101,8 @@
   gather_subset: "all"
   gather_facts: yes
   tasks:
-    - setup:
-      register: facts
+    #- setup:
+    #  register: facts
     - name: Test that retrieving all facts works
       assert:
         that:
@@ -36,7 +119,7 @@
   tasks:
     - setup:
         filter: "*env*"
-      register: facts_results
+        # register: fact_results
 
     - name: Test that retrieving all facts filtered to env works
       assert:
@@ -53,7 +136,7 @@
   tasks:
     - setup:
         filter: "ansible_user_id"
-      register: facts_results
+        # register: fact_results
 
     - name: Test that retrieving all facts filtered to specific fact ansible_user_id works
       assert:
@@ -72,7 +155,7 @@
   tasks:
     - setup:
         filter: "*"
-      register: facts
+        # register: fact_results
 
     - name: Test that retrieving all facts filtered to splat
       assert:
@@ -89,7 +172,7 @@
   tasks:
     - setup:
         filter: ""
-      register: facts
+        # register: fact_results
 
     - name: Test that retrieving all facts filtered to empty filter_spec works
       assert:
@@ -119,16 +202,19 @@
 - hosts: facthost2
   tags: [ 'fact_network' ]
   connection: local
-  gather_subset: "network"
+  gather_subset: "!all,!min,network"
   gather_facts: yes
   tasks:
+    - name: debug facthost2 part deux
+      debug:
+        var: hostvars['facthost2']
     - name: Test that retrieving network facts work
       assert:
         that:
-          - 'ansible_user_id|default("UNDEF_MIN") != "UNDEF_MIN"'
+          - 'ansible_user_id|default("UNDEF") == "UNDEF"'
           - 'ansible_interfaces|default("UNDEF_NET") != "UNDEF_NET"'
-          - 'ansible_mounts|default("UNDEF_MOUNT") == "UNDEF_MOUNT"'
-          - 'ansible_virtualization_role|default("UNDEF_VIRT") == "UNDEF_VIRT"'
+          - 'ansible_mounts|default("UNDEF") == "UNDEF"'
+          - 'ansible_virtualization_role|default("UNDEF") == "UNDEF"'
 
 - hosts: facthost3
   tags: [ 'fact_hardware' ]

--- a/test/integration/targets/gathering_facts/test_gathering_facts.yml
+++ b/test/integration/targets/gathering_facts/test_gathering_facts.yml
@@ -9,7 +9,7 @@
       setup:
        gather_subset:
            - "!hardware"
-             # register: not_hardware_facts
+      register: not_hardware_facts
 
 - name: min and network test for platform added
   hosts: facthost21
@@ -18,9 +18,6 @@
   gather_subset: "!all,network"
   gather_facts: yes
   tasks:
-    - name: debug min+network platform
-      debug:
-        var: hostvars['facthost21']
     - name: Test that retrieving network facts works and gets prereqs from platform and distribution
       assert:
         that:
@@ -43,9 +40,6 @@
   gather_subset: "hardware"
   gather_facts: yes
   tasks:
-    - name: debug min+hardware platform
-      debug:
-        var: hostvars['facthost22']
     # we should also collect platform, but not distribution
     - name: Test that retrieving hardware facts works and gets prereqs from platform and distribution
       assert:
@@ -76,9 +70,6 @@
   gather_subset: "!all,service_mgr"
   gather_facts: yes
   tasks:
-    - name: debug min+service_mgr platform
-      debug:
-        var: hostvars['facthost23']
     - name: Test that retrieving service_mgr facts works and gets prereqs from platform and distribution
       assert:
         that:
@@ -119,7 +110,7 @@
   tasks:
     - setup:
         filter: "*env*"
-        # register: fact_results
+      register: fact_results
 
     - name: Test that retrieving all facts filtered to env works
       assert:
@@ -136,7 +127,7 @@
   tasks:
     - setup:
         filter: "ansible_user_id"
-        # register: fact_results
+      register: fact_results
 
     - name: Test that retrieving all facts filtered to specific fact ansible_user_id works
       assert:
@@ -155,7 +146,7 @@
   tasks:
     - setup:
         filter: "*"
-        # register: fact_results
+      register: fact_results
 
     - name: Test that retrieving all facts filtered to splat
       assert:
@@ -172,7 +163,7 @@
   tasks:
     - setup:
         filter: ""
-        # register: fact_results
+      register: fact_results
 
     - name: Test that retrieving all facts filtered to empty filter_spec works
       assert:
@@ -205,9 +196,6 @@
   gather_subset: "!all,!min,network"
   gather_facts: yes
   tasks:
-    - name: debug facthost2 part deux
-      debug:
-        var: hostvars['facthost2']
     - name: Test that retrieving network facts work
       assert:
         that:

--- a/test/units/module_utils/facts/test_collector.py
+++ b/test/units/module_utils/facts/test_collector.py
@@ -20,12 +20,59 @@
 from __future__ import (absolute_import, division)
 __metaclass__ = type
 
+from collections import defaultdict
+import pprint
+
 # for testing
 from ansible.compat.tests import unittest
 
 from ansible.module_utils.facts import collector
 
 from ansible.module_utils.facts import default_collectors
+
+
+class TestFindCollectorsForPlatform(unittest.TestCase):
+    def test(self):
+        compat_platforms = [{'system': 'Generic'}]
+        res = collector.find_collectors_for_platform(default_collectors.collectors,
+                                                     compat_platforms)
+        # pprint.pprint(default_collectors.collectors)
+        # pprint.pprint(res)
+        for coll_class in res:
+            self.assertIn(coll_class._platform, ('Generic'))
+
+    def test_linux(self):
+        compat_platforms = [{'system': 'Linux'}]
+        res = collector.find_collectors_for_platform(default_collectors.collectors,
+                                                     compat_platforms)
+        # pprint.pprint(default_collectors.collectors)
+        # pprint.pprint(res)
+        for coll_class in res:
+            self.assertIn(coll_class._platform, ('Linux'))
+
+    def test_linux_or_generic(self):
+        compat_platforms = [{'system': 'Generic'}, {'system': 'Linux'}]
+        res = collector.find_collectors_for_platform(default_collectors.collectors,
+                                                     compat_platforms)
+        # pprint.pprint(default_collectors.collectors)
+        # pprint.pprint(res)
+        for coll_class in res:
+            self.assertIn(coll_class._platform, ('Generic', 'Linux'))
+
+
+class TestSelectCollectorNames(unittest.TestCase):
+    def test(self):
+        collector_names = set(['distribution', 'all_ipv4_addresses',
+                               'local', 'pkg_mgr'])
+        all_fact_subsets = defaultdict(list)
+        _data = {'pkg_mgr': [default_collectors.PkgMgrFactCollector],
+                 'distribution': [default_collectors.DistributionFactCollector],
+                 'network': [default_collectors.LinuxNetworkCollector]}
+        for key, value in _data.items():
+            all_fact_subsets[key] = value
+
+        res = collector.select_collector_classes(collector_names, all_fact_subsets)
+        pprint.pprint(res)
 
 
 class TestGetCollectorNames(unittest.TestCase):

--- a/test/units/module_utils/facts/test_collector.py
+++ b/test/units/module_utils/facts/test_collector.py
@@ -21,7 +21,6 @@ from __future__ import (absolute_import, division)
 __metaclass__ = type
 
 from collections import defaultdict
-import pprint
 
 # for testing
 from ansible.compat.tests import unittest
@@ -36,8 +35,6 @@ class TestFindCollectorsForPlatform(unittest.TestCase):
         compat_platforms = [{'system': 'Generic'}]
         res = collector.find_collectors_for_platform(default_collectors.collectors,
                                                      compat_platforms)
-        # pprint.pprint(default_collectors.collectors)
-        # pprint.pprint(res)
         for coll_class in res:
             self.assertIn(coll_class._platform, ('Generic'))
 
@@ -45,8 +42,6 @@ class TestFindCollectorsForPlatform(unittest.TestCase):
         compat_platforms = [{'system': 'Linux'}]
         res = collector.find_collectors_for_platform(default_collectors.collectors,
                                                      compat_platforms)
-        # pprint.pprint(default_collectors.collectors)
-        # pprint.pprint(res)
         for coll_class in res:
             self.assertIn(coll_class._platform, ('Linux'))
 
@@ -54,8 +49,6 @@ class TestFindCollectorsForPlatform(unittest.TestCase):
         compat_platforms = [{'system': 'Generic'}, {'system': 'Linux'}]
         res = collector.find_collectors_for_platform(default_collectors.collectors,
                                                      compat_platforms)
-        # pprint.pprint(default_collectors.collectors)
-        # pprint.pprint(res)
         for coll_class in res:
             self.assertIn(coll_class._platform, ('Generic', 'Linux'))
 
@@ -69,7 +62,6 @@ class TestSelectCollectorNames(unittest.TestCase):
         res = collector.select_collector_classes(collector_names,
                                                  all_fact_subsets,
                                                  all_collector_classes)
-        pprint.pprint(res)
 
         expected = [default_collectors.DistributionFactCollector,
                     default_collectors.PkgMgrFactCollector]
@@ -85,7 +77,6 @@ class TestSelectCollectorNames(unittest.TestCase):
         res = collector.select_collector_classes(collector_names,
                                                  all_fact_subsets,
                                                  all_collector_classes)
-        pprint.pprint(res)
 
         expected = [default_collectors.PkgMgrFactCollector,
                     default_collectors.DistributionFactCollector]
@@ -99,17 +90,14 @@ class TestSelectCollectorNames(unittest.TestCase):
                                                                          compat_platforms)
 
         all_fact_subsets, aliases_map = collector.build_fact_id_to_collector_map(collectors_for_platform)
-        pprint.pprint((dict(all_fact_subsets), dict(aliases_map)))
 
         all_valid_subsets = frozenset(all_fact_subsets.keys())
         collector_names = collector.get_collector_names(valid_subsets=all_valid_subsets,
                                                         aliases_map=aliases_map,
                                                         platform_info=platform_info)
-        res = collector.select_collector_classes(collector_names,
-                                                 all_fact_subsets,
-                                                 default_collectors.collectors)
-
-        pprint.pprint(res)
+        collector.select_collector_classes(collector_names,
+                                           all_fact_subsets,
+                                           default_collectors.collectors)
 
     def _all_collector_classes(self):
         return [default_collectors.DistributionFactCollector,

--- a/test/units/module_utils/facts/test_collector.py
+++ b/test/units/module_utils/facts/test_collector.py
@@ -64,15 +64,67 @@ class TestSelectCollectorNames(unittest.TestCase):
     def test(self):
         collector_names = set(['distribution', 'all_ipv4_addresses',
                                'local', 'pkg_mgr'])
+        all_fact_subsets = self._all_fact_subsets()
+        all_collector_classes = self._all_collector_classes()
+        res = collector.select_collector_classes(collector_names,
+                                                 all_fact_subsets,
+                                                 all_collector_classes)
+        pprint.pprint(res)
+
+        expected = [default_collectors.DistributionFactCollector,
+                    default_collectors.PkgMgrFactCollector]
+
+        self.assertEqual(res, expected)
+
+    def test_reverse(self):
+        collector_names = set(['distribution', 'all_ipv4_addresses',
+                               'local', 'pkg_mgr'])
+        all_fact_subsets = self._all_fact_subsets()
+        all_collector_classes = self._all_collector_classes()
+        all_collector_classes.reverse()
+        res = collector.select_collector_classes(collector_names,
+                                                 all_fact_subsets,
+                                                 all_collector_classes)
+        pprint.pprint(res)
+
+        expected = [default_collectors.PkgMgrFactCollector,
+                    default_collectors.DistributionFactCollector]
+
+        self.assertEqual(res, expected)
+
+    def test_default_collectors(self):
+        platform_info = {'system': 'Generic'}
+        compat_platforms = [platform_info]
+        collectors_for_platform = collector.find_collectors_for_platform(default_collectors.collectors,
+                                                                         compat_platforms)
+
+        all_fact_subsets, aliases_map = collector.build_fact_id_to_collector_map(collectors_for_platform)
+        pprint.pprint((dict(all_fact_subsets), dict(aliases_map)))
+
+        all_valid_subsets = frozenset(all_fact_subsets.keys())
+        collector_names = collector.get_collector_names(valid_subsets=all_valid_subsets,
+                                                        aliases_map=aliases_map,
+                                                        platform_info=platform_info)
+        res = collector.select_collector_classes(collector_names,
+                                                 all_fact_subsets,
+                                                 default_collectors.collectors)
+
+        pprint.pprint(res)
+
+    def _all_collector_classes(self):
+        return [default_collectors.DistributionFactCollector,
+                default_collectors.PkgMgrFactCollector,
+                default_collectors.LinuxNetworkCollector]
+
+    def _all_fact_subsets(self, data=None):
         all_fact_subsets = defaultdict(list)
         _data = {'pkg_mgr': [default_collectors.PkgMgrFactCollector],
                  'distribution': [default_collectors.DistributionFactCollector],
                  'network': [default_collectors.LinuxNetworkCollector]}
-        for key, value in _data.items():
+        data = data or _data
+        for key, value in data.items():
             all_fact_subsets[key] = value
-
-        res = collector.select_collector_classes(collector_names, all_fact_subsets)
-        pprint.pprint(res)
+        return all_fact_subsets
 
 
 class TestGetCollectorNames(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
    Flip the loops when building collector names
    
    iterate over the ordered default_collectors list
    selecting them for the final list in order instead
    of driving it from the unordered collector_names set.
    
    This lets the list returned by select_collector_classes
    to stay in the same order as default_collectors.collectors
    
    For collectors that have implicit deps on other fact collectors,
    the default collectors can be ordered to include those early.

For issues like https://github.com/ansible/ansible/issues/30753 and sort
of https://github.com/ansible/ansible/pull/30725

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts/
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fact_collector_ordering 4f1276d0e8) last updated 2017/09/22 16:06:57 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
