### PR TITLE
Fix vault --ask-vault-pass with no tty

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -214,7 +214,6 @@ class CLI(with_metaclass(ABCMeta, object)):
         # if an action needs an encrypt password (create_new_password=True) and we dont
         # have other secrets setup, then automatically add a password prompt as well.
         # prompts cant/shouldnt work without a tty, so dont add prompt secrets
-        print('isatty: %s' % sys.stdin.isatty())
         if not vault_ids:
             if ask_vault_pass or (auto_prompt and sys.stdin.isatty()):
 
@@ -260,7 +259,6 @@ class CLI(with_metaclass(ABCMeta, object)):
                                         create_new_password,
                                         auto_prompt=auto_prompt)
 
-        print('build vault ids: %s' % vault_ids)
         for vault_id_slug in vault_ids:
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
@@ -273,7 +271,6 @@ class CLI(with_metaclass(ABCMeta, object)):
                 # always gets the old format for Tower compatibility.
                 # ie, we used --ask-vault-pass, so we need to use the old vault password prompt
                 # format since Tower needs to match on that format.
-                print('Adding a vault password prompt for vault_id=%s' % built_vault_id)
                 prompted_vault_secret = PromptVaultSecret(prompt_formats=prompt_formats[vault_id_value],
                                                           vault_id=built_vault_id)
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -214,11 +214,10 @@ class CLI(with_metaclass(ABCMeta, object)):
         # if an action needs an encrypt password (create_new_password=True) and we dont
         # have other secrets setup, then automatically add a password prompt as well.
         # prompts cant/shouldnt work without a tty, so dont add prompt secrets
-        if not vault_ids:
-            if ask_vault_pass or (auto_prompt and sys.stdin.isatty()):
+        if ask_vault_pass or (not vault_ids and auto_prompt):
 
-                id_slug = u'%s@%s' % (C.DEFAULT_VAULT_IDENTITY, u'prompt_ask_vault_pass')
-                vault_ids.append(id_slug)
+            id_slug = u'%s@%s' % (C.DEFAULT_VAULT_IDENTITY, u'prompt_ask_vault_pass')
+            vault_ids.append(id_slug)
 
         return vault_ids
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -260,10 +260,6 @@ class CLI(with_metaclass(ABCMeta, object)):
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
 
-                # prompts cant/shouldnt work without a tty, so dont add prompt secrets
-                if not sys.stdin.isatty():
-                    continue
-
                 # --vault-id some_name@prompt_ask_vault_pass --vault-id other_name@prompt_ask_vault_pass will be a little
                 # confusing since it will use the old format without the vault id in the prompt
                 built_vault_id = vault_id_name or C.DEFAULT_VAULT_IDENTITY

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -213,9 +213,13 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # if an action needs an encrypt password (create_new_password=True) and we dont
         # have other secrets setup, then automatically add a password prompt as well.
-        if ask_vault_pass or (auto_prompt and not vault_ids):
-            id_slug = u'%s@%s' % (C.DEFAULT_VAULT_IDENTITY, u'prompt_ask_vault_pass')
-            vault_ids.append(id_slug)
+        # prompts cant/shouldnt work without a tty, so dont add prompt secrets
+        print('isatty: %s' % sys.stdin.isatty())
+        if not vault_ids:
+            if ask_vault_pass or (auto_prompt and sys.stdin.isatty()):
+
+                id_slug = u'%s@%s' % (C.DEFAULT_VAULT_IDENTITY, u'prompt_ask_vault_pass')
+                vault_ids.append(id_slug)
 
         return vault_ids
 
@@ -256,6 +260,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                                         create_new_password,
                                         auto_prompt=auto_prompt)
 
+        print('build vault ids: %s' % vault_ids)
         for vault_id_slug in vault_ids:
             vault_id_name, vault_id_value = CLI.split_vault_id(vault_id_slug)
             if vault_id_value in ['prompt', 'prompt_ask_vault_pass']:
@@ -268,6 +273,7 @@ class CLI(with_metaclass(ABCMeta, object)):
                 # always gets the old format for Tower compatibility.
                 # ie, we used --ask-vault-pass, so we need to use the old vault password prompt
                 # format since Tower needs to match on that format.
+                print('Adding a vault password prompt for vault_id=%s' % built_vault_id)
                 prompted_vault_secret = PromptVaultSecret(prompt_formats=prompt_formats[vault_id_value],
                                                           vault_id=built_vault_id)
 

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -329,7 +329,6 @@ class PromptVaultSecret(VaultSecret):
         self._bytes = self.ask_vault_passwords()
 
     def ask_vault_passwords(self):
