### PR TITLE
Fixes nxos_igmp_interface idempotence issue for N1 images (#31220)

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
+++ b/lib/ansible/modules/network/nxos/nxos_igmp_interface.py
@@ -335,13 +335,13 @@ def get_igmp_interface(module, interface):
     if body:
         resource = body['TABLE_vrf']['ROW_vrf']['TABLE_if']['ROW_if']
         igmp = apply_key_map(key_map, resource)
-        report_llg = str(resource['ReportingForLinkLocal'])
+        report_llg = str(resource['ReportingForLinkLocal']).lower()
         if report_llg == 'true':
             igmp['report_llg'] = True
         elif report_llg == 'false':
             igmp['report_llg'] = False
 
-        immediate_leave = str(resource['ImmediateLeave'])  # returns en or dis
+        immediate_leave = str(resource['ImmediateLeave']).lower()  # returns en or dis
         if immediate_leave == 'en' or immediate_leave == 'true':
             igmp['immediate_leave'] = True
         elif immediate_leave == 'dis' or immediate_leave == 'false':


### PR DESCRIPTION
(cherry picked from commit 1378861fe75fcae2d0ad7b880e70999112d20609)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
