### PR TITLE
Validate parse_cli filter inputs

### DIFF
--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -27,7 +27,7 @@ import json
 from collections import Mapping
 
 from ansible.module_utils.network_common import Template
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.six import iteritems, string_types
 from ansible.errors import AnsibleError
 
 try:
@@ -76,6 +76,12 @@ def re_search(regex, value):
 
 
 def parse_cli(output, tmpl):
+    if not isinstance(output, string_types):
+        raise AnsibleError("parse_cli input should be a string, but was given a input of %s" % (type(output)))
+
+    if not os.path.exists(tmpl):
+        raise AnsibleError('unable to locate parse_cli template: %s' % tmpl)
+
     try:
         template = Template()
     except ImportError as exc:

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -222,6 +222,9 @@ def parse_cli_textfsm(value, template):
     if not HAS_TEXTFSM:
         raise AnsibleError('parse_cli_textfsm filter requires TextFSM library to be installed')
 
+    if not isinstance(value, string_types):
+        raise AnsibleError("parse_cli_textfsm input should be a string, but was given a input of %s" % (type(value)))
+
     if not os.path.exists(template):
         raise AnsibleError('unable to locate parse_cli_textfsm template: %s' % template)
 

--- a/lib/ansible/plugins/filter/network.py
+++ b/lib/ansible/plugins/filter/network.py
@@ -223,7 +223,7 @@ def parse_cli_textfsm(value, template):
         raise AnsibleError('parse_cli_textfsm filter requires TextFSM library to be installed')
 
     if not os.path.exists(template):
-        raise AnsibleError('unable to locate parse_cli template: %s' % template)
+        raise AnsibleError('unable to locate parse_cli_textfsm template: %s' % template)
 
     try:
         template = open(template)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30517

*  Add check to validate input is of type string
*  Add check to confirm template file exist
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
filter/network.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before (input to parse_cli filter is of type list):
```
fatal: [ios01]: FAILED! => {
    "msg": "Unexpected templating type error occurred on ({{ result.stdout | parse_cli('/tmp/vlan_spec.yml') }}): expected string or buffer"
}
```

After (input to parse_cli filter is of type list):
```
fatal: [ios01]: FAILED! => {
    "msg": "parse_cli input should be a string, but was given a input of <type 'list'>"
}
```