### PR TITLE
nxos_vpc/nxos_vpc_interface fix for n1 images

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vpc.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc.py
@@ -181,7 +181,7 @@ def get_vpc(module):
         pkl_vrf = None
         peer_gw = False
 
-        run = get_config(module, flags=['section vpc'])
+        run = get_config(module, flags=['vpc'])
         if run:
             vpc_list = run.split('\n')
             for each in vpc_list:

--- a/lib/ansible/modules/network/nxos/nxos_vpc_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_vpc_interface.py
@@ -131,7 +131,7 @@ def get_existing_portchannel_to_vpc_mappings(module):
 
 def peer_link_exists(module):
     found = False
-    run = get_config(module, flags=['section vpc'])
+    run = get_config(module, flags=['vpc'])
 
     vpc_list = run.split('\n')
     for each in vpc_list:
@@ -262,9 +262,10 @@ def main():
     active_peer_link = None
 
     if portchannel not in get_portchannel_list(module):
-        module.fail_json(msg="The portchannel you are trying to make a"
-                             " VPC or PL is not created yet. "
-                             "Create it first!")
+        if not portchannel.isdigit() or int(portchannel) not in get_portchannel_list(module):
+            module.fail_json(msg="The portchannel you are trying to make a"
+                                 " VPC or PL is not created yet. "
+                                 "Create it first!")
     if vpc:
         mapping = get_existing_portchannel_to_vpc_mappings(module)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30846. 
- change `show running section vpc` to `show running vpc`
- on N1 platforms `show port-channel summary | json` returns the group as int as compared to a string on other platforms. Handled this nxos variancy in the module.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_vpc
- nxos_vpc_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0 (detached HEAD d14467b029) last updated 2017/09/22 13:55:10 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```