### PR TITLE
ovirt_clusters: add alias performance_preset for memory_policy

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -536,7 +536,7 @@ def main():
         trusted_service=dict(default=None, type='bool'),
         vm_reason=dict(default=None, type='bool'),
         host_reason=dict(default=None, type='bool'),
-        memory_policy=dict(default=None, choices=['disabled', 'server', 'desktop']),
+        memory_policy=dict(default=None, choices=['disabled', 'server', 'desktop'], aliases=['performance_preset']),
         rng_sources=dict(default=None, type='list'),
         spice_proxy=dict(default=None),
         fence_enabled=dict(default=None, type='bool'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add alias `performance_preset` for `memory_policy` attribute.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_cluster

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
