### PR TITLE
WIP PostgreSQL: allow to escape identifier

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -102,7 +102,7 @@ class NotSupportedError(Exception):
 
 def ext_exists(cursor, ext, ver=None):
     if ver:
-        query = "SELECT * FROM pg_extension WHERE extname=%(ext)s and extversion=$(ver)s"
+        query = "SELECT * FROM pg_extension WHERE extname=%(ext)s and extversion=%(ver)s"
     else:
         query = "SELECT * FROM pg_extension WHERE extname=%(ext)s"
     cursor.execute(query, {'ext': ext, 'ver': ver})
@@ -119,16 +119,16 @@ def ext_delete(cursor, ext):
 def ext_create(cursor, ext, ver=None):
     if not ext_exists(cursor, ext):
         if ver:
-            query = 'CREATE EXTENSION "%s" VERSION "%s"' % ( ext, ver)
+            query = 'CREATE EXTENSION "%(ext)s" VERSION "%(ver)s"'
         else:
-            query = 'CREATE EXTENSION "%s"' % ext
-        cursor.execute(query)
+            query = 'CREATE EXTENSION "%(ext)s"'
+        cursor.execute(query, {'ext': ext, 'ver': ver})
         return True
     else:
         if ver:
             if not ext_exists(cursor, ext, ver):
-                query = 'ALTER EXTENSION "%s" UPDATE TO "%s"' % ( ext, ver )
-            cursor.execute(query)
+                query = 'ALTER EXTENSION "%(ext)s" UPDATE TO "%(ver)s"'
+            cursor.execute(query, {'ext': ext, 'ver': ver})
             return True
         return False
 

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -30,6 +30,7 @@ options:
       - version of the extension to add or remove (or update to)
     required: false
     default: null
+    version_added: "2.4"
   db:
     description:
       - name of the database to add or remove the extension to/from
@@ -101,9 +102,9 @@ class NotSupportedError(Exception):
 
 def ext_exists(cursor, ext, ver=None):
     if ver:
-      query = "SELECT * FROM pg_extension WHERE extname=%(ext)s and extversion=$(ver)s"
+        query = "SELECT * FROM pg_extension WHERE extname=%(ext)s and extversion=$(ver)s"
     else:
-      query = "SELECT * FROM pg_extension WHERE extname=%(ext)s"
+        query = "SELECT * FROM pg_extension WHERE extname=%(ext)s"
     cursor.execute(query, {'ext': ext, 'ver': ver})
     return cursor.rowcount == 1
 
@@ -118,15 +119,15 @@ def ext_delete(cursor, ext):
 def ext_create(cursor, ext, ver=None):
     if not ext_exists(cursor, ext):
         if ver:
-          query = 'CREATE EXTENSION "%s" VERSION "%s"' % ext % ver
+            query = 'CREATE EXTENSION "%s" VERSION "%s"' % ext % ver
         else:
-          query = 'CREATE EXTENSION "%s"' % ext
+            query = 'CREATE EXTENSION "%s"' % ext
         cursor.execute(query)
         return True
     else:
         if ver:
-          if not ext_exists(cursor, ext, ver):
-            query = 'ALTER EXTENSION "%s" UPDATE TO "%s"' % ext % ver
+            if not ext_exists(cursor, ext, ver):
+                query = 'ALTER EXTENSION "%s" UPDATE TO "%s"' % ext % ver
             cursor.execute(query)
             return True
         return False

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -145,7 +145,7 @@ def main():
             port=dict(default="5432"),
             db=dict(required=True),
             ext=dict(required=True, aliases=['name']),
-            version=dict(default="", aliases=['version']),
+            version=dict(default=""),
             state=dict(default="present", choices=["absent", "present"]),
         ),
         supports_check_mode = True

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -194,7 +194,7 @@ def main():
             if state == "present":
                 changed = not ext_exists(cursor, ext, version)
             elif state == "absent":
