### PR TITLE
added name parameter

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -187,8 +187,8 @@ def main():
         api_data = get_api_definitions(module, swagger_file=swagger_file,
                                        swagger_dict=swagger_dict, swagger_text=swagger_text)
         conf_res, dep_res, ren_res = ensure_api_in_correct_state(module, client, name=name,
-                                                        api_id=api_id, api_data=api_data,
-                                                        stage=stage, deploy_desc=deploy_desc)
+                                                                  api_id=api_id, api_data=api_data,
+                                                                  stage=stage, deploy_desc=deploy_desc)
     if state == "absent":
         del_res = delete_rest_api(module, client, api_id)
 

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -34,6 +34,7 @@ options:
     description:
       - The name of the API to manage.  If api_id is None, then the name will be
         used to lookup the api_id.  This means the name should be unique.
+    version_added: '2.5'
   api_id:
     description:
       - The ID of the API you want to manage.

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -188,8 +188,8 @@ def main():
         api_data = get_api_definitions(module, swagger_file=swagger_file,
                                        swagger_dict=swagger_dict, swagger_text=swagger_text)
         conf_res, dep_res, ren_res = ensure_api_in_correct_state(module, client, name=name,
-                                                                  api_id=api_id, api_data=api_data,
-                                                                  stage=stage, deploy_desc=deploy_desc)
+                                                                 api_id=api_id, api_data=api_data,
+                                                                 stage=stage, deploy_desc=deploy_desc)
     if state == "absent":
         del_res = delete_rest_api(module, client, api_id)
 

--- a/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
+++ b/lib/ansible/modules/cloud/amazon/aws_api_gateway.py
@@ -30,7 +30,7 @@ description:
 version_added: '2.4'
 requirements: [ boto3 ]
 options:
-   name:
+  name:
     description:
       - The name of the API to manage.  If api_id is None, then the name will be
         used to lookup the api_id.  This means the name should be unique.
@@ -186,9 +186,9 @@ def main():
             api_id = create_empty_api(module, client)
         api_data = get_api_definitions(module, swagger_file=swagger_file,
                                        swagger_dict=swagger_dict, swagger_text=swagger_text)
-        conf_res, dep_res, ren_res = ensure_api_in_correct_state(module, client, name=name, api_id=api_id,
-                                                        api_data=api_data, stage=stage,
-                                                        deploy_desc=deploy_desc)
+        conf_res, dep_res, ren_res = ensure_api_in_correct_state(module, client, name=name,
+                                                        api_id=api_id, api_data=api_data,
+                                                        stage=stage, deploy_desc=deploy_desc)
     if state == "absent":
         del_res = delete_rest_api(module, client, api_id)
 
@@ -359,6 +359,7 @@ def create_deployment(client, api_id=None, stage=None, description=None):
     # we can also get None as an argument so we don't do this as a defult
     return client.create_deployment(restApiId=api_id, stageName=stage, description=description)
 
+
 @AWSRetry.backoff(**retry_params)
 def get_rest_apis(client, limit=500):
     return client.get_rest_apis(limit=limit)
@@ -368,9 +369,9 @@ def get_rest_apis(client, limit=500):
 def rename_api(client, name, api_id):
     operations = [
         {
-            'op':'replace',
-            'path':'/name',
-            'value':name
+            'op': 'replace',
+            'path': '/name',
+            'value': name
         }
     ]
     return client.update_rest_api(restApiId=api_id, patchOperations=operations)


### PR DESCRIPTION
##### SUMMARY
Added a name parameter.  The name would be used as the title for the API and would be used as a unique identifier.  As mentioned in the module already, there's no real way of having a unique identifier on the APIs, but you can use the name as a convention to be unique.

The change facilitates using the name as a unique identifier, only coming into play when the api_id is omitted.  It looks up all the APIs and gets the api_id of the first API with the name.  The modification also renames the API if the swagger info changes it.  As a side effect, the Swagger info.title can be omitted also.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aws_api_gateway

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.2 (default, Sep 13 2017, 14:26:54) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Added
    "rename_response": {
        "created_date": "2017-09-25T21:27:55+00:00", 
        "id": "xxxx", 
        "name": "my-api", 
        "response_metadata": {
            "http_headers": {
                "connection": "keep-alive", 
                "content-length": "108", 
                "content-type": "application/json", 
                "date": "Mon, 25 Sep 2017 21:28:21 GMT", 
                "x-amzn-requestid": "12345"
            }, 
            "http_status_code": 200, 
            "request_id": "12345", 
            "retry_attempts": 0
        }
    }
```
