### PR TITLE
Correct usage for shutil.rmtree

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -943,13 +943,13 @@ def create_archive(git_path, module, dest, archive, version, repo, result):
             result.update(changed=False)
             # Cleanup before exiting
             try:
-                shutil.remove(tempdir)
+                shutil.rmtree(tempdir)
             except OSError:
                 pass
         else:
             try:
                 shutil.move(new_archive, archive)
-                shutil.remove(tempdir)
+                shutil.rmtree(tempdir)
                 result.update(changed=True)
             except OSError as e:
                 module.fail_json(msg="Failed to move %s to %s" %

--- a/test/integration/targets/git/tasks/ambiguous-ref.yml
+++ b/test/integration/targets/git/tasks/ambiguous-ref.yml
@@ -1,31 +1,37 @@
----
-
 # test for https://github.com/ansible/ansible-modules-core/pull/3386
 
-- name: clone repo
+- name: AMBIGUOUS-REF | clone repo
   git:
     repo: '{{ repo_format1 }}'
     dest: '{{ checkout_dir }}'
 
-- name: rename remote to be ambiguous
-  command: git remote rename origin v0.1 chdir="{{ checkout_dir }}"
+- name: AMBIGUOUS-REF | rename remote to be ambiguous
+  command: git remote rename origin v0.1
+  args:
+    chdir: "{{ checkout_dir }}"
 
-- name: switch to HEAD
+- name: AMBIGUOUS-REF | switch to HEAD
   git:
     repo: '{{ repo_format1 }}'
     dest: '{{ checkout_dir }}'
     remote: v0.1
 
-- name: rev-parse remote HEAD
-  command: git rev-parse v0.1/HEAD chdir="{{ checkout_dir }}"
+- name: AMBIGUOUS-REF | rev-parse remote HEAD
+  command: git rev-parse v0.1/HEAD
+  args:
+    chdir: "{{ checkout_dir }}"
   register: git_remote_head
 
-- name: rev-parse local HEAD
-  command: git rev-parse HEAD chdir="{{ checkout_dir }}"
+- name: AMBIGUOUS-REF | rev-parse local HEAD
+  command: git rev-parse HEAD
+  args:
+    chdir: "{{ checkout_dir }}"
   register: git_local_head
 
 - assert:
     that: git_remote_head.stdout == git_local_head.stdout
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: AMBIGUOUS-REF | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"

--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -1,9 +1,9 @@
----
+- name: ARCHIVE | Clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
-
-- name: Archive repo using various archival format
+- name: ARCHIVE | Archive repo using various archival format
   git:
     repo: '{{ repo_format1 }}'
     dest: '{{ checkout_dir }}'
@@ -16,9 +16,9 @@
     - zip
 
 - assert:
-    that: "git_archive.results | map(attribute='changed') | unique | list == [true]"
+    that: git_archive.results | map(attribute='changed') | unique | list == [true]
 
-- name: Check if archive file is created or not
+- name: ARCHIVE | Check if archive file is created or not
   stat:
     path: '{{ checkout_dir }}/test_role.{{ item }}'
   register: archive_check
@@ -29,4 +29,4 @@
     - zip
 
 - assert:
-    that: "archive_check.results | map(attribute='stat.exists') | unique | list == [true]"
+    that: archive_check.results | map(attribute='stat.exists') | unique | list == [true]

--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -9,7 +9,7 @@
     dest: '{{ checkout_dir }}'
     archive: '{{ checkout_dir }}/test_role.{{ item }}'
   register: git_archive
-  with_items: "{{ git_archive_extensions[ansible_os_family ~ ansible_distribution_major_version] | default(git_archive_extensions.default) }}"
+  with_items: "{{ git_archive_extensions[ansible_os_family ~ ansible_distribution_major_version | default('default') ] | default(git_archive_extensions.default) }}"
 
 # The map filter was added in Jinja2 2.7, which is newer than the version on RHEL/CentOS 6,
 # so we skip this validation on those hosts
@@ -24,7 +24,7 @@
   stat:
     path: '{{ checkout_dir }}/test_role.{{ item }}'
   register: archive_check
-  with_items: "{{ git_archive_extensions[ansible_os_family ~ ansible_distribution_major_version] | default(git_archive_extensions.default) }}"
+  with_items: "{{ git_archive_extensions[ansible_os_family ~ ansible_distribution_major_version | default('default') ] | default(git_archive_extensions.default) }}"
 
 - name: ARCHIVE | Assert that archive files exist
   assert:

--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -9,24 +9,26 @@
     dest: '{{ checkout_dir }}'
     archive: '{{ checkout_dir }}/test_role.{{ item }}'
   register: git_archive
-  with_items:
-    - tar.gz
-    - tar
-    - tgz
-    - zip
+  with_items: "{{ git_archive_extensions[ansible_os_family ~ ansible_distribution_major_version] | default(git_archive_extensions.default) }}"
 
-- assert:
-    that: git_archive.results | map(attribute='changed') | unique | list == [true]
+# The map filter was added in Jinja2 2.7, which is newer than the version on RHEL/CentOS 6,
+# so we skip this validation on those hosts
+- name: ARCHIVE | Assert that archives were downloaded
+  assert:
+    that: (git_archive.results | map(attribute='changed') | unique | list)[0]
+  when:
+    - "ansible_os_family == 'RedHat'"
+    - ansible_distribution_major_version | version_compare('7', '>=')
 
 - name: ARCHIVE | Check if archive file is created or not
   stat:
     path: '{{ checkout_dir }}/test_role.{{ item }}'
   register: archive_check
-  with_items:
-    - tar.gz
-    - tar
-    - tgz
-    - zip
+  with_items: "{{ git_archive_extensions[ansible_os_family ~ ansible_distribution_major_version] | default(git_archive_extensions.default) }}"
 
-- assert:
-    that: archive_check.results | map(attribute='stat.exists') | unique | list == [true]
+- name: ARCHIVE | Assert that archive files exist
+  assert:
+    that: (archive_check.results | map(attribute='stat.exists') | unique | list)[0]
+  when:
+    - "ansible_os_family == 'RedHat'"
+    - ansible_distribution_major_version | version_compare('7', '>=')

--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -1,0 +1,32 @@
+---
+
+- name: clear checkout_dir
+  file: state=absent path={{ checkout_dir }}
+
+- name: Archive repo using various archival format
+  git:
+    repo: '{{ repo_format1 }}'
+    dest: '{{ checkout_dir }}'
+    archive: '{{ checkout_dir }}/test_role.{{ item }}'
+  register: git_archive
+  with_items:
+    - tar.gz
+    - tar
+    - tgz
+    - zip
+
+- assert:
+    that: "git_archive.results | map(attribute='changed') | unique | list == [true]"
+
+- name: Check if archive file is created or not
+  stat:
+    path: '{{ checkout_dir }}/test_role.{{ item }}'
+  register: archive_check
+  with_items:
+    - tar.gz
+    - tar
+    - tgz
+    - zip
+
+- assert:
+    that: "archive_check.results | map(attribute='stat.exists') | unique | list == [true]"

--- a/test/integration/targets/git/tasks/change-repo-url.yml
+++ b/test/integration/targets/git/tasks/change-repo-url.yml
@@ -1,91 +1,103 @@
----
-
 # test change of repo url
 # see https://github.com/ansible/ansible-modules-core/pull/721
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: Clone example git repo
+- name: CHANGE-REPO-URL | Clone example git repo
   git:
-    repo: '{{ repo_update_url_1 }}'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_update_url_1 }}"
+    dest: "{{ checkout_dir }}"
 
