### PR TITLE
[FIX] RDS config should be getboolean, as per ec2.ini instructions

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -354,7 +354,7 @@ class Ec2Inventory(object):
         self.route53_excluded_zones = [a for a in config.get('ec2', 'route53_excluded_zones').split(',') if a]
 
         # Include RDS instances?
-        self.rds_enabled = config.get('ec2', 'rds')
+        self.rds_enabled = config.getboolean('ec2', 'rds')
 
         # Include RDS cluster instances?
         self.include_rds_clusters = config.getboolean('ec2', 'include_rds_clusters')


### PR DESCRIPTION
##### SUMMARY
A very simple change, seems like a missout. The ec2.ini `rds` config option is clearly a boolean:
https://github.com/ansible/ansible/blob/devel/contrib/inventory/ec2.ini#L70

And evidently, it actually was one:
https://github.com/ansible/ansible/commit/d35ef1fc21c313a31b0c8b68754c4c3d35ba03ca
( @jtyr )

##### ISSUE TYPE

    Bug Report


Apologies if any extra info is needed here, but it seems straight forward enough I hope.

Feel free to close if this is not of any help.