### PR TITLE
Remove stray " and replace include: with import_tasks:

### DIFF
--- a/lib/ansible/modules/utilities/logic/import_tasks.py
+++ b/lib/ansible/modules/utilities/logic/import_tasks.py
@@ -49,7 +49,7 @@ EXAMPLES = """
     - debug:
         msg: task1
 
-    - include: stuff.yml"
+    - import_tasks: stuff.yml
       when: hostvar is defined
 """
 


### PR DESCRIPTION
##### SUMMARY
Fixes #30967

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
import_tasks

##### ANSIBLE VERSION
all versions with import_tasks.py

##### ADDITIONAL INFORMATION
See stray " and use of ```include:``` in action on http://docs.ansible.com/ansible/latest/import_tasks_module.html
