### PR TITLE
Add python level locale handling back

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -159,6 +159,7 @@ import binascii
 import copy
 import hashlib
 import json
+import locale
 import os
 import re
 import shutil
@@ -791,6 +792,7 @@ def main():
 
     # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+    locale.setlocale(locale.LC_ALL, 'C')
 
     cert_days = get_cert_days(module, module.params['dest'])
     if cert_days < module.params['remaining_days']:


### PR DESCRIPTION
##### SUMMARY
locale.setlocale() call removed in 6b5291d68f150c629e9958bb6e910b529b0d8cef is actually needed by time.strptime(). AnsibleModule() changes both: environment variables and python level locale settings so both need to be reset.

Setting environment variables will affect external commands (e.g. `openssl`) but will not be used by `time.strptime()` which uses `locale.getlocale(locale.LC_TIME)` to get current locale. After the last change, `openssl` call will correctly output "C" dates but `time.strptime()` can fail to parse them in some cases.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```