### PR TITLE
facts: add bios / firmware versions for Linux on SPARC64 and PPC64

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -81,7 +81,7 @@ class LinuxHardware(Hardware):
 
         cpu_facts = self.get_cpu_facts(collected_facts=collected_facts)
         memory_facts = self.get_memory_facts()
-        dmi_facts = self.get_dmi_facts()
+        dmi_facts = self.get_dmi_facts(collected_facts=collected_facts)
         device_facts = self.get_device_facts()
         uptime_facts = self.get_uptime_facts()
         lvm_facts = self.get_lvm_facts()
@@ -255,13 +255,14 @@ class LinuxHardware(Hardware):
 
         return cpu_facts
 
-    def get_dmi_facts(self):
+    def get_dmi_facts(self, collected_facts=None):
         ''' learn dmi facts from system
 
         Try /sys first for dmi related facts.
         If that is not available, fall back to dmidecode executable '''
 
         dmi_facts = {}
+        collected_facts = collected_facts or {}
 
         if os.path.exists('/sys/devices/virtual/dmi/id/product_name'):
             # Use kernel DMI info, if available

--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -329,6 +329,20 @@ class LinuxHardware(Hardware):
                         dmi_facts[k] = 'NA'
                 else:
                     dmi_facts[k] = 'NA'
+                if k == 'bios_version':
+                    # process firmware/bios version info for Linux on SPARC64 and PPC64 architectures
+                    if collected_facts.get('ansible_architecture') == 'sparc64':
+                        if os.access('/proc/cpuinfo', os.R_OK):
+                            for line in get_file_lines('/proc/cpuinfo'):
+                                data = line.split(":", 1)
+                                key = data[0].strip()
+                                if key == "prom":
+                                    dmi_facts[k] = data[1].strip()
+                    elif collected_facts.get('ansible_architecture') == 'ppc64':
+                        if os.access('/proc/device-tree/openprom/ibm,fw-vernum_encoded', os.R_OK):
+                            line = get_file_content('/proc/device-tree/openprom/ibm,fw-vernum_encoded')
+                            if line is not None:
+                                dmi_facts[k] = line
 
         return dmi_facts
 


### PR DESCRIPTION
Current facts module implementation on Linux works for hosts which have
DMI/SMBIOS/dmidecode available, which is Intel/AMD only. Add support for
SPARC and PowerPC architectures, parsing files with firmware information.
In case of SPARC - version is OpenBoot PROM (OBP), and for PowerPC - server
firmware level. Patch was tested on SPARC on Oracle VM LDOM and on a
physical machine (baremetal). For PowerPC/PPC64 patch was tested on IBM
PowerVM LPAR.



##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Sep 17 2017, 18:50:44) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
facts before the patch:

$ ansible localhost -m setup -a "filter=ansible_bios*"
 [WARNING]: provided hosts list is empty, only localhost is available

localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_bios_date": "NA",
        "ansible_bios_version": "NA"
    },
    "changed": false
}

facts after the patch for SPARC64 ldom:

$ ansible localhost -i inventory.ini -m setup -a 'filter=ansible_bios*'
localhost | SUCCESS => {
    "ansible_facts": {
        "ansible_bios_date": "NA",
        "ansible_bios_version": "OBP 4.38.8 2017/02/22 13:51"
    },
    "changed": false
}

facts after the patch for SPARC64 physical machine:

$ ansible v215 -i inventory.ini -m setup -a 'filter=ansible_bios*'
v215 | SUCCESS => {
    "ansible_facts": {
        "ansible_bios_date": "NA",
        "ansible_bios_version": "OBP 4.22.33 2007/06/18 12:47"
    },
    "changed": false
}

facts after the patch for PPC64 LPAR:

$ ansible redpanda -i inventory.ini -m setup -a 'filter=ansible_bios*'
redpanda | SUCCESS => {
    "ansible_facts": {
        "ansible_bios_date": "NA",
        "ansible_bios_version": "FW840.24 (SV840_132)\u0000"
    },
    "changed": false
}
```
