### PR TITLE
OC Module - Disable complex list merging. Fixes #31196

### DIFF
--- a/lib/ansible/modules/clustering/oc.py
+++ b/lib/ansible/modules/clustering/oc.py
@@ -347,27 +347,9 @@ class OC(object):
                     _, changed = self.merge(value, node, changed)
 
             elif isinstance(value, list) and key in destination.keys():
-                try:
-                    if set(destination[key]) != set(destination[key] +
-                                                    source[key]):
-                        destination[key] = source[key]
-                        changed = True
-                except TypeError:
-                    for new_dict in source[key]:
-                        found = False
-                        for old_dict in destination[key]:
-                            if ('name' in old_dict.keys() and
-                                    'name' in new_dict.keys()):
-                                if old_dict['name'] == new_dict['name']:
-                                    destination[key].remove(old_dict)
-                                    break
-                            if old_dict == new_dict:
-                                found = True
-                                break
-
-                        if not found:
-                            destination[key].append(new_dict)
-                            changed = True
+                if destination[key] != source[key]:
+                    destination[key] = source[key]
+                    changed = True
 
             elif (key not in destination.keys() or
                   destination[key] != source[key]):

--- a/lib/ansible/modules/clustering/oc.py
+++ b/lib/ansible/modules/clustering/oc.py
@@ -350,8 +350,7 @@ class OC(object):
                 try:
                     if set(destination[key]) != set(destination[key] +
                                                     source[key]):
-                        destination[key] = list(set(destination[key] +
-                                                    source[key]))
+                        destination[key] = source[key]
                         changed = True
                 except TypeError:
                     for new_dict in source[key]:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
oc

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Disabled complex list comparison because lists aren't easily comparable when containing dicts and there was still a bug when attempting to gracefully merge two lists containing dicts.
This takes into account order of items in the list, but alternative would be to deep compare two lists to check if it contains the same items. This is also not desirable becuase sometimes the order of the list in OS resource yaml actually matters. E.g. `args` field of container.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

