### PR TITLE
Fixes #30529 nxos_facts ipv6 interface

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -348,14 +348,20 @@ class Interfaces(FactsBase):
         return objects
 
     def parse_ipv6_interfaces(self, data):
-        data = data['TABLE_intf']
-        if isinstance(data, dict):
-            data = [data]
-        for item in data:
-            name = item['ROW_intf']['intf-name']
-            intf = self.facts['interfaces'][name]
-            intf['ipv6'] = self.transform_dict(item, self.INTERFACE_IPV6_MAP)
-            self.facts['all_ipv6_addresses'].append(item['ROW_intf']['addr'])
+        try:
+            data = data['TABLE_intf']
+            if data:
+                if isinstance(data, dict):
+                    data = [data]
+                for item in data:
+                    name = item['ROW_intf']['intf-name']
+                    intf = self.facts['interfaces'][name]
+                    intf['ipv6'] = self.transform_dict(item, self.INTERFACE_IPV6_MAP)
+                    self.facts['all_ipv6_addresses'].append(item['ROW_intf']['addr'])
+            else:
+                return ""
+        except TypeError:
+            return ""
 
 
 class Legacy(FactsBase):


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30529
nxos_facts errors out when ipv6 is not configured.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_facts
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```