-                changed = ext_exists(cursor, ext, version)
+                changed = ext_exists(cursor, ext)
         else:
             if state == "absent":
                 changed = ext_delete(cursor, ext)

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -132,7 +132,7 @@ def ext_create(cursor, ext, ver=None):
             if not ext_exists(cursor, ext, ver):
                 query = 'ALTER EXTENSION "%(ext)s" UPDATE TO "%(ver)s"'
                 cursor.execute(query, {'ext': ext, 'ver': ver})
-            return True
+                return True
         return False
 
 # ===========================================

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -142,7 +142,7 @@ def ext_exists(cursor, ext, ver=None):
 
 def ext_delete(cursor, ext):
     if ext_exists(cursor, ext):
-        query = "DROP EXTENSION %(ext)s"
+        query = "DROP EXTENSION {ext}"
         params = {}
         query = prepare_ext_query(cursor, query, params, ext)
         cursor.execute(query, params)

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -27,7 +27,7 @@ options:
     default: null
   version:
     description:
-      - version of the extension to add or remove (or update to),
+      - version of the extension to add or update to,
         has no effect when requested state is "absent", when not
         specified (with state "present") it will add latest
         available version

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -27,7 +27,10 @@ options:
     default: null
   version:
     description:
-      - version of the extension to add or remove (or update to)
+      - version of the extension to add or remove (or update to),
+        has no effect when requested state is "absent", when not
+        specified (with state "present") it will add latest
+        available version
     required: false
     default: null
     version_added: "2.4"

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -131,7 +131,7 @@ def ext_create(cursor, ext, ver=None):
         if ver:
             if not ext_exists(cursor, ext, ver):
                 query = 'ALTER EXTENSION "%(ext)s" UPDATE TO "%(ver)s"'
-            cursor.execute(query, {'ext': ext, 'ver': ver})
+                cursor.execute(query, {'ext': ext, 'ver': ver})
             return True
         return False
 
@@ -159,7 +159,7 @@ def main():
 
     db = module.params["db"]
     ext = module.params["ext"]
-    ver = module.params["version"]
+    version = module.params["version"]
     port = module.params["port"]
     state = module.params["state"]
     changed = False
@@ -192,15 +192,15 @@ def main():
     try:
         if module.check_mode:
             if state == "present":
-                changed = not ext_exists(cursor, ext, ver)
+                changed = not ext_exists(cursor, ext, version)
             elif state == "absent":
-                changed = ext_exists(cursor, ext, ver)
+                changed = ext_exists(cursor, ext, version)
         else:
             if state == "absent":
                 changed = ext_delete(cursor, ext)
 
             elif state == "present":
-                changed = ext_create(cursor, ext, ver)
+                changed = ext_create(cursor, ext, version)
     except NotSupportedError as e:
         module.fail_json(msg=to_native(e), exception=traceback.format_exc())
     except Exception as e:

--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -119,7 +119,7 @@ def ext_delete(cursor, ext):
 def ext_create(cursor, ext, ver=None):
     if not ext_exists(cursor, ext):
         if ver:
-            query = 'CREATE EXTENSION "%s" VERSION "%s"' % ext % ver
+            query = 'CREATE EXTENSION "%s" VERSION "%s"' % ( ext, ver)
         else:
             query = 'CREATE EXTENSION "%s"' % ext
         cursor.execute(query)
@@ -127,7 +127,7 @@ def ext_create(cursor, ext, ver=None):
     else:
         if ver:
             if not ext_exists(cursor, ext, ver):
-                query = 'ALTER EXTENSION "%s" UPDATE TO "%s"' % ext % ver
+                query = 'ALTER EXTENSION "%s" UPDATE TO "%s"' % ( ext, ver )
             cursor.execute(query)
             return True
         return False
@@ -156,7 +156,7 @@ def main():
 
     db = module.params["db"]
     ext = module.params["ext"]
-    ver = module.params["ver"]
+    ver = module.params["version"]
     port = module.params["port"]
     state = module.params["state"]
     changed = False

--- a/test/integration/targets/postgresql/defaults/main.yml
+++ b/test/integration/targets/postgresql/defaults/main.yml
@@ -6,7 +6,3 @@ db_user2: 'ansible_db_user2'
 db_user3: 'ansible_db_user3'
 
 tmp_dir: '/tmp'
