### PR TITLE
Fix Packet guide to comply with latest version of the packet module

### DIFF
--- a/docs/docsite/rst/guide_packet.rst
+++ b/docs/docsite/rst/guide_packet.rst
@@ -152,7 +152,7 @@ The following playbook will create an SSH key, 3 Packet servers, and then wait u
           plan: baremetal_0
           facility: ewr1
           project_id: <your_project_id>
-          wait: true
+          wait_for_public_IPv: 4
           user_data: |
             #cloud-config
             coreos:
@@ -185,7 +185,7 @@ As with most Ansible modules, the default states of the Packet modules are idemp
 
 The second module call provisions 3 Packet Type 0 (specified using the 'plan' parameter) servers in the project identified via the 'project_id' parameter. The servers are all provisioned with CoresOS beta (the 'operating_system' parameter) and are customized with cloud-config user data passed to the 'user_data' parameter.
 
-The ``packet_device`` module has a boolean 'wait' parameter that defaults to 'false'. If set to 'true', Ansible will wait until the GET API call for a device will contain an Internet-routeable IP address. The 'wait' parameter allows us to use the IP address of the device as soon as it's available.
+The ``packet_device`` module has a `wait_for_public_IPv` parameter. If set to `4` or `6`, Ansible will wait until the GET API call for a device will contain an Internet-routeable IP addressi of the respective version. If we want to refer to an IP address in consequent module calls, it's wise to use the `wait_for_public_IPv` parameter.
 
 Run the playbook:
 

--- a/docs/docsite/rst/guide_packet.rst
+++ b/docs/docsite/rst/guide_packet.rst
@@ -185,7 +185,7 @@ As with most Ansible modules, the default states of the Packet modules are idemp
 
 The second module call provisions 3 Packet Type 0 (specified using the 'plan' parameter) servers in the project identified via the 'project_id' parameter. The servers are all provisioned with CoresOS beta (the 'operating_system' parameter) and are customized with cloud-config user data passed to the 'user_data' parameter.
 
-The ``packet_device`` module has a `wait_for_public_IPv` parameter. If set to `4` or `6`, Ansible will wait until the GET API call for a device will contain an Internet-routeable IP addressi of the respective version. If we want to refer to an IP address in consequent module calls, it's wise to use the `wait_for_public_IPv` parameter.
+The packet_device module has a ``wait_for_public_IPv`` parameter. If set to 4 or 6, Ansible will wait until the GET API call for a device will contain an Internet-routeable IP address of the respective version. If we want to refer to an IP address in consequent module calls, it's wise to use the ``wait_for_public_IPv`` parameter.
 
 Run the playbook:
 

--- a/docs/docsite/rst/guide_packet.rst
+++ b/docs/docsite/rst/guide_packet.rst
@@ -185,7 +185,7 @@ As with most Ansible modules, the default states of the Packet modules are idemp
 
 The second module call provisions 3 Packet Type 0 (specified using the 'plan' parameter) servers in the project identified via the 'project_id' parameter. The servers are all provisioned with CoresOS beta (the 'operating_system' parameter) and are customized with cloud-config user data passed to the 'user_data' parameter.
 
-The ``packet_device`` module has a ``wait_for_public_IPv`` is used to specify the version of the IP address to wait for (4 or 6). If specified, Ansible will wait until the GET API call for a device contains an Internet-routeable IP address. When referring to an IP address of created device in consequent module calls, it's wise to use the ``wait_for_public_IPv`` parameter, or ``state: active`` in the packet_device module call.
+The ``packet_device`` module has a ``wait_for_public_IPv`` that is used to specify the version of the IP address to wait for (valid values are ``4`` or ``6`` for IPv4 or IPv6). If specified, Ansible will wait until the GET API call for a device contains an Internet-routeable IP address of the specified version. When referring to an IP address of a created device in subsequent module calls, it's wise to use the ``wait_for_public_IPv`` parameter, or ``state: active`` in the packet_device module call.
 
 Run the playbook:
 

--- a/docs/docsite/rst/guide_packet.rst
+++ b/docs/docsite/rst/guide_packet.rst
@@ -185,7 +185,7 @@ As with most Ansible modules, the default states of the Packet modules are idemp
 
 The second module call provisions 3 Packet Type 0 (specified using the 'plan' parameter) servers in the project identified via the 'project_id' parameter. The servers are all provisioned with CoresOS beta (the 'operating_system' parameter) and are customized with cloud-config user data passed to the 'user_data' parameter.
 
-The packet_device module has a ``wait_for_public_IPv`` parameter. If set to 4 or 6, Ansible will wait until the GET API call for a device will contain an Internet-routeable IP address of the respective version. If we want to refer to an IP address in consequent module calls, it's wise to use the ``wait_for_public_IPv`` parameter.
+The ``packet_device`` module has a ``wait_for_public_IPv`` is used to specify the version of the IP address to wait for (4 or 6). If specified, Ansible will wait until the GET API call for a device contains an Internet-routeable IP address. When referring to an IP address of created device in consequent module calls, it's wise to use the ``wait_for_public_IPv`` parameter, or ``state: active`` in the packet_device module call.
 
 Run the playbook:
 


### PR DESCRIPTION
##### SUMMARY
This PR fixes the Packet Guide doc to follow the latest merged changes in the packet_device module.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/guide_packet.rst

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix-packet-guide-to-comply-with-latest-device-module acdda6f020) last updated 2017/10/06 15:03:35 (GMT +300)
  config file = None
  configured module search path = [u'/home/tomk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tomk/ansible/lib/ansible
  executable location = /home/tomk/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


