### PR TITLE
Add host vars compatibility  with new precedence parameter

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1737,9 +1737,9 @@ USE_PERSISTENT_CONNECTIONS:
   - {key: use_persistent_connections, section: defaults}
   type: boolean
 VARIABLE_PRECEDENCE:
-  name: Group variable precedence
-  default: ['all_inventory', 'groups_inventory', 'all_plugins_inventory', 'all_plugins_play', 'groups_plugins_inventory', 'groups_plugins_play']
-  description: Allows to change the group variable precedence merge order.
+  name: Variable precedence
+  default: ['all_inventory', 'groups_inventory', 'all_plugins_inventory', 'all_plugins_play', 'groups_plugins_inventory', 'groups_plugins_play', 'hosts_inventory', 'hosts_plugins_inventory', 'hosts_plugins_play']
+  description: Allows to change the variable precedence merge order. Caution, hosts variables will always be loaded after groups variables.
   env: [{name: ANSIBLE_PRECEDENCE}]
   ini:
   - {key: precedence, section: defaults}


### PR DESCRIPTION
##### SUMMARY
I like the new `precedence` parameter but I can't use it to change host vars order. This PR add host vars management.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vars/manager.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
```