### PR TITLE
Update --extra-vars documentation. Fixes #11647

### DIFF
--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -764,7 +764,7 @@ Passing Variables On The Command Line
 
 In addition to ``vars_prompt`` and ``vars_files``, it is possible to set variables at the
 command line using the ``--extra-vars`` (or ``-e``) argument.  Variables can be defined using
-either as a single quoted string (containing one or more variables), or by referencing a JSON 
+a single quoted string (containing one or more variables), or by referencing a JSON 
 or YAML file containing the variable definitions.  This is particularly useful when writing a 
 generic release playbook where you may want to pass in the version of the application to deploy.
 
@@ -791,7 +791,7 @@ YAML string format::
 vars from a JSON or YAML file::
     ansible-playbook release.yml --extra-vars "@some_file.json"
 
-This is useful, for, among other things, setting the hosts group or the user for the playbook.
+This is useful for, among other things, setting the hosts group or the user for the playbook.
 
 Example::
 

--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -762,11 +762,34 @@ The contents of each variables file is a simple YAML dictionary, like this::
 Passing Variables On The Command Line
 `````````````````````````````````````
 
-In addition to ``vars_prompt`` and ``vars_files``, it is possible to send variables over
-the Ansible command line.  This is particularly useful when writing a generic release playbook
-where you may want to pass in the version of the application to deploy::
+In addition to ``vars_prompt`` and ``vars_files``, it is possible to set variables at the
+command line using the ``--extra-vars`` (or ``-e``) argument.  Variables can be defined using
+either as a single quoted string (containing one or more variables), or by referencing a JSON 
+or YAML file containing the variable definitions.  This is particularly useful when writing a 
+generic release playbook where you may want to pass in the version of the application to deploy.
 
+key=value format::
     ansible-playbook release.yml --extra-vars "version=1.23.45 other_variable=foo"
+
+JSON string format::
+    ansible-playbook release.yml --extra-vars '{"version":"1.23.45","other_variable":"foo"}'
+    ansible-playbook arcade.yml --extra-vars '{"pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
+
+YAML string format::
+    ansible-playbook release.yml --extra-vars '
+    version: "1.23.45"
+    other_variable: foo'
+
+    ansible-playbook arcade.yml --extra-vars '
+    pacman: mrs
+    ghosts:
+      - inky
+      - pinky
+      - clyde
+      - sue'
+
+vars from a JSON or YAML file::
+    ansible-playbook release.yml --extra-vars "@some_file.json"
 
 This is useful, for, among other things, setting the hosts group or the user for the playbook.
 
@@ -782,21 +805,25 @@ Example::
 
     ansible-playbook release.yml --extra-vars "hosts=vipers user=starbuck"
 
-As of Ansible 1.2, you can also pass in extra vars as quoted JSON, like so::
+Escaping quotes and other special characters:
 
-    --extra-vars '{"pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
+If your variable definition string contains quotes (e.g. JSON), and especially if the 
+your variables' themselves contain quotes, you'll need to ensure you're escaping these 
+quotes appropriately for both your data format (JSON or YAML), and for the shell.  This 
+can lead to some very difficult to read definitions::
 
-The ``key=value`` form is obviously simpler, but it's there if you need it!
+    ansible-playbook arcade.yml --extra-vars "{\"name\":\"Conan O\'Brien\"}"
+    ansible-playbook arcade.yml --extra-vars '{"name":"Conan O'\\\''Brien"}'
+    ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"
+
+In these cases, it's probably best to use a JSON or YAML file contianing the variable 
+definitions.
 
 .. note:: Values passed in using the ``key=value`` syntax are interpreted as strings.
           Use the JSON format if you need to pass in anything that shouldn't be a string (Booleans, integers, floats, lists etc).
-
-As of Ansible 1.3, extra vars can be loaded from a JSON file with the ``@`` syntax::
-
-    --extra-vars "@some_file.json"
-
-Also as of Ansible 1.3, extra vars can be formatted as YAML, either on the command line
-or in a file as above.
+.. note:: JSON format isn't available prior to Ansible 1.2
+.. note:: YAML format isn't available prior to Ansible 1.3
+.. note:: @filename isn't available prior to Ansible 1.3
 
 .. _ansible_variable_precedence:
 

--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -783,10 +783,10 @@ YAML string format::
     ansible-playbook arcade.yml --extra-vars '
     pacman: mrs
     ghosts:
-      - inky
-      - pinky
-      - clyde
-      - sue'
+    - inky
+    - pinky
+    - clyde
+    - sue'
 
 vars from a JSON or YAML file::
     ansible-playbook release.yml --extra-vars "@some_file.json"

--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -764,18 +764,24 @@ Passing Variables On The Command Line
 
 In addition to ``vars_prompt`` and ``vars_files``, it is possible to set variables at the
 command line using the ``--extra-vars`` (or ``-e``) argument.  Variables can be defined using
-a single quoted string (containing one or more variables), or by referencing a JSON 
-or YAML file containing the variable definitions.  This is particularly useful when writing a 
-generic release playbook where you may want to pass in the version of the application to deploy.
+a single quoted string (containing one or more variables) using one of the formats below 
 
-key=value format::
+key=value format:
+.. code-block:: none
     ansible-playbook release.yml --extra-vars "version=1.23.45 other_variable=foo"
 
-JSON string format::
+.. note:: Values passed in using the ``key=value`` syntax are interpreted as strings.
+          Use the JSON format if you need to pass in anything that shouldn't be a string (Booleans, integers, floats, lists etc).
+
+.. versionadded:: 1.2
+JSON string format:
+.. code-block:: none
     ansible-playbook release.yml --extra-vars '{"version":"1.23.45","other_variable":"foo"}'
     ansible-playbook arcade.yml --extra-vars '{"pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
 
-YAML string format::
+.. versionadded:: 1.3
+YAML string format:
+.. code-block:: none
     ansible-playbook release.yml --extra-vars '
     version: "1.23.45"
     other_variable: foo'
@@ -788,42 +794,25 @@ YAML string format::
     - clyde
     - sue'
 
-vars from a JSON or YAML file::
+.. versionadded:: 1.3
+vars from a JSON or YAML file:
+.. code-block:: none
     ansible-playbook release.yml --extra-vars "@some_file.json"
-
 This is useful for, among other things, setting the hosts group or the user for the playbook.
-
-Example::
-
-    ---
-
-    - hosts: '{{ hosts }}'
-      remote_user: '{{ user }}'
-
-      tasks:
-         - ...
-
-    ansible-playbook release.yml --extra-vars "hosts=vipers user=starbuck"
 
 Escaping quotes and other special characters:
 
-If your variable definition string contains quotes (e.g. JSON), and especially if the 
-your variables' themselves contain quotes, you'll need to ensure you're escaping these 
-quotes appropriately for both your data format (JSON or YAML), and for the shell.  This 
-can lead to some very difficult to read definitions::
-
+.. versionadded:: 1.2
+Ensure you're escaping quotes appropriately for both your markup (e.g. JSON), and for 
+the shell you're operating in.
+.. code-block:: none
     ansible-playbook arcade.yml --extra-vars "{\"name\":\"Conan O\'Brien\"}"
     ansible-playbook arcade.yml --extra-vars '{"name":"Conan O'\\\''Brien"}'
     ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"
 
+.. versionadded:: 1.3
 In these cases, it's probably best to use a JSON or YAML file contianing the variable 
 definitions.
-
-.. note:: Values passed in using the ``key=value`` syntax are interpreted as strings.
-          Use the JSON format if you need to pass in anything that shouldn't be a string (Booleans, integers, floats, lists etc).
-.. note:: JSON format isn't available prior to Ansible 1.2
-.. note:: YAML format isn't available prior to Ansible 1.3
-.. note:: @filename isn't available prior to Ansible 1.3
 
 .. _ansible_variable_precedence:
 

--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -774,12 +774,14 @@ key=value format::
           Use the JSON format if you need to pass in anything that shouldn't be a string (Booleans, integers, floats, lists etc).
 
 .. versionadded:: 1.2
+
 JSON string format::
 
     ansible-playbook release.yml --extra-vars '{"version":"1.23.45","other_variable":"foo"}'
     ansible-playbook arcade.yml --extra-vars '{"pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
 
 .. versionadded:: 1.3
+
 YAML string format::
 
     ansible-playbook release.yml --extra-vars '
@@ -795,6 +797,7 @@ YAML string format::
     - sue'
 
 .. versionadded:: 1.3
+
 vars from a JSON or YAML file::
 
     ansible-playbook release.yml --extra-vars "@some_file.json"
@@ -804,6 +807,7 @@ This is useful for, among other things, setting the hosts group or the user for 
 Escaping quotes and other special characters:
 
 .. versionadded:: 1.2
+
 Ensure you're escaping quotes appropriately for both your markup (e.g. JSON), and for 
 the shell you're operating in.::
 
@@ -812,6 +816,7 @@ the shell you're operating in.::
     ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"
 
 .. versionadded:: 1.3
+
 In these cases, it's probably best to use a JSON or YAML file contianing the variable 
 definitions.
 

--- a/docs/docsite/rst/playbooks_variables.rst
+++ b/docs/docsite/rst/playbooks_variables.rst
@@ -766,22 +766,22 @@ In addition to ``vars_prompt`` and ``vars_files``, it is possible to set variabl
 command line using the ``--extra-vars`` (or ``-e``) argument.  Variables can be defined using
 a single quoted string (containing one or more variables) using one of the formats below 
 
-key=value format:
-.. code-block:: none
+key=value format::
+
     ansible-playbook release.yml --extra-vars "version=1.23.45 other_variable=foo"
 
 .. note:: Values passed in using the ``key=value`` syntax are interpreted as strings.
           Use the JSON format if you need to pass in anything that shouldn't be a string (Booleans, integers, floats, lists etc).
 
 .. versionadded:: 1.2
-JSON string format:
-.. code-block:: none
+JSON string format::
+
     ansible-playbook release.yml --extra-vars '{"version":"1.23.45","other_variable":"foo"}'
     ansible-playbook arcade.yml --extra-vars '{"pacman":"mrs","ghosts":["inky","pinky","clyde","sue"]}'
 
 .. versionadded:: 1.3
-YAML string format:
-.. code-block:: none
+YAML string format::
+
     ansible-playbook release.yml --extra-vars '
     version: "1.23.45"
     other_variable: foo'
@@ -795,17 +795,18 @@ YAML string format:
     - sue'
 
 .. versionadded:: 1.3
-vars from a JSON or YAML file:
-.. code-block:: none
+vars from a JSON or YAML file::
+
     ansible-playbook release.yml --extra-vars "@some_file.json"
+
 This is useful for, among other things, setting the hosts group or the user for the playbook.
 
 Escaping quotes and other special characters:
 
 .. versionadded:: 1.2
 Ensure you're escaping quotes appropriately for both your markup (e.g. JSON), and for 
-the shell you're operating in.
-.. code-block:: none
+the shell you're operating in.::
+
     ansible-playbook arcade.yml --extra-vars "{\"name\":\"Conan O\'Brien\"}"
     ansible-playbook arcade.yml --extra-vars '{"name":"Conan O'\\\''Brien"}'
     ansible-playbook script.yml --extra-vars "{\"dialog\":\"He said \\\"I just can\'t get enough of those single and double-quotes"\!"\\\"\"}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updated documentation on --extra-vars command line option to address concerns brought up in #11647 

Added examples on the various formats variables can be passed in.

Added notes on escaping special characters for both the data format (e.g. JSON, YAML) and for the shell.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
docs/docsite/rst/playbooks_variables.rst
Passing Variables on the Command Line

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
