### PR TITLE
Use the group-d1 moId instead of i8ln based names to identify the root folder.

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -235,7 +235,7 @@ def compile_folder_path_for_object(vobj):
     thisobj = vobj
     while hasattr(thisobj, 'parent'):
         thisobj = thisobj.parent
-        if thisobj.name == 'Datacenters':
+        if thisobj._moId == 'group-d1':
             break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)


### PR DESCRIPTION
##### SUMMARY

The top level folder (Datacenters/Datencenter/etc) has a managed objectid of "group-d1" which is consistent across the various languages vmware supports.

Addresses #29043

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```



