### PR TITLE
win_chocolately document improvements, mention win_hotfix and use of become

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.py
+++ b/lib/ansible/modules/windows/win_chocolatey.py
@@ -133,6 +133,9 @@ notes:
 - When using verbosity 4 (C(-vvvv)) the C(stdout) output will be more verbose.
 - When using verbosity 5 (C(-vvvvv)) the C(stdout) output will include debug output.
 - This module will install or upgrade Chocolatey when needed.
+- Some packages need an interactive user logon in order to install.  You can use (C(become)) to achieve this.
+- Even if you are connecting as local Administrator, using (C(become)) to become Administrator will give you an interactive user logon, see examples below.
+- Use (M(win_hotfix) to install hotfixes instead of (M(win_chocolatey)) as (M(win_hotfix)) avoids using wusa.exe which cannot be run remotely.
 author:
 - Trond Hindenes (@trondhindenes)
 - Peter Mounce (@petemounce)
@@ -173,10 +176,10 @@ EXAMPLES = r'''
     name: git
     state: absent
 
-- name: install multiple packages
+- name: Install multiple packages
   win_chocolatey:
     name: '{{ item }}'
-    state: absent
+    state: present
   with_items:
   - pscx
   - windirstat
@@ -202,6 +205,13 @@ EXAMPLES = r'''
     proxy_url: http://proxy-server:8080/
     proxy_username: user with \"escaped\" double quotes
     proxy_password: pass with \"escaped\" double quotes
+
+- name: Install a package that requires 'become'
+  win_chocolatey:
+    name: officepro2013
+  become: yes
+  become_user: Administrator
+  become_method: runas
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Following on from WIndows Sprint 2 review of issues reported with win_chocolatey, this
PR attempts to document its limitations and available workarounds.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #27155
Fixes #29702 (already closed)
Fixes #26385


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_chocolatey
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (choco_become_doc c1ec4a5341) last updated 2017/09/29 06:48:51 (GMT +000)
  config file = None
  configured module search path = [u'/home/pi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pi/ansible-dev/lib/ansible
  executable location = /home/pi/ansible-dev/bin/ansible
  python version = 2.7.9 (default, Aug 13 2016, 16:41:35) [GCC 4.9.2]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
