### PR TITLE
recreate docker containers when env variables are removed

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -1346,11 +1346,11 @@ class Container(DockerBaseClass):
                         self.log("comparing list of dict: %s" % key)
                         match = self._compare_dictionary_lists(getattr(self.parameters, key), value)
                     else:
-                        # compare two lists. Is list_a in list_b?
+                        # compare two lists. Is list_a equal list_b?
                         self.log("comparing lists: %s" % key)
                         set_a = set(getattr(self.parameters, key))
                         set_b = set(value)
-                        match = (set_b >= set_a)
+                        match = (set_b == set_a)
                 elif isinstance(getattr(self.parameters, key), list) and not len(getattr(self.parameters, key)) \
                         and value is None:
                     # an empty list and None are ==


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes #31338. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/home/julian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.4.1.0-py2.7.egg/ansible
  executable location = /home/julian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

```


##### ADDITIONAL INFORMATION
This fixes what I believe is a bug in `has_different_configuration`. Checking for list/set inclusion is not enough, we need to check for equality.
