### PR TITLE
fix monit version check

### DIFF
--- a/lib/ansible/modules/monitoring/monit.py
+++ b/lib/ansible/modules/monitoring/monit.py
@@ -79,11 +79,11 @@ def main():
         # Use only major and minor even if there are more these should be enough
         return int(version[0]), int(version[1])
 
-    def is_version_higher_than_18():
-        return MONIT_MAJOR_VERSION > 3 or MONIT_MAJOR_VERSION == 3 and MONIT_MINOR_VERSION > 18
+    def is_version_higher_than_5_18():
+        return (MONIT_MAJOR_VERSION, MONIT_MINOR_VERSION) > (5, 18)
 
     def parse(parts):
-        if is_version_higher_than_18():
+        if is_version_higher_than_5_18():
             return parse_current(parts)
         else:
             return parse_older_versions(parts)
@@ -138,7 +138,7 @@ def main():
 
     MONIT_MAJOR_VERSION, MONIT_MINOR_VERSION = monit_version()
 
-    SUMMARY_COMMAND = ('summary', 'summary -B')[is_version_higher_than_18()]
+    SUMMARY_COMMAND = ('summary', 'summary -B')[is_version_higher_than_5_18()]
 
     if state == 'reloaded':
         if module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Fixes #30614. There is logic to distinguish `monit` versions that do and don't support/require the use of `-B` to get colorless output; this logic was erroneously checking > 3.18 instead of > 5.18. 

Current version as the time of this writing is 5.24.0 (https://mmonit.com/monit/) and color support (and consequently support for/requirement of `-B` for colorless output) was introduced in 5.18.0 (https://mmonit.com/monit/changes/). However, currently the major version is being compared with 3 rather than 5. I believe this to be a simple typo.

In addition to change 3 to 5, I also changed the expression behind it to be more obvious and the function name to be more explicit.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/monitoring/monit.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /home/droberts/commcarehq-ansible/ansible/ansible.cfg
  configured module search path = [u'/home/droberts/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/droberts/.virtualenvs/ansible/local/lib/python2.7/site-packages/ansible
  executable location = /home/droberts/.virtualenvs/ansible/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
Before
```
TASK [couchdb2 : monit] ************************************************************************************************************************************************************************************
fatal: [xx.xx.xx.xx]: FAILED! => {"changed": false, "cmd": "/usr/bin/monit summary -B", "failed": true, "msg": "monit: invalid option -- B  (-h will show valid options)", "rc": 1, "stderr": "monit: invalid option -- B  (-h will show valid options)\n", "stderr_lines": ["monit: invalid option -- B  (-h will show valid options)"], "stdout": "", "stdout_lines": []}
	to retry, use: --limit @/home/droberts/commcarehq-ansible/ansible/deploy_stack.retry
```
After
```
TASK [couchdb2 : monit] ************************************************************************************************************************************************************************************
ok: [xx.xx.xx.xx]
```