### PR TITLE
win_copy: Add missing check_mode fix

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -76,9 +76,7 @@ Function Copy-File($source, $dest) {
         }
 
         if (Test-Path -Path $dest -PathType Leaf) {
-            if (-not $check_mode) {
-                Remove-Item -Path $dest -Force -Recurse | Out-Null
-            }
+            Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode | Out-Null
             $diff += "-$dest`n"
         }
 

--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -76,7 +76,9 @@ Function Copy-File($source, $dest) {
         }
 
         if (Test-Path -Path $dest -PathType Leaf) {
-            Remove-Item -Path $dest -Force -Recurse | Out-Null
+            if (-not $check_mode) {
+                Remove-Item -Path $dest -Force -Recurse | Out-Null
+            }
             $diff += "-$dest`n"
         }
 


### PR DESCRIPTION
##### SUMMARY
win_copy would remove the destination file if it existed even when running with check_mode: yes

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_copy

##### ANSIBLE VERSION
2.4.0

