### PR TITLE
Fixes #30769 - nxos_vtp_version errors out on N1 images. (#30770)

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vtp_domain.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_domain.py
@@ -149,10 +149,13 @@ def get_vtp_config(module):
 def get_vtp_password(module):
     command = 'show vtp password'
     body = execute_show_command(command, module)[0]
-    password = body['passwd']
-    if password:
-        return str(password)
-    else:
+    try:
+        password = body['passwd']
+        if password:
+            return str(password)
+        else:
+            return ""
+    except TypeError:
         return ""
 
 

--- a/lib/ansible/modules/network/nxos/nxos_vtp_password.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_password.py
@@ -180,10 +180,13 @@ def get_vtp_config(module):
 def get_vtp_password(module):
     command = 'show vtp password'
     body = execute_show_command(command, module)[0]
-    password = body['passwd']
-    if password:
-        return str(password)
-    else:
+    try:
+        password = body['passwd']
+        if password:
+            return str(password)
+        else:
+            return ""
+    except TypeError:
         return ""
 
 

--- a/lib/ansible/modules/network/nxos/nxos_vtp_version.py
+++ b/lib/ansible/modules/network/nxos/nxos_vtp_version.py
@@ -147,10 +147,13 @@ def get_vtp_config(module):
 def get_vtp_password(module):
     command = 'show vtp password'
     body = execute_show_command(command, module)[0]
-    password = body['passwd']
-    if password:
-        return str(password)
-    else:
+    try:
+        password = body['passwd']
+        if password:
+            return str(password)
+        else:
+            return ""
+    except TypeError:
         return ""
 
 


### PR DESCRIPTION
* Fixes #30769

* add the same fix for 2 more vtp modules

(cherry picked from commit a12a05c2199422d671f756f3bcb4f632efd08aff)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
