### PR TITLE
Param type path

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/use-argspec-type-path.rst
@@ -1,0 +1,11 @@
+Sanity Tests » use-argspec-type-path
+====================================
+
+The AnsibleModule argument_spec knows of several types beyond the standard python types.  One of
+these is ``path``.  When used, type ``path`` ensures that an argument is a string and expands any
+shell variables and tilde characters.
+
+This test looks for use of :meth:`os.path.expanduser` in modules.  When found, it tells the user to
+replace it with ``type='path'`` in the module's argument_spec or list it as a false positive in the
+test.
+

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -512,7 +512,7 @@ def main():
     argument_spec.update(
         dict(
             bucket=dict(required=True),
-            dest=dict(default=None),
+            dest=dict(default=None, type='path'),
             encrypt=dict(default=True, type='bool'),
             expiry=dict(default=600, type='int', aliases=['expiration']),
             headers=dict(type='dict'),
@@ -561,9 +561,6 @@ def main():
     rgw = module.params.get('rgw')
     src = module.params.get('src')
     ignore_nonexistent_bucket = module.params.get('ignore_nonexistent_bucket')
-
-    if dest:
-        dest = os.path.expanduser(dest)
 
     object_canned_acl = ["private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control"]
     bucket_canned_acl = ["private", "public-read", "public-read-write", "authenticated-read"]

--- a/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
@@ -221,9 +221,9 @@ class AzureRMStorageBlob(AzureRMModuleBase):
         self.module_arg_spec = dict(
             storage_account_name=dict(required=True, type='str', aliases=['account_name', 'storage_account']),
             blob=dict(type='str', aliases=['blob_name']),
-            blob_type=dict(type='str', default='block', choices=['block','page']),
+            blob_type=dict(type='str', default='block', choices=['block', 'page']),
             container=dict(required=True, type='str', aliases=['container_name']),
-            dest=dict(type='str'),
+            dest=dict(type='path'),
             force=dict(type='bool', default=False),
             resource_group=dict(required=True, type='str', aliases=['resource_group_name']),
             src=dict(type='str'),
@@ -296,7 +296,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
                 if self.src and self.src_is_valid():
                     if self.blob_obj and not self.force:
                         self.log("Cannot upload to {0}. Blob with that name already exists. "
-                            "Use the force option".format(self.blob))
+                                 "Use the force option".format(self.blob))
                     else:
                         self.upload_blob()
                 elif self.dest and self.dest_is_valid():
@@ -329,7 +329,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
         return self.results
 
     def get_container(self):
-        result  = dict()
+        result = {}
         container = None
         if self.container:
             try:
@@ -365,7 +365,7 @@ class AzureRMStorageBlob(AzureRMModuleBase):
                     content_language=blob.properties.content_settings.content_language,
                     content_disposition=blob.properties.content_settings.content_disposition,
                     cache_control=blob.properties.content_settings.cache_control,
-                    content_md5 =blob.properties.content_settings.content_md5
+                    content_md5=blob.properties.content_settings.content_md5
                 )
             )
         return result
@@ -443,8 +443,6 @@ class AzureRMStorageBlob(AzureRMModuleBase):
 
     def dest_is_valid(self):
         if not self.check_mode:
-            self.dest = os.path.expanduser(self.dest)
-            self.dest = os.path.expandvars(self.dest)
             if not os.path.basename(self.dest):
                 # dest is a directory
                 if os.path.isdir(self.dest):

--- a/lib/ansible/modules/cloud/docker/docker_login.py
+++ b/lib/ansible/modules/cloud/docker/docker_login.py
@@ -204,9 +204,9 @@ class LoginManager(DockerBaseClass):
         '''
 
         cmd = "%s logout " % self.client.module.get_bin_path('docker', True)
-        #TODO: docker does not support config file in logout, restore this when they do
-        #if self.config_path and self.config_file_exists(self.config_path):
-        #    cmd += "--config '%s' " % self.config_path
+        # TODO: docker does not support config file in logout, restore this when they do
+        # if self.config_path and self.config_file_exists(self.config_path):
+        #     cmd += "--config '%s' " % self.config_path
         cmd += "'%s'" % self.registry_url
 
         (rc, out, err) = self.client.module.run_command(cmd)
@@ -250,7 +250,7 @@ class LoginManager(DockerBaseClass):
         :return: None
         '''
 
