### PR TITLE
Adds sub-interface support for nxos_interface and nxos_ip_interface

### DIFF
--- a/test/units/modules/network/nxos/test_nxos_ip_interface.py
+++ b/test/units/modules/network/nxos/test_nxos_ip_interface.py
@@ -58,7 +58,6 @@ class TestNxosIPInterfaceModule(TestNxosModule):
         self.assertEqual(result['commands'],
                          ['interface eth2/1',
                           'no ip address 1.1.1.1/8',
-                          'interface eth2/1',
                           'ip address 1.1.1.2/8'])
 
     def test_nxos_ip_interface_ip_idempotent(self):


### PR DESCRIPTION
##### SUMMARY
Existing modules didn't have sub-interface configuration support.

- Adds sub-interface support for nxos_interface and nxos_ip_interface
 - Support dot1q encapsulation on routed sub-interface

Fixes #29164 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/nxos

##### ANSIBLE VERSION
```
devel(2.5.0)
```
