### PR TITLE
Docs: Fixed RST hyperlink issues

### DIFF
--- a/docs/docsite/rst/community/how_can_I_help.rst
+++ b/docs/docsite/rst/community/how_can_I_help.rst
@@ -43,7 +43,7 @@ If you should discover that the bug you're trying to file already exists in an i
 Review and submit pull requests
 -------------------------------
 
-As you become more familiar with how Ansible works, you may be able to fix issues or develop new features yourself. If you think you've got a solution to a bug you've found in Ansible, or if you've got a new feature that you've written and would like to share with millions of Ansible users, read all about the `Ansible development process <http://docs.ansible.com/ansible/latest/community/development_process.rst>` to learn how to get your code accepted into Ansible.
+As you become more familiar with how Ansible works, you may be able to fix issues or develop new features yourself. If you think you've got a solution to a bug you've found in Ansible, or if you've got a new feature that you've written and would like to share with millions of Ansible users, read all about the `Ansible development process <http://docs.ansible.com/ansible/latest/community/development_process.rst>`_ to learn how to get your code accepted into Ansible.
 
 Another good way to help is to review pull requests that other Ansible users have submitted. The Ansible community keeps a full list of `open pull requests by file <https://ansible.sivel.net/byfile.html>`_, so if there's a particular module or plug-in that particularly interests you, you can easily keep track of all the relevant new pull requests and provide testing or feedback.
 

--- a/docs/docsite/rst/community/other_tools_and_programs.rst
+++ b/docs/docsite/rst/community/other_tools_and_programs.rst
@@ -17,4 +17,4 @@ of some of the most popular of these tools.
 
 - `Awesome Ansible <https://github.com/jdauphant/awesome-ansible>`_ is a collaboratively curated list of awesome Ansible resources.
 
-- `Ansible Inventory Grapher <http://github.com/willthames/ansible-inventory-grapher>_` can be used to visually display inventory inheritance hierarchies and at what level a variable is defined in inventory.
+- `Ansible Inventory Grapher <http://github.com/willthames/ansible-inventory-grapher>`_ can be used to visually display inventory inheritance hierarchies and at what level a variable is defined in inventory.

--- a/docs/docsite/rst/community/reporting_bugs_and_features.rst
+++ b/docs/docsite/rst/community/reporting_bugs_and_features.rst
@@ -32,4 +32,4 @@ Requesting a feature
 
 The best way to get a feature into Ansible is to submit a pull request.
 
-The next best way of getting a feature into Ansible is to submit a proposal through the `Ansible proposal process  <https://github.com/ansible/proposals>` .
+The next best way of getting a feature into Ansible is to submit a proposal through the `Ansible proposal process  <https://github.com/ansible/proposals>`_.

--- a/docs/docsite/rst/community/triage_process.rst
+++ b/docs/docsite/rst/community/triage_process.rst
@@ -2,7 +2,7 @@
 Triage Process
 **************
 
-The issue and PR triage processes are driven by the `Ansibot <https://github.com/ansible/ansibullbot>`. Whenever an issue or PR is filed, the Ansibot examines the issue to ensure that all relevant data is present, and handles the routing of the issue as it works its way to eventual completion.
+The issue and PR triage processes are driven by the `Ansibot <https://github.com/ansible/ansibullbot>`_. Whenever an issue or PR is filed, the Ansibot examines the issue to ensure that all relevant data is present, and handles the routing of the issue as it works its way to eventual completion.
 
 For details on how Ansibot manages the triage process, please consult the `Ansibot
-Issue Guide <https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md>`.
+Issue Guide <https://github.com/ansible/ansibullbot/blob/master/ISSUE_HELP.md>`_.

--- a/docs/docsite/rst/vault.rst
+++ b/docs/docsite/rst/vault.rst
@@ -377,7 +377,7 @@ hexlify()'ied result of:
 - hexlify()'ed string of the salt, followed by a newline ('\n')
 - hexlify()'ed string of the crypted HMAC, followed by a newline. The HMAC is:
 
-  - a `RFC2104 <https://www.ietf.org/rfc/rfc2104.txt>` style HMAC
+  - a `RFC2104 <https://www.ietf.org/rfc/rfc2104.txt>`_ style HMAC
 
     - inputs are:
 
@@ -402,6 +402,6 @@ hexlify()'ied result of:
       - the plaintext
 
         - the original plaintext
-        - padding up to the AES256 blocksize. (The data used for padding is based on `RFX5652 <https://tools.ietf.org/html/rfc5652#section-6.3>`)
+        - padding up to the AES256 blocksize. (The data used for padding is based on `RFX5652 <https://tools.ietf.org/html/rfc5652#section-6.3>`_)
 
 


### PR DESCRIPTION
##### SUMMARY

Fix RST syntax issues resulting in incorrectly rendered hyperlinks

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME

Docs - Community, Vault, Plugin

##### ANSIBLE VERSION

```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/lhill/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION

Some hyperlinks were not rendered properly by RST, due to missing `_`. e.g. see http://docs.ansible.com/ansible/latest/community/how_can_I_help.html#review-and-submit-pull-requests - that should be rendered properly as a hyperlink.

Post-change, this should be rendered properly.