### PR TITLE
ovirt_hosts: print error when host for iscsi login not found

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -241,6 +241,7 @@ from ansible.module_utils.ovirt import (
     create_connection,
     equal,
     get_entity,
+    get_id_by_name,
     ovirt_full_argument_spec,
     search_by_name,
     wait,
@@ -262,8 +263,8 @@ class StorageDomainModule(BaseModule):
     def _login(self, storage_type, storage):
         if storage_type == 'iscsi':
             hosts_service = self._connection.system_service().hosts_service()
-            host = search_by_name(hosts_service, self._module.params['host'])
-            hosts_service.host_service(host.id).iscsi_login(
+            host_id = get_id_by_name(hosts_service, self._module.params['host'])
+            hosts_service.host_service(host_id).iscsi_login(
                 iscsi=otypes.IscsiDetails(
                     username=storage.get('username'),
                     password=storage.get('password'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When host for adding ISCSI storage is not found , we need to print reasonable error.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_storage_domains

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.3.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Task:
```yaml
 - ovirt_storage_domains:
            auth: "{{ ovirt_auth }}"
            name: '{{name_of_storage_domain}}'
            host: "{{my_host}}"
            data_center: "Default"
            timeout: 360
            state: 'present'
            wait: True
            iscsi:
              target: "{{iscsi_target_wwn}}"
              lun_id: "{{iscsi_target_LUN}}"
              address: "{{iscsi_target_ip}}"
              override_luns: True
```

Before:
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_DsQAjY/ansible_module_ovirt_storage_domains.py", line 447, in main
    sd_id = storage_domains_module.create()['id']
  File "/tmp/ansible_DsQAjY/ansible_modlib.zip/ansible/module_utils/ovirt.py", line 573, in create
    self.build_entity(),
  File "/tmp/ansible_DsQAjY/ansible_module_ovirt_storage_domains.py", line 236, in build_entity
    self._login(storage_type, storage)
  File "/tmp/ansible_DsQAjY/ansible_module_ovirt_storage_domains.py", line 224, in _login
    hosts_service.host_service(host.id).iscsi_login(
AttributeError: 'NoneType' object has no attribute 'id'
```

After:
```
Exception: Entity 'host1' was not found.
```