### PR TITLE
We want the ini and env vars to both override in the same order

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -66,8 +66,8 @@ ANSIBLE_PIPELINING:
     - "However this conflicts with privilege escalation (become). For example, when using 'sudo:' operations you must first
       disable 'requiretty' in /etc/sudoers on all managed hosts, which is why it is disabled by default."
   env:
-    - name: ANSIBLE_SSH_PIPELINING
     - name: ANSIBLE_PIPELINING
+    - name: ANSIBLE_SSH_PIPELINING
   ini:
   - section: connection
     key: pipelining


### PR DESCRIPTION
There's an ssh version and a generic version.  We want the ssh version
to override the generic version in both cases.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/config/base.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```

