### PR TITLE
Ensure absence of public_dns_name doesn't halt ec2 module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1618,7 +1618,8 @@ def warn_if_public_ip_assignment_changed(module, instance):
     assign_public_ip = module.params.get('assign_public_ip')
 
     # Check that public ip assignment is the same and warn if not
-    if (assign_public_ip or instance.public_dns_name) and (not instance.public_dns_name or not assign_public_ip):
+    public_dns_name = getattr(instance, 'public_dns_name', None)
+    if (assign_public_ip or public_dns_name) and (not public_dns_name or not assign_public_ip):
         module.warn("Unable to modify public ip assignment to {0} for instance {1}. "
                     "Whether or not to assign a public IP is determined during instance creation.".format(assign_public_ip, instance.id))
 


### PR DESCRIPTION
##### SUMMARY
Prevents exception introduced by https://github.com/ansible/ansible/commit/efe3c94b1b0f5c537daf012480939421a01c4267 by taking instances without provided public_dns_name into consideration.  This is often the case when a fresh ec2 is partially provisioned.

```
Traceback (most recent call last):
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_BYeiZJ/ansible_module_ec2.py", line 1741, in <module>
    main()
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_BYeiZJ/ansible_module_ec2.py", line 1735, in main
    (tagged_instances, instance_dict_array, new_instance_ids, changed) = enforce_count(module, ec2, vpc)
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_BYeiZJ/ansible_module_ec2.py", line 991, in enforce_count
    warn_if_public_ip_assignment_changed(module, inst)
  File "/var/folders/d_/ws2shnvj1_lf5kpslt_jsllw0000gn/T/ansible_BYeiZJ/ansible_module_ec2.py", line 1621, in warn_if_public_ip_assignment_changed
    if (assign_public_ip or instance.public_dns_name) and (not instance.public_dns_name or not assign_public_ip):
AttributeError: 'dict' object has no attribute 'public_dns_name'
```

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ec2_module

##### ANSIBLE VERSION
```
ansible 2.5.0
```
