### PR TITLE
Removed the unused argument description from lxd_container module

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -216,7 +216,7 @@ EXAMPLES = '''
         flat: true
 '''
 
-RETURN='''
+RETURN = '''
 addresses:
   description: Mapping from the network device name to a list of IPv4 addresses in the container
   returned: when state is started or restarted
@@ -542,9 +542,6 @@ def main():
             config=dict(
                 type='dict',
             ),
-            description=dict(
-                type='str',
-            ),
             devices=dict(
                 type='dict',
             ),
@@ -585,7 +582,7 @@ def main():
                 type='str',
                 default='{}/.config/lxc/client.crt'.format(os.environ['HOME'])
             ),
-            trust_password=dict( type='str', no_log=True )
+            trust_password=dict(type='str', no_log=True)
         ),
         supports_check_mode=False,
     )


### PR DESCRIPTION
##### SUMMARY
This PR removes the unused and undocumented 'description' argument of the lxd_container module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lxd_container

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
This argument is not used anywhere in the module, furthermore, this is not even a valid configuration for an lxd container :

```
$ lxc config show test
architecture: x86_64
config:
  image.architecture: amd64
  image.build: "20171007_03:49"
  image.description: Ubuntu xenial (amd64) (20171007_03:49)
  image.distribution: ubuntu
  image.release: xenial
  volatile.base_image: ed1e7b0fee83d0653095d08fe519c0e1196088a584a4348728a8401907914024
  volatile.eth0.hwaddr: 00:16:3e:25:ba:bf
  volatile.idmap.base: "0"
  volatile.idmap.next: '[{"Isuid":true,"Isgid":false,"Hostid":165536,"Nsid":0,"Maprange":65536},{"Isuid":false,"Isgid":true,"Hostid":165536,"Nsid":0,"Maprange":65536}]'
  volatile.last_state.idmap: '[{"Isuid":true,"Isgid":false,"Hostid":165536,"Nsid":0,"Maprange":65536},{"Isuid":false,"Isgid":true,"Hostid":165536,"Nsid":0,"Maprange":65536}]'
  volatile.last_state.power: RUNNING
devices: {}
ephemeral: false
profiles:
- default
stateful: false
description: ""

$ lxc config set test description test
error: Bad key: description
```
