### PR TITLE
Network and cloudstack wildcard imports

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/_cs_nic.py
+++ b/lib/ansible/modules/cloud/cloudstack/_cs_nic.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2016, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['deprecated'],
@@ -165,9 +155,13 @@ project:
   type: string
   sample: Production
 '''
+try:
+    from cs import CloudStackException
+except ImportError:
+    pass  # Handled in AnsibleCloudStack.__init__
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.cloudstack import *
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
 
 
 class AnsibleCloudStackNic(AnsibleCloudStack):
@@ -294,6 +288,7 @@ def main():
         module.fail_json(msg='CloudStackException: %s' % str(e))
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -416,8 +406,14 @@ instance_name:
 
 import base64
 
-# import cloudstack common
-from ansible.module_utils.cloudstack import *
+try:
+    from cs import CloudStackException
+except ImportError:
+    pass  # Handled in AnsibleCloudStack.__init__
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import (AnsibleCloudStack, CS_HYPERVISORS, cs_argument_spec,
+                                             cs_required_together)
 
 
 class AnsibleCloudStackInstance(AnsibleCloudStack):
@@ -1067,7 +1063,6 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_instance_facts.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2016, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -187,10 +177,9 @@ cloudstack_instance.volumes:
   sample: '[ { name: "ROOT-1369", type: "ROOT", size: 10737418240 }, { name: "data01, type: "DATADISK", size: 10737418240 } ]'
 '''
 
-import base64
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec
 
-# import cloudstack common
-from ansible.module_utils.cloudstack import *
 
 class AnsibleCloudStackInstanceFacts(AnsibleCloudStack):
 
@@ -296,6 +285,6 @@ def main():
     cs_facts_result = dict(changed=False, ansible_facts=cs_instance_facts)
     module.exit_json(**cs_facts_result)
 
-from ansible.module_utils.basic import *
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_portforward.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_portforward.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -237,9 +227,13 @@ network:
   type: string
   sample: dmz
 '''
+try:
+    from cs import CloudStackException
+except ImportError:
+    pass  # Handled in AnsibleCloudStack.__init__
 
-# import cloudstack common
-from ansible.module_utils.cloudstack import *
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
 
 
 class AnsibleCloudStackPortforwarding(AnsibleCloudStack):
@@ -430,7 +424,6 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_securitygroup.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_securitygroup.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -117,9 +107,14 @@ account:
   type: string
   sample: example account
 '''
+try:
+    from cs import CloudStackException
+except ImportError:
+    pass  # Handled in AnsibleCloudStack.__init__
 
-# import cloudstack common
-from ansible.module_utils.cloudstack import *
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
+
 
 
 class AnsibleCloudStackSecurityGroup(AnsibleCloudStack):
@@ -218,7 +213,6 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_securitygroup_rule.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_securitygroup_rule.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2015, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -186,8 +176,13 @@ end_port:
   sample: 80
 '''
 
-# import cloudstack common
-from ansible.module_utils.cloudstack import *
+try:
+    from cs import CloudStackException
+except ImportError:
+    pass  # Handled in AnsibleCloudStack.__init__
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
 
 
 class AnsibleCloudStackSecurityGroupRule(AnsibleCloudStack):
@@ -370,7 +365,6 @@ class AnsibleCloudStackSecurityGroupRule(AnsibleCloudStack):
         return self.result
 
 
-
 def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
@@ -420,7 +414,6 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
+
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_snapshot_policy.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_snapshot_policy.py
@@ -2,21 +2,11 @@
 # -*- coding: utf-8 -*-
 #
 # (c) 2016, René Moser <mail@renemoser.net>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
@@ -216,9 +206,13 @@ domain:
   type: string
   sample: example domain
 '''
+try:
+    from cs import CloudStackException
+except ImportError:
+    pass  # Handled in AnsibleCloudStack.__init__
 
-# import cloudstack common
-from ansible.module_utils.cloudstack import *
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.cloudstack import AnsibleCloudStack, cs_argument_spec, cs_required_together
 
 
 class AnsibleCloudStackSnapshotPolicy(AnsibleCloudStack):
@@ -381,8 +375,6 @@ def main():
 
     module.exit_json(**result)
 
