### PR TITLE
Do not check for known root datacenter names in vmware_guest

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -232,13 +232,26 @@ def compile_folder_path_for_object(vobj):
     if isinstance(vobj, vim.Folder):
         paths.append(vobj.name)
 
+    broke = False
+
     thisobj = vobj
-    while hasattr(thisobj, 'parent'):
-        thisobj = thisobj.parent
-        if thisobj.name == 'Datacenters':
+    while True:
+        try:
+            thisobj = thisobj.parent
+            if thisobj is None:
+                broke = True
+                break
+        except (IndexError, AttributeError) as err:
+            broke = True
             break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)
+        else:
+            """ break as soon as we hit something that is not a folder """
+            break
+    if broke:
+        """ we reached the top. Remove the 'datacenters' folder from the list """
+        paths.pop()
     paths.reverse()
     return '/' + '/'.join(paths)
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -447,10 +447,13 @@ class PyVmomiCache(object):
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
+                # make temp copy
+                tmpobjs = objects.copy()
                 for k, v in objects.items():
                     parent_dc = self.get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        objects.pop(k, None)
+                        tmpobjs.pop(k, None)
+                objects = tmpobjs
             else:
                 # everything else should be a list
                 objects = [x for x in objects if self.get_parent_datacenter(x).name == self.dc_name]


### PR DESCRIPTION
Just do not rely on known 'datacenter' names. For example,
on a german windows vCenter server, the root datacenter is
called 'Datencenter'. Hence, the folder path will always be wrong.

Fixes #29043

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/vmware vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel e4c9ffa7e6) last updated 2017/09/25 08:02:01 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.12 (default, Jun 29 2016, 08:57:23) [GCC 5.3.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Playbook given (cutted...)

```
      vmware_guest:
        hostname: "{{ vcenter }}"
        username: "{{ user }}"
        password: "{{ pass }}"
        validate_certs: no
        annotation: "Created by ansible"
        state: present
        resource_pool: Resources
        datacenter: TEST
        cluster: "TEST"
        name: "ansible_test1"
        folder: "ansible_test"
        guest_id: "debian7_64Guest"
```

Before
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_I23I2j/ansible_module_vmware_guest.py", line 1503, in <module>
    main()
  File "/tmp/ansible_I23I2j/ansible_module_vmware_guest.py", line 1494, in main
    result = pyv.deploy_vm()
  File "/tmp/ansible_I23I2j/ansible_module_vmware_guest.py", line 1189, in deploy_vm
    dcpath = compile_folder_path_for_object(datacenter)
  File "/tmp/ansible_I23I2j/ansible_modlib.zip/ansible/module_utils/vmware.py", line 237, in compile_folder_path_for_object
AttributeError: 'NoneType' object has no attribute 'name'
```
This is because our root datacenter name is `Datencenter` and not `Datacenters`

After patch...vm is created correctly in the given folder (also cutted)

```
    "invocation": {
        "module_args": {
            "annotation": "Created by ansible",
            "cluster": "TEST",
            "customization": {},
            "customvalues": [],
            "datacenter": "TEST",
            "disk": [
                {
                    "autoselect_datastore": true,
                    "size_gb": 30,
                    "type": "thin"
                }
            ],
            "esxi_hostname": null,
            "folder": "/ansible_test",
            "is_template": false,
            "linked_clone": false,
            "name": "ansible_test1",
            "name_match": "first",
            ...
            ...
            "resource_pool": "Resources",

```

