### PR TITLE
ovirt_vms: Support to specify VM id

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -640,6 +640,7 @@ class VmsModule(BaseModule):
         disk_attachments = self.__get_storage_domain_and_all_template_disks(template)
 
         return otypes.Vm(
+            id=self.param('id'),
             name=self.param('name'),
             cluster=otypes.Cluster(
                 name=self.param('cluster')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: https://github.com/ansible/ansible/issues/30873

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Vm with specific ID is successfully created.
```yaml
- name: Create vm from template
      ovirt_vms:
        auth: "{{ ovirt_auth }}"
        id: a8c55f31-558c-4f2f-9af6-feba94e54591
        cluster: cl2
        name: mycustomID
        template: cirros
```
