### PR TITLE
Sets sane defaults for follow in file modules

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -71,7 +71,7 @@ options:
   follow:
     description:
       - 'This flag indicates that filesystem links, if they exist, should be followed.'
-      - 'Previous to Ansible 2.5, this was C(yes) by default.'
+      - 'Previous to Ansible 2.5, this was C(no) by default.'
     type: bool
     default: 'yes'
     version_added: "1.8"

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -71,8 +71,9 @@ options:
   follow:
     description:
       - 'This flag indicates that filesystem links, if they exist, should be followed.'
+      - 'Previous to Ansible 2.5, this was C(yes) by default.'
     type: bool
-    default: "no"
+    default: 'yes'
     version_added: "1.8"
 '''
 
@@ -176,6 +177,7 @@ def main():
             original_basename=dict(required=False),  # Internal use only, for recursive ops
             recurse=dict(default=False, type='bool'),
             force=dict(required=False, default=False, type='bool'),
+            follow=dict(required=False, default=True, type='bool'),
             diff_peek=dict(default=None),  # Internal use only, for internal checks in the action plugins
             validate=dict(required=False, default=None),  # Internal use only, for template and copy
             src=dict(required=False, default=None, type='path'),

--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -78,12 +78,6 @@ options:
   others:
     description:
       - All arguments accepted by the M(file) module also work here.
-  follow:
-    description:
-      - 'This flag indicates that filesystem links, if they exist, should be followed.'
-    type: bool
-    default: "no"
-    version_added: "1.9"
   encoding:
     description:
       - "The character encoding for reading and writing the file."
@@ -269,8 +263,8 @@ def main():
     if changed and not module.check_mode:
         if params['backup'] and os.path.exists(path):
             res_args['backup_file'] = module.backup_local(path)
-        if params['follow'] and os.path.islink(path):
-            path = os.path.realpath(path)
+        # We should always follow symlinks so that we change the real file
+        path = os.path.realpath(path)
         write_changes(module, to_bytes(result[0], encoding=encoding), path)
 
     res_args['msg'], res_args['changed'] = check_file_attrs(module, changed, msg)

--- a/lib/ansible/modules/files/replace.py
+++ b/lib/ansible/modules/files/replace.py
@@ -85,6 +85,7 @@ options:
     version_added: "2.4"
 notes:
   - As of Ansible 2.3, the I(dest) option has been changed to I(path) as default, but I(dest) still works as well.
+  - Option I(follow) has been removed in version 2.5, because this module modifies the contents of the file so I(follow=no) doesn't make sense.
 """
 
 EXAMPLES = r"""


### PR DESCRIPTION
##### SUMMARY
As discussed in https://github.com/ansible/proposals/issues/69

I also update how `blockinfile` displays diff headers. Previously it displayed the file name of a dereferenced symlink, but now it prints the `path`, the same as `replace` and `lineinfile` and as was discussed on IRC with @abadger and @mikedlr.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
file modules

##### ANSIBLE VERSION
```
2.5.0
```


##### ADDITIONAL INFORMATION
Still need to see what will I do with the `fetch` module and if it even needs changing.