### PR TITLE
pip module: allow to use both 'name' and 'requirements' parameters

### DIFF
--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -502,25 +502,24 @@ def main():
             err += err_pip
 
             changed = False
-            if name:
-                pkg_list = [p for p in out.split('\n') if not p.startswith('You are using') and not p.startswith('You should consider') and p]
+            pkg_list = [p for p in out.split('\n') if not p.startswith('You are using') and not p.startswith('You should consider') and p]
 
-                if pkg_cmd.endswith(' freeze') and ('pip' in name or 'setuptools' in name):
-                    # Older versions of pip (pre-1.3) do not have pip list.
-                    # pip freeze does not list setuptools or pip in its output
-                    # So we need to get those via a specialcase
-                    for pkg in ('setuptools', 'pip'):
-                        if pkg in name:
-                            formatted_dep = _get_package_info(module, pkg, env)
-                            if formatted_dep is not None:
-                                pkg_list.append(formatted_dep)
-                                out += '%s\n' % formatted_dep
+            if pkg_cmd.endswith(' freeze') and ('pip' in name or 'setuptools' in name):
+                # Older versions of pip (pre-1.3) do not have pip list.
+                # pip freeze does not list setuptools or pip in its output
+                # So we need to get those via a specialcase
+                for pkg in ('setuptools', 'pip'):
+                    if pkg in name:
+                        formatted_dep = _get_package_info(module, pkg, env)
+                        if formatted_dep is not None:
+                            pkg_list.append(formatted_dep)
+                            out += '%s\n' % formatted_dep
 
-                for pkg in name:
-                    is_present = _is_present(pkg, version, pkg_list, pkg_cmd)
-                    if (state == 'present' and not is_present) or (state == 'absent' and is_present):
-                        changed = True
-                        break
+            for pkg in name:
+                is_present = _is_present(pkg, version, pkg_list, pkg_cmd)
+                if (state == 'present' and not is_present) or (state == 'absent' and is_present):
+                    changed = True
+                    break
             module.exit_json(changed=changed, cmd=pkg_cmd, stdout=out, stderr=err)
 
         out_freeze_before = None

--- a/lib/ansible/modules/packaging/language/pip.py
+++ b/lib/ansible/modules/packaging/language/pip.py
@@ -368,7 +368,7 @@ def main():
             umask=dict(type='str'),
         ),
         required_one_of=[['name', 'requirements']],
-        mutually_exclusive=[['name', 'requirements'], ['executable', 'virtualenv']],
+        mutually_exclusive=[['executable', 'virtualenv']],
         supports_check_mode=True,
     )
 
@@ -488,9 +488,9 @@ def main():
         if name:
             for pkg in name:
                 cmd += ' %s' % _get_full_name(pkg, version)
-        else:
-            if requirements:
-                cmd += ' -r %s' % requirements
+
+        if requirements:
+            cmd += ' -r %s' % requirements
 
         if module.check_mode:
             if extra_args or requirements or state == 'latest' or not name:

--- a/test/integration/integration_config.yml
+++ b/test/integration/integration_config.yml
@@ -2,4 +2,3 @@
 win_output_dir: 'C:\ansible_testing'
 output_dir: ~/ansible_testing
 non_root_test_user: ansible
-pip_test_package: isort

--- a/test/integration/targets/pip/defaults/main.yml
+++ b/test/integration/targets/pip/defaults/main.yml
@@ -1,0 +1,1 @@
+pip_test_package: isort

--- a/test/integration/targets/pip/tasks/main.yml
+++ b/test/integration/targets/pip/tasks/main.yml
@@ -1,5 +1,7 @@
 # Current pip unconditionally uses md5.
 # We can re-enable if pip switches to a different hash or allows us to not check md5.
 
-- include: 'pip.yml'
+- block:
+  - import_tasks: setup.yml
+  - import_tasks: pip.yml
   when: ansible_fips|bool != True

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -183,6 +183,38 @@
       that:
         - "pip_install_venv.changed"
 
