### PR TITLE
yaml inventory: Better error reporting on typo. fixes (#31118)

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -19,12 +19,13 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from collections import MutableMapping
 import hashlib
 import os
 import re
 import string
 
-from ansible.errors import AnsibleError, AnsibleOptionsError
+from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.module_utils.six import string_types
@@ -80,6 +81,9 @@ class BaseInventoryPlugin(object):
         pass
 
     def populate_host_vars(self, hosts, variables, group=None, port=None):
+        if not isinstance(variables, MutableMapping):
+            raise AnsibleParserError("Invalid data from file, expected dictionary and got:\n\n%s" % to_native(variables))
+
         for host in hosts:
             self.inventory.add_host(host, group=group, port=port)
             for k in variables:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Add an exception so the reported error while parsing yaml (and maybe other future formats?) is more understandable, from `TypeError: string indices must be integers` to `[WARNING]:  * Failed to parse [...]/inventory.yml with yaml plugin: Invalid data from file, expected dictionary and got:  ansible_host=1.2.3.4`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
 fixes #31118

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

inventory/yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel b444332412) last updated 2017/09/27 17:41:21 (GMT +200)
  config file = None
  configured module search path = ['/home/julien/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/julien/ansible/lib/ansible
  executable location = /home/julien/.venvs/my-ansible/bin/ansible
  python version = 3.5.3 (default, Jan 19 2017, 14:11:04) [GCC 6.3.0 20170118]

```

