### PR TITLE
vmware_guest - Cluster option stopped working #30879

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1170,7 +1170,7 @@ class PyVmomiHelper(object):
 
         resource_pool = None
 
-        if self.params['esxi_hostname']:
+        if self.params['esxi_hostname'] or self.params['cluster']:
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
         else:
@@ -1261,8 +1261,7 @@ class PyVmomiHelper(object):
                 # create the relocation spec
                 relospec = vim.vm.RelocateSpec()
 
-                # Only select specific host when ESXi hostname is provided
-                if self.params['esxi_hostname']:
+                if self.params['esxi_hostname'] or self.params['cluster']:
                     relospec.host = self.select_host()
                 relospec.datastore = datastore
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

When creating a VM using a template the module was ignoring the "cluster" option. The error I was receiving was that it could not find the template. After examining the source it appears that the VM Host was not getting set if a cluster name was specified and the creation was using a template.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible/lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /Users/xxx/.ansible.cfg
  configured module search path = [u'/Users/xxx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
