### PR TITLE
Remove provider option from  ios integration test

### DIFF
--- a/test/integration/targets/ios_banner/tests/cli/basic-login.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-login.yaml
@@ -5,7 +5,6 @@
     banner: login
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: Set login
   ios_banner:
@@ -16,7 +15,6 @@
       string
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -36,7 +34,6 @@
       string
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-motd.yaml
@@ -4,7 +4,6 @@
   ios_banner:
     banner: motd
     state: absent
-    provider: "{{ cli }}"
     authorize: yes
 
 - name: Set motd
@@ -16,7 +15,6 @@
       string
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -36,7 +34,6 @@
       string
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_banner/tests/cli/basic-no-login.yaml
+++ b/test/integration/targets/ios_banner/tests/cli/basic-no-login.yaml
@@ -7,14 +7,12 @@
       over multiple lines
     state: present
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: remove login
   ios_banner:
     banner: login
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - debug:
@@ -30,7 +28,6 @@
     banner: login
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_command/tests/cli/bad_operator.yaml
+++ b/test/integration/targets/ios_command/tests/cli/bad_operator.yaml
@@ -6,6 +6,7 @@
     commands:
       - show version
       - show interfaces GigabitEthernet 0/0
+    authorize: yes
     wait_for:
       - "result[0] contains 'Description: Foo'"
   register: result

--- a/test/integration/targets/ios_command/tests/cli/contains.yaml
+++ b/test/integration/targets/ios_command/tests/cli/contains.yaml
@@ -6,6 +6,7 @@
     commands:
       - show version
       - show interface loopback 888
+    authorize: yes
     wait_for:
       - "result[0] contains Cisco"
       - "result[1] contains Loopback888"

--- a/test/integration/targets/ios_command/tests/cli/invalid.yaml
+++ b/test/integration/targets/ios_command/tests/cli/invalid.yaml
@@ -4,6 +4,7 @@
 - name: run invalid command
   ios_command:
     commands: show foo
+    authorize: yes
   register: result
   ignore_errors: yes
 
@@ -16,6 +17,7 @@
     commands:
       - show version
       - show foo
+    authorize: yes
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/ios_command/tests/cli/output.yaml
+++ b/test/integration/targets/ios_command/tests/cli/output.yaml
@@ -5,6 +5,7 @@
   ios_command:
     commands:
       - show version
+    authorize: yes
   register: result
 
 - assert:
@@ -17,6 +18,7 @@
     commands:
       - show version
       - show interfaces
+    authorize: yes
   register: result
 
 - assert:

--- a/test/integration/targets/ios_command/tests/cli/timeout.yaml
+++ b/test/integration/targets/ios_command/tests/cli/timeout.yaml
@@ -5,6 +5,7 @@
   ios_command:
     commands:
       - show version
+    authorize: yes
     wait_for:
       - "result[0] contains bad_value_string"
   register: result

--- a/test/integration/targets/ios_config/tests/cli/backup.yaml
+++ b/test/integration/targets/ios_config/tests/cli/backup.yaml
@@ -9,7 +9,7 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: collect any backup files
   find:
@@ -28,7 +28,7 @@
   ios_config:
     src: basic/config.j2
     backup: yes
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/defaults.yaml
+++ b/test/integration/targets/ios_config/tests/cli/defaults.yaml
@@ -9,13 +9,13 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure device with defaults included
   ios_config:
     src: defaults/config.j2
     defaults: yes
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - debug: var=result
@@ -30,7 +30,7 @@
   ios_config:
     src: defaults/config.j2
     defaults: yes
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - debug: var=result

--- a/test/integration/targets/ios_config/tests/cli/save.yaml
+++ b/test/integration/targets/ios_config/tests/cli/save.yaml
@@ -9,13 +9,13 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 
 - name: save config
   ios_config:
     save: true
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 # FIXME https://github.com/ansible/ansible-modules-core/issues/5008
   ignore_errors: true
@@ -29,7 +29,7 @@
 - name: save should always run
   ios_config:
     save: true
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 # FIXME https://github.com/ansible/ansible-modules-core/issues/5008
   ignore_errors: true

--- a/test/integration/targets/ios_config/tests/cli/src_basic.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_basic.yaml
@@ -9,12 +9,12 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure device with config
   ios_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - name: debug, remove me
@@ -30,7 +30,7 @@
 - name: check device with config
   ios_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/src_invalid.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_invalid.yaml
@@ -6,6 +6,7 @@
 - name: configure with invalid src
   ios_config:
     src: basic/foobar.j2
+    authorize: yes
   register: result
   ignore_errors: yes
 