-- name: Clone repo with changed url to the same place
+- name: CHANGE-REPO-URL | Clone repo with changed url to the same place
   git:
-    repo: '{{ repo_update_url_2 }}'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_update_url_2 }}"
+    dest: "{{ checkout_dir }}"
   register: clone2
 
 - assert:
     that: "clone2|success"
 
-- name: check url updated
+- name: CHANGE-REPO-URL | check url updated
   shell: git remote show origin | grep Fetch
   register: remote_url
   args:
-    chdir: '{{ checkout_dir }}'
+    chdir: "{{ checkout_dir }}"
   environment:
     LC_ALL: C
 
 - assert:
-    that: 
+    that:
     - "'git-test-new' in remote_url.stdout"
     - "'git-test-old' not in remote_url.stdout"
 
-- name: check for new content in git-test-new
+- name: CHANGE-REPO-URL | check for new content in git-test-new
   stat: path={{ checkout_dir }}/newfilename
   register: repo_content
 
-- name: assert presence of new file in repo (i.e. working copy updated)
+- name: CHANGE-REPO-URL | assert presence of new file in repo (i.e. working copy updated)
   assert:
     that: "repo_content.stat.exists"
 
 # Make sure 'changed' result is accurate in check mode.
 # See https://github.com/ansible/ansible-modules-core/pull/4243
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: clone repo
-  git: repo={{ repo_update_url_1 }} dest={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clone repo
+  git:
+    repo: "{{ repo_update_url_1 }}"
+    dest: "{{ checkout_dir }}"
 
-- name: clone repo with same url to same destination
-  git: repo={{ repo_update_url_1 }} dest={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clone repo with same url to same destination
+  git:
+    repo: "{{ repo_update_url_1 }}"
+    dest: "{{ checkout_dir }}"
   register: checkout_same_url
 
-- name: check repo not changed
+- name: CHANGE-REPO-URL | check repo not changed
   assert:
     that:
       - not checkout_same_url|changed
 
 
-- name: clone repo with new url to same destination
-  git: repo={{ repo_update_url_2 }} dest={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clone repo with new url to same destination
+  git:
+    repo: "{{ repo_update_url_2 }}"
+    dest: "{{ checkout_dir }}"
   register: checkout_new_url
 
-- name: check repo changed
+- name: CHANGE-REPO-URL | check repo changed
   assert:
     that:
       - checkout_new_url|changed
 
 
-- name: clone repo with new url in check mode
-  git: repo={{ repo_update_url_1 }} dest={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clone repo with new url in check mode
+  git:
+    repo: "{{ repo_update_url_1 }}"
+    dest: "{{ checkout_dir }}"
   register: checkout_new_url_check_mode
   check_mode: True
 
-- name: check repo reported changed in check mode
+- name: CHANGE-REPO-URL | check repo reported changed in check mode
   assert:
     that:
-      - checkout_new_url_check_mode|changed
-  when: git_version.stdout | version_compare("{{git_version_supporting_ls_remote}}", '>=')
+      - checkout_new_url_check_mode | changed
+  when: git_version.stdout | version_compare(git_version_supporting_ls_remote, '>=')
 
-- name: clone repo with new url after check mode
-  git: repo={{ repo_update_url_1 }} dest={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clone repo with new url after check mode
+  git:
+    repo: "{{ repo_update_url_1 }}"
+    dest: "{{ checkout_dir }}"
   register: checkout_new_url_after_check_mode
 
-- name: check repo still changed after check mode
+- name: CHANGE-REPO-URL | check repo still changed after check mode
   assert:
     that:
       - checkout_new_url_after_check_mode|changed
@@ -93,26 +105,28 @@
 
 # Test that checkout by branch works when the branch is not in our current repo but the sha is
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: CHANGE-REPO-URL | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: "Clone example git repo that we're going to modify"
+- name: CHANGE-REPO-URL | "Clone example git repo that we're going to modify"
   git:
-    repo: '{{ repo_update_url_1 }}'
-    dest: '{{ checkout_dir }}/repo'
+    repo: "{{ repo_update_url_1 }}"
+    dest: "{{ checkout_dir }}/repo"
 
-- name: Clone the repo again - this is what we test
+- name: CHANGE-REPO-URL | Clone the repo again - this is what we test
   git:
-    repo: '{{ checkout_dir }}/repo'
-    dest: '{{ checkout_dir }}/checkout'
+    repo: "{{ checkout_dir }}/repo"
+    dest: "{{ checkout_dir }}/checkout"
 
-- name: Add a branch to the repo
+- name: CHANGE-REPO-URL | Add a branch to the repo
   command: git branch new-branch
   args:
-    chdir: '{{ checkout_dir }}/repo'
+    chdir: "{{ checkout_dir }}/repo"
 
-- name: Checkout the new branch in the checkout
+- name: CHANGE-REPO-URL | Checkout the new branch in the checkout
   git:
-    repo: '{{ checkout_dir}}/repo'
+    repo: "{{ checkout_dir}}/repo"
     version: 'new-branch'
-    dest: '{{ checkout_dir }}/checkout'
+    dest: "{{ checkout_dir }}/checkout"

--- a/test/integration/targets/git/tasks/checkout-new-tag.yml
+++ b/test/integration/targets/git/tasks/checkout-new-tag.yml
@@ -1,5 +1,3 @@
----
-
 # test for  https://github.com/ansible/ansible-modules-core/issues/527
 # clone a repo, add a tag to the same commit and try to checkout the new commit
 
@@ -7,12 +5,12 @@
 - name: clear checkout_dir
   file:
     state: absent
-    path: '{{ checkout_dir }}'
+    path: "{{ checkout_dir }}"
 
 - name: checkout example repo
   git:
-    repo: '{{ repo_dir }}/format1'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_dir }}/format1"
+    dest: "{{ checkout_dir }}"
 
 - name: get tags of head
   command: git tag --contains
@@ -32,8 +30,8 @@
 
 - name: update copy with new tag
   git:
-    repo: '{{ repo_dir }}/format1'
-    dest: '{{checkout_dir}}'
+    repo: "{{ repo_dir }}/format1"
+    dest: "{{checkout_dir}}"
     version: newtag
   register: update_new_tag
 
@@ -53,4 +51,4 @@
 - name: clear checkout_dir
   file:
     state: absent
-    path: '{{ checkout_dir }}'
+    path: "{{ checkout_dir }}"

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -1,30 +1,30 @@
----
-
 # Test the depth option and fetching revisions that were ignored first
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: DEPTH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: Clone example git repo with depth 1
+- name: DEPTH | Clone example git repo with depth 1
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
 
-- name: try to access earlier commit
+- name: DEPTH | try to access earlier commit
   command: "git checkout {{git_shallow_head_1.stdout}}"
   register: checkout_early
   failed_when: False
   args:
     chdir: '{{ checkout_dir }}'
 
-- name: make sure the old commit was not fetched
+- name: DEPTH | make sure the old commit was not fetched
   assert:
     that: 'checkout_early.rc != 0'
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
 # tests https://github.com/ansible/ansible/issues/14954
-- name: fetch repo again with depth=1
+- name: DEPTH | fetch repo again with depth=1
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
@@ -33,22 +33,22 @@
 
 - assert:
     that: "not checkout2|changed"
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
-- name: again try to access earlier commit
+- name: DEPTH | again try to access earlier commit
   shell: "git checkout {{git_shallow_head_1.stdout}}"
   register: checkout_early
   failed_when: False
   args:
     chdir: '{{ checkout_dir }}'
 
-- name: again make sure the old commit was not fetched
+- name: DEPTH | again make sure the old commit was not fetched
   assert:
     that: 'checkout_early.rc != 0'
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
 # make sure we are still able to fetch other versions
-- name: Clone same repo with older version
+- name: DEPTH | Clone same repo with older version
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
@@ -57,20 +57,20 @@
   register: cloneold
 
 - assert:
-    that: "cloneold|success"
+    that: cloneold | success
 
-- name: try to access earlier commit
+- name: DEPTH | try to access earlier commit
   shell: "git checkout {{git_shallow_head_1.stdout}}"
   args:
     chdir: '{{ checkout_dir }}'
 
-- name: clear checkout_dir
+- name: DEPTH | clear checkout_dir
   file:
     state: absent
     path: "{{ checkout_dir }}"
 
 # Test for https://github.com/ansible/ansible/issues/21316
-- name: Shallow clone with tag
+- name: DEPTH | Shallow clone with tag
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
@@ -79,9 +79,9 @@
   register: cloneold
 
 - assert:
-    that: "cloneold|success"
+    that: cloneold | success
 
-- name: clear checkout_dir
+- name: DEPTH | clear checkout_dir
   file:
     state: absent
     path: "{{ checkout_dir }}"
@@ -90,14 +90,14 @@
   # Test for https://github.com/ansible/ansible-modules-core/issues/3456
   # clone a repo with depth and version specified
 
-- name: clone repo with both version and depth specified
+- name: DEPTH | clone repo with both version and depth specified
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
     version: master
 
-- name: run a second time (now fetch, not clone)
+- name: DEPTH | run a second time (now fetch, not clone)
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
@@ -105,22 +105,24 @@
     version: master
   register: git_fetch
 
-- name: ensure the fetch succeeded
+- name: DEPTH | ensure the fetch succeeded
   assert:
-    that: git_fetch|success
+    that: git_fetch | success
 
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: DEPTH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: clone repo with both version and depth specified
+- name: DEPTH | clone repo with both version and depth specified
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
     version: master
 
-- name: switch to older branch with depth=1 (uses fetch)
+- name: DEPTH | switch to older branch with depth=1 (uses fetch)
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
@@ -128,28 +130,30 @@
     version: earlybranch
   register: git_fetch
 
-- name: ensure the fetch succeeded
+- name: DEPTH | ensure the fetch succeeded
   assert:
-    that: git_fetch|success
+    that: git_fetch | success
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: DEPTH | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
 # test for https://github.com/ansible/ansible-modules-core/issues/3782
 # make sure shallow fetch works when no version is specified
 
-- name: checkout old repo
+- name: DEPTH | checkout old repo
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
     depth: 1
 
-- name: "update repo"
+- name: DEPTH | "update repo"
   shell: echo "3" > a; git commit -a -m "3"
   args:
-    chdir: "{{repo_dir}}/shallow"
+    chdir: "{{ repo_dir }}/shallow"
 
-- name: fetch updated repo
+- name: DEPTH | fetch updated repo
   git:
     repo: 'file://{{ repo_dir|expanduser }}/shallow'
     dest: '{{ checkout_dir }}'
@@ -157,13 +161,13 @@
   register: git_fetch
   ignore_errors: yes
 
-- name: check update arrived
+- name: DEPTH | check update arrived
   assert:
     that:
       - "{{ lookup('file', checkout_dir+'/a' )}} == 3"
-      - git_fetch|changed
+      - git_fetch | changed
 
-- name: clear checkout_dir
+- name: DEPTH | clear checkout_dir
   file:
     state: absent
     path: "{{ checkout_dir }}"

--- a/test/integration/targets/git/tasks/formats.yml
+++ b/test/integration/targets/git/tasks/formats.yml
@@ -1,12 +1,10 @@
----
-
-- name: initial checkout
+- name: FORMATS | initial checkout
   git:
     repo: "{{ repo_format1 }}"
     dest: "{{ repo_dir }}/format1"
   register: git_result
 
-- name: verify information about the initial clone
+- name: FORMATS | verify information about the initial clone
   assert:
     that:
       - "'before' in git_result"
@@ -14,29 +12,29 @@
       - "not git_result.before"
       - "git_result.changed"
 
-- name: repeated checkout
+- name: FORMATS | repeated checkout
   git:
     repo: "{{ repo_format1 }}"
     dest: "{{ repo_dir }}/format1"
   register: git_result2
 
-- name: check for tags
+- name: FORMATS | check for tags
   stat:
     path: "{{ repo_dir }}/format1/.git/refs/tags"
   register: tags
 
-- name: check for HEAD
+- name: FORMATS | check for HEAD
   stat:
     path: "{{ repo_dir }}/format1/.git/HEAD"
   register: head
 
-- name: assert presence of tags/trunk/branches
+- name: FORMATS | assert presence of tags/trunk/branches
   assert:
     that:
       - "tags.stat.isdir"
       - "head.stat.isreg"
 
-- name: verify on a reclone things are marked unchanged
+- name: FORMATS | verify on a reclone things are marked unchanged
   assert:
     that:
       - "not git_result2.changed"

--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -1,40 +1,39 @@
----
 # Test for verification of GnuPG signatures
 
-- name: Create GnuPG verification workdir
+- name: GPG-VERIFICATION | Create GnuPG verification workdir
   tempfile:
     state: directory
   register: git_gpg_workdir
 
-- name: Define variables based on workdir
+- name: GPG-VERIFICATION | Define variables based on workdir
   set_fact:
     git_gpg_keyfile: "{{ git_gpg_workdir.path }}/testkey.asc"
     git_gpg_source: "{{ git_gpg_workdir.path }}/source"
     git_gpg_dest: "{{ git_gpg_workdir.path }}/dest"
     git_gpg_gpghome: "{{ git_gpg_workdir.path }}/gpg"
 
-- name: Temporary store GnuPG test key
+- name: GPG-VERIFICATION | Temporary store GnuPG test key
   copy:
     content: "{{ git_gpg_testkey }}"
     dest: "{{ git_gpg_keyfile }}"
 
-- name: Create temporary GNUPGHOME directory
+- name: GPG-VERIFICATION | Create temporary GNUPGHOME directory
   file:
     path: "{{ git_gpg_gpghome }}"
     state: directory
     mode: 0700
 
-- name: Import GnuPG test key
+- name: GPG-VERIFICATION | Import GnuPG test key
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   command: gpg --import {{ git_gpg_keyfile }}
 
-- name: Create local GnuPG signed repository directory
+- name: GPG-VERIFICATION | Create local GnuPG signed repository directory
   file:
     path: "{{ git_gpg_source }}"
     state: directory
 
-- name: Generate local GnuPG signed repository
+- name: GPG-VERIFICATION | Generate local GnuPG signed repository
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   shell: |
@@ -57,19 +56,19 @@
   args:
     chdir: "{{ git_gpg_source }}"
 
-- name: Get hash of an unsigned commit
+- name: GPG-VERIFICATION | Get hash of an unsigned commit
   command: git show-ref --hash --verify refs/tags/lightweight_tag/unsigned_commit
   args:
     chdir: "{{ git_gpg_source }}"
   register: git_gpg_unsigned_commit
 
-- name: Get hash of a signed commit
+- name: GPG-VERIFICATION | Get hash of a signed commit
   command: git show-ref --hash --verify refs/tags/lightweight_tag/signed_commit
   args:
     chdir: "{{ git_gpg_source }}"
   register: git_gpg_signed_commit
 
-- name: Clone repo and verify signed HEAD
+- name: GPG-VERIFICATION | Clone repo and verify signed HEAD
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -77,7 +76,7 @@
     dest: "{{ git_gpg_dest }}"
     verify_commit: yes
 
-- name: Clone repo and verify a signed lightweight tag
+- name: GPG-VERIFICATION | Clone repo and verify a signed lightweight tag
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -86,7 +85,7 @@
     version: lightweight_tag/signed_commit
     verify_commit: yes
 
-- name: Clone repo and verify an unsigned lightweight tag (should fail)
+- name: GPG-VERIFICATION | Clone repo and verify an unsigned lightweight tag (should fail)
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -97,13 +96,13 @@
   register: git_verify
   ignore_errors: yes
 
-- name: Check that unsigned lightweight tag verification failed
+- name: GPG-VERIFICATION | Check that unsigned lightweight tag verification failed
   assert:
     that:
       - git_verify|failed
       - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
 
-- name: Clone repo and verify a signed commit
+- name: GPG-VERIFICATION | Clone repo and verify a signed commit
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -112,7 +111,7 @@
     version: "{{ git_gpg_signed_commit.stdout }}"
     verify_commit: yes
 
-- name: Clone repo and verify an unsigned commit
+- name: GPG-VERIFICATION | Clone repo and verify an unsigned commit
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -123,13 +122,13 @@
   register: git_verify
   ignore_errors: yes
 
-- name: Check that unsigned commit verification failed
+- name: GPG-VERIFICATION | Check that unsigned commit verification failed
   assert:
     that:
       - git_verify|failed
       - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
 
-- name: Clone repo and verify a signed annotated tag
+- name: GPG-VERIFICATION | Clone repo and verify a signed annotated tag
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -138,7 +137,7 @@
     version: signed_annotated_tag
     verify_commit: yes
 
-- name: Clone repo and verify an unsigned annotated tag (should fail)
+- name: GPG-VERIFICATION | Clone repo and verify an unsigned annotated tag (should fail)
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -149,13 +148,13 @@
   register: git_verify
   ignore_errors: yes
 
-- name: Check that unsigned annotated tag verification failed
+- name: GPG-VERIFICATION | Check that unsigned annotated tag verification failed
   assert:
     that:
       - git_verify|failed
       - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
 
-- name: Clone repo and verify a signed branch
+- name: GPG-VERIFICATION | Clone repo and verify a signed branch
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -164,7 +163,7 @@
     version: some_branch/signed_tip
     verify_commit: yes
 
-- name: Clone repo and verify an unsigned branch (should fail)
+- name: GPG-VERIFICATION | Clone repo and verify an unsigned branch (should fail)
   environment:
     - GNUPGHOME: "{{ git_gpg_gpghome }}"
   git:
@@ -175,13 +174,13 @@
   register: git_verify
   ignore_errors: yes
 
-- name: Check that unsigned branch verification failed
+- name: GPG-VERIFICATION | Check that unsigned branch verification failed
   assert:
     that:
       - git_verify|failed
       - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
 
-- name: Remove GnuPG verification workdir
+- name: GPG-VERIFICATION | Remove GnuPG verification workdir
   file:
     path: "{{ git_gpg_workdir.path }}"
     state: absent

--- a/test/integration/targets/git/tasks/localmods.yml
+++ b/test/integration/targets/git/tasks/localmods.yml
@@ -1,39 +1,37 @@
----
-
 # test for https://github.com/ansible/ansible-modules-core/pull/5505
-- name: prepare old git repo
+- name: LOCALMODS | prepare old git repo
   shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
   args:
     chdir: "{{repo_dir}}"
 
-- name: checkout old repo
+- name: LOCALMODS | checkout old repo
   git:
     repo: '{{ repo_dir }}/localmods'
     dest: '{{ checkout_dir }}'
 
-- name: "update repo"
+- name: LOCALMODS | "update repo"
   shell: echo "2" > a; git commit -a -m "2"
   args:
     chdir: "{{repo_dir}}/localmods"
 
-- name: "add local mods"
+- name: LOCALMODS | "add local mods"
   shell: echo "3" > a
   args:
     chdir: "{{ checkout_dir }}"
 
-- name: fetch with local mods without force (should fail)
+- name: LOCALMODS | fetch with local mods without force (should fail)
   git:
     repo: '{{ repo_dir }}/localmods'
     dest: '{{ checkout_dir }}'
   register: git_fetch
   ignore_errors: yes
 
-- name: check fetch with localmods failed
+- name: LOCALMODS | check fetch with localmods failed
   assert:
     that:
       - git_fetch|failed
 
-- name: fetch with local mods with force
+- name: LOCALMODS | fetch with local mods with force
   git:
     repo: '{{ repo_dir }}/localmods'
     dest: '{{ checkout_dir }}'
@@ -41,38 +39,38 @@
   register: git_fetch_force
   ignore_errors: yes
 
-- name: check update arrived
+- name: LOCALMODS | check update arrived
   assert:
     that:
       - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
       - git_fetch_force|changed
 
-- name: clear checkout_dir
+- name: LOCALMODS | clear checkout_dir
   file: state=absent path={{ checkout_dir }}
 
 # localmods and shallow clone
-- name: prepare old git repo
+- name: LOCALMODS | prepare old git repo
   shell: rm -rf localmods; mkdir localmods; cd localmods; git init; echo "1" > a; git add a; git commit -m "1"
   args:
     chdir: "{{repo_dir}}"
 
-- name: checkout old repo
+- name: LOCALMODS | checkout old repo
   git:
     repo: '{{ repo_dir }}/localmods'
     dest: '{{ checkout_dir }}'
     depth: 1
 
-- name: "update repo"
+- name: LOCALMODS | "update repo"
   shell: echo "2" > a; git commit -a -m "2"
   args:
     chdir: "{{repo_dir}}/localmods"
 
-- name: "add local mods"
+- name: LOCALMODS | "add local mods"
   shell: echo "3" > a
   args:
     chdir: "{{ checkout_dir }}"
 
-- name: fetch with local mods without force (should fail)
+- name: LOCALMODS | fetch with local mods without force (should fail)
   git:
     repo: '{{ repo_dir }}/localmods'
     dest: '{{ checkout_dir }}'
@@ -80,12 +78,12 @@
   register: git_fetch
   ignore_errors: yes
 
-- name: check fetch with localmods failed
+- name: LOCALMODS | check fetch with localmods failed
   assert:
     that:
       - git_fetch|failed
 
-- name: fetch with local mods with force
+- name: LOCALMODS | fetch with local mods with force
   git:
     repo: '{{ repo_dir }}/localmods'
     dest: '{{ checkout_dir }}'
@@ -94,11 +92,11 @@
   register: git_fetch_force
   ignore_errors: yes
 
-- name: check update arrived
+- name: LOCALMODS | check update arrived
   assert:
     that:
       - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
       - git_fetch_force|changed
 
-- name: clear checkout_dir
+- name: LOCALMODS | clear checkout_dir
   file: state=absent path={{ checkout_dir }}

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -16,23 +16,23 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- include: setup.yml
-- include: setup-local-repos.yml
+- include_tasks: setup.yml
+- include_tasks: setup-local-repos.yml
 
-- include: formats.yml
-- include: missing_hostkey.yml
-- include: no-destination.yml
-- include: specific-revision.yml
-- include: submodules.yml
-- include: change-repo-url.yml
-- include: depth.yml
-- include: checkout-new-tag.yml
-- include: gpg-verification.yml
-  when: >
-    not gpg_version.stderr and
-    gpg_version.stdout and
-    git_version.stdout | version_compare("2.1.0", '>=')
-- include: localmods.yml
-- include: reset-origin.yml
-- include: ambiguous-ref.yml
+- include_tasks: formats.yml
+- include_tasks: missing_hostkey.yml
+- include_tasks: no-destination.yml
+- include_tasks: specific-revision.yml
+- include_tasks: submodules.yml
+- include_tasks: change-repo-url.yml
+- include_tasks: depth.yml
+- include_tasks: checkout-new-tag.yml
+- include_tasks: gpg-verification.yml
+  when:
+    - not gpg_version.stderr
+    - gpg_version.stdout
+    - git_version.stdout | version_compare("2.1.0", '>=')
+- include_tasks: localmods.yml
+- include_tasks: reset-origin.yml
+- include_tasks: ambiguous-ref.yml
 - include_tasks: archive.yml

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -35,3 +35,4 @@
 - include: localmods.yml
 - include: reset-origin.yml
 - include: ambiguous-ref.yml
+- include_tasks: archive.yml

--- a/test/integration/targets/git/tasks/missing_hostkey.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey.yml
@@ -1,6 +1,4 @@
----
-
-- name: checkout ssh://git@github.com repo without accept_hostkey (expected fail)
+- name: MISSING-HOSTKEY | checkout ssh://git@github.com repo without accept_hostkey (expected fail)
   git:
     repo: '{{ repo_format2 }}'
     dest: '{{ checkout_dir }}'
@@ -10,9 +8,9 @@
 
 - assert:
     that:
-      - 'git_result.failed'
+      - git_result | failed
 
-- name: checkout git@github.com repo with accept_hostkey (expected pass)
+- name: MISSING-HOSTKEY | checkout git@github.com repo with accept_hostkey (expected pass)
   git:
     repo: '{{ repo_format2 }}'
     dest: '{{ checkout_dir }}'
@@ -24,16 +22,16 @@
 
 - assert:
     that:
-      - 'git_result.changed'
+      - git_result | changed
   when: github_ssh_private_key is defined
 
-- name: clear checkout_dir
+- name: MISSING-HOSTKEY | clear checkout_dir
   file:
     state: absent
     path: '{{ checkout_dir }}'
   when: github_ssh_private_key is defined
 
-- name: checkout ssh://git@github.com repo with accept_hostkey (expected pass)
+- name: MISSING-HOSTKEY | checkout ssh://git@github.com repo with accept_hostkey (expected pass)
   git:
     repo: '{{ repo_format3 }}'
     dest: '{{ checkout_dir }}'
@@ -46,5 +44,5 @@
 
 - assert:
     that:
-      - 'git_result.changed'
+      - git_result | changed
   when: github_ssh_private_key is defined

--- a/test/integration/targets/git/tasks/no-destination.yml
+++ b/test/integration/targets/git/tasks/no-destination.yml
@@ -1,7 +1,6 @@
----
 # Test a non-updating repo query with no destination specified
 
-- name: get info on a repo without updating and with no destination specified
+- name: NO-DESTINATION | get info on a repo without updating and with no destination specified
   git:
     repo: '{{ repo_dir }}/minimal'
     update: no
@@ -11,4 +10,4 @@
 
 - assert:
     that:
-      - 'git_result.changed'
+      - git_result | changed

--- a/test/integration/targets/git/tasks/reset-origin.yml
+++ b/test/integration/targets/git/tasks/reset-origin.yml
@@ -1,6 +1,4 @@
----
-
-- name: Clean up the directories
+- name: RESET-ORIGIN | Clean up the directories
   file:
     state: absent
     path: "{{ item }}"
@@ -8,17 +6,17 @@
     - "{{ repo_dir }}/origin"
     - "{{ checkout_dir }}"
 
-- name: Create a directory
+- name: RESET-ORIGIN | Create a directory
   file:
     name: "{{ repo_dir }}/origin"
     state: directory
 
-- name: Initialise the repo with a file named origin,see github.com/ansible/ansible/pull/22502
+- name: RESET-ORIGIN | Initialise the repo with a file named origin,see github.com/ansible/ansible/pull/22502
   shell: git init; echo "PR 22502" > origin; git add origin; git commit -m "PR 22502"
   args:
     chdir: "{{ repo_dir }}/origin"
 
-- name: Clone a git repo with file named origin
+- name: RESET-ORIGIN | Clone a git repo with file named origin
   git:
     repo: "{{ repo_dir }}/origin"
     dest: "{{ checkout_dir }}"

--- a/test/integration/targets/git/tasks/setup-local-repos.yml
+++ b/test/integration/targets/git/tasks/setup-local-repos.yml
@@ -1,28 +1,26 @@
----
-
-- name: create dirs
+- name: SETUP-LOCAL-REPOS | create dirs
   file:
-    name: "{{item}}"
+    name: "{{ item }}"
     state: directory
   with_items:
-    - "{{repo_dir}}/minimal"
-    - "{{repo_dir}}/shallow"
+    - "{{ repo_dir }}/minimal"
+    - "{{ repo_dir }}/shallow"
 
-- name: prepare minimal git repo
+- name: SETUP-LOCAL-REPOS | prepare minimal git repo
   shell: git init; echo "1" > a; git add a; git commit -m "1"
   args:
-    chdir: "{{repo_dir}}/minimal"
+    chdir: "{{ repo_dir }}/minimal"
 
-- name: prepare git repo for shallow clone
+- name: SETUP-LOCAL-REPOS | prepare git repo for shallow clone
   shell: |
     git init;
     echo "1" > a; git add a; git commit -m "1"; git tag earlytag; git branch earlybranch;
     echo "2" > a; git add a; git commit -m "2";
   args:
-    chdir: "{{repo_dir}}/shallow"
+    chdir: "{{ repo_dir }}/shallow"
 
-- name: set old hash var for shallow test
+- name: SETUP-LOCAL-REPOS | set old hash var for shallow test
   command: 'git rev-parse HEAD~1'
   register: git_shallow_head_1
   args:
-    chdir: "{{repo_dir}}/shallow"
+    chdir: "{{ repo_dir }}/shallow"

--- a/test/integration/targets/git/tasks/setup.yml
+++ b/test/integration/targets/git/tasks/setup.yml
@@ -1,31 +1,31 @@
----
-
-- name: clean out the output_dir
+- name: SETUP | clean out the output_dir
   file:
     path: "{{ output_dir }}"
     state: absent
 
-- name: create clean output_dir
+- name: SETUP | create clean output_dir
   file:
     path: "{{ output_dir }}"
     state: directory
 
-- name: verify that git is installed so this test can continue
+- name: SETUP | verify that git is installed so this test can continue
   shell: which git
 
-- name: get git version, only newer than {{git_version_supporting_depth}} has fixed git depth
+- name: SETUP | get git version, only newer than {{git_version_supporting_depth}} has fixed git depth
   shell: git --version | grep 'git version' | sed 's/git version //'
   register: git_version
 
-- name: get gpg version
+- name: SETUP | get gpg version
   shell: gpg --version 2>1 | head -1 | sed -e 's/gpg (GnuPG) //'
   register: gpg_version
 
-- name: set git global user.email if not already set
+- name: SETUP | set git global user.email if not already set
   shell: git config --global user.email || git config --global user.email "noreply@example.com"
 
-- name: set git global user.name if not already set
+- name: SETUP | set git global user.name if not already set
   shell: git config --global user.name  || git config --global user.name  "Ansible Test Runner"
 
-- name: create repo_dir
-  file: path={{repo_dir}} state=directory
+- name: SETUP | create repo_dir
+  file:
+    path: "{{ repo_dir }}"
+    state: directory

--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -1,19 +1,17 @@
----
-
 # Test that a specific revision can be checked out
 
-- name: clear checkout_dir
+- name: SPECIFIC-REVISION | clear checkout_dir
   file:
     state: absent
     path: '{{ checkout_dir }}'
 
-- name: clone to specific revision
+- name: SPECIFIC-REVISION | clone to specific revision
   git:
     repo: "{{ repo_dir }}/format1"
     dest: "{{ checkout_dir }}"
     version: df4612ba925fbc1b3c51cbb006f51a0443bd2ce9
 
-- name: check HEAD after clone to revision
+- name: SPECIFIC-REVISION | check HEAD after clone to revision
   command: git rev-parse HEAD
   args:
     chdir: "{{ checkout_dir }}"
@@ -23,7 +21,7 @@
     that:
       - 'git_result.stdout == "df4612ba925fbc1b3c51cbb006f51a0443bd2ce9"'
 
-- name: update to specific revision
+- name: SPECIFIC-REVISION | update to specific revision
   git:
     repo: "{{ repo_dir }}/format1"
     dest: "{{ checkout_dir }}"
@@ -32,9 +30,9 @@
 
 - assert:
     that:
-      - 'git_result.changed'
+      - git_result | changed
 
-- name: check HEAD after update to revision
+- name: SPECIFIC-REVISION | check HEAD after update to revision
   command: git rev-parse HEAD
   args:
     chdir: "{{ checkout_dir }}"
@@ -46,7 +44,7 @@
 
 # Test a revision not available under refs/heads/ or refs/tags/
 
-- name: attempt to get unavailable revision
+- name: SPECIFIC-REVISION | attempt to get unavailable revision
   git:
     repo: "{{ repo_dir }}/format1"
     dest: "{{ checkout_dir }}"
@@ -56,18 +54,18 @@
 
 - assert:
     that:
-      - 'git_result.failed'
+      - git_result | failed
 
 # Same as the previous test, but this time we specify which ref
 # contains the SHA1
-- name: update to revision by specifying the refspec
+- name: SPECIFIC-REVISION | update to revision by specifying the refspec
   git:
     repo: https://github.com/ansible/ansible-examples.git
     dest: '{{ checkout_dir }}'
     version: 5473e343e33255f2da0b160f53135c56921d875c
     refspec: refs/pull/7/merge
 
-- name: check HEAD after update with refspec
+- name: SPECIFIC-REVISION | check HEAD after update with refspec
   command: git rev-parse HEAD
   args:
     chdir: "{{ checkout_dir }}"
@@ -78,12 +76,12 @@
       - 'git_result.stdout == "5473e343e33255f2da0b160f53135c56921d875c"'
 
 # try out combination of refspec and depth
-- name: clear checkout_dir
+- name: SPECIFIC-REVISION | clear checkout_dir
   file:
     state: absent
-    path: '{{ checkout_dir }}'
+    path: "{{ checkout_dir }}"
 
-- name: update to revision by specifying the refspec with depth=1
+- name: SPECIFIC-REVISION | update to revision by specifying the refspec with depth=1
   git:
     repo: https://github.com/ansible/ansible-examples.git
     dest: '{{ checkout_dir }}'
@@ -91,7 +89,7 @@
     refspec: refs/pull/7/merge
     depth: 1
 
-- name: check HEAD after update with refspec
+- name: SPECIFIC-REVISION | check HEAD after update with refspec
   command: git rev-parse HEAD
   args:
     chdir: "{{ checkout_dir }}"
@@ -101,33 +99,33 @@
     that:
       - 'git_result.stdout == "5473e343e33255f2da0b160f53135c56921d875c"'
 
-- name: try to access other commit
+- name: SPECIFIC-REVISION | try to access other commit
   shell: git checkout 0ce1096
   register: checkout_shallow
   failed_when: False
   args:
-    chdir: '{{ checkout_dir }}'
+    chdir: "{{ checkout_dir }}"
 
-- name: "make sure the old commit was not fetched, task is 'forced success'"
+- name: SPECIFIC-REVISION | "make sure the old commit was not fetched, task is 'forced success'"
   assert:
     that:
-      - 'checkout_shallow.rc != 0'
-      - checkout_shallow|success
-  when: git_version.stdout | version_compare("{{git_version_supporting_depth}}", '>=')
+      - checkout_shallow.rc != 0
+      - checkout_shallow | success
+  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
 
-- name: clear checkout_dir
+- name: SPECIFIC-REVISION | clear checkout_dir
   file:
     state: absent
-    path: '{{ checkout_dir }}'
+    path: "{{ checkout_dir }}"
 
-- name: clone to revision by specifying the refspec
+- name: SPECIFIC-REVISION | clone to revision by specifying the refspec
   git:
     repo: https://github.com/ansible/ansible-examples.git
-    dest: '{{ checkout_dir }}'
+    dest: "{{ checkout_dir }}"
     version: 5473e343e33255f2da0b160f53135c56921d875c
     refspec: refs/pull/7/merge
 
-- name: check HEAD after update with refspec
+- name: SPECIFIC-REVISION | check HEAD after update with refspec
   command: git rev-parse HEAD
   args:
     chdir: "{{ checkout_dir }}"
@@ -139,76 +137,91 @@
 
 # Test that a forced shallow checkout referincing branch only always fetches latest head
 
-- name: clear checkout_dir
-  file: state=absent path={{ item }}
+- name: SPECIFIC-REVISION | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ item }}"
   with_items:
     - "{{ checkout_dir }}"
     - "{{ checkout_dir }}.copy"
 
-- name: create original repo dir
-  file: state=directory path="{{checkout_dir}}"
+- name: SPECIFIC-REVISION | create original repo dir
+  file:
+    state: directory
+    path: "{{ checkout_dir }}"
 
-- name: prepare origina repo
+- name: SPECIFIC-REVISION | prepare origina repo
   shell: git init; echo "1" > a; git add a; git commit -m "1"
   args:
-    chdir: "{{checkout_dir}}"
+    chdir: "{{ checkout_dir }}"
 
-- name: clone example repo locally
-  git: 
+- name: SPECIFIC-REVISION | clone example repo locally
+  git:
     repo: "{{ checkout_dir }}"
-    dest: "{{checkout_dir}}.copy"
+    dest: "{{ checkout_dir }}.copy"
 
-- name: create branch in original
-  command: git checkout -b test/branch chdir="{{checkout_dir}}"
+- name: SPECIFIC-REVISION | create branch in original
+  command: git checkout -b test/branch
+  args:
+    chdir: "{{ checkout_dir }}"
 
-- name: get commit for HEAD on new branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}.copy"
+- name: SPECIFIC-REVISION | get commit for HEAD on new branch
+  command: git rev-parse HEAD
+  args:
+    chdir: "{{ checkout_dir }}.copy"
   register: originaltip0
 
