### PR TITLE
Properly handle user selection of `None` as vars_files

### DIFF
--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -277,7 +277,7 @@ class Play(Base, Taggable, Become):
         return self.vars.copy()
 
     def get_vars_files(self):
-        return self.vars_files
+        return self.vars_files or []
 
     def get_handlers(self):
         return self.handlers[:]

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -277,7 +277,9 @@ class Play(Base, Taggable, Become):
         return self.vars.copy()
 
     def get_vars_files(self):
-        return self.vars_files or []
+        if self.vars_files is None:
+            return []
+        return self.vars_files
 
     def get_handlers(self):
         return self.handlers[:]

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -385,8 +385,8 @@ class VariableManager:
                                 raise AnsibleFileNotFound("vars file %s was not found" % vars_file_item)
                     except (UndefinedError, AnsibleUndefinedVariable):
                         if host is not None and self._fact_cache.get(host.name, dict()).get('module_setup') and task is not None:
-                            raise AnsibleUndefinedVariable("an undefined variable was found when attempting to template the vars_files item '%s'" % vars_file_item,
-                                                           obj=vars_file_item)
+                            raise AnsibleUndefinedVariable("an undefined variable was found when attempting to template the vars_files item '%s'"
+                                                           % vars_file_item, obj=vars_file_item)
                         else:
                             # we do not have a full context here, and the missing variable could be because of that
                             # so just show a warning and continue

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -345,7 +345,12 @@ class VariableManager:
         if play:
             all_vars = combine_vars(all_vars, play.get_vars())
 
-            for vars_file_item in play.get_vars_files():
+            vars_files = play.get_vars_files()
+            if not hasattr(vars_files, '__iter__'):
+                raise AnsibleParserError("Error while reading vars files - please supply a list of file names. "
+                                         "Got %s" % type(vars_files))
+
+            for vars_file_item in vars_files:
                 # create a set of temporary vars here, which incorporate the extra
                 # and magic vars so we can properly template the vars_files entries
                 temp_vars = combine_vars(all_vars, self._extra_vars)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -346,57 +346,57 @@ class VariableManager:
             all_vars = combine_vars(all_vars, play.get_vars())
 
             vars_files = play.get_vars_files()
-            if not hasattr(vars_files, '__iter__'):
-                raise AnsibleParserError("Error while reading vars files - please supply a list of file names. "
-                                         "Got %s" % type(vars_files))
+            try:
+                for vars_file_item in vars_files:
+                    # create a set of temporary vars here, which incorporate the extra
+                    # and magic vars so we can properly template the vars_files entries
+                    temp_vars = combine_vars(all_vars, self._extra_vars)
+                    temp_vars = combine_vars(temp_vars, magic_variables)
+                    templar = Templar(loader=self._loader, variables=temp_vars)
 
-            for vars_file_item in vars_files:
-                # create a set of temporary vars here, which incorporate the extra
-                # and magic vars so we can properly template the vars_files entries
-                temp_vars = combine_vars(all_vars, self._extra_vars)
-                temp_vars = combine_vars(temp_vars, magic_variables)
-                templar = Templar(loader=self._loader, variables=temp_vars)
+                    # we assume each item in the list is itself a list, as we
+                    # support "conditional includes" for vars_files, which mimics
+                    # the with_first_found mechanism.
+                    vars_file_list = vars_file_item
+                    if not isinstance(vars_file_list, list):
+                        vars_file_list = [vars_file_list]
 
