### PR TITLE
Updates to aruba terminal plugin

### DIFF
--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -30,11 +30,14 @@ from ansible.plugins.terminal import TerminalBase
 class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
-        re.compile(br"[\r\n]?[\w]*\(.+\) ?#(?:\s*)$")
+        re.compile(br"[\r\n]?[\w]*\(.+\) ?#(?:\s*)$"),
+        re.compile(br"[pP]assword:$")
     ]
 
     terminal_stderr_re = [
         re.compile(br"% ?Error"),
+        re.compile(br"Error:", re.M),
+        re.compile(br"^% \w+", re.M),
         re.compile(br"% ?Bad secret"),
         re.compile(br"invalid input", re.I),
         re.compile(br"(?:incomplete|ambiguous) command", re.I),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding new stdout regex to allow local password changes. Adding stderr regex to catch more errors.

The command to update the management user `mgmt-user <username> <rolename>` leaves you on prompts `Password:` and `Re-Type password:`. Those needed to be treated as a valid stdout prompt to continue. If the passwords entered did not match the error is `Error: Passwords don't match Try again`. Catching that with new stderr regex.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aruba.py terminal plugin
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
--version
ansible 2.5.0 (aruba_terminal 5caa0347dd) last updated 2017/09/27 08:50:41 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