--- a/test/integration/targets/ios_config/tests/cli/src_match_none.yaml
+++ b/test/integration/targets/ios_config/tests/cli/src_match_none.yaml
@@ -9,13 +9,13 @@
     parents:
       - interface Loopback999
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure device with config
   ios_config:
     src: basic/config.j2
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -28,7 +28,7 @@
 - name: check device with config
   ios_config:
     src: basic/config.j2
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:

--- a/test/integration/targets/ios_config/tests/cli/sublevel.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel.yaml
@@ -7,13 +7,13 @@
       - 'no ip access-list extended test'
       - 'no ip access-list standard test'
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure sub level command
   ios_config:
     lines: ['permit ip any any log']
     parents: ['ip access-list extended test']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -26,7 +26,7 @@
   ios_config:
     lines: ['permit ip any any log']
     parents: ['ip access-list extended test']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -38,6 +38,6 @@
     lines:
       - 'no ip access-list extended test'
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/sublevel.yaml"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_block.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_block.yaml
@@ -10,7 +10,7 @@
     parents: ['ip access-list extended test']
     before: ['no ip access-list extended test']
     after: ['exit']
-    provider: "{{ cli }}"
+    authorize: yes
     match: none
 
 - name: configure sub level command using block resplace
@@ -23,7 +23,7 @@
     parents: ['ip access-list extended test']
     replace: block
     after: ['exit']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -45,7 +45,7 @@
     parents: ['ip access-list extended test']
     replace: block
     after: ['exit']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -57,6 +57,6 @@
     lines:
       - no ip access-list extended test
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/sublevel_block.yaml"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_exact.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_exact.yaml
@@ -13,7 +13,7 @@
     before: no ip access-list extended test
     after: exit
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure sub level command using exact match
   ios_config:
@@ -26,7 +26,7 @@
     before: no ip access-list extended test
     after: exit
     match: exact
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -48,7 +48,7 @@
       - permit ip host 4.4.4.4 any log
     parents: ip access-list extended test
     match: exact
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -60,6 +60,6 @@
     lines:
       - no ip access-list extended test
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/sublevel_exact.yaml"

--- a/test/integration/targets/ios_config/tests/cli/sublevel_strict.yaml
+++ b/test/integration/targets/ios_config/tests/cli/sublevel_strict.yaml
@@ -12,7 +12,7 @@
     parents: ip access-list extended test
     before: no ip access-list extended test
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure sub level command using strict match
   ios_config:
@@ -23,7 +23,7 @@
       - permit ip host 4.4.4.4 any log
     parents: ip access-list extended test
     match: strict
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -39,7 +39,7 @@
     parents: ip access-list extended test
     after: exit
     match: strict
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -56,6 +56,6 @@
   ios_config:
     lines: no ip access-list extended test
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/sublevel_strict.yaml"

--- a/test/integration/targets/ios_config/tests/cli/toplevel.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel.yaml
@@ -5,12 +5,12 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure top level command
   ios_config:
     lines: ['hostname foo']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -21,7 +21,7 @@
 - name: configure top level command idempotent check
   ios_config:
     lines: ['hostname foo']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -32,6 +32,6 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/toplevel.yaml"

--- a/test/integration/targets/ios_config/tests/cli/toplevel_after.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_after.yaml
@@ -7,13 +7,13 @@
       - "snmp-server contact ansible"
       - "hostname {{ shorter_hostname }}"
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure top level command with before
   ios_config:
     lines: ['hostname foo']
     after: ['snmp-server contact bar']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -26,7 +26,7 @@
   ios_config:
     lines: ['hostname foo']
     after: ['snmp-server contact foo']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -39,6 +39,6 @@
       - "no snmp-server contact"
       - "hostname {{ shorter_hostname }}"
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/toplevel_after.yaml"

--- a/test/integration/targets/ios_config/tests/cli/toplevel_before.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_before.yaml
@@ -7,13 +7,13 @@
       - "snmp-server contact ansible"
       - "hostname {{ shorter_hostname }}"
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure top level command with before
   ios_config:
     lines: ['hostname foo']
     before: ['snmp-server contact bar']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -26,7 +26,7 @@
   ios_config:
     lines: ['hostname foo']
     before: ['snmp-server contact foo']
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -39,6 +39,6 @@
       - "no snmp-server contact"
       - "hostname {{ shorter_hostname }}"
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/toplevel_before.yaml"

--- a/test/integration/targets/ios_config/tests/cli/toplevel_nonidempotent.yaml
+++ b/test/integration/targets/ios_config/tests/cli/toplevel_nonidempotent.yaml
@@ -5,13 +5,13 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - name: configure top level command
   ios_config:
     lines: ['hostname foo']
     match: strict
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -23,7 +23,7 @@
   ios_config:
     lines: ['hostname foo']
     match: strict
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:
@@ -34,6 +34,6 @@
   ios_config:
     lines: ['hostname {{ shorter_hostname }}']
     match: none
