### PR TITLE
Fix host deserialization in inventory groups.

### DIFF
--- a/lib/ansible/inventory/group.py
+++ b/lib/ansible/inventory/group.py
@@ -72,7 +72,7 @@ class Group:
         self.name = data.get('name')
         self.vars = data.get('vars', dict())
         self.depth = data.get('depth', 0)
-        self.hosts = data.get('hosts', {})
+        self.hosts = data.get('hosts', [])
 
         self._hosts = set(self.hosts)
 

--- a/lib/ansible/inventory/host.py
+++ b/lib/ansible/inventory/host.py
@@ -45,7 +45,7 @@ class Host:
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash(self.name)
+        return hash(self._uuid)
 
     def __str__(self):
         return self.get_name()
@@ -68,13 +68,12 @@ class Host:
         )
 
     def deserialize(self, data):
-        self.__init__(gen_uuid=False)
-
         self.name = data.get('name')
         self.vars = data.get('vars', dict())
         self.address = data.get('address', '')
         self._uuid = data.get('uuid', None)
         self.implicit = data.get('implicit', False)
+        self.groups = []
 
         groups = data.get('groups', [])
         for group_data in groups:
@@ -82,11 +81,20 @@ class Host:
             g.deserialize(group_data)
             self.groups.append(g)
 
-    def __init__(self, name=None, port=None, gen_uuid=True):
+    def __getnewargs__(self):
+        return self.name, None, False, self._uuid
+
+    def __new__(cls, name=None, port=None, gen_uuid=True, uuid=None):
+        obj = super(Host, cls).__new__(cls)
+        obj.name = name
+        obj._uuid = uuid
+        return obj
+
+    def __init__(self, name=None, port=None, gen_uuid=True, uuid=None):
 
         self.vars = {}
         self.groups = []
-        self._uuid = None
+        self._uuid = uuid
 
         self.name = name
         self.address = name

--- a/test/units/inventory/test_host.py
+++ b/test/units/inventory/test_host.py
@@ -39,7 +39,7 @@ class TestHost(unittest.TestCase):
 
     def test_hashability(self):
         # equality implies the hash values are the same
-        self.assertEqual(hash(self.hostA), hash(Host('a')))
+        self.assertEqual(hash(self.hostA), hash(Host(name=self.hostA.name, gen_uuid=False, uuid=self.hostA._uuid)))
 
     def test_get_vars(self):
         host_vars = self.hostA.get_vars()


### PR DESCRIPTION
##### SUMMARY

Fix host deserialization in inventory groups.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

inventory

##### ANSIBLE VERSION

```
ansible 2.5.0 (deserialization-fix fa679a10a1) last updated 2017/09/28 01:31:44 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
