### PR TITLE
ec2_group should never try to iterate over None

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -307,11 +307,11 @@ def make_rule_key(prefix, rule, group_id, cidr_ip):
 
 def add_rules_to_lookup(ipPermissions, group_id, prefix, dict):
     for rule in ipPermissions:
-        for groupGrant in rule.get('UserIdGroupPairs'):
+        for groupGrant in rule.get('UserIdGroupPairs', []):
             dict[make_rule_key(prefix, rule, group_id, groupGrant.get('GroupId'))] = (rule, groupGrant)
-        for ipv4Grants in rule.get('IpRanges'):
+        for ipv4Grants in rule.get('IpRanges', []):
             dict[make_rule_key(prefix, rule, group_id, ipv4Grants.get('CidrIp'))] = (rule, ipv4Grants)
-        for ipv6Grants in rule.get('Ipv6Ranges'):
+        for ipv6Grants in rule.get('Ipv6Ranges', []):
             dict[make_rule_key(prefix, rule, group_id, ipv6Grants.get('CidrIpv6'))] = (rule, ipv6Grants)
 
 
@@ -759,7 +759,7 @@ def main():
                                 ips = ip_permission
                                 if vpc_id:
                                     [useridpair.update({'VpcId': vpc_id}) for useridpair in
-                                     ip_permission.get('UserIdGroupPairs')]
+                                     ip_permission.get('UserIdGroupPairs', [])]
                                 try:
                                     client.authorize_security_group_ingress(GroupId=group['GroupId'], IpPermissions=[ips])
                                 except botocore.exceptions.ClientError as e:
@@ -824,7 +824,7 @@ def main():
                                 ips = ip_permission
                                 if vpc_id:
                                     [useridpair.update({'VpcId': vpc_id}) for useridpair in
-                                     ip_permission.get('UserIdGroupPairs')]
+                                     ip_permission.get('UserIdGroupPairs', [])]
                                 try:
                                     client.authorize_security_group_egress(GroupId=group['GroupId'], IpPermissions=[ips])
                                 except botocore.exceptions.ClientError as e:


### PR DESCRIPTION
##### SUMMARY
Merged to devel in #31455.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_group.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0 (2.4_ec2_group_nonetype_iterable_bug 350d48f7d9) last updated 2017/10/10 10:13:07 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = [u'/Users/shertel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 30 2016, 19:40:32) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```