### PR TITLE
facts: fix SPARC cpu count on linux

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -1162,6 +1162,7 @@ class LinuxHardware(Hardware):
 
             # model name is for Intel arch, Processor (mind the uppercase P)
             # works for some ARM devices, like the Sheevaplug.
+            # 'ncpus active' is SPARC attribute
             if key in ['model name', 'Processor', 'vendor_id', 'cpu', 'Vendor']:
                 if 'processor' not in self.facts:
                     self.facts['processor'] = []
@@ -1185,6 +1186,8 @@ class LinuxHardware(Hardware):
                 cores[coreid] = int(data[1].strip())
             elif key == '# processors':
                 self.facts['processor_cores'] = int(data[1].strip())
+            elif key == 'ncpus active':
+                i = int(data[1].strip())
 
         # Skip for platforms without vendor_id/model_name in cpuinfo (e.g ppc64le)
         if vendor_id_occurrence > 0:


### PR DESCRIPTION
##### SUMMARY

On sparc64, /proc/cpuinfo has no usual 'model name', 'Processor', 'vendor_id', 'Vendor',
as a result "ansible_processor_vcpus" is always 1.
Add check element "ncpus active" to fix the issue.

Backport from e93ecac0da87741d0bd6daed85af6962f8d5b4d6 (#30261)

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

facts

##### ADDITIONAL INFORMATION

This is not a straight cherry-pick from e93ecac0da87741d0bd6daed85af6962f8d5b4d6 (#30261) because some code has been moved around.  But the actual change is exactly the same.