### PR TITLE
module_utils.(eos, nxos) - Support use_proxy argument

### DIFF
--- a/lib/ansible/module_utils/network/eos/eos.py
+++ b/lib/ansible/module_utils/network/eos/eos.py
@@ -50,6 +50,7 @@ eos_provider_spec = {
     'auth_pass': dict(no_log=True, fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS'])),
 
     'use_ssl': dict(default=True, type='bool'),
+    'use_proxy': dict(default=True, type='bool'),
     'validate_certs': dict(default=True, type='bool'),
     'timeout': dict(type='int'),
 
@@ -292,10 +293,11 @@ class Eapi:
 
         headers = {'Content-Type': 'application/json-rpc'}
         timeout = self._module.params['timeout']
+        use_proxy = self._module.params['provider']['use_proxy']
 
         response, headers = fetch_url(
             self._module, self._url, data=data, headers=headers,
-            method='POST', timeout=timeout
+            method='POST', timeout=timeout, use_proxy=use_proxy
         )
 
         if headers['status'] != 200:

--- a/lib/ansible/module_utils/network/nxos/nxos.py
+++ b/lib/ansible/module_utils/network/nxos/nxos.py
@@ -50,6 +50,7 @@ nxos_provider_spec = {
     'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE'])),
 
     'use_ssl': dict(type='bool'),
+    'use_proxy': dict(default=True, type='bool'),
     'validate_certs': dict(type='bool'),
 
     'timeout': dict(type='int'),
@@ -309,6 +310,7 @@ class Nxapi:
         headers = {'Content-Type': 'application/json'}
         result = list()
         timeout = self._module.params['timeout']
+        use_proxy = self._module.params['provider']['use_proxy']
 
         for req in requests:
             if self._nxapi_auth:
@@ -316,7 +318,7 @@ class Nxapi:
 
             response, headers = fetch_url(
                 self._module, self._url, data=req, headers=headers,
-                timeout=timeout, method='POST'
+                timeout=timeout, method='POST', use_proxy=use_proxy
             )
             self._nxapi_auth = headers.get('set-cookie')
 

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -120,6 +120,13 @@ options:
             on personally controlled sites using self-signed certificates.  If the transport
             argument is not eapi, this value is ignored.
         choices: ['yes', 'no']
+      use_proxy:
+        description:
+          - If C(no), the environment variables C(http_proxy) and C(https_proxy) will be ignored.
+        default: 'yes'
+        choices: ['yes', 'no']
+        version_added: "2.5"
+
 notes:
   - For more information on using Ansible to manage Arista EOS devices see U(https://www.ansible.com/ansible-arista-networks).
 

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -95,6 +95,13 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
+  use_proxy:
+    description:
+      - If C(no), the environment variables C(http_proxy) and C(https_proxy) will be ignored.
+    default: 'yes'
+    choices: ['yes', 'no']
+    version_added: "2.5"
+
 notes:
   - For more information on using Ansible to manage Cisco devices see U(https://www.ansible.com/ansible-cisco).
 """


### PR DESCRIPTION
##### SUMMARY
Running ansible with a proxy set in the environment causes the eos module to
attempt to connect to devices via the proxy.

To prevent this behaviour the only way is to unset the proxy out of the
environment, either by wrapping the ansible calls or doing it in a piece of code
executed before connect, such as a vars_module (though this is very hacky).

This change allows you to set `use_proxy: no` under the provider config.

The default value is set to True, which mirrors the behaviour seen today.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/eos.py
modules/network/eos/*.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/home/dzaremba/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/blue-python/3.6/lib/python3.6/site-packages/ansible
  executable location = /bin/ansible
  python version = 3.6.2 (default, Jul 18 2017, 11:34:24) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```
(This is a straight package of the upstream release)

##### ADDITIONAL INFORMATION
Executing the below eos_config task without this change and https_proxy set in your environment (to a proxy that can't connect to the target) the execution fails with `Request failed: <urlopen error Tunnel connection failed: 503 Service Unavailable>`

```
    - name: Test
      eos_config:
        src: "{{ device_conf }}"
        replace: config
        provider:
          transport: eapi
      check_mode: yes
```

With this change and the below eos_config task, the task is executed as expected, directly connecting to the device.

```
    - name: Test
      eos_config:
        src: "{{ device_conf }}"
        replace: config
        provider:
          transport: eapi
          use_proxy: no
      check_mode: yes
```