### PR TITLE
remove action plugin only fields from 'file' calls

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -186,11 +186,9 @@ def _walk_dirs(topdir, base_path=None, local_follow=False, trailing_slash_detect
 
 class ActionModule(ActionBase):
 
-    def _remove_action_keys(self, module_args):
+    def _create_remote_file_args(self, module_args):
         # remove action plugin only keys
-        for key in ('content', 'decrypt'):
-            if key in module_args:
-                del module_args[key]
+        return dict((k, v) for k, v in module_args.items() if k not in ('content', 'decrypt'))
 
     def _copy_file(self, source_full, source_rel, content, content_tempfile,
                    dest, task_vars, tmp, delete_remote_tmp):
@@ -292,7 +290,7 @@ class ActionModule(ActionBase):
 
             # src and dest here come after original and override them
             # we pass dest only to make sure it includes trailing slash in case of recursive copy
-            new_module_args = self._task.args.copy()
+            new_module_args = self._create_remote_file_args(self._task.args)
             new_module_args.update(
                 dict(
                     src=tmp_src,
@@ -302,8 +300,6 @@ class ActionModule(ActionBase):
             )
             if lmode:
                 new_module_args['mode'] = lmode
-
-            self._remove_action_keys(new_module_args)
 
             module_return = self._execute_module(module_name='copy',
                                                  module_args=new_module_args, task_vars=task_vars,
@@ -329,7 +325,7 @@ class ActionModule(ActionBase):
                     dest = dest_status_nofollow['lnk_source']
 
             # Build temporary module_args.
-            new_module_args = self._task.args.copy()
+            new_module_args = self._create_remote_file_args(self._task.args)
             new_module_args.update(
                 dict(
                     src=source_rel,
@@ -338,8 +334,6 @@ class ActionModule(ActionBase):
                     state='file',
                 )
             )
-
-            self._remove_action_keys(new_module_args)
 
             if lmode:
                 new_module_args['mode'] = lmode

--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -186,6 +186,12 @@ def _walk_dirs(topdir, base_path=None, local_follow=False, trailing_slash_detect
 
 class ActionModule(ActionBase):
 
+    def _remove_action_keys(self, module_args):
+        # remove action plugin only keys
+        for key in ('content', 'decrypt'):
+            if key in module_args:
+                del module_args[key]
+
     def _copy_file(self, source_full, source_rel, content, content_tempfile,
                    dest, task_vars, tmp, delete_remote_tmp):
         decrypt = boolean(self._task.args.get('decrypt', True), strict=False)
@@ -297,10 +303,7 @@ class ActionModule(ActionBase):
             if lmode:
                 new_module_args['mode'] = lmode
 
-            # remove action plugin only keys
-            for key in ('content', 'decrypt'):
-                if key in new_module_args:
-                    del new_module_args[key]
+            self._remove_action_keys(new_module_args)
 
             module_return = self._execute_module(module_name='copy',
                                                  module_args=new_module_args, task_vars=task_vars,
@@ -335,6 +338,9 @@ class ActionModule(ActionBase):
                     state='file',
                 )
             )
+
+            self._remove_action_keys(new_module_args)
+
             if lmode:
                 new_module_args['mode'] = lmode
 
@@ -513,8 +519,7 @@ class ActionModule(ActionBase):
         for source_full, source_rel in source_files['files']:
             # copy files over.  This happens first as directories that have
             # a file do not need to be created later
-            module_return = self._copy_file(source_full, source_rel, content, content_tempfile,
-                                            dest, task_vars, tmp, delete_remote_tmp)
+            module_return = self._copy_file(source_full, source_rel, content, content_tempfile, dest, task_vars, tmp, delete_remote_tmp)
             if module_return is None:
                 continue
 

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -102,6 +102,7 @@
   copy:
     src: foo.txt
     dest: "{{ remote_file }}"
+    decrypt: no
   register: copy_result2
 
 - name: Assert that the file was not changed
@@ -113,6 +114,7 @@
   copy:
     content: "modified"
     dest: "{{ remote_file }}"
+    decrypt: no
   register: copy_result3
 
 - name: Check the stat results of the file
@@ -137,6 +139,7 @@
     content: "modified"
     dest: "{{ remote_file }}"
     mode: 0700
+    decrypt: no
   register: copy_result4
 
 - name: Check the stat results of the file
@@ -167,6 +170,7 @@
     content: 'modified'
     dest: '{{ remote_file }}'
     mode: 0700
+    decrypt: no
   register: copy_results
 
 - name: Check the stat results of the file
@@ -191,6 +195,7 @@
     content: 'modified'
     dest: '{{ remote_file }}'
     mode: 0404
+    decrypt: no
   register: copy_results
 
 - name: Check the stat results of the file


### PR DESCRIPTION
##### SUMMARY

fixes #30556


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
copy
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.3/2.4/2.5
```