+  # Check that 'name' and 'requirements' can be used together
+  - name: overwrite requirement file
+    copy: dest={{ output_dir }}/pipreq.txt
+      content="q"
+
+  - name: check that test packages are not already installed
+    command: 'pip show {{ item }}'
+    with_items: ['q', 'six'] # relative small packages, compatible py2/py3, with wheels
+    ignore_errors: True
+    register: dep_already_installed
+
+  - assert:
+      that:
+        - "{{ dep_already_installed | failed }}"
+
+  - name: "test that 'name' and 'requirements' can be used together"
+    pip:
+      name: six
+      requirements: "{{ output_dir}}/pipreq.txt"
+      virtualenv: "{{ output_dir }}/pipenv"
+    register: pip_install_venv_name_req
+
+  - name: check that test packages are installed
+    shell: '. {{ output_dir }}/pipenv/bin/activate && pip show {{ item }}'
+    with_items: ['q', 'six']
+
+  - name: Ensure installation was successful
+    assert:
+      that:
+        - "pip_install_venv_name_req|changed"
+        - "pip_install_venv_name_req|success"
+
   always:
     - name: "Remove test env"
       file: "state=absent name={{ item }}"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -81,103 +81,111 @@
 - name: "make sure the test env doesn't exist"
   file: state=absent name={{ output_dir }}/pipenv
 
-- name: install a working version of setuptools in the virtualenv
-  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present version=33.1.1
+- block:
+  - name: install a working version of setuptools in the virtualenv
+    pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present version=33.1.1
+  
+  - name: create a requirement file with an vcs url
+    copy: dest={{ output_dir }}/pipreq.txt
+      content="-e git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
+  
+  - name: install the requirement file in a virtualenv
+    pip: requirements={{ output_dir}}/pipreq.txt
+      virtualenv={{ output_dir }}/pipenv
+    register: req_installed
+  
+  - name: check that a change occurred
+    assert:
+      that:
+        - "req_installed.changed"
+  
+  - name: "repeat installation to check status didn't change"
+    pip: requirements={{ output_dir}}/pipreq.txt
+      virtualenv={{ output_dir }}/pipenv
+    register: req_installed
+  
+  - name: "check that a change didn't occurr this time (bug ansible#1705)"
+    assert:
+      that:
+        - "not req_installed.changed"
+  
+  - name: install the same module from url
+    pip: 
+      name: "git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
+      virtualenv: "{{ output_dir }}/pipenv"
+      editable: True
+    register: url_installed
+  
+  - name: "check that a change didn't occurr (bug ansible-modules-core#1645)"
+    assert:
+      that:
+        - "not url_installed.changed"
+  
+  # Test pip package in check mode doesn't always report changed.
+  
+  # Special case for pip
+  - name: check for pip package
+    pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
+  
+  - name: check for pip package in check_mode
+    pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
+    check_mode: True
+    register: pip_check_mode
+  
+  - name: make sure pip in check_mode doesn't report changed
+    assert:
+      that:
+        - "not pip_check_mode.changed"
+  
+  # Special case for setuptools
+  - name: check for setuptools package
+    pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present
+  
+  - name: check for setuptools package in check_mode
+    pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present
+    check_mode: True
+    register: setuptools_check_mode
+  
+  - name: make sure setuptools in check_mode doesn't report changed
+    assert:
+      that:
+        - "not setuptools_check_mode.changed"
+  
+  
+  # Normal case
+  - name: check for q package
+    pip: name=q virtualenv={{ output_dir }}/pipenv state=present
+  
+  - name: check for q package in check_mode
+    pip: name=q virtualenv={{ output_dir }}/pipenv state=present
+    check_mode: True
+    register: q_check_mode
+  
+  - name: make sure q in check_mode doesn't report changed
+    assert:
+      that:
+        - "not q_check_mode.changed"
+  
+  # ansible#23204
+  - name: ensure is a fresh virtualenv
+    file:
+      state: absent
+      name: "{{ output_dir }}/pipenv"
+  
+  - name: install pip throught pip into fresh virtualenv
+    pip:
+      name: pip
+      virtualenv: "{{ output_dir }}/pipenv"
+    register: pip_install_venv
+  
+  - name: make sure pip in fresh virtualenv report changed
+    assert:
+      that:
+        - "pip_install_venv.changed"
 
