### PR TITLE
Try to cleanup after the rpm_key test

### DIFF
--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -1,4 +1,24 @@
 ---
+#
+# Save initial state
+#
+- name: Retrieve a list of gpg keys are installed for package checking
+  shell: 'rpm -q gpg-pubkey | sort'
+  register: list_of_pubkeys
+
+- name: Retrieve the gpg keys used to verify packages
+  command: 'rpm -q --qf %{description} gpg-pubkey'
+  register: pubkeys
+
+- name: Save gpg keys to a file
+  copy:
+    content: "{{ pubkeys['stdout'] }}\n"
+    dest: '{{ output_dir }}/pubkeys'
+    mode: 0600
+
+#
+# Tests start
+#
 - name: download EPEL GPG key
   get_url:
     url: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
@@ -109,3 +129,29 @@
   rpm_key:
     state: present
     key: https://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-7
+
+- name: check GPG signature of sl. Should return okay
+  shell: "rpm --checksig /tmp/sl.rpm"
+  register: sl_check
+
+- name: confirm that signature check succeeded
+  assert:
+    that: "'rsa sha1 (md5) pgp md5 OK' in sl_check.stdout"
+
+#
+# Cleanup
+#
+- name: remove all keys from key ring
+  shell: "rpm -q  gpg-pubkey | xargs rpm -e"
+
+- name: Restore the gpg keys normally installed on the system
+  command: 'rpm --import {{ output_dir }}/pubkeys'
+
+- name: Retrieve a list of gpg keys are installed for package checking
+  shell: 'rpm -q gpg-pubkey | sort'
+  register: new_list_of_pubkeys
+
+- name: Confirm that we've restored all the pubkeys
+  assert:
+    that:
+      - 'list_of_pubkeys["stdout"] == new_list_of_pubkeys["stdout"]'


### PR DESCRIPTION
##### SUMMARY
The new integration tests for rpm_key are removing all of the keys from the system.  This causes problems for later tests which need to verify rpm packages.  This PR attempts to save the installed keys prior to running any tests and then restore them afterwards

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/rpm_key

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```
