### PR TITLE
Set desired capacity to min_size if no instances exist

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -957,10 +957,11 @@ def create_autoscaling_group(connection, module):
             min_size = as_group['MinSize']
         if max_size is None:
             max_size = as_group['MaxSize']
-        if desired_capacity is None and as_group['DesiredCapacity'] is None:
-            desired_capacity = min_size
-        elif desired_capacity is None:
-            desired_capacity = as_group['DesiredCapacity']
+        if desired_capacity is None:
+            if as_group['DesiredCapacity'] is None:
+                desired_capacity = min_size
+            else:
+                desired_capacity = as_group['DesiredCapacity']
         launch_config_name = launch_config_name or as_group['LaunchConfigurationName']
 
         launch_configs = describe_launch_configurations(connection, launch_config_name)
@@ -1116,10 +1117,11 @@ def replace(connection, module):
         min_size = as_group['MinSize']
     if max_size is None:
         max_size = as_group['MaxSize']
-    if desired_capacity is None and as_group['DesiredCapacity'] is None:
-        desired_capacity = min_size
-    elif desired_capacity is None:
-        desired_capacity = as_group['DesiredCapacity']
+    if desired_capacity is None:
+        if as_group['DesiredCapacity'] is None:
+            desired_capacity = min_size
+        else:
+            desired_capacity = as_group['DesiredCapacity']
     # set temporary settings and wait for them to be reached
     # This should get overwritten if the number of instances left is less than the batch size.
 

--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -806,6 +806,8 @@ def create_autoscaling_group(connection, module):
         launch_configs = describe_launch_configurations(connection, launch_config_name)
         if len(launch_configs['LaunchConfigurations']) == 0:
             module.fail_json(msg="No launch config found with name %s" % launch_config_name)
+        if desired_capacity is None:
+            desired_capacity = min_size
         ag = dict(
             AutoScalingGroupName=group_name,
             LaunchConfigurationName=launch_configs['LaunchConfigurations'][0]['LaunchConfigurationName'],
@@ -958,10 +960,7 @@ def create_autoscaling_group(connection, module):
         if max_size is None:
             max_size = as_group['MaxSize']
         if desired_capacity is None:
-            if as_group['DesiredCapacity'] is None:
-                desired_capacity = min_size
-            else:
-                desired_capacity = as_group['DesiredCapacity']
+            desired_capacity = as_group['DesiredCapacity']
         launch_config_name = launch_config_name or as_group['LaunchConfigurationName']
 
         launch_configs = describe_launch_configurations(connection, launch_config_name)
@@ -1118,10 +1117,7 @@ def replace(connection, module):
     if max_size is None:
         max_size = as_group['MaxSize']
     if desired_capacity is None:
-        if as_group['DesiredCapacity'] is None:
-            desired_capacity = min_size
-        else:
-            desired_capacity = as_group['DesiredCapacity']
+        desired_capacity = as_group['DesiredCapacity']
     # set temporary settings and wait for them to be reached
     # This should get overwritten if the number of instances left is less than the batch size.
 


### PR DESCRIPTION
##### SUMMARY
This PR changes the logic in the ec2_asg module to set desired capacity to min size if no instances currently exist. Before, it would try setting the desired capacity to the number of running instances if you didn't specify a value for the desired capacity, which resulted in a type error. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_asg module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/brad/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Sep 11 2017, 09:13:23) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Error output
```
TASK [Create Auto Scaling Group for logstash ingest nodes] ***************************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /Users/brad/code/aws-infrastructure/ansible/logstash.yml:55
Using module file /usr/local/lib/python2.7/site-packages/ansible/modules/cloud/amazon/ec2_asg.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: brad
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625 `" && echo ansible-tmp-1506374232.91-166116721061625="` echo /Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625 `" ) && sleep 0'
<127.0.0.1> PUT /var/folders/dz/8c2jdqws34d0ddwkzp21cq2dqx1h_5/T/tmpOnmJxI TO /Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625/ec2_asg.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625/ /Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625/ec2_asg.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/local/opt/python/bin/python2.7 /Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625/ec2_asg.py; rm -rf "/Users/brad/.ansible/tmp/ansible-tmp-1506374232.91-166116721061625/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/var/folders/dz/8c2jdqws34d0ddwkzp21cq2dqx1h_5/T/ansible_hzYsPR/ansible_module_ec2_asg.py", line 832, in create_autoscaling_group
    create_asg(connection, **ag)
  File "/var/folders/dz/8c2jdqws34d0ddwkzp21cq2dqx1h_5/T/ansible_hzYsPR/ansible_modlib.zip/ansible/module_utils/cloud.py", line 153, in retry_func
    raise e
ParamValidationError: Parameter validation failed:
Invalid type for parameter DesiredCapacity, value: None, type: <type 'NoneType'>, valid types: <type 'int'>, <type 'long'>

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "availability_zones": null,
            "aws_access_key": null,
            "aws_secret_key": null,
            "default_cooldown": 300,
            "desired_capacity": null,
            "ec2_url": null,
            "health_check_period": 300,
            "health_check_type": "EC2",
            "max_size": 12,
            "min_size": 5,
        -- TRUNCATED --
        }
    },
    "msg": "Failed to create Autoscaling Group."
}
```
