### PR TITLE
Updated changelog to show that 2.4 is no longer RC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Ansible Changes By Release
 
 <a id="2.4"></a>
 
-## 2.4 "Dancing Days" - RELEASE CANDIDATE
+## 2.4 "Dancing Days" - 2017/09/18
 
 ### Major Changes
 


### PR DESCRIPTION
##### SUMMARY
It was annoying me that 2.4 was still listed as an RC when it has been officially released. I've updated the `CHANGELOG.md` file to have a title that conforms with the other releases.