### PR TITLE
unarchive module: remove query string from url when using remote src

### DIFF
--- a/lib/ansible/modules/files/unarchive.py
+++ b/lib/ansible/modules/files/unarchive.py
@@ -796,7 +796,8 @@ def main():
         # If remote_src=true, and src= contains ://, try and download the file to a temp directory.
         elif '://' in src:
             tempdir = os.path.dirname(os.path.realpath(__file__))
-            package = os.path.join(tempdir, str(src.rsplit('/', 1)[1]))
+            tempfile = re.search(r'\/([^/?]*)(\?.*)?$', src)[1]
+            package = os.path.join(tempdir, str(tempfile))
             try:
                 rsp, info = fetch_url(module, src)
                 # If download fails, raise a proper exception


### PR DESCRIPTION
##### SUMMARY
Fix filename too long when downloading URL 
Fixes #29680

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
unarchive module

##### ANSIBLE VERSION
```
Tower 3.1.4
Ansible 2.3.1.0 
```


##### ADDITIONAL INFORMATION
Before:
```
Failure downloading https://***.s3.amazonaws.com/**/filename.tar.gz?Signature=**/abcdefg**, 
[Errno 36] File name too long: '/tmp/ansible_aNhluJ/abcdef**'"
}
```