### PR TITLE
Fix nxos_banner removal idempotence issue in N1 images

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -90,14 +90,16 @@ commands:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.nxos import load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
-
+import re
 
 def map_obj_to_commands(want, have, module):
     commands = list()
     state = module.params['state']
+    platform_regex = 'Nexus.*Switch'
 
-    if (state == 'absent' and (have.get('text') and have.get('text') != 'User Access Verification')):
-        commands.append('no banner %s' % module.params['banner'])
+    if state == 'absent':
+        if (have.get('text') and not ((have.get('text') == 'User Access Verification') or re.match(platform_regex, have.get('text')))):
+            commands.append('no banner %s' % module.params['banner'])
 
     elif state == 'present' and want.get('text') != have.get('text'):
         banner_cmd = 'banner %s @\n%s\n@' % (module.params['banner'], want['text'].strip())

--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -92,6 +92,7 @@ from ansible.module_utils.nxos import load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
 import re
 
+
 def map_obj_to_commands(want, have, module):
     commands = list()
     state = module.params['state']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Default banner for N1 image is different and hence idempotency check was failing.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_banner

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0 (detached HEAD d14467b029) last updated 2017/10/02 15:33:27 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```