### PR TITLE
Document apt module taking multiple package names

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -27,9 +27,10 @@ options:
   name:
     description:
       - A package name, like C(foo), or package specifier with version, like C(foo=1.0). Name wildcards (fnmatch) like C(apt*) and version wildcards
-        like C(foo=1.0*) are also supported.  Note that the apt-get commandline supports implicit regex matches here but we do not because it can let
-        typos through easier (If you typo C(foo) as C(fo) apt-get would install packages that have "fo" in their name with a warning and a prompt for
-        the user.  Since we don't have warnings and prompts before installing we disallow this.  Use an explicit fnmatch pattern if you want wildcarding)
+        like C(foo=1.0*) are also supported.  Can also take a comma-separated list of values to manage multiple packages at once.  Note that the apt-get
+        commandline supports implicit regex matches here but we do not because it can let typos through easier (If you typo C(foo) as C(fo) apt-get would
+        install packages that have "fo" in their name with a warning and a prompt for the user.  Since we don't have warnings and prompts before
+        installing we disallow this.  Use an explicit fnmatch pattern if you want wildcarding)
     required: false
     default: null
     aliases: [ 'pkg', 'package' ]
@@ -163,6 +164,11 @@ EXAMPLES = '''
 - name: Install the version '1.00' of package "foo"
   apt:
     name: foo=1.00
+    state: present
+
+- name: Install both the "foo" and "bar" packages with the same command
+  apt:
+    name: foo,bar
     state: present
 
 - name: Update the repository cache and update package "nginx" to latest version using default release squeeze-backport


### PR DESCRIPTION
##### SUMMARY
The apt module can manage multiple packages at once by specifying them as a comma-separated list, but was not mentioned in the documentation. This commit adds that information.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Module: apt

##### ANSIBLE VERSION
```
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/dave/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dave/develop/ansible/lib/ansible
  executable location = /home/dave/develop/ansible/bin/ansible
  python version = 3.6.2 (default, Oct  2 2017, 09:59:08) [GCC 6.3.0 20170406]
```
