### PR TITLE
ec2_vpc_igw: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
@@ -90,8 +90,6 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-    if __name__ != '__main__':
-        raise
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import AnsibleAWSError, connect_to_aws, ec2_argument_spec, get_aws_connection_info

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,5 +1,4 @@
 lib/ansible/modules/cloud/amazon/cloudtrail.py
-lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
 lib/ansible/modules/cloud/amazon/ec2_win_password.py
 lib/ansible/modules/cloud/amazon/s3_sync.py


### PR DESCRIPTION
##### SUMMARY
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `ec2_vpc_igw` module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_igw

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel ae5d8e5ebb) last updated 2017/10/09 01:29:51 (GMT +200)
  python version = 3.6.2 (default, Sep  5 2017, 20:23:28) [GCC 7.2.0]
```