-- name: shallow force checkout new branch in copy
-  git: 
-    repo: "{{checkout_dir}}" 
-    dest: "{{checkout_dir}}.copy"
-    version: test/branch 
-    depth: 1 
+- name: SPECIFIC-REVISION | shallow force checkout new branch in copy
+  git:
+    repo: "{{ checkout_dir }}"
+    dest: "{{ checkout_dir }}.copy"
+    version: test/branch
+    depth: 1
     force: yes
 
-- name: create new commit in original
+- name: SPECIFIC-REVISION | create new commit in original
   shell: git init; echo "2" > b; git add b; git commit -m "2"
   args:
-    chdir: "{{checkout_dir}}"
+    chdir: "{{ checkout_dir }}"
 
-- name: get commit for new HEAD on original branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}"
+- name: SPECIFIC-REVISION | get commit for new HEAD on original branch
+  command: git rev-parse HEAD
+  args:
+    chdir: "{{ checkout_dir }}"
   register: originaltip1
 
-- name: get commit for HEAD on new branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}.copy"
+- name: SPECIFIC-REVISION | get commit for HEAD on new branch
+  command: git rev-parse HEAD
+  args:
+    chdir: "{{ checkout_dir }}.copy"
   register: newtip
 
-- name: assert that copy is still pointing at previous tip
+- name: SPECIFIC-REVISION | assert that copy is still pointing at previous tip
   assert:
     that:
