### PR TITLE
Change ping docs to refer to win_ping

### DIFF
--- a/lib/ansible/modules/system/ping.py
+++ b/lib/ansible/modules/system/ping.py
@@ -23,9 +23,9 @@ description:
      contact. It does not make sense in playbooks, but it is useful from
      C(/usr/bin/ansible) to verify the ability to login and that a usable python is configured.
    - This is NOT ICMP ping, this is just a trivial test module.
-   - For Windows targets, use the M(ping) module instead.
+   - For Windows targets, use the M(win_ping) module instead.
 notes:
-   - For Windows targets, use the M(ping) module instead.
+   - For Windows targets, use the M(win_ping) module instead.
 options:
   data:
     description:


### PR DESCRIPTION
##### SUMMARY
Ping module docs told windows users to use the ping module instead.  Should be telling windows users to use the win_ping module instead.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/ping.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.4
```