-    provider: "{{ cli }}"
+    authorize: yes
 
 - debug: msg="END cli/toplevel_nonidempotent.yaml"

--- a/test/integration/targets/ios_facts/tests/cli/all_facts.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/all_facts.yaml
@@ -6,7 +6,7 @@
   ios_facts:
     gather_subset:
       - all
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 

--- a/test/integration/targets/ios_facts/tests/cli/default_facts.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/default_facts.yaml
@@ -4,7 +4,7 @@
 
 - name: test getting default facts
   ios_facts:
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:

--- a/test/integration/targets/ios_facts/tests/cli/invalid_subset.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/invalid_subset.yaml
@@ -6,7 +6,7 @@
   ios_facts:
     gather_subset:
       - "foobar"
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
   ignore_errors: true
 
@@ -29,7 +29,7 @@
     gather_subset:
       - "!hardware"
       - "hardware"
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
   ignore_errors: true
 

--- a/test/integration/targets/ios_facts/tests/cli/not_hardware.yaml
+++ b/test/integration/targets/ios_facts/tests/cli/not_hardware.yaml
@@ -6,7 +6,7 @@
   ios_facts:
     gather_subset:
       - "!hardware"
-    provider: "{{ cli }}"
+    authorize: yes
   register: result
 
 - assert:

--- a/test/integration/targets/ios_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/basic.yaml
@@ -10,7 +10,6 @@
     mtu: 256
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - name: Confgure interface
@@ -19,7 +18,6 @@
     description: test-interface-initial
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -34,7 +32,6 @@
     description: test-interface-initial
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -49,7 +46,6 @@
     mtu: 512
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -69,7 +65,6 @@
     mtu: 256
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -86,7 +81,6 @@
     name: GigabitEthernet0/2
     enabled: False
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -100,7 +94,6 @@
     name: GigabitEthernet0/2
     enabled: True
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -118,7 +111,6 @@
     mtu: 516
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - name: Add interface aggregate
@@ -130,7 +122,6 @@
     speed: 100
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -156,7 +147,6 @@
     speed: 100
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -171,7 +161,6 @@
     enabled: False
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -190,7 +179,6 @@
     enabled: True
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -216,7 +204,6 @@
     - name: Loopback10
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -232,7 +219,6 @@
     - name: Loopback10
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -248,7 +234,6 @@
     - name: Loopback10
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -6,7 +6,6 @@
     name: 172.16.0.1
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: Remove console
   ios_logging:
@@ -14,7 +13,6 @@
     level: warnings
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: Remove buffer
   ios_logging:
@@ -22,7 +20,6 @@
     size: 8000
     authorize: yes
     state: absent
-    provider: "{{ cli }}"
 
 # start tests
 - name: Set up host logging
@@ -31,7 +28,6 @@
     name: 172.16.0.1
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -46,7 +42,6 @@
     name: 172.16.0.1
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -59,7 +54,6 @@
     name: 172.16.0.1
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -73,7 +67,6 @@
     name: 172.16.0.1
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -86,7 +79,6 @@
     level: warnings
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -99,7 +91,6 @@
     dest: buffered
     size: 8000
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -113,7 +104,6 @@
       - { dest: console, level: notifications }
       - { dest: buffered, size: 9000 }
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -129,7 +119,6 @@
       - { dest: buffered, size: 9000 }
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_ping/tests/cli/ping.yaml
+++ b/test/integration/targets/ios_ping/tests/cli/ping.yaml
@@ -4,24 +4,28 @@
 - name: expected successful ping
   ios_ping: &valid_ip
     dest: '8.8.8.8'
+    authorize: yes
   register: esp
   
 - name: unexpected unsuccessful ping
   ios_ping: &invalid_ip
     dest: '10.255.255.250'
     timeout: 45
+    authorize: yes
   register: uup
 
 - name: unexpected successful ping
   ios_ping:
     <<: *valid_ip
     state: 'absent'
+    authorize: yes
   register: usp
 
 - name: expected unsuccessful ping
   ios_ping:
     <<: *invalid_ip
     state: 'absent'
+    authorize: yes
   register: eup
 
 - name: assert

