### PR TITLE
Param type path need subspec list

### DIFF
--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -150,7 +150,7 @@ def main():
             path = dict(type='list', elements='path', required=True),
             format = dict(choices=['gz', 'bz2', 'zip', 'tar'], default='gz', required=False),
             dest = dict(required=False, type='path'),
-            exclude_path = dict(type='list', elements='path', required=False),
+            exclude_path = dict(type='list', elements='path', required=False, default=[]),
             remove = dict(required=False, default=False, type='bool'),
         ),
         add_file_common_args=True,

--- a/lib/ansible/modules/files/archive.py
+++ b/lib/ansible/modules/files/archive.py
@@ -147,10 +147,10 @@ from ansible.module_utils._text import to_native
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            path = dict(type='list', required=True),
+            path = dict(type='list', elements='path', required=True),
             format = dict(choices=['gz', 'bz2', 'zip', 'tar'], default='gz', required=False),
             dest = dict(required=False, type='path'),
-            exclude_path = dict(type='list', required=False),
+            exclude_path = dict(type='list', elements='path', required=False),
             remove = dict(required=False, default=False, type='bool'),
         ),
         add_file_common_args=True,
@@ -176,7 +176,6 @@ def main():
     successes = []
 
     for path in paths:
-        path = os.path.expanduser(os.path.expandvars(path))
 
         # Expand any glob characters. If found, add the expanded glob to the
         # list of expanded_paths, which might be empty.
@@ -192,7 +191,6 @@ def main():
     # Only attempt to expand the exclude paths if it exists
     if exclude_paths:
         for exclude_path in exclude_paths:
-            exclude_path = os.path.expanduser(os.path.expandvars(exclude_path))
 
             # Expand any glob characters. If found, add the expanded glob to the
             # list of expanded_paths, which might be empty.

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -263,7 +263,7 @@ def statinfo(st):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            paths=dict(type='list', required=True, aliases=['name', 'path']),
+            paths=dict(type='list', elements='path', required=True, aliases=['name', 'path']),
             patterns=dict(type='list', default=['*'], aliases=['pattern']),
             contains=dict(type='str'),
             file_type=dict(type='str', default="file", choices=['any', 'directory', 'file', 'link']),
@@ -309,7 +309,6 @@ def main():
     msg = ''
     looked = 0
     for npath in params['paths']:
-        npath = os.path.expanduser(os.path.expandvars(npath))
         if os.path.isdir(npath):
             ''' ignore followlinks for python version < 2.6 '''
             for root, dirs, files in (sys.version_info < (2, 6, 0) and os.walk(npath)) or os.walk(npath, followlinks=params['follow']):

--- a/test/sanity/code-smell/use-argspec-type-path.sh
+++ b/test/sanity/code-smell/use-argspec-type-path.sh
@@ -2,7 +2,9 @@
 
 # Add valid uses of expanduser to this list
 WHITELIST='cloud/lxc/lxc_container.py
+cloud/rackspace/rax.py
 cloud/rackspace/rax_files_objects.py
+cloud/rackspace/rax_scaling_group.py
 database/mongodb/mongodb_parameter.py
 database/mongodb/mongodb_user.py
 database/postgresql/postgresql_db.py
@@ -15,17 +17,7 @@ web_infrastructure/ansible_tower/tower_host.py
 web_infrastructure/ansible_tower/tower_group.py
 web_infrastructure/jenkins_plugin.py'
 
-# Modules which need to be ported to get rid of expanduser.  See: https://github.com/ansible/ansible/projects/12
-GRANDFATHERED_NEED_PORTING='cloud/rackspace/rax.py
-cloud/rackspace/rax_scaling_group.py
-files/find.py
-files/archive.py'
-
 for FILE in $WHITELIST ; do
-    GREP_FORMAT_WHITELIST="$GREP_FORMAT_WHITELIST -e $FILE"
-done
-
-for FILE in $GRANDFATHERED_NEED_PORTING ; do
     GREP_FORMAT_WHITELIST="$GREP_FORMAT_WHITELIST -e $FILE"
 done
 


### PR DESCRIPTION
##### SUMMARY
Port modules to use type=path in their arg_spec.  This requires that the subspecs for lists fix in #31445 be applied

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
