### PR TITLE
Fixes # if include_vars dir is file instead of directory code breaks

### DIFF
--- a/lib/ansible/plugins/action/include_vars.py
+++ b/lib/ansible/plugins/action/include_vars.py
@@ -109,15 +109,18 @@ class ActionModule(ActionBase):
         if self.source_dir:
             self._set_dir_defaults()
             self._set_root_dir()
-            if path.exists(self.source_dir):
+            if not path.exists(self.source_dir):
+                failed = True
+                err_msg = ('{0} directory does not exist'.format(self.source_dir))
+            elif not path.isdir(self.source_dir):
+                failed = True
+                err_msg = ('{0} is not a directory'.format(self.source_dir))
+            else:
                 for root_dir, filenames in self._traverse_dir_depth():
                     failed, err_msg, updated_results = (self._load_files_in_dir(root_dir, filenames))
                     if failed:
                         break
                     results.update(updated_results)
-            else:
-                failed = True
-                err_msg = ('{0} directory does not exist'.format(self.source_dir))
         else:
             try:
                 self.source_file = self._find_needle('vars', self.source_file)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Bug fix for include_var plugin

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

- name: 'Include all variables'
  include_vars:
    dir: 'vars/webserver'
    extensions: ['yml']

Include_var plugin expects a directory in dir parameter. However if  its a file instead of directory the code breaks.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
include_vars plugin 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/home/xtreme/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/xtreme/helper-venv/lib/python3.6/site-packages/ansible
  executable location = /home/xtreme/helper-venv/bin/ansible
  python version = 3.6.2 (default, Aug 12 2017, 21:28:03) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
If the dir param is a file instead of a directory for the include_vars plugin the code breaks with following error. 
```
Before:
  File "/home/xtreme/helper-venv/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 125, in run
    res = self._execute()
  File "/home/xtreme/helper-venv/lib/python3.6/site-packages/ansible/executor/task_executor.py", line 528, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/xtreme/helper-venv/lib/python3.6/site-packages/ansible/plugins/action/include_vars.py", line 142, in run
    if failed:
UnboundLocalError: local variable 'failed' referenced before assignment

```
After change it gives you a message that given path is not a directory.

TASK [webserver : Include all variables] *************************************************************************************************************************
task path: /home/xtreme/workspace/gearbox/gearbox.git/ops/deploy/roles/webserver/tasks/main.yml:2
fatal: [54.210.139.47]: FAILED! => {
    "ansible_facts": {},
    "ansible_included_var_files": [],
    "changed": false,
    "failed": true,
    "message": "vars/webserver is not a directory"
}