-        path = os.path.expanduser(self.config_path)
+        path = self.config_path
         if not self.config_file_exists(path):
             self.create_config_file(path)
 
@@ -291,14 +291,14 @@ class LoginManager(DockerBaseClass):
 
 def main():
 
-    argument_spec=dict(
+    argument_spec = dict(
         registry_url=dict(type='str', required=False, default=DEFAULT_DOCKER_REGISTRY, aliases=['registry', 'url']),
         username=dict(type='str', required=False),
         password=dict(type='str', required=False, no_log=True),
         email=dict(type='str'),
         reauthorize=dict(type='bool', default=False, aliases=['reauth']),
         state=dict(type='str', default='present', choices=['present', 'absent']),
-        config_path=dict(type='str', default='~/.docker/config.json', aliases=['self.config_path', 'dockercfg_path']),
+        config_path=dict(type='path', default='~/.docker/config.json', aliases=['self.config_path', 'dockercfg_path']),
     )
 
     required_if = [

--- a/lib/ansible/modules/cloud/rackspace/rax_clb_nodes.py
+++ b/lib/ansible/modules/cloud/rackspace/rax_clb_nodes.py
@@ -124,7 +124,6 @@ from ansible.module_utils.rax import rax_argument_spec, rax_clb_node_to_dict, ra
 
 
 def _activate_virtualenv(path):
-    path = os.path.expanduser(path)
     activate_this = os.path.join(path, 'bin', 'activate_this.py')
     with open(activate_this) as f:
         code = compile(f.read(), activate_this, 'exec')
@@ -159,7 +158,7 @@ def main():
             port=dict(type='int'),
             state=dict(default='present', choices=['present', 'absent']),
             type=dict(choices=['primary', 'secondary']),
-            virtualenv=dict(),
+            virtualenv=dict(type='path'),
             wait=dict(default=False, type='bool'),
             wait_timeout=dict(default=30, type='int'),
             weight=dict(type='int'),

--- a/lib/ansible/modules/database/postgresql/postgresql_db.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_db.py
@@ -365,14 +365,13 @@ def main():
         lc_collate=dict(default=""),
         lc_ctype=dict(default=""),
         state=dict(default="present", choices=["absent", "present", "dump", "restore"]),
-        target=dict(default=""),
+        target=dict(default="", type="path"),
         target_opts=dict(default=""),
     ))
 
-
     module = AnsibleModule(
         argument_spec=argument_spec,
-        supports_check_mode = True
+        supports_check_mode=True
     )
 
     if not HAS_PSYCOPG2:
@@ -411,8 +410,6 @@ def main():
 
     if target == "":
         target = "{0}/{1}.sql".format(os.getcwd(), db)
-        target = os.path.expanduser(target)
-    else:
         target = os.path.expanduser(target)
 
     try:

--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -175,7 +175,7 @@ def main():
     archive = False
     successes = []
 
-    for i, path in enumerate(paths):
+    for path in paths:
         path = os.path.expanduser(os.path.expandvars(path))
 
         # Expand any glob characters. If found, add the expanded glob to the
@@ -191,7 +191,7 @@ def main():
 
     # Only attempt to expand the exclude paths if it exists
     if exclude_paths:
-        for i, exclude_path in enumerate(exclude_paths):
+        for exclude_path in exclude_paths:
             exclude_path = os.path.expanduser(os.path.expandvars(exclude_path))
 
             # Expand any glob characters. If found, add the expanded glob to the

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -148,7 +148,6 @@ def main():
     # Create type object as namespace for module params
     p = type('Params', (), module.params)
 
