### PR TITLE
New Network modules for Brocade IronWare routers

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1388,7 +1388,7 @@ MERGE_MULTIPLE_CLI_TAGS:
   version_added: "2.3"
 NETWORK_GROUP_MODULES:
   name: Network module families
-  default: [eos, nxos, ios, iosxr, junos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos]
+  default: [eos, nxos, ios, iosxr, junos, ce, vyos, sros, dellos9, dellos10, dellos6, asa, aruba, aireos, ironware]
   description: 'TODO: write it'
   env: [{name: NETWORK_GROUP_MODULES}]
   ini:

--- a/lib/ansible/module_utils/ironware.py
+++ b/lib/ansible/module_utils/ironware.py
@@ -1,0 +1,134 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# (c) 2016 Red Hat Inc.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import env_fallback, return_values
+from ansible.module_utils.network_common import to_list, EntityCollection
+from ansible.module_utils.connection import Connection, exec_command
+
+_DEVICE_CONFIGS = {}
+_CONNECTION = None
+
+ironware_argument_spec = {
+    'host': dict(),
+    'port': dict(type='int'),
+    'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
+    'password': dict(fallback=(env_fallback, ['ANSIBLE_NET_PASSWORD']), no_log=True),
+    'ssh_keyfile': dict(fallback=(env_fallback, ['ANSIBLE_NET_SSH_KEYFILE']), type='path'),
+    'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
+    'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
+    'timeout': dict(type='int'),
+    'provider': dict(type='dict'),
+    'passwords': dict()
+}
+
+command_spec = {
+    'command': dict(key=True),
+    'prompt': dict(),
+    'answer': dict()
+}
+
+
+def get_argspec():
+    return ironware_argument_spec
+
+
+def check_args(module):
+    provider = module.params['provider'] or {}
+
+    for key in ironware_argument_spec:
+        if key not in ['passwords', 'provider', 'authorize'] and module.params[key]:
+            module.warn('argument %s has been deprecated and will be removed in a future version' % key)
+
+    if provider:
+        for param in ('auth_pass', 'password'):
+            if provider.get(param):
+                module.no_log_values.update(return_values(provider[param]))
+
+
+def get_connection(module):
+    global _CONNECTION
+    if _CONNECTION:
+        return _CONNECTION
+    _CONNECTION = Connection(module)
+
+    return _CONNECTION
+
+
+def to_commands(module, commands):
+    assert isinstance(commands, list), 'argument must be of type <list>'
+
+    transform = EntityCollection(module, command_spec)
+    commands = transform(commands)
+
+    for index, item in enumerate(commands):
+        if module.check_mode and not item['command'].startswith('show'):
+            module.warn('only show commands are supported when using check '
+                        'mode, not executing `%s`' % item['command'])
+
+    return commands
+
+
+def run_commands(module, commands, check_rc=True):
+    connection = get_connection(module)
+
+    commands = to_commands(module, to_list(commands))
+
+    responses = list()
+
+    for cmd in commands:
+        out = connection.get(**cmd)
+        responses.append(to_text(out, errors='surrogate_then_replace'))
+
+    return responses
+
+
+def get_config(module, flags=[]):
+    passwords = module.params['passwords']
+    if passwords:
+        cmd = 'more startup-config '
+    else:
+        cmd = 'show running-config '
+        cmd += ' '.join(flags)
+        cmd = cmd.strip()
+
+    try:
+        return _DEVICE_CONFIGS[cmd]
+    except KeyError:
+        conn = get_connection(module)
+        out = conn.get(cmd)
+        cfg = to_text(out, errors='surrogate_then_replace').strip()
+        _DEVICE_CONFIGS[cmd] = cfg
+        return cfg
+
+
+def load_config(module, config):
+    conn = get_connection(module)
+    conn.edit_config(config)

