### PR TITLE
Better error message when file lookup fails

### DIFF
--- a/lib/ansible/plugins/lookup/__init__.py
+++ b/lib/ansible/plugins/lookup/__init__.py
@@ -118,6 +118,6 @@ class LookupBase(with_metaclass(ABCMeta, object)):
             result = self._loader.path_dwim_relative_stack(paths, subdir, needle)
         except AnsibleFileNotFound:
             if not ignore_missing:
-                self._display.warning("Unable to find '%s' in expected paths." % needle)
+                self._display.warning("Unable to find '%s' in expected paths (use -vvvvv to see paths)" % needle)
 
         return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change alerts the user to a debug command that will show them what they need to fix their playbook. Ideally the debug information would be shown to them when they get the error, but this is better than the current situation.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Lookup plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
```
