### PR TITLE
Fix typo in docs spelling_word_choice

### DIFF
--- a/docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst
+++ b/docs/docsite/rst/dev_guide/style_guide/spelling_word_choice.rst
@@ -250,7 +250,7 @@ Correct. Do not use "trouble shoot" or "trouble-shoot." To isolate the source of
 
 UK
 ++++++++++++++
-Correst as is, no periods.
+Correct as is, no periods.
 
 UNIX®
 ++++++++++++++
@@ -262,7 +262,7 @@ Don't use. Use Clear.
 
 US
 ++++++++++++++
-Correst as is, no periods.
+Correct as is, no periods.
 
 User
 ++++++++++++++


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR fixes a simple typo in document grammar_punctuation.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

N/A

##### ANSIBLE VERSION

N/A
<!--- Paste verbatim output from "ansible --version" between quotes below -->

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

N/A