### PR TITLE
ec2_lc #31269 - No need to set a default tenancy

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -394,7 +394,7 @@ def main():
             classic_link_vpc_security_groups=dict(type='list'),
             classic_link_vpc_id=dict(),
             vpc_id=dict(),
-            placement_tenancy=dict(default='default', choices=['default', 'dedicated'])
+            placement_tenancy=dict(choices=['default', 'dedicated'])
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
Fixes #31269

Remove setting placment_tenancy default value

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_lc

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/test/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Remove the default for placement_tenancy to allow the spot price launch configuration to be created

After change only, before is in #31269 
```
$ ansible-playbook -i hosts poc.yml -vvv
ansible-playbook 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/test/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
Using /etc/ansible/ansible.cfg as config file
Parsed /home/test/git/ansible/hosts inventory source with ini plugin

PLAYBOOK: poc.yml ***************************************************************************************************************************************
1 plays in poc.yml
Read vars_file 'awssecrets'
Read vars_file 'awssecrets'

PLAY [POC] **********************************************************************************************************************************************
Read vars_file 'awssecrets'

TASK [Gathering Facts] **********************************************************************************************************************************
Using module file /usr/lib/python2.7/site-packages/ansible/modules/system/setup.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: test
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278 `" && echo ansible-tmp-1507075716.84-42123438649278="` echo /home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278 `" ) && sleep 0'
<localhost> PUT /tmp/tmpTlxsAw TO /home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278/setup.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278/ /home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278/setup.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278/setup.py; rm -rf "/home/test/.ansible/tmp/ansible-tmp-1507075716.84-42123438649278/" > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers
Read vars_file 'awssecrets'

TASK [ec2_lc] *******************************************************************************************************************************************
task path: /home/test/git/ansible/poc.yml:11
Using module file /usr/lib/python2.7/site-packages/ansible/modules/cloud/amazon/ec2_lc.py
<localhost> ESTABLISH LOCAL CONNECTION FOR USER: test
<localhost> EXEC /bin/sh -c 'echo ~ && sleep 0'
<localhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855 `" && echo ansible-tmp-1507075719.16-85404625485855="` echo /home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855 `" ) && sleep 0'
<localhost> PUT /tmp/tmpMykvzo TO /home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855/ec2_lc.py
<localhost> EXEC /bin/sh -c 'chmod u+x /home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855/ /home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855/ec2_lc.py && sleep 0'
<localhost> EXEC /bin/sh -c '/usr/bin/python /home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855/ec2_lc.py; rm -rf "/home/test/.ansible/tmp/ansible-tmp-1507075719.16-85404625485855/" > /dev/null 2>&1 && sleep 0'
changed: [localhost] => {
    "arn": "arn:aws:autoscaling:eu-west-1:111111111111:launchConfiguration:68fef398-ee11-40dc-b1d5-81c74d386174:launchConfigurationName/ec2 launch config with spot fail poc", 
    "changed": true, 
    "created_time": "2017-10-04 00:08:40.373000+00:00", 
    "failed": false, 
    "image_id": "ami-ca18d8b3", 
    "instance_type": "i3.large", 
    "invocation": {
        "module_args": {
            "assign_public_ip": null, 
            "associate_public_ip_address": null, 
            "aws_access_key": null, 
            "aws_secret_key": null, 
            "classic_link_vpc_id": null, 
            "classic_link_vpc_security_groups": null, 
            "ebs_optimized": false, 
            "ec2_url": null, 
            "image_id": "ami-ca18d8b3", 
            "instance_id": null, 
            "instance_monitoring": false, 
            "instance_profile_name": null, 
            "instance_type": "i3.large", 
            "kernel_id": null, 
            "key_name": null, 
            "name": "ec2 launch config with spot fail poc", 
            "placement_tenancy": null, 
            "profile": null, 
            "ramdisk_id": null, 
            "region": "eu-west-1", 
            "security_groups": [], 
            "security_token": null, 
            "spot_price": 0.02, 
            "state": "present", 
            "user_data": null, 
            "user_data_path": null, 
            "validate_certs": true, 
            "volumes": null, 
            "vpc_id": null
        }
    }, 
    "name": "ec2 launch config with spot fail poc", 
    "result": {
        "block_device_mappings": [], 
        "classic_link_vpc_security_groups": [], 
        "created_time": "2017-10-04 00:08:40.373000+00:00", 
        "ebs_optimized": false, 
        "image_id": "ami-ca18d8b3", 
        "instance_monitoring": true, 
        "instance_type": "i3.large", 
        "kernel_id": "", 
        "key_name": "", 
        "launch_configuration_arn": "arn:aws:autoscaling:eu-west-1:111111111111:launchConfiguration:68fef398-ee11-40dc-b1d5-81c74d386174:launchConfigurationName/ec2 launch config with spot fail poc", 
        "launch_configuration_name": "ec2 launch config with spot fail poc", 
        "ramdisk_id": "", 
        "security_groups": [], 
        "spot_price": "0.02", 
        "user_data": ""
    }, 
    "security_groups": []
}
META: ran handlers
META: ran handlers

PLAY RECAP **********************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0 
```