-      - "newtip.stdout == originaltip0.stdout"
+      - newtip.stdout == originaltip0.stdout
 
-- name: create a local modification in the copy
+- name: SPECIFIC-REVISION | create a local modification in the copy
   shell: echo "3" > c
   args:
     chdir: "{{ checkout_dir }}.copy"
 
-- name: shallow force checkout new branch in copy (again)
-  git: 
-    repo: "{{checkout_dir}}"
-    dest: "{{checkout_dir}}.copy" 
+- name: SPECIFIC-REVISION | shallow force checkout new branch in copy (again)
+  git:
+    repo: "{{ checkout_dir }}"
+    dest: "{{ checkout_dir }}.copy"
     version: test/branch
-    depth: 1 
+    depth: 1
     force: yes
 
-- name: get commit for HEAD on new branch
-  command: git rev-parse HEAD chdir="{{checkout_dir}}.copy"
+- name: SPECIFIC-REVISION | get commit for HEAD on new branch
+  command: git rev-parse HEAD
+  args:
+    chdir: "{{ checkout_dir }}.copy"
   register: newtip
 
-- name: make sure copy tip is not pointing at previous sha and that new tips match
+- name: SPECIFIC-REVISION | make sure copy tip is not pointing at previous sha and that new tips match
   assert:
     that:
