### PR TITLE
iam_managed_policy: use python 3 compatible policy comparison - fixes #31474

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -573,7 +573,7 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
     return sec_group_id_list
 
 
-def hashable_policy(policy, policy_list):
+def _hashable_policy(policy, policy_list):
     """
         Takes a policy and returns a list, the contents of which are all hashable and sorted.
         Example input policy:
@@ -594,7 +594,7 @@ def hashable_policy(policy, policy_list):
     """
     if isinstance(policy, list):
         for each in policy:
-            tupleified = hashable_policy(each, [])
+            tupleified = _hashable_policy(each, [])
             if isinstance(tupleified, list):
                 tupleified = tuple(tupleified)
             policy_list.append(tupleified)
@@ -604,7 +604,7 @@ def hashable_policy(policy, policy_list):
         sorted_keys = list(policy.keys())
         sorted_keys.sort()
         for key in sorted_keys:
-            tupleified = hashable_policy(policy[key], [])
+            tupleified = _hashable_policy(policy[key], [])
             if isinstance(tupleified, list):
                 tupleified = tuple(tupleified)
             policy_list.append((key, tupleified))
@@ -646,7 +646,7 @@ def compare_policies(current_policy, new_policy):
     """ Compares the existing policy and the updated policy
         Returns True if there is a difference between policies.
     """
-    return set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, []))
+    return set(_hashable_policy(new_policy, [])) != set(_hashable_policy(current_policy, []))
 
 
 def sort_json_policy_dict(policy_dict):

--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -29,8 +29,9 @@
 import os
 import re
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.cloud import CloudRetry
+from ansible.module_utils.six import string_types, binary_type, text_type
 
 try:
     import boto
@@ -46,7 +47,13 @@ try:
 except:
     HAS_BOTO3 = False
 
-from ansible.module_utils.six import string_types, binary_type, text_type
+try:
+    # Although this is to allow Python 3 the ability to use the custom comparison as a key, Python 2.7 also
+    # uses this (and it works as expected). Python 2.6 will trigger the ImportError.
+    from functools import cmp_to_key
+    PY3_COMPARISON = True
+except ImportError:
+    PY3_COMPARISON = False
 
 
 class AnsibleAWSError(Exception):
@@ -564,6 +571,82 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
     sec_group_id_list += [str(get_sg_id(all_sg, boto3)) for all_sg in all_sec_groups if str(get_sg_name(all_sg, boto3)) in sec_group_name_list]
 
     return sec_group_id_list
+
+
+def hashable_policy(policy, policy_list):
+    """
+        Takes a policy and returns a list, the contents of which are all hashable and sorted.
+        Example input policy:
+        {'Version': '2012-10-17',
+         'Statement': [{'Action': 's3:PutObjectAcl',
+                        'Sid': 'AddCannedAcl2',
+                        'Resource': 'arn:aws:s3:::test_policy/*',
+                        'Effect': 'Allow',
+                        'Principal': {'AWS': ['arn:aws:iam::XXXXXXXXXXXX:user/username1', 'arn:aws:iam::XXXXXXXXXXXX:user/username2']}
+                       }]}
+        Returned value:
+        [('Statement',  ((('Action', (u's3:PutObjectAcl',)),
+                          ('Effect', (u'Allow',)),
+                          ('Principal', ('AWS', ((u'arn:aws:iam::XXXXXXXXXXXX:user/username1',), (u'arn:aws:iam::XXXXXXXXXXXX:user/username2',)))),
+                          ('Resource', (u'arn:aws:s3:::test_policy/*',)), ('Sid', (u'AddCannedAcl2',)))),
+         ('Version', (u'2012-10-17',)))]
+
+    """
+    if isinstance(policy, list):
+        for each in policy:
+            tupleified = hashable_policy(each, [])
+            if isinstance(tupleified, list):
+                tupleified = tuple(tupleified)
+            policy_list.append(tupleified)
+    elif isinstance(policy, string_types):
+        return [(to_text(policy))]
+    elif isinstance(policy, dict):
+        sorted_keys = list(policy.keys())
+        sorted_keys.sort()
+        for key in sorted_keys:
+            tupleified = hashable_policy(policy[key], [])
+            if isinstance(tupleified, list):
+                tupleified = tuple(tupleified)
+            policy_list.append((key, tupleified))
+
+    # ensure we aren't returning deeply nested structures of length 1
+    if len(policy_list) == 1 and isinstance(policy_list[0], tuple):
+        policy_list = policy_list[0]
+    if isinstance(policy_list, list):
+        if PY3_COMPARISON:
+            policy_list.sort(key=cmp_to_key(py3cmp))
+        else:
+            policy_list.sort()
+    return policy_list
+
+
+def py3cmp(a, b):
+    """ Python 2 can sort lists of mixed types. Strings < tuples. Without this function this fails on Python 3."""
+    try:
+        if a > b:
+            return 1
+        elif a < b:
+            return -1
+        else:
+            return 0
+    except TypeError as e:
+        # check to see if they're tuple-string
+        # always say strings are less than tuples (to maintain compatibility with python2)
+        str_ind = to_text(e).find('str')
+        tup_ind = to_text(e).find('tuple')
+        if -1 not in (str_ind, tup_ind):
+            if str_ind < tup_ind:
+                return -1
+            elif tup_ind < str_ind:
+                return 1
+        raise
+
+
+def compare_policies(current_policy, new_policy):
+    """ Compares the existing policy and the updated policy
+        Returns True if there is a difference between policies.
+    """
+    return set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, []))
 
 
 def sort_json_policy_dict(policy_dict):