-        print('Prompting for vault password for vault_id=%s' % self.vault_id)
         b_vault_passwords = []
 
         for prompt_format in self.prompt_formats:

--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -329,6 +329,7 @@ class PromptVaultSecret(VaultSecret):
         self._bytes = self.ask_vault_passwords()
 
     def ask_vault_passwords(self):
+        print('Prompting for vault password for vault_id=%s' % self.vault_id)
         b_vault_passwords = []
 
         for prompt_format in self.prompt_formats:

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -34,41 +34,44 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
-# tests related to https://github.com/ansible/ansible/issues/30993
-CMD='ansible-playbook -vvvvv --ask-vault-pass test_vault.yml'
-setsid sh -c "echo test-vault-password|${CMD}" < /dev/null > log 2>&1 && :
-WRONG_RC=$?
-cat log
-echo "rc was $WRONG_RC (0 is expected)"
-[ $WRONG_RC -eq 0 ]
+# Use linux setsid to test without a tty. No setsid if osx/bsd though...
+if [ -x "$(command -v setsid)" ]; then
+    # tests related to https://github.com/ansible/ansible/issues/30993
+    CMD='ansible-playbook -vvvvv --ask-vault-pass test_vault.yml'
+    setsid sh -c "echo test-vault-password|${CMD}" < /dev/null > log 2>&1 && :
+    WRONG_RC=$?
+    cat log
+    echo "rc was $WRONG_RC (0 is expected)"
+    [ $WRONG_RC -eq 0 ]
 
-setsid sh -c 'tty; ansible-vault --ask-vault-pass -vvvvv view test_vault.yml' < /dev/null > log 2>&1 && :
-WRONG_RC=$?
-echo "rc was $WRONG_RC (1 is expected)"
-[ $WRONG_RC -eq 1 ]
-cat log
+    setsid sh -c 'tty; ansible-vault --ask-vault-pass -vvvvv view test_vault.yml' < /dev/null > log 2>&1 && :
+    WRONG_RC=$?
+    echo "rc was $WRONG_RC (1 is expected)"
+    [ $WRONG_RC -eq 1 ]
+    cat log
 
-setsid sh -c 'tty; echo passbhkjhword|ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1 && :
-WRONG_RC=$?
-echo "rc was $WRONG_RC (1 is expected)"
-[ $WRONG_RC -eq 1 ]
-cat log
+    setsid sh -c 'tty; echo passbhkjhword|ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1 && :
+    WRONG_RC=$?
+    echo "rc was $WRONG_RC (1 is expected)"
+    [ $WRONG_RC -eq 1 ]
+    cat log
 
-setsid sh -c 'tty; echo test-vault-password |ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
-echo $?
-cat log
+    setsid sh -c 'tty; echo test-vault-password |ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
+    echo $?
+    cat log
 
-setsid sh -c 'tty; echo test-vault-password|ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
-echo $?
-cat log
+    setsid sh -c 'tty; echo test-vault-password|ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
+    echo $?
+    cat log
 
-setsid sh -c 'tty; echo test-vault-password |ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
-echo $?
-cat log
+    setsid sh -c 'tty; echo test-vault-password |ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
+    echo $?
+    cat log
 
-setsid sh -c 'tty; echo test-vault-password|ansible-vault --ask-vault-pass -vvvvv view vaulted.inventory' < /dev/null > log 2>&1
-echo $?
-cat log
+    setsid sh -c 'tty; echo test-vault-password|ansible-vault --ask-vault-pass -vvvvv view vaulted.inventory' < /dev/null > log 2>&1
+    echo $?
+    cat log
+fi
 
 # old format
 ansible-vault view "$@" --vault-password-file vault-password-ansible format_1_0_AES.yml

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -34,6 +34,23 @@ WRONG_RC=$?
 echo "rc was $WRONG_RC (1 is expected)"
 [ $WRONG_RC -eq 1 ]
 
