### PR TITLE
Addition of TCP protocol to ELB target group

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -549,7 +549,7 @@ def create_or_update_target_group(connection, module):
     if stickiness_lb_cookie_duration is not None:
         if str(stickiness_lb_cookie_duration) != current_tg_attributes['stickiness_lb_cookie_duration_seconds']:
             update_attributes.append({'Key': 'stickiness.lb_cookie.duration_seconds', 'Value': str(stickiness_lb_cookie_duration)})
-    if stickiness_type is not None:
+    if stickiness_type is not None and "stickiness_type" in current_tg_attributes:
         if stickiness_type != current_tg_attributes['stickiness_type']:
             update_attributes.append({'Key': 'stickiness.type', 'Value': stickiness_type})
 

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -28,7 +28,7 @@ options:
     description:
       - The protocol the load balancer uses when performing health checks on targets.
     required: false
-    choices: [ 'http', 'https' ]
+    choices: [ 'http', 'https', 'tcp' ]
   health_check_port:
     description:
       - The port the load balancer uses when performing health checks on targets.
@@ -68,7 +68,7 @@ options:
     description:
       - The protocol to use for routing traffic to the targets. Required when I(state) is C(present).
     required: false
-    choices: [ 'http', 'https' ]
+    choices: [ 'http', 'https', 'tcp' ]
   purge_tags:
     description:
       - If yes, existing tags will be purged from the resource to match exactly what is defined by I(tags) parameter. If the tag parameter is not set then
@@ -620,7 +620,7 @@ def main():
     argument_spec.update(
         dict(
             deregistration_delay_timeout=dict(type='int'),
-            health_check_protocol=dict(choices=['http', 'https', 'HTTP', 'HTTPS'], type='str'),
+            health_check_protocol=dict(choices=['http', 'https', 'tcp', 'HTTP', 'HTTPS', 'TCP'], type='str'),
             health_check_port=dict(type='int'),
             health_check_path=dict(default=None, type='str'),
             health_check_interval=dict(type='int'),
@@ -629,7 +629,7 @@ def main():
             modify_targets=dict(default=True, type='bool'),
             name=dict(required=True, type='str'),
             port=dict(type='int'),
-            protocol=dict(choices=['http', 'https', 'HTTP', 'HTTPS'], type='str'),
+            protocol=dict(choices=['http', 'https', 'tcp', 'HTTP', 'HTTPS', 'TCP'], type='str'),
             purge_tags=dict(default=True, type='bool'),
             stickiness_enabled=dict(type='bool'),
             stickiness_type=dict(default='lb_cookie', type='str'),


### PR DESCRIPTION
… HTTP/S and TCP now

##### SUMMARY
Update existing elb_target_group module to support the addition of TCP protocol for protocol and health check protocol.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/Etherdaemon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/Etherdaemon/python_virtualenvs/ansibletrial/lib/python2.7/site-packages/ansible
  executable location = /Users/Etherdaemon/python_virtualenvs/ansibletrial/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:46:44) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
AWS have added support for TCP protocol on their ELB target groups in order to be attached to either Application Load Balancers or their new Network Load Balancers. This PR is to support this new change so that we can create target groups for NLBs.

