### PR TITLE
Fix git ls-remote exit code (#30780)

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -183,7 +183,7 @@ options:
               Allowed archive formats ["zip", "tar.gz", "tar", "tgz"]
 
 requirements:
-    - git>=1.7.1 (the command line tool)
+    - git>=1.7.6 (the command line tool)
 
 notes:
     - "If the task seems to be hanging, first verify remote host is in C(known_hosts).

--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -525,15 +525,15 @@ def get_remote_head(git_path, module, dest, version, remote, bare):
     if version == 'HEAD':
         if cloning:
             # cloning the repo, just get the remote's HEAD version
-            cmd = '%s ls-remote %s -h HEAD' % (git_path, remote)
+            cmd = '%s ls-remote --exit-code -h %s HEAD' % (git_path, remote)
         else:
             head_branch = get_head_branch(git_path, module, dest, remote, bare)
-            cmd = '%s ls-remote %s -h refs/heads/%s' % (git_path, remote, head_branch)
+            cmd = '%s ls-remote --exit-code -h %s refs/heads/%s' % (git_path, remote, head_branch)
     elif is_remote_branch(git_path, module, dest, remote, version):
-        cmd = '%s ls-remote %s -h refs/heads/%s' % (git_path, remote, version)
+        cmd = '%s ls-remote --exit-code -h %s refs/heads/%s' % (git_path, remote, version)
     elif is_remote_tag(git_path, module, dest, remote, version):
         tag = True
-        cmd = '%s ls-remote %s -t refs/tags/%s*' % (git_path, remote, version)
+        cmd = '%s ls-remote --exit-code -t %s refs/tags/%s*' % (git_path, remote, version)
     else:
         # appears to be a sha1.  return as-is since it appears
         # cannot check for a specific sha1 on remote
@@ -558,7 +558,7 @@ def get_remote_head(git_path, module, dest, version, remote, bare):
 
 
 def is_remote_tag(git_path, module, dest, remote, version):
-    cmd = '%s ls-remote %s -t refs/tags/%s' % (git_path, remote, version)
+    cmd = '%s ls-remote --exit-code -t %s refs/tags/%s' % (git_path, remote, version)
     (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
     if to_native(version, errors='surrogate_or_strict') in out:
         return True
@@ -593,7 +593,7 @@ def get_annotated_tags(git_path, module, dest):
 
 
 def is_remote_branch(git_path, module, dest, remote, version):
-    cmd = '%s ls-remote %s -h refs/heads/%s' % (git_path, remote, version)
+    cmd = '%s ls-remote --exit-code -h %s refs/heads/%s' % (git_path, remote, version)
     (rc, out, err) = module.run_command(cmd, check_rc=True, cwd=dest)
     if to_native(version, errors='surrogate_or_strict') in out:
         return True
@@ -665,7 +665,7 @@ def get_head_branch(git_path, module, dest, remote, bare=False):
 
 def get_remote_url(git_path, module, dest, remote):
     '''Return URL of remote source for repo.'''
-    command = [git_path, 'ls-remote', '--get-url', remote]
+    command = [git_path, 'ls-remote', '--exit-code', '--get-url', remote]
     (rc, out, err) = module.run_command(command, cwd=dest)
     if rc != 0:
         # There was an issue getting remote URL, most likely


### PR DESCRIPTION
##### SUMMARY

The `git` module checks exit code of `git ls-remote` command, but the command does not return non-zero in most case if `--exit-code` option is given. From [git ls-remote man page](https://git-scm.com/docs/git-ls-remote.html#git-ls-remote---exit-code):

> Usually the command exits with status "0" to indicate it successfully talked with the remote repository, whether it found any matching refs.

As a result, ansible git module always treats ref as remote branch name. #30780 is one example.

To fix it, this pull request adds `--exit-code` option to all `ls-remote` option.

Also, many `ls-remote` commands incorrect - placing options after `repository`.  This pull request also fixes them.

`--exit-code` option for `ls-remote` was introduced at [1.7.6](https://github.com/git/git/blob/master/Documentation/RelNotes/1.7.6.txt#L81), which is later than the current git version requirement from git (1.7.1). This pull request also updates the documentation on the required git version.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- git module

##### ANSIBLE VERSION

- v2.4.0.0-1

##### ADDITIONAL INFORMATION