--- a/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
+++ b/lib/ansible/modules/cloud/amazon/iam_managed_policy.py
@@ -117,7 +117,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (boto3_conn, get_aws_connection_info, ec2_argument_spec, AWSRetry,
-                                      sort_json_policy_dict, camel_dict_to_snake_dict, HAS_BOTO3)
+                                      camel_dict_to_snake_dict, HAS_BOTO3, compare_policies)
 from ansible.module_utils._text import to_native
 
 
@@ -174,8 +174,8 @@ def get_or_create_policy_version(module, iam, policy, policy_document):
             module.fail_json(msg="Couldn't get policy version %s: %s" % (v['VersionId'], str(e)),
                              exception=traceback.format_exc(),
                              **camel_dict_to_snake_dict(e.response))
-        if sort_json_policy_dict(document) == sort_json_policy_dict(
-                json.loads(policy_document)):
+        # If the current policy matches the existing one
+        if not compare_policies(document, json.loads(to_native(policy_document))):
             return v, False
 
     # No existing version so create one

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -220,11 +220,10 @@ def _create_or_update_bucket(connection, module, location):
             # only show changed if there was already a policy
             changed = bool(current_policy)
 
-        else:
-            changed = compare_policies(current_policy, policy)
+        elif compare_policies(current_policy, policy):
+            changed = True
             try:
-                if changed:
-                    bucket.set_policy(json.dumps(policy))
+                bucket.set_policy(json.dumps(policy))
                 current_policy = json.loads(to_native(bucket.get_policy()))
             except S3ResponseError as e:
                 module.fail_json(msg=e.message)

--- a/lib/ansible/modules/cloud/amazon/s3_bucket.py
+++ b/lib/ansible/modules/cloud/amazon/s3_bucket.py
@@ -120,10 +120,10 @@ import xml.etree.ElementTree as ET
 
 import ansible.module_utils.six.moves.urllib.parse as urlparse
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec
-from ansible.module_utils.ec2 import sort_json_policy_dict
+from ansible.module_utils.ec2 import sort_json_policy_dict, compare_policies
 
 try:
     import boto.ec2
@@ -133,14 +133,6 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-
-try:
-    # Although this is to allow Python 3 the ability to use the custom comparison as a key, Python 2.7 also
-    # uses this (and it works as expected). Python 2.6 will trigger the ImportError.
-    from functools import cmp_to_key
-    PY3_COMPARISON = True
-except ImportError:
-    PY3_COMPARISON = False
 
 
 def get_request_payment_status(bucket):
@@ -162,82 +154,6 @@ def create_tags_container(tags):
 
     tags_obj.add_tag_set(tag_set)
     return tags_obj
