### PR TITLE
Fix rpm_key absent.

### DIFF
--- a/lib/ansible/modules/packaging/os/rpm_key.py
+++ b/lib/ansible/modules/packaging/os/rpm_key.py
@@ -183,7 +183,7 @@ class RpmKey(object):
 
     def drop_key(self, keyid):
         if not self.module.check_mode:
-            self.execute_command([self.rpm, '--erase', '--allmatches', "gpg-pubkey-%s" % keyid[8:].lower()])
+            self.execute_command([self.rpm, '--erase', '--allmatches', "gpg-pubkey-%s" % keyid[-8:].lower()])
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY

When trying to remove a gpg key with the rpm_key module, if keyid is 8 charactes long, drop_key function cuts everything issuing an error: "package gpg-pubkey- is not installed"

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

rpm_key

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /home/eduardo/.ansible.cfg
  configured module search path = [u'/home/eduardo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/eduardo/.local/lib/python2.7/site-packages/ansible
  executable location = /home/eduardo/.local/bin/ansible
  python version = 2.7.13 (default, Mar  6 2017, 16:32:24) [GCC 5.4.0]
```

##### ADDITIONAL INFORMATION

Create an ansible centos machine and try, install a key and try to remove it with rpm_key module.

- `Vagrantfile`
```ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|
  config.vm.box = "centos/7"
  config.vm.provision "ansible" do |ansible|
    ansible.verbose = "v"
    ansible.playbook = "rpm_key-absent.yml"
  end
end
```

- `rpm_key-absent.yml`
```yaml
---
- hosts: all
  tasks:
    - rpm_key:
        key: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7
    - rpm_key:
        key: f4a80eb5
        state: absent
 ```