-      - "newtip.stdout != originaltip0.stdout and newtip.stdout == originaltip1.stdout"
+      - newtip.stdout != originaltip0.stdout
+      - newtip.stdout == originaltip1.stdout

--- a/test/integration/targets/git/tasks/submodules.yml
+++ b/test/integration/targets/git/tasks/submodules.yml
@@ -1,5 +1,3 @@
----
-
 #
 # Submodule tests
 #
@@ -16,50 +14,54 @@
 # Repository III for a second submodule (repo_submodule2)
 #   Has 1 file checked in
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: SUBMODULES | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
-- name: Test that clone without recursive does not retrieve submodules
+- name: SUBMODULES | Test that clone without recursive does not retrieve submodules
   git:
-    repo: '{{ repo_submodules }}'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_submodules }}"
+    dest: "{{ checkout_dir }}"
     recursive: no
 
 - command: 'ls -1a {{ checkout_dir }}/submodule1'
   register: submodule1
 
 - assert:
-    that: '{{ submodule1.stdout_lines|length }} == 2'
+    that: '{{ submodule1.stdout_lines | length }} == 2'
 
-- name: clear checkout_dir
-  file: state=absent path={{ checkout_dir }}
+- name: SUBMODULES | clear checkout_dir
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 
 
-- name: Test that clone with recursive retrieves submodules
+- name: SUBMODULES | Test that clone with recursive retrieves submodules
   git:
