### PR TITLE
ec2_instance_facts: requires boto3 and botocore

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_instance_facts.py
@@ -20,6 +20,7 @@ version_added: "2.4"
 author:
   - Michael Schuett, @michaeljs1990
   - Rob White, @wimnat
+requirements: [ "boto3", "botocore" ]
 options:
   instance_ids:
     description:


### PR DESCRIPTION
##### SUMMARY
This is a new module in 2.4 and it requires boto3 and botocore.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_instance_facts.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
```
