### PR TITLE
Get the moid in a more failsafe manner

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -239,7 +239,7 @@ def compile_folder_path_for_object(vobj):
             moid = thisobj._moId
         except AttributeError:
             moid = None
-        if moid == 'group-d1':
+        if moid in ['group-d1', 'ha-folder-root']:
             break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -235,7 +235,11 @@ def compile_folder_path_for_object(vobj):
     thisobj = vobj
     while hasattr(thisobj, 'parent'):
         thisobj = thisobj.parent
-        if thisobj._moId == 'group-d1':
+        try:
+            moid = thisobj._moId
+        except AttributeError:
+            moid = None
+        if moid == 'group-d1':
             break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -447,10 +447,13 @@ class PyVmomiCache(object):
         if confine_to_datacenter:
             if hasattr(objects, 'items'):
                 # resource pools come back as a dictionary
+                # make a copy
+                tmpobjs = objects.copy()
                 for k, v in objects.items():
                     parent_dc = self.get_parent_datacenter(k)
                     if parent_dc.name != self.dc_name:
-                        objects.pop(k, None)
+                        tmpobjs.pop(k, None)
+                objects = tmpobjs
             else:
                 # everything else should be a list
                 objects = [x for x in objects if self.get_parent_datacenter(x).name == self.dc_name]


### PR DESCRIPTION
##### SUMMARY
The _moId property seems a bit wonky and I'm not sure if that's due to vcsim or pyvmomi. In either case, this patch seems to work on vcsim + integration tests.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


