### PR TITLE
Fix cloudwatchevent_rule exception handling

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
+++ b/lib/ansible/modules/cloud/amazon/cloudwatchevent_rule.py
@@ -121,7 +121,7 @@ except ImportError:
     # module_utils.ec2.HAS_BOTO3 will do the right thing
     pass
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import (HAS_BOTO3, boto3_conn, camel_dict_to_snake_dict,
                                       ec2_argument_spec, get_aws_connection_info)
 
@@ -136,6 +136,7 @@ class CloudWatchEventRule(object):
         self.event_pattern = event_pattern
         self.description = description
         self.role_arn = role_arn
+        self.module = module
 
     def describe(self):
         """Returns the existing details of the rule in AWS"""
@@ -145,7 +146,9 @@ class CloudWatchEventRule(object):
             error_code = e.response.get('Error', {}).get('Code')
             if error_code == 'ResourceNotFoundException':
                 return {}
-            raise
+            self.module.fail_json_aws(e, msg="Could not describe rule")
+        except botocore.exceptions.BotoCoreError as e:
+            self.module.fail_json_aws(e, msg="Could not describe rule")
         return self._snakify(rule_info)
 
     def put(self, enabled=True):
@@ -193,7 +196,9 @@ class CloudWatchEventRule(object):
             error_code = e.response.get('Error', {}).get('Code')
             if error_code == 'ResourceNotFoundException':
                 return []
-            raise
+            self.module.fail_json_aws(e, msg="Could not describe rule")
+        except botocore.exceptions.BotoCoreError as e:
+            self.module.fail_json_aws(e, msg="Could not describe rule")
         return self._snakify(targets)['targets']
 
     def put_targets(self, targets):
@@ -394,7 +399,7 @@ def main():
         role_arn             = dict(),
         targets              = dict(type='list', default=[]),
     ))
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')


### PR DESCRIPTION
##### SUMMARY

Where it is currently present, this change fixes the exception handling.
However, there are many places that it is lacking.

Fixes #30806

(cherry picked from commit fb5693e0b353bdd7d1f2740bbda49f39b5c1f9f8)

backport of #30823

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudwatch_event_rule

##### ANSIBLE VERSION
```
ansible 2.4.0.0 (stable-2.4 64737e1446) last updated 2017/09/27 09:54:13 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
