### PR TITLE
[Docs] Fix old YAML style in async docs

### DIFF
--- a/docs/docsite/rst/playbooks_async.rst
+++ b/docs/docsite/rst/playbooks_async.rst
@@ -56,28 +56,31 @@ Alternatively, if you do not need to wait on the task to complete, you may
    Using a higher value for ``--forks`` will result in kicking off asynchronous
    tasks even faster.  This also increases the efficiency of polling.
 
-If you would like to perform a variation of the "fire and forget" where you 
-"fire and forget, check on it later" you can perform a task similar to the 
+If you would like to perform a variation of the "fire and forget" where you
+"fire and forget, check on it later" you can perform a task similar to the
 following::
 
-      --- 
+      ---
       # Requires ansible 1.8+
       - name: 'YUM - fire and forget task'
-        yum: name=docker-io state=installed
+        yum:
+          name: docker-io
+          state: installed
         async: 1000
         poll: 0
         register: yum_sleeper
 
       - name: 'YUM - check on fire and forget task'
-        async_status: jid={{ yum_sleeper.ansible_job_id }}
+        async_status:
+          jid: "{{ yum_sleeper.ansible_job_id }}"
         register: job_result
         until: job_result.finished
         retries: 30
 
 .. note::
-   If the value of ``async:`` is not high enough, this will cause the 
+   If the value of ``async:`` is not high enough, this will cause the
    "check on it later" task to fail because the temporary status file that
-   the ``async_status:`` is looking for will not have been written or no longer exist 
+   the ``async_status:`` is looking for will not have been written or no longer exist
 
 If you would like to run multiple asynchronous tasks while limiting the amount
 of tasks running concurrently, you can do it this way::

--- a/docs/docsite/rst/playbooks_async.rst
+++ b/docs/docsite/rst/playbooks_async.rst
@@ -33,7 +33,7 @@ poll value is 10 seconds if you do not specify a value for `poll`::
    default.
 
 Alternatively, if you do not need to wait on the task to complete, you may
-"fire and forget" by specifying a poll value of 0::
+run the task asynchronously by specifying a poll value of 0::
 
     ---
 
@@ -48,21 +48,20 @@ Alternatively, if you do not need to wait on the task to complete, you may
         poll: 0
 
 .. note::
-   You shouldn't "fire and forget" with operations that require
-   exclusive locks, such as yum transactions, if you expect to run other
+   You shouldn't attempt run a task asynchronously by specifying a poll value of 0:: to with operations that require
+   exclusive locks (such as yum transactions) if you expect to run other
    commands later in the playbook against those same resources.
 
 .. note::
    Using a higher value for ``--forks`` will result in kicking off asynchronous
    tasks even faster.  This also increases the efficiency of polling.
 
-If you would like to perform a variation of the "fire and forget" where you
-"fire and forget, check on it later" you can perform a task similar to the
+If you would like to perform a task asynchroniusly and check on it later you can perform a task similar to the
 following::
 
       ---
       # Requires ansible 1.8+
-      - name: 'YUM - fire and forget task'
+      - name: 'YUM - async task'
         yum:
           name: docker-io
           state: installed
@@ -70,7 +69,7 @@ following::
         poll: 0
         register: yum_sleeper
 
-      - name: 'YUM - check on fire and forget task'
+      - name: 'YUM - check on async task'
         async_status:
           jid: "{{ yum_sleeper.ansible_job_id }}"
         register: job_result


### PR DESCRIPTION
##### SUMMARY
Fix old YAML style in `async` docs

This patch fixes some old-style YAML in the documentation for asynchronous playbooks.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`async`

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/home/major/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/major/.pyenv/versions/venv-2.x/lib/python2.7/site-packages/ansible
  executable location = /home/major/.pyenv/versions/venv-2.x/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
```
N/A
```