### PR TITLE
Add Digital Ocean dynamic inventory script maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -811,6 +811,14 @@ files:
     labels:
     - "c:inventory/contrib_script"
     support: community
+  contrib/inventory/digital_ocean.py:
+    keywords:
+    - digital_ocean dynamic inventory script
+    maintainers: BondAnthony
+    labels:
+    - cloud
+    - digital_ocean
+    support: community
   contrib/inventory/linode.py:
     keywords:
     - linode dynamic inventory script


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Digital Ocean dynamic inventory script is currently default supported by core. Hopefully to reduce work on core resources I would like to help maintain more of the Digital Ocean functionality within Ansible.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Maintainer update for bot.

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/digital_ocean.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
Ansible 2.5.0
```