### PR TITLE
Remove print statements from play_context

### DIFF
--- a/lib/ansible/playbook/play_context.py
+++ b/lib/ansible/playbook/play_context.py
@@ -533,8 +533,6 @@ class PlayContext(Base):
             # set flags to use for the privilege escalation method, with various overrides
             flags = self.become_flags or getattr(self, '%s_flags' % self.become_method, '')
 
-            print(exe)
-            print(flags)
             if self.become_method == 'sudo':
                 # If we have a password, we run sudo with a randomly-generated
                 # prompt set using -p. Otherwise we run it with default -n, which makes


### PR DESCRIPTION
##### SUMMARY
The `print` statements in play_context cause spurious output, particularly obvious when in `become` mode
fixes #30893
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
play_context

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel cb5f2c7ac3) last updated 2017/09/26 11:45:15 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
