### PR TITLE
win_reg_stat actually sets properties to be a dictionary, not a list

### DIFF
--- a/lib/ansible/modules/windows/win_reg_stat.py
+++ b/lib/ansible/modules/windows/win_reg_stat.py
@@ -73,10 +73,10 @@ exists:
   type: boolean
   sample: True
 properties:
-  description: A list of all the properties and their values in the key.
+  description: A dictionary containing all the properties and their values in the registry key.
   returned: success, path exists and property not specified
-  type: list
-  sample: [
+  type: dict
+  sample: {
     "binary_property" : {
       "raw_value": ["0x01", "0x16"],
       "type": "REG_BINARY",
@@ -87,7 +87,7 @@ properties:
       "type": "REG_MULTI_SZ",
       "value": ["a", "b"]
     }
-    ]
+    }
 sub_keys:
   description: A list of all the sub keys of the key specified.
   returned: success, path exists and property not specified


### PR DESCRIPTION
##### SUMMARY
win_reg_stat actually sets properties to be a dictionary, not a list

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
win_reg_stat

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
Looking at the history I believe this has always been the case.