### PR TITLE
Add list handling for subspecs

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2047,7 +2047,7 @@ class AnsibleModule(object):
                 self._options_context.pop()
             # Defaulting the contents of a list to str is not something we've done before so not
             # going to do it now.  It may be something we should do in a revised API, though
-            elif wanted == 'list' and v.get('elements', None) is not None:
+            elif wanted == 'list' and v.get('elements', None) is not None and isinstance(params[k], list):
                 elem_type = v['elements']
                 for idx, element in enumerate(params[k]):
                     try:


### PR DESCRIPTION
##### SUMMARY
subspecs check that the elements of a dict are the type specified but it doesn't check that the type of a list is.  This PR adds code to do that correctly.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```