-    repo: '{{ repo_submodules }}'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_submodules }}"
+    dest: "{{ checkout_dir }}"
     recursive: yes
 
 - command: 'ls -1a {{ checkout_dir }}/submodule1'
   register: submodule1
 
 - assert:
-    that: '{{ submodule1.stdout_lines|length }} == 4'
+    that: '{{ submodule1.stdout_lines | length }} == 4'
 
-- name: Copy the checkout so we can run several different tests on it
+- name: SUBMODULES | Copy the checkout so we can run several different tests on it
   command: 'cp -pr {{ checkout_dir }} {{ checkout_dir }}.bak'
 
 
 
-- name: Test that update without recursive does not change submodules
+- name: SUBMODULES | Test that update without recursive does not change submodules
   command: 'git config --replace-all remote.origin.url {{ repo_submodules_newer }}'
   args:
     chdir: '{{ checkout_dir }}'
 
 - git:
-    repo: '{{ repo_submodules_newer }}'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_submodules_newer }}"
+    dest: "{{ checkout_dir }}"
     recursive: no
     update: yes
     track_submodules: yes
@@ -68,31 +70,33 @@
   register: submodule1
 
 - stat:
-    path: '{{ checkout_dir }}/submodule2'
+    path: "{{ checkout_dir }}/submodule2"
   register: submodule2
 