-
-ext_name: 'postgis'
-ext_ver_1: '2.2.0'
-ext_ver_2: '2.3.0'

--- a/test/integration/targets/postgresql/defaults/main.yml
+++ b/test/integration/targets/postgresql/defaults/main.yml
@@ -6,3 +6,7 @@ db_user2: 'ansible_db_user2'
 db_user3: 'ansible_db_user3'
 
 tmp_dir: '/tmp'
+
+ext_name: 'postgis'
+ext_ver_1: '2.2.0'
+ext_ver_2: '2.3.0'

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -785,6 +785,7 @@
     vars:
       ext_name: dummy
       ext_version: '{{ item }}'
+      ext_default_version: '1.0'
     with_items:
       - null
       - '1.0'

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -772,14 +772,32 @@
 # test extension loading
 # ============================================================
 - name: Test extension loading
-  include_tasks: test_postgresql_ext.yml
-  vars:
-    ext_name: dummy
-    ext_version: '{{ item }}'
-  with_items:
-    - null
-    - '1.0'
-    - '2.0'
+  block:
+  - name: Create DB
+    become_user: "{{ pg_user }}"
+    become: True
+    postgresql_db:
+      state: present
+      name: "{{ db_name }}"
+      login_user: "{{ pg_user }}"
+
+  - include_tasks: test_postgresql_ext.yml
+    vars:
+      ext_name: dummy
+      ext_version: '{{ item }}'
+    with_items:
+      - null
+      - '1.0'
+      - '2.0'
+
+  always:
+  - name: Destroy DB
+    become_user: "{{ pg_user }}"
+    become: True
+    postgresql_db:
+      state: absent
+      name: "{{ db_name }}"
+      login_user: "{{ pg_user }}"
 
 #
 # Cleanup

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -771,13 +771,15 @@
 
 # test extension loading
 # ============================================================
-- include: test_postgresql_ext.yml
+- name: Test extension loading
+  include_tasks: test_postgresql_ext.yml
   vars:
+    ext_name: dummy
     ext_version: '{{ item }}'
   with_items:
-    - nil
-    - '{ext_version_1}'
-    - '{ext_version_2}'
+    - null
+    - '1.0'
+    - '2.0'
 
 #
 # Cleanup

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -798,6 +798,7 @@
       state: absent
       name: "{{ db_name }}"
       login_user: "{{ pg_user }}"
+  when: pg_extension_supported
 
 #
 # Cleanup

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -769,6 +769,16 @@
 # ============================================================
 - include: state_dump_restore.yml file=dbdata.tar test_fixture=admin
 
+# test extension loading
+# ============================================================
+- include: test_postgresql_ext.yml
+  vars:
+    ext_version: '{{ item }}'
+  with_items:
+    - nil
+    - '{ext_version_1}'
+    - '{ext_version_2}'
+
 #
 # Cleanup
 #

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -47,8 +47,7 @@
 
 - assert:
     that:
-      - "result.stdout_lines[-1] == '(1 row)'"
-      - "result.stdout_lines[-2].strip() == ext_version|default(ext_default_version)"
+      - "result.stdout.strip() == ext_version|default(ext_default_version)"
 
 - name: Disable extension
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -88,4 +88,4 @@
 
 - assert:
     that:
-      - "result.stdout_lines[-1] == '(0 row)'"
+      - "result.stdout_lines[-1] == '(0 rows)'"

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -39,7 +39,7 @@
 - assert:
     that:
       - "result.stdout_lines[-1] == '(1 row)'"
-      - "ext_version|default(ext_default_version) in result.stdout"
+      - "ext_version|default(ext_default_version, boolean=True) in result.stdout"
 
 - name: Check that the function defined by extension is available
   become_user: "{{ pg_user }}"
@@ -49,7 +49,7 @@
 
 - assert:
     that:
