### PR TITLE
 Pin docker simulator versions.

### DIFF
--- a/test/integration/targets/vmware_maintenancemode/aliases
+++ b/test/integration/targets/vmware_maintenancemode/aliases
@@ -1,3 +1,2 @@
-posix/ci/cloud/group1/vcenter
 cloud/vcenter
 destructive

--- a/test/runner/lib/cloud/cs.py
+++ b/test/runner/lib/cloud/cs.py
@@ -52,7 +52,8 @@ class CsCloudProvider(CloudProvider):
         """
         super(CsCloudProvider, self).__init__(args, config_extension='.ini')
 
-        self.image = 'ansible/ansible:cloudstack-simulator'
+        # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
+        self.image = 'ansible/ansible:cloudstack-simulator@sha256:885aedb7f34ce7114eaa383a2541ede93c4f8cb543c05edf90b694def67b1a6a'
         self.container_name = ''
         self.endpoint = ''
         self.host = ''

--- a/test/runner/lib/cloud/vcenter.py
+++ b/test/runner/lib/cloud/vcenter.py
@@ -39,7 +39,8 @@ class VcenterProvider(CloudProvider):
         """
         super(VcenterProvider, self).__init__(args, config_extension='.ini')
 
-        self.image = 'ansible/ansible:vcenter-simulator'
+        # The simulator must be pinned to a specific version to guarantee CI passes with the version used.
+        self.image = 'ansible/ansible:vcenter-simulator@sha256:1a92e84f477ae4c45f9070a5419a0fc2b46abaecdb5bc396826741bca65ce028'
         self.container_name = ''
 
     def filter(self, targets, exclude):


### PR DESCRIPTION
##### SUMMARY

Pin docker simulator versions. Disable failing vmware_maintenancemode test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (simulator-fix 488bfd07be) last updated 2017/10/02 12:15:45 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
