### PR TITLE
Documenting second parameter of the default filter

### DIFF
--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -71,7 +71,7 @@ In the above example, if the variable 'some_variable' is not defined, the value 
 being raised.
 
 If the variable evaluates to an empty string, the second parameter of the filter should be set to
-`true`:
+`true`::
 
     {{ lookup('env', 'MY_USER') | default('admin', true) }}
 

--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -70,6 +70,11 @@ Jinja2 provides a useful 'default' filter, that is often a better approach to fa
 In the above example, if the variable 'some_variable' is not defined, the value used will be 5, rather than an error
 being raised.
 
+If the variable evaluates to a false value (e.g. empty string), the second parameter of the filter have to be set to
+`true`:
+
+    {{ lookup('env', 'MY_USER') | default('admin', true) }}
+
 
 .. _omitting_undefined_variables:
 

--- a/docs/docsite/rst/playbooks_filters.rst
+++ b/docs/docsite/rst/playbooks_filters.rst
@@ -63,14 +63,14 @@ The variable value will be used as is, but the template evaluation will raise an
 Defaulting Undefined Variables
 ``````````````````````````````
 
-Jinja2 provides a useful 'default' filter, that is often a better approach to failing if a variable is not defined::
+Jinja2 provides a useful 'default' filter that is often a better approach to failing if a variable is not defined::
 
     {{ some_variable | default(5) }}
 
 In the above example, if the variable 'some_variable' is not defined, the value used will be 5, rather than an error
 being raised.
 
-If the variable evaluates to a false value (e.g. empty string), the second parameter of the filter have to be set to
+If the variable evaluates to an empty string, the second parameter of the filter should be set to
 `true`:
 
     {{ lookup('env', 'MY_USER') | default('admin', true) }}


### PR DESCRIPTION
##### SUMMARY
This PR is adding documentation for the second parameter of the `default` Jinja2 filter.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
`default` Jinja2 filter

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION

None