### PR TITLE
minor fix in docs for gce_backend_service examples

### DIFF
--- a/lib/ansible/modules/cloud/google/gcp_backend_service.py
+++ b/lib/ansible/modules/cloud/google/gcp_backend_service.py
@@ -96,7 +96,7 @@ EXAMPLES = '''
     backends:
     - instance_group: managed_instance_group_1
     healthchecks:
-    - name: healthcheck_name_for_backend_service
+    - healthcheck_name_for_backend_service
     port_name: myhttpport
     state: present
 
@@ -114,7 +114,7 @@ EXAMPLES = '''
       max_utilization: 0.5
       max_rate: 4
     healthchecks:
-    - name: healthcheck_name_for_backend_service
+    - healthcheck_name_for_backend_service
     port_name: myhttpport
     state: present
     timeout: 60


### PR DESCRIPTION
##### SUMMARY
gce_backend_service module expects healthchecks to be an array of string. The previous example incorrectly mentioned healthchecks as an array of objects each containing a `name` key.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
gce_backend_service

##### ANSIBLE VERSION
```
2.4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Error when using the given examples
```
libcloud.common.google.InvalidRequestError: {u'locationType': u'parameter', u'domain': u'global', u'message': u"Invalid value '{'name': 'sample1-healthcheck'}'. Values must match the followi
ng regular expression: '[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?'", u'reason': u'invalidParameter', u'location': u'httpHealthCheck'}
```
