### PR TITLE
Add alias to command option in telnet

### DIFF
--- a/lib/ansible/modules/commands/telnet.py
+++ b/lib/ansible/modules/commands/telnet.py
@@ -22,6 +22,7 @@ options:
     description:
       - List of commands to be executed in the telnet session.
     required: True
+    aliases: ['commands']
   host:
     description:
         - The host/target on which to execute the command

--- a/lib/ansible/plugins/action/telnet.py
+++ b/lib/ansible/plugins/action/telnet.py
@@ -43,7 +43,7 @@ class ActionModule(ActionBase):
             login_prompt = self._task.args.get('login_prompt', "login: ")
             password_prompt = self._task.args.get('password_prompt', "Password: ")
             prompts = self._task.args.get('prompts', "$ ")
-            commands = self._task.args.get('command')
+            commands = self._task.args.get('command') or self._task.args.get('commands')
 
             if isinstance(commands, text_type):
                 commands = commands.split(',')


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Add commands alias to telnet option
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
telnet

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook:
```
  - name: send configuration commands to IOS
    telnet:
      user: xxxx
      password: xxxx
      login_prompt: "Username: "
      prompts:
        - "[>|#]"
      commands:
        - terminal length 0
```
Before:
```
fatal: [ios01]: FAILED! => {
    "changed": true,
    "failed": true,
    "msg": "Telnet requires a command to execute"
}
```
After:
```
changed: [ios01] => {
    "changed": true,
    "failed": false,
    "output": [
        "terminal length 0\r\nios01#"
    ]
}
META: ran handlers
META: ran handlers

PLAY RECAP *******************************************************************************************************
ios01                      : ok=2    changed=1    unreachable=0    failed=0
```