-      - "result.stdout.strip() == ext_version|default(ext_default_version)"
+      - "result.stdout.strip() == ext_version|default(ext_default_version, boolean=True)"
 
 - name: Disable extension
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -39,6 +39,17 @@
       - "result.stdout_lines[-1] == '(1 row)'"
       - "ext_version|default(ext_default_version) in result.stdout"
 
+- name: Check that the function defined by extension is available
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select dummy_display_ext_version();" | psql -d "{{ db_name }}" -t -c "select dummy_display_ext_version();"
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+      - "result.stdout_lines[-2].strip() == ext_version|default(ext_default_version)"
+
 - name: Disable extension
   become_user: "{{ pg_user }}"
   become: True

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -11,7 +11,7 @@
 - name: assert that module reports a change
   assert:
     that:
-       - "result.changed == true"
+       - "result.changed"
 
 - name: Enable extension - idempotence test
   become_user: "{{ pg_user }}"
@@ -26,7 +26,7 @@
 - name: assert that module reports no change
   assert:
     that:
-       - "result.changed == false"
+       - "not result.changed"
 
 - name: Check that the extension is available
   become_user: "{{ pg_user }}"
@@ -51,7 +51,7 @@
 - name: assert that module reports a change
   assert:
     that:
-       - "result.changed == true"
+       - "result.changed"
 
 - name: Disable extension - idempotence test
   become_user: "{{ pg_user }}"
@@ -65,7 +65,7 @@
 - name: assert that module reports no change
   assert:
     that:
-       - "result.changed == false"
+       - "not result.changed"
 
 - name: Check that the extension is not available
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -37,7 +37,7 @@
 - assert:
     that:
       - "result.stdout_lines[-1] == '(1 row)'"
-      - "not ext_version or ext_version in result.stdout"
+      - "ext_version|default(ext_default_version) in result.stdout"
 
 - name: Disable extension
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -1,0 +1,91 @@
+- name: Enable extension
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_ext:
+    db: "{{ db_name }}"
+    state: present
+    name: "{{ ext_name }}"
+    version: "{{ ext_version }}"
+  register: result
+
+- name: assert that module reports a change
+  assert:
+    that:
+       - "result.changed == true"
+
+- name: Enable extension - idempotence test
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_ext:
+    db: "{{ db_name }}"
+    state: present
+    name: "{{ ext_name }}"
+    version: "{{ ext_version }}"
+  register: result
+
+- name: assert that module reports no change
+  assert:
+    that:
+       - "result.changed == false"
+
+- name: Check that the extension is available
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select extname,extversion from pg_extension where extname = '{{ ext_name }}'" | psql -d "{{ db_name }}";
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(1 row)'"
+
+- assert:
+    that:
+      - "'{{ ext_version }}' in result.stdout"
+  when:
+    - '{{ ext_version }}'
+
+- name: Disable extension
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_ext:
+    db: "{{ db_name }}"
+    state: absent
+    name: "{{ ext_name }}"
+  register: result
+  when:
+    - not '{{ ext_version }}'
+
+- name: assert that module reports a change
+  assert:
+    that:
+       - "result.changed == true"
+  when:
+    - not '{{ ext_version }}'
+
+- name: Disable extension - idempotence test
+  become_user: "{{ pg_user }}"
+  become: True
+  postgresql_ext:
+    db: "{{ db_name }}"
+    state: present
+    name: "{{ ext_name }}"
+  register: result
+  when:
+    - not '{{ ext_version }}'
+
+- name: assert that module reports no change
+  assert:
+    that:
+       - "result.changed == false"
+  when:
+    - not '{{ ext_version }}'
+
+- name: Check that the extension is not available
+  become_user: "{{ pg_user }}"
+  become: True
+  shell: echo "select extname,extversion from pg_extension where extname = '{{ ext_name }}'" | psql -d "{{ db_name }}";
+  register: result
+
+- assert:
+    that:
+      - "result.stdout_lines[-1] == '(0 row)'"

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -67,7 +67,7 @@
   become: True
   postgresql_ext:
     db: "{{ db_name }}"
-    state: present
+    state: absent
     name: "{{ ext_name }}"
   register: result
   when:

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -3,6 +3,7 @@
   become: True
   postgresql_ext:
     db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
     state: present
     name: "{{ ext_name }}"
     version: "{{ ext_version }}"
