### PR TITLE
remove ext requirement for yaml inventory plugin

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -74,7 +74,7 @@ class InventoryModule(BaseFileInventoryPlugin):
         valid = False
         if super(InventoryModule, self).verify_file(path):
             file_name, ext = os.path.splitext(path)
-            if ext and ext in C.YAML_FILENAME_EXTENSIONS:
+            if not ext or ext in C.YAML_FILENAME_EXTENSIONS:
                 valid = True
         return valid
 


### PR DESCRIPTION
##### SUMMARY
returns to the state before 2.4 made it a requirement
fixes #30855



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/inventory/yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```
