### PR TITLE
check if existing network is VDS and has port attribute

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -629,9 +629,10 @@ class PyVmomiHelper(PyVmomi):
                 # VDS switch
                 pg_obj = find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_devices[key]['name'])
 
-                if (nic.device.backing and
-                        (nic.device.backing.port.portgroupKey != pg_obj.key or
-                         nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid)):
+                if (nic.device.backing and not hasattr(nic.device.backing, 'port')):
+                    nic_change_detected = True
+                elif (nic.device.backing and (nic.device.backing.port.portgroupKey != pg_obj.key or
+                      nic.device.backing.port.switchUuid != pg_obj.config.distributedVirtualSwitch.uuid)):
                     nic_change_detected = True
 
                 dvs_port_connection = vim.dvs.PortConnection()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When checking to see if the guest network has changed, attributes of the existing and new network are compared. However, the current check assumes that if the new network is associated with a VDS, the existing network must be as well - the end result that it tries to compare a "port" attribute, which fails when the existing network is not associated with a VDS.

For example, when a VM has existing network 'VM Network' (the default), and an attempt is made to change it to a portgroup that is associated to a VDS, the following error is generated:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'vim.vm.device.VirtualEthernetCard.NetworkBackingIn' object has no attribute 'port'
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_UkXVTS/ansible_module_vmware_guest.py\", line 1503, in <module>\n    main()\n  File \"/tmp/ansible_UkXVTS/ansible_module_vmware_guest.py\", line 1479, in main\n    result = pyv.reconfigure_vm()\n  File \"/tmp/ansible_UkXVTS/ansible_module_vmware_guest.py\", line 1351, in reconfigure_vm\n    self.configure_network(vm_obj=self.current_vm_obj)\n  File \"/tmp/ansible_UkXVTS/ansible_module_vmware_guest.py\", line 727, in configure_network\n    (nic.device.backing.port.portgroupKey != pg_obj.key or\nAttributeError: '**vim.vm.device.VirtualEthernetCard.NetworkBackingIn' object has no attribute 'port'**\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
```

The change that was made was to check whether the existing network was a VDS first, before attempting to compare VDS-related attributes.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes #30524 that I had opened, and fix was based on recommended change by @nrwahl2 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloud/vmware/vmware_guest.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (issue30524 9fe65e0420) last updated 2017/10/04 17:44:35 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
