### PR TITLE
nxos_acl: change ports to non well known ports and drop time_range for N1

### DIFF
--- a/test/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -1,6 +1,9 @@
 ---
 - debug: msg="START TRANSPORT:{{ connection.transport }} nxos_acl sanity test"
 
+- set_fact: time_range="ans-range"
+  when: not (platform | match("N5K"))
+
 - name: "Setup: Cleanup possibly existing acl."
   nxos_acl: &remove
     name: TEST_ACL
@@ -17,8 +20,8 @@
     proto: tcp
     src: 1.1.1.1/24
     src_port_op: range
-    src_port1: 5
-    src_port2: 20
+    src_port1: 1900
+    src_port2: 1910
     ack: 'enable'
     dscp: 'af43'
     dest: any
@@ -29,7 +32,7 @@
     fin: 'enable'
     rst: 'enable'
     syn: 'enable'
-    time_range: 'ans-range'
+    time_range: "{{time_range|default(omit)}}"
     state: present
     provider: "{{ connection }}"
   register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
N1 images don't support time_range property and have a weird behavior for port numbers. Changing tests to use non well known ports.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - IT Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_acl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0 (detached HEAD d14467b029) last updated 2017/10/03 15:40:50 (GMT -400)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```