### PR TITLE
fix typos in slack callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/slack.py
+++ b/lib/ansible/plugins/callback/slack.py
@@ -90,9 +90,9 @@ class CallbackModule(CallbackBase):
                                   'installed. Disabling the Slack callback '
                                   'plugin.')
 
-        self.webhook_url = self._plugin_options['webook_url']
-        self.channel = self._plugin_options['channel']
-        self.username = self._plugin_options['username']
+        self.webhook_url = self._plugin_options.get('webhook_url')
+        self.channel = self._plugin_options.get('channel')
+        self.username = self._plugin_options.get('username')
         self.show_invocation = (self._display.verbosity > 1)
 
         if self.webhook_url is None:


### PR DESCRIPTION
##### SUMMARY

There were two issues:

1. there was a typo in key name ('webook_url' vs 'webhook_url')
2. `_plugin_options` can be an empty dict, so we should use `.get()` instead of `[]`

This is pr #30838 rebased on devel branch.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`plugins/callback/slack`

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/hiciu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Before:
```
2017-09-25 14:01:12,741 p=46127 u=hiciu |   [WARNING]: The `prettytable` python module is not installed. Disabling the
Slack callback plugin.

2017-09-25 14:01:12,742 p=46127 u=hiciu |  ERROR! Unexpected Exception, this is probably a bug: 'webook_url'
2017-09-25 14:01:12,742 p=46127 u=hiciu |  to see the full traceback, use -vvv
2017-09-25 14:01:12,744 p=46127 u=hiciu |  the full traceback was:
Traceback (most recent call last):
  File "/usr/bin/ansible-playbook", line 106, in <module>
    exit_code = cli.run()
  File "/usr/lib/python2.7/site-packages/ansible/cli/playbook.py", line 130, in run
    results = pbex.run()
  File "/usr/lib/python2.7/site-packages/ansible/executor/playbook_executor.py", line 90, in run
    self._tqm.load_callbacks()
  File "/usr/lib/python2.7/site-packages/ansible/executor/task_queue_manager.py", line 202, in load_callbacks
    callback_obj = callback_plugin()
  File "/usr/lib/python2.7/site-packages/ansible/plugins/callback/slack.py", line 93, in __init__
    self.webhook_url = self._plugin_options['webook_url']
KeyError: 'webook_url'
```

After:
```
2017-09-25 14:24:49,633 p=53921 u=hiciu |   [WARNING]: The `prettytable` python module is not installed. Disabling the
Slack callback plugin.
2017-09-25 14:24:49,634 p=53921 u=hiciu |   [WARNING]: Slack Webhook URL was not provided. The Slack Webhook URL can be
provided using the `SLACK_WEBHOOK_URL` environment variable.
```