### PR TITLE
aws_s3: Don't remove profile, security_token by default

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -604,8 +604,9 @@ def main():
 
     # Look at s3_url and tweak connection settings
     # if connecting to RGW, Walrus or fakes3
-    for key in ['validate_certs', 'security_token', 'profile_name']:
-        aws_connect_kwargs.pop(key, None)
+    if s3_url:
+        for key in ['validate_certs', 'security_token', 'profile_name']:
+            aws_connect_kwargs.pop(key, None)
     try:
         s3 = get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url)
     except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound) as e:


### PR DESCRIPTION


##### SUMMARY
Currently the aws_s3 module deletes the security_token and profile_name
values from the connection parameters, thus breaking S3 for anyone using profiles or STS.

Comment above suggests only removing the values for non-S3 services, so let's just do that.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION

```
ansible 2.5.0 (devel cb5f2c7ac3) last updated 2017/09/26 11:45:15 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
Must be backported to stable-2.4