### PR TITLE
Mention Ansible in package descriptions

### DIFF
--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -12,7 +12,7 @@
 pkgname=ansible-git
 pkgver=1.6.0.1835.ga1809a3
 pkgrel=1
-pkgdesc='Radically simple IT automation platform'
+pkgdesc='Ansible IT Automation'
 arch=('any')
 url='https://www.ansible.com'
 license=('GPL3')

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,7 +9,7 @@ Homepage: http://ansible.github.com/
 Package: ansible
 Architecture: all
 Depends: python-jinja2, python-yaml, python-paramiko, python-httplib2, python-six, python-crypto (>= 2.6), python-setuptools, sshpass, ${misc:Depends}, ${python:Depends}
-Description: A radically simple IT automation platform
+Description: Ansible IT Automation
  A radically simple IT automation platform that makes your applications and
  systems easier to deploy. Avoid writing scripts or custom code to deploy and
  update your applications— automate in a language that approaches plain English,

--- a/packaging/macports/sysutils/ansible/Portfile
+++ b/packaging/macports/sysutils/ansible/Portfile
@@ -12,7 +12,7 @@ supported_archs noarch
 maintainers     nomaintainer
 
 homepage        https://ansible.com/
-description     Radically simple IT automation
+description     Ansible IT Automation
 long_description \
     Ansible is a radically simple model-driven configuration \
     management, multi-node deployment, and orchestration \


### PR DESCRIPTION
##### SUMMARY
These values are used by software updaters to show which applications
are being updates to the user. In the case of Ubuntu, it will now show
clearly that it is updating Ansible instead of a radically simple IT
automation platform.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Packaging

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 2e4dcc9dda) last updated 2017/10/05 14:22:30 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/xa49mq/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/xa49mq/git/ansible/lib/ansible
  executable location = /home/xa49mq/git/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Found something interesting... i just got the standard popup from ubuntu saying i have software updates... where 1 application identifies itself as "A radically simple IT automation platform"... no reference to ansible anywhere.

https://imgur.com/a/8Uq8F
