### PR TITLE
fixes #31080 - nxos_pim_interface idempotence issues for N1 images

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_pim_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_pim_interface.py
@@ -298,12 +298,14 @@ def get_pim_interface(module, interface):
         pim_interface['hello_interval'] = str(hello_interval_msec)
 
     border = get_data.get('is-border')
+    border = border.lower() if border else border
     if border == 'true':
         pim_interface['border'] = True
     elif border == 'false':
         pim_interface['border'] = False
 
     isauth = get_data.get('isauth-config')
+    isauth = isauth.lower() if isauth else isauth
     if isauth == 'true':
         pim_interface['isauth'] = True
     elif isauth == 'false':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #31080 

Lowers the properties the `boolean` properties obtained to satisfy string equality.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_pim_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0 (detached HEAD d14467b029) last updated 2017/09/28 13:41:53 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```