### PR TITLE
Create VM without vCenter Server.

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -234,7 +234,7 @@ def compile_folder_path_for_object(vobj):
     thisobj = vobj
     while hasattr(thisobj, 'parent'):
         thisobj = thisobj.parent
-        if thisobj.name == 'Datacenters':
+        if thisobj.name == 'Datacenters' or thisobj.name == 'root':
             break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1213,16 +1213,15 @@ class PyVmomiHelper(object):
         else:
             vm_obj = None
 
-        # need a resource pool if cloning from template
-        if self.params['resource_pool'] or self.params['template']:
-            if self.params['esxi_hostname']:
-                host = self.select_host()
-                resource_pool = self.select_resource_pool_by_host(host)
-            else:
-                resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
+        # resource_pool is mandatory for CreateVM_task
+        if self.params['esxi_hostname']:
+            host = self.select_host()
+            resource_pool = self.select_resource_pool_by_host(host)
+        else:
+            resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
 
-            if resource_pool is None:
-                self.module.fail_json(msg='Unable to find resource pool "%(resource_pool)s"' % self.params)
+        if resource_pool is None:
+            self.module.fail_json(msg='Unable to find resource pool "%(resource_pool)s"' % self.params)
 
         # set the destination datastore for VM & disks
         (datastore, datastore_name) = self.select_datastore(vm_obj)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Enable to create VM without vCenter Server.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel b233f3f296) last updated 2017/09/23 17:07:22 (GMT +900)

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Tested on ESXi 6.5.0 (Build 4887370)

---
- hosts: all
  gather_facts: no
  tasks:
    - vmware_guest:
        hostname: 192.168.1.17
        username: root
        password: ************
        validate_certs: no
        datacenter: "ha-datacenter"
        name: TEST01
        guest_id: rhel7_64guest
        state: present
        folder: "ha-datacenter/vm"
        disk:
          - size_gb: 1
            datastore: datastore1
        hardware:
          memory_mb: 512
          num_cpus: 1
        esxi_hostname: 192
          
      delegate_to: localhost
```
