### PR TITLE
Fixes #25725: strip quotes from lsb_release and distribution descript…

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -92,6 +92,8 @@ class DistributionFiles:
         'Archlinux': 'Arch Linux'
     }
 
+    STRIP_QUOTES = r'\'\"\\'
+
     def __init__(self, module):
         self.module = module
 
@@ -108,6 +110,7 @@ class DistributionFiles:
 
     def _parse_dist_file(self, name, dist_file_content, path, collected_facts):
         dist_file_dict = {}
+        dist_file_content = dist_file_content.strip(DistributionFiles.STRIP_QUOTES)
         if name in self.SEARCH_STRING:
             # look for the distribution string in the data and replace according to RELEASE_NAME_MAP
             # only the distribution name is set, the version is assumed to be correct from platform.dist()

--- a/lib/ansible/module_utils/facts/system/lsb.py
+++ b/lib/ansible/module_utils/facts/system/lsb.py
@@ -27,6 +27,7 @@ from ansible.module_utils.facts.collector import BaseFactCollector
 class LSBFactCollector(BaseFactCollector):
     name = 'lsb'
     _fact_ids = set()
+    STRIP_QUOTES = r'\'\"\\'
 
     def _lsb_release_bin(self, lsb_path, module):
         lsb_facts = {}
@@ -96,6 +97,10 @@ class LSBFactCollector(BaseFactCollector):
 
         if lsb_facts and 'release' in lsb_facts:
             lsb_facts['major_release'] = lsb_facts['release'].split('.')[0]
+
+        for k, v in lsb_facts.items():
+            if v:
+                lsb_facts[k] = v.strip(LSBFactCollector.STRIP_QUOTES)
 
         facts_dict['lsb'] = lsb_facts
         return facts_dict

--- a/test/units/module_utils/facts/system/test_lsb.py
+++ b/test/units/module_utils/facts/system/test_lsb.py
@@ -88,7 +88,7 @@ class TestLSBFacts(BaseFactsTest):
         self.assertIsInstance(facts_dict, dict)
         self.assertEqual(facts_dict['lsb']['release'], '14.04')
         self.assertEqual(facts_dict['lsb']['id'], 'Ubuntu')
-        self.assertEqual(facts_dict['lsb']['description'], '"Ubuntu 14.04.3 LTS"')
+        self.assertEqual(facts_dict['lsb']['description'], 'Ubuntu 14.04.3 LTS')
         self.assertEqual(facts_dict['lsb']['codename'], 'trusty')
 
     def test_etc_lsb_release_no_decimal_release(self):
@@ -104,5 +104,5 @@ class TestLSBFacts(BaseFactsTest):
         self.assertIsInstance(facts_dict, dict)
         self.assertEqual(facts_dict['lsb']['release'], '11')
         self.assertEqual(facts_dict['lsb']['id'], 'AwesomeOS')
-        self.assertEqual(facts_dict['lsb']['description'], '"AwesomeÖS 11"')
+        self.assertEqual(facts_dict['lsb']['description'], 'AwesomeÖS 11')
         self.assertEqual(facts_dict['lsb']['codename'], 'stonehenge')


### PR DESCRIPTION
##### SUMMARY

Strip quotes from distribution output retrieved by lsb_release or /etc/xxx-release

Fixes #25725



##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
set_fact module

##### ANSIBLE VERSION
```
ansible 2.5.0 (25725-fix-set_facts-distro-quotes 19e4047e81) last updated 2017/10/01 06:28:16 (GMT +200)
  config file = /home/rpolli/workspace-ansible/ansible/ansible.cfg
  configured module search path = [u'/home/rpolli/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/rpolli/workspace-ansible/ansible/lib/ansible
  executable location = /home/rpolli/workspace-ansible/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:36) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


