### PR TITLE
Do not fail if gce_ip state is absent and ip does not exist

### DIFF
--- a/lib/ansible/modules/cloud/google/gce_eip.py
+++ b/lib/ansible/modules/cloud/google/gce_eip.py
@@ -201,9 +201,6 @@ def main():
         if not address:
             # Doesn't exist in GCE, and state==absent.
             changed = False
-            module.fail_json(
-                msg="Cannot delete unknown address: %s" %
-                (params['name']))
         else:
             # Delete
             (changed, json_output['address']) = delete_address(address)


### PR DESCRIPTION
##### SUMMARY
Currently the gce_ip module fails if it is asked to delete an ip that does not exist (state=absent). This does not match Ansible idempotent behavior.

With this fix, the gce_ip module no more fails in this case and returns gracefully.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gce_ip

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/deployer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
