### PR TITLE
add a vault --encrypt-vault-to specify vault id to use for encrypt

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -199,6 +199,7 @@ class CLI(with_metaclass(ABCMeta, object)):
     def build_vault_ids(vault_ids, vault_password_files=None,
                         ask_vault_pass=None, create_new_password=None,
                         auto_prompt=True):
+        print('vault_ids0: %s' % vault_ids)
         vault_password_files = vault_password_files or []
         vault_ids = vault_ids or []
 
@@ -211,6 +212,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             # used by --vault-id and --vault-password-file
             vault_ids.append(id_slug)
 
+        print('vault_ids: %s' % vault_ids)
         # if an action needs an encrypt password (create_new_password=True) and we dont
         # have other secrets setup, then automatically add a password prompt as well.
         # prompts cant/shouldnt work without a tty, so dont add prompt secrets

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -199,7 +199,6 @@ class CLI(with_metaclass(ABCMeta, object)):
     def build_vault_ids(vault_ids, vault_password_files=None,
                         ask_vault_pass=None, create_new_password=None,
                         auto_prompt=True):
-        print('vault_ids0: %s' % vault_ids)
         vault_password_files = vault_password_files or []
         vault_ids = vault_ids or []
 
@@ -212,7 +211,6 @@ class CLI(with_metaclass(ABCMeta, object)):
             # used by --vault-id and --vault-password-file
             vault_ids.append(id_slug)
 
-        print('vault_ids: %s' % vault_ids)
         # if an action needs an encrypt password (create_new_password=True) and we dont
         # have other secrets setup, then automatically add a password prompt as well.
         # prompts cant/shouldnt work without a tty, so dont add prompt secrets

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -367,7 +367,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         if self.options.ask_su_pass or self.options.su_user:
             _dep('su')
 
-    def validate_conflicts(self, vault_opts=False, runas_opts=False, fork_opts=False):
+    def validate_conflicts(self, vault_opts=False, runas_opts=False, fork_opts=False, vault_rekey_opts=False):
         ''' check for conflicting options '''
 
         op = self.options
@@ -377,6 +377,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             if (op.ask_vault_pass and op.vault_password_files):
                 self.parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
 
+        if vault_rekey_opts:
             if (op.new_vault_id and op.new_vault_password_file):
                 self.parser.error("--new-vault-password-file and --new-vault-id are mutually exclusive")
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -377,6 +377,9 @@ class CLI(with_metaclass(ABCMeta, object)):
             if (op.ask_vault_pass and op.vault_password_files):
                 self.parser.error("--ask-vault-pass and --vault-password-file are mutually exclusive")
 
+            if (op.new_vault_id and op.new_vault_password_file):
+                self.parser.error("--new-vault-password-file and --new-vault-id are mutually exclusive")
+
         if runas_opts:
             # Check for privilege escalation conflicts
             if ((op.su or op.su_user) and (op.sudo or op.sudo_user) or
@@ -452,8 +455,8 @@ class CLI(with_metaclass(ABCMeta, object)):
                               help='the vault identity to use')
 
         if vault_rekey_opts:
-            parser.add_option('--new-vault-password-file', default=[], dest='new_vault_password_files',
-                              help="new vault password file for rekey", action="callback", callback=CLI.unfrack_paths, type='string')
+            parser.add_option('--new-vault-password-file', default=None, dest='new_vault_password_file',
+                              help="new vault password file for rekey", action="callback", callback=CLI.unfrack_path, type='string')
             parser.add_option('--new-vault-id', default=None, dest='new_vault_id', type='string',
                               help='the new vault identity to use for rekey')
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -106,6 +106,12 @@ class VaultCLI(CLI):
         elif self.action == "rekey":
             self.parser.set_usage("usage: %prog rekey [options] file_name")
 
