### PR TITLE
 vmware_guest - Cluster option stopped working #30879

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1170,9 +1170,12 @@ class PyVmomiHelper(object):
 
         resource_pool = None
 
-        if self.params['esxi_hostname'] or self.params['cluster']:
+        if self.params['esxi_hostname']:
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
+        elif self.params['cluster']:
+            cluster = self.cache.get_cluster(self.params['cluster'])
+            resource_pool = cluster.resourcePool
         else:
             resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1170,7 +1170,7 @@ class PyVmomiHelper(object):
 
         resource_pool = None
 
-        if self.params['esxi_hostname']:
+        if self.params['esxi_hostname'] or self.params['cluster']:
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
         else:
@@ -1261,8 +1261,7 @@ class PyVmomiHelper(object):
                 # create the relocation spec
                 relospec = vim.vm.RelocateSpec()
 
-                # Only select specific host when ESXi hostname is provided
-                if self.params['esxi_hostname']:
+                if self.params['esxi_hostname'] or self.params['cluster']:
                     relospec.host = self.select_host()
                 relospec.datastore = datastore
 


### PR DESCRIPTION
##### SUMMARY
In addition to the issue solved by #31139, I also found that if there were multiple clusters with the same resource pool name, the module was selecting the incorrect resource pool. To remove this ambiguity, this change will explicitly select the resource pool associated with the given cluster.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/xxxxx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/xxxxx/VirtualEnv/ansible/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /Users/xxxxx/VirtualEnv/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]

```


##### ADDITIONAL INFORMATION

