### PR TITLE
Fix backwards compatibility of constants.get_config

### DIFF
--- a/lib/ansible/constants.py
+++ b/lib/ansible/constants.py
@@ -15,7 +15,7 @@ from string import ascii_letters, digits
 from ansible.module_utils._text import to_text
 from ansible.module_utils.parsing.convert_bool import boolean, BOOLEANS_TRUE
 from ansible.module_utils.six import string_types
-from ansible.config.manager import ConfigManager, ensure_type
+from ansible.config.manager import ConfigManager, ensure_type, get_ini_config_value
 
 
 def _deprecated(msg):
@@ -43,7 +43,7 @@ def get_config(parser, section, key, env_var, default_value, value_type=None, ex
     value = os.environ.get(env_var, None)
     if value is None:
         try:
-            value = config.get_ini_config(parser, [{'key': key, 'section': section}])
+            value = get_ini_config_value(parser, {'key': key, 'section': section})
         except:
             pass
     if value is None:


### PR DESCRIPTION
get_config would use ConfigManager.get_ini_value which does not
exist. What we are meant to use is
ansible.config.manager.get_ini_config_value and this method does not
expect a list, only a dictionary with a section and a key.

##### SUMMARY
get_config used ConfigManager.get_ini_value which does not exist and was silently failing due to the blind exception pass.
This caused configuration parameters to be set to their defaults.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ConfigManager

##### ANSIBLE VERSION
Applicable to Ansible 2.4 and 2.5