@@ -18,6 +19,7 @@
   become: True
   postgresql_ext:
     db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
     state: present
     name: "{{ ext_name }}"
     version: "{{ ext_version }}"
@@ -54,6 +56,7 @@
   become: True
   postgresql_ext:
     db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
     state: absent
     name: "{{ ext_name }}"
   register: result
@@ -68,6 +71,7 @@
   become: True
   postgresql_ext:
     db: "{{ db_name }}"
+    login_user: "{{ pg_user }}"
     state: absent
     name: "{{ ext_name }}"
   register: result

--- a/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
+++ b/test/integration/targets/postgresql/tasks/test_postgresql_ext.yml
@@ -37,12 +37,7 @@
 - assert:
     that:
       - "result.stdout_lines[-1] == '(1 row)'"
-
-- assert:
-    that:
-      - "'{{ ext_version }}' in result.stdout"
-  when:
-    - '{{ ext_version }}'
+      - "not ext_version or ext_version in result.stdout"
 
 - name: Disable extension
   become_user: "{{ pg_user }}"
@@ -52,15 +47,11 @@
     state: absent
     name: "{{ ext_name }}"
   register: result
-  when:
-    - not '{{ ext_version }}'
 
 - name: assert that module reports a change
   assert:
     that:
        - "result.changed == true"
-  when:
-    - not '{{ ext_version }}'
 
 - name: Disable extension - idempotence test
   become_user: "{{ pg_user }}"
@@ -70,15 +61,11 @@
     state: absent
     name: "{{ ext_name }}"
   register: result
-  when:
-    - not '{{ ext_version }}'
 
 - name: assert that module reports no change
   assert:
     that:
        - "result.changed == false"
-  when:
-    - not '{{ ext_version }}'
 
 - name: Check that the extension is not available
   become_user: "{{ pg_user }}"

--- a/test/integration/targets/setup_postgresql_db/files/dummy--1.0.sql
+++ b/test/integration/targets/setup_postgresql_db/files/dummy--1.0.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''1.0'')::text';

--- a/test/integration/targets/setup_postgresql_db/files/dummy--2.0.sql
+++ b/test/integration/targets/setup_postgresql_db/files/dummy--2.0.sql
@@ -1,0 +1,2 @@
+CREATE OR REPLACE FUNCTION dummy_display_ext_version()
+RETURNS text LANGUAGE SQL AS 'SELECT (''2.0'')::text';

--- a/test/integration/targets/setup_postgresql_db/files/dummy.control
+++ b/test/integration/targets/setup_postgresql_db/files/dummy.control
@@ -1,0 +1,3 @@
+comment = 'dummy extension used to test postgresql_ext Ansible module'
+default_version = '1.0'
+relocatable = true

--- a/test/integration/targets/setup_postgresql_db/tasks/create_dummy_extension.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/create_dummy_extension.yml
@@ -17,7 +17,7 @@
 
   - set_fact:
       pg_extension_dir: '{{ sql_features_path.files[0].path | dirname }}/extension'
-  when: pg_extension_dir is not set
+  when: pg_extension_dir is undefined
 
 - name: retrieve fact for extension directory
   stat:

--- a/test/integration/targets/setup_postgresql_db/tasks/create_dummy_extension.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/create_dummy_extension.yml
@@ -1,0 +1,45 @@
+# pg_config requires postgresql-server-dev package,
+# try find extension path using one way for all systems
+- name: find PostgreSQL extension directory
+  find:
+    file_type: file
+    paths: /usr/share
+    patterns: sql_features.txt
+    recurse: yes
+    follow: yes
+  register: sql_features_path
+
+- name: ensure that only one path was found
+  assert:
+    that:
+      - 'sql_features_path.matched == 1'
+
+- set_fact:
+    postgresql_ext_dir: '{{ sql_features_path.files[0].path | dirname }}/extension'
+
+- name: retrieve fact for extension directory
+  stat:
+    path: '{{ postgresql_ext_dir }}'
+  register: extension_directory
+
+- name: ensure that extension directory exists
+  assert:
+    that:
+      - 'extension_directory.stat.exists and extension_directory.stat.isdir'
+
+- name: copy control file
+  copy:
+    src: dummy.control
+    dest: '{{ postgresql_ext_dir }}'
+    mode: 0444
+    owner: '{{ extension_directory.stat.pw_name }}'
+
+- name: copy extension files
+  copy:
+    src: 'dummy--{{ item }}.sql'
+    dest: '{{ postgresql_ext_dir }}'
+    mode: 0444
+    owner: '{{ extension_directory.stat.pw_name }}'
+  with_items:
+    - '1.0'
+    - '2.0'

