### PR TITLE
Reenable 'test' label for test related pull requests

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1097,6 +1097,8 @@ files:
     notify: dharmabumstead
   packaging/:
     # 'packaging' automatically added to labels
+  test/:
+    # 'test' is a component path, then 'test' label will be automatically added
 macros:
   module_utils: lib/ansible/module_utils
   modules: lib/ansible/modules

--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1096,7 +1096,6 @@ files:
     labels: docs_pull_request
     notify: dharmabumstead
   packaging/:
-    # 'packaging' automatically added to labels
   test/:
     # 'test' is a component path, then 'test' label will be automatically added
 macros:


### PR DESCRIPTION
##### SUMMARY
Reenable `test` label for test related pull requests

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
.github/BOTMETA.yml

##### ANSIBLE VERSION
```
2.5.0
```

##### ADDITIONAL INFORMATION
See:
- https://github.com/ansible/ansible/pull/29660#issuecomment-335157115
- https://github.com/ansible/ansibullbot/issues/764