### PR TITLE
Assign executable in popen only if it is explicitly set

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2602,15 +2602,11 @@ class AnsibleModule(object):
             strings on python3, use encoding=None to turn decoding to text off.
         '''
 
-        shell = False
         if isinstance(args, list):
             if use_unsafe_shell:
                 args = " ".join([shlex_quote(x) for x in args])
-                shell = True
         elif isinstance(args, (binary_type, text_type)):
-            if use_unsafe_shell:
-                shell = True
-            else:
+            if not use_unsafe_shell:
                 # On python2.6 and below, shlex has problems with text type
                 # On python3, shlex needs a text type.
                 if PY2:
@@ -2622,9 +2618,12 @@ class AnsibleModule(object):
             msg = "Argument 'args' to run_command must be list or string"
             self.fail_json(rc=257, cmd=args, msg=msg)
 
+        shell = False
         if use_unsafe_shell:
             if executable:
                 args = [executable, '-c', args]
+            else:
+                shell = True
 
         prompt_re = None
         if prompt_regex:

--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2602,6 +2602,7 @@ class AnsibleModule(object):
             strings on python3, use encoding=None to turn decoding to text off.
         '''
 
+        shell = False
         if isinstance(args, list):
             if use_unsafe_shell:
                 args = " ".join([shlex_quote(x) for x in args])
@@ -2621,14 +2622,9 @@ class AnsibleModule(object):
             msg = "Argument 'args' to run_command must be list or string"
             self.fail_json(rc=257, cmd=args, msg=msg)
 
-        shell = False
         if use_unsafe_shell:
-            if executable is None:
-                executable = os.environ.get('SHELL')
             if executable:
                 args = [executable, '-c', args]
-            else:
-                shell = True
 
         prompt_re = None
         if prompt_regex:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #30836

*  As default executable is None assign executable value
   only if it set explicitly.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Playbook:
```
- name: Test playbook
  vars:
    output: [u'Port      Name               Status       Reason               Err-disabled Vlans\\nFa1/0/1   EDGE_IF_VLAN_341   err-disabled bpduguard\\nFa1/0/33  EDGE_IF_VLAN_341   err-disabled bpduguard']
  tasks:
  - name: Test task
    shell: echo {{ output }} | grep -Po '.*bpduguard' | awk '{ print $1 }'
    register: disabled_ports
  - debug: msg={{ disabled_ports }}
```
Before:

```
 {
    "changed": true,
    "cmd": "echo [u'Port      Name               Status       Reason               Err-disabled Vlans\\nFa1/0/1   EDGE_IF_VLAN_341   err-disabled bpduguard\\nFa1/0/33  EDGE_IF_VLAN_341   err-disabled bpduguard'] | grep -Po '.*bpduguard' | awk '{ print $1 }'",
    "delta": "0:00:00.004178",
    "end": "2017-10-05 04:53:20.899535",
    "failed": false,
    "invocation": {
        "module_args": {
            "_raw_params": "echo [u'Port      Name               Status       Reason               Err-disabled Vlans\\nFa1/0/1   EDGE_IF_VLAN_341   err-disabled bpduguard\\nFa1/0/33  EDGE_IF_VLAN_341   err-disabled bpduguard'] | grep -Po '.*bpduguard' | awk '{ print $1 }'",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "warn": true
        }
    },
    "rc": 0,
    "start": "2017-10-05 04:53:20.895357",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "[uPort",
    "stdout_lines": [
        "[uPort"
    ]
}
```

After
```
{
    "changed": true,
    "cmd": "echo [u'Port      Name               Status       Reason               Err-disabled Vlans\\nFa1/0/1   EDGE_IF_VLAN_341   err-disabled bpduguard\\nFa1/0/33  EDGE_IF_VLAN_341   err-disabled bpduguard'] | grep -Po '.*bpduguard' | awk '{ print $1 }'",
    "delta": "0:00:00.005992",
    "end": "2017-10-05 06:19:45.140702",
    "failed": false,
    "invocation": {
        "module_args": {
            "_raw_params": "echo [u'Port      Name               Status       Reason               Err-disabled Vlans\\nFa1/0/1   EDGE_IF_VLAN_341   err-disabled bpduguard\\nFa1/0/33  EDGE_IF_VLAN_341   err-disabled bpduguard'] | grep -Po '.*bpduguard' | awk '{ print $1 }'",
            "_uses_shell": true,
            "chdir": null,
            "creates": null,
            "executable": null,
            "removes": null,
            "stdin": null,
            "warn": true
        }
    },
    "rc": 0,
    "start": "2017-10-05 06:19:45.134710",
    "stderr": "",
    "stderr_lines": [],
    "stdout": "Fa1/0/1\nFa1/0/33",
    "stdout_lines": [
        "Fa1/0/1",
        "Fa1/0/33"
    ]
}
```
