### PR TITLE
Backport 'fix broken rpm link' #29667

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -115,7 +115,7 @@ RPMs for RHEL6 are available from yum for `EPEL
 <http://fedoraproject.org/wiki/EPEL>`_ 6 and currently supported
 Fedora distributions.
 
-Ansible will also have RPMs/YUM-repo available at `<https://releases.ansible.com/ansible/rpms/`.
+Ansible will also have RPMs/YUM-repo available at `<https://releases.ansible.com/ansible/rpm/>`.
 
 Ansible version 2.4 can manage earlier operating
 systems that contain Python 2.6 or higher.


### PR DESCRIPTION
##### SUMMARY
Backport `fix broken rpm link` (#29667) to 2.4

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
ansible 2.4.1.0 (stable-2.4 f7b0908315) last updated 2017/09/28 12:03:43 (GMT +200)
```