### PR TITLE
Support to add instance into an explicit group

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -149,6 +149,9 @@ group_by_elasticache_cluster = True
 group_by_elasticache_parameter_group = True
 group_by_elasticache_replication_group = True
 
+# Tag key holding the information about the instance group(s).
+# group_tag_key = ansible_group
+
 # If you only want to include hosts that match a certain regular expression
 # pattern_include = staging-*
 


### PR DESCRIPTION
##### SUMMARY

This PR is adding the possibility to define an Ansible group with an explicit group name based on a specific EC2 instance tag. This simplifies the combination of multiple inventories (e.g. local and EC2) to make the hosts from multiple inventories share the same groups. Like this, one inventory can create hierarchical inventory structure using `:children` and other inventories can add hosts into this structure. See example bellow.


##### ISSUE TYPE

Feature Pull Request


##### COMPONENT NAME

`ec2.py`


##### ANSIBLE VERSION

```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION

Example of using local and EC2 inventory together:

```bash
mkdir inventory_scripts
# Create local inventory with hierarchical inventory structure
cat > inventory_scripts/01_local <<END
[aws:children]
aws-dev

[aws-dev:children]
aws-dev-jenkins

[aws-dev-jenkins]
END
# Get the ec2.py inventory script (using my fork to have this PR changes included)
curl -o inventory_scripts/02_ec2.py https://raw.githubusercontent.com/jtyr/ansible/jtyr-ec2_group/contrib/inventory/ec2.py
chmod +x inventory_scripts/02_ec2.py
# Configure the EC2 inventory script
cat > inventory_scripts/ec2.ini <<END
[ec2]
# Disable all other groups creation
group_by_instance_id = False
group_by_region = False
group_by_availability_zone = False
group_by_ami_id = False
group_by_instance_type = False
group_by_platform = False
group_by_key_pair = False
group_by_vpc_id = False
group_by_security_group = False
group_by_tag_keys = False
group_by_tag_none = False
group_by_route53_names = False
group_by_rds_engine = False
group_by_rds_parameter_group = False
group_by_elasticache_engine = False
group_by_elasticache_cluster = False
group_by_elasticache_parameter_group = False
group_by_elasticache_replication_group = False

# Tag key holding the information about the instance group(s).
group_tag_key = ansible_group
END
mkdir group_vars
# Create group vars file defining variable for the aws-dev group
cat > group_vars/aws-dev <<END
---

env: dev
END
# Create simple playbook
cat > site.yaml <<END
---

- hosts: all
  tasks:
    - debug:
        var: env
END
```

Then when we point to the `inventory_scripts` directory as the Ansible inventory, the two inventories will get evaluated in alphabetical order where the local inventory (`01_local`) defines the inventory structure and the EC2 inventory script (`02_ec2.py`) adds hosts into that structure (assuming there is an EC2 instance with `ansible_group=aws-dev-jenkins` tag):

```
ansible-playbook -i inventory_scripts -u ec2-user site.yaml

PLAY [all] ***********************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [35.176.17.81]

TASK [debug] ***********************************************************************************************************************
ok: [35.176.17.81] => {
    "env": "dev"
}

PLAY RECAP ***********************************************************************************************************************
35.176.17.81             : ok=2    changed=0    unreachable=0    failed=0   

```