### PR TITLE
 Fixes #30073: Remove 'Consider hg command' warning.

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -124,7 +124,7 @@ def check_command(module, commandline):
     arguments = {'chown': 'owner', 'chmod': 'mode', 'chgrp': 'group',
                  'ln': 'state=link', 'mkdir': 'state=directory',
                  'rmdir': 'state=absent', 'rm': 'state=absent', 'touch': 'state=touch'}
-    commands = {'hg': 'hg', 'curl': 'get_url or uri', 'wget': 'get_url or uri',
+    commands = {'curl': 'get_url or uri', 'wget': 'get_url or uri',
                 'svn': 'subversion', 'service': 'service',
                 'mount': 'mount', 'rpm': 'yum, dnf or zypper', 'yum': 'yum', 'apt-get': 'apt',
                 'tar': 'unarchive', 'unzip': 'unarchive', 'sed': 'template or lineinfile',

--- a/lib/ansible/modules/source_control/hg.py
+++ b/lib/ansible/modules/source_control/hg.py
@@ -78,6 +78,7 @@ options:
             - Path to hg executable to use. If not supplied,
               the normal mechanism for resolving binary paths will be used.
 notes:
+    - "This module does not support push capability. See U(https://github.com/ansible/ansible/issues/31156)."
     - "If the task seems to be hanging, first verify remote host is in C(known_hosts).
       SSH will prompt user to authorize the first contact with a remote host.  To avoid this prompt,
       one solution is to add the remote host public key in C(/etc/ssh/ssh_known_hosts) before calling


### PR DESCRIPTION
##### SUMMARY
This PR addresses two issues:

1. The hg module was added to command module's check_command list,
so if someone runs hg directly from the command module, the command
module would warn the user "Consider using hg module rather than running hg".

We address issue 1 by removing hg from the list.

2. We added a new note to tell users push feature will be addressed
in issue #31156.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
hg module

##### ANSIBLE VERSION
```
ansible 2.5.0 (hg_issue_30073 6c4fecdaa7) last updated 2017/10/01 20:09:26 (GMT -400)
  config file = None
  configured module search path = [u'/Users/yeukhon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/yeukhon/git-workstation/ansible/lib/ansible
  executable location = /Users/yeukhon/git-workstation/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:24:00) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```
