### PR TITLE
Windows Domain Controller: Read Only

### DIFF
--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -117,11 +117,12 @@ $domain_admin_user = Get-AnsibleParam $param "domain_admin_user" -failifempty $r
 $domain_admin_password = Get-AnsibleParam $param "domain_admin_password" -failifempty $result
 $local_admin_password = Get-AnsibleParam $param "local_admin_password"
 
-$dc_type = Get-AnsibleParam $param "read_only" -default $false
+$dc_type = Get-AnsibleParam $param "read_only" -type "bool" -default $false
 $site = "none"
-if (!$dc_type) {
+if ($dc_type) {
     $site = Get-AnsibleParam $param "sitecode" -failifempty $result
 }
+
 
 $state = Get-AnsibleParam $param "state" -validateset ("domain_controller", "member_server") -failifempty $result
 $log_path = Get-AnsibleParam $param "log_path"
@@ -217,7 +218,7 @@ Try {
                 else {
                     $install_result = Install-ADDSDomainController -NoRebootOnCompletion -DomainName $dns_domain_name -Credential $domain_admin_cred -SafeModeAdministratorPassword $safe_mode_secure -Force
                 }
-
+  
 
                 Write-DebugLog "Installation completed, needs reboot..."
             }

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -211,7 +211,7 @@ Try {
                 $safe_mode_secure = $safe_mode_password | ConvertTo-SecureString -AsPlainText -Force
                 Write-DebugLog "Installing domain controller..."
 
-                if ($type) {
+                if ($dc_type) {
                     $install_result = Install-ADDSDomainController -NoRebootOnCompletion -DomainName $dns_domain_name -Credential $domain_admin_cred -SafeModeAdministratorPassword $safe_mode_secure -ReadOnlyReplica:$true -SiteName $site -Force		
                 }
                 else {

--- a/lib/ansible/modules/windows/win_domain_controller.ps1
+++ b/lib/ansible/modules/windows/win_domain_controller.ps1
@@ -215,7 +215,7 @@ Try {
                     $install_result = Install-ADDSDomainController -NoRebootOnCompletion -DomainName $dns_domain_name -Credential $domain_admin_cred -SafeModeAdministratorPassword $safe_mode_secure -ReadOnlyReplica:$true -SiteName $site -Force		
                 }
                 else {
-                    $install_result = Install-ADDSDomainController -NoRebootOnCompletion -DomainName $dns_domain_name -Credential $domain_admin_cred -SafeModeAdministratorPassword $safe_mode_secure
+                    $install_result = Install-ADDSDomainController -NoRebootOnCompletion -DomainName $dns_domain_name -Credential $domain_admin_cred -SafeModeAdministratorPassword $safe_mode_secure -Force
                 }
 
 

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -50,7 +50,7 @@ options:
       - password to be assigned to the local C(Administrator) user (required when C(state) is C(member_server))
   read_only:
     description:
-      - optional variable, is set to true, the domain controller will be promoted as a read only replica (default is False). 
+      - optional variable, if set to true, the domain controller will be promoted as a read only replica (default is False). 
   sitecode:
     description:
       - active directory site where the read only domain controller should be deployed, this option is required if read_only is set to true.

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -48,6 +48,12 @@ options:
   local_admin_password:
     description:
       - password to be assigned to the local C(Administrator) user (required when C(state) is C(member_server))
+  read_only:
+    description:
+      - optional variable, is set to true, the domain controller will be promoted as a read only replica (default is False). 
+  sitecode:
+    description:
+      - active directory site where the read only domain controller should be deployed, this option is required if read_only is set to true.
   state:
     description:
       - whether the target host should be a domain controller or a member server
@@ -79,6 +85,21 @@ EXAMPLES = r'''
       safe_mode_password: password123!
       state: domain_controller
       log_path: c:\ansible_win_domain_controller.txt
+
+# ensure a server is a read-only domain controller, if read_only is set to True, the sitecode variable is required.
+# if the read_only variable is not set it will default to false.
+- hosts: winclient
+  gather_facts: no
+  tasks:
+  - win_domain_controller:
+      dns_domain_name: ansible.vagrant
+      domain_admin_user: testguy@ansible.vagrant
+      domain_admin_password: password123!
+      safe_mode_password: password123!
+      state: domain_controller
+      log_path: c:\ansible_win_domain_controller.txt
+      read_only: True
+      sitecode: "london"
 
 # ensure a server is not a domain controller
 # note that without an action wrapper, in the case where a DC is demoted,

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -51,6 +51,7 @@ options:
   read_only:
     description:
       - optional variable, if set to true, the domain controller will be promoted as a read only replica (default is False). 
+    version_added: "2.5"
   sitecode:
     description:
       - active directory site where the read only domain controller should be deployed, this option is required if read_only is set to true.
@@ -91,7 +92,8 @@ EXAMPLES = r'''
 - hosts: winclient
   gather_facts: no
   tasks:
-  - win_domain_controller:
+  - name: "Promote read only domain controller."
+    win_domain_controller:
       dns_domain_name: ansible.vagrant
       domain_admin_user: testguy@ansible.vagrant
       domain_admin_password: password123!


### PR DESCRIPTION
##### SUMMARY
This change adds the option for users to enter "read_only: True" when promoting a domain controller, this will then create a read only domain controller rather than writable.

This feature could be very useful for a lot of large companies.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_domain_controller

##### ANSIBLE VERSION
2.5devel
