### PR TITLE
Example of idempotent (pseudo-)random() usage.

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -451,7 +451,10 @@ To get a sha512 password hash (random salt)::
 To get a sha256 password hash with a specific salt::
 
     {{ 'secretpassword'|password_hash('sha256', 'mysecretsalt') }}
+    
+An idempotent method to generate unique hashes per system is to use a salt that is consistent between runs::
 
+    {{ 'secretpassword'|password_hash('sha512', 65534|random(seed=inventory_hostname)|string) }}
 
 Hash types available depend on the master system running ansible,
 'hash' depends on hashlib password_hash depends on passlib (http://passlib.readthedocs.io/en/stable/lib/passlib.hash.html).


### PR DESCRIPTION
Add note to use idempotent random() seed based on inventory_hostname.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Provide an example of how to use the password_hash in an idempotent manner.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
Applies to Ansible 1.9 and later.
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/my_modules/']
  python version = 2.7.11 (default, Jan 15 2016, 09:50:41) [GCC 4.4.7 20120313 (Red Hat 4.4.7-16)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
