### PR TITLE
Add processor_vcpu fact for Darwin

### DIFF
--- a/lib/ansible/module_utils/facts.py
+++ b/lib/ansible/module_utils/facts.py
@@ -2377,6 +2377,7 @@ class Darwin(Hardware):
             system_profile = self.get_system_profile()
             self.facts['processor'] = '%s @ %s' % (system_profile['Processor Name'], system_profile['Processor Speed'])
             self.facts['processor_cores'] = self.sysctl['hw.physicalcpu']
+        self.facts['processor_vcpus'] = self.sysctl.get('hw.logicalcpu') or self.sysctl.get('hw.ncpu') or ''
 
     def get_memory_facts(self):
         self.facts['memtotal_mb'] = int(self.sysctl['hw.memsize']) // 1024 // 1024


### PR DESCRIPTION
##### SUMMARY
Fix adds fact related to vcpu in Darwin's setup.
Backport for stable-23 branch.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/hardware/darwin.py

##### ANSIBLE VERSION
```
stable-2.3
```