### PR TITLE
Add flags to regex filters

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -149,26 +149,46 @@ def fileglob(pathname):
     return [g for g in glob.glob(pathname) if os.path.isfile(g)]
 
 
-def regex_replace(value='', pattern='', replacement='', ignorecase=False):
+def regex_replace(value='', pattern='', replacement='', **kwargs):
     ''' Perform a `re.sub` returning a string '''
 
     value = to_text(value, errors='surrogate_or_strict', nonstring='simplerepr')
 
-    if ignorecase:
-        flags = re.I
-    else:
-        flags = 0
+    flags = 0
+    if kwargs.get('ignorecase') or kwargs.get('I'):
+        flags |= re.I
+    if kwargs.get('locale') or kwargs.get('L'):
+        flags |= re.L
+    if kwargs.get('multiline') or kwargs.get('M'):
+        flags |= re.M
+    if kwargs.get('dotall') or kwargs.get('S'):
+        flags |= re.S
+    if kwargs.get('unicode') or kwargs.get('U'):
+        flags |= re.U
+    if kwargs.get('verbose') or kwargs.get('X'):
+        flags |= re.X
+
     _re = re.compile(pattern, flags=flags)
     return _re.sub(replacement, value)
 
 
-def regex_findall(value, regex, multiline=False, ignorecase=False):
+def regex_findall(value, regex, **kwargs):
     ''' Perform re.findall and return the list of matches '''
+
     flags = 0
-    if ignorecase:
+    if kwargs.get('ignorecase') or kwargs.get('I'):
         flags |= re.I
-    if multiline:
+    if kwargs.get('locale') or kwargs.get('L'):
+        flags |= re.L
+    if kwargs.get('multiline') or kwargs.get('M'):
         flags |= re.M
+    if kwargs.get('dotall') or kwargs.get('S'):
+        flags |= re.S
+    if kwargs.get('unicode') or kwargs.get('U'):
+        flags |= re.U
+    if kwargs.get('verbose') or kwargs.get('X'):
+        flags |= re.X
+
     return re.findall(regex, value, flags)
 
 
@@ -187,10 +207,18 @@ def regex_search(value, regex, *args, **kwargs):
             raise errors.AnsibleFilterError('Unknown argument')
 
     flags = 0
-    if kwargs.get('ignorecase'):
+    if kwargs.get('ignorecase') or kwargs.get('I'):
         flags |= re.I
-    if kwargs.get('multiline'):
+    if kwargs.get('locale') or kwargs.get('L'):
+        flags |= re.L
+    if kwargs.get('multiline') or kwargs.get('M'):
         flags |= re.M
+    if kwargs.get('dotall') or kwargs.get('S'):
+        flags |= re.S
+    if kwargs.get('unicode') or kwargs.get('U'):
+        flags |= re.U
+    if kwargs.get('verbose') or kwargs.get('X'):
+        flags |= re.X
 
     match = re.search(regex, value, flags)
     if match:
@@ -203,17 +231,17 @@ def regex_search(value, regex, *args, **kwargs):
             return items
 
 
+def regex_escape(string):
+    '''Escape all regular expressions special characters from STRING.'''
+    return re.escape(string)
+
+
 def ternary(value, true_val, false_val):
     '''  value ? true_val : false_val '''
     if bool(value):
         return true_val
     else:
         return false_val
-
-
-def regex_escape(string):
-    '''Escape all regular expressions special characters from STRING.'''
-    return re.escape(string)
 
 
 def from_yaml(data):
@@ -524,9 +552,9 @@ class FilterModule(object):
 
             # regex
             'regex_replace': regex_replace,
-            'regex_escape': regex_escape,
-            'regex_search': regex_search,
             'regex_findall': regex_findall,
+            'regex_search': regex_search,
+            'regex_escape': regex_escape,
 
             # ? : ;
             'ternary': ternary,

