### PR TITLE
vmware_guest_snapshot - Add the ability to rename a snapshot, or change it's description.

### DIFF
--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,0 +1,4 @@
+posix/ci/cloud/group1/vcenter
+cloud/vcenter
+skip/python3
+destructive

--- a/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
@@ -1,0 +1,178 @@
+- name: make sure pyvmomi is installed
+  pip:
+    name: pyvmomi
+    state: latest
+  when: ansible_user_id == 'root'
+
+- name: store the vcenter container ip
+  set_fact:
+    vcsim: "{{ lookup('env', 'vcenter_host') }}"
+- debug: var=vcsim
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim with no folders
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=1' }}"
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim   
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=VM' }}"
+  register: vmlist
+
+- set_fact:
+    vm1: "{{ vmlist['json'][0] }}"
+
+- name: get a list of datacenters from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=DC' }}"
+  register: datacenters
+
+- set_fact:
+    dc1: "{{ datacenters['json'][0] }}"
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+- debug: var=vm1
+- debug: var=dc1
+
+# FIXME: VCSIM does not currently implement snapshots
+#   Awaiting: https://github.com/vmware/govmomi/pull/861/files
+#
+# # Test0001: Try to delete the non-existent snapshot
+# - name: 0001 - Delete non-existent snapshot
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: absent
+#     snapshot_name: snap_a
+
+# # Test0002: Create two snapshots
+# - name: 0002 - Create snapshot
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: present
+#     snapshot_name: "snap_{{item}}"
+#     description: "snap named {{item}}"
+#   with_items:
+#     - a
+#     - b
+
+# # Test0003: Reanme a to c
+# - name: 0003 - Rename snapshot
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: present
+#     snapshot_name: snap_a
+#     new_snapshot_name: snap_c
+
+# # Test0004: Create snap_a again
+# - name: 0004 - Re-create snapshot a
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: present
+#     snapshot_name: snap_a
+#     description: "snap named a"
+
+# # Test0005: Change description of snap_c
+# - name: 0005 - Change description of snap_c
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: present
+#     snapshot_name: snap_c
+#     new_description: "renamed to snap_c from snap_a"
+
+# # Test0006: Delete snap_b with child remove
+# - name: 0006 - Delete snap_b with child remove
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: absent
+#     snapshot_name: snap_b
+#     remove_children: True
+
+# # Test0007: Delete all snapshots
+# - name: 0007 - Delete all snapshots
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: remove_all
+
+# # Test0008: Create snap_a again and revert to it
+# - name: 0008 - Re-create snapshot a
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: present
+#     snapshot_name: snap_a
+#     description: "snap named a"
+
+# - name: 0008 - Revert to snap_a
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: revert
+#     snapshot_name: snap_a


### PR DESCRIPTION
Add the ability to rename a snapshot, or change it's description.
Also add tests for vmware_guest_snapshot, but disable them due to vcsim not fully supporting such operations yet.

##### SUMMARY
vmware_guest_snapshot currently has no way to rename a snapshot, or change it's description.  This patch adds the ability to do so with two new options, new_snapshot_name, and new_description.  If state == present, and these options are specified, it will rename the snapshot to the new name, or change the description, as needed.

This allows me to snap a machine in a loop, always keeping a set number of snapshots, such as a daily snapshot, with 3 I could revert to.
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vmware_snapshot_rename 2e14b1ad29) last updated 2017/10/07 15:56:47 (GMT +000)
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible/lib/ansible
  executable location = /home/ec2-user/ansible/bin/ansible
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 - name: Rename snapshot
   vmware_guest_snapshot:
     validate_certs: False
     hostname: host
     username: user
     password: password
     datacenter: dc1
     folder: /path/to/vm
     name: vm_name
     state: present
     snapshot_name: snap_a
     new_snapshot_name: snap_c
     new_description: "Renamed a to c"

```
