### PR TITLE
Consul inventory script - Add environmental variable support

### DIFF
--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -49,12 +49,14 @@ Other options include:
 'datacenter':
 
 which restricts the included nodes to those from the given datacenter
+This can also be set with the environmental variable CONSUL_DATACENTER
 
 'url':
 
 the URL of the Consul cluster. host, port and scheme are derived from the
 URL. If not specified, connection configuration defaults to http requests
 to localhost on port 8500.
+This can also be set with the environmental variable CONSUL_URL
 
 'domain':
 
@@ -416,6 +418,7 @@ class ConsulConfig(dict):
     def __init__(self):
         self.read_settings()
         self.read_cli_args()
+        self.read_env_vars()
 
     def has_config(self, name):
         if hasattr(self, name):
@@ -459,6 +462,14 @@ class ConsulConfig(dict):
         for arg in arg_names:
             if getattr(args, arg):
                 setattr(self, arg, getattr(args, arg))
+
+    def read_env_vars(self):
+        env_var_options = ['datacenter', 'url']
+        for option in env_var_options:
+            value = None
+            env_var = 'CONSUL_' + option.upper()
+            if os.environ.get(env_var):
+                setattr(self, option, os.environ.get(env_var))
 
     def get_availability_suffix(self, suffix, default):
         if self.has_config(suffix):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This change adds environmental variable support for the URL and Data center config options in the consul_io.py inventory script. 

This allows the script to be used without the consul_io.ini configuration file being present this is very useful when running from Tower or AWX. The environmental variables are CONSUL_DATACENTER and CONSUL_URL and are fully backwards compatible with values set in the config file but will take precedence over values from args or config file. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/consul_io.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/user/Virtualenvs/ansible2.4/lib/python2.7/site-packages/ansible
  executable location = /Users/user/Virtualenvs/ansible2.4/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

$ ./consul_io.py --list
{
  "_meta": {
    "hostvars": {
      "10.150.75.30": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul1",
        "consul_services": [
          "consul"
        ]
      },
      "10.150.75.40": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul2",
        "consul_services": [
          "consul"
        ]
      },
      "10.150.75.50": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul3",
        "consul_services": [
          "consul"
        ]
      }
    }
  },
  "all": [
    "10.150.75.30",
    "10.150.75.40",
    "10.150.75.50"
  ],
  "consul": [
    "10.150.75.30",
    "10.150.75.40",
    "10.150.75.50"
  ],
  "dc1": [
    "10.150.75.30",
    "10.150.75.40",
    "10.150.75.50"
  ]
}


export CONSUL_URL=http://consul.test.systems:8500
export CONSUL_DATACENTER=dc1
$ ./consul_io.py --list
{
  "_meta": {
    "hostvars": {
      "10.150.75.30": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul1",
        "consul_services": [
          "consul"
        ]
      },
      "10.150.75.40": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul2",
        "consul_services": [
          "consul"
        ]
      },
      "10.150.75.50": {
        "consul_datacenter": "dc1",
        "consul_nodename": "consul3",
        "consul_services": [
          "consul"
        ]
      }
    }
  },
  "all": [
    "10.150.75.30",
    "10.150.75.40",
    "10.150.75.50"
  ],
  "consul": [
    "10.150.75.30",
    "10.150.75.40",
    "10.150.75.50"
  ],
  "dc1": [
    "10.150.75.30",
    "10.150.75.40",
    "10.150.75.50"
  ]
}


```
