### PR TITLE
add yum versionlock support

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -44,7 +44,8 @@ options:
         use can also list the following: C(installed), C(updates), C(available) and C(repos)."
   state:
     description:
-      - Whether to install (C(present) or C(installed), C(latest)), or remove (C(absent) or C(removed)) or (un)lock version of (C(locked) or C(unlocked)) a package.
+      - Whether to install (C(present) or C(installed), C(latest)), or remove (C(absent) or C(removed))
+        or (un)lock version of (C(locked) or C(unlocked)) a package.
     choices: [ absent, installed, latest, present, removed, locked, unlocked ]
     default: present
   enablerepo:
@@ -219,7 +220,7 @@ EXAMPLES = '''
   yum:
     list: ansible
   register: result
-  
+
 - name: Lock java at current version
   yum:
     name: "{{item}}"


### PR DESCRIPTION
##### SUMMARY
Add yum versionlock support to yum module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
yum module

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules', u'/Users/mkomon/ansible-ios-pmtud', u'/Users/mkomon/Documents/github/ansible-junos-stdlib/library']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
Add code to support yum lock/unlock version of packages so you can do: 
```
- name: Lock java at current version
  yum:
    name: "{{item}}"
    state: locked
  with_items:
    - java-1.7.0-openjdk
    - java-1.7.0-openjdk-devel
    - java-1.7.0-openjdk-headless
```

[How-to and more info](https://access.redhat.com/solutions/98873) on versionlock from Red Hat.

Requires yum-plugin-versionlock package installed but I'm not sure how to handle such dependencies. Any advice welcome.

Tested successfully on CentOS Linux release 7.1.1503 (Core).