### PR TITLE
Fix urlparse import for Python3

### DIFF
--- a/contrib/inventory/consul_io.py
+++ b/contrib/inventory/consul_io.py
@@ -473,10 +473,7 @@ class ConsulConfig(dict):
         scheme = 'http'
 
         if hasattr(self, 'url'):
-            try:
-                from urlparse import urlparse
-            except ImportError:
-                from urllib.parse import urlparse
+            from ansible.module_utils.six.moves.urllib.parse import urlparse
             o = urlparse(self.url)
             if o.hostname:
                 host = o.hostname

--- a/contrib/inventory/rudder.py
+++ b/contrib/inventory/rudder.py
@@ -56,12 +56,8 @@ import argparse
 import six
 import httplib2 as http
 from time import time
-from six.moves import configparser
-
-try:
-    from urlparse import urlparse
-except ImportError:
-    from urllib.parse import urlparse
+from ansible.module_utils.six.moves import configparser
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 try:
     import json

--- a/contrib/inventory/windows_azure.py
+++ b/contrib/inventory/windows_azure.py
@@ -39,7 +39,7 @@ import re
 import sys
 import argparse
 import os
-from urlparse import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 from time import time
 try:
     import json

--- a/lib/ansible/module_utils/known_hosts.py
+++ b/lib/ansible/module_utils/known_hosts.py
@@ -30,10 +30,7 @@ import os
 import hmac
 import re
 
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 try:
     from hashlib import sha1
@@ -75,7 +72,7 @@ def get_fqdn_and_port(repo_url):
             fqdn = repo_url.split("/")[0]
     elif "://" in repo_url:
         # this should be something we can parse with urlparse
-        parts = urlparse.urlparse(repo_url)
+        parts = urlparse(repo_url)
         # parts[1] will be empty on python2.4 on ssh:// or git:// urls, so
         # ensure we actually have a parts[1] before continuing.
         if parts[1] != '':

--- a/lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py
+++ b/lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py
@@ -166,7 +166,7 @@ firewall_policy:
 __version__ = '${version}'
 
 import os
-import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 from time import sleep
 from distutils.version import LooseVersion
 
@@ -288,7 +288,7 @@ class ClcFirewallPolicy:
         :return: policy_id: firewall policy id from creation call
         """
         url = response.get('links')[0]['href']
-        path = urlparse.urlparse(url).path
+        path = urlparse(url).path
         path_list = os.path.split(path)
         policy_id = path_list[-1]
         return policy_id

--- a/lib/ansible/modules/cloud/docker/_docker.py
+++ b/lib/ansible/modules/cloud/docker/_docker.py
@@ -516,11 +516,7 @@ EXAMPLES = '''
 import json
 import os
 import shlex
-try:
-    from urlparse import urlparse
-except ImportError:
-    # python3
-    from urllib.parse import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 try:
     import docker.client

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -236,11 +236,7 @@ import ssl
 from httplib import HTTPSConnection
 from httplib import IncompleteRead
 
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
-
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 try:
     import ovirtsdk4.types as otypes

--- a/lib/ansible/plugins/action/ce_template.py
+++ b/lib/ansible/plugins/action/ce_template.py
@@ -22,7 +22,7 @@ __metaclass__ = type
 import os
 import time
 import glob
-import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlsplit
 
 from ansible.module_utils._text import to_text
 from ansible.plugins.action.ce import ActionModule as _ActionModule
@@ -72,7 +72,7 @@ class ActionModule(_ActionModule):
 
         working_path = self._get_working_path()
 
-        if os.path.isabs(src) or urlparse.urlsplit(src).scheme:
+        if os.path.isabs(src) or urlsplit(src).scheme:
             source = src
         else:
             source = self._loader.path_dwim_relative(working_path, 'templates', src)

--- a/lib/ansible/plugins/lookup/consul_kv.py
+++ b/lib/ansible/plugins/lookup/consul_kv.py
@@ -61,7 +61,7 @@ RETURN = """
 
 import os
 import sys
-from urlparse import urlparse
+from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 


### PR DESCRIPTION
##### SUMMARY
Fix urlparse import error in lib/ansible/plugins/lookup/consul_kv.py with Python3

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/lookup

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/home/fs/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.6.2 (default, Jul 20 2017, 03:52:27) [GCC 7.1.1 20170630]
```


##### ADDITIONAL INFORMATION

The output of atom plugin, running on Archlinux:

```
autocomplete-ansible traceback output:

Command failed: /usr/bin/python "/home/fs/.atom/packages/autocomplete-ansible/lib/parse_ansible.py"

Traceback (most recent call last):
  File "/home/fs/.atom/packages/autocomplete-ansible/lib/parse_ansible.py", line 83, in <module>
    main()
  File "/home/fs/.atom/packages/autocomplete-ansible/lib/parse_ansible.py", line 75, in main
    for lookup in lookup_loader.all():
  File "/usr/lib/python3.6/site-packages/ansible/plugins/loader.py", line 426, in all
    self._module_cache[path] = self._load_module_source(name, path)
  File "/usr/lib/python3.6/site-packages/ansible/plugins/loader.py", line 339, in _load_module_source
    module = imp.load_source(full_name, path, module_file)
  File "/usr/lib/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 675, in _load
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "/usr/lib/python3.6/site-packages/ansible/plugins/lookup/consul_kv.py", line 65, in <module>
    from urlparse import urlparse

ModuleNotFoundError: No module named 'urlparse'
```
