### PR TITLE
Rejiggering apache2_module as apache2_enable

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_enable.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_enable.py
@@ -1,0 +1,308 @@
+#!/usr/bin/python
+# coding: utf-8 -*-
+
+# Adapted by Sean Reifschneider <jafo00@gmail.com>
+# Adapted from apache2_module.py by:
+# (c) 2013-2014, Christian Berendt <berendt@b1-systems.de>
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: apache2_enable
+version_added: 2.5
+author:
+    - Sean Reifschneider (@linsomniac)
+    - Christian Berendt (@berendt)
+    - Ralf Hertel (@n0trax)
+    - Robin Roth (@robinro)
+short_description: enables/disables a site/conf/module in the Apache2 webserver
+description:
+   - Used to manage the "enabled" links in Apache configurations for
+     en/disabling sites, modules, and configurations, using "a2ensite" and
+     similar.
+options:
+   name:
+     description:
+        - name of the site/conf/module to enable/disable
+     required: true
+   type:
+     description:
+        - The type of the object to enable/disable.
+     choices: ['module', 'site', 'conf']
+     required: true
+   state:
+     description:
+        - indicate the desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+   force:
+     description:
+        - force disabling of default modules and override Debian warnings (for
+          modules only).
+     required: false
+     choices: ['True', 'False']
+     default: False
+     version_added: "2.1"
+   ignore_configcheck:
+     description:
+        - Ignore configuration checks about inconsistent module configuration.
+          Especially for mpm_* modules.
+     choices: ['True', 'False']
+     default: False
+     version_added: "2.3"
+requirements: ["a2ensite","a2dissite", "a2enmod", "a2dismod", "a2enconf",
+               "a2disconf"]
+'''
+
+EXAMPLES = '''
+# enables the site "public"
+- apache2_enable:
+    name: public
+    type: site
+    state: present
+# disables the site "public"
+- apache2_enable:
+    name: public
+    type: site
+    state: absent
+# enables the module "proxy"
+- apache2_enable:
+    name: proxy
+    type: module
+# disable default site for Debian and ignore any config warnings
+- apache2_enable:
+    state: absent
+    name: 000-default
+    type: site
+    ignore_configcheck: True
+'''
+
+RETURN = '''
+result:
+    description: message about action taken
+    returned: always
+    type: string
+warnings:
+    description: list of warning messages
+    returned: when needed
+    type: list
+rc:
+    description: return code of underlying command
+    returned: failed
+    type: int
+stdout:
+    description: stdout of underlying command
+    returned: failed
+    type: string
+stderr:
+    description: stderr of underlying command
+    returned: failed
+    type: string
+'''
+
+import re
+import os
+
+
+def _run_threaded(item):
+    control_binary = _get_control_binary(item)
+
+    result, stdout, stderr = item.run_command("%s -V" % control_binary)
+
+    return bool(re.search(r'threaded:[ ]*yes', stdout))
+
+
+def _get_binary(item, *commands):
+    '''Find the path for the first of the specified commands.'''
+    for command in commands:
+        command_path = item.get_bin_path(command)
+        if command_path is not None:
+            return command_path
+
+    item.fail_json(msg=(
+        'No path to required program "%s" found.' % '" or "'.join(commands)))
+
+
+def _get_control_binary(item):
+    return _get_binary(item, 'apache2ctl', 'apachectl')
+
+
+def _get_serverroot(item):
+    control_binary = _get_control_binary(item)
+    ignore_configcheck = item.params['ignore_configcheck']
+
+    result, stdout, stderr = item.run_command(
+        "%s -t -D DUMP_RUN_CFG" % control_binary)
+
+    if result != 0:
+        error_msg = "Error executing %s: %s" % (control_binary, stderr)
+        if ignore_configcheck:
+            item.warnings.append(error_msg)
+            return False
+        else:
+            item.fail_json(msg=error_msg)
+
+    m = re.search(r'^ServerRoot: "([^"]+)"$', stdout, re.MULTILINE)
+    if not m:
+        item.fail_json(
+            msg='Unable to determine Server Root via '
+            '"%s -t -D DUMP_RUN_CFG"' % control_binary)
+        return False
+
+    return m.group(1)
+
+
+def create_apache_identifier(name):
+    """
+    By convention if a module is loaded via name, it appears in
+    "apache2ctl -M" as name_module.
+
+    Some modules don't follow this convention and we use replacements
+    for those."""
+
+    # a2enmod name replacement to apache2ctl -M names
+    text_workarounds = [
+        ('shib2', 'mod_shib'),
+        ('evasive', 'evasive20_module'),
+    ]
+
+    # re expressions to extract subparts of names
+    re_workarounds = [
+        ('php', r'^(php\d)\.'),
+    ]
+
+    for a2enmod_spelling, module_name in text_workarounds:
+        if a2enmod_spelling in name:
+            return module_name
+
+    for search, reexpr in re_workarounds:
+        if search in name:
+            rematch = re.search(reexpr, name)
+            return rematch.group(1) + '_module'
+
+    return name + '_module'
+
+
+def _module_is_enabled(module):
+    control_binary = _get_control_binary(module)
+    name = module.params['name']
+    ignore_configcheck = module.params['ignore_configcheck']
+
+    result, stdout, stderr = module.run_command("%s -M" % control_binary)
+
+    if result != 0:
+        error_msg = "Error executing %s: %s" % (control_binary, stderr)
+        if ignore_configcheck:
+            if 'AH00534' in stderr and 'mpm_' in name:
+                module.warnings.append(
+                    'No MPM module loaded! apache2 reload AND other module '
+                    'actions will fail if no MPM module is loaded immediately.'
+                )
+            else:
+                module.warnings.append(error_msg)
+            return False
+        else:
+            module.fail_json(msg=error_msg)
+
+    searchstring = ' ' + create_apache_identifier(name)
+    return searchstring in stdout
+
+
+def _is_enabled(item):
+    name = item.params['name']
+    typ = item.params['type']
+
+    if typ == 'module':
+        return _module_is_enabled(item)
+    elif typ == 'conf' or typ == 'site':
+        server_root = _get_serverroot(item)
+        dirname = {'site': 'sites', 'conf': 'conf'}[typ]
+        return os.path.exists(os.path.join(
+            server_root, '%s-enabled' % dirname, name + '.conf'))
+
+
+def _set_state(item, state):
+    name = item.params['name']
+    typ = item.params['type']
+    typUpper = typ[0].upper() + typ[1:]
+
+    want_enabled = state == 'present'
+    state_string = {'present': 'enabled', 'absent': 'disabled'}[state]
+    success_msg = "%s %s %s" % (typUpper, name, state_string)
+    binary_name_map = {
+        ('conf', 'present'): 'a2enconf',
+        ('conf', 'absent'): 'a2disconf',
+        ('site', 'present'): 'a2ensite',
+        ('site', 'absent'): 'a2dissite',
+        ('module', 'present'): 'a2enmod',
+        ('module', 'absent'): 'a2dismod',
+    }
+
+    if _is_enabled(item) != want_enabled:
+        if item.check_mode:
+            item.exit_json(
+                changed=True, result=success_msg, warnings=item.warnings)
+
+        binary_name = binary_name_map[(typ, state)]
+        a2binary = item.get_bin_path(binary_name)
+        if a2binary is None:
+            item.fail_json(
+                msg='%s not found. Perhaps this system does not use %s'
+                ' to manage apache' % (a2binary, a2binary))
+
+        result, stdout, stderr = item.run_command(
+            "%s %s" % (a2binary, name))
+
+        if _is_enabled(item) == want_enabled:
+            item.exit_json(
+                changed=True, result=success_msg, warnings=item.warnings)
+        else:
+            item.fail_json(
+                msg="Failed to set site %s to %s: %s"
+                % (name, state_string, stdout),
+                rc=result, stdout=stdout, stderr=stderr)
+    else:
+        item.exit_json(
+            changed=False, result=success_msg, warnings=item.warnings)
+
+
+def main():
+    item = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True),
+            type=dict(required=True),
+            force=dict(required=False, type='bool', default=False),
+            state=dict(default='present', choices=['absent', 'present']),
+            ignore_configcheck=dict(
+                required=False, type='bool', default=False),
+        ),
+        supports_check_mode=True,
+    )
+
+    item.warnings = []
+
+    name = item.params['name']
+    typ = item.params['type']
+
+    if typ == 'module' and name == 'cgi' and _run_threaded(item):
+        item.fail_json(
+            msg='Your MPM seems to be threaded. No automatic actions on '
+            'module %s possible.' % name)
+
+    if item.params['state'] in ['present', 'absent']:
+        _set_state(item, item.params['state'])
+
+# import module snippets
+from ansible.module_utils.basic import AnsibleModule
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/web_infrastructure/apache2_enable.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_enable.py
@@ -235,6 +235,7 @@ def _is_enabled(item):
 def _set_state(item, state):
     name = item.params['name']
     typ = item.params['type']
+    force = item.params['force']
     typUpper = typ[0].upper() + typ[1:]
 
     want_enabled = state == 'present'
@@ -260,6 +261,10 @@ def _set_state(item, state):
             item.fail_json(
                 msg='%s not found. Perhaps this system does not use %s'
                 ' to manage apache' % (a2binary, a2binary))
+
+        if typ == 'module' and not want_enabled and force:
+            # force exists only for a2dismod on debian
+            a2binary += ' -f'
 
         result, stdout, stderr = item.run_command(
             "%s %s" % (a2binary, name))

--- a/lib/ansible/modules/web_infrastructure/apache2_enable.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_enable.py
@@ -225,7 +225,7 @@ def _is_enabled(item):
 
     if typ == 'module':
         return _module_is_enabled(item)
-    elif typ == 'conf' or typ == 'site':
+    elif typ in ('conf', 'site'):
         server_root = _get_serverroot(item)
         dirname = {'site': 'sites', 'conf': 'conf'}[typ]
         return os.path.exists(os.path.join(
@@ -274,8 +274,8 @@ def _set_state(item, state):
                 changed=True, result=success_msg, warnings=item.warnings)
         else:
             item.fail_json(
-                msg="Failed to set site %s to %s: %s"
-                % (name, state_string, stdout),
+                msg="Failed to set %s %s to %s: %s"
+                % (typ, name, state_string, stdout),
                 rc=result, stdout=stdout, stderr=stderr)
     else:
         item.exit_json(

--- a/lib/ansible/modules/web_infrastructure/apache2_enable.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_enable.py
@@ -112,6 +112,7 @@ stderr:
 
 import re
 import os
+from ansible.module_utils.basic import AnsibleModule
 
 
 def _run_threaded(item):
@@ -302,7 +303,5 @@ def main():
     if item.params['state'] in ['present', 'absent']:
         _set_state(item, item.params['state'])
 
-# import module snippets
-from ansible.module_utils.basic import AnsibleModule
 if __name__ == '__main__':
     main()

--- a/test/integration/targets/apache2_enable/aliases
+++ b/test/integration/targets/apache2_enable/aliases
@@ -1,0 +1,2 @@
+destructive
+posix/ci/group1

--- a/test/integration/targets/apache2_enable/meta/main.yml
+++ b/test/integration/targets/apache2_enable/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - prepare_tests

--- a/test/integration/targets/apache2_enable/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_enable/tasks/actualtest.yml
@@ -106,38 +106,38 @@
 
 - name: Set up test site file
   copy:
-    dest: /etc/apache2/sites-available/apache2_enable_site.conf
+    dest: /etc/apache2/sites-available/testsite.conf
     content: "#  test file"
   when: "ansible_os_family == 'Debian'"
 
 - name: enable apache2_enable site
   apache2_enable:
-    name: apache2_enable_site
+    name: testsite
     type: site
   when: "ansible_os_family == 'Debian'"
 
 - name: disable apache2_enable site
   apache2_enable:
-    name: apache2_enable_site
+    name: testsite
     type: site
     state: absent
   when: "ansible_os_family == 'Debian'"
 
 - name: Set up test conf file
   copy:
-    dest: /etc/apache2/sites-available/apache2_enable_conf.conf
+    dest: /etc/apache2/conf-available/testconfig.conf
     content: "#  test file"
   when: "ansible_os_family == 'Debian'"
 
 - name: enable apache2_enable conf
   apache2_enable:
-    name: apache2_enable_conf
+    name: testconfig
     type: conf
   when: "ansible_os_family == 'Debian'"
 
 - name: disable apache2_enable conf
   apache2_enable:
-    name: apache2_enable_conf
+    name: testconfig
     type: conf
     state: absent
   when: "ansible_os_family == 'Debian'"

--- a/test/integration/targets/apache2_enable/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_enable/tasks/actualtest.yml
@@ -103,3 +103,41 @@
     state: present
     type: module
   when: "ansible_os_family == 'Debian'"
+
+- name: Set up test site file
+  file:
+    path: /etc/apache2/sites-available/apache2_enable_site.conf
+    contents: "#  test file"
+  when: "ansible_os_family == 'Debian'"
+
+- name: enable apache2_enable site
+  apache2_enable:
+    name: apache2_enable_site
+    type: site
+  when: "ansible_os_family == 'Debian'"
+
+- name: disable apache2_enable site
+  apache2_enable:
+    name: apache2_enable_site
+    type: site
+    state: absent
+  when: "ansible_os_family == 'Debian'"
+
+- name: Set up test conf file
+  file:
+    path: /etc/apache2/sites-available/apache2_enable_conf.conf
+    contents: "#  test file"
+  when: "ansible_os_family == 'Debian'"
+
+- name: enable apache2_enable conf
+  apache2_enable:
+    name: apache2_enable_conf
+    type: conf
+  when: "ansible_os_family == 'Debian'"
+
+- name: disable apache2_enable conf
+  apache2_enable:
+    name: apache2_enable_conf
+    type: conf
+    state: absent
+  when: "ansible_os_family == 'Debian'"

--- a/test/integration/targets/apache2_enable/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_enable/tasks/actualtest.yml
@@ -106,7 +106,7 @@
 
 - name: Set up test site file
   copy:
-    path: /etc/apache2/sites-available/apache2_enable_site.conf
+    dest: /etc/apache2/sites-available/apache2_enable_site.conf
     content: "#  test file"
   when: "ansible_os_family == 'Debian'"
 
@@ -125,7 +125,7 @@
 
 - name: Set up test conf file
   copy:
-    path: /etc/apache2/sites-available/apache2_enable_conf.conf
+    dest: /etc/apache2/sites-available/apache2_enable_conf.conf
     content: "#  test file"
   when: "ansible_os_family == 'Debian'"
 

--- a/test/integration/targets/apache2_enable/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_enable/tasks/actualtest.yml
@@ -105,9 +105,9 @@
   when: "ansible_os_family == 'Debian'"
 
 - name: Set up test site file
-  file:
+  copy:
     path: /etc/apache2/sites-available/apache2_enable_site.conf
-    contents: "#  test file"
+    content: "#  test file"
   when: "ansible_os_family == 'Debian'"
 
 - name: enable apache2_enable site
@@ -124,9 +124,9 @@
   when: "ansible_os_family == 'Debian'"
 
 - name: Set up test conf file
-  file:
+  copy:
     path: /etc/apache2/sites-available/apache2_enable_conf.conf
-    contents: "#  test file"
+    content: "#  test file"
   when: "ansible_os_family == 'Debian'"
 
 - name: enable apache2_enable conf

--- a/test/integration/targets/apache2_enable/tasks/actualtest.yml
+++ b/test/integration/targets/apache2_enable/tasks/actualtest.yml
@@ -1,0 +1,105 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: install apache via apt
+  apt:
+    name: "{{item}}"
+    state: present
+  when: "ansible_os_family == 'Debian'"
+  with_items:
+    - apache2
+    - libapache2-mod-evasive
+
+- name: install apache via zypper
+  zypper:
+    name: apache2
+    state: present
+  when: "ansible_os_family == 'Suse'"
+
+- name: disable userdir module
+  apache2_enable:
+    name: userdir
+    state: absent
+    type: module
+
+- name: disable userdir module, second run
+  apache2_enable:
+    name: userdir
+    state: absent
+    type: module
+  register: disable
+
+- name: ensure apache2_enable is idempotent
+  assert:
+    that:
+      - 'not disable.changed'
+
+- name: enable userdir module
+  apache2_enable:
+    name: userdir
+    state: present
+    type: module
+  register: enable
+
+- name: ensure changed on successful enable
+  assert:
+    that:
+      - 'enable.changed'
+
+- name: enable userdir module, second run
+  apache2_enable:
+    name: userdir
+    state: present
+    type: module
+  register: enabletwo
+
+- name: ensure apache2_enable is idempotent
+  assert:
+    that:
+      - 'not enabletwo.changed'
+
+- name: disable userdir module, final run
+  apache2_enable:
+    name: userdir
+    state: absent
+    type: module
+  register: disablefinal
+
+- name: ensure changed on successful disable
+  assert:
+    that:
+      - 'disablefinal.changed'
+
+- name: ensure autoindex enabled
+  apache2_enable:
+    name: autoindex
+    state: present
+    type: module
+
+- name: force disable of autoindex  # bug #2499
+  apache2_enable:
+    name: autoindex
+    state: absent
+    force: True
+    type: module
+  when: "ansible_os_family == 'Debian'"
+
+
+- name: enable evasive module, test https://github.com/ansible/ansible/issues/22635
+  apache2_enable:
+    name: evasive
+    state: present
+    type: module
+  when: "ansible_os_family == 'Debian'"

--- a/test/integration/targets/apache2_enable/tasks/main.yml
+++ b/test/integration/targets/apache2_enable/tasks/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: include only on supported systems
+  include: actualtest.yml
+  when: ansible_os_family in ['Debian', 'Suse']
+  # centos/RHEL does not have a2enmod/a2dismod

--- a/test/units/modules/web_infrastructure/test_apache2_enable.py
+++ b/test/units/modules/web_infrastructure/test_apache2_enable.py
@@ -1,0 +1,17 @@
+import pytest
+
+from ansible.modules.web_fnfrastructure.apache2_enable import create_apache_identifier
+
+REPLACEMENTS = [
+    ('php7.1', 'php7_module'),
+    ('php5.6', 'php5_module'),
+    ('shib2', 'mod_shib'),
+    ('evasive', 'evasive20_module'),
+    ('thismoduledoesnotexist', 'thismoduledoesnotexist_module'),  # the default
+]
+
+
+@pytest.mark.parametrize("replacement", REPLACEMENTS, ids=lambda x: x[0])
+def test_apache_identifier(replacement):
+    "test the correct replacement of an a2enmod name with an apache2ctl name"
+    assert create_apache_identifier(replacement[0]) == replacement[1]

--- a/test/units/modules/web_infrastructure/test_apache2_enable.py
+++ b/test/units/modules/web_infrastructure/test_apache2_enable.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ansible.modules.web_fnfrastructure.apache2_enable import create_apache_identifier
+from ansible.modules.web_infrastructure.apache2_enable import create_apache_identifier
 
 REPLACEMENTS = [
     ('php7.1', 'php7_module'),


### PR DESCRIPTION
This new version supports enabling/disabling of modules, sites, and
configs.  Used apache2_module.py as a starting point and then
reviewed, added support for other types, reviewed, and made PEP-8
compliant.

##### SUMMARY
The apache2_module module works great, but then you also have similar tasks for enabling Apache sites and configs.  Previously I was just managing the symlinks manually using the file module, but this always felt lacking.  So I used the apache2_module as the basis, and made it also work for conf-available and sites-available.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
apache2_enable

##### ANSIBLE VERSION
Change made against current github, tested using:

ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]


##### ADDITIONAL INFORMATION
Parts of the ansible2_module that I retained, I edited for PEP8 compliance, so I could more easily catch issues with my own code.