--- a/test/integration/targets/ios_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_static_route/tests/cli/basic.yaml
@@ -6,7 +6,6 @@
     next_hop: 10.0.0.8
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -21,7 +20,6 @@
     next_hop: 10.0.0.8
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -36,7 +34,6 @@
     admin_distance: 2
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -52,7 +49,6 @@
     admin_distance: 2
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -67,7 +63,6 @@
     admin_distance: 2
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -83,7 +78,6 @@
     admin_distance: 2
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -97,7 +91,6 @@
       - { prefix: 172.16.33.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -113,7 +106,6 @@
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -129,7 +121,6 @@
       - { prefix: 172.16.34.0, mask: 255.255.255.0, next_hop: 10.0.0.8 }
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:

--- a/test/integration/targets/ios_system/tests/cli/set_domain_list.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_domain_list.yaml
@@ -8,14 +8,12 @@
       - no ip domain-list redhat.com
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: configure domain_search
   ios_system:
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -30,7 +28,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -42,7 +39,6 @@
   ios_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -55,7 +51,6 @@
   ios_system:
     domain_search:
       - ansible.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -68,7 +63,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -82,7 +76,6 @@
     domain_search:
       - ansible.com
       - redhat.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -95,7 +88,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -111,7 +103,6 @@
     domain_search:
       - ansible.com
       - eng.ansible.com
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -127,6 +118,5 @@
       - no ip domain-list eng.ansible.com
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_search.yaml"

--- a/test/integration/targets/ios_system/tests/cli/set_domain_name.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_domain_name.yaml
@@ -6,13 +6,11 @@
     lines: no ip domain-name
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: configure domain_name
   ios_system:
     domain_name: eng.ansible.com
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -23,7 +21,6 @@
   ios_system:
     domain_name: eng.ansible.com
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,6 +32,5 @@
     lines: no ip domain-name
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_domain_name.yaml"

--- a/test/integration/targets/ios_system/tests/cli/set_hostname.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_hostname.yaml
@@ -6,13 +6,11 @@
     lines: hostname switch
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: configure hostname
   ios_system:
     hostname: foo
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -23,7 +21,6 @@
   ios_system:
     hostname: foo
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -35,6 +32,5 @@
     lines: "hostname {{ inventory_hostname }}"
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_hostname.yaml"

--- a/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
@@ -8,12 +8,10 @@
       - vrf definition ansible
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: configure lookup_source
   ios_system:
     lookup_source: Loopback10
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -25,7 +23,6 @@
 - name: verify lookup_source
   ios_system:
     lookup_source: Loopback10
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -36,7 +33,6 @@
 - name: Disable lookup_source
   ios_system:
     lookup_enabled: False
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -48,7 +44,6 @@
 - name: Disable lookup_source
   ios_system:
     lookup_enabled: True
-    provider: "{{ cli }}"
     authorize: yes
   register: result
 
@@ -93,7 +88,6 @@
       - no vrf definition ansible
     match: none
     authorize: yes
-    provider: "{{ cli }}"
   ignore_errors: yes
 # FIXME: Not sure why this is failing with msg": "no vrf definition ansible\r\n% IPv4 and IPv6 addresses from all interfaces in VRF ansible have been removed\r\nfoo(config)#", rc:1
 

--- a/test/integration/targets/ios_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_name_servers.yaml
@@ -7,7 +7,6 @@
       - no ip name-server
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - name: configure name_servers
   ios_system:
@@ -16,7 +15,6 @@
       - 2.2.2.2
       - 3.3.3.3
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -34,7 +32,6 @@
       - 2.2.2.2
       - 3.3.3.3
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -76,7 +73,6 @@
       - 1.1.1.1
       - 2.2.2.2
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -91,6 +87,5 @@
       - no ip domain lookup source-interface
     match: none
     authorize: yes
-    provider: "{{ cli }}"
 
 - debug: msg="END cli/set_name_servers.yaml"

--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -7,7 +7,6 @@
       role: network-operator
       state: present
       authorize: yes
-      provider: "{{ cli }}"
       configured_password: pass123
 
   - name: test login
@@ -34,6 +33,5 @@
     ios_user:
       name: auth_user
       state: absent
-      provider: "{{ cli }}"
       authorize: yes
     register: result

--- a/test/integration/targets/ios_user/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_user/tests/cli/basic.yaml
@@ -7,7 +7,6 @@
       - name: ansibletest3
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - name: Create user (SetUp)
@@ -17,7 +16,6 @@
     role: network-operator
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -33,7 +31,6 @@
     authorize: yes
     state: present
     view: network-admin
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -48,7 +45,6 @@
     role: network-operator
     state: present
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -64,7 +60,6 @@
     authorize: yes
     state: present
     view: network-admin
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -80,7 +75,6 @@
       - name: ansibletest3
     state: absent
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Remove provider from each task as it is not required.
*  Add `authorize: yes` whereever required
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
