### PR TITLE
aws_s3: fix upload_file's ExtraArgs - fixes #31232

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -396,6 +396,8 @@ def path_check(path):
 def option_in_extra_args(option):
     if '-' in option:
         temp_option = option.replace('-', '').lower()
+    else:
+        temp_option = option.lower()
 
     allowed_extra_args = {'acl': 'ACL', 'cachecontrol': 'CacheControl', 'contentdisposition': 'ContentDisposition',
                           'contentencoding': 'ContentEncoding', 'contentlanguage': 'ContentLanguage',

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -400,7 +400,7 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
         if encrypt:
             extra['ServerSideEncryption'] = 'AES256'
         if metadata:
-            extra['Metadata'] = dict(metadata)
+            extra.update(metadata)
         s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
         for acl in module.params.get('permission'):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -393,17 +393,19 @@ def path_check(path):
 
 
 def option_in_extra_args(option):
-    allowed_extra_args = ['ACL', 'CacheControl', 'ContentDisposition', 'ContentEncoding', 'ContentLanguage',
-                          'ContentType', 'Expires', 'GrantFullControl', 'GrantRead', 'GrantReadACP', 'GrantWriteACP',
-                          'Metadata', 'RequestPayer', 'ServerSideEncryption', 'StorageClass', 'SSECustomerAlgorithm',
-                          'SSECustomerKey', 'SSECustomerKeyMD5', 'SSEKMSKeyId', 'WebsiteRedirectLocation']
-    extra_args_with_hyphen = ['Cache-Control', 'Content-Disposition', 'Content-Encoding', 'Content-Language',
-                              'Content-Type', 'Website-Redirect-Location']
+    if '-' in option:
+        temp_option = option.replace('-', '').lower()
 
-    if option not in allowed_extra_args and option in extra_args_with_hyphen:
-        return option.replace('-', '')
-    elif option in allowed_extra_args:
-        return option
+    allowed_extra_args = {'acl': 'ACL', 'cachecontrol': 'CacheControl', 'contentdisposition': 'ContentDisposition',
+                          'contentencoding': 'ContentEncoding', 'contentlanguage': 'ContentLanguage',
+                          'contenttype': 'ContentType', 'expires': 'Expires', 'grantfullcontrol': 'GrantFullControl',
+                          'grantread': 'GrantRead', 'grantreadacp': 'GrantReadACP', 'grantwriteacp': 'GrantWriteACP',
+                          'metadata': 'Metadata', 'requestpayer': 'RequestPayer', 'serversideencryption': 'ServerSideEncryption',
+                          'storageclass': 'StorageClass', 'ssecustomeralgorithm': 'SSECustomerAlgorithm', 'ssecustomerkey': 'SSECustomerKey',
+                          'ssecustomerkeymd5': 'SSECustomerKeyMD5', 'ssekmskeyid': 'SSEKMSKeyId', 'websiteredirectlocation': 'WebsiteRedirectLocation'}
+
+    if temp_option in list(allowed_extra_args.keys()):
+        return allowed_extra_args[temp_option]
 
 
 def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers):

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -394,10 +394,7 @@ def path_check(path):
 
 
 def option_in_extra_args(option):
-    if '-' in option:
-        temp_option = option.replace('-', '').lower()
-    else:
-        temp_option = option.lower()
+    temp_option = option.replace('-', '').lower()
 
     allowed_extra_args = {'acl': 'ACL', 'cachecontrol': 'CacheControl', 'contentdisposition': 'ContentDisposition',
                           'contentencoding': 'ContentEncoding', 'contentlanguage': 'ContentLanguage',
@@ -422,7 +419,7 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
             extra['Metadata'] = {}
 
             # determine object metadata and extra arguments
-            for option in list(metadata.keys()):
+            for option in metadata:
                 extra_args_option = option_in_extra_args(option)
                 if extra_args_option is not None:
                     extra[extra_args_option] = metadata[option]


### PR DESCRIPTION
##### SUMMARY
The aws_s3 module option `metadata` may be for extra arguments rather than S3 object ExtraArgs[Metadata]: update ExtraArgs variable. Fixes #31232.

~With this fix you can set Cache-Control again, but it will need to be specified as CacheControl, without the hyphen.~ Added a commit to correct names with hyphens for backwards compatibility. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_s3.py

##### ANSIBLE VERSION
```
2.5.0
```

