### PR TITLE
Fix documentation issue for nxos_snmp_user module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_snmp_user.py
+++ b/lib/ansible/modules/network/nxos/nxos_snmp_user.py
@@ -43,15 +43,15 @@ options:
         description:
             - Group to which the user will belong to.
         required: true
-    auth:
+    authentication:
         description:
-            - Auth parameters for the user.
+            - Authentication parameters for the user.
         required: false
         default: null
         choices: ['md5', 'sha']
     pwd:
         description:
-            - Auth password when using md5 or sha.
+            - Authentication password when using md5 or sha.
         required: false
         default: null
     privacy:
@@ -77,7 +77,7 @@ EXAMPLES = '''
 - nxos_snmp_user:
     user: ntc
     group: network-operator
-    auth: md5
+    authentication: md5
     pwd: test_password
 '''
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30941
*  Change auth to authentication in module document
   to be in sync with module params
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
nxos_snmp_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
