### PR TITLE
Add processor_vcpu fact for Darwin

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/darwin.py
+++ b/lib/ansible/module_utils/facts/hardware/darwin.py
@@ -79,6 +79,7 @@ class DarwinHardware(Hardware):
             system_profile = self.get_system_profile()
             cpu_facts['processor'] = '%s @ %s' % (system_profile['Processor Name'], system_profile['Processor Speed'])
             cpu_facts['processor_cores'] = self.sysctl['hw.physicalcpu']
+        cpu_facts['processor_vcpus'] = self.sysctl.get('hw.logicalcpu') or self.sysctl.get('hw.ncpu') or ''
 
         return cpu_facts
 


### PR DESCRIPTION
##### SUMMARY
Fix adds fact related to vcpu in Darwin's setup.
Backport for stable-24 branch.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/hardware/darwin.py

##### ANSIBLE VERSION
```
stable-2.4
```