### PR TITLE
Fix php module detection. Fixes #30827

### DIFF
--- a/lib/ansible/modules/web_infrastructure/apache2_module.py
+++ b/lib/ansible/modules/web_infrastructure/apache2_module.py
@@ -166,8 +166,11 @@ def create_apache_identifier(name):
 
     for search, reexpr in re_workarounds:
         if search in name:
-            rematch = re.search(reexpr, name)
-            return rematch.group(1) + '_module'
+            try:
+                rematch = re.search(reexpr, name)
+                return rematch.group(1) + '_module'
+            except AttributeError:
+                pass
 
     return name + '_module'
 


### PR DESCRIPTION
##### SUMMARY
As described in BugReport #30827 the php5 module detection is failing, because in debian jessie and ubuntu trusty the php5 module has no minor version number in the name. Therefore the regex in the create_apache_identifier method does not match. This PR fixes #30827

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
web_infrastructure/apache2_module.py

##### ANSIBLE VERSION
```
ansible 2.4.0
```