### PR TITLE
Fixes #31056 - nxos_portchannel idempotence failure on N1 images

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_portchannel.py
+++ b/lib/ansible/modules/network/nxos/nxos_portchannel.py
@@ -203,6 +203,8 @@ def get_portchannel(module, netcfg=None):
         for pc in pc_table:
             if pc['group'] == module.params['group']:
                 portchannel_table = pc
+            elif module.params['group'].isdigit() and pc['group'] == int(module.params['group']):
+                portchannel_table = pc
     except (KeyError, AttributeError, TypeError, IndexError):
         return {}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Output of show port-channel summary | json returns group as int as compared to a string on other platforms. This causes idempotence issues on N1 images. The fix is to check for both string and int equality.

Fixes #31056 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_portchannel

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0 (detached HEAD d14467b029) last updated 2017/09/28 11:09:55 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```