### PR TITLE
Included ansible_devices for AIX facts/hardware

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -225,7 +225,7 @@ class AIXHardware(Hardware):
                 'state': field[1],
                 'type': ' '.join(field[2:]),
                 'attributes': device_attrs
-                }
+            }
 
         return device_facts
 

--- a/lib/ansible/module_utils/facts/hardware/aix.py
+++ b/lib/ansible/module_utils/facts/hardware/aix.py
@@ -216,14 +216,20 @@ class AIXHardware(Hardware):
             field = line.split()
 
             device_attrs = {}
-            rc, out_lsattr, err = self.module.run_command("%s -El %s" % (lsattr_cmd, field[0]))
+            device_name = field[0]
+            device_state = field[1]
+            device_type = field[2:]
+            lsattr_cmd_args = [lsattr_cmd, '-E', '-l', device_name]
+            rc, out_lsattr, err = self.module.run_command(lsattr_cmd_args)
             for attr in out_lsattr.splitlines():
-                attr_field = attr.split()
-                device_attrs[attr_field[0]] = attr_field[1]
+                attr_fields = attr.split()
+                attr_name = attr_fields[0]
+                attr_parameter = attr_fields[1]
+                device_attrs[attr_name] = attr_parameter
 
-            device_facts['devices'][field[0]] = {
-                'state': field[1],
-                'type': ' '.join(field[2:]),
+            device_facts['devices'][device_name] = {
+                'state': device_state,
+                'type': ' '.join(device_type),
                 'attributes': device_attrs
             }
 


### PR DESCRIPTION
##### SUMMARY
Included devices for AIX on facts/hardware/aix.py.
These information is very useful for AIX environment.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/hardware/aix.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (facts_devices_aix 4fcf172068) last updated 2017/10/10 21:33:38 (GMT +200)
  config file = None
  configured module search path = ['/Users/kairo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kairo/Dev/Ansible/facts_devices_aix/ansible/lib/ansible
  executable location = /Users/kairo/Dev/Ansible/facts_devices_aix/ansible/bin/ansible
  python version = 3.6.3 (v3.6.3:2c5fed86e0, Oct  3 2017, 00:32:08) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```


##### ADDITIONAL INFORMATION
Example of full output of -m setup with ansible_devices for AIX.
https://gist.github.com/kairoaraujo/a9c56b078191842bffb35065e1642d1d

Example of use:

- Playbook
```yml
---
- name: Devices
  hosts: all

  tasks:
  - debug:
      msg: "{{ ansible_devices.sda }}"
    when: ansible_devices.sda is defined

  - debug:
      msg: "{{ ansible_devices.hdisk0 }}"
    when: ansible_devices.hdisk0 is defined
```

Output
```shell
PLAY [Devices] ******************************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************************
ok: [172.16.229.4]
ok: [172.16.100.21]

TASK [debug] ********************************************************************************************************************
skipping: [172.16.100.21]
ok: [172.16.229.4] => {
    "msg": {
        "holders": [],
        "host": "",
        "links": {
            "ids": [],
            "labels": [],
            "masters": [],
            "uuids": []
        },
        "model": "Virtual disk",
        "partitions": {
            "sda1": {
                "holders": [],
                "links": {
                    "ids": [],
                    "labels": [],
                    "masters": [],
                    "uuids": [
                        "4116b0d3-6305-46d7-9869-5f04854f7a84"
                    ]
                },
                "sectors": "1024000",
                "sectorsize": 512,
                "size": "500.00 MB",
                "start": "2048",
                "uuid": "4116b0d3-6305-46d7-9869-5f04854f7a84"
            },
            "sda2": {
                "holders": [
                    "rhel-swap",
                    "rhel-root"
                ],
                "links": {
                    "ids": [
                        "lvm-pv-uuid-lbLyNd-1JGf-SVmD-lDsL-Hapj-RuoN-pUeWIF"
                    ],
                    "labels": [],
                    "masters": [
                        "dm-0",
                        "dm-1"
                    ],
                    "uuids": []
                },
                "sectors": "40916992",
                "sectorsize": 512,
                "size": "19.51 GB",
                "start": "1026048",
                "uuid": null
            }
        },
        "removable": "0",
        "rotational": "1",
        "sas_address": null,
        "sas_device_handle": null,
        "scheduler_mode": "deadline",
        "sectors": "41943040",
        "sectorsize": "512",
        "size": "20.00 GB",
        "support_discard": "0",
        "vendor": "VMware",
        "virtual": 1
    }
}

TASK [debug] ********************************************************************************************************************
skipping: [172.16.229.4]
ok: [172.16.100.21] => {
    "msg": {
        "attributes": {
            "PCM": "PCM/friend/vscsi",
            "PR_key_value": "none",
            "algorithm": "fail_over",
            "hcheck_cmd": "test_unit_rdy",
            "hcheck_interval": "20",
            "hcheck_mode": "nonactive",
            "max_transfer": "0x40000",
            "pvid": "00f7c85d376eb73b0000000000000000",
            "queue_depth": "20",
            "reserve_policy": "no_reserve"
        },
        "state": "Available",
        "type": "Virtual SCSI Disk Drive"
    }
}

PLAY RECAP **********************************************************************************************************************
172.16.100.21              : ok=2    changed=0    unreachable=0    failed=0
172.16.229.4               : ok=2    changed=0    unreachable=0    failed=0
```