### PR TITLE
correct the Python 3 virtualenv pip environment setup instructions

### DIFF
--- a/docs/docsite/rst/python_3_support.rst
+++ b/docs/docsite/rst/python_3_support.rst
@@ -21,19 +21,26 @@ Testing Python 3 with commands and playbooks
 
 .. code-block:: shell
 
-    python3 /usr/bin/ansible localhost -m ping
-    python3 /usr/bin/ansible-playbook sample-playbook.yml
+    $ python3 /usr/bin/ansible localhost -m ping
+    $ python3 /usr/bin/ansible-playbook sample-playbook.yml
 
 You can also install Ansible using :program:`pip` for Python3 which will make the default
 :command:`/usr/bin/ansible` run with Python3:
 
 .. code-block:: shell
 
-    $ virtualenv py3-ansible
-    $ source ./bin/activate
+    $ virtualenv --python=python3 py3-ansible
+    $ source ./py3-ansible/bin/activate
     $ pip3 install ansible
-    $ ansible --version|grep python
-    python version = 3.5.3 (default, May 10 2017, 15:05:55) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
+    $ ansible --version | grep "python version"
+      python version = 3.6.2 (default, Sep 22 2017, 08:28:09) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
+
+On systems with SELinux installed, such as Red Hat Enterprise Linux or Fedora, the SELinux Python libraries also need to be copied over.
+
+.. code-block:: shell
+
+    $ cp -r -v /usr/lib64/python3.*/site-packages/selinux/ ./py3-ansible/lib64/python3.*/site-packages/
+    $ cp -v /usr/lib64/python3.*/site-packages/*selinux*.so ./py3-ansible/lib64/python3.*/site-packages/
 
 .. note:: Individual Linux distribution packages may be packaged for Python2 or Python3.  When running from
     distro packages you'll only be able to use Ansible with the Python version for which it was
@@ -58,14 +65,14 @@ Testing Python 3 module support
     [py3-hosts:vars]
     ansible_python_interpreter=/usr/bin/python3
 
-  See the :ref:`inventory documentation <inventory>` for more information.
+See the :ref:`inventory documentation <inventory>` for more information.
 
 * Run your command or playbook:
 
 .. code-block:: shell
 
-    ansible localhost-py3 -m ping
-    ansible-playbook sample-playbook.yml
+    $ ansible localhost-py3 -m ping
+    $ ansible-playbook sample-playbook.yml
 
 
 Note that you can also use the :option:`-e` command line option to manually
@@ -73,8 +80,8 @@ set the python interpreter when you run a command. For example:
 
 .. code-block:: shell
 
-  ansible localhost -m ping -e 'ansible_python_interpreter=/usr/bin/python3'
-  ansible-playbook sample-playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+    $ ansible localhost -m ping -e 'ansible_python_interpreter=/usr/bin/python3'
+    $ ansible-playbook sample-playbook.yml -e 'ansible_python_interpreter=/usr/bin/python3'
 
 What to do if an incompatibility is found
 -----------------------------------------


### PR DESCRIPTION
##### SUMMARY
Parts of the original instructions for how to install Ansible into a virtualenv with Python 3 were incorrect and did not work on all systems. This updated guide forces the virtualenv to use Python 3, it correctly sources the "activate" script, and I have added additional documentation for how to handle the SELinux libraries on RHEL based systems.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Python 3 Support

##### ANSIBLE VERSION
2.4.0

##### ADDITIONAL INFORMATION
Other minor formatting has been updated to make it consistent (such as spacing for code blocks and starting commands with "$ " to indicate a non-root user shell prompt).