### PR TITLE
Add example showing how to add host to multiple groups

### DIFF
--- a/lib/ansible/modules/inventory/add_host.py
+++ b/lib/ansible/modules/inventory/add_host.py
@@ -49,6 +49,13 @@ EXAMPLES = '''
     groups: just_created
     foo: 42
 
+# add a host to multiple groups
+- add_host:
+    hostname: "{{ new_ip }}"
+    groups:
+      - group1
+      - group2
+
 # add a host with a non-standard port local to your machines
 - add_host:
     name: "{{ new_ip }}:{{ new_port }}"

--- a/lib/ansible/modules/inventory/add_host.py
+++ b/lib/ansible/modules/inventory/add_host.py
@@ -43,31 +43,31 @@ author:
 '''
 
 EXAMPLES = '''
-# add host to group 'just_created' with variable foo=42
-- add_host:
+- name: add host to group 'just_created' with variable foo=42
+  add_host:
     name: "{{ ip_from_ec2 }}"
     groups: just_created
     foo: 42
 
-# add a host to multiple groups
-- add_host:
+- name: add host to multiple groups
+  add_host:
     hostname: "{{ new_ip }}"
     groups:
       - group1
       - group2
 
-# add a host with a non-standard port local to your machines
-- add_host:
+- name: add a host with a non-standard port local to your machines
+  add_host:
     name: "{{ new_ip }}:{{ new_port }}"
 
-# add a host alias that we reach through a tunnel (Ansible <= 1.9)
-- add_host:
+- name: add a host alias that we reach through a tunnel (Ansible <= 1.9)
+  add_host:
     hostname: "{{ new_ip }}"
     ansible_ssh_host: "{{ inventory_hostname }}"
     ansible_ssh_port: "{{ new_port }}"
 
-# add a host alias that we reach through a tunnel (Ansible >= 2.0)
-- add_host:
+- name: add a host alias that we reach through a tunnel (Ansible >= 2.0)
+  add_host:
     hostname: "{{ new_ip }}"
     ansible_host: "{{ inventory_hostname }}"
     ansible_port: "{{ new_port }}"


### PR DESCRIPTION
##### SUMMARY
Added an example showing how to add host to multiple groups

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/inventory/add_host.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```
