### PR TITLE
aws_s3: Reenable support for encryption when uploading files to S3.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -396,11 +396,12 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
     try:
+        extra = {}
+        if encrypt:
+            extra['ServerSideEncryption'] = 'AES256'
         if metadata:
-            extra = {'Metadata': dict(metadata)}
-            s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
-        else:
-            s3.upload_file(Filename=src, Bucket=bucket, Key=obj)
+            extra['Metadata'] = dict(metadata)
+        s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
         for acl in module.params.get('permission'):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
         url = s3.generate_presigned_url(ClientMethod='put_object',


### PR DESCRIPTION
##### SUMMARY
The porting of the `aws_s3` from `boto2` to `boto3` broke encryption support when uploading a file to S3. This PR reenables support for encryption by setting `ServerSideEncryption` to `AES256` when uploading files.

Note that the `headers` parameter is still unused. There did not seem to be an obvious fix for it, so I left it alone for now.

Long term, the feature should probably be more flexible and allow for KMS or custom keys.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION

```
ansible-playbook 2.4.0.0
  config file = <REDACTED>/ansible.cfg
  configured module search path = [u'<REDACTED>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = <REDACTED>/.venv/local/lib/python2.7/site-packages/ansible
  executable location = <REDACTED>/.venv/bin/ansible-playbook
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```