--- a/lib/ansible/modules/network/ironware/ironware_command.py
+++ b/lib/ansible/modules/network/ironware/ironware_command.py
@@ -1,0 +1,194 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: ironware_command
+version_added: "2.5"
+author: "Paul Baker (@paulquack)"
+short_description: Run arbitrary commands on Brocade IronWare devices
+description:
+  - Sends arbitrary commands to a Brocade Ironware node and returns the results
+    read from the device. The C(ironware_command) module includes an
+    argument that will cause the module to wait for a specific condition
+    before returning or timing out if the condition is not met.
+extends_documentation_fragment: ironware
+options:
+  commands:
+    description:
+      - List of commands to send to the remote device over the
+        configured provider. The resulting output from the command
+        is returned. If the I(wait_for) argument is provided, the
+        module is not returned until the condition is satisfied or
+        the number of retires as expired.
+    required: true
+  wait_for:
+    description:
+      - List of conditions to evaluate against the output of the
+        command. The task will wait for each condition to be true
+        before moving forward. If the conditional is not true
+        within the configured number of retries, the task fails.
+        See examples.
+    required: false
+    default: null
+    aliases: ['waitfor']
+  match:
+    description:
+      - The I(match) argument is used in conjunction with the
+        I(wait_for) argument to specify the match policy.  Valid
+        values are C(all) or C(any).  If the value is set to C(all)
+        then all conditionals in the wait_for must be satisfied.  If
+        the value is set to C(any) then only one of the values must be
+        satisfied.
+    required: false
+    default: all
+    choices: ['any', 'all']
+  retries:
+    description:
+      - Specifies the number of retries a command should by tried
+        before it is considered failed. The command is run on the
+        target device every retry and evaluated against the
+        I(wait_for) conditions.
+    required: false
+    default: 10
+  interval:
+    description:
+      - Configures the interval in seconds to wait between retries
+        of the command. If the command does not pass the specified
+        conditions, the interval indicates how long to wait before
+        trying the command again.
+    required: false
+    default: 1
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+---
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: username
+    password: secret
+    authorize: yes
+    auth_pass: supersecret
+    transport: cli
+
+---
+- ironware_command:
+    commands:
+      - show version
+    provider: "{{ cli }}"
+
+- ironware_command:
+    commands:
+      - show interfaces brief wide
+      - show mpls vll
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: The value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+failed_conditions:
+  description: the conditionals that failed
+  returned: failed
+  type: list
+  sample: ['...', '...']
+"""
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ironware import ironware_argument_spec, check_args
+from ansible.module_utils.ironware import run_commands
+from ansible.module_utils.netcli import Conditional
+from ansible.module_utils.six import string_types
+
+
+def to_lines(stdout):
+    for item in stdout:
+        if isinstance(item, string_types):
+            item = str(item).split('\n')
+        yield item
+
+
+def main():
+    spec = dict(
+        # { command: <str>, prompt: <str>, response: <str> }
+        commands=dict(type='list', required=True),
+
+        wait_for=dict(type='list', aliases=['waitfor']),
+        match=dict(default='all', choices=['all', 'any']),
+
+        retries=dict(default=10, type='int'),
+        interval=dict(default=1, type='int')
+    )
+
+    spec.update(ironware_argument_spec)
+
+    module = AnsibleModule(argument_spec=spec, supports_check_mode=True)
+    check_args(module)
+
+    result = {'changed': False}
+
+    wait_for = module.params['wait_for'] or list()
+    conditionals = [Conditional(c) for c in wait_for]
+
+    commands = module.params['commands']
+    retries = module.params['retries']
+    interval = module.params['interval']
+    match = module.params['match']
+
+    while retries > 0:
+        responses = run_commands(module, commands)
+
+        for item in list(conditionals):
+            if item(responses):
+                if match == 'any':
+                    conditionals = list()
+                    break
+                conditionals.remove(item)
+
+        if not conditionals:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+
+    if conditionals:
+        failed_conditions = [item.raw for item in conditionals]
+        msg = 'One or more conditional statements have not be satisfied'
+        module.fail_json(msg=msg, failed_conditions=failed_conditions)
+
+    result.update({
+        'changed': False,
+        'stdout': responses,
+        'stdout_lines': list(to_lines(responses))
+    })
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -1,0 +1,323 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: ironware_config
+version_added: "2.5"
+author: "Paul Baker (@paulquack)"
+short_description: Manage configuration sections on Brocade Ironware devices
+description:
+  - Brocade Ironware configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with Ironware configuration sections in
+    a deterministic way.
+extends_documentation_fragment: ironware
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is mutually
+        exclusive with I(lines).
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct
+    required: false
+    default: line
+    choices: ['line', 'block']
+  update:
+    description:
+      - The I(update) argument controls how the configuration statements
+        are processed on the remote device.  Valid choices for the I(update)
+        argument are I(merge) and I(check).  When the argument is set to
+        I(merge), the configuration changes are merged with the current
+        device running configuration.  When the argument is set to I(check)
+        the configuration updates are determined but not actually configured
+        on the remote device.
+    required: false
+    default: merge
+    choices: ['merge', 'check']
+  commit:
+    description:
+      - This argument specifies the update method to use when applying the
+        configuration changes to the remote node.  If the value is set to
+        I(merge) the configuration updates are merged with the running-
+        config.  If the value is set to I(check), no changes are made to
+        the remote host.
+    required: false
+    default: merge
+    choices: ['merge', 'check']
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The C(config) argument allows the playbook designer to supply
+        the base configuration to be used to validate configuration
+        changes necessary.  If this argument is provided, the module
+        will not download the running-config from the remote node.
+    required: false
+    default: null
+  save:
+    description:
+      - The C(save) argument instructs the module to save the running-
+        config to the startup-config at the conclusion of the module
+        running.  If check mode is specified, this argument is ignored.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+---
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: username
+    password: secret
+    authorize: yes
+    auth_pass: supersecret
+    transport: cli
+
+---
+- ironware_config:
+    lines:
+      - port-name test
+      - enable
+      - load-interval 30
+      - rate-limit input broadcast unknown-unicast multicast 521216 64000
+    parents: ['interface ethernet 1/2']
+    provider: "{{ cli }}"
+
+- ironware_config:
+    host: "{{ inventory_hostname }}"
+    lines:
+      - to 10.0.0.1
+      - adaptive
+      - reoptimize-timer 1800
+      - frr
+      -  facility-backup
+      - revert-timer 300
+      - enable
+    match: line
+    parents: ['router mpls', 'lsp test-lsp']
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['...', '...']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: string
+  sample: /playbooks/ansible/backup/ironware_config.2016-07-16@22:28:34
+"""
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ironware import ironware_argument_spec, check_args
+from ansible.module_utils.ironware import get_config, load_config, run_commands
+from ansible.module_utils.netcfg import NetworkConfig as _NetworkConfig, dumps, ConfigLine
+from ansible.module_utils._text import to_native
+
+
+class NetworkConfig(_NetworkConfig):
+    def add_load(self, lines, parents=None):
+        config = list()
+        offset = 0
+
+        # global config command
+        if not parents:
+            self.load("\n".join(lines))
+        else:
+            for index, p in enumerate(parents):
+                # add parent to config
+                offset = index * self._indent
+                config.append(p.rjust(len(p) + offset))
+
+            for line in lines:
+                # add lines to config
+                offset = len(parents) * self._indent
+                config.append(line.rjust(len(line) + offset))
+            self.load("\n".join(config))
+
+
+def get_candidate(module):
+    candidate = NetworkConfig(indent=1)
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add_load(module.params['lines'], parents=parents)
+    return candidate
+
+
+def run(module, result):
+    match = module.params['match']
+    replace = module.params['replace']
+    path = module.params['parents']
+
+    candidate = get_candidate(module)
+    if match != 'none':
+        contents = module.params['config']
+        if not contents:
+            contents = get_config(module)
+            config = NetworkConfig(indent=1, contents=contents)
+            configobjs = candidate.difference(config, path=path, match=match,
+                                              replace=replace)
+
+    else:
+        configobjs = candidate.items
+    if configobjs:
+        commands = dumps(configobjs, 'commands').split('\n')
+
+        if module.params['lines']:
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+        result['updates'] = commands
+
+        # send the configuration commands to the device and merge
+        # them with the current running config
+        if not module.check_mode:
+            load_config(module, commands)
+        result['changed'] = True
+
+    if module.params['save']:
+        if not module.check_mode:
+            module.config.save_config()
+        result['changed'] = True
+
+
+def main():
+    """ main entry point for module execution
+    """
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block']),
+
+        config=dict(),
+
+        backup=dict(type='bool', default=False),
+        save=dict(type='bool', default=False),
+    )
+
+    argument_spec.update(ironware_argument_spec)
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    result = {'changed': False}
+
+    check_args(module)
+
+    config = None
+
+    if module.params['backup']:
+        result['__backup__'] = get_config(module)
+
+    run(module, result)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -224,7 +224,7 @@ class NetworkConfig(_NetworkConfig):
 def get_candidate(module):
     candidate = NetworkConfig(indent=1)
     if module.params['src']:
