### PR TITLE
intro_installation.rst: Fedora 25+ Workstation does not have `python2`

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -82,10 +82,10 @@ default this uses sftp. If that's not available, you can switch to scp in
    Ansible 2.2 introduces a tech preview of support for Python 3. For more information, see `Python 3 Support <http://docs.ansible.com/ansible/python_3_support.html>`_.
 
    By default, Ansible uses Python 2 in order to maintain compatibility with older distributions
-   such as RHEL 6. However, some Linux distributions (Gentoo, Arch) may not have a
+   such as RHEL 6. However, some Linux distributions (Fedora, Arch, Gentoo) may not have a
    Python 2.X interpreter installed by default.  On those systems, you should install one, and set
    the 'ansible_python_interpreter' variable in inventory (see :doc:`intro_inventory`) to point at your 2.X Python.  Distributions
-   like Red Hat Enterprise Linux, CentOS, Fedora, and Ubuntu all have a 2.X interpreter installed
+   like Red Hat Enterprise Linux, CentOS, and Ubuntu all have a 2.X interpreter installed
    by default and this does not apply to those distributions.  This is also true of nearly all
    Unix systems.
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The Fedora 25 Live Workstation installer does not include `python2`.

Also re-order the list of such distributions.  I believe there is a clear gradation of difficulty / uncommon-ness :), with Fedora being the easiest of these distributions.  A wholly unscientific search gave me 5x as many results for Arch as Gentoo.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
intro

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
devel

##### ADDITIONAL INFORMATION
N/A