### PR TITLE
Do not run systemctl daemon-reload in check mode

### DIFF
--- a/lib/ansible/modules/system/systemd.py
+++ b/lib/ansible/modules/system/systemd.py
@@ -322,7 +322,7 @@ def main():
             module.fail_json(msg="name is also required when specifying %s" % requires)
 
     # Run daemon-reload first, if requested
-    if module.params['daemon_reload']:
+    if module.params['daemon_reload'] and not module.check_mode:
         (rc, out, err) = module.run_command("%s daemon-reload" % (systemctl))
         if rc != 0:
             module.fail_json(msg='failure %d during daemon-reload: %s' % (rc, err))


### PR DESCRIPTION
##### SUMMARY
`systemd` module with `daemon_reload=yes` runs `systemctl daemon-reload` even in check mode, and because that command makes changes on the system, it shouldn't run in check mode.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`systemd` module

##### ANSIBLE VERSION
```
2.5.0
```
