### PR TITLE
Fix for issue #30566 - lvol - logical volume extension with resizefs parameter

### DIFF
--- a/lib/ansible/modules/system/lvol.py
+++ b/lib/ansible/modules/system/lvol.py
@@ -58,7 +58,7 @@ options:
     version_added: "1.5"
   opts:
     description:
-    - Free-form options to be passed to the lvcreate command
+    - Free-form options to be passed to the lvcreate command.
     version_added: "2.0"
   snapshot:
     description:
@@ -66,16 +66,20 @@ options:
     version_added: "2.1"
   pvs:
     description:
-    - Comma separated list of physical volumes e.g. /dev/sda,/dev/sdb
+    - Comma separated list of physical volumes (e.g. /dev/sda,/dev/sdb).
     version_added: "2.2"
   shrink:
     description:
-    - shrink if current size is higher than size requested
+    - Shrink if current size is higher than size requested.
     type: bool
     default: 'yes'
     version_added: "2.2"
-notes:
-  - Filesystems on top of the volume are not resized.
+  resizefs:
+    description:
+    - Resize the underlying filesystem together with the logical volume.
+    type: bool
+    default: 'yes'
+    version_added: "2.5"
 '''
 
 EXAMPLES = '''
@@ -135,6 +139,7 @@ EXAMPLES = '''
     vg: firefly
     lv: test
     size: 100%PVS
+    resizefs: true
 
 - name: Resize the logical volume to % of VG
   lvol:
@@ -244,7 +249,8 @@ def main():
             shrink=dict(type='bool', default=True),
             active=dict(type='bool', default=True),
             snapshot=dict(type='str'),
-            pvs=dict(type='str')
+            pvs=dict(type='str'),
+            resizefs=dict(type='bool', default=False),
         ),
         supports_check_mode=True,
     )
@@ -267,6 +273,7 @@ def main():
     force = module.boolean(module.params['force'])
     shrink = module.boolean(module.params['shrink'])
     active = module.boolean(module.params['active'])
+    resizefs = module.boolean(module.params['resizefs'])
     size_opt = 'L'
     size_unit = 'm'
     snapshot = module.params['snapshot']
@@ -421,6 +428,8 @@ def main():
                     tool = '%s %s' % (tool, '--force')
 
             if tool:
+                if resizefs:
+                    tool = '%s %s' % (tool, '--resizefs')
                 cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
                 rc, out, err = module.run_command(cmd)
                 if "Reached maximum COW size" in out:
@@ -450,6 +459,8 @@ def main():
                     tool = '%s %s' % (tool, '--force')
 
             if tool:
+                if resizefs:
+                    tool = '%s %s' % (tool, '--resizefs')
                 cmd = "%s %s -%s %s%s %s/%s %s" % (tool, test_opt, size_opt, size, size_unit, vg, this_lv['name'], pvs)
                 rc, out, err = module.run_command(cmd)
                 if "Reached maximum COW size" in out:


### PR DESCRIPTION
Fix for issue #30566 - lvol - logical volume extension with resizefs parameter

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a resizefs option to lvol module to automatically resize the filesystem on grow, by issuing the --resizefs option to extendlv.  Fixes #30566
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/system/lvol.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (lvol_resizefs a5305c08ba) last updated 2017/09/30 17:32:17 (GMT +000)
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible/lib/ansible
  executable location = /home/ec2-user/ansible/bin/ansible
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# Extend the logical volume to take all remaining space of the PVs and resize the filesystem
- lvol:
    vg: firefly
    lv: test
    size: 100%PVS
    resizefs: true
```