--- a/test/integration/targets/setup_postgresql_db/tasks/create_dummy_extension.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/create_dummy_extension.yml
@@ -1,25 +1,27 @@
 # pg_config requires postgresql-server-dev package,
 # try find extension path using one way for all systems
-- name: find PostgreSQL extension directory
-  find:
-    file_type: file
-    paths: /usr/share
-    patterns: sql_features.txt
-    recurse: yes
-    follow: yes
-  register: sql_features_path
+- block:
+  - name: find PostgreSQL extension directory
+    find:
+      file_type: file
+      paths: '/usr/share/'
+      patterns: sql_features.txt
+      recurse: yes
+      follow: yes
+    register: sql_features_path
 
-- name: ensure that only one path was found
-  assert:
-    that:
-      - 'sql_features_path.matched == 1'
+  - name: ensure that only one path was found
+    assert:
+      that:
+        - 'sql_features_path.matched == 1'
 
-- set_fact:
-    postgresql_ext_dir: '{{ sql_features_path.files[0].path | dirname }}/extension'
+  - set_fact:
+      pg_extension_dir: '{{ sql_features_path.files[0].path | dirname }}/extension'
+  when: pg_extension_dir is not set
 
 - name: retrieve fact for extension directory
   stat:
-    path: '{{ postgresql_ext_dir }}'
+    path: '{{ pg_extension_dir }}'
   register: extension_directory
 
 - name: ensure that extension directory exists
@@ -30,14 +32,14 @@
 - name: copy control file
   copy:
     src: dummy.control
-    dest: '{{ postgresql_ext_dir }}'
+    dest: '{{ pg_extension_dir }}'
     mode: 0444
     owner: '{{ extension_directory.stat.pw_name }}'
 
 - name: copy extension files
   copy:
     src: 'dummy--{{ item }}.sql'
-    dest: '{{ postgresql_ext_dir }}'
+    dest: '{{ pg_extension_dir }}'
     mode: 0444
     owner: '{{ extension_directory.stat.pw_name }}'
   with_items:

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -133,3 +133,5 @@
 
 - name: restart postgresql service
   service: name={{ postgresql_service }} state=restarted
+
+- import_tasks: create_dummy_extension.yml

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -134,4 +134,14 @@
 - name: restart postgresql service
   service: name={{ postgresql_service }} state=restarted
 
+- name: Check if extension are supported
+  # extension supported since PostgreSQL 9.1
+  shell: echo "select pg_available_extensions();" | psql -d postgres
+  register: extension_supported
+  ignore_errors: True
+
+- set_fact:
+    pg_extension_supported: '{{ extension_supported|success }}'
+
 - import_tasks: create_dummy_extension.yml
+  when: pg_extension_supported

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -137,6 +137,8 @@
 - name: Check if extension are supported
   # extension supported since PostgreSQL 9.1
   shell: echo "select pg_available_extensions();" | psql -d postgres
+  become_user: "{{ pg_user }}"
+  become: True
   register: extension_supported
   ignore_errors: True
 

--- a/test/integration/targets/setup_postgresql_db/vars/Debian-8.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Debian-8.yml
@@ -5,4 +5,5 @@ postgresql_packages:
 
 pg_hba_location: "/etc/postgresql/9.4/main/pg_hba.conf"
 pg_dir: "/var/lib/postgresql/9.4/main"
