### PR TITLE
EC2_AMI - fix for failing test

### DIFF
--- a/test/integration/targets/ec2_ami/tasks/main.yml
+++ b/test/integration/targets/ec2_ami/tasks/main.yml
@@ -158,7 +158,7 @@
       assert:
         that:
           - "result.failed"
-          - "result.msg == 'image_id needs to be an ami image to registered/delete'"
+          - "result.msg == 'state is absent but the following are missing&#58; image_id'"
 
     # ============================================================
 


### PR DESCRIPTION
##### SUMMARY
This is a fix for a test that was failing in the ec2 ami integration tests in #30435 used for #28506 .

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/ec2_ami/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (ec2_ami_test_fix dce716019d) last updated 2017/09/26 20:29:53 (GMT +1100)
  config file = None
  configured module search path = [u'/Users/willvk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/willvk/Source/gits/ansibles/ansible/lib/ansible
  executable location = /Users/willvk/Source/gits/ansibles/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```