### PR TITLE
Implement 'this' from proposals#74

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -675,12 +675,14 @@ class TaskExecutor:
                 if self._task.changed_when is not None and self._task.changed_when:
                     cond = Conditional(loader=self._loader)
                     cond.when = self._task.changed_when
+                    cond.this = result
                     result['changed'] = cond.evaluate_conditional(templar, vars_copy)
 
             def _evaluate_failed_when_result(result):
                 if self._task.failed_when:
                     cond = Conditional(loader=self._loader)
                     cond.when = self._task.failed_when
+                    cond.this = result
                     failed_when_result = cond.evaluate_conditional(templar, vars_copy)
                     result['failed_when_result'] = result['failed'] = failed_when_result
                 else:
@@ -728,6 +730,7 @@ class TaskExecutor:
             if retries > 1:
                 cond = Conditional(loader=self._loader)
                 cond.when = self._task.until
+                cond.this = result
                 if cond.evaluate_conditional(templar, vars_copy):
                     break
                 else:

--- a/lib/ansible/playbook/conditional.py
+++ b/lib/ansible/playbook/conditional.py
@@ -47,6 +47,7 @@ class Conditional:
     '''
 
     _when = FieldAttribute(isa='list', default=list, extend=True, prepend=True)
+    this = None
 
     def __init__(self, loader=None):
         # when used directly, this class needs a loader, but we want to
@@ -124,6 +125,15 @@ class Conditional:
             display.warning('conditional statements should not include jinja2 '
                             'templating delimiters such as {{ }} or {%% %%}. '
                             'Found: %s' % conditional)
+
+        if self.this is not None:
+            if 'this' in all_vars:
+                display.warning("variable 'this' is a reserved keyword and should not be set")
+            else:
+                # Avoid polluting all_vars
+                all_vars = all_vars.copy()
+                all_vars['this'] = self.this
+
         # make sure the templar is using the variables specified with this method
         templar.set_available_variables(variables=all_vars)
 


### PR DESCRIPTION
##### SUMMARY
As discussed in ansible/proposals#74 it is very convenient to be able to access the task result directly from `changed_when`, `failed_when` and `until`.

For this we reserve the keyword `this`.

Examples:

```yaml
  # Wait until file exists
  - stat:
      path: /tmp/some.file
    until: this.stat.exists

  # Fail task when both files are identical
  - raw: diff foo/file1 bar/file2
    failed_when: this.rc == 0

  # Report a change when rc is not 2
  - shell: /usr/bin/billybass --mode="take me to the river"
    changed_when: this.rc != 2
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
task_executor

##### ANSIBLE VERSION
v2.5