-# import module snippets
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -155,13 +145,13 @@ failed_conditions:
 """
 import time
 
-from ansible.module_utils.nxos import run_commands
-from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import string_types
 from ansible.module_utils.netcli import Conditional, FailedConditionalError
 from ansible.module_utils.network_common import ComplexList
-from ansible.module_utils.nxos import nxos_argument_spec, check_args
+from ansible.module_utils.nxos import check_args, nxos_argument_spec, run_commands
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
+
 
 def to_lines(stdout):
     lines = list()
@@ -170,6 +160,7 @@ def to_lines(stdout):
             item = str(item).split('\n')
         lines.append(item)
     return lines
+
 
 def parse_commands(module, warnings):
     transform = ComplexList(dict(
@@ -199,6 +190,7 @@ def to_cli(obj):
         cmd += ' | json'
     return cmd
 
+
 def main():
     """entry point for module execution
     """
@@ -218,7 +210,6 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
 
-
     result = {'changed': False}
 
     warnings = list()
@@ -230,9 +221,8 @@ def main():
 
     try:
         conditionals = [Conditional(c) for c in wait_for]
-    except AttributeError:
-        exc = get_exception()
-        module.fail_json(msg=str(exc))
+    except AttributeError as exc:
+        module.fail_json(msg=to_native(exc))
 
     retries = module.params['retries']
     interval = module.params['interval']
@@ -248,9 +238,8 @@ def main():
                         conditionals = list()
                         break
                     conditionals.remove(item)
-            except FailedConditionalError:
-                exc = get_exception()
-                module.fail_json(msg=str(exc))
+            except FailedConditionalError as exc:
+                module.fail_json(msg=to_native(exc))
 
         if not conditionals:
             break

--- a/lib/ansible/modules/network/nxos/nxos_ntp.py
+++ b/lib/ansible/modules/network/nxos/nxos_ntp.py
@@ -1,20 +1,10 @@
 #!/usr/bin/python
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -127,11 +117,10 @@ changed:
     sample: true
 '''
 
-from ansible.module_utils.nxos import get_config, load_config, run_commands
-from ansible.module_utils.nxos import nxos_argument_spec, check_args
-from ansible.module_utils.basic import AnsibleModule
-
 import re
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.nxos import check_args, load_config, nxos_argument_spec, run_commands
 
 
 def execute_show_command(command, module, command_type='cli_show'):
@@ -319,10 +308,10 @@ def main():
     argument_spec.update(nxos_argument_spec)
 
     module = AnsibleModule(argument_spec=argument_spec,
-                                mutually_exclusive=[
-                                    ['server','peer'],
-                                    ['source_addr','source_int']],
-                                supports_check_mode=True)
+                           mutually_exclusive=[
+                               ['server', 'peer'],
+                               ['source_addr', 'source_int']],
+                           supports_check_mode=True)
 
     warnings = list()
     check_args(module, warnings)
@@ -424,6 +413,5 @@ def main():
     module.exit_json(**results)
 
 
-from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()

--- a/test/sanity/code-smell/no-get-exception.sh
+++ b/test/sanity/code-smell/no-get-exception.sh
@@ -10,7 +10,6 @@ get_exception=$(find . -path ./test/runner/.tox -prune \
         -o -path ./lib/ansible/modules/storage/netapp -prune \
         -o -path ./lib/ansible/modules/packaging/os -prune \
         -o -path ./lib/ansible/modules/network/panos -prune \
-        -o -path ./lib/ansible/modules/network/nxos -prune \
         -o -path ./lib/ansible/modules/network/junos -prune \
         -o -path ./lib/ansible/modules/network/vyos -prune \
         -o -path ./lib/ansible/modules/network/fortios -prune \

--- a/test/sanity/code-smell/no-wildcard-import.sh
+++ b/test/sanity/code-smell/no-wildcard-import.sh
@@ -17,10 +17,7 @@ wildcard_imports=$(find . -path ./test/runner/.tox -prune \
         -o -path ./test/units/plugins/action/test_action.py \
         -o -path ./lib/ansible/compat/tests/mock.py -prune \
         -o -path ./lib/ansible/compat/tests/unittest.py \
-        -o -path ./test/units/modules/network/cumulus/test_nclu.py -prune \
-        -o -path ./lib/ansible/modules/cloud/cloudstack -prune \
         -o -path ./lib/ansible/modules/network/f5 -prune \
-        -o -path ./lib/ansible/modules/network/nxos -prune \
         -o -path ./lib/ansible/modules/packaging/os -prune \
         -o -name '*.py' -type f -exec grep -H 'import \*' '{}' '+')
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -258,7 +258,6 @@ lib/ansible/modules/network/netvisor/pn_vrouterlbif.py
 lib/ansible/modules/net_tools/nmcli.py
 lib/ansible/modules/network/nxos/_nxos_mtu.py
 lib/ansible/modules/network/nxos/nxos_aaa_server_host.py
-lib/ansible/modules/network/nxos/nxos_command.py
 lib/ansible/modules/network/nxos/nxos_config.py
 lib/ansible/modules/network/nxos/nxos_gir.py
 lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
@@ -266,7 +265,6 @@ lib/ansible/modules/network/nxos/nxos_igmp.py
 lib/ansible/modules/network/nxos/nxos_igmp_interface.py
 lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
 lib/ansible/modules/network/nxos/nxos_install_os.py
-lib/ansible/modules/network/nxos/nxos_ntp.py
 lib/ansible/modules/network/nxos/nxos_ntp_auth.py
 lib/ansible/modules/network/nxos/nxos_ntp_options.py
 lib/ansible/modules/network/nxos/nxos_nxapi.py

--- a/test/units/modules/network/cumulus/test_nclu.py
+++ b/test/units/modules/network/cumulus/test_nclu.py
@@ -14,11 +14,9 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import sys
-import time
+import os.path
 import unittest
 
-from ansible.module_utils.basic import *
 from ansible.modules.network.cumulus import nclu
 
 


### PR DESCRIPTION
##### SUMMARY
Clean up wildcard imports in nxos, f5, and cloudstack.  wildcard imports confuse some static analysis tools and are not good practice.  Getting close to having these all cleaned up so that we can have pylint detect these for us automatically.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```