### PR TITLE
Fixes #31090. network parse_cli filter plugin doesn't use single match when using start/end blocks

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -106,8 +106,6 @@ def parse_cli(output, tmpl):
                 match_end = end_block.match(line)
 
                 if match_start:
-                    if lines:
-                        blocks.append('\n'.join(lines))
                     lines = list()
                     lines.append(line)
                     block_started = True
@@ -115,6 +113,7 @@ def parse_cli(output, tmpl):
                 elif match_end:
                     if lines:
                         lines.append(line)
+                        blocks.append('\n'.join(lines))
                     block_started = False
 
                 elif block_started:


### PR DESCRIPTION

##### SUMMARY

Fixes #31090. Moves the creation of a new ``block`` from the ``match_start`` section to the ``match_end`` section. This problem only occurs if one uses the ``start_block`` and ``end_block`` feature.

##### ISSUE TYPE
 - Bugfix Pull Request
 

##### COMPONENT NAME
filter_plugins/network.py

##### ANSIBLE VERSION

```
ansible 2.4.0
  config file = None
  configured module search path = [u'/home/skamithi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/skamithi/fix_parser/local/lib/python2.7/site-packages/ansible
  executable location = /home/skamithi/fix_parser/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```