+# tests related to https://github.com/ansible/ansible/issues/30993
+CMD='ansible-playbook -vvvvv --ask-vault-pass test_vault.yml'
+setsid sh -c "echo password|${CMD}" < /dev/null > log 2>&1 && :
+echo "cmd: ${CMD}"
+cat log
+
+setsid sh -c 'tty; ansible-vault --ask-vault-pass -vvvvv view ping_noop.yml' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo passbhkjhword|ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
+ setsid sh -c 'tty; echo password |ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo password|ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo password |ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo password|ansible-vault --ask-vault-pass -vvvvv view ping_noop.yml' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo password|ansible-vault -vvvvv --ask-vault-pass encrypt bar.txt' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo password|ansible-vault -vvvvv encrypt bar.txt' < /dev/null > log 2>&1
+setsid sh -c 'tty; echo password|ansible-vault -vvvvv view ping_noop.yml' < /dev/null > log 2>&1
+ setsid sh -c 'tty; ps -jp "$$"; echo test' < /dev/null > log 2>&1
+
 # old format
 ansible-vault view "$@" --vault-password-file vault-password-ansible format_1_0_AES.yml
 

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -36,9 +36,11 @@ echo "rc was $WRONG_RC (1 is expected)"
 
 # tests related to https://github.com/ansible/ansible/issues/30993
 CMD='ansible-playbook -vvvvv --ask-vault-pass test_vault.yml'
-setsid sh -c "echo test-vault-password|${CMD}" < /dev/null > log 2>&1
-echo $?
+setsid sh -c "echo test-vault-password|${CMD}" < /dev/null > log 2>&1 && :
+WRONG_RC=$?
 cat log
+echo "rc was $WRONG_RC (0 is expected)"
+[ $WRONG_RC -eq 0 ]
 
 setsid sh -c 'tty; ansible-vault --ask-vault-pass -vvvvv view test_vault.yml' < /dev/null > log 2>&1 && :
 WRONG_RC=$?

--- a/test/integration/targets/vault/runme.sh
+++ b/test/integration/targets/vault/runme.sh
@@ -36,20 +36,37 @@ echo "rc was $WRONG_RC (1 is expected)"
 
 # tests related to https://github.com/ansible/ansible/issues/30993
 CMD='ansible-playbook -vvvvv --ask-vault-pass test_vault.yml'
-setsid sh -c "echo password|${CMD}" < /dev/null > log 2>&1 && :
-echo "cmd: ${CMD}"
+setsid sh -c "echo test-vault-password|${CMD}" < /dev/null > log 2>&1
+echo $?
 cat log
 
-setsid sh -c 'tty; ansible-vault --ask-vault-pass -vvvvv view ping_noop.yml' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo passbhkjhword|ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
- setsid sh -c 'tty; echo password |ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo password|ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo password |ansible-playbook -vvvvv --ask-vault-pass ping_noop.yml' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo password|ansible-vault --ask-vault-pass -vvvvv view ping_noop.yml' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo password|ansible-vault -vvvvv --ask-vault-pass encrypt bar.txt' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo password|ansible-vault -vvvvv encrypt bar.txt' < /dev/null > log 2>&1
-setsid sh -c 'tty; echo password|ansible-vault -vvvvv view ping_noop.yml' < /dev/null > log 2>&1
- setsid sh -c 'tty; ps -jp "$$"; echo test' < /dev/null > log 2>&1
+setsid sh -c 'tty; ansible-vault --ask-vault-pass -vvvvv view test_vault.yml' < /dev/null > log 2>&1 && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+cat log
+
+setsid sh -c 'tty; echo passbhkjhword|ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1 && :
+WRONG_RC=$?
+echo "rc was $WRONG_RC (1 is expected)"
+[ $WRONG_RC -eq 1 ]
+cat log
+
+setsid sh -c 'tty; echo test-vault-password |ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
+echo $?
+cat log
+
+setsid sh -c 'tty; echo test-vault-password|ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
+echo $?
+cat log
+
+setsid sh -c 'tty; echo test-vault-password |ansible-playbook -vvvvv --ask-vault-pass test_vault.yml' < /dev/null > log 2>&1
+echo $?
+cat log
+
+setsid sh -c 'tty; echo test-vault-password|ansible-vault --ask-vault-pass -vvvvv view vaulted.inventory' < /dev/null > log 2>&1
+echo $?
+cat log
 
 # old format
 ansible-vault view "$@" --vault-password-file vault-password-ansible format_1_0_AES.yml

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -110,9 +110,6 @@ class TestCliBuildVaultIds(unittest.TestCase):
                                       create_new_password=True,
                                       auto_prompt=False)
 