--- a/test/units/plugins/filter/test_regex_filters.yml
+++ b/test/units/plugins/filter/test_regex_filters.yml
@@ -1,0 +1,163 @@
+---
+
+- name: "Test regex plugins"
+  strategy: debug
+  gather_facts: false
+  hosts: localhost
+  tasks:
+
+    # TODO: Test unicode (U) and locale (L) flags as well
+
+    - name: "regex_search tests"
+      vars:
+        text: |
+          Early to bed and early to rise,
+          makes a man stupid and blind in the eyes.
+        verbose_regex: |
+          [ ]      # a single space
+          [a-z]{3} # three lowercase letters
+          [ ]      # another single space
+      with_items:
+        - name: ignorecase1
+          test: "{{ text | regex_search('early', ignorecase=True) }}"
+          desiredresult: "Early"
+        - name: ignorecase2
+          test: "{{ text | regex_search('early', I=True) }}"
+          desiredresult: "Early"
+        - name: multiline1
+          test: "{{ text | regex_search('rise,$', multiline=True) }}"
+          desiredresult: "rise,"
+        - name: multiline2
+          test: "{{ text | regex_search('rise,$', M=True) }}"
+          desiredresult: "rise,"
+        - name: dotall1
+          test: "{{ text | regex_search('rise,.*man', dotall=True) }}"
+          desiredresult: "rise,\nmakes a man"
+        - name: dotall2
+          test: "{{ text | regex_search('rise,.*man', S=True) }}"
+          desiredresult: "rise,\nmakes a man"
+        - name: verbose1
+          test: "{{ text | regex_search(verbose_regex, verbose=True) }}"
+          desiredresult: " bed " 
+        - name: verbose2
+          test: "{{ text | regex_search(verbose_regex, X=True) }}"
+          desiredresult: " bed " 
+      debug:
+        msg:
+          - "{{ item.name }}: '{{ item.test }}' should == '{{ item.desiredresult }}'"
+      failed_when:
+        item.test != item.desiredresult
+
+    - name: "regex_findall tests"
+      vars:
+        text: |
+          Early to bed and early to rise,
+          makes a man stupid and blind in the eyes.
+        verbose_regex: |
+          [ ]      # a single space
+          [a-z]{3} # three lowercase letters
+          [ ]      # another single space
+      with_items:
+        - name: ignorecase1
+          test: "{{ text | regex_findall('early', ignorecase=True) }}"
+          desiredresult: 
+            - "Early"
+            - "early"
+        - name: ignorecase2
+          test: "{{ text | regex_findall('early', I=True) }}"
+          desiredresult: 
+            - "Early"
+            - "early"
+        - name: multiline1
+          test: "{{ text | regex_findall('rise,$', multiline=True) }}"
+          desiredresult: 
+            - "rise,"
+        - name: multiline2
+          test: "{{ text | regex_findall('rise,$', M=True) }}"
+          desiredresult: 
+            - "rise,"
+        - name: dotall1
+          test: "{{ text | regex_findall('rise,.*man', dotall=True) }}"
+          desiredresult: 
+            - "rise,\nmakes a man"
+        - name: dotall2
+          test: "{{ text | regex_findall('rise,.*man', S=True) }}"
+          desiredresult: 
+            - "rise,\nmakes a man"
+        - name: verbose1
+          test: "{{ text | regex_findall(verbose_regex, verbose=True) }}"
+          desiredresult: 
+            - " bed "
+            - " man "
+            - " and "
+            - " the "
+        - name: verbose2
+          test: "{{ text | regex_findall(verbose_regex, X=True) }}"
+          desiredresult: 
+            - " bed "
+            - " man "
+            - " and "
+            - " the "
+      debug:
+        msg:
+          - "{{ item.name }}: '{{ item.test }}' should == '{{ item.desiredresult }}'"
+      failed_when:
+        item.test != item.desiredresult
+
+    - name: "regex_replace tests"
+      vars:
+        text: |
+          Early to bed and early to rise,
+          makes a man stupid and blind in the eyes.
+        verbose_regex: |
+          [ ]      # a single space
+          [a-z]{3} # three lowercase letters
+          [ ]      # another single space
+      with_items:
+        - name: ignorecase1
+          test: "{{ text | regex_replace('(early|stupid|blind)', 'SUPER-\\1', ignorecase=True) }}"
+          desiredresult: |
+            SUPER-Early to bed and SUPER-early to rise,
+            makes a man SUPER-stupid and SUPER-blind in the eyes.
+        - name: ignorecase2
+          test: "{{ text | regex_replace('(early|stupid|blind)', 'SUPER-\\1', I=True) }}"
+          desiredresult: |
+            SUPER-Early to bed and SUPER-early to rise,
+            makes a man SUPER-stupid and SUPER-blind in the eyes.
+        - name: multiline1
+          test: "{{ text | regex_replace('rise,$', 'wake up,', multiline=True) }}"
+          desiredresult: |
+            Early to bed and early to wake up,
+            makes a man stupid and blind in the eyes.
+        - name: multiline2
+          test: "{{ text | regex_replace('rise,$', 'wake up,', M=True) }}"
+          desiredresult: |
+            Early to bed and early to wake up,
+            makes a man stupid and blind in the eyes.
+        - name: dotall1
+          test: "{{ text | regex_replace('rise,.*man', 'wake up,\nmakes a dude', dotall=True) }}"
+          desiredresult: |
+            Early to bed and early to wake up,
+            makes a dude stupid and blind in the eyes.
+        - name: dotall2
+          test: "{{ text | regex_replace('rise,.*man', 'wake up,\nmakes a dude', S=True) }}"
+          desiredresult: |
+            Early to bed and early to wake up,
+            makes a dude stupid and blind in the eyes.
+        - name: verbose1
+          test: "{{ text | regex_replace(verbose_regex, ' bleep ', verbose=True) }}"
+          desiredresult: |
+            Early to bleep and early to rise,
+            makes a bleep stupid bleep blind in bleep eyes.
+        - name: verbose2
+          test: "{{ text | regex_replace(verbose_regex, ' bleep ', X=True) }}"
+          desiredresult: |
+            Early to bleep and early to rise,
+            makes a bleep stupid bleep blind in bleep eyes.
+      debug:
+        msg:
+          - "{{ item.name }}: '{{ item.test }}' should == '{{ item.desiredresult }}'"
+      failed_when:
+        item.test != item.desiredresult
+
+

