### PR TITLE
Switch CI for OS X back to a single job.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -15,6 +15,7 @@ matrix:
     - env: T=units/3.5
     - env: T=units/3.6
 
+    - env: T=osx/10.11
     - env: T=rhel/7.4
 
     - env: T=windows/1
@@ -23,7 +24,6 @@ matrix:
 
     - env: T=network
 
-    - env: T=osx/10.11/1
     - env: T=freebsd/10.3-STABLE/1
     - env: T=freebsd/11.0-STABLE/1
     - env: T=linux/centos6/1
@@ -36,7 +36,6 @@ matrix:
     - env: T=linux/ubuntu1604/1
     - env: T=linux/ubuntu1604py3/1
 
-    - env: T=osx/10.11/2
     - env: T=freebsd/10.3-STABLE/2
     - env: T=freebsd/11.0-STABLE/2
     - env: T=linux/centos6/2
@@ -49,7 +48,6 @@ matrix:
     - env: T=linux/ubuntu1604/2
     - env: T=linux/ubuntu1604py3/2
 
-    - env: T=osx/10.11/3
     - env: T=freebsd/10.3-STABLE/3
     - env: T=freebsd/11.0-STABLE/3
     - env: T=linux/centos6/3

--- a/test/utils/shippable/cloud.sh
+++ b/test/utils/shippable/cloud.sh
@@ -5,9 +5,9 @@ set -o pipefail
 declare -a args
 IFS='/:' read -ra args <<< "$1"
 
-image="ansible/ansible:${args[1]}"
+image="${args[1]}"
 target="posix/ci/cloud/group${args[2]}/"
 
 # shellcheck disable=SC2086
-ansible-test integration --color -v --retry-on-error "${target}" --docker "${image}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-    --changed-all-target "${target}smoketest/"
+ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    --docker "${image}" --changed-all-target "${target}smoketest/"

--- a/test/utils/shippable/freebsd.sh
+++ b/test/utils/shippable/freebsd.sh
@@ -7,8 +7,14 @@ IFS='/:' read -ra args <<< "$1"
 
 platform="${args[0]}"
 version="${args[1]}"
-target="posix/ci/group${args[2]}/"
+
+if [ "${#args[@]}" -gt 2 ]; then
+    target="posix/ci/group${args[2]}/"
+else
+    target="posix/ci/"
+fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-     --remote "${platform}/${version}" --remote-terminate always
+    --exclude "posix/ci/cloud/" \
+    --remote "${platform}/${version}" --remote-terminate always

--- a/test/utils/shippable/linux.sh
+++ b/test/utils/shippable/linux.sh
@@ -5,9 +5,15 @@ set -o pipefail
 declare -a args
 IFS='/:' read -ra args <<< "$1"
 
-image="ansible/ansible:${args[1]}"
-target="posix/ci/group${args[2]}/"
+image="${args[1]}"
+
+if [ "${#args[@]}" -gt 2 ]; then
+    target="posix/ci/group${args[2]}/"
+else
+    target="posix/ci/"
+fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-     --docker "${image}"
+    --exclude "posix/ci/cloud/" \
+    --docker "${image}"

--- a/test/utils/shippable/osx.sh
+++ b/test/utils/shippable/osx.sh
@@ -7,8 +7,14 @@ IFS='/:' read -ra args <<< "$1"
 
 platform="${args[0]}"
 version="${args[1]}"
-target="posix/ci/group${args[2]}/"
+
+if [ "${#args[@]}" -gt 2 ]; then
+    target="posix/ci/group${args[2]}/"
+else
+    target="posix/ci/"
+fi
 
 # shellcheck disable=SC2086
 ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-     --remote "${platform}/${version}" --remote-terminate always
+    --exclude "posix/ci/cloud/" \
+    --remote "${platform}/${version}" --remote-terminate always

--- a/test/utils/shippable/rhel.sh
+++ b/test/utils/shippable/rhel.sh
@@ -7,8 +7,14 @@ IFS='/:' read -ra args <<< "$1"
 
 platform="${args[0]}"
 version="${args[1]}"
-target="posix/ci/"
+
+if [ "${#args[@]}" -gt 2 ]; then
+    target="posix/ci/group${args[2]}/"
+else
+    target="posix/ci/"
+fi
 
 # shellcheck disable=SC2086
-ansible-test integration --color -v --retry-on-error "${target}" --remote "${platform}/${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-    --exclude "posix/ci/cloud/"
+ansible-test integration --color -v --retry-on-error "${target}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
+    --exclude "posix/ci/cloud/" \
+    --remote "${platform}/${version}" --remote-terminate always


### PR DESCRIPTION
##### SUMMARY

Switch CI for OS X back to a single job. The OS X VM host can't consistently handle the load from 3 test groups.

Also re-work the Shippable scripts to make it easier to switch between groups without causing CI failures for queued and in-flight CI jobs.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

Shippable

##### ANSIBLE VERSION

```
ansible 2.5.0 (ci-update 967898e0bf) last updated 2017/10/03 14:11:15 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
