### PR TITLE
fix(ec2.py): RDS still listed despite rds = false in ec2.ini

### DIFF
--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -354,7 +354,7 @@ class Ec2Inventory(object):
         self.route53_excluded_zones = [a for a in config.get('ec2', 'route53_excluded_zones').split(',') if a]
 
         # Include RDS instances?
-        self.rds_enabled = config.get('ec2', 'rds')
+        self.rds_enabled = config.getboolean('ec2', 'rds')
 
         # Include RDS cluster instances?
         self.include_rds_clusters = config.getboolean('ec2', 'include_rds_clusters')


### PR DESCRIPTION
##### SUMMARY
Fixes issue raised in #30129. 

`./ec2.py --list` still lists RDS instances despite the fact that ec2.ini contains `rds = False`.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/ec2.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
__Expected behavior__
Adding `rds = False` inside __ec2.ini__ should allow the user to run ansible using dynamic inventory while ignoring RDS instances thus allowing AWS permissions to be kept in line with the principle of least privilege.

__Actual behavior__
Adding `rds = False` inside __ec2.ini__ __does not__ allow the user to run ansible using dynamic inventory while ignoring RDS instances. __ec2.py__ still tries to retrieve RDS instances.

__Cause__
`self.rds_enabled` (value that is checked to evaluate whether or not RDS instances should be retrieved) is a __string__. Therefore, if self.rds_enabled is always true no matter what the value is in __ec2.ini__

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before (with rds = False)
```
./ec2.py --list
Traceback (most recent call last):
  File "./ec2.py", line 1664, in <module>
    Ec2Inventory()
  File "./ec2.py", line 247, in __init__
    self.do_api_calls_update_cache()
  File "./ec2.py", line 518, in do_api_calls_update_cache
    self.get_rds_instances_by_region(region)
  File "./ec2.py", line 652, in get_rds_instances_by_region
    db_instances = client.describe_db_instances()
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 312, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python2.7/dist-packages/botocore/client.py", line 601, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the DescribeDBInstances operation: User: arn:aws:sts::************:assumed-role/<ROLE>/<EC2 INSTANCE ID> is not authorized to perform: rds:DescribeDBInstances
```
After (with rds = False)
```
./ec2.py --list
<ec2 instance list as expected>
```
