### PR TITLE
Allow pdb to enter post-mortem debugging mode on unhandled expception…

### DIFF
--- a/bin/ansible
+++ b/bin/ansible
@@ -129,6 +129,10 @@ if __name__ == '__main__':
         display.error("User interrupted execution")
         exit_code = 99
     except Exception as e:
+        if C.DEFAULT_DEBUG:
+            # Show raw stacktraces in debug mode, It also allow pdb to
+            # enter post mortem mode.
+            raise
         have_cli_options = cli is not None and cli.options is not None
         display.error("Unexpected Exception, this is probably a bug: %s" % to_text(e), wrap_text=False)
         if not have_cli_options or have_cli_options and cli.options.verbosity > 2:


### PR DESCRIPTION
##### SUMMARY

Playing around https://github.com/ansible/ansible/issues/31086, I'm trying to get pdb enter post-mortem state on unhandled exceptions.

<!--- Describe the change, including rationale and design decisions -->

Currently, unhandled exceptions are handled, probably for at least two good reasons:

- Hide them to the newcomers so they don't fear too much
- Log them in the log files

So I didn't removed the `except Exception`, I tried to keep the current advantages, and I propose to re-raise the exception during a "-vvv" execution so pdb sees it literally as an unhandled exception and enters post-mortem "as expected" (OK, -vvv and entering post-mortem is not really linked semantically, only linked by the fact that one is trying to debug something).


Before the patch, behavior is: "If user give -vvv, print exception while logging it in file; exit(250)".

Unpatched run without `-vvv`:
```
ansible-playbook playbook.yml
ERROR! Unexpected Exception, this is probably a bug: string indices must be integers
to see the full traceback, use -vvv
```

Unpatched run with `-vvv`:
```
ansible-playbook -vvv playbook.yml
ansible-playbook 2.5.0 (devel b444332412) last updated 2017/09/27 17:41:21 (GMT +200)
  config file = /home/julien/meltygroup-ansible/ansible.cfg
  configured module search path = ['/home/julien/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/julien/ansible/lib/ansible
  executable location = /home/julien/ansible/bin/ansible-playbook
  python version = 3.5.3 (default, Jan 19 2017, 14:11:04) [GCC 6.3.0 20170118]
Using /home/julien/meltygroup-ansible/ansible.cfg as config file
ERROR! Unexpected Exception, this is probably a bug: string indices must be integers
the full traceback was:

Traceback (most recent call last):
  File "/home/julien/ansible/bin/ansible-playbook", line 109, in <module>
    exit_code = cli.run()
  File "/home/julien/ansible/lib/ansible/cli/playbook.py", line 104, in run
    loader, inventory, variable_manager = self._play_prereqs(self.options)
  File "/home/julien/ansible/lib/ansible/cli/__init__.py", line 788, in _play_prereqs
    inventory = InventoryManager(loader=loader, sources=options.inventory)
  File "/home/julien/ansible/lib/ansible/inventory/manager.py", line 144, in __init__
    self.parse_sources()
  File "/home/julien/ansible/lib/ansible/inventory/manager.py", line 205, in parse_sources
    parse = self.parse_source(source, cache=cache)
  File "/home/julien/ansible/lib/ansible/inventory/manager.py", line 259, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/julien/ansible/lib/ansible/plugins/inventory/yaml.py", line 98, in parse
    self._parse_group(group_name, data[group_name])
  File "/home/julien/ansible/lib/ansible/plugins/inventory/yaml.py", line 118, in _parse_group
    self._parse_group(subgroup, group_data['children'][subgroup])
  File "/home/julien/ansible/lib/ansible/plugins/inventory/yaml.py", line 124, in _parse_group
    self.populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
  File "/home/julien/ansible/lib/ansible/plugins/inventory/__init__.py", line 86, in populate_host_vars
    self.inventory.set_variable(host, k, variables[k])
TypeError: string indices must be integers
```

After the patch, behavior is "log exception; if user give -vvv: re-raise, so the interpreter will print the exception and exit 1, excepted if pdb is loaded, in which case pdb enter post-mortem status.".

Patched run without `-vvv`:

```
ansible-playbook playbook.yml
ERROR! Unexpected Exception, this is probably a bug: string indices must be integers
to see the full traceback, use -vvv
```

Patched with `-vvv`:
```
ansible-playbook -vvv playbook.yml
ansible-playbook 2.5.0 (issue-31086-pdb-post-mortem 3c2cbe61cb) last updated 2017/09/29 22:58:19 (GMT +200)
  config file = /home/julien/meltygroup-ansible/ansible.cfg
  configured module search path = ['/home/julien/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/julien/ansible/lib/ansible
  executable location = /home/julien/ansible/bin/ansible-playbook
  python version = 3.5.3 (default, Jan 19 2017, 14:11:04) [GCC 6.3.0 20170118]
Using /home/julien/meltygroup-ansible/ansible.cfg as config file
ERROR! Unexpected Exception, this is probably a bug: string indices must be integers
Traceback (most recent call last):
  File "/home/julien/ansible/bin/ansible-playbook", line 109, in <module>
    exit_code = cli.run()
  File "/home/julien/ansible/lib/ansible/cli/playbook.py", line 104, in run
    loader, inventory, variable_manager = self._play_prereqs(self.options)
  File "/home/julien/ansible/lib/ansible/cli/__init__.py", line 788, in _play_prereqs
    inventory = InventoryManager(loader=loader, sources=options.inventory)
  File "/home/julien/ansible/lib/ansible/inventory/manager.py", line 144, in __init__
    self.parse_sources()
  File "/home/julien/ansible/lib/ansible/inventory/manager.py", line 205, in parse_sources
    parse = self.parse_source(source, cache=cache)
  File "/home/julien/ansible/lib/ansible/inventory/manager.py", line 259, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/julien/ansible/lib/ansible/plugins/inventory/yaml.py", line 98, in parse
    self._parse_group(group_name, data[group_name])
  File "/home/julien/ansible/lib/ansible/plugins/inventory/yaml.py", line 118, in _parse_group
    self._parse_group(subgroup, group_data['children'][subgroup])
  File "/home/julien/ansible/lib/ansible/plugins/inventory/yaml.py", line 124, in _parse_group
    self.populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
  File "/home/julien/ansible/lib/ansible/plugins/inventory/__init__.py", line 86, in populate_host_vars
    self.inventory.set_variable(host, k, variables[k])
TypeError: string indices must be integers
```

They are highly similar, but a `python3 -m pdb /path/to/ansible-playbook -vvv playbook.yml`, on an unhandled exception, before the patch makes pdb restart ansible on failure, after the patch pdb enters post-mortem debugging.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible and pdb interaction

##### ANSIBLE VERSION
ansible 2.5.0 (issue-31086-pdb-post-mortem b95b80750c) last updated 2017/09/29 22:51:45 (GMT +200)
  config file = None
  configured module search path = ['/home/julien/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/julien/ansible/lib/ansible
  executable location = /home/julien/.venvs/meltygroup-ansible/bin/ansible
  python version = 3.5.3 (default, Jan 19 2017, 14:11:04) [GCC 6.3.0 20170118]

