### PR TITLE
Fix flush_cache on redis cache

### DIFF
--- a/lib/ansible/plugins/cache/redis.py
+++ b/lib/ansible/plugins/cache/redis.py
@@ -116,7 +116,7 @@ class CacheModule(BaseCacheModule):
         return (self._db.zrank(self._keys_set, key) is not None)
 
     def delete(self, key):
-        del self.cache[key]
+        del self._cache[key]
         self._db.delete(self._make_key(key))
         self._db.zrem(self._keys_set, key)
 


### PR DESCRIPTION

##### SUMMARY
Fix flush_cache on redis cache

Fix a del on non existent self.cache.

Fixes #31148


##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/cache/redis.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (redis_cache_delete_31148 35a62f68c9) last updated 2017/10/02 13:54:25 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