--- a/test/units/plugins/filter/test_regex_filters.yml
+++ b/test/units/plugins/filter/test_regex_filters.yml
@@ -1,13 +1,10 @@
 ---
-
 - name: "Test regex plugins"
   strategy: debug
   gather_facts: false
   hosts: localhost
   tasks:
-
     # TODO: Test unicode (U) and locale (L) flags as well
-
     - name: "regex_search tests"
       vars:
         text: |
@@ -47,7 +44,6 @@
           - "{{ item.name }}: '{{ item.test }}' should == '{{ item.desiredresult }}'"
       failed_when:
         item.test != item.desiredresult
-
     - name: "regex_findall tests"
       vars:
         text: |
@@ -103,7 +99,6 @@
           - "{{ item.name }}: '{{ item.test }}' should == '{{ item.desiredresult }}'"
       failed_when:
         item.test != item.desiredresult
-
     - name: "regex_replace tests"
       vars:
         text: |
@@ -159,5 +154,3 @@
           - "{{ item.name }}: '{{ item.test }}' should == '{{ item.desiredresult }}'"
       failed_when:
         item.test != item.desiredresult
-
-


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The regex filters were missing the option to use several flags provided by re.  I extended regex_replace, regex_search and regex_findall to allow for flags provided by re (except re.debug, because I didn't think that made much sense).

I also added a playbook which tests most of these flags (I don't know how to test the re.UNICODE or re.LOCALE flags).  I'm not sure I put the playbook in the right folder, though

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible/lib/ansible/plugins/filter/core.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (gmd-filters-regex-add-multiline 2a51c5e94b) last updated 2017/10/05 00:12:10 (GMT -400)
  config file = None
  configured module search path = [u'/home/dude/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/dude/git/ansible/lib/ansible
  executable location = /home/dude/git/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
I got the flags from the Python documentation here:
https://docs.python.org/2/library/re.html#contents-of-module-re

I also colocated the regex_* filters within core.py, and re-ordered their references at the end to match the order in which the functions appear.  Those edits are just cosmetic.
