### PR TITLE
Handle multiple Content-Type headers correctly

### DIFF
--- a/changelogs/fragments/31238-uri-multi-content-type.yaml
+++ b/changelogs/fragments/31238-uri-multi-content-type.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- uri - Handle multiple Content-Type headers correctly
+  (https://github.com/ansible/ansible/pull/31238)

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -655,10 +655,29 @@ def main():
     content_encoding = 'utf-8'
     if 'content_type' in uresp:
         # Handle multiple Content-Type headers
-        for ct in uresp['content_type'].split(','):
-            content_type, params = cgi.parse_header(ct)
+        charsets = []
+        content_types = []
+        for value in uresp['content_type'].split(','):
+            ct, params = cgi.parse_header(value)
+            if ct not in content_types:
+                content_types.append(ct)
             if 'charset' in params:
-                content_encoding = params['charset']
+                if params['charset'] not in charsets:
+                    charsets.append(params['charset'])
+
+        if content_types:
+            content_type = content_types[0]
+            if len(content_types) > 1:
+                module.warn(
+                    'Received multiple conflicting Content-Type values (%s), using %s' % (', '.join(content_types), content_type)
+                )
+        if charsets:
+            content_encoding = charsets[0]
+            if len(charsets) > 1:
+                module.warn(
+                    'Received multiple conflicting charset values (%s), using %s' % (', '.join(charsets), content_encoding)
+                )
+
         u_content = to_text(content, encoding=content_encoding)
         if any(candidate in content_type for candidate in JSON_CANDIDATES):
             try:

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -654,9 +654,11 @@ def main():
     # Default content_encoding to try
     content_encoding = 'utf-8'
     if 'content_type' in uresp:
-        content_type, params = cgi.parse_header(uresp['content_type'])
-        if 'charset' in params:
-            content_encoding = params['charset']
+        # Handle multiple Content-Type headers
+        for ct in uresp['content_type'].split(','):
+            content_type, params = cgi.parse_header(ct)
+            if 'charset' in params:
+                content_encoding = params['charset']
         u_content = to_text(content, encoding=content_encoding)
         if any(candidate in content_type for candidate in JSON_CANDIDATES):
             try:


### PR DESCRIPTION

##### SUMMARY
Avoids situations where mulitple Content-Type headers including charset information can result in errors like 
```
LookupError: unknown encoding: UTF-8, text/html
```

https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2 states that duplicate headers are ok. 
Urllib correctly returns a comma-seperated list of Content-Type values - but cgi.parse_header isn't able to handle that, so we need to split it up. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/basics/uri.py

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
```
- name: Waiting for isalive urls
  become: False
  uri:
    url: http://domain/healthcheck
    status_code: 200
    return_content: true
  register: response
  until: response.content == 'isalive'
  retries: 2
  delay: 2
```
... can result in...
```
"module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_vadAlD/ansible_module_uri.py\", line 498, in <module>\r\n    main()\r\n  File \"/tmp/ansible_vadAlD/ansible_module_uri.py\", line 478, in main\r\n    u_content = to_text(content, encoding=content_encoding)\r\n  File \"/tmp/ansible_vadAlD/ansible_modlib.zip/ansible/module_utils/_text.py\", line 235, in to_text\r\nLookupError: unknown encoding: UTF-8, text/html\r\n",
```

... if the http response returns multiple Content-Type headers like this ...
```
Content-Type: text/html; charset=UTF-8
Content-Length: 500
Set-Cookie: JSESSIONID=sdfsdfsdfsdf; Path=/url; HttpOnly
Date: Tue, 03 Oct 2017 07:37:09 GMT
Content-Type: text/html
```

The combined content-type is currently sendt comma-seperated to cgi.parse_header, which isn't able to handle multiple values, so it returns "charset=UTF8, text/html", which then is used for decoding and results in the unknown encoding error message.

The pull request simply sends one content_header value at a time to cgi.parse_header to get the right encoding. 