### PR TITLE
Fix aws_s3 connection exception handling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -609,9 +609,8 @@ def main():
             aws_connect_kwargs.pop(key, None)
     try:
         s3 = get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url)
-    except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound) as e:
-        module.fail_json(msg="Can't authorize connection. Check your credentials and profile.",
-                         exceptions=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    except botocore.exceptions.ProfileNotFound as e:
+        module.fail_json(msg=to_native(e))
 
     validate = not ignore_nonexistent_bucket
 


### PR DESCRIPTION
##### SUMMARY
`ProfileNotFound` does not have a `response` attribute, and
`NoCredentialsError` does not occur at connection creation time.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel b672fd1f45) last updated 2017/09/27 09:20:53 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
