### PR TITLE
2.4 Due to an ImportError botocore is never successfully imported.

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -116,8 +116,7 @@ targets:
 '''  # NOQA
 
 try:
-    import boto3.exception
-    import botocore.exceptions
+    import botocore
 except ImportError:
     # module_utils.ec2.HAS_BOTO3 will do the right thing
     pass
@@ -379,7 +378,7 @@ def get_cloudwatchevents_client(module):
                           resource='events',
                           region=region, endpoint=ec2_url,
                           **aws_conn_kwargs)
-    except boto3.exception.NoAuthHandlerFound as e:
+    except botocore.exceptions.ProfileNotFound as e:
         module.fail_json(msg=str(e))
 
 


### PR DESCRIPTION
##### SUMMARY
This is a bare-minimum fix for cloudwatch_rule. Since there is no boto3 module called exception, botocore is never successfully imported though it may be available.

This was fixed in devel in #30823.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0 (2.4fix_broken_import_cloudwatch_rule 97fc27fc59) last updated 2017/09/26 13:29:43 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = [u'/Users/shertel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
