### PR TITLE
Avoid msrest version 0.4.15 for Azure modules.

### DIFF
--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -6,6 +6,7 @@ azure-mgmt-storage>=1.2.0,<2
 azure-mgmt-resource>=1.1.0,<2
 azure-storage>=0.35.1,<0.36
 azure-cli-core>=2.0.12,<3
+msrest!=0.4.15
 msrestazure>=0.4.11,<0.5
 azure-mgmt-dns>=1.0.1,<2
 azure-mgmt-keyvault>=0.40.0,<0.41


### PR DESCRIPTION
##### SUMMARY

Avoid msrest version 0.4.15 for Azure modules.

This version has known regressions preventing modules such as
azure_rm_dnsrecordset from working.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Azure Modules

##### ANSIBLE VERSION

```
ansible 2.5.0 (azure-dep 6347ec834c) last updated 2017/10/04 15:04:11 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
