### PR TITLE
create cliconf plugin for enos - enos.py

### DIFF
--- a/lib/ansible/plugins/cliconf/enos.py
+++ b/lib/ansible/plugins/cliconf/enos.py
@@ -1,0 +1,96 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by
+# Ansible still belong to the author of the module, and may assign their own
+# license to the complete work.
+#
+# Copyright (C) 2018 Lenovo, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Contains CLI Configuration Plugin methods for ENOS Modules
+# Lenovo Networking
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import re
+import json
+
+from itertools import chain
+
+from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.network_common import to_list
+from ansible.plugins.cliconf import CliconfBase, enable_mode
+
+
+class Cliconf(CliconfBase):
+
+    def get_device_info(self):
+        device_info = {}
+
+        device_info['network_os'] = 'enos'
+        reply = self.get(b'show version')
+        data = to_text(reply, errors='surrogate_or_strict').strip()
+
+        match = re.search(r'^Software Version (.*?) ', data, re.M | re.I)
+        if match:
+            device_info['network_os_version'] = match.group(1)
+
+        match = re.search(r'^Lenovo RackSwitch (\S+)', data, re.M | re.I)
+        if match:
+            device_info['network_os_model'] = match.group(1)
+
+        match = re.search(r'^(.+) uptime', data, re.M)
+        if match:
+            device_info['network_os_hostname'] = match.group(1)
+        else:
+            device_info['network_os_hostname'] = "NA"
+
+        return device_info
+
+    @enable_mode
+    def get_config(self, source='running'):
+        if source not in ('running', 'startup'):
+            msg = "fetching configuration from %s is not supported"
+            return self.invalid_params(msg % source)
+        if source == 'running':
+            cmd = b'show running-config'
+        else:
+            cmd = b'show startup-config'
+        return self.send_command(cmd)
+
+    @enable_mode
+    def edit_config(self, command):
+        for cmd in chain([b'configure terminal'], to_list(command), [b'end']):
+            self.send_command(cmd)
+
+    def get(self, *args, **kwargs):
+        return self.send_command(*args, **kwargs)
+
+    def get_capabilities(self):
+        result = {}
+        result['rpc'] = self.get_base_rpc()
+        result['network_api'] = 'cliconf'
+        result['device_info'] = self.get_device_info()
+        return json.dumps(result)


### PR DESCRIPTION
##### SUMMARY
Creating cli conf plugin for the modules for enos from Lenovo.


##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
lib/ansible/plugins/cliconf/enos.py

##### ANSIBLE VERSION
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]


##### ADDITIONAL INFORMATION

This is an effort to create modules for eos based switches from Lenovo. 