+        # For encrypting actions, we can also specify which of multiple vault ids should be used for encrypting
+        if self.action in ['create', 'edit', 'encrypt', 'encrypt_string', 'rekey']:
+            self.parser.add_option('--encrypt-vault-id', default=[], dest='encrypt_vault_id',
+                                   action='store', type='string',
+                                   help='the vault id used to encrypt (required if more than vault-id is provided)')
+
     def parse(self):
 
         self.parser = CLI.base_parser(
@@ -174,8 +180,8 @@ class VaultCLI(CLI):
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
-        if self.action in ['encrypt', 'encrypt_string', 'create']:
-            if len(vault_ids) > 1:
+        if self.action in ['encrypt', 'encrypt_string', 'create', 'edit']:
+            if len(vault_ids) > 1 and not self.options.encrypt_vault_id:
                 raise AnsibleOptionsError("Only one --vault-id can be used for encryption")
 
             vault_secrets = None
@@ -192,10 +198,9 @@ class VaultCLI(CLI):
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
-            encrypt_secret = match_encrypt_secret(vault_secrets)
+            encrypt_secret = match_encrypt_secret(vault_secrets,
+                                                  encrypt_vault_id=self.options.encrypt_vault_id)
             # only one secret for encrypt for now, use the first vault_id and use its first secret
-            # self.encrypt_vault_id = list(vault_secrets.keys())[0]
-            # self.encrypt_secret = vault_secrets[self.encrypt_vault_id][0]
             self.encrypt_vault_id = encrypt_secret[0]
             self.encrypt_secret = encrypt_secret[1]
 
@@ -214,8 +219,10 @@ class VaultCLI(CLI):
             if not new_vault_secrets:
                 raise AnsibleOptionsError("A new vault password is required to use Ansible's Vault rekey")
 
-            # There is only one new_vault_id currently and one new_vault_secret
-            new_encrypt_secret = match_encrypt_secret(new_vault_secrets)
+            # There is only one new_vault_id currently and one new_vault_secret, or we
+            # use the id specified in --encrypt-vault-id
+            new_encrypt_secret = match_encrypt_secret(new_vault_secrets,
+                                                      encrypt_vault_id=self.options.encrypt_vault_id)
 
             self.new_encrypt_vault_id = new_encrypt_secret[0]
             self.new_encrypt_secret = new_encrypt_secret[1]

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -211,8 +211,16 @@ class VaultCLI(CLI):
             self.encrypt_secret = encrypt_secret[1]
 
         if self.action in ['rekey']:
+            default_encrypt_vault_id = C.DEFAULT_VAULT_ENCRYPT_IDENTITY
+            encrypt_vault_id = self.options.encrypt_vault_id or C.DEFAULT_VAULT_ENCRYPT_IDENTITY
+            print('encrypt_vault_id: %s' % encrypt_vault_id)
+            print('default_encrypt_vault_id: %s' % default_encrypt_vault_id)
+
             # new_vault_ids should only ever be one item, from
+            # load the default vault ids if we are using encrypt-vault-id
             new_vault_ids = []
+            if encrypt_vault_id:
+                new_vault_ids = default_vault_ids
             if self.options.new_vault_id:
                 new_vault_ids.append(self.options.new_vault_id)
 
@@ -224,8 +232,8 @@ class VaultCLI(CLI):
                 self.setup_vault_secrets(loader,
                                          vault_ids=new_vault_ids,
                                          vault_password_files=new_vault_password_files,
-                                         ask_vault_pass=self.options.ask_vault_pass,
-                                         # set encrypt_vault_id here?
+                                         ask_vault_pass=False,
+                                         #ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
 
             if not new_vault_secrets:
@@ -234,7 +242,7 @@ class VaultCLI(CLI):
             # There is only one new_vault_id currently and one new_vault_secret, or we
             # use the id specified in --encrypt-vault-id
             new_encrypt_secret = match_encrypt_secret(new_vault_secrets,
-                                                      encrypt_vault_id=self.options.encrypt_vault_id)
+                                                      encrypt_vault_id=encrypt_vault_id)
 
             self.new_encrypt_vault_id = new_encrypt_secret[0]
             self.new_encrypt_secret = new_encrypt_secret[1]

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -181,9 +181,6 @@ class VaultCLI(CLI):
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
         if self.action in ['encrypt', 'encrypt_string', 'create', 'edit']:
-            if len(vault_ids) > 1 and not self.options.encrypt_vault_id:
-                raise AnsibleOptionsError("Only one --vault-id can be used for encryption")
-
             vault_secrets = None
             vault_secrets = \
                 self.setup_vault_secrets(loader,
@@ -192,8 +189,9 @@ class VaultCLI(CLI):
                                          ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
 
-            if len(vault_secrets) > 1:
-                raise AnsibleOptionsError("Only one --vault-id can be used for encryption. This includes passwords from configuration and cli.")
+            if len(vault_secrets) > 1 and not self.options.encrypt_vault_id:
+                raise AnsibleOptionsError("The vault-ids %s are available to encrypt. Specify the vault-id to encrypt with --encrypt-vault-id" %
+                                          ','.join([x[0] for x in vault_secrets]))
 
             if not vault_secrets:
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -200,6 +200,7 @@ class VaultCLI(CLI):
 
             encrypt_secret = match_encrypt_secret(vault_secrets,
                                                   encrypt_vault_id=self.options.encrypt_vault_id)
+
             # only one secret for encrypt for now, use the first vault_id and use its first secret
             self.encrypt_vault_id = encrypt_secret[0]
             self.encrypt_secret = encrypt_secret[1]

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -182,10 +182,10 @@ class VaultCLI(CLI):
 
         if self.action in ['encrypt', 'encrypt_string', 'create', 'edit']:
 
-            default_encrypt_vault_id = C.DEFAULT_VAULT_ENCRYPT_IDENTITY
-            encrypt_vault_id = self.options.encrypt_vault_id or C.DEFAULT_VAULT_ENCRYPT_IDENTITY
-            print('encrypt_vault_id: %s' % encrypt_vault_id)
-            print('default_encrypt_vault_id: %s' % default_encrypt_vault_id)
+            encrypt_vault_id = None
+            # no --encrypt-vault-id self.options.encrypt_vault_id for 'edit'
+            if self.action not in ['edit']:
+                encrypt_vault_id = self.options.encrypt_vault_id or C.DEFAULT_VAULT_ENCRYPT_IDENTITY
 
             vault_secrets = None
             vault_secrets = \
@@ -232,8 +232,7 @@ class VaultCLI(CLI):
                 self.setup_vault_secrets(loader,
                                          vault_ids=new_vault_ids,
                                          vault_password_files=new_vault_password_files,
-                                         ask_vault_pass=False,
-                                         #ask_vault_pass=self.options.ask_vault_pass,
+                                         ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
 
             if not new_vault_secrets:

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -211,10 +211,9 @@ class VaultCLI(CLI):
             self.encrypt_secret = encrypt_secret[1]
 
         if self.action in ['rekey']:
-            default_encrypt_vault_id = C.DEFAULT_VAULT_ENCRYPT_IDENTITY
             encrypt_vault_id = self.options.encrypt_vault_id or C.DEFAULT_VAULT_ENCRYPT_IDENTITY
-            print('encrypt_vault_id: %s' % encrypt_vault_id)
-            print('default_encrypt_vault_id: %s' % default_encrypt_vault_id)
+            # print('encrypt_vault_id: %s' % encrypt_vault_id)
+            # print('default_encrypt_vault_id: %s' % default_encrypt_vault_id)
 
             # new_vault_ids should only ever be one item, from
             # load the default vault ids if we are using encrypt-vault-id

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -125,6 +125,7 @@ class VaultCLI(CLI):
         self.set_action()
 
         super(VaultCLI, self).parse()
+        self.validate_conflicts(vault_opts=True, vault_rekey_opts=True)
 
         display.verbosity = self.options.verbosity
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -169,6 +169,10 @@ class VaultCLI(CLI):
 
         default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
         vault_ids = default_vault_ids + vault_ids
+        default_encrypt_vault_id = C.DEFAULT_VAULT_ENCRYPT_IDENTITY
+        encrypt_vault_id = self.options.encrypt_vault_id or C.DEFAULT_VAULT_ENCRYPT_IDENTITY
+        print('encrypt_vault_id: %s' % encrypt_vault_id)
+        print('default_encrypt_vault_id: %s' % default_encrypt_vault_id)
 
         # TODO: instead of prompting for these before, we could let VaultEditor
         #       call a callback when it needs it.
@@ -189,7 +193,7 @@ class VaultCLI(CLI):
                                          ask_vault_pass=self.options.ask_vault_pass,
                                          create_new_password=True)
 
-            if len(vault_secrets) > 1 and not self.options.encrypt_vault_id:
+            if len(vault_secrets) > 1 and not encrypt_vault_id:
                 raise AnsibleOptionsError("The vault-ids %s are available to encrypt. Specify the vault-id to encrypt with --encrypt-vault-id" %
                                           ','.join([x[0] for x in vault_secrets]))
 
@@ -197,9 +201,10 @@ class VaultCLI(CLI):
                 raise AnsibleOptionsError("A vault password is required to use Ansible's Vault")
 
             encrypt_secret = match_encrypt_secret(vault_secrets,
-                                                  encrypt_vault_id=self.options.encrypt_vault_id)
+                                                  encrypt_vault_id=encrypt_vault_id)
 
             # only one secret for encrypt for now, use the first vault_id and use its first secret
+            # TODO: exception if more than one?
             self.encrypt_vault_id = encrypt_secret[0]
             self.encrypt_secret = encrypt_secret[1]
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1102,6 +1102,14 @@ DEFAULT_VAULT_IDENTITY:
   ini:
   - {key: vault_identity, section: defaults}
   yaml: {key: defaults.vault_identity}
+DEFAULT_VAULT_ENCRYPT_IDENTITY:
+  name: Vault id to use for encryption
+  default:
+  description: 'The vault of of the vault secret to use for encryption if not otherwise specified'
+  env: [{name: ANSIBLE_VAULT_ENCRYPT_IDENTITY}]
+  ini:
+  - {key: vault_encrypt_identity, section: defaults}
+  yaml: {key: defaults.vault_encrypt_identity}
 DEFAULT_VAULT_IDENTITY_LIST:
   name: Default vault ids
   default: []

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1105,7 +1105,7 @@ DEFAULT_VAULT_IDENTITY:
 DEFAULT_VAULT_ENCRYPT_IDENTITY:
   name: Vault id to use for encryption
   default:
-  description: 'The vault of of the vault secret to use for encryption if not otherwise specified'
+  description: 'The vault_id to use for encrypting by default. If multiple vault_ids are provided, this specifies which to use for encryption. The --encrypt-vault-id cli option overrides the configured value.'
   env: [{name: ANSIBLE_VAULT_ENCRYPT_IDENTITY}]
   ini:
   - {key: vault_encrypt_identity, section: defaults}

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -558,19 +558,35 @@ def match_best_secret(secrets, target_vault_ids):
     return None
 
 
+def match_encrypt_vault_id_secret(secrets, encrypt_vault_id=None):
+    # See if the --encrypt-vault-id matches a vault-id
+    display.vvvv('encrypt_vault_id=%s' % encrypt_vault_id)
+
+    if encrypt_vault_id is None:
+        raise AnsibleError('match_encrypt_vault_id_secret requires a non None encrypt_vault_id')
+
+    encrypt_vault_id_matchers = [encrypt_vault_id]
+    encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
+    print('encrypt_secret: %s' % repr(encrypt_secret))
+
+    # return the best match for --encrypt-vault-id
+    if encrypt_secret:
+        return encrypt_secret
+
+    # If we specified a encrypt_vault_id and we couldn't find it, dont
+    # fallback to using the first/best secret
+    raise AnsibleVaultError('Did not find a match for --encrypt-vault-id=%s in the known vault-ids %s' % (encrypt_vault_id,
+                                                                                                          [_v for _v, _vs in secrets]))
+
+
 def match_encrypt_secret(secrets, encrypt_vault_id=None):
     '''Find the best/first/only secret in secrets to use for encrypting'''
 
     display.vvvv('encrypt_vault_id=%s' % encrypt_vault_id)
     # See if the --encrypt-vault-id matches a vault-id
     if encrypt_vault_id:
-        encrypt_vault_id_matchers = [encrypt_vault_id]
-        encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
-        print('encrypt_secret: %s' % repr(encrypt_secret))
-
-        # return the best match for --encrypt-vault-id
-        if encrypt_secret:
-            return encrypt_secret
+        return match_encrypt_vault_id_secret(secrets,
+                                             encrypt_vault_id=encrypt_vault_id)
 
     # Find the best/first secret from secrets since we didnt specify otherwise
     # ie, consider all of the available secrets as matches

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -653,7 +653,11 @@ class VaultLib:
             raise AnsibleError(u"{0} cipher could not be found".format(self.cipher_name))
 
         # encrypt data
-        display.vvvvv('Encrypting with vault secret %s' % secret)
+        if vault_id:
+            display.vvvvv('Encrypting with vault_id "%s" and vault secret %s' % (vault_id, secret))
+        else:
+            display.vvvvv('Encrypting without a vault_id using vault secret %s' % secret)
+
         b_ciphertext = this_cipher.encrypt(b_plaintext, secret)
 
         # format the data for output to the file

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -540,7 +540,6 @@ def match_secrets(secrets, target_vault_ids):
     if not secrets:
         return []
 
-    print('match_secrets: secrets: %s target_vault_ids: %s' % (secrets, target_vault_ids))
     matches = [(vault_id, secret) for vault_id, secret in secrets if vault_id in target_vault_ids]
     return matches
 
@@ -551,7 +550,6 @@ def match_best_secret(secrets, target_vault_ids):
     Since secrets should be ordered so the early secrets are 'better' than later ones, this
     just finds all the matches, then returns the first secret'''
     matches = match_secrets(secrets, target_vault_ids)
-    print('match_best_secret matches: %s' % matches)
     if matches:
         return matches[0]
     # raise exception?
@@ -567,7 +565,6 @@ def match_encrypt_vault_id_secret(secrets, encrypt_vault_id=None):
 
     encrypt_vault_id_matchers = [encrypt_vault_id]
     encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
-    print('encrypt_secret: %s' % repr(encrypt_secret))
 
     # return the best match for --encrypt-vault-id
     if encrypt_secret:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -540,6 +540,7 @@ def match_secrets(secrets, target_vault_ids):
     if not secrets:
         return []
 
+    print('match_secrets: secrets: %s target_vault_ids: %s' % (secrets, target_vault_ids))
     matches = [(vault_id, secret) for vault_id, secret in secrets if vault_id in target_vault_ids]
     return matches
 
@@ -550,18 +551,32 @@ def match_best_secret(secrets, target_vault_ids):
     Since secrets should be ordered so the early secrets are 'better' than later ones, this
     just finds all the matches, then returns the first secret'''
     matches = match_secrets(secrets, target_vault_ids)
+    print('match_best_secret matches: %s' % matches)
     if matches:
         return matches[0]
     # raise exception?
     return None
 
 
-def match_encrypt_secret(secrets):
+def match_encrypt_secret(secrets, encrypt_vault_id=None):
     '''Find the best/first/only secret in secrets to use for encrypting'''
 
+    display.vvvv('encrypt_vault_id=%s' % encrypt_vault_id)
+    # See if the --encrypt-vault-id matches a vault-id
+    if encrypt_vault_id:
+        encrypt_vault_id_matchers = [encrypt_vault_id]
+        encrypt_secret = match_best_secret(secrets, encrypt_vault_id_matchers)
+        print('encrypt_secret: %s' % repr(encrypt_secret))
+
+        # return the best match for --encrypt-vault-id
+        if encrypt_secret:
+            return encrypt_secret
+
+    # Find the best/first secret from secrets since we didnt specify otherwise
     # ie, consider all of the available secrets as matches
     _vault_id_matchers = [_vault_id for _vault_id, dummy in secrets]
     best_secret = match_best_secret(secrets, _vault_id_matchers)
+
     # can be empty list sans any tuple
     return best_secret
 

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -185,6 +185,13 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
+# try specifying a --encrypt-vault-id that doesnt exist, should exit with an error indicating
+# that --encrypt-vault-id and the known vault-ids
+ansible-vault encrypt "$@" --vault-password-file vault-password --encrypt-vault-id doesnt_exist "${TEST_FILE}" && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+
 # encrypt it
 ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -259,6 +259,12 @@ ansible-vault encrypt "$@" --vault-password-file vault-password "${TEST_FILE}"
 
 ansible-vault rekey "$@" --vault-password-file vault-password --new-vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
 
+# --new-vault-password-file and --new-vault-id should cause options error
+ansible-vault rekey "$@" --vault-password-file vault-password --new-vault-id=foobar --new-vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}" && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (2 is expected)"
+[ $WRONG_RC -eq 2 ]
+
 ansible-vault view "$@" --vault-password-file "${NEW_VAULT_PASSWORD}" "${TEST_FILE}"
 
 # view with old password file and new password file


### PR DESCRIPTION
##### SUMMARY

Fixes #30878
Parts of #30491

Add a way to specify which vault id to use for encrypt if there are multiple vault-ids configured
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/vault.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vault_output_dash_30550 8773040315) last updated 2017/09/28 16:42:10 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
