### PR TITLE
Reduce chance of mistakes with unsafe_shell check during refactor

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2606,10 +2606,10 @@ class AnsibleModule(object):
             if use_unsafe_shell:
                 args = " ".join([shlex_quote(x) for x in args])
                 shell = True
-        elif isinstance(args, (binary_type, text_type)) and use_unsafe_shell:
-            shell = True
         elif isinstance(args, (binary_type, text_type)):
-            if not use_unsafe_shell:
+            if use_unsafe_shell:
+                shell = True
+            else:
                 # On python2.6 and below, shlex has problems with text type
                 # On python3, shlex needs a text type.
                 if PY2:


### PR DESCRIPTION
Code like this:
``` python
if cond1 and cond2:
    pass
elif cond1:
    pass
```
Has a hidden dependency on the order that the conditions are checked.
This makes them fragile and subject to breakage during refactors.
Rewrite the code like this:
``` python
if cond1:
    if cond2:
        pass
    else:
        pass
```
The nested structure makes the ordering explicit and less likely for
someone to break the code when they refactor.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

