### PR TITLE
Validate context after update of magic variables

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -412,7 +412,7 @@ class TaskExecutor:
             # fields set from the play/task may be based on variables, so we have to
             # do the same kind of post validation step on it here before we use it.
             self._play_context.post_validate(templar=templar)
-            
+
             # FIXME: update connection/shell plugin options
         except AnsibleError as e:
             # save the error, which we'll raise later if we don't end up

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -400,10 +400,6 @@ class TaskExecutor:
             # the options specified on the command line
             self._play_context = self._play_context.set_task_and_variable_override(task=self._task, variables=variables, templar=templar)
 
-            # fields set from the play/task may be based on variables, so we have to
-            # do the same kind of post validation step on it here before we use it.
-            self._play_context.post_validate(templar=templar)
-
             # now that the play context is finalized, if the remote_addr is not set
             # default to using the host's address field as the remote address
             if not self._play_context.remote_addr:
@@ -413,6 +409,10 @@ class TaskExecutor:
             # a certain subset of variables exist.
             self._play_context.update_vars(variables)
 
+            # fields set from the play/task may be based on variables, so we have to
+            # do the same kind of post validation step on it here before we use it.
+            self._play_context.post_validate(templar=templar)
+            
             # FIXME: update connection/shell plugin options
         except AnsibleError as e:
             # save the error, which we'll raise later if we don't end up


### PR DESCRIPTION
##### SUMMARY

Currently, you cannot use magic variables as variables in `become_user` for example. The post_validate step will do a fatal error because these variables are undefined.

By moving the post_validate step after these variables are added to the context, it becomes possible to use them in templates.

This used to work in 1.8, when doing 'sudo_user: "{{ansible_ssh_user}}"'
it now breaks with 'become_user: "{{ansible_user}}"'

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

executor/task_executor.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0 (stable-2.4 4025b47629) last updated 2017/09/29 09:21:06 (GMT +000)
  config file = /home/juser/ansible.cfg
  configured module search path = [u'/home/juser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/juser/ansiwork-git/lib/ansible
  executable location = /home/juser/ansiwork-git/bin/ansible
  python version = 2.7.5 (default, Jun 26 2014, 11:55:39) [GCC 4.8.2 20131212 (Red Hat 4.8.2-7)]
```


##### ADDITIONAL INFORMATION

you can test with the following playbook

````
- hosts: ovh-1
  gather_facts: no
  tasks:
  - name: works
    debug:
      msg: "hello {{ ansible_user }}"


- hosts: ovh-1
  gather_facts: no
  tasks:
  - name: does not work
    debug:
      msg: "hello {{ ansible_user }}"
    become: yes
    become_user: "{{ansible_user}}"
````

````
command
ansible-playbook -u juser -i ansiconf/production ansiconf/sample.yml



result before
PLAY [ovh-1] ***************************************************************************************************************************************************************

TASK [Echo current user] ***************************************************************************************************************************************************
ok: [xxx.ovh.net] => {
    "msg": "hello juser"
}

PLAY [ovh-1] ***************************************************************************************************************************************************************

TASK [Echo current user] ***************************************************************************************************************************************************
fatal: [xxx.ovh.net]: FAILED! => {"msg": "The field 'become_user' has an invalid value, which includes an undefined variable. The error was: 'ansible_user' is undefined\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: 'ansible_user' is undefined"}
        to retry, use: --limit @/home/juser/ansiconf/sample.retry

PLAY RECAP *****************************************************************************************************************************************************************
xxx.ovh.net           : ok=1    changed=0    unreachable=0    failed=1




result after
PLAY [ovh-1] ***************************************************************************************************************************************************************

TASK [Echo current user] ***************************************************************************************************************************************************
ok: [vps33957.ovh.net] => {
    "msg": "hello juser"
}

PLAY [ovh-1] ***************************************************************************************************************************************************************

TASK [Echo current user] ***************************************************************************************************************************************************
ok: [xxx.ovh.net] => {
    "msg": "hello juser"
}

PLAY RECAP *****************************************************************************************************************************************************************
xxx.ovh.net           : ok=2    changed=0    unreachable=0    failed=0

```