-        import pprint
-        pprint.pprint(res)
-
         self.assertEqual(set(res), set(['blip@prompt', 'baz@prompt_ask_vault_pass',
                                         'default@prompt_ask_vault_pass',
                                         'some-password-file', 'qux@another-password-file',
@@ -175,14 +172,15 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
         self.mock_isatty.return_value = False
         mock_prompt_secret.return_value = MagicMock(bytes=b'prompt1_password',
                                                     vault_id='prompt1',
-                                                    name='bytes_should_be_prompt1_password')
+                                                    name='bytes_should_be_prompt1_password',
+                                                    spec=vault.PromptVaultSecret)
         res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
                                           vault_ids=['prompt1@prompt'],
                                           ask_vault_pass=True,
                                           auto_prompt=False)
 
         self.assertIsInstance(res, list)
-        self.assertEqual(len(res), 1)
+        self.assertEqual(len(res), 2)
         matches = vault.match_secrets(res, ['prompt1'])
         self.assertIn('prompt1', [x[0] for x in matches])
         self.assertEquals(len(matches), 1)
@@ -213,7 +211,7 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
         self.assertIsInstance(res, list)
         len_ids = len(vault_id_names)
         matches = vault.match_secrets(res, vault_id_names)
-        self.assertEqual(len(res), len_ids)
+        self.assertEqual(len(res), len_ids, 'len(res):%s does not match len_ids:%s' % (len(res), len_ids))
         self.assertEqual(len(matches), len_ids)
         for index, prompt in enumerate(vault_id_names):
             self.assertIn(prompt, [x[0] for x in matches])
@@ -235,6 +233,7 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
 
     @patch('ansible.cli.PromptVaultSecret')
     def test_multiple_prompts_and_ask_vault_pass(self, mock_prompt_secret):
+        self.mock_isatty.return_value = False
         mock_prompt_secret.return_value = MagicMock(bytes=b'prompt1_password',
                                                     vault_id='prompt1')
 
@@ -244,9 +243,8 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
                                                      'prompt3@prompt_ask_vault_pass'],
                                           ask_vault_pass=True)
 
-        import pprint
-        pprint.pprint(res)
-
+        # We provide some vault-ids and secrets, so auto_prompt shouldn't get triggered,
+        # so there is
         vault_id_names = ['prompt1', 'prompt2', 'prompt3', 'default']
         self._assert_ids(vault_id_names, res)
 
@@ -266,16 +264,27 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
         res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
                                           vault_ids=[],
                                           create_new_password=False,
-                                          ask_vault_pass=True)
+                                          ask_vault_pass=False)
 
-        import pprint
-        pprint.pprint(res)
         self.assertIsInstance(res, list)
         matches = vault.match_secrets(res, ['default'])
         # --vault-password-file/DEFAULT_VAULT_PASSWORD_FILE is higher precendce than prompts
         # if the same vault-id ('default') regardless of cli order since it didn't matter in 2.3
+
+        self.assertEqual(matches[0][1].bytes, b'file1_password')
+        self.assertEqual(len(matches), 1)
+
+        res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
+                                          vault_ids=[],
+                                          create_new_password=False,
+                                          ask_vault_pass=True,
+                                          auto_prompt=True)
+
+        self.assertIsInstance(res, list)
+        matches = vault.match_secrets(res, ['default'])
         self.assertEqual(matches[0][1].bytes, b'file1_password')
         self.assertEqual(matches[1][1].bytes, b'prompt1_password')
+        self.assertEqual(len(matches), 2)
 
     @patch('ansible.cli.get_file_vault_secret')
     @patch('ansible.cli.PromptVaultSecret')

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -109,6 +109,10 @@ class TestCliBuildVaultIds(unittest.TestCase):
                                       ask_vault_pass=True,
                                       create_new_password=True,
                                       auto_prompt=False)
+
+        import pprint
+        pprint.pprint(res)
+
         self.assertEqual(set(res), set(['blip@prompt', 'baz@prompt_ask_vault_pass',
                                         'default@prompt_ask_vault_pass',
                                         'some-password-file', 'qux@another-password-file',
@@ -170,18 +174,18 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
     def test_prompt_no_tty(self, mock_prompt_secret):
         self.mock_isatty.return_value = False
         mock_prompt_secret.return_value = MagicMock(bytes=b'prompt1_password',
-                                                    vault_id='prompt1')
+                                                    vault_id='prompt1',
+                                                    name='bytes_should_be_prompt1_password')
         res = cli.CLI.setup_vault_secrets(loader=self.fake_loader,
                                           vault_ids=['prompt1@prompt'],
                                           ask_vault_pass=True,
                                           auto_prompt=False)
 
-        # import pprint
-        # pprint.pprint(res)
         self.assertIsInstance(res, list)
-        self.assertEqual(len(res), 0)
+        self.assertEqual(len(res), 1)
         matches = vault.match_secrets(res, ['prompt1'])
-        self.assertEquals(len(matches), 0)
+        self.assertIn('prompt1', [x[0] for x in matches])
+        self.assertEquals(len(matches), 1)
 
     @patch('ansible.cli.get_file_vault_secret')
     @patch('ansible.cli.PromptVaultSecret')
@@ -240,6 +244,9 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
                                                      'prompt3@prompt_ask_vault_pass'],
                                           ask_vault_pass=True)
 
