### PR TITLE
fixed  pull's ansible/git invocation options

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -159,6 +159,7 @@ class PullCLI(CLI):
         # Attempt to use the inventory passed in as an argument
         # It might not yet have been downloaded so use localhost as default
         inv_opts = ''
+        host_opts = 'all'
         if getattr(self.options, 'inventory'):
             for inv in self.options.inventory:
                 if isinstance(inv, list):
@@ -167,6 +168,10 @@ class PullCLI(CLI):
                     inv_opts += ' -i %s ' % inv
         else:
             inv_opts = "-i 'localhost,'"
+
+        # use localhost instead of all if no usable inventory and need implicit
+        if not inv_opts:
+            host_opts = 'localhost'
 
         # FIXME: enable more repo modules hg/svn?
         if self.options.module_name == 'git':
@@ -198,7 +203,7 @@ class PullCLI(CLI):
 
         bin_path = os.path.dirname(os.path.abspath(sys.argv[0]))
         # hardcode local and inventory/host as this is just meant to fetch the repo
-        cmd = '%s/ansible %s %s -m %s -a "%s" all -l "%s"' % (bin_path, inv_opts, base_opts, self.options.module_name, repo_opts, limit_opts)
+        cmd = '%s/ansible %s %s -m %s -a "%s" "%s" -l "%s"' % (bin_path, inv_opts, base_opts, self.options.module_name, repo_opts, host_opts, limit_opts)
 
         for ev in self.options.extra_vars:
             cmd += ' -e "%s"' % ev

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -239,7 +239,6 @@ class PullCLI(CLI):
             for vault_password_file in self.options.vault_password_files:
                 cmd += " --vault-password-file=%s" % vault_password_file
 
-
         for ev in self.options.extra_vars:
             cmd += ' -e "%s"' % ev
         if self.options.ask_sudo_pass or self.options.ask_su_pass or self.options.become_ask_pass:


### PR DESCRIPTION
##### SUMMARY
now falls back to using localhost as 'all' does not include implicit accidentally anymore

fixes #30636

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-pull

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```