### PR TITLE
create terminal plugin for enos modules

### DIFF
--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -1,0 +1,101 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by
+# Ansible still belong to the author of the module, and may assign their own
+# license to the complete work.
+#
+# Copyright (C) 2018 Lenovo, Inc.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Contains Terminal Plugin methods for ENOS Modules
+# Lenovo Networking
+#
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+import re
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils._text import to_text, to_bytes
+from ansible.plugins.terminal import TerminalBase
+
+
+class TerminalModule(TerminalBase):
+
+    terminal_stdout_re = [
+        re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
+        re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$"),
+        re.compile(br">[\r\n]?")
+    ]
+
+    terminal_stderr_re = [
+        re.compile(br"% ?Error"),
+        re.compile(br"% ?Bad secret"),
+        re.compile(br"invalid input", re.I),
+        re.compile(br"(?:incomplete|ambiguous) command", re.I),
+        re.compile(br"connection timed out", re.I),
+        re.compile(br"[^\r\n]+ not found"),
+        re.compile(br"'[^']' +returned error code: ?\d+"),
+    ]
+
+    def on_open_shell(self):
+        try:
+            for cmd in (b'\n', b'terminal-length 0\n'):
+                self._exec_cli_command(cmd)
+        except AnsibleConnectionFailure:
+            raise AnsibleConnectionFailure('unable to set terminal parameters')
+
+    def on_authorize(self, passwd=None):
+        if self._get_prompt().endswith(b'#'):
+            return
+
+        cmd = {u'command': u'enable'}
+        if passwd:
+            # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
+            # an r string and use to_text to ensure it's text
+            # on both py2 and py3.
+            cmd[u'prompt'] = to_text(r"[\r\n]?password: $",
+                                     errors='surrogate_or_strict')
+            cmd[u'answer'] = passwd
+
+        try:
+            self._exec_cli_command(to_bytes(json.dumps(cmd),
+                                   errors='surrogate_or_strict'))
+        except AnsibleConnectionFailure:
+            msg = 'unable to elevate privilege to enable mode'
+            raise AnsibleConnectionFailure(msg)
+
+    def on_deauthorize(self):
+        prompt = self._get_prompt()
+        if prompt is None:
+            # if prompt is None most likely the terminal is hung up at a prompt
+            return
+
+        if b'(config' in prompt:
+            self._exec_cli_command(b'end')
+            self._exec_cli_command(b'disable')
+
+        elif prompt.endswith(b'#'):
+            self._exec_cli_command(b'disable')


### PR DESCRIPTION
##### SUMMARY
Creating terminal plugin for the modules for enos from Lenovo.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
lib/ansible/plugins/terminal/enos.py

##### ANSIBLE VERSION
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]


##### ADDITIONAL INFORMATION

This is an effort to create modules for eos based switches from Lenovo. 