### PR TITLE
add https_proxy

### DIFF
--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -152,24 +152,24 @@ def import_cert_url(module, executable, url, port, keystore_path, keystore_pass,
     bypass_proxy = False
     if no_proxy is not None:
 
-      for pattern in no_proxy.split(','):
-        # If the pattern starts with a dot, match all hostnames that end
-        # with the given pattern. Otherwise, the hostname has to match
-        # the pattern exactly to be excluded from proxy access.
-        if re.match('^\..+', pattern):
-          if re.match(r'.+' + pattern.replace('.', '\.') + '$', url):
-            bypass_proxy = True
-            break
-        elif url == pattern:
-          bypass_proxy = True
-          break
+        for pattern in no_proxy.split(','):
+            # If the pattern starts with a dot, match all hostnames that end
+            # with the given pattern. Otherwise, the hostname has to match
+            # the pattern exactly to be excluded from proxy access.
+            if re.match('^\..+', pattern):
+                if re.match(r'.+' + pattern.replace('.', '\.') + '$', url):
+                    bypass_proxy = True
+                    break
+            elif url == pattern:
+                bypass_proxy = True
+                break
 
     if https_proxy is None or bypass_proxy:
-      fetch_cmd = ("%s -printcert -rfc -sslserver %s:%d")%(executable, url, port)
+        fetch_cmd = ("%s -printcert -rfc -sslserver %s:%d")%(executable, url, port)
     else:
-      (proxy_host, proxy_port) = https_proxy.split(':')
+        (proxy_host, proxy_port) = https_proxy.split(':')
 
-      fetch_cmd = ("%s -printcert -rfc -J-Dhttps.proxyHost=%s -J-Dhttps.proxyPort=%s -sslserver %s:%d")%(executable, proxy_host, proxy_port, url, port)
+        fetch_cmd = ("%s -printcert -rfc -J-Dhttps.proxyHost=%s -J-Dhttps.proxyPort=%s -sslserver %s:%d")%(executable, proxy_host, proxy_port, url, port)
 
     import_cmd = ("%s -importcert -noprompt -keystore '%s' "
                   "-storepass '%s' -alias '%s'")%(executable, keystore_path,

--- a/lib/ansible/modules/system/java_cert.py
+++ b/lib/ansible/modules/system/java_cert.py
@@ -144,7 +144,33 @@ def check_cert_present(module, executable, keystore_path, keystore_pass, alias):
 
 def import_cert_url(module, executable, url, port, keystore_path, keystore_pass, alias):
     ''' Import certificate from URL into keystore located at keystore_path '''
-    fetch_cmd = ("%s -printcert -rfc -sslserver %s:%d")%(executable, url, port)
+    import re
+
+    https_proxy = os.getenv("https_proxy")
+    no_proxy = os.getenv("no_proxy")
+
+    bypass_proxy = False
+    if no_proxy is not None:
+
+      for pattern in no_proxy.split(','):
+        # If the pattern starts with a dot, match all hostnames that end
+        # with the given pattern. Otherwise, the hostname has to match
+        # the pattern exactly to be excluded from proxy access.
+        if re.match('^\..+', pattern):
+          if re.match(r'.+' + pattern.replace('.', '\.') + '$', url):
+            bypass_proxy = True
+            break
+        elif url == pattern:
+          bypass_proxy = True
+          break
+
+    if https_proxy is None or bypass_proxy:
+      fetch_cmd = ("%s -printcert -rfc -sslserver %s:%d")%(executable, url, port)
+    else:
+      (proxy_host, proxy_port) = https_proxy.split(':')
+
+      fetch_cmd = ("%s -printcert -rfc -J-Dhttps.proxyHost=%s -J-Dhttps.proxyPort=%s -sslserver %s:%d")%(executable, proxy_host, proxy_port, url, port)
+
     import_cmd = ("%s -importcert -noprompt -keystore '%s' "
                   "-storepass '%s' -alias '%s'")%(executable, keystore_path,
                                                   keystore_pass, alias)


### PR DESCRIPTION
##### SUMMARY
The java_cert module did not honor the https_proxy and no_proxy environment variables, which can be set as described in http://docs.ansible.com/ansible/latest/playbooks_environment.html and which work with many other modules.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module java_cert

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  python version = 2.7.6
```

##### ADDITIONAL INFORMATION
This commit changes the keytool -printcert invocation to pass the appropriate parameters if the environment variables are set. The keytool parameter syntax was taken from https://docs.oracle.com/javase/8/docs/technotes/tools/unix/keytool.html