+pg_extension_dir: '/usr/share/postgresql/9.4/extension'
 pg_ver: 9.4

--- a/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
@@ -4,6 +4,7 @@ postgresql_packages:
 
 pg_hba_location: "/usr/local/pgsql/data/pg_hba.conf"
 pg_dir: "/usr/local/pgsql/data"
+pg_extension_dir: '/usr/local/share/postgresql/extension'
 pg_ver: 9.5
 pg_user: pgsql
 pg_group: pgsql

--- a/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/FreeBSD.yml
@@ -5,7 +5,6 @@ postgresql_packages:
 pg_hba_location: "/usr/local/pgsql/data/pg_hba.conf"
 pg_dir: "/usr/local/pgsql/data"
 pg_extension_dir: '/usr/local/share/postgresql/extension'
-pg_ver: 9.5
 pg_user: pgsql
 pg_group: pgsql
 

--- a/test/integration/targets/setup_postgresql_db/vars/RedHat.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/RedHat.yml
@@ -5,3 +5,6 @@ postgresql_packages:
 
 pg_hba_location: "/var/lib/pgsql/data/pg_hba.conf"
 pg_dir: "/var/lib/pgsql/data"
+# pg_extension_dir not set here because path contains PostgreSQL version which
+# is not the same for all RedHat based distributions (pg_ver is used only for
+# tasks run on Debian based distributions).

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-12.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-12.yml
@@ -5,4 +5,5 @@ postgresql_packages:
 
 pg_hba_location: "/etc/postgresql/9.1/main/pg_hba.conf"
 pg_dir: "/var/lib/postgresql/9.1/main"
+pg_extension_dir: "/usr/share/postgresql/9.1/extension"
 pg_ver: 9.1

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-14.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-14.yml
@@ -5,4 +5,5 @@ postgresql_packages:
 
 pg_hba_location: "/etc/postgresql/9.3/main/pg_hba.conf"
 pg_dir: "/var/lib/postgresql/9.3/main"
+pg_extension_dir: "/usr/share/postgresql/9.3/extension"
 pg_ver: 9.3

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16-py3.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16-py3.yml
@@ -5,4 +5,5 @@ postgresql_packages:
 
 pg_hba_location: "/etc/postgresql/9.5/main/pg_hba.conf"
 pg_dir: "/var/lib/postgresql/9.5/main"
+pg_extension_dir: "/usr/share/postgresql/9.5/extension"
 pg_ver: 9.5

--- a/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16.yml
+++ b/test/integration/targets/setup_postgresql_db/vars/Ubuntu-16.yml
@@ -5,4 +5,5 @@ postgresql_packages:
 
 pg_hba_location: "/etc/postgresql/9.5/main/pg_hba.conf"
 pg_dir: "/var/lib/postgresql/9.5/main"
+pg_extension_dir: "/usr/share/postgresql/9.5/extension"
 pg_ver: 9.5

--- a/test/units/module_utils/test_postgresql.py
+++ b/test/units/module_utils/test_postgresql.py
@@ -4,15 +4,20 @@ import sys
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import patch, MagicMock
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import basic
 from ansible.module_utils.six.moves import builtins
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_bytes
 from units.mock.procenv import swap_stdin_and_argv
 
 
 import pprint
 
 realimport = builtins.__import__
+
+
+class MockCursor(object):
+    def execute(self, query, vars=None):
+        return query
 
 
 class TestPostgres(unittest.TestCase):
@@ -33,6 +38,7 @@ class TestPostgres(unittest.TestCase):
         mod = builtins.__import__('ansible.module_utils.postgres')
 
         self.assertFalse(mod.module_utils.postgres.HAS_PSYCOPG2)
+        self.assertFalse(mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT)
 
         with self.assertRaises(mod.module_utils.postgres.LibraryError) as context:
             mod.module_utils.postgres.ensure_libs(sslrootcert=None)
@@ -50,6 +56,7 @@ class TestPostgres(unittest.TestCase):
         mod = builtins.__import__('ansible.module_utils.postgres')
 
         self.assertTrue(mod.module_utils.postgres.HAS_PSYCOPG2)