-
-
-def hashable_policy(policy, policy_list):
-    """
-        Takes a policy and returns a list, the contents of which are all hashable and sorted.
-        Example input policy:
-        {'Version': '2012-10-17',
-         'Statement': [{'Action': 's3:PutObjectAcl',
-                        'Sid': 'AddCannedAcl2',
-                        'Resource': 'arn:aws:s3:::test_policy/*',
-                        'Effect': 'Allow',
-                        'Principal': {'AWS': ['arn:aws:iam::XXXXXXXXXXXX:user/username1', 'arn:aws:iam::XXXXXXXXXXXX:user/username2']}
-                       }]}
-        Returned value:
-        [('Statement',  ((('Action', (u's3:PutObjectAcl',)),
-                          ('Effect', (u'Allow',)),
-                          ('Principal', ('AWS', ((u'arn:aws:iam::XXXXXXXXXXXX:user/username1',), (u'arn:aws:iam::XXXXXXXXXXXX:user/username2',)))),
-                          ('Resource', (u'arn:aws:s3:::test_policy/*',)), ('Sid', (u'AddCannedAcl2',)))),
-         ('Version', (u'2012-10-17',)))]
-
-    """
-    if isinstance(policy, list):
-        for each in policy:
-            tupleified = hashable_policy(each, [])
-            if isinstance(tupleified, list):
-                tupleified = tuple(tupleified)
-            policy_list.append(tupleified)
-    elif isinstance(policy, string_types):
-        return [(to_text(policy))]
-    elif isinstance(policy, dict):
-        sorted_keys = list(policy.keys())
-        sorted_keys.sort()
-        for key in sorted_keys:
-            tupleified = hashable_policy(policy[key], [])
-            if isinstance(tupleified, list):
-                tupleified = tuple(tupleified)
-            policy_list.append((key, tupleified))
-
-    # ensure we aren't returning deeply nested structures of length 1
-    if len(policy_list) == 1 and isinstance(policy_list[0], tuple):
-        policy_list = policy_list[0]
-    if isinstance(policy_list, list):
-        if PY3_COMPARISON:
-            policy_list.sort(key=cmp_to_key(py3cmp))
-        else:
-            policy_list.sort()
-    return policy_list
-
-
-def py3cmp(a, b):
-    """ Python 2 can sort lists of mixed types. Strings < tuples. Without this function this fails on Python 3."""
-    try:
-        if a > b:
-            return 1
-        elif a < b:
-            return -1
-        else:
-            return 0
-    except TypeError as e:
-        # check to see if they're tuple-string
-        # always say strings are less than tuples (to maintain compatibility with python2)
-        str_ind = to_text(e).find('str')
-        tup_ind = to_text(e).find('tuple')
-        if -1 not in (str_ind, tup_ind):
-            if str_ind < tup_ind:
-                return -1
-            elif tup_ind < str_ind:
-                return 1
-        raise
-
-
-def compare_policies(current_policy, new_policy):
-    """ Compares the existing policy and the updated policy
-        Returns True if there is a difference between policies.
-    """
-    return set(hashable_policy(new_policy, [])) != set(hashable_policy(current_policy, []))
 
 
 def _create_or_update_bucket(connection, module, location):
@@ -289,7 +205,7 @@ def _create_or_update_bucket(connection, module, location):
 
     # Policy
     try:
-        current_policy = json.loads(bucket.get_policy())
+        current_policy = json.loads(to_native(bucket.get_policy()))
     except S3ResponseError as e:
         if e.error_code == "NoSuchBucketPolicy":
             current_policy = {}
@@ -304,13 +220,12 @@ def _create_or_update_bucket(connection, module, location):
             # only show changed if there was already a policy
             changed = bool(current_policy)
 
-        elif sort_json_policy_dict(current_policy) != sort_json_policy_dict(policy):
-            # doesn't necessarily mean the policy has changed; syntax could differ
-            changed = compare_policies(sort_json_policy_dict(current_policy), sort_json_policy_dict(policy))
+        else:
+            changed = compare_policies(current_policy, policy)
             try:
                 if changed:
                     bucket.set_policy(json.dumps(policy))
-                current_policy = json.loads(bucket.get_policy())
+                current_policy = json.loads(to_native(bucket.get_policy()))
             except S3ResponseError as e:
                 module.fail_json(msg=e.message)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #31474. I had previously fixed policy comparisons for s3_bucket - moved that solution into module_utils/ec2 and used it in the iam_managed_policy module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
iam_managed_policy

##### ANSIBLE VERSION
```
2.5.0
```