### PR TITLE
fix misformatted doc link

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -326,7 +326,7 @@ Maintenance Info
 ~~~~~~~~~~~~~~~~
 
 For more information about Red Hat's this support of this module, please
-refer to this `knowledge base article<https://access.redhat.com/articles/rhel-top-support-policies>`
+refer to this `knowledge base article<https://access.redhat.com/articles/rhel-top-support-policies>`_
 
 {% endif %}
 {% endif %}


### PR DESCRIPTION
##### SUMMARY
fix misformatted docsite link

reason: The link is showing verbatim in the docs, (e.g. [here](http://docs.ansible.com/ansible/latest/assemble_module.html#maintenance-info)) where it should only
show "knowledge base article".

Also, generating the docs shows a lot of:

`docs/docsite/rst/win_acl_module.rst:424: WARNING: Unknown target name: "know ledge base article<https://access.redhat.com/articles/rhel-top-support-policies>".`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docsite

##### ADDITIONAL INFO

I could not confirm as of yet if this fixes the link, the doc is still building here :)