### PR TITLE
OC Module - Minor fix for lists.  Fixes #31196

### DIFF
--- a/lib/ansible/modules/clustering/oc.py
+++ b/lib/ansible/modules/clustering/oc.py
@@ -350,8 +350,7 @@ class OC(object):
                 try:
                     if set(destination[key]) != set(destination[key] +
                                                     source[key]):
-                        destination[key] = list(set(destination[key] +
-                                                    source[key]))
+                        destination[key] = source[key]
                         changed = True
                 except TypeError:
                     for new_dict in source[key]:


### PR DESCRIPTION
##### SUMMARY
In what is probably an overcomplicated attempt to kindly merge lists of items in an OpenShift definition, items were being appended.  Now, the list just gets replaced.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
oc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
```
