### PR TITLE
first path check missing forward slash between dcpath and datacenter

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1111,7 +1111,7 @@ class PyVmomiHelper(PyVmomi):
 
         # Check for full path first in case it was already supplied
         if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm') or
-            self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
+                self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
             fullpath = self.params['folder']
         elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
             fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1110,7 +1110,8 @@ class PyVmomiHelper(PyVmomi):
         dcpath = compile_folder_path_for_object(datacenter)
 
         # Check for full path first in case it was already supplied
-        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')) or (self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
+        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm') or
+            self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
             fullpath = self.params['folder']
         elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
             fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1110,7 +1110,7 @@ class PyVmomiHelper(PyVmomi):
         dcpath = compile_folder_path_for_object(datacenter)
 
         # Check for full path first in case it was already supplied
-        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):
+        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')) or (self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
             fullpath = self.params['folder']
         elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
             fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The following was being evaluated as false when VM folder structure is /folder/datacenter/vm because there is no forward slash between ```dcpath``` and ```self.params['datacenter']```.  This was causing the module to fail for ```No folder matched the path```.  Adding a ``` '/' + ``` resolves this issue and allows it to be evaluated as true.

```python
if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm')):
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 9c81257ce3) last updated 2017/10/09 15:01:26 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /data01/ansible/lib/ansible
  executable location = /data01/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
```console
govc ls /DCC/S605141SL7/
/DCC/S605141SL7/vm
/DCC/S605141SL7/network
/DCC/S605141SL7/host
/DCC/S605141SL7/datastore
```
```yaml
   - name: Create VM 
     vmware_guest:
      username: "{{ username }}"
      password: "{{ password }}"
      validate_certs: False
      name: "{{ guest }}"
      hostname: "{{ vcenter_hostname }}"
      esxi_hostname: "{{ hostname }}"
      state: present
      folder: /DCC/S605141SL7/vm
      guest_id: "{{ osid }}"
      hardware:
       memory_mb: "{{ memory_mb }}"
       num_cpus: "{{ num_cpus }}"
       scsi: lsilogicsas
      disk:
       - size_gb: "{{ size_gb }}"
         type: "{{ type }}"
         datastore: "{{ datastore }}"
      networks:
       - name: vlan632
         device_type: "{{ vmnic_type }}"
      datacenter: S605141SL7
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [10.12.32.121 -> localhost]: FAILED! => {"changed": false, "failed": true, "msg": "No folder matched the path: /DCC/S605141SL7/vm"}
```
After:
```
changed: [10.12.32.121 -> localhost]
```