### PR TITLE
Fix documentation of "state" param

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -33,7 +33,7 @@ options:
     state:
         description: ["The designated state of the monitor."]
         required: true
-        choices: ['present', 'absent', 'muted', 'unmuted']
+        choices: ['present', 'absent', 'mute', 'unmute']
     tags:
         description: ["A list of tags to associate with your monitor when creating or updating. This can help you categorize and filter monitors."]
         required: false


### PR DESCRIPTION
##### SUMMARY
The current module documentation point to misspelled parameter values for parameter "state". 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/monitoring/datadog_monitor.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jun 27 2017, 15:16:43) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```