### PR TITLE
Remove robinro as git maintainer

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -544,7 +544,7 @@ files:
   $modules/remote_management/stacki/stacki_host.py: bbyhuy bsanders
   $modules/remote_management/wakeonlan.py: dagwieers
   $modules/source_control/bzr.py: andreparames
-  $modules/source_control/git.py: $team_ansible robinro
+  $modules/source_control/git.py: $team_ansible
   $modules/source_control/git_config.py: djmattyg007
   $modules/source_control/github_deploy_key.py: bincyber
   $modules/source_control/github_hooks.py: pcgentry


### PR DESCRIPTION
##### SUMMARY
Remove robinro as git maintainer

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
git

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
The git module needs full-time attention, which I can no longer provide.
Also mixing core support and community maintainers doesn't seem to work well for me, see e.g. https://github.com/ansible/ansible/pull/29069 which got merged without proper review.