### PR TITLE
Set 'Resources' as default resource_pool in vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -105,7 +105,8 @@ options:
   resource_pool:
     description:
     - Affect machine to the given resource pool.
-    - Resource pool should be child of the selected host parent.
+    - Resource pool should be child of the selected host or cluster parent.
+    default: 'Resources'
     version_added: '2.3'
   wait_for_ip_address:
     description:
@@ -1445,7 +1446,7 @@ def main():
         snapshot_src=dict(type='str'),
         linked_clone=dict(type='bool', default=False),
         networks=dict(type='list', default=[]),
-        resource_pool=dict(type='str'),
+        resource_pool=dict(type='str', default='Resources'),
         customization=dict(type='dict', default={}, no_log=True),
     )
 


### PR DESCRIPTION
A resource pool is not only needed when cloning from a template, but also when creating a new virtual machine. Even if you do not use (or created) resource pool on the ESXi host or vCenter server at all, there is a default 'hidden' resource pool named 'Resources' available. So this is now given as default

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Set `Resources` as default `resource_pool`in `vmware_guest`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`vmware_guest`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vmware_guest_default_resource_pool 1572989490) last updated 2017/09/24 12:38:45 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.12 (default, Jun 29 2016, 08:57:23) [GCC 5.3.0]

```


##### ADDITIONAL INFORMATION
A `resource_pool` is needed when you want to create a virtual machine. In case you do not work with resource pools at all, there is always a 'hidden' resource pool 'Resources' that has to be used. Instead of specifying this within the playbook, set this as default.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
