### PR TITLE
Fix typo in haproxy.py doc string

### DIFF
--- a/lib/ansible/modules/net_tools/haproxy.py
+++ b/lib/ansible/modules/net_tools/haproxy.py
@@ -27,7 +27,7 @@ notes:
       sockets configured for level 'admin'. For example, you can add the line
       'stats socket /var/run/haproxy.sock level admin' to the general section of
       haproxy.cfg. See U(http://haproxy.1wt.eu/download/1.5/doc/configuration.txt).
-    - Depends on netcat (nc) being available; you need to install the appriate
+    - Depends on netcat (nc) being available; you need to install the appropriate
       package for your operating system before this module can be used.
 options:
   backend:


### PR DESCRIPTION
Fix small typo in haproxy.py doc string.