### PR TITLE
[cloud] Improve boto3_tag_list_to_ansible_dict backward compatibility…

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -28,7 +28,6 @@
 
 import os
 import re
-from time import sleep
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.cloud import CloudRetry
@@ -437,7 +436,7 @@ def ansible_dict_to_boto3_filter_list(filters_dict):
     return filters_list
 
 
-def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name='Key', tag_value_key_name='Value'):
+def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_key_name=None):
 
     """ Convert a boto3 list of resource tags to a flat dict of key:value pairs
     Args:
@@ -460,12 +459,17 @@ def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name='Key', tag_value
         }
     """
 
-    tags_dict = {}
-    for tag in tags_list:
-        if tag_name_key_name in tag:
-            tags_dict[tag[tag_name_key_name]] = tag[tag_value_key_name]
+    if tag_name_key_name and tag_value_key_name:
+        tag_candidates = {tag_name_key_name: tag_value_key_name}
+    else:
+        tag_candidates = {'key': 'value', 'Key': 'Value'}
 
-    return tags_dict
+    if not tags_list:
+        return {}
+    for k, v in tag_candidates.items():
+        if k in tags_list[0] and v in tags_list[0]:
+            return dict((tag[k], tag[v]) for tag in tags_list)
+    raise ValueError("Couldn't find tag key (candidates %s) in tag list %s" % (str(tag_candidates), str(tags_list)))
 
 
 def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value_key_name='Value'):


### PR DESCRIPTION
… (#30622)

##### SUMMARY
Default to trying both `key` and `Key`, and corresponding
`value`/`Value`.

Alternative to #30542

Merged to devel in #30622.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0 (2.4_boto3_tag_fix 5d97fe4b6d) last updated 2017/09/29 09:25:04 (GMT -400)
  config file = None
  configured module search path = ['/Users/shertel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/while_running_tests/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/while_running_tests/ansible/bin/ansible
  python version = 3.5.2 (default, Oct 11 2016, 04:59:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```
