### PR TITLE
Make YUM repo URL clickable again

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -115,7 +115,7 @@ RPMs for RHEL6 are available from yum for `EPEL
 <http://fedoraproject.org/wiki/EPEL>`_ 6 and currently supported
 Fedora distributions.
 
-Ansible will also have RPMs/YUM-repo available `here <https://releases.ansible.com/ansible/rpm/>`_.
+Ansible will also have RPMs/YUM-repo available `here <https://releases.ansible.com/ansible/rpm>`_.
 
 Ansible version 2.4 can manage earlier operating
 systems that contain Python 2.6 or higher.


### PR DESCRIPTION
Make YUM repo URL clickable again

##### SUMMARY

deleted trailing slash from URL that breaks the ability to double-click and led to displaying fragments of html code to the end user.

##### ISSUE TYPE
 - Docs Pull Request


<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