-- command: 'ls -1a {{ checkout_dir }}/submodule2'
+- command: ls -1a {{ checkout_dir }}/submodule2
   register: submodule2
 
 - assert:
     that: '{{ submodule1.stdout_lines|length }} == 4'
+
 - assert:
     that: '{{ submodule2.stdout_lines|length }} == 2'
 
 
-
-- name: Restore checkout to prior state
-  file: state=absent path={{ checkout_dir }}
+- name: SUBMODULES | Restore checkout to prior state
+  file:
+    state: absent
+    path: "{{ checkout_dir }}"
 - command: 'cp -pr {{ checkout_dir }}.bak {{ checkout_dir }}'
 
-- name: Test that update with recursive updated existing submodules
+- name: SUBMODULES | Test that update with recursive updated existing submodules
   command: 'git config --replace-all remote.origin.url {{ repo_submodules_newer }}'
   args:
-    chdir: '{{ checkout_dir }}'
+    chdir: "{{ checkout_dir }}"
 
 - git:
-    repo: '{{ repo_submodules_newer }}'
-    dest: '{{ checkout_dir }}'
+    repo: "{{ repo_submodules_newer }}"
+    dest: "{{ checkout_dir }}"
     update: yes
     recursive: yes
     track_submodules: yes
@@ -104,7 +108,7 @@
     that: '{{ submodule1.stdout_lines|length }} == 5'
 
 
