### PR TITLE
[cloud] Fix handling of `encrypt` option in aws_s3 module (#30822)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -395,11 +395,12 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
     try:
+        extra = {}
+        if encrypt:
+            extra['ServerSideEncryption'] = 'AES256'
         if metadata:
-            extra = {'Metadata': dict(metadata)}
-            s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
-        else:
-            s3.upload_file(Filename=src, Bucket=bucket, Key=obj)
+            extra['Metadata'] = dict(metadata)
+        s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
         for acl in module.params.get('permission'):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
         url = s3.generate_presigned_url(ClientMethod='put_object',


### PR DESCRIPTION
##### SUMMARY
Reenables encryption for aws_s3. Merged to devel in #30822.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_s3.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0 (2.4_aws_s3_encryption e67e7785d3) last updated 2017/10/02 13:22:53 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = ['/Users/shertel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 3.5.2 (default, Oct 11 2016, 04:59:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```