### PR TITLE
Fix typo in vault decrypt error message

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -587,7 +587,7 @@ class VaultLib:
                              (vault_secret_id, filename, e))
                 continue
         else:
-            msg = "Decryption failed (no vault secrets would found that could decrypt)"
+            msg = "Decryption failed (no vault secrets were found that could decrypt)"
             if filename:
                 msg += " on %s" % filename
             raise AnsibleVaultError(msg)

--- a/test/units/parsing/yaml/test_loader.py
+++ b/test/units/parsing/yaml/test_loader.py
@@ -201,7 +201,7 @@ class TestAnsibleLoaderVault(unittest.TestCase, YamlTestUtils):
             self.vault.decrypt(ciphertext)
         except Exception as e:
             self.assertIsInstance(e, errors.AnsibleError)
-            self.assertEqual(e.message, 'Decryption failed (no vault secrets would found that could decrypt)')
+            self.assertEqual(e.message, 'Decryption failed (no vault secrets were found that could decrypt)')
 
     def _encrypt_plaintext(self, plaintext):
         # Construct a yaml repr of a vault by hand


### PR DESCRIPTION
##### SUMMARY
- Trivial documentation edit

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- vault

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 6f3c7a8d86) last updated 2017/10/05 12:31:27 (GMT +800)
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible/lib/ansible
  executable location = /home/user/ansible/bin/ansible
  python version = 2.7.11 (default, Sep 29 2016, 13:33:00) [GCC 5.3.1 20160406 (Red Hat 5.3.1-6)]
```