### PR TITLE
Adding doc for the description argument of lxd_profile module

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_profile.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_profile.py
@@ -26,6 +26,10 @@ options:
         description:
           - Name of a profile.
         required: true
+    description:
+        description:
+          - Description of the profile.
+        version_added: "2.5"
     config:
         description:
           - 'The config for the container (e.g. {"limits.memory": "4GB"}).
@@ -147,7 +151,7 @@ EXAMPLES = '''
         state: present
 '''
 
-RETURN='''
+RETURN = '''
 old_state:
   description: The old state of the profile
   returned: success
@@ -356,7 +360,7 @@ def main():
                 type='str',
                 default='{}/.config/lxc/client.crt'.format(os.environ['HOME'])
             ),
-            trust_password=dict( type='str', no_log=True)
+            trust_password=dict(type='str', no_log=True)
         ),
         supports_check_mode=False,
     )

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -95,7 +95,6 @@ lib/ansible/modules/cloud/google/gcpubsub.py
 lib/ansible/modules/cloud/google/gcspanner.py
 lib/ansible/modules/cloud/lxc/lxc_container.py
 lib/ansible/modules/cloud/lxd/lxd_container.py
-lib/ansible/modules/cloud/lxd/lxd_profile.py
 lib/ansible/modules/cloud/misc/ovirt.py
 lib/ansible/modules/cloud/misc/rhevm.py
 lib/ansible/modules/cloud/misc/serverless.py


### PR DESCRIPTION
##### SUMMARY
This PR add documentation for the 'description' argument of the lxd_profile module along with some minor style adjustment for PEP8 validating.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lxd_profile

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
The 'description' argument works as expected :
```
$ ansible -m lxd_profile -a "name=test devices={} config={} description='This is a test'" localhost
localhost | SUCCESS => {
    "actions": [
        "create"
    ],
    "changed": true,
    "failed": false,
    "old_state": "absent"
}

$ lxc profile show test
config: {}
description: This is a test
devices: {}
name: test
used_by: []
```
The argument is even present in the examples, for instance :
```
# An example for creating a profile
- hosts: localhost
  connection: local
  tasks:
    - name: Create a profile
      lxd_profile:
        name: macvlan
        state: present
        config: {}
        description: my macvlan profile
        devices:
          eth0:
            nictype: macvlan
            parent: br0
            type: nic
```