### PR TITLE
Fail if LVM device path is not absolute.

### DIFF
--- a/lib/ansible/modules/system/lvg.py
+++ b/lib/ansible/modules/system/lvg.py
@@ -153,6 +153,8 @@ def main():
 
     # LVM always uses real paths not symlinks so replace symlinks with actual path
     for idx, dev in enumerate(dev_list):
+        if not os.path.isabs(dev):
+            module.fail_json(msg="Device path should not be relative: %s" % dev)
         dev_list[idx] = os.path.realpath(dev)
 
     if state=='present':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fails if the device path is relative.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module/lvg.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /hgi-systems/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.2 (default, Sep  8 2017, 06:15:13) [GCC 4.9.2]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
We encountered an odd error message earlier from the lvg module:
```
fatal: [consul-server-delta-hgiarvados-03]: FAILED! => {"changed": false, "err": "  Device /home/ubuntu not found (or ignored by filtering).\n", "failed": true, "msg": "Creating physical volume '/home/ubuntu' failed", "rc": 5}
```

This was caused when the device path was erroneously set to empty string. This incorrect input got caught up by the code that resolves symlinks to real paths, to give an unexpected result (the current directory):
https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/system/lvg.py#L154-L156

This bugfix ensures device paths are absolute and fails if this is not the case.