### PR TITLE
remove 'new internal vars' from dumps

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -30,8 +30,15 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-INTERNAL_VARS = frozenset(['ansible_facts', 'ansible_version',
+INTERNAL_VARS = frozenset(['ansible_diff_mode',
+                           'ansible_facts',
+                           'ansible_forks',
+                           'ansible_inventory_sources',
+                           'ansible_limit',
                            'ansible_playbook_python',
+                           'ansible_run_tags',
+                           'ansible_skip_tags',
+                           'ansible_version',
                            'inventory_dir',
                            'inventory_file',
                            'inventory_hostname',


### PR DESCRIPTION
##### SUMMARY

fixes #30924

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```