### PR TITLE
modify class TimeoutError

### DIFF
--- a/lib/ansible/module_utils/facts/timeout.py
+++ b/lib/ansible/module_utils/facts/timeout.py
@@ -25,7 +25,7 @@ GATHER_TIMEOUT = None
 DEFAULT_GATHER_TIMEOUT = 10
 
 
-class TimeoutError(Exception):
+class TimeoutError(BaseException):
     pass
 
 


### PR DESCRIPTION
##### SUMMARY
When setup module works with long time self.module.run_command,
the TimeoutError will been except by the following code of **ansible/lib/ansible/module_utils/basic.py**
```
except Exception as e:
    self.log("Error Executing CMD:%s Exception:%s" % (clean_args, to_native(traceback.format_exc())))
    self.fail_json(rc=257, msg=to_native(e), exception=traceback.format_exc(), cmd=clean_args)
```

so unfortunately, setup module returns an error because the individual task runs out of time.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
setup

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules']
  python version = 2.7.13 (default, Jul 20 2017, 16:11:29) [GCC 4.4.7 20120313 (Red Hat 4.4.7-18)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
#Before
class TimeoutError(Exception): 
     pass

#After
class TimeoutError(BaseException):
     pass
```
