### PR TITLE
Add support for IP based ELB target groups. Fixes #30962

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -103,6 +103,12 @@ options:
     description:
       - A dictionary of one or more tags to assign to the target group.
     required: false
+  target_type:
+    description:
+      - Indicate whether the target group consists of instances IDS 'instance' or IP addresses 'ip'. Default is 'instance'.
+    choices: ['instance', 'ip']
+    required: false
+    version_added: "2.5"
   targets:
     description:
       - A list of targets to assign to the target group. This parameter defaults to an empty list. Unless you set the 'modify_targets' parameter then
@@ -377,6 +383,10 @@ def create_or_update_target_group(connection, module):
             params['Matcher'] = {}
             params['Matcher']['HttpCode'] = module.params.get("successful_response_codes")
 
+    # Get target type
+    if module.params.get("target_type") is not None:
+        params['TargetType'] = module.params.get("target_type")
+
     # Get target group
     tg = get_target_group(connection, module)
 
@@ -637,6 +647,7 @@ def main():
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             successful_response_codes=dict(type='str'),
             tags=dict(default={}, type='dict'),
+            target_type=dict(default='instance', choices=['instance', 'ip'], type='str'),
             targets=dict(type='list'),
             unhealthy_threshold_count=dict(type='int'),
             vpc_id=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
Add support for IP address based target groups

Fixes #30962

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description, but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
Latest

##### ADDITIONAL INFORMATION
Adds support for a new module parameter target_type ('instance' or 'ip', defaults to 'instance' within AWS API if not specified).
Injects 'TargetType' parameter using above values.
Updated module parameter validation as above.