-- name: create a requirement file with an vcs url
-  copy: dest={{ output_dir }}/pipreq.txt
-    content="-e git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
-
-- name: install the requirement file in a virtualenv
-  pip: requirements={{ output_dir}}/pipreq.txt
-    virtualenv={{ output_dir }}/pipenv
-  register: req_installed
-
-- name: check that a change occurred
-  assert:
-    that:
-      - "req_installed.changed"
-
-- name: "repeat installation to check status didn't change"
-  pip: requirements={{ output_dir}}/pipreq.txt
-    virtualenv={{ output_dir }}/pipenv
-  register: req_installed
-
-- name: "check that a change didn't occurr this time (bug ansible#1705)"
-  assert:
-    that:
-      - "not req_installed.changed"
-
-- name: install the same module from url
-  pip: 
-    name: "git+https://github.com/dvarrazzo/pyiso8601#egg=pyiso8601"
-    virtualenv: "{{ output_dir }}/pipenv"
-    editable: True
-  register: url_installed
-
-- name: "check that a change didn't occurr (bug ansible-modules-core#1645)"
-  assert:
-    that:
-      - "not url_installed.changed"
-
-# Test pip package in check mode doesn't always report changed.
-
-# Special case for pip
-- name: check for pip package
-  pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
-
-- name: check for pip package in check_mode
-  pip: name=pip virtualenv={{ output_dir }}/pipenv state=present
-  check_mode: True
-  register: pip_check_mode
-
-- name: make sure pip in check_mode doesn't report changed
-  assert:
-    that:
-      - "not pip_check_mode.changed"
-
-# Special case for setuptools
-- name: check for setuptools package
-  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present
-
-- name: check for setuptools package in check_mode
-  pip: name=setuptools virtualenv={{ output_dir }}/pipenv state=present
-  check_mode: True
-  register: setuptools_check_mode
-
-- name: make sure setuptools in check_mode doesn't report changed
-  assert:
-    that:
-      - "not setuptools_check_mode.changed"
-
-
-# Normal case
-- name: check for q package
-  pip: name=q virtualenv={{ output_dir }}/pipenv state=present
-
-- name: check for q package in check_mode
-  pip: name=q virtualenv={{ output_dir }}/pipenv state=present
-  check_mode: True
-  register: q_check_mode
-
-- name: make sure q in check_mode doesn't report changed
-  assert:
-    that:
-      - "not q_check_mode.changed"
-
-# ansible#23204
-- name: ensure is a fresh virtualenv
-  file:
-    state: absent
-    name: "{{ output_dir }}/pipenv"
-
-- name: install pip throught pip into fresh virtualenv
-  pip:
-    name: pip
-    virtualenv: "{{ output_dir }}/pipenv"
-  register: pip_install_venv
-
-- name: make sure pip in fresh virtualenv report changed
-  assert:
-    that:
-      - "pip_install_venv.changed"
+  always:
+    - name: "Remove test env"
+      file: "state=absent name={{ item }}"
+      with_items:
+        - "{{ output_dir }}/pipenv"
+        - "{{ output_dir }}/pipreq.txt"

--- a/test/integration/targets/pip/tasks/pip.yml
+++ b/test/integration/targets/pip/tasks/pip.yml
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# FIXME: replace the python test package
-
 # first some tests installed system-wide
 # verify things were not installed to start with
 

--- a/test/integration/targets/pip/tasks/setup.yml
+++ b/test/integration/targets/pip/tasks/setup.yml
@@ -1,0 +1,11 @@
+- block:
+  - apt:
+      name: '{{ item }}'
+      state: present
+      install_recommends: no
+    with_items:
+      - python-pip
+      - python3-pip
+      - virtualenv
+      - git  # for requirement file with an vcs url
+  when: ansible_distribution == 'Debian'


### PR DESCRIPTION
##### SUMMARY
Allow to use both `name` and `requirements` parameters. Integration test provided.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pip

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 7d74c126a9) last updated 2017/10/02 22:32:39 (GMT +200)
```

##### ADDITIONAL INFORMATION

Without the change:
```
fatal: [myapp]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "chdir": "/src/myapp/",
            "extra_args": "--process-dependency-links",
            "name": "myapp[webapp]",
            "requirements": "requirements.txt",
            "virtualenv": "/home/pilou/venv",
            "virtualenv_python": "python2.7"
        }
    }
}

MSG:

parameters are mutually exclusive: ['name', 'requirements']
```

I tested with an old version of Pip (1.5.1), using both `name` and `requirements` is supported:
```
$ python -c "import six"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named six
$ python -c "import jinja"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ImportError: No module named jinja
$ pip --version
pip 1.5.1 from /tmp/testenv2/local/lib/python2.7/site-packages (python 2.7)
$ echo six > /tmp/req.txt
$ pip install -r /tmp/req.txt Jinja
Downloading/unpacking Jinja
  Downloading Jinja-1.2.tar.gz (252kB): 252kB downloaded
  Running setup.py (path:/tmp/testenv2/build/Jinja/setup.py) egg_info for package Jinja
Downloading/unpacking six (from -r /tmp/req.txt (line 1))
  Downloading six-1.11.0-py2.py3-none-any.whl
Installing collected packages: Jinja, six
  Running setup.py install for Jinja
    building 'jinja._debugger' extension
    [...]
    deleting Jinja.egg-info/native_libs.txt
  Could not find .egg-info directory in install record for Jinja
Successfully installed Jinja six
Cleaning up...
$ python -c "import six; import jinja"
$ echo $?
0
```