### PR TITLE
Fix up_connection return types in create_connection method

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -1007,8 +1007,7 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_team()
                 self.execute_command(cmd)
-                cmd=self.up_connection()
-                return self.execute_command(cmd)
+                return self.up_connection()
             elif (self.dns4 is None) or (self.dns6 is None):
                 cmd=self.create_connection_team()
                 return self.execute_command(cmd)
@@ -1018,7 +1017,6 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_team_slave()
                 self.execute_command(cmd)
-                # cmd=self.up_connection()
                 return self.execute_command(cmd)
             else:
                 cmd=self.create_connection_team_slave()
@@ -1029,8 +1027,7 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_bond()
                 self.execute_command(cmd)
-                cmd=self.up_connection()
-                return self.execute_command(cmd)
+                return self.up_connection()
             else:
                 cmd=self.create_connection_bond()
                 return self.execute_command(cmd)
@@ -1042,8 +1039,7 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_ethernet()
                 self.execute_command(cmd)
-                cmd=self.up_connection()
-                return self.execute_command(cmd)
+                return self.up_connection()
             else:
                 cmd=self.create_connection_ethernet()
                 return self.execute_command(cmd)


### PR DESCRIPTION
##### SUMMARY
Fixes issue #20925

The return type create_connection currently expects that the call
to up_connection return a string rather than the return type of
self.execute_command, which is a tuple.

This was partially addressed in the following pull request:
https://github.com/ansible/ansible/pull/25818

There hasn't been any movement on that PR from the author since June,
so I'm creating this PR to fix it.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
nmcli

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```