### PR TITLE
Update secrets.py example to include 'datacenter'

### DIFF
--- a/docs/docsite/rst/guide_gce.rst
+++ b/docs/docsite/rst/guide_gce.rst
@@ -83,7 +83,7 @@ Create a file ``secrets.py`` looking like following, and put it in some folder w
 .. code-block:: python
 
     GCE_PARAMS = ('i...@project.googleusercontent.com', '/path/to/project.json')
-    GCE_KEYWORD_PARAMS = {'project': 'project_id'}
+    GCE_KEYWORD_PARAMS = {'project': 'project_id', 'datacenter': ''}
 
 Ensure to enter the email address from the created services account and not the one from your main account.
 


### PR DESCRIPTION
##### SUMMARY
When relying on secrets.py omitting the 'datacenter' field from GCE_KEYWORK_PARAMS results in the below exception being thrown:
```
$ ./gce.py --list
Traceback (most recent call last):
  File "./gce.py", line 508, in <module>
    GceInventory()
  File "./gce.py", line 170, in __init__
    self.driver = self.get_gce_driver()
  File "./gce.py", line 315, in get_gce_driver
    kwargs['datacenter'] = os.environ.get('GCE_ZONE', kwargs['datacenter'])
KeyError: 'datacenter'
```
As this can be easily avoided by supplying an empty argument I would like to propose the document is updated to avoid confusion for new users.  I will also look into logging an issue against gce.py to make it more gracefully handle the datacenter parameter being omitted.

This is my first ansible docs pull request, and would appreciate any feedback if I've missed any processes etc.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
GCE Guide

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/Users/alex4408/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alex4408/dev/mgcp-ansible/venv/lib/python3.6/site-packages/ansible
  executable location = /Users/alex4408/dev/mgcp-ansible/venv/bin/ansible
  python version = 3.6.0a3 (v3.6.0a3:f3edf13dc339, Jul 11 2016, 21:21:39) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION
If a new user follows the guide as currently written they will receive an exception, this change removes that.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before:
$ cat secrets.py #as directed in documentation
GCE_PARAMS = ('XXX@XXX.iam.gserviceaccount.com', 'XXXXXXX')
GCE_KEYWORD_PARAMS = {'project': 'XXXXXXX'}
$ ./gce.py --list
Traceback (most recent call last):
  File "./gce.py", line 508, in <module>
    GceInventory()
  File "./gce.py", line 170, in __init__
    self.driver = self.get_gce_driver()
  File "./gce.py", line 315, in get_gce_driver
    kwargs['datacenter'] = os.environ.get('GCE_ZONE', kwargs['datacenter'])
KeyError: 'datacenter'

After:
$ cat secrets.py #as in pull request
GCE_PARAMS = ('XXX@XXX.iam.gserviceaccount.com', 'XXXXXXX')
GCE_KEYWORD_PARAMS = {'project': 'XXXXXXX', 'datacenter': ''}
$ ./gce.py --list --pretty
{
  "10.0.1.2": [
    "vm-us-1"
  ],
<snip>
}
```
