### PR TITLE
s3_sync: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/amazon/s3_sync.py
+++ b/lib/ansible/modules/cloud/amazon/s3_sync.py
@@ -99,6 +99,7 @@ options:
 requirements:
   - boto3 >= 1.4.4
   - botocore
+  - python-dateutil
 
 author: tedder
 extends_documentation_fragment:
@@ -209,12 +210,17 @@ import mimetypes
 import os
 import stat as osstat  # os.stat constants
 import traceback
-from dateutil import tz
 
 # import module snippets
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn, get_aws_connection_info, HAS_BOTO3, boto_exception
 from ansible.module_utils._text import to_text
+
+try:
+    from dateutil import tz
+    HAS_DATEUTIL = True
+except ImportError:
+    HAS_DATEUTIL = False
 
 try:
     import botocore
@@ -497,6 +503,10 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
     )
+
+    if not HAS_DATEUTIL:
+        module.fail_json(msg='dateutil required for this module')
+
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')
 

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -2,7 +2,6 @@ lib/ansible/modules/cloud/amazon/cloudtrail.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_igw.py
 lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
 lib/ansible/modules/cloud/amazon/ec2_win_password.py
-lib/ansible/modules/cloud/amazon/s3_sync.py
 lib/ansible/modules/cloud/azure/azure.py
 lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
 lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py


### PR DESCRIPTION
##### SUMMARY
Fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports) in `s3_sync` module

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_sync

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel ae5d8e5ebb) last updated 2017/10/09 01:29:51 (GMT +200)
  python version = 3.6.2 (default, Sep  5 2017, 20:23:28) [GCC 7.2.0]
```

##### ADDITIONAL INFORMATION
This fix reuse the same logic that the one used in [s3_lifecycle](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/s3_lifecycle.py).