### PR TITLE
[cloud] Fix ec2_group when security group lacks a VPC (#31526)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,7 @@ Ansible Changes By Release
 * Better error message when attempting to use include or import with /usr/bin/ansible (https://github.com/ansible/ansible/pull/31492/)
 * Fix `sysctl` module to remove etries when `state=absent` (https://github.com/ansible/ansible/issues/29920)
 * Fix for ec2_group to avoid trying to iterate over None (https://github.com/ansible/ansible/pull/31531)
+* Fix for ec2_group for a possible KeyError bug (https://github.com/ansible/ansible/pull/31540)
 
 <a id="2.4"></a>
 

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -657,7 +657,7 @@ def main():
 
         if group_id and sg['GroupId'] == group_id:
             group = sg
-        elif groupName == name and (vpc_id is None or sg['VpcId'] == vpc_id):
+        elif groupName == name and (vpc_id is None or sg.get('VpcId') == vpc_id):
             group = sg
 
     # Ensure requested group is absent


### PR DESCRIPTION
##### SUMMARY
Merged to devel in #31526.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
```
ansible 2.4.1.0 (2.4_fix_sg_without_vpc 9b6b360e5f) last updated 2017/10/10 13:21:45 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = ['/Users/shertel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 3.5.2 (default, Oct 11 2016, 04:59:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```