### PR TITLE
Add optional port parameter to nsupdate module

### DIFF
--- a/lib/ansible/modules/net_tools/nsupdate.py
+++ b/lib/ansible/modules/net_tools/nsupdate.py
@@ -39,6 +39,11 @@ options:
         description:
             - Apply DNS modification on this server.
         required: true
+    port:
+        description:
+            - Use this TCP port when connecting to C(server).
+        default: 53
+        version_added: 2.5
     key_name:
         description:
             - Use TSIG key name to authenticate against DNS C(server)
@@ -195,7 +200,7 @@ class RecordManager(object):
     def __do_update(self, update):
         response = None
         try:
-            response = dns.query.tcp(update, self.module.params['server'], timeout=10)
+            response = dns.query.tcp(update, self.module.params['server'], timeout=10, port=self.module.params['port'])
         except (dns.tsig.PeerBadKey, dns.tsig.PeerBadSignature) as e:
             self.module.fail_json(msg='TSIG update error (%s): %s' % (e.__class__.__name__, to_native(e)))
         except (socket_error, dns.exception.Timeout) as e:
@@ -324,6 +329,7 @@ def main():
         argument_spec=dict(
             state=dict(required=False, default='present', choices=['present', 'absent'], type='str'),
             server=dict(required=True, type='str'),
+            port=dict(required=False, default=53, type='int'),
             key_name=dict(required=False, type='str'),
             key_secret=dict(required=False, type='str', no_log=True),
             key_algorithm=dict(required=False, default='hmac-md5', choices=tsig_algs, type='str'),


### PR DESCRIPTION
##### SUMMARY
An example of when it's useful to be able to specify a custom port
number is when one is using an (ssh) tunnel to update a hidden master.

##### ISSUE TYPE
 - Feature Pull Request
##### COMPONENT NAME
nsupdate

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel a9942353fe) last updated 2017/10/08 03:22:52 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/lab/ansible/devel/lib/ansible
  executable location = /home/andreas/lab/ansible/devel/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```