+        self.assertTrue(mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT)
 
         ensure_ret = mod.module_utils.postgres.ensure_libs(sslrootcert=None)
         self.assertFalse(ensure_ret)
@@ -73,3 +80,54 @@ class TestPostgres(unittest.TestCase):
         with self.assertRaises(mod.module_utils.postgres.LibraryError) as context:
             mod.module_utils.postgres.ensure_libs(sslrootcert='yes')
         self.assertIn('psycopg2 must be at least 2.4.3 in order to use', to_native(context.exception))
+
+    @patch.object(builtins, '__import__')
+    def test_escape_identifier_cursor(self, mock_import):
+        self._psycopg2_mock = MagicMock()
+        self._psycopg2_mock.__version__ = '2.4.1'
+        self._psycopg2_mock.quote_ident.return_value = 'quote_ident'
+
+        def _mock_import(name, *args, **kwargs):
+            if 'psycopg2' in name:
+                return self._psycopg2_mock
+            return realimport(name, *args, **kwargs)
+
+        # module.warning required needed for escape_identifier_cursor
+        args = json.dumps({'ANSIBLE_MODULE_ARGS': {}})
+        basic._ANSIBLE_ARGS = to_bytes(args)
+        module = basic.AnsibleModule({})
+
+        self.clear_modules(['psycopg2.extras', 'psycopg2.extensions', 'psycopg2', 'ansible.module_utils.postgres'])
+        mock_import.side_effect = _mock_import
+        mod = builtins.__import__('ansible.module_utils.postgres')
+
+        klass = mod.module_utils.postgres.escape_identifier_cursor(module, MockCursor)
+        cursor = klass()
+
+        with patch.object(cursor, 'escape_identifier', return_value='escape_identifier',
+                          autospec=True) as mock_escape_identifier:
+
+            mod.module_utils.postgres.HAS_PSYCOPG2 = True
+            mod.module_utils.postgres.HAS_LIBPQ_QUOTE_IDENT = False
+            mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT = False
+            ret = cursor.execute('select * from ${table}', identifiers={'table': 'users'})
+            self.assertEqual(self._psycopg2_mock.quote_ident.call_count, 0)
+            self.assertEqual(mock_escape_identifier.call_count, 0)
+            self.assertEqual(mock_escape_identifier.call_count, 0)
+            self.assertEqual(ret, 'select * from %(table)s')
+
+            mod.module_utils.postgres.HAS_PSYCOPG2 = True
+            mod.module_utils.postgres.HAS_LIBPQ_QUOTE_IDENT = True
+            mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT = True
+            ret = cursor.execute('select * from ${table}', identifiers={'table': 'users'})
+            self.assertEqual(self._psycopg2_mock.quote_ident.call_count, 1)
+            self.assertEqual(mock_escape_identifier.call_count, 0)
+            self.assertEqual(ret, 'select * from quote_ident')
+
+            mod.module_utils.postgres.HAS_PSYCOPG2 = True
+            mod.module_utils.postgres.HAS_PSYCOPG2_QUOTE_IDENT = False
+            mod.module_utils.postgres.HAS_LIBPQ_QUOTE_IDENT = True
+            ret = cursor.execute('select * from ${table}', identifiers={'table': 'users'})
+            self.assertEqual(self._psycopg2_mock.quote_ident.call_count, 1)
+            self.assertEqual(mock_escape_identifier.call_count, 1)
+            self.assertEqual(ret, 'select * from escape_identifier')


### PR DESCRIPTION
##### SUMMARY
PostgreSQL `module_utils`: allow to escape identifiers.

This pull request will allow PostgreSQL modules to escape identifiers, either using Psycopg2 (2.7 required) or libpq (9.0 required). When both are unavailable, only unquoted identifiers are allowed.

As an example, `postgresql_ext` module is updated in order to use `escape_identifier_cursor`, that's why this pull request branch is based on [strk:postgresql_ext_version](#26737) branch. Take a look at the last three commits only.

unit tests provided.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/postgres.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```