### PR TITLE
The keyword 'cloud' has been deprecated in favor of the 'profile' key…

### DIFF
--- a/contrib/inventory/openstack.yml
+++ b/contrib/inventory/openstack.yml
@@ -6,7 +6,7 @@ clouds:
       username: fb886a9b-c37b-442a-9be3-964bed961e04
       password: fantastic-password1
   rax:
-    cloud: rackspace
+    profile: rackspace
     auth:
       username: example
       password: spectacular-password


### PR DESCRIPTION
…word by os-client-config.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The keyword 'cloud' has been deprecated in favor of the 'profile' keyword by the pip package os-client-config. This is shown in the example file openstack.yml.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openstack inventory plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
