### PR TITLE
facts: fix SPARC cpu count on linux

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -193,6 +193,7 @@ class LinuxHardware(Hardware):
 
             # model name is for Intel arch, Processor (mind the uppercase P)
             # works for some ARM devices, like the Sheevaplug.
+            # 'ncpus active' is SPARC attribute
             if key in ['model name', 'Processor', 'vendor_id', 'cpu', 'Vendor', 'processor']:
                 if 'processor' not in cpu_facts:
                     cpu_facts['processor'] = []
@@ -216,6 +217,8 @@ class LinuxHardware(Hardware):
                 cores[coreid] = int(data[1].strip())
             elif key == '# processors':
                 cpu_facts['processor_cores'] = int(data[1].strip())
+            elif key == 'ncpus active':
+                i = int(data[1].strip())
 
         # Skip for platforms without vendor_id/model_name in cpuinfo (e.g ppc64le)
         if vendor_id_occurrence > 0:


### PR DESCRIPTION
On sparc64, /proc/cpuinfo has no usual 'model name', 'Processor', 'vendor_id', 'Vendor',
as a result "ansible_processor_vcpus" is always 1.
Add check element "ncpus active" to fix the issue.

Without a patch:

$ ansible localhost -m setup -a 'filter=ansible_processor*'
[WARNING]: provided hosts list is empty, only localhost is available

localhost | SUCCESS => {
"ansible_facts": {
"ansible_processor": [
"UltraSparc T5 (Niagara5)"
],
"ansible_processor_cores": 1,
"ansible_processor_count": 1,
"ansible_processor_threads_per_core": 1,
"ansible_processor_vcpus": 1
},
"changed": false
}

with the patch:

$ ansible localhost -m setup -a 'filter=ansible_processor*'
[WARNING]: provided hosts list is empty, only localhost is available

localhost | SUCCESS => {
"ansible_facts": {
"ansible_processor": [
"UltraSparc T5 (Niagara5)"
],
"ansible_processor_cores": 1,
"ansible_processor_count": 8,
"ansible_processor_threads_per_core": 1,
"ansible_processor_vcpus": 8
},
"changed": false
}

$ cat /proc/cpuinfo
cpu : UltraSparc T5 (Niagara5)
fpu : UltraSparc T5 integrated FPU
pmu : niagara5
prom : OBP 4.38.8 2017/02/22 13:51
type : sun4v
ncpus probed : 8
ncpus active : 8
D$ parity tl1 : 0
I$ parity tl1 : 0
cpucaps : flush,stbar,swap,muldiv,v9,blkinit,n2,mul32,div32,v8plus,popc,vis,vis2,ASIBlkInit,fmaf,vis3,hpc,ima,pause,cbcond,aes,des,kasumi,camellia,md5,sha1,sha256,sha512,mpmul,montmul,montsqr,crc32c
Cpu0ClkTck : 00000000d6924470
Cpu1ClkTck : 00000000d6924470
Cpu2ClkTck : 00000000d6924470
Cpu3ClkTck : 00000000d6924470
Cpu4ClkTck : 00000000d6924470
Cpu5ClkTck : 00000000d6924470
Cpu6ClkTck : 00000000d6924470
Cpu7ClkTck : 00000000d6924470
MMU Type : Hypervisor (sun4v)
MMU PGSZs : 8K,64K,4MB,256MB,2GB
State:
CPU0: online
CPU1: online
CPU2: online
CPU3: online
CPU4: online
CPU5: online
CPU6: online
CPU7: online

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
