### PR TITLE
Fix sensu_silence module boolean parameter declaration

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -264,7 +264,7 @@ def main():
             check=dict(required=False),
             creator=dict(required=False),
             expire=dict(required=False),
-            expire_on_resolve=dict(type=bool, required=False),
+            expire_on_resolve=dict(type='bool', required=False),
             reason=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),
             subscription=dict(required=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The `sensu_silence` module fails when the parameter `expire_on_resolve` is given.

```
fatal: [example.com]: FAILED! => {"changed": false, "failed": true, "msg": "implementation error: unknown type <type 'bool'> requested for expire_on_resolve"}
```

By fixing the `expire_on_resolve` parameter declaration, the module works just fine.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`modules/monitoring/sensu_silence.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0.0-1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
