### PR TITLE
[cloud] Fix #31271 - cast all tag values as strings (#31272)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -377,6 +377,7 @@ import time
 import logging as log
 import traceback
 
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, HAS_BOTO3, camel_dict_to_snake_dict, get_aws_connection_info, AWSRetry
 
@@ -793,7 +794,7 @@ def create_autoscaling_group(connection, module):
         for k, v in tag.items():
             if k != 'propagate_at_launch':
                 asg_tags.append(dict(Key=k,
-                                     Value=v,
+                                     Value=to_native(v),
                                      PropagateAtLaunch=bool(tag.get('propagate_at_launch', True)),
                                      ResourceType='auto-scaling-group',
                                      ResourceId=group_name))


### PR DESCRIPTION
##### SUMMARY
* Fix #31271 - cast all tag values as strings

* Replace `str` with `to_native`

Merged to devel in #31272.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_asg

##### ANSIBLE VERSION
```
ansible 2.4.0.0 (2.4_ec2_asg_tag_values 154191f56d) last updated 2017/10/09 17:18:03 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = [u'/Users/shertel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```