-    p.src = os.path.expanduser(p.src)
     if not os.access(p.src, os.R_OK):
         module.fail_json(msg="src %s doesn't exist or not readable" % (p.src))
 

--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -353,7 +353,7 @@ def main():
             dest = dict(required=True),
             dest_port = dict(default=None, type='int'),
             delete = dict(default='no', type='bool'),
-            private_key = dict(default=None),
+            private_key = dict(type='path', default=None),
             rsync_path = dict(default=None),
             _local_rsync_path = dict(default='rsync', type='path'),
             _substitute_controller = dict(default='no', type='bool'),
@@ -467,7 +467,7 @@ def main():
     if is_rsh_needed(source, dest):
         ssh_cmd = [module.get_bin_path('ssh', required=True), '-S', 'none']
         if private_key is not None:
-            ssh_cmd.extend(['-i', os.path.expanduser(private_key) ])
+            ssh_cmd.extend(['-i', private_key])
         # If the user specified a port value
         # Note:  The action plugin takes care of setting this to a port from
         # inventory if the user didn't specify an explicit dest_port

--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -326,7 +326,6 @@ def uri(module, url, dest, body, body_format, method, headers, socket_timeout):
         # we'll reset back to the supplied value soon
         follow_redirects = module.params['follow_redirects']
         module.params['follow_redirects'] = False
-        dest = os.path.expanduser(dest)
         if os.path.isdir(dest):
             # first check if we are redirected to a file download
             _, redir_info = fetch_url(module, url, data=body,

--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -337,7 +337,7 @@ def write_changes(module, lines, dest):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            dest=dict(default='/etc/network/interfaces', required=False),
+            dest=dict(default='/etc/network/interfaces', required=False, type='path'),
             iface=dict(required=False),
             option=dict(required=False),
             value=dict(required=False),
@@ -348,8 +348,7 @@ def main():
         supports_check_mode=True
     )
 
-    dest = os.path.expanduser(module.params['dest'])
-
+    dest = module.params['dest']
     iface = module.params['iface']
     option = module.params['option']
     value = module.params['value']

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -178,7 +178,7 @@ def main():
         host=dict(),
         username=dict(),
         password=dict(no_log=True),
-        ssh_key_data=dict(no_log=True),
+        ssh_key_data=dict(no_log=True, type='path'),
         ssh_key_unlock=dict(no_log=True),
         authorize=dict(type='bool', default=False),
         authorize_password=dict(no_log=True),
@@ -223,7 +223,6 @@ def main():
 
             if params['ssh_key_data']:
                 filename = params['ssh_key_data']
-                filename = os.path.expanduser(filename)
                 if not os.path.exists(filename):
                     module.fail_json(msg='file not found: %s' % filename)
                 if os.path.isdir(filename):

--- a/lib/ansible/modules/web_infrastructure/django_manage.py
+++ b/lib/ansible/modules/web_infrastructure/django_manage.py
@@ -148,7 +148,7 @@ def _ensure_virtualenv(module):
     if venv_param is None:
         return
 
-    vbin = os.path.join(os.path.expanduser(venv_param), 'bin')
+    vbin = os.path.join(venv_param, 'bin')
     activate = os.path.join(vbin, 'activate')
 
     if not os.path.exists(activate):
@@ -224,10 +224,10 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             command=dict(default=None, required=True),
-            app_path=dict(default=None, required=True),
+            app_path=dict(default=None, required=True, type='path'),
             settings=dict(default=None, required=False),
             pythonpath=dict(default=None, required=False, aliases=['python_path']),
-            virtualenv=dict(default=None, required=False, aliases=['virtual_env']),
+            virtualenv=dict(default=None, required=False, type='path', aliases=['virtual_env']),
 
             apps=dict(default=None, required=False),
             cache_table=dict(default=None, required=False),
@@ -244,7 +244,7 @@ def main():
     )
 
     command = module.params['command']
-    app_path = os.path.expanduser(module.params['app_path'])
+    app_path = module.params['app_path']
     virtualenv = module.params['virtualenv']
 
     for param in specific_params:
