### PR TITLE
added optional environment passthrough for MacOS 10.13 compatibility

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -208,6 +208,9 @@ def common_environment():
         'HTTPTESTER',
         'LD_LIBRARY_PATH',
         'SSH_AUTH_SOCK',
+        # MacOS High Sierra Compatibility
+        # http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html
+        'OBJC_DISABLE_INITIALIZE_FORK_SAFETY',
     )
 
     env.update(pass_vars(required=required, optional=optional))


### PR DESCRIPTION
##### SUMMARY
When running with a Python that was compiled with MacOS 10.13 High Sierra, there is an issue when calling fork() with Python's current implementation that is incompatible with this version. Unfortunately there is no fix yet as this is a relatively new release but there is a workaround. When setting `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES`, MacOS will run with the original behaviour of ignoring these errors allowing us to continuing running. This change allows this value to be passed through on the ansible-test runner if set by the user in their profile.

See http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html for more details.

I don't see this as a permanent fix but rather temporary and may be removed once the upstream libraries make their changes to handle this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
```
2.5
```