### PR TITLE
Fix rollback in junos_config (#31424)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,7 @@ Ansible Changes By Release
 * Fix for aws_s3 metadata to use the correct parameters when uploading a file (https://github.com/ansible/ansible/issues/31232)
 * Fix for the yum module when installing from file/url crashes (https://github.com/ansible/ansible/pull/31529)
 * Improved error messaging for Windows become/runas when username is bogus (https://github.com/ansible/ansible/pull/31551)
+* Fix rollback feature in junos_config to now allow configuration rollback on device (https://github.com/ansible/ansible/pull/31424)
 
 <a id="2.4"></a>
 

--- a/lib/ansible/module_utils/junos.py
+++ b/lib/ansible/module_utils/junos.py
@@ -178,9 +178,9 @@ def locked_config(module):
         unlock_configuration(module)
 
 
-def get_diff(module):
+def get_diff(module, rollback='0'):
 
-    reply = get_configuration(module, compare=True, format='text')
+    reply = get_configuration(module, compare=True, format='text', rollback=rollback)
     # if warning is received from device diff is empty.
     if isinstance(reply, list):
         return None

--- a/test/integration/targets/junos_config/tests/netconf/single.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/single.yaml
@@ -41,6 +41,37 @@
     that:
       - "result.changed == true"
 
+- name: teardown for rollback test
+  junos_config:
+    lines:
+    - delete system syslog file test1
+    provider: "{{ netconf }}"
+
+- name: Configure syslog file
+  junos_config:
+    lines:
+    - set system syslog file test1 any any
+    provider: "{{ netconf }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - result.diff.prepared | search("\+ *file test1")
+      - result.diff.prepared | search("\+ *any any")
+
+- name: Rollback junos config
+  junos_config:
+    rollback: 1
+    provider: "{{ netconf }}"
+  register: result
+
+- assert:
+    that:
+      - "result.changed == true"
+      - result.diff.prepared | search("\+ *file test1")
+      - result.diff.prepared | search("\+ *any any")
+
 - name: teardown
   junos_config:
     lines:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #30778

*  Call `load_configuration` with rollback id in case
   the id is given as input
*  Pass rollback id to `get_diff()` to fetch diff from device

* Fix unit test

(cherry picked from commit 88da95bb77cf20f56035e7ba5d0230c0a2785f2b)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