@@ -278,7 +278,7 @@ def main():
         if module.params[param]:
             cmd = '%s %s' % (cmd, module.params[param])
 
-    rc, out, err = module.run_command(cmd, cwd=os.path.expanduser(app_path))
+    rc, out, err = module.run_command(cmd, cwd=app_path)
     if rc != 0:
         if command == 'createcachetable' and 'table' in err and 'already exists' in err:
             out = 'Already exists.'

--- a/test/sanity/code-smell/use-argspec-type-path.sh
+++ b/test/sanity/code-smell/use-argspec-type-path.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# Add valid uses of expanduser to this list
+WHITELIST='cloud/lxc/lxc_container.py
+cloud/rackspace/rax_files_objects.py
+database/mongodb/mongodb_parameter.py
+database/mongodb/mongodb_user.py
+database/postgresql/postgresql_db.py
+files/synchronize.py
+source_control/git.py
+system/puppet.py
+utilities/logic/async_status.py
+utilities/logic/async_wrapper.py
+web_infrastructure/ansible_tower/tower_host.py
+web_infrastructure/ansible_tower/tower_group.py
+web_infrastructure/jenkins_plugin.py'
+
+# Modules which need to be ported to get rid of expanduser.  See: https://github.com/ansible/ansible/projects/12
+GRANDFATHERED_NEED_PORTING='cloud/rackspace/rax.py
+cloud/rackspace/rax_scaling_group.py
+files/find.py
+files/archive.py'
+
+for FILE in $WHITELIST ; do
+    GREP_FORMAT_WHITELIST="$GREP_FORMAT_WHITELIST -e $FILE"
+done
+
+for FILE in $GRANDFATHERED_NEED_PORTING ; do
+    GREP_FORMAT_WHITELIST="$GREP_FORMAT_WHITELIST -e $FILE"
+done
+
+# GREP_FORMAT_WHITELIST has been formatted so that wordsplitting is wanted.  Therefore no double quotes around the var
+# shellcheck disable=SC2086
+egrep -r 'expanduser' lib/ansible/modules | egrep -v $GREP_FORMAT_WHITELIST
+
+if [ $? -ne 1 ]; then
+    printf 'The module(s) listed above use expanduser.\n'
+    printf 'This may indicate the module should be using an argpsec type="path" instead of type="str"\n'
+    printf 'If this is a false positive, add to the whitelist in:\n'
+    printf '  test/sanity/code-smell/use-argspec-type-path.sh\n'
+    exit 1
+fi

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -62,7 +62,6 @@ lib/ansible/modules/cloud/azure/azure_rm_networkinterface.py
 lib/ansible/modules/cloud/azure/azure_rm_publicipaddress.py
 lib/ansible/modules/cloud/azure/azure_rm_publicipaddress_facts.py
 lib/ansible/modules/cloud/azure/azure_rm_storageaccount.py
-lib/ansible/modules/cloud/azure/azure_rm_storageblob.py
 lib/ansible/modules/cloud/azure/azure_rm_subnet.py
 lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
 lib/ansible/modules/cloud/azure/azure_rm_virtualnetwork.py
@@ -79,7 +78,6 @@ lib/ansible/modules/cloud/docker/_docker.py
 lib/ansible/modules/cloud/docker/docker_container.py
 lib/ansible/modules/cloud/docker/docker_image.py
 lib/ansible/modules/cloud/docker/docker_image_facts.py
-lib/ansible/modules/cloud/docker/docker_login.py
 lib/ansible/modules/cloud/docker/docker_network.py
 lib/ansible/modules/cloud/google/gc_storage.py
 lib/ansible/modules/cloud/google/gcdns_record.py


### PR DESCRIPTION
##### SUMMARY

Add a simplistic test for whether a module might be needing to use an argument_spec with type=path instead of type=str.  Also port most of the modules that should be fixed to have type-str.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Various modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
Not important enough for a backport