-        candidate.load(module.params['src'])
+        candidate.loadfd(module.params['src'])
     elif module.params['lines']:
         parents = module.params['parents'] or list()
         candidate.add_load(module.params['lines'], parents=parents)

--- a/lib/ansible/modules/network/ironware/ironware_facts.py
+++ b/lib/ansible/modules/network/ironware/ironware_facts.py
@@ -1,0 +1,686 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+DOCUMENTATION = """
+---
+module: ironware_facts
+version_added: "2.5"
+author: "Paul Baker (@paulquack)"
+short_description: Collect facts from remote devices running Brocade Ironware
+description:
+  - Collects a base set of device facts from a remote device that
+    is running Ironware.  This module prepends all of the
+    base network fact keys with C(ansible_net_<fact>).  The facts
+    module will always collect a base set of facts from the device
+    and can enable or disable collection of additional facts.
+extends_documentation_fragment: ironware
+notes:
+  - Tested against Ironware 5.8e
+options:
+  gather_subset:
+    description:
+      - When supplied, this argument will restrict the facts collected
+        to a given subset.  Possible values for this argument include
+        all, hardware, config, mpls and interfaces.  Can specify a list of
+        values to include a larger subset.  Values can also be used
+        with an initial C(M(!)) to specify that a specific subset should
+        not be collected.
+    required: false
+    default: ['!config','!mpls']
+"""
+
+EXAMPLES = """
+# Note: examples below use the following provider dict to handle
+#       transport and authentication to the node.
+---
+vars:
+  cli:
+    host: "{{ inventory_hostname }}"
+    username: username
+    password: secret
+    transport: cli
+
+---
+# Collect all facts from the device
+- ironware_facts:
+    gather_subset: all
+    provider: "{{ cli }}"
+
+# Collect only the config and default facts
+- ironware_facts:
+    gather_subset:
+      - config
+    provider: "{{ cli }}"
+
+# Do not collect hardware facts
+- ironware_facts:
+    gather_subset:
+      - "!hardware"
+    provider: "{{ cli }}"
+"""
+
+RETURN = """
+ansible_net_gather_subset:
+  description: The list of fact subsets collected from the device
+  returned: always
+  type: list
+
+# default
+ansible_net_model:
+  description: The model name returned from the device
+  returned: always
+  type: str
+ansible_net_serialnum:
+  description: The serial number of the remote device
+  returned: always
+  type: str
+ansible_net_version:
+  description: The operating system version running on the remote device
+  returned: always
+  type: str
+ansible_net_hostname:
+  description: The configured hostname of the device
+  returned: always
+  type: string
+ansible_net_image:
+  description: The image file the device is running
+  returned: always
+  type: string
+
+# hardware
+ansible_net_filesystems:
+  description: All file system names available on the device
+  returned: when hardware is configured
+  type: list
+ansible_net_memfree_mb:
+  description: The available free memory on the remote device in Mb
+  returned: when hardware is configured
+  type: int
+ansible_net_memtotal_mb:
+  description: The total memory on the remote device in Mb
+  returned: when hardware is configured
+  type: int
+
+# config
+ansible_net_config:
+  description: The current active config from the device
+  returned: when config is configured
+  type: str
+
+# mpls
+ansible_net_mpls_lsps:
+  description: All MPLS LSPs configured on the device
+  returned: When LSP is configured
+  type: dict
+ansible_net_mpls_vll:
+  description: All VLL instances configured on the device
+  returned: When MPLS VLL is configured
+  type: dict
+ansible_net_mpls_vll_local:
+  description: All VLL-LOCAL instances configured on the device
+  returned: When MPLS VLL-LOCAL is configured
+  type: dict
+ansible_net_mpls_vpls:
+  description: All VPLS instances configured on the device
+  returned: When MPLS VPLS is configured
+  type: dict
+
+# interfaces
+ansible_net_all_ipv4_addresses:
+  description: All IPv4 addresses configured on the device
+  returned: when interfaces is configured
+  type: list
+ansible_net_all_ipv6_addresses:
+  description: All IPv6 addresses configured on the device
+  returned: when interfaces is configured
+  type: list
+ansible_net_interfaces:
+  description: A hash of all interfaces running on the system
+  returned: when interfaces is configured
+  type: dict
+ansible_net_neighbors:
+  description: The list of LLDP neighbors from the remote device
+  returned: when interfaces is configured
+  type: dict
+"""
+import re
+
+from ansible.module_utils.ironware import run_commands
+from ansible.module_utils.ironware import ironware_argument_spec, check_args
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six.moves import zip
+
+
+class FactsBase(object):
+
+    COMMANDS = list()
+
+    def __init__(self, module):
+        self.module = module
+        self.facts = dict()
+        self.responses = None
+
+    def populate(self):
+        self.responses = run_commands(self.module, self.COMMANDS, check_rc=False)
+
+    def run(self, cmd):
+        return run_commands(self.module, cmd, check_rc=False)
+
+
+class Default(FactsBase):
+
+    COMMANDS = [
+        'show version',
+        'show chassis'
+    ]
+
+    def populate(self):
+        super(Default, self).populate()
+        data = self.responses[0]
+        if data:
+            self.facts['version'] = self.parse_version(data)
+            self.facts['serialnum'] = self.parse_serialnum(data)
+
+        data = self.responses[1]
+        if data:
+            self.facts['model'] = self.parse_model(data)
+
+    def parse_version(self, data):
+        match = re.search(r'IronWare : Version (\S+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_model(self, data):
+        match = re.search(r'^\*\*\* (.+) \*\*\*$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_serialnum(self, data):
+        match = re.search(r'Serial #: (\S+),', data)
+        if match:
+            return match.group(1)
+
+
+class Hardware(FactsBase):
+
+    COMMANDS = [
+        'dir | include Directory',
+        'show memory'
+    ]
+
+    def populate(self):
+        super(Hardware, self).populate()
+        data = self.responses[0]
+        if data:
+            self.facts['filesystems'] = self.parse_filesystems(data)
+
+        data = self.responses[1]
+        if data:
+            self.facts['memtotal_mb'] = int(self.parse_memtotal(data)) / 1024 / 1024
+            self.facts['memfree_mb'] = int(self.parse_memfree(data)) / 1024 / 1024
+
+    def parse_filesystems(self, data):
+        return re.findall(r'^Directory of (\S+)/', data, re.M)
+
+    def parse_memtotal(self, data):
+        match = re.search(r'Total SDRAM\D*(\d+)\s', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_memfree(self, data):
+        match = re.search(r'(Total Free Memory|Available Memory)\D*(\d+)\s', data, re.M)
+        if match:
+            return match.group(2)
+
+
+class Config(FactsBase):
+
+    COMMANDS = ['show running-config']
+
+    def populate(self):
+        super(Config, self).populate()
+        data = self.responses[0]
+        if data:
+            self.facts['config'] = data
+
+
+class MPLS(FactsBase):
+
+    COMMANDS = [
+        'show mpls lsp detail',
+        'show mpls vll-local detail',
+        'show mpls vll detail',
+        'show mpls vpls detail'
+    ]
+
+    def populate(self):
+        super(MPLS, self).populate()
+        data = self.responses[0]
+        if data:
+            data = self.parse_mpls(data)
+            self.facts['mpls_lsps'] = self.populate_lsps(data)
+
+        data = self.responses[1]
+        if data:
+            data = self.parse_mpls(data)
+            self.facts['mpls_vll_local'] = self.populate_vll_local(data)
+
+        data = self.responses[2]
+        if data:
+            data = self.parse_mpls(data)
+            self.facts['mpls_vll'] = self.populate_vll(data)
+
+        data = self.responses[3]
+        if data:
+            data = self.parse_mpls(data)
+            self.facts['mpls_vpls'] = self.populate_vpls(data)
+
+    def parse_mpls(self, data):
+        parsed = dict()
+        for line in data.split('\n'):
+            if not line:
+                continue
+            elif line[0] == ' ':
+                parsed[key] += '\n%s' % line
+            else:
+                match = re.match(r'^(LSP|VLL|VPLS) ([^\s,]+)', line)
+                if match:
+                    key = match.group(2)
+                    parsed[key] = line
+        return parsed
+
+    def populate_vpls(self, vpls):
+        facts = dict()
+        for key, value in iteritems(vpls):
+            vpls = dict()
+            vpls['endpoints'] = self.parse_vpls_endpoints(value)
+            vpls['vc-id'] = self.parse_vpls_vcid(value)
+            facts[key] = vpls
+        return facts
+
+    def populate_vll_local(self, vll_locals):
+        facts = dict()
+        for key, value in iteritems(vll_locals):
+            vll = dict()
+            vll['endpoints'] = self.parse_vll_endpoints(value)
+            facts[key] = vll
+        return facts
+
+    def populate_vll(self, vlls):
+        facts = dict()
+        for key, value in iteritems(vlls):
+            vll = dict()
+            vll['endpoints'] = self.parse_vll_endpoints(value)
+            vll['vc-id'] = self.parse_vll_vcid(value)
+            vll['cos'] = self.parse_vll_cos(value)
+            facts[key] = vll
+        return facts
+
+    def parse_vll_vcid(self, data):
+        match = re.search(r'VC-ID (\d+),', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_vll_cos(self, data):
+        match = re.search(r'COS +: +(\d+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_vll_endpoints(self, data):
+        facts = list()
+        regex = r'End-point[0-9 ]*: +(?P<tagged>tagged|untagged) +(vlan +(?P<vlan>[0-9]+) +)?(inner- vlan +(?P<innervlan>[0-9]+) +)?(?P<port>e [0-9/]+|--)'
+        matches = re.finditer(regex, data, re.IGNORECASE | re.DOTALL)
+        for n, match in enumerate(matches):
+            f = match.groupdict()
+            f['type'] = 'local'
+            facts.append(f)
+
+        regex = r'Vll-Peer +: +(?P<vllpeer>[0-9\.]+).*Tunnel LSP +: +(?P<lsp>\S+)'
+        matches = re.finditer(regex, data, re.IGNORECASE | re.DOTALL)
+        for n, match in enumerate(matches):
+            f = match.groupdict()
+            f['type'] = 'remote'
+            facts.append(f)
+
+        return facts
+
+    def parse_vpls_vcid(self, data):
+        match = re.search(r'Id (\d+),', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_vpls_endpoints(self, data):
+        facts = list()
+        regex = r'Vlan (?P<vlanid>[0-9]+)\s(?: +(?:L2.*)\s| +Tagged: (?P<tagged>.+)+\s| +Untagged: (?P<untagged>.+)\s)*'
+        matches = re.finditer(regex, data, re.IGNORECASE)
+        for n, match in enumerate(matches):
+            f = match.groupdict()
+            f['type'] = 'local'
+            facts.append(f)
+
+        regex = r'Peer address: (?P<vllpeer>[0-9\.]+)'
+        matches = re.finditer(regex, data, re.IGNORECASE)
+        for n, match in enumerate(matches):
+            f = match.groupdict()
+            f['type'] = 'remote'
+            facts.append(f)
+
+        return facts
+
+    def populate_lsps(self, lsps):
+        facts = dict()
+        for key, value in iteritems(lsps):
+            lsp = dict()
+            lsp['to'] = self.parse_lsp_to(value)
+            lsp['from'] = self.parse_lsp_from(value)
+            lsp['adminstatus'] = self.parse_lsp_adminstatus(value)
+            lsp['operstatus'] = self.parse_lsp_operstatus(value)
+            lsp['pri_path'] = self.parse_lsp_pripath(value)
+            lsp['sec_path'] = self.parse_lsp_secpath(value)
+            lsp['frr'] = self.parse_lsp_frr(value)
+
+            facts[key] = lsp
+
+        return facts
+
+    def parse_lsp_to(self, data):
+        match = re.search(r'^LSP .* to (\S+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lsp_from(self, data):
+        match = re.search(r'From: ([^\s,]+),', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lsp_adminstatus(self, data):
+        match = re.search(r'admin: (\w+),', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lsp_operstatus(self, data):
+        match = re.search(r'From: .* status: (\w+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lsp_pripath(self, data):
+        match = re.search(r'Pri\. path: ([^\s,]+), up: (\w+), active: (\w+)', data, re.M)
+        if match:
+            path = dict()
+            path['name'] = match.group(1) if match.group(1) != 'NONE' else None
+            path['up'] = True if match.group(2) == 'yes' else False
+            path['active'] = True if match.group(3) == 'yes' else False
+            return path
+
+    def parse_lsp_secpath(self, data):
+        match = re.search(r'Sec\. path: ([^\s,]+), active: (\w+).*\n.* status: (\w+)', data, re.M)
+        if match:
+            path = dict()
+            path['name'] = match.group(1) if match.group(1) != 'NONE' else None
+            path['up'] = True if match.group(3) == 'up' else False
+            path['active'] = True if match.group(2) == 'yes' else False
+            return path
+
+    def parse_lsp_frr(self, data):
+        match = re.search(r'Backup LSP: (\w+)', data, re.M)
+        if match:
+            path = dict()
+            path['up'] = True if match.group(1) == 'UP' else False
+            path['name'] = None
+            if path['up']:
+                match = re.search('bypass_lsp: (\S)', data, re.M)
+                path['name'] = match.group(1) if match else None
+            return path
+
+
+class Interfaces(FactsBase):
+
+    COMMANDS = [
+        'show interfaces',
+        'show ipv6 interface',
+        'show lldp'
+    ]
+
+    def populate(self):
+        super(Interfaces, self).populate()
+
+        self.facts['all_ipv4_addresses'] = list()
+        self.facts['all_ipv6_addresses'] = list()
+
+        data = self.responses[0]
+        if data:
+            interfaces = self.parse_interfaces(data)
+            self.facts['interfaces'] = self.populate_interfaces(interfaces)
+
+        data = self.responses[1]
+        if data:
+            data = self.parse_interfaces(data)
+            self.populate_ipv6_interfaces(data)
+
+        data = self.responses[2]
+        if False and data and 'LLDP is not running' not in data:
+            neighbors = self.run(['show lldp neighbors'])
+            if neighbors:
+                self.facts['neighbors'] = self.parse_neighbors(neighbors[0])
+
+    def populate_interfaces(self, interfaces):
+        facts = dict()
+        for key, value in iteritems(interfaces):
+            intf = dict()
+            intf['description'] = self.parse_description(value)
+            intf['macaddress'] = self.parse_macaddress(value)
+
+            ipv4 = self.parse_ipv4(value)
+            intf['ipv4'] = self.parse_ipv4(value)
+            if ipv4:
+                self.add_ip_address(ipv4['address'], 'ipv4')
+
+            intf['mtu'] = self.parse_mtu(value)
+            intf['bandwidth'] = self.parse_bandwidth(value)
+            intf['duplex'] = self.parse_duplex(value)
+            intf['lineprotocol'] = self.parse_lineprotocol(value)
+            intf['operstatus'] = self.parse_operstatus(value)
+            intf['type'] = self.parse_type(value)
+
+            facts[key] = intf
+        return facts
+
+    def populate_ipv6_interfaces(self, data):
+        for key, value in iteritems(data):
+            self.facts['interfaces'][key]['ipv6'] = list()
+            addresses = re.findall(r'\s(\d+:+[\d:]+/\d+)\s', value, re.M)
+            for addr in addresses:
+                address, masklen = addr.split('/')
+                ipv6 = dict(address=address, masklen=int(masklen))
+                self.add_ip_address(addr.strip(), 'ipv6')
+                self.facts['interfaces'][key]['ipv6'].append(ipv6)
+
+    def add_ip_address(self, address, family):
+        if family == 'ipv4':
+            self.facts['all_ipv4_addresses'].append(address)
+        else:
+            self.facts['all_ipv6_addresses'].append(address)
+
+    def parse_neighbors(self, neighbors):
+        facts = dict()
+        for line in neighbors.split('\n'):
+            if line == '':
+                continue
+            match = re.search(r'^([\d\/]+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)$', line, re.M)
+            if match:
+                intf = match.groups(1)
+                if intf not in facts:
+                    facts[intf] = list()
+                fact = dict()
+                fact['host'] = match.group(5)
+                fact['port'] = match.group(3)
+                facts[intf].append(fact)
+        return facts
+
+    def parse_interfaces(self, data):
+        parsed = dict()
+        for line in data.split('\n'):
+            if not line:
+                continue
+            elif line[0] == ' ':
+                parsed[key] += '\n%s' % line
+            else:
+                match = re.match(r'^(\S+Ethernet|eth )(\S+)', line)
+                if match:
+                    key = match.group(2)
+                    parsed[key] = line
+        return parsed
+
+    def parse_description(self, data):
+        match = re.search(r'Port name is (.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_macaddress(self, data):
+        match = re.search(r'address is (\S+)', data)
+        if match:
+            return match.group(1)
+
+    def parse_ipv4(self, data):
+        match = re.search(r'Internet address is ([^\s,]+)', data)
+        if match:
+            addr, masklen = match.group(1).split('/')
+            return dict(address=addr, masklen=int(masklen))
+
+    def parse_mtu(self, data):
+        match = re.search(r'MTU (\d+)', data)
+        if match:
+            return int(match.group(1))
+
+    def parse_bandwidth(self, data):
+        match = re.search(r'BW is (\d+)', data)
+        if match:
+            return int(match.group(1))
+
+    def parse_duplex(self, data):
+        match = re.search(r'configured duplex \S+ actual (\S+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_mediatype(self, data):
+        match = re.search(r'Type\s*:\s*(.+)$', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_type(self, data):
+        match = re.search(r'Hardware is (.+),', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_lineprotocol(self, data):
+        match = re.search(r'line protocol is (\S+)', data, re.M)
+        if match:
+            return match.group(1)
+
+    def parse_operstatus(self, data):
+        match = re.search(r'^(?:.+) is (.+),', data, re.M)
+        if match:
+            return match.group(1)
+
+
+FACT_SUBSETS = dict(
+    default=Default,
+    hardware=Hardware,
+    interfaces=Interfaces,
+    config=Config,
+    mpls=MPLS,
+)
+
+VALID_SUBSETS = frozenset(FACT_SUBSETS.keys())
+
+
+def main():
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        gather_subset=dict(default=["!config", "!mpls"], type='list')
+    )
+
+    argument_spec.update(ironware_argument_spec)
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    gather_subset = module.params['gather_subset']
+
+    runable_subsets = set()
+    exclude_subsets = set()
+
+    for subset in gather_subset:
+        if subset == 'all':
+            runable_subsets.update(VALID_SUBSETS)
+            continue
+
+        if subset.startswith('!'):
+            subset = subset[1:]
+            if subset == 'all':
+                exclude_subsets.update(VALID_SUBSETS)
+                continue
+            exclude = True
+        else:
+            exclude = False
+
+        if subset not in VALID_SUBSETS:
+            module.fail_json(msg='Bad subset')
+
+        if exclude:
+            exclude_subsets.add(subset)
+        else:
+            runable_subsets.add(subset)
+
+    if not runable_subsets:
+        runable_subsets.update(VALID_SUBSETS)
+
+    runable_subsets.difference_update(exclude_subsets)
+    runable_subsets.add('default')
+
+    facts = dict()
+    facts['gather_subset'] = list(runable_subsets)
+
+    instances = list()
+    for key in runable_subsets:
+        instances.append(FACT_SUBSETS[key](module))
+
+    for inst in instances:
+        inst.populate()
+        facts.update(inst.facts)
+
+    ansible_facts = dict()
+    for key, value in iteritems(facts):
+        key = 'ansible_net_%s' % key
+        ansible_facts[key] = value
+
+    check_args(module)
+
+    module.exit_json(ansible_facts=ansible_facts)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -1,0 +1,107 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import sys
+import copy
+import json
+
+from ansible import constants as C
+from ansible.plugins.action.normal import ActionModule as _ActionModule
+from ansible.module_utils.basic import AnsibleFallbackNotFound
+from ansible.module_utils.ironware import ironware_argument_spec
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.connection import request_builder
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+class ActionModule(_ActionModule):
+
+    def run(self, tmp=None, task_vars=None):
+
+        if self._play_context.connection != 'local':
+            return dict(
+                failed=True,
+                msg='invalid connection specified, expected connection=local, '
+                    'got %s' % self._play_context.connection
+            )
+
+        provider = self.load_provider()
+
+        pc = copy.deepcopy(self._play_context)
+        pc.connection = 'network_cli'
+        pc.network_os = 'ironware'
+        pc.remote_addr = provider['host'] or self._play_context.remote_addr
+        pc.port = int(provider['port'] or self._play_context.port or 22)
+        pc.remote_user = provider['username'] or self._play_context.connection_user
+        pc.password = provider['password'] or self._play_context.password
+        pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
+        pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
+        pc.become = provider['authorize'] or False
+        pc.become_pass = provider['auth_pass']
+
+        display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
+        connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
+
+        socket_path = connection.run()
+
+        display.vvvv('socket_path: %s' % socket_path, pc.remote_addr)
+        if not socket_path:
+            return {'failed': True,
+                    'msg': 'unable to open shell. Please see: ' +
+                           'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
+
+        task_vars['ansible_socket'] = socket_path
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        return result
+
+    def load_provider(self):
+        provider = self._task.args.get('provider', {})
+        for key, value in iteritems(ironware_argument_spec):
+            if key != 'provider' and key not in provider:
+                if key in self._task.args:
+                    provider[key] = self._task.args[key]
+                elif 'fallback' in value:
+                    provider[key] = self._fallback(value['fallback'])
+                elif key not in provider:
+                    provider[key] = None
+        return provider
+
+    def _fallback(self, fallback):
+        strategy = fallback[0]
+        args = []
+        kwargs = {}
+
+        for item in fallback[1:]:
+            if isinstance(item, dict):
+                kwargs = item
+            else:
+                args = item
+        try:
+            return strategy(*args, **kwargs)
+        except AnsibleFallbackNotFound:
+            pass

--- a/lib/ansible/plugins/cliconf/ironware.py
+++ b/lib/ansible/plugins/cliconf/ironware.py
@@ -1,0 +1,74 @@
+#
+# (c) 2017 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import json
+
+from itertools import chain
+
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.network_common import to_list
+from ansible.plugins.cliconf import CliconfBase, enable_mode
+
+
+class Cliconf(CliconfBase):
+
+    def get_device_info(self):
+        device_info = {}
+
+        device_info['network_os'] = 'ironware'
+        reply = self.get(b'show version')
+        data = to_text(reply, errors='surrogate_or_strict').strip()
+
+        match = re.search(r'IronWare : Version (\S+),', data)
+        if match:
+            device_info['network_os_version'] = match.group(1)
+
+        match = re.search(r'^(?:System Mode\:|System\:) (CES|CER|MLX|XMR)', data, re.M)
+        if match:
+            device_info['network_os_model'] = match.group(1)
+
+        return device_info
+
+    @enable_mode
+    def get_config(self, source='running'):
+        if source not in ('running', 'startup'):
+            return self.invalid_params("fetching configuration from %s is not supported" % source)
+        if source == 'running':
+            cmd = b'show running-config'
+        else:
+            cmd = b'show configuration'
+        return self.send_command(cmd)
+
+    @enable_mode
+    def edit_config(self, command):
+        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+            self.send_command(cmd)
+
+    def get(self, *args, **kwargs):
+        return self.send_command(*args, **kwargs)
+
+    def get_capabilities(self):
+        result = {}
+        result['rpc'] = self.get_base_rpc()
+        result['network_api'] = 'cliconf'
+        result['device_info'] = self.get_device_info()
+        return json.dumps(result)

--- a/lib/ansible/plugins/terminal/ironware.py
+++ b/lib/ansible/plugins/terminal/ironware.py
@@ -1,0 +1,83 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import json
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text, to_bytes
+from ansible.plugins.terminal import TerminalBase
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(r"[\r\n]?(?:\w+@)?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$")
+    ]
+
+    terminal_stderr_re = [
+        re.compile(r"[\r\n]Error - "),
+        # re.compile(r"^%? ?Bad secret"),
+        re.compile(r"[\r\n](?:incomplete|ambiguous|unrecognised|invalid) (?:command|input)", re.I)
+        # re.compile(r"connection timed out", re.I),
+        # re.compile(r"[^\r\n]+ not found", re.I),
+        # re.compile(r"'[^']' +returned error code: ?\d+")
+    ]
+
+    def on_open_shell(self):
+        # if self._get_prompt().strip().endswith(b'#'):
+        self.disable_pager()
+
+    def disable_pager(self):
+        cmd = {u'command': u'terminal length 0'}
+        try:
+            self._exec_cli_command(u'terminal length 0')
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to disable terminal pager')
+
+    def on_authorize(self, passwd=None):
+        if self._get_prompt().strip().endswith(b'#'):
+            return
+
+        cmd = {u'command': u'enable'}
+        if passwd:
+            # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
+            # an r string and use to_text to ensure it's text on both py2 and py3.
+            cmd[u'prompt'] = to_text(r"[\r\n]?password: ?$", errors='surrogate_or_strict')
+            cmd[u'answer'] = passwd
+
+        try:
+            self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
+
+    def on_deauthorize(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if b'(config' in prompt:
+            self._exec_cli_command(b'end')
+            self._exec_cli_command(b'exit')
+
+        elif prompt.endswith(b'#'):
+            self._exec_cli_command(b'exit')

--- a/lib/ansible/utils/module_docs_fragments/ironware.py
+++ b/lib/ansible/utils/module_docs_fragments/ironware.py
@@ -1,0 +1,92 @@
+#
+# (c) 2016, Peter Sprygada <psprygada@ansible.com>
+# (c) 2016, Patrick Ogenstad <@ogenstad>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+
+    # Standard files documentation fragment
+    DOCUMENTATION = """
+options:
+  authorize:
+    description:
+      - Instructs the module to enter privileged mode on the remote device
+        before sending any commands.  If not specified, the device will
+        attempt to execute all commands in non-privileged mode. If the value
+        is not specified in the task, the value of environment variable
+        C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+    default: no
+    choices: ['yes', 'no']
+  provider:
+    description:
+      - A dict object containing connection details.
+    default: null
+    suboptions:
+      host:
+        description:
+          - Specifies the DNS host name or address for connecting to the remote
+            device over the specified transport.  The value of host is used as
+            the destination address for the transport.
+      port:
+        description:
+          - Specifies the port to use when building the connection to the remote
+            device.
+        default: 22
+      username:
+        description:
+          - Configures the username to use to authenticate the connection to
+            the remote device.  This value is used to authenticate
+            the SSH session. If the value is not specified in the task, the
+            value of environment variable C(ANSIBLE_NET_USERNAME) will be used instead.
+      password:
+        description:
+          - Specifies the password to use to authenticate the connection to
+            the remote device.   This value is used to authenticate
+            the SSH session. If the value is not specified in the task, the
+            value of environment variable C(ANSIBLE_NET_PASSWORD) will be used instead.
+        default: null
+      ssh_keyfile:
+        description:
+          - Specifies the SSH key to use to authenticate the connection to
+            the remote device.   This value is the path to the
+            key used to authenticate the SSH session. If the value is not specified
+            in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
+            will be used instead.
+      authorize:
+        description:
+          - Instructs the module to enter privileged mode on the remote device
+            before sending any commands.  If not specified, the device will
+            attempt to execute all commands in non-privileged mode. If the value
+            is not specified in the task, the value of environment variable
+            C(ANSIBLE_NET_AUTHORIZE) will be used instead.
+        default: no
+        choices: ['yes', 'no']
+      auth_pass:
+        description:
+          - Specifies the password to use if required to enter privileged mode
+            on the remote device.  If I(authorize) is false, then this argument
+            does nothing. If the value is not specified in the task, the value of
+            environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
+        default: none
+      timeout:
+        description:
+          - Specifies idle timeout in seconds for the connection, in seconds. Useful
+            if the console freezes before continuing. For example when saving
+            configurations.
+        default: 10
+"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New Network modules for Brocade IronWare routers
Added ironware to NETWORK_GROUP_MODULES
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
 - ironware_config
 - ironware_command
 - ironware_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0 (ironware-module fc9bda3574) last updated 2017/10/06 12:53:41 (GMT +1100)
  config file = /Users/paul.baker/.ansible.cfg
  configured module search path = [u'/Users/paul.baker/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/paul.baker/ansible/lib/ansible
  executable location = ./ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The ironware_config module also extends NetworkConfig to provide a new function "add_load" which interprets the "lines" parameter in block indented format, meaning we enter all the right commands in the right hierarchy, even if match == line. Please comment if you need this to be removed/added as a PR against that module, or if you think its a terrible idea!

I also noted that when using the "src" parameter,  various modules are passing the filename directly into the config rather than the contents of that file. This issue is fixed in this module by calling "candidate.loadfd" instead of "candidate.load"
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
