### PR TITLE
Fix encoding error with path to ssh

### DIFF
--- a/lib/ansible/utils/ssh_functions.py
+++ b/lib/ansible/utils/ssh_functions.py
@@ -22,6 +22,8 @@ __metaclass__ = type
 
 import subprocess
 
+from ansible.module_utils._text import to_bytes
+
 
 _HAS_CONTROLPERSIST = {}
 
@@ -33,9 +35,10 @@ def check_for_controlpersist(ssh_executable):
     except KeyError:
         pass
 
+    b_ssh_exec = to_bytes(ssh_executable, errors='surrogate_or_strict')
     has_cp = True
     try:
-        cmd = subprocess.Popen([ssh_executable, '-o', 'ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        cmd = subprocess.Popen([b_ssh_exec, '-o', 'ControlPersist'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         (out, err) = cmd.communicate()
         if b"Bad configuration option" in err or b"Usage:" in err:
             has_cp = False


### PR DESCRIPTION
As reported on the mailing list, if ssh_executable (from a config
setting) contains nonascii characters then we could get a UnicodeError
here.  Transform into bytes before passing to subprocess so that
subprocess doesn't transform to bytes for us.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/utils/ssh_functions.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```
