### PR TITLE
win_become: move error handling to Ansible outside of shell

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -801,8 +801,8 @@ Function Run($payload) {
         # FUTURE: decode CLIXML stderr output (and other streams?)
 
         $rc = [Ansible.Shell.NativeProcessUtil]::GetProcessExitCode($pi.hProcess)
-        [Console]::Out.WriteLine($str_stdout)
-        [Console]::Error.WriteLine($str_stderr)
+        [Console]::Out.WriteLine($str_stdout.Trim())
+        [Console]::Error.WriteLine($str_stderr.Trim())
     }
     Catch {
         $excep = $_

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -811,7 +811,7 @@ Function Run($payload) {
     Finally {
         Remove-Item $temp -ErrorAction SilentlyContinue
     }
-    exit $rc
+    $host.SetShouldExit($rc)
 }
 
 '''  # end become_wrapper

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -801,15 +801,8 @@ Function Run($payload) {
         # FUTURE: decode CLIXML stderr output (and other streams?)
 
         $rc = [Ansible.Shell.NativeProcessUtil]::GetProcessExitCode($pi.hProcess)
-
-        If ($rc -eq 0) {
-            $str_stdout
-            $str_stderr
-        }
-        Else {
-            Throw "failed, rc was $rc, stderr was $str_stderr, stdout was $str_stdout"
-        }
-
+        [Console]::Out.WriteLine($str_stdout)
+        [Console]::Error.WriteLine($str_stderr)
     }
     Catch {
         $excep = $_
@@ -818,7 +811,7 @@ Function Run($payload) {
     Finally {
         Remove-Item $temp -ErrorAction SilentlyContinue
     }
-
+    exit $rc
 }
 
 '''  # end become_wrapper

--- a/test/integration/targets/win_become/tasks/main.yml
+++ b/test/integration/targets/win_become/tasks/main.yml
@@ -71,7 +71,7 @@
         that:
         - whoami_out.stdout_lines[0].endswith(become_test_username)
   
-  - name: test with module that will return non-zero exit code
+  - name: test with module that will return non-zero exit code (https://github.com/ansible/ansible/issues/30468)
     vars: *become_vars
     setup:
 

--- a/test/integration/targets/win_become/tasks/main.yml
+++ b/test/integration/targets/win_become/tasks/main.yml
@@ -70,6 +70,10 @@
       assert:
         that:
         - whoami_out.stdout_lines[0].endswith(become_test_username)
+  
+  - name: test with module that will return non-zero exit code
+    vars: *become_vars
+    setup:
 
 # FUTURE: test raw + script become behavior once they're running under the exec wrapper again
 # FUTURE: add standalone playbook tests to include password prompting and play become keywords


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible/ansible/issues/30468. Instead of handling the error in the shell plugin with the become wrapper. The become wrapper will just pass along the stdout/stderr stream and exit code for it to be handled by the Ansible engine like a normal execution.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
windows
become

##### ANSIBLE VERSION
```
2.5
```