### PR TITLE
systemd.py fails inside Anaconda installer chroot

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -448,8 +448,8 @@ def main():
                         if rc != 0:
                             module.fail_json(msg="Unable to %s service %s: %s" % (action, unit, err))
             else:
-                # this should not happen?
-                module.fail_json(msg="Service is in unknown state", status=result['status'])
+                # this condition occurs when running inside the Anaconda installer chroot environment
+                pass
 
 
     module.exit_json(**result)


### PR DESCRIPTION


##### SUMMARY
When running a playbook that uses systemd inside of the Anaconda installer chroot, the failure condition at line 452 is encountered. Removing this line causes the playbooks to continue as expected inside the chroot. Perhaps there is a better way to detect if Ansible is running inside of Anaconda, I was not aware of any such magic.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
systemd

##### ANSIBLE VERSION
2.4
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