-- name: Test that update with recursive found new submodules
+- name: SUBMODULES | Test that update with recursive found new submodules
   command: 'ls -1a {{ checkout_dir }}/submodule2'
   register: submodule2
 

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -1,3 +1,14 @@
+git_archive_extensions:
+  default:
+    - tar.gz
+    - tar
+    - tgz
+    - zip
+  RedHat6:
+    - tar
+    - zip
+
+
 checkout_dir: '{{ output_dir }}/git'
 repo_dir: '{{ output_dir }}/local_repos'
 repo_format1: 'https://github.com/jimi-c/test_role'

--- a/test/integration/targets/git/vars/main.yml
+++ b/test/integration/targets/git/vars/main.yml
@@ -1,5 +1,3 @@
----
-
 checkout_dir: '{{ output_dir }}/git'
 repo_dir: '{{ output_dir }}/local_repos'
 repo_format1: 'https://github.com/jimi-c/test_role'
@@ -21,7 +19,7 @@ git_version_supporting_ls_remote: 1.7.5
 # github_ssh_private_key: "{{ lookup('env', 'HOME') }}/.ssh/id_rsa"
 git_gpg_testkey: |
   -----BEGIN PGP PRIVATE KEY BLOCK-----
-  
+
   lQOYBFlkmX0BCACtE81Xj/351nnvwnAWMf8ZUP9B1YOPe9ohqNsCQY1DxODVJc9y
   ljCoh9fTdoHXuaUMUFistozxCMP81RuZxfbfsGePnl8OAOgWT5Sln6yEG45oClJ0
   RmJJZdDT1lF3VaVwK9NQ5E1oqmk1IOjISi7iFa9TmMn1h7ISP/p+/xtMxQhzUXt8
@@ -52,7 +50,7 @@ git_gpg_testkey: |
   =tV71
   -----END PGP PRIVATE KEY BLOCK-----
   -----BEGIN PGP PUBLIC KEY BLOCK-----
-  
+
   mQENBFlkmX0BCACtE81Xj/351nnvwnAWMf8ZUP9B1YOPe9ohqNsCQY1DxODVJc9y
   ljCoh9fTdoHXuaUMUFistozxCMP81RuZxfbfsGePnl8OAOgWT5Sln6yEG45oClJ0
   RmJJZdDT1lF3VaVwK9NQ5E1oqmk1IOjISi7iFa9TmMn1h7ISP/p+/xtMxQhzUXt8


### PR DESCRIPTION
##### SUMMARY
Fix adds correct usage of shutil.rmtree in git module

Fixes: #31225

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/source_control/git.py

##### ANSIBLE VERSION
```
2.5devel
```