### PR TITLE
aws_s3: 2.4 aws s3 extra args fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ Ansible Changes By Release
 * Fix for ec2_group to avoid trying to iterate over None (https://github.com/ansible/ansible/pull/31531)
 * Fix for ec2_group for a possible KeyError bug (https://github.com/ansible/ansible/pull/31540)
 * Fix for the rpm_key module when importing the first gpg key on a system (https://github.com/ansible/ansible/pull/31514)
+* Fix for aws_s3 metadata to use the correct parameters when uploading a file (https://github.com/ansible/ansible/issues/31232)
 
 <a id="2.4"></a>
 

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -237,6 +237,7 @@ EXAMPLES = '''
 '''
 
 import os
+import mimetypes
 import traceback
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ssl import SSLError
@@ -391,6 +392,21 @@ def path_check(path):
         return False
 
 
+def option_in_extra_args(option):
+    temp_option = option.replace('-', '').lower()
+
+    allowed_extra_args = {'acl': 'ACL', 'cachecontrol': 'CacheControl', 'contentdisposition': 'ContentDisposition',
+                          'contentencoding': 'ContentEncoding', 'contentlanguage': 'ContentLanguage',
+                          'contenttype': 'ContentType', 'expires': 'Expires', 'grantfullcontrol': 'GrantFullControl',
+                          'grantread': 'GrantRead', 'grantreadacp': 'GrantReadACP', 'grantwriteacp': 'GrantWriteACP',
+                          'metadata': 'Metadata', 'requestpayer': 'RequestPayer', 'serversideencryption': 'ServerSideEncryption',
+                          'storageclass': 'StorageClass', 'ssecustomeralgorithm': 'SSECustomerAlgorithm', 'ssecustomerkey': 'SSECustomerKey',
+                          'ssecustomerkeymd5': 'SSECustomerKeyMD5', 'ssekmskeyid': 'SSEKMSKeyId', 'websiteredirectlocation': 'WebsiteRedirectLocation'}
+
+    if temp_option in allowed_extra_args:
+        return allowed_extra_args[temp_option]
+
+
 def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, headers):
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
@@ -399,7 +415,23 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
         if encrypt:
             extra['ServerSideEncryption'] = 'AES256'
         if metadata:
-            extra['Metadata'] = dict(metadata)
+            extra['Metadata'] = {}
+
+            # determine object metadata and extra arguments
+            for option in metadata:
+                extra_args_option = option_in_extra_args(option)
+                if extra_args_option is not None:
+                    extra[extra_args_option] = metadata[option]
+                else:
+                    extra['Metadata'][option] = metadata[option]
+
+        if 'ContentType' not in extra:
+            content_type = mimetypes.guess_type(src)[0]
+            if content_type is None:
+                # s3 default content type
+                content_type = 'binary/octet-stream'
+            extra['ContentType'] = content_type
+
         s3.upload_file(Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
         for acl in module.params.get('permission'):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)


### PR DESCRIPTION
##### SUMMARY

* Module option metadata are extra arguments rather than S3 object metadata: update ExtraArgs variable.

* Remove hyphens from ExtraArgs to maintain backwards compatibility

* Map lowercase extra args to CamelCase

* Maintain backwards compatibility by guessing at content type rather than always defaulting to binary/octet-stream.

* Fix ExtraArgs for non-hyphenated options

* Simplify logic

Merged to devel in #31487

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
ansible 2.4.1.0 (2.4_aws_s3_ExtraArgs_fix 2df3244c45) last updated 2017/10/10 13:16:37 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = ['/Users/shertel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 3.5.2 (default, Oct 11 2016, 04:59:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```
