### PR TITLE
Handle vault decrypt --output=- 

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -180,9 +180,6 @@ class VaultCLI(CLI):
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
         if self.action in ['encrypt', 'encrypt_string', 'create', 'edit']:
-            if len(vault_ids) > 1 and not self.options.encrypt_vault_id:
-                raise AnsibleOptionsError("Only one --vault-id can be used for encryption")
-
             vault_secrets = None
             vault_secrets = \
                 self.setup_vault_secrets(loader,
@@ -191,8 +188,9 @@ class VaultCLI(CLI):
                                          ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
 
-            if len(vault_secrets) > 1:
-                raise AnsibleOptionsError("Only one --vault-id can be used for encryption. This includes passwords from configuration and cli.")
+            if len(vault_secrets) > 1 and not self.options.encrypt_vault_id:
+                raise AnsibleOptionsError("The vault-ids %s are available to encrypt. Specify the vault-id to encrypt with --encrypt-vault-id" %
+                                          ','.join([x[0] for x in vault_secrets]))
 
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -199,6 +199,7 @@ class VaultCLI(CLI):
 
             encrypt_secret = match_encrypt_secret(vault_secrets,
                                                   encrypt_vault_id=self.options.encrypt_vault_id)
+
             # only one secret for encrypt for now, use the first vault_id and use its first secret
             self.encrypt_vault_id = encrypt_secret[0]
             self.encrypt_secret = encrypt_secret[1]

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -396,7 +396,6 @@ def match_secrets(secrets, target_vault_ids):
     if not secrets:
         return []
 
-    print('match_secrets: secrets: %s target_vault_ids: %s' % (secrets, target_vault_ids))
     matches = [(vault_id, secret) for vault_id, secret in secrets if vault_id in target_vault_ids]
     return matches
 
@@ -407,7 +406,6 @@ def match_best_secret(secrets, target_vault_ids):
     Since secrets should be ordered so the early secrets are 'better' than later ones, this
     just finds all the matches, then returns the first secret'''
     matches = match_secrets(secrets, target_vault_ids)
-    print('match_best_secret matches: %s' % matches)
     if matches:
         return matches[0]
     # raise exception?
@@ -423,7 +421,6 @@ def match_encrypt_vault_id_secret(secrets, encrypt_vault_id=None):
 
     encrypt_vault_id_matchers = [encrypt_vault_id]
     encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
-    print('encrypt_secret: %s' % repr(encrypt_secret))
 
     # return the best match for --encrypt-vault-id
     if encrypt_secret:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -414,19 +414,35 @@ def match_best_secret(secrets, target_vault_ids):
     return None
 
 
+def match_encrypt_vault_id_secret(secrets, encrypt_vault_id=None):
+    # See if the --encrypt-vault-id matches a vault-id
+    display.vvvv('encrypt_vault_id=%s' % encrypt_vault_id)
+
+    if encrypt_vault_id is None:
+        raise AnsibleError('match_encrypt_vault_id_secret requires a non None encrypt_vault_id')
+
+    encrypt_vault_id_matchers = [encrypt_vault_id]
+    encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
+    print('encrypt_secret: %s' % repr(encrypt_secret))
+
+    # return the best match for --encrypt-vault-id
+    if encrypt_secret:
+        return encrypt_secret
+
+    # If we specified a encrypt_vault_id and we couldn't find it, dont
+    # fallback to using the first/best secret
+    raise AnsibleVaultError('Did not find a match for --encrypt-vault-id=%s in the known vault-ids %s' % (encrypt_vault_id,
+                                                                                                          [_v for _v, _vs in secrets]))
+
+
 def match_encrypt_secret(secrets, encrypt_vault_id=None):
     '''Find the best/first/only secret in secrets to use for encrypting'''
 
     display.vvvv('encrypt_vault_id=%s' % encrypt_vault_id)
     # See if the --encrypt-vault-id matches a vault-id
     if encrypt_vault_id:
-        encrypt_vault_id_matchers = [encrypt_vault_id]
-        encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
-        print('encrypt_secret: %s' % repr(encrypt_secret))
-
-        # return the best match for --encrypt-vault-id
-        if encrypt_secret:
-            return encrypt_secret
+        return match_encrypt_vault_id_secret(secrets,
+                                             encrypt_vault_id=encrypt_vault_id)
 
     # Find the best/first secret from secrets since we didnt specify otherwise
     # ie, consider all of the available secrets as matches

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -396,6 +396,7 @@ def match_secrets(secrets, target_vault_ids):
     if not secrets:
         return []
 
+    print('match_secrets: secrets: %s target_vault_ids: %s' % (secrets, target_vault_ids))
     matches = [(vault_id, secret) for vault_id, secret in secrets if vault_id in target_vault_ids]
     return matches
 
@@ -406,18 +407,32 @@ def match_best_secret(secrets, target_vault_ids):
     Since secrets should be ordered so the early secrets are 'better' than later ones, this
     just finds all the matches, then returns the first secret'''
     matches = match_secrets(secrets, target_vault_ids)
+    print('match_best_secret matches: %s' % matches)
     if matches:
         return matches[0]
     # raise exception?
     return None
 
 
-def match_encrypt_secret(secrets):
+def match_encrypt_secret(secrets, encrypt_vault_id=None):
     '''Find the best/first/only secret in secrets to use for encrypting'''
 
+    display.vvvv('encrypt_vault_id=%s' % encrypt_vault_id)
+    # See if the --encrypt-vault-id matches a vault-id
+    if encrypt_vault_id:
+        encrypt_vault_id_matchers = [encrypt_vault_id]
+        encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
+        print('encrypt_secret: %s' % repr(encrypt_secret))
+
+        # return the best match for --encrypt-vault-id
+        if encrypt_secret:
+            return encrypt_secret
+
+    # Find the best/first secret from secrets since we didnt specify otherwise
     # ie, consider all of the available secrets as matches
     _vault_id_matchers = [_vault_id for _vault_id, dummy in secrets]
     best_secret = match_best_secret(secrets, _vault_id_matchers)
+
     # can be empty list sans any tuple
     return best_secret
 

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -118,6 +118,13 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
+# try specifying a --encrypt-vault-id that doesnt exist, should exit with an error indicating
+# that --encrypt-vault-id and the known vault-ids
+ansible-vault encrypt "$@" --vault-password-file vault-password --encrypt-vault-id doesnt_exist "${TEST_FILE}" && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
 # encrypt it
 ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 


### PR DESCRIPTION
In cli.CLI.unfrack_path callback, special case if the
value of '--output' is '-', and avoid expanding
it to a full path.

vault cli already has special cases for '-', so it
just needs to get the original value to work.

Fixes #30550

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vault_output_dash_30550 c6b7de955d) last updated 2017/09/28 14:51:40 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```

