### PR TITLE
refactor azure dynamic inventory script configparser import to support python3

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -187,14 +187,18 @@ Version: 1.0.0
 '''
 
 import argparse
-import ConfigParser
 import json
 import os
 import re
 import sys
 import inspect
-import traceback
 
+try:
+    # python2
+    import ConfigParser as cp
+except ModuleNotFoundError:
+    # python3
+    import configparser as cp
 
 from packaging.version import Version
 
@@ -326,7 +330,7 @@ class AzureRM(object):
         path = expanduser("~")
         path += "/.azure/credentials"
         try:
-            config = ConfigParser.ConfigParser()
+            config = cp.ConfigParser()
             config.read(path)
         except Exception as exc:
             self.fail("Failed to access {0}. Check that the file exists and you have read "
@@ -795,7 +799,7 @@ class AzureInventory(object):
         config = None
         settings = None
         try:
-            config = ConfigParser.ConfigParser()
+            config = cp.ConfigParser()
             config.read(path)
         except:
             pass

--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -196,7 +196,7 @@ import inspect
 try:
     # python2
     import ConfigParser as cp
-except ModuleNotFoundError:
+except ImportError:
     # python3
     import configparser as cp
 


### PR DESCRIPTION
##### SUMMARY

The `./contrib/inventory/azure_rm.py` Azure dynamic inventory script doesn't currently support python3, as the `ConfigParser` module was renamed to `configparser`. This PR does some error handling to account for this.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`./contrib/inventory/azure_rm.py` (Azure dynamic inventory script)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/trstringer/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/trstringer/dev/ansible-dev/venv/lib64/python3.6/site-packages/ansible
  executable location = /home/trstringer/dev/ansible-dev/venv/bin/ansible
  python version = 3.6.2 (default, Sep 22 2017, 08:28:09) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```