### PR TITLE
fixes issue where filter wouldn't error on undefined var

### DIFF
--- a/lib/ansible/module_utils/network_common.py
+++ b/lib/ansible/module_utils/network_common.py
@@ -35,7 +35,7 @@ from ansible.module_utils.six import iteritems, string_types
 from ansible.module_utils.basic import AnsibleFallbackNotFound
 
 try:
-    from jinja2 import Environment
+    from jinja2 import Environment, StrictUndefined
     from jinja2.exceptions import UndefinedError
     HAS_JINJA2 = True
 except ImportError:
@@ -376,11 +376,12 @@ class Template:
             raise ImportError("jinja2 is required but does not appear to be installed.  "
                               "It can be installed using `pip install jinja2`")
 
-        self.env = Environment()
+        self.env = Environment(undefined=StrictUndefined)
         self.env.filters.update({'ternary': ternary})
 
     def __call__(self, value, variables=None, fail_on_undefined=True):
         variables = variables or {}
+
         if not self.contains_vars(value):
             return value
 
@@ -398,13 +399,6 @@ class Template:
                 return str(value)
         else:
             return None
-
-    def can_template(self, tmpl):
-        try:
-            self(tmpl)
-            return True
-        except:
-            return False
 
     def contains_vars(self, data):
         if isinstance(data, string_types):

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -84,9 +84,11 @@ def parse_cli(output, tmpl):
     for name, attrs in iteritems(spec['keys']):
         value = attrs['value']
 
-        if template.can_template(value):
+        try:
             variables = spec.get('vars', {})
             value = template(value, variables)
+        except:
+            pass
 
         if 'start_block' in attrs and 'end_block' in attrs:
             start_block = re.compile(attrs['start_block'])


### PR DESCRIPTION
The filter will now correctly error on an undefined variable when trying
to template the key `value`

