### PR TITLE
module_utils.urls - Encode the proxy connect as binary

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -728,7 +728,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                 port = proxy_parts.get('port') or 443
                 s = socket.create_connection((proxy_parts.get('hostname'), port))
                 if proxy_parts.get('scheme') == 'http':
-                    s.sendall((self.CONNECT_COMMAND % (self.hostname, self.port)).encode())
+                    s.sendall(to_bytes(self.CONNECT_COMMAND % (self.hostname, self.port)))
                     if proxy_parts.get('username'):
                         credentials = "%s:%s" % (proxy_parts.get('username', ''), proxy_parts.get('password', ''))
                         s.sendall(b'Proxy-Authorization: Basic %s\r\n' % base64.b64encode(to_bytes(credentials, errors='surrogate_or_strict')).strip())

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -728,7 +728,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                 port = proxy_parts.get('port') or 443
                 s = socket.create_connection((proxy_parts.get('hostname'), port))
                 if proxy_parts.get('scheme') == 'http':
-                    s.sendall(self.CONNECT_COMMAND % (self.hostname, self.port))
+                    s.sendall((self.CONNECT_COMMAND % (self.hostname, self.port)).encode())
                     if proxy_parts.get('username'):
                         credentials = "%s:%s" % (proxy_parts.get('username', ''), proxy_parts.get('password', ''))
                         s.sendall(b'Proxy-Authorization: Basic %s\r\n' % base64.b64encode(to_bytes(credentials, errors='surrogate_or_strict')).strip())

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -728,7 +728,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
                 port = proxy_parts.get('port') or 443
                 s = socket.create_connection((proxy_parts.get('hostname'), port))
                 if proxy_parts.get('scheme') == 'http':
-                    s.sendall(to_bytes(self.CONNECT_COMMAND % (self.hostname, self.port)))
+                    s.sendall(to_bytes(self.CONNECT_COMMAND % (self.hostname, self.port), errors='surrogate_or_strict'))
                     if proxy_parts.get('username'):
                         credentials = "%s:%s" % (proxy_parts.get('username', ''), proxy_parts.get('password', ''))
                         s.sendall(b'Proxy-Authorization: Basic %s\r\n' % base64.b64encode(to_bytes(credentials, errors='surrogate_or_strict')).strip())


### PR DESCRIPTION
##### SUMMARY
Under Python3 the sendall method expects binary not a string.

Prior to this change the below exception was being thrown;
```
Traceback (most recent call last):
  File "/tmp/ansible_umxox7_x/ansible_modlib.zip/ansible/module_utils/urls.py", line 1044, in fetch_url
    client_key=client_key, cookies=cookies)
  File "/tmp/ansible_umxox7_x/ansible_modlib.zip/ansible/module_utils/urls.py", line 951, in open_url
    r = urllib_request.urlopen(*urlopen_args)
  File "/opt/blue-python/3.6/lib/python3.6/urllib/request.py", line 223, in urlopen
    return opener.open(url, data, timeout)
  File "/opt/blue-python/3.6/lib/python3.6/urllib/request.py", line 524, in open
    req = meth(req)
  File "/tmp/ansible_umxox7_x/ansible_modlib.zip/ansible/module_utils/urls.py", line 729, in http_request
    s.sendall((self.CONNECT_COMMAND % (self.hostname, self.port)).decode())
AttributeError: 'str' object has no attribute 'decode'
```

Encoding the value is inline with the lines below (Proxy-Authorization etc) which are being sent as binary.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/urls.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/home/dzaremba/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/blue-python/3.6/lib/python3.6/site-packages/ansible
  executable location = /bin/ansible
  python version = 3.6.2 (default, Jul 18 2017, 11:34:24) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```
(This is a straight package of the upstream release)

##### ADDITIONAL INFORMATION
This can be replicated using the below eos_config task config;

```
  tasks:
    - name: Test
      eos_config:
        src: "{{ device_conf }}"
        replace: config
        transport: eapi
      check_mode: yes
```