-                # we assume each item in the list is itself a list, as we
-                # support "conditional includes" for vars_files, which mimics
-                # the with_first_found mechanism.
-                vars_file_list = vars_file_item
-                if not isinstance(vars_file_list, list):
-                    vars_file_list = [vars_file_list]
-
-                # now we iterate through the (potential) files, and break out
-                # as soon as we read one from the list. If none are found, we
-                # raise an error, which is silently ignored at this point.
-                try:
-                    for vars_file in vars_file_list:
-                        vars_file = templar.template(vars_file)
-                        try:
-                            data = preprocess_vars(self._loader.load_from_file(vars_file, unsafe=True))
-                            if data is not None:
-                                for item in data:
-                                    all_vars = combine_vars(all_vars, item)
-                            break
-                        except AnsibleFileNotFound:
-                            # we continue on loader failures
+                    # now we iterate through the (potential) files, and break out
+                    # as soon as we read one from the list. If none are found, we
+                    # raise an error, which is silently ignored at this point.
+                    try:
+                        for vars_file in vars_file_list:
+                            vars_file = templar.template(vars_file)
+                            try:
+                                data = preprocess_vars(self._loader.load_from_file(vars_file, unsafe=True))
+                                if data is not None:
+                                    for item in data:
+                                        all_vars = combine_vars(all_vars, item)
+                                break
+                            except AnsibleFileNotFound:
+                                # we continue on loader failures
+                                continue
+                            except AnsibleParserError:
+                                raise
+                        else:
+                            # if include_delegate_to is set to False, we ignore the missing
+                            # vars file here because we're working on a delegated host
+                            if include_delegate_to:
+                                raise AnsibleFileNotFound("vars file %s was not found" % vars_file_item)
+                    except (UndefinedError, AnsibleUndefinedVariable):
+                        if host is not None and self._fact_cache.get(host.name, dict()).get('module_setup') and task is not None:
+                            raise AnsibleUndefinedVariable("an undefined variable was found when attempting to template the vars_files item '%s'" % vars_file_item,
+                                                           obj=vars_file_item)
+                        else:
+                            # we do not have a full context here, and the missing variable could be because of that
+                            # so just show a warning and continue
+                            display.vvv("skipping vars_file '%s' due to an undefined variable" % vars_file_item)
                             continue
-                        except AnsibleParserError:
-                            raise
-                    else:
-                        # if include_delegate_to is set to False, we ignore the missing
-                        # vars file here because we're working on a delegated host
-                        if include_delegate_to:
-                            raise AnsibleFileNotFound("vars file %s was not found" % vars_file_item)
-                except (UndefinedError, AnsibleUndefinedVariable):
-                    if host is not None and self._fact_cache.get(host.name, dict()).get('module_setup') and task is not None:
-                        raise AnsibleUndefinedVariable("an undefined variable was found when attempting to template the vars_files item '%s'" % vars_file_item,
-                                                       obj=vars_file_item)
-                    else:
-                        # we do not have a full context here, and the missing variable could be because of that
-                        # so just show a warning and continue
-                        display.vvv("skipping vars_file '%s' due to an undefined variable" % vars_file_item)
-                        continue
 
-                display.vvv("Read vars_file '%s'" % vars_file_item)
+                    display.vvv("Read vars_file '%s'" % vars_file_item)
+            except TypeError:
+                raise AnsibleParserError("Error while reading vars files - please supply a list of file names. "
+                                         "Got '%s' of type %s" % (vars_files, type(vars_files)))
 
             # By default, we now merge in all vars from all roles in the play,
             # unless the user has disabled this via a config option


### PR DESCRIPTION
In a playbook, if a user has a playbook like:

```
- hosts: localhost
  connection: local
  vars_files:
  tasks:
  - ....
```

Then `vars_files` will be none, and cause a `TypeError` in vars-manager when it
tries to iterate over them. To avoid this, I changed the getter to either send
back the vars files from the user, or an empty list when the user passed
`None`.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vars manager
 
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel bba941cd5b) last updated 2017/10/03 15:59:31 (GMT -400)
  config file = None
  configured module search path = [u'/home/ryansb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  python version = 2.7.12 (default, Sep 27 2016, 18:08:33) [GCC 6.2.1 20160916 (Red Hat 6.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This fixes #31249 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
BEFORE:


PLAYBOOK: lol.yml *******************************************************************************
1 plays in /tmp/lol.yml
ERROR! Unexpected Exception, this is probably a bug: 'NoneType' object is not iterable
the full traceback was:

Traceback (most recent call last):
  File "/tmp/ansible/bin/ansible-playbook", line 109, in <module>
    exit_code = cli.run()
  File "/tmp/ansible/lib/ansible/cli/playbook.py", line 130, in run
    results = pbex.run()
  File "/tmp/ansible/lib/ansible/executor/playbook_executor.py", line 126, in run
    all_vars = self._variable_manager.get_vars(play=play)
  File "/tmp/ansible/lib/ansible/vars/manager.py", line 348, in get_vars
    for vars_file_item in play.get_vars_files():
TypeError: 'NoneType' object is not iterable


AFTER


TASK [debug] ************************************************************************************
task path: /tmp/lol.yml:5
ok: [localhost] => {
    "msg": "hi"
}
META: ran handlers
META: ran handlers

PLAY RECAP **************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0  
```