+        import pprint
+        pprint.pprint(res)
+
         vault_id_names = ['prompt1', 'prompt2', 'prompt3', 'default']
         self._assert_ids(vault_id_names, res)
 
@@ -261,6 +268,8 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
                                           create_new_password=False,
                                           ask_vault_pass=True)
 
+        import pprint
+        pprint.pprint(res)
         self.assertIsInstance(res, list)
         matches = vault.match_secrets(res, ['default'])
         # --vault-password-file/DEFAULT_VAULT_PASSWORD_FILE is higher precendce than prompts

--- a/test/units/cli/test_cli.py
+++ b/test/units/cli/test_cli.py
@@ -176,8 +176,8 @@ class TestCliSetupVaultSecrets(unittest.TestCase):
                                           ask_vault_pass=True,
                                           auto_prompt=False)
 
-        import pprint
-        pprint.pprint(res)
+        # import pprint
+        # pprint.pprint(res)
         self.assertIsInstance(res, list)
         self.assertEqual(len(res), 0)
         matches = vault.match_secrets(res, ['prompt1'])

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -53,14 +53,18 @@ class TestVaultCli(unittest.TestCase):
         cli = VaultCLI(args=['ansible-vault', 'view', '/dev/null/foo'])
         cli.parse()
 
-    def test_view_missing_file_no_secret(self):
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    def test_view_missing_file_no_secret(self, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = []
         cli = VaultCLI(args=['ansible-vault', 'view', '/dev/null/foo'])
         cli.parse()
         self.assertRaisesRegexp(errors.AnsibleOptionsError,
                                 "A vault password is required to use Ansible's Vault",
                                 cli.run)
 
-    def test_encrypt_missing_file_no_secret(self):
+    @patch('ansible.cli.vault.VaultCLI.setup_vault_secrets')
+    def test_encrypt_missing_file_no_secret(self, mock_setup_vault_secrets):
+        mock_setup_vault_secrets.return_value = []
         cli = VaultCLI(args=['ansible-vault', 'encrypt', '/dev/null/foo'])
         cli.parse()
         self.assertRaisesRegexp(errors.AnsibleOptionsError,

--- a/test/units/cli/test_vault.py
+++ b/test/units/cli/test_vault.py
@@ -32,6 +32,13 @@ from ansible.cli.vault import VaultCLI
 
 
 class TestVaultCli(unittest.TestCase):
+    def setUp(self):
+        self.tty_patcher = patch('ansible.cli.sys.stdin.isatty', return_value=False)
+        self.mock_isatty = self.tty_patcher.start()
+
+    def tearDown(self):
+        self.tty_patcher.stop()
+
     def test_parse_empty(self):
         cli = VaultCLI([])
         self.assertRaisesRegexp(errors.AnsibleOptionsError,


### PR DESCRIPTION
2.4.0 added a check for isatty() that would skip setting up interactive
vault password prompts if not running on a tty.

But... getpass.getpass() will fallback to reading from stdin if
it gets that far without a tty. Since 2.4.0 skipped the interactive
prompts / getpass.getpass() in that case, it would never get a chance
to fall back to stdin.

So if 'echo $VAULT_PASSWORD| ansible-playbook --ask-vault-pass site.yml'
was ran without a tty (ie, from a jenkins job or via the vagrant
ansible provisioner) the 2.4 behavior was different than 2.3. 2.4
would never read the password from stdin, resulting in a vault password
error like:

        ERROR! Attempting to decrypt but no vault secrets found

Fix is just to always call the interactive password prompts based
on getpass.getpass() on --ask-vault-pass or --vault-id @prompt and
let getpass sort it out.

Fixes vagrant bug https://github.com/hashicorp/vagrant/issues/9033

Fixes #30993

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/cli/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 5bf9f271b3) last updated 2017/10/09 15:54:27 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
