### PR TITLE
boto3 is required for cloudformation

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -121,7 +121,7 @@ author: "James S. Martin (@jsmartin)"
 extends_documentation_fragment:
 - aws
 - ec2
-requirements: [ botocore>=1.4.57 ]
+requirements: [ boto3, botocore>=1.4.57 ]
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
boto3 is required for cloudformation module

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`cloudformation`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.2.0
```
