### PR TITLE
windows: removed #Requires from PS pipelines as it causes false positives

### DIFF
--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -35,7 +35,6 @@ if _powershell_version:
     _common_args = ['PowerShell', '-Version', _powershell_version] + _common_args[1:]
 
 exec_wrapper = br'''
-#Requires -Version 3.0
 begin {
     $DebugPreference = "Continue"
     $ErrorActionPreference = "Stop"
@@ -880,7 +879,6 @@ namespace Ansible
 "@
 
 $exec_wrapper = {
-    #Requires -Version 3.0
     Set-StrictMode -Version 2
     $DebugPreference = "Continue"
     $ErrorActionPreference = "Stop"
@@ -1004,7 +1002,6 @@ $ErrorActionPreference = "Stop"
 # return asyncresult to controller
 
 $exec_wrapper = {
-#Requires -Version 3.0
 $DebugPreference = "Continue"
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2


### PR DESCRIPTION
##### SUMMARY
Removed the `#Requires -Version 3.0` statement in the powershell exec wrappers as they cause false positives in the STDERR stream on every module invocation as shown when running with `-vvvvvv`

```
<192.168.56.155> WINRM STDERR An error occurred while creating the pipeline.
    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : RuntimeException
```

This may have caused an issue with a certain module invocation on a specific commit as shown here https://github.com/ansible/ansible/issues/31423 but it is no longer an issue. We should still remove them or come up with another solution so the false positives are no longer there.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
powershell.py

##### ANSIBLE VERSION
```
2.5
```