### PR TITLE
Add Opsview Host module

### DIFF
--- a/lib/ansible/module_utils/opsview.py
+++ b/lib/ansible/module_utils/opsview.py
@@ -1,0 +1,264 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# (c) 2017, Opsview Ltd.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import copy
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import _load_params
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import iteritems
+
+try:
+    from pyopsview import OpsviewClient
+    PYOV_IMPORT_EXC = None
+except ImportError as e:
+    PYOV_IMPORT_EXC = (to_native(e), traceback.format_exc())
+
+# List of keys which should never be omitted from the module parameters,
+# even if they were not specified by the user. These will also, by default,
+# be omitted from the final payload.
+_MODULE_ONLY_FIELDS = ('username', 'password', 'token', 'endpoint',
+                       'verify_ssl', 'object_id', 'state')
+
+
+def new_module(argspec, always_include=_MODULE_ONLY_FIELDS):
+    """Initializes a new AnsibleModule with the specified argument spec,
+    removing any fields from the final params unless they've been explicitly
+    specified.
+
+    Keys in `always_include` will never be omitted.
+    """
+    pre_params = copy.deepcopy(_load_params())
+    module = AnsibleModule(supports_check_mode=True, argument_spec=argspec)
+
+    # dict(...) creates a shallow copy to prevent changed size during iter
+    for (k, v) in iteritems(dict(module.params)):
+        if k not in pre_params and v is None and k not in always_include:
+            del module.params[k]
+
+    return module
+
+
+def new_opsview_client(username, endpoint, token=None, password=None, **kwds):
+    """Initializes a new OpsviewClient using the parameters specified to the
+    module.
+    """
+    if not (password or token):
+        raise ValueError("'password' or 'token' must be specified")
+
+    return OpsviewClient(username=username, endpoint=endpoint, token=token,
+                         password=password, **kwds)
+
+
+def get_config_manager(opsview_client, object_type):
+    """Return the configuration manager for a specified object type from the
+    specified OpsviewClient instance.
+    """
+    return getattr(opsview_client.config, object_type)
+
+
+def find_existing_object(manager, identity, **kwds):
+    """Return the first object matching the parameters specified in `ident`.
+    """
+    return manager.find_one(params=kwds, **identity)
+
+
+def create_object_payload(module_params, omit_fields=_MODULE_ONLY_FIELDS,
+                          payload_finalize_hook=None):
+    """Returns a copy of the module parameters correctly formatted for the
+    OpsviewClient's manager with any non-object fields removed.
+    """
+    payload = copy.deepcopy(module_params)
+    for field in omit_fields:
+        try:
+            del payload[field]
+        except KeyError:
+            pass
+
+    if payload_finalize_hook:
+        return payload_finalize_hook(payload)
+
+    return payload
+
+
+def _cmp_dict(a, b):
+    try:
+        return any(_cmp_recursive(a[k], b[k]) for k in b)
+    except (KeyError, TypeError):
+        return True
+
+
+def _cmp_list(a, b):
+    try:
+        a_s, b_s = sorted(a), sorted(b)
+    except TypeError:
+        return True
+
+    try:
+        return any(_cmp_recursive(a_s[i], n) for (i, n) in enumerate(b_s))
+    except (IndexError, TypeError):
+        return True
+
+
+def _cmp_recursive(a, b):
+    """Recursively compare 2 objects. Return True if data in b does
+    not match data in a.
+    """
+    if isinstance(b, dict):
+        return _cmp_dict(a, b)
+    elif isinstance(b, (list, tuple)):
+        return _cmp_list(a, b)
+
+    return a != b
+
+
+def object_requires_update(encoder, existing, new, pre_compare_hook=None):
+    """Compares two objects and returns whether an update is required.
+    The encoder is used to ensure that the objects match the required
+    serialization format expected by the Opsview API.
+
+    An optional `pre_compare_hook` can be specified which should be a callable
+    returning the new object in a format which matches the one returned
+    by the Opsview API, if different.
+    """
+    if pre_compare_hook:
+        # Ensure that the original dict is not mutated by the hook function
+        new = pre_compare_hook(copy.deepcopy(new))
+
+    existing_encoded, new_encoded = encoder(existing), encoder(new)
+
+    try:
+        return _cmp_recursive(existing_encoded, new_encoded)
+    except (TypeError, KeyError, AttributeError, IndexError):
+        return True
+
+
+def ensure_absent(manager, existing, check_mode=False):
+    """Ensures that the object contained in `existing` is deleted.
+
+    Returns a dictionary to be merged with the arguments to `module.exit_json`,
+    indicating whether a change took place.
+    """
+    changed = (existing is not None)
+    if changed and not check_mode:
+        manager.delete(existing['id'])
+
+    return {'changed': changed}
+
+
+def ensure_present(manager, existing, new, check_mode=False):
+    """Ensures that the object contained in `existing` is present.
+
+    Returns a dictionary to be merged with the arguments to `module.exit_json`,
+    indicating whether a change took place and the Opsview ID of the object.
+    """
+    changed = (existing is None)
+    status = {'changed': changed}
+
+    if changed and not check_mode:
+        created = manager.create(**new)
+        if 'id' in created:
+            status['object_id'] = created['id']
+
+    elif 'id' in existing:
+        status['object_id'] = existing['id']
+
+    return status
+
+
+def ensure_updated(manager, existing, new, check_mode=False,
+                   pre_compare_hook=None):
+    """Ensures that the object is updated to contain all of the changes
+    specified in the `new` object.  The object will be created if it does not
+    already exist.
+
+    Returns a dictionary to be merged with the arguments to `module.exit_json`,
+    indicating whether a change took place and the Opsview ID of the object.
+    """
+    if existing is None:
+        return ensure_present(manager, existing, new)
+
+    changed = object_requires_update(manager._encode, existing, new,
+                                     pre_compare_hook=pre_compare_hook)
+
+    status = {'changed': changed}
+    if 'id' in existing:
+        status['object_id'] = existing['id']
+
+    if changed and not check_mode:
+        manager.update(existing['id'], **new)
+
+    return status
+
+
+def config_module_main(module, object_type, get_params=None,
+                       payload_finalize_hook=None, pre_compare_hook=None):
+    """Helper to execute a standard Opsview Configuration module and return
+    a dict which can be used as the arguments to module.exit_json
+    """
+    opsview_client = new_opsview_client(
+        username=module.params['username'],
+        password=module.params['password'],
+        endpoint=module.params['endpoint'],
+        token=module.params['token'],
+        verify=module.params['verify_ssl'],
+    )
+
+    config_manager = get_config_manager(opsview_client, object_type)
+    if module.params.get('object_id'):
+        identity = {'id': module.params['object_id']}
+    elif module.params.get('name'):
+        identity = {'name': module.params['name']}
+    else:
+        raise ValueError("'name' or 'object_id' must be specified")
+
+    if get_params is None:
+        get_params = {}
+
+    existing_object = find_existing_object(config_manager, identity,
+                                           **get_params)
+
+    if module.params['state'] == 'absent':
+        return ensure_absent(config_manager, existing_object,
+                             check_mode=module.check_mode)
+
+    payload = create_object_payload(
+        module.params, payload_finalize_hook=payload_finalize_hook
+    )
+
+    if module.params['state'] == 'present':
+        return ensure_present(config_manager, existing_object, payload,
+                              check_mode=module.check_mode)
+
+    elif module.params['state'] == 'updated':
+        return ensure_updated(config_manager, existing_object, payload,
+                              pre_compare_hook=pre_compare_hook,
+                              check_mode=module.check_mode)
+
+    raise ValueError("Unknown value for 'state': '%s'" % module.params['state'])

--- a/lib/ansible/module_utils/opsview.py
+++ b/lib/ansible/module_utils/opsview.py
@@ -233,7 +233,7 @@ def config_module_main(module, object_type, get_params=None,
         password=module.params['password'],
         endpoint=module.params['endpoint'],
         token=module.params['token'],
-        verify=module.params['verify_ssl'],
+        verify=verify,
     )
 
     config_manager = get_config_manager(opsview_client, object_type)

--- a/lib/ansible/module_utils/opsview.py
+++ b/lib/ansible/module_utils/opsview.py
@@ -27,6 +27,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import copy
+import os.path
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
@@ -222,6 +223,11 @@ def config_module_main(module, object_type, get_params=None,
     """Helper to execute a standard Opsview Configuration module and return
     a dict which can be used as the arguments to module.exit_json
     """
+    verify = module.params['verify_ssl']
+
+    if not os.path.exists(verify):
+        verify = module.boolean(verify)
+
     opsview_client = new_opsview_client(
         username=module.params['username'],
         password=module.params['password'],

--- a/lib/ansible/modules/monitoring/opsview_bsm_component.py
+++ b/lib/ansible/modules/monitoring/opsview_bsm_component.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_bsm_component
+short_description: Manages Opsview BSM Components
+description:
+  - Manages BSM Components within Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+    required: true
+  hosts:
+    description:
+      - List of Hosts to be included in this BSM Component.
+    required: true
+  host_template:
+    description:
+      - Name of the Host Template to enumerate the Service Checks which will
+        be included in this BSM Component.
+    required: true
+  operational_zone:
+    description:
+      - The percentage of Hosts in this BSM Component which must be available
+        before the BSM Component is considered to be unavailable.
+      - The trailing '%' should be omitted.
+    required: true
+"""
+
+EXAMPLES = """
+---
+- name: Create BSM Component in Opsview
+  opsview_bsm_component:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: prod-nginx
+    hosts:
+      - uk-web-01
+      - uk-web-02
+    host_template: Application - NGINX
+    operational_zone: 50
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+
+ARG_SPEC = {
+    "username": {
+        "required": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True
+    },
+    "token": {
+        "no_log": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "name": {
+        "required": True,
+    },
+    "hosts": {
+        "type": "list",
+        "required": True,
+    },
+    "host_template": {
+        "required": True,
+    },
+    "operational_zone": {
+        "type": "float",
+        "required": True,
+    }
+}
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = ov.config_module_main(module, 'bsmcomponents')
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_bsm_service.py
+++ b/lib/ansible/modules/monitoring/opsview_bsm_service.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_bsm_service
+short_description: Manages Opsview BSM Services
+description:
+  - Manages BSM Services within Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+    required: true
+  components:
+    description:
+      - List of BSM Components to be included in this BSM Service.
+    required: true
+"""
+
+EXAMPLES = """
+---
+- name: Create BSM Service in Opsview
+  opsview_bsm_service:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: www-production
+    components:
+      - prod-nginx
+      - prod-phpfpm
+      - prod-mysql
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+
+ARG_SPEC = {
+    "username": {
+        "required": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True
+    },
+    "token": {
+        "no_log": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "name": {
+        "required": True,
+    },
+    "components": {
+        "type": "list",
+        "required": True,
+    }
+}
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = ov.config_module_main(module, 'bsmservices')
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_flow_source.py
+++ b/lib/ansible/modules/monitoring/opsview_flow_source.py
@@ -1,0 +1,271 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """\
+---
+module: opsview_flow_source
+short_description: Manages Opsview sFlow and NetFlow sources
+description:
+  - Manages sFlow and NetFlow sources in Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+      - Must correspond with the host name in Opsview.
+    required: true
+  collector:
+    description:
+      - The name of the flow collector as configured in Opsview.
+    required: true
+  flow_type:
+    description:
+      - The flow protocol to be used.
+    choices: [netflow, sflow]
+    default: netflow
+  alt_address:
+    description:
+      - IP address from which flow data will be received if different from the
+        address stored for the host in Opsview.
+"""
+
+EXAMPLES = """
+---
+- name: Create Flow Source in Opsview
+  opsview_flow_source:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: cisco-uk-01
+    flow_type: sflow
+    alt_address: 10.0.17.24
+    collector: Master Collector
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import functools
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import iteritems
+
+ARG_SPEC = {
+    "username": {
+        "required": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True
+    },
+    "token": {
+        "no_log": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "name": {
+        "required": True,
+    },
+    "collector": {
+        "required": True,
+    },
+    "flow_type": {
+        "default": "netflow",
+        "choices": ["netflow", "sflow"],
+    },
+    "alt_address": {},
+}
+
+
+def _hook_trans_payload(params, opsview_client, module):
+    if 'collector' in params and 'collector_id' not in params:
+        # Get the collector by name
+        collector = opsview_client.config.flowcollectors\
+            .find_one(name=params['collector'])
+
+        if not collector:
+            module.fail_json(msg='No flow collector exists with name \'%s\'' %
+                             params['collector'])
+
+        # Set the collector ID and unset the collector name
+        params['collector_id'] = collector.get('id')
+
+    # Ensure that the flow type is lowercased
+    params['flow_type'] = params['flow_type'].lower()
+
+    if 'host_id' not in params:
+        # Get the IP address of the host by name
+        host = opsview_client.config.hosts.find_one(name=params['name'])
+        if not host:
+            module.fail_json(msg='No host exists with name \'%s\'' %
+                             params['name'])
+
+        # Set the host ID
+        params['host_id'] = host.get('id')
+
+    if 'address' not in params:
+        # Set the host IP address and set the override flag if necessary
+        src_addr = params.get('alt_address')
+        if not src_addr:
+            src_addr = host['address']
+
+        params['ip_override'] = (src_addr != host['address'])
+        params['address'] = src_addr
+
+    for field in ('collector', 'name', 'alt_address'):
+        try:
+            del params[field]
+        except KeyError:
+            pass
+
+    return params
+
+
+def module_main(module):
+    opsview_client = ov.new_opsview_client(
+        username=module.params['username'],
+        password=module.params['password'],
+        endpoint=module.params['endpoint'],
+        token=module.params['token'],
+        verify=module.params['verify_ssl'],
+    )
+
+    # Wrap up the hook function to already have the module and opsview client
+    hook_trans_payload = functools.partial(_hook_trans_payload, module=module,
+                                           opsview_client=opsview_client)
+
+    config_manager = ov.get_config_manager(opsview_client, 'flowsources')
+
+    # if finding the flow source by name, must first find the host and then
+    # find the associated flow source
+    if module.params.get('object_id'):
+        identity = {'id': module.params['object_id']}
+
+    elif module.params.get('name'):
+        host_manager = ov.get_config_manager(opsview_client, 'hosts')
+        host_identity = {'name': module.params['name']}
+        host = ov.find_existing_object(host_manager, host_identity)
+        if host and 'id' in host:
+            identity = {'host_id': host['id']}
+        else:
+            identity = None
+    else:
+        raise ValueError("'name' or 'object_id' must be specified")
+
+    if identity:
+        existing_object = ov.find_existing_object(config_manager, identity)
+    else:
+        existing_object = None
+
+    if module.params['state'] == 'absent':
+        return ov.ensure_absent(config_manager, existing_object,
+                                check_mode=module.check_mode)
+
+    payload = ov.create_object_payload(
+        module.params, payload_finalize_hook=hook_trans_payload
+    )
+
+    if module.params['state'] == 'present':
+        return ov.ensure_present(config_manager, existing_object, payload,
+                                 check_mode=module.check_mode)
+
+    elif module.params['state'] == 'updated':
+        return ov.ensure_updated(config_manager, existing_object, payload,
+                                 pre_compare_hook=hook_trans_payload,
+                                 check_mode=module.check_mode)
+
+    raise ValueError("Unknown value for 'state': '%s'" %
+                     module.params['state'])
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = module_main(module)
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_hashtag.py
+++ b/lib/ansible/modules/monitoring/opsview_hashtag.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_hashtag
+short_description: Manages Opsview Hashtags
+description:
+  - Manages Hashtags within Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+    required: true
+  description:
+    description:
+      - User-defined description for this hashtag.
+  enabled:
+    description:
+      - Do not display failures which have been marked as handled.
+    default: 'no'
+    choices: ['yes', 'no']
+  hosts:
+    description:
+      - List of Hosts to apply this Hashtag to.
+  all_service_checks:
+    description:
+      - Apply the Hashtag to all Service Checks on the specified Hosts.
+    default: 'no'
+    choices: ['yes', 'no']
+  service_checks:
+    description:
+      - List of Service Checks to apply this Hashtag to.
+  all_hosts:
+    description:
+      - Apply the Hashtag to all Hosts with the specified Service Checks.
+    default: 'no'
+    choices: ['yes', 'no']
+  exclude_handled:
+    description:
+      - Do not display failures which have been marked as handled.
+    default: 'no'
+    choices: ['yes', 'no']
+  public:
+    description:
+      - Allow unauthenticated users to view this Hashtag in Monitoring>Hashtags
+    default: 'no'
+    choices: ['yes', 'no']
+"""
+
+EXAMPLES = """
+---
+- name: Create HashTag in Opsview
+  opsview_hashtag:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: web-uk
+    description: UK Web Servers
+    hosts:
+      - uk-web-01
+      - uk-web-02
+      - uk-web-03
+      - uk-web-04
+    all_service_checks: yes
+    exclude_handled: yes
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import string_types
+
+ARG_SPEC = {
+    "username": {
+        "required": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True
+    },
+    "token": {
+        "no_log": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "name": {
+        "required": True
+    },
+    "description": {},
+    "enabled": {
+        "type": "bool",
+        "default": True,
+    },
+    "all_hosts": {
+        "type": "bool",
+        "default": True,
+    },
+    "hosts": {
+        "type": "list",
+    },
+    "all_service_checks": {
+        "type": "bool",
+        "default": True,
+    },
+    "service_checks": {
+        "type": "list",
+    },
+    "exclude_handled": {
+        "type": "bool",
+        "default": False,
+    },
+    "public": {
+        "type": "bool",
+        "default": False,
+    },
+}
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = ov.config_module_main(module, 'hashtags')
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_host.py
+++ b/lib/ansible/modules/monitoring/opsview_host.py
@@ -1,0 +1,536 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_host
+short_description: Manages Opsview hosts
+description:
+  - Manages hosts within Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+    required: true
+  address:
+    description:
+      - Primary network address for the host.
+    required: true
+  host_group:
+    description:
+      - Host group to assign this host to.
+    required: true
+  monitored_by:
+    description:
+      - The monitoring server/cluster which will monitor this host.
+    default: Master Monitoring Server
+  alias:
+    description:
+      - Alternative name for this host as shown in the UI.
+  check_attempts:
+    description:
+      - The number of checks before the host enters a HARD state.
+    default: '2'
+  check_command:
+    description:
+      - Name of the command used for monitoring this host.
+    default: ping
+  check_interval:
+    description:
+      - Number of seconds between each host check execution.
+    default: '600'
+  check_period:
+    description:
+      - Timeperiod within which this host will be monitored.
+    default: 24x7
+  description:
+    description:
+      - User-defined description for this host.
+  enable_snmp:
+    description:
+      - Enable active SNMP checks for this host.
+    choices: ['yes', 'no']
+  encrypted_rancid_password:
+    description:
+      - The password for logging into the host with RANCID.
+      - Must be pre-encrypted with the opsview_crypt utility.
+  encrypted_snmp_community:
+    description:
+      - The community string to be used with SNMP 1/2c
+      - Must be pre-encrypted with the opsview_crypt utility.
+  encrypted_snmpv3_auth_password:
+    description:
+      - The authentication password to be used with SNMP v3
+      - Must be pre-encrypted with the opsview_crypt utility.
+  encrypted_snmpv3_priv_password:
+    description:
+      - The privacy password to be used with SNMP v3
+      - Must be pre-encrypted with the opsview_crypt utility.
+  event_handler:
+    description:
+      - Script to execute whenever a state change occurs for this host.
+  event_handler_always_exec:
+    description:
+      - Execute the event handler after every check result.
+    choices: ['yes', 'no']
+  flap_detection_enabled:
+    description:
+      - Enable flapping states for this host.
+    default: 'yes'
+    choices: ['yes', 'no']
+  hashtags:
+    description:
+      - List of Hashtags to be applied to this host.
+  host_templates:
+    description:
+      - List of Host Templates to be applied to this host
+  icon:
+    description:
+      - The name of the icon to be used for this host.
+  notification_interval:
+    description:
+      - Number of seconds between sending re-notifications for this host when
+        it is in DOWN or UNREACHABLE states.
+  notification_options:
+    description:
+      - Comma-separated list of states to notify on.
+      - C(u)=UNREACHABLE, C(d)=DOWN, C(r)=RECOVERY, C(f)=FLAPPING.
+    default: u,d,r
+  notification_period:
+    description:
+      - Timeperiod within which notifications for this host will be sent.
+    default: 24x7
+  other_addresses:
+    description:
+      - Comma-separated list of additional network addresses for this host.
+  parents:
+    description:
+      - List of host names (as configured in Opsview) which directly determine
+        the reachability of this host. For example, the network switches
+        connected to this host.
+  rancid_auto_enable:
+    description:
+      - Host has autoenable when connecting to this host with RANCID.
+    choices: ['yes', 'no']
+  rancid_connection_type:
+    description:
+      - Method used for connecting to this host with RANCID.
+    choices: [ssh, telnet]
+    default: ssh
+  rancid_password:
+    description:
+      - Password for logging into the host with RANCID.
+      - C(encrypted_rancid_password) is preferred.
+  rancid_username:
+    description:
+      - Username for logging into the host with RANCID.
+  rancid_vendor:
+    description:
+      - The host's vendor, as configured in RANCID. You may have to consult the
+        UI for the full list of options.
+  retry_check_interval:
+    description:
+      - Number of seconds between rechecks before a HARD state.
+  service_checks:
+    description:
+      - A list of discrete Service Checks to add to the host, aside from those
+        specified via Host Templates.
+      - See examples for the argument format.
+  snmp_community:
+    description:
+      - The community string to be used with SNMP 1/2c.
+      - C(encrypted_snmp_community) is preferred.
+  snmp_extended_throughput_data:
+    description:
+      - Turn on the collection of broadcast, multicast and and unicast stats.
+    choices: ['yes', 'no']
+  snmp_max_msg_size:
+    description:
+      - The maximum message size, in octets, for SNMP messages. For default,
+        use 0.
+    default: '0'
+  snmp_port:
+    description:
+      - The listening SNMP port on the host.
+    default: '161'
+  snmp_use_getnext:
+    description:
+      - Use SNMP C(GetNext) instead of SNMP C(GetBulk).
+    choices: ['yes', 'no']
+  snmp_use_ifname:
+    description:
+      - Use SNMP C(ifName) instead of SNMP C(ifDescr).
+    choices: ['yes', 'no']
+  snmp_version:
+    description:
+      - The SNMP protocol version to use.
+    choices: ['1', '2c', '3']
+    default: '2c'
+  snmpv3_auth_password:
+    description:
+      - The authentication password to be used with SNMP v3.
+      - C(encrypted_snmpv3_auth_password) is preferred.
+  snmpv3_auth_protocol:
+    description:
+      - The authentication protocol to be used with SNMP v3.
+    choices: [md5, sha]
+  snmpv3_priv_password:
+    description:
+      - The privacy password to be used with SNMP v3.
+      - C(encrypted_snmpv3_priv_password) is preferred.
+  snmpv3_priv_protocol:
+    description:
+      - The privacy protocol to be used with SNMP v3.
+    choices: [des, aes, aes128]
+  snmpv3_username:
+    description:
+      - The username to be used with SNMP v3.
+  tidy_ifdescr_level:
+    description:
+      - Level of cleaning to do on the C(ifDescr) to reduce the length of
+        interface names.
+      - Refer to https://knowledge.opsview.com/docs/host#section-interfaces
+    choices: [0, 1, 2, 3, 4, 5]
+  use_rancid:
+    description:
+      - Enable RANCID.
+    choices: ['yes', 'no']
+  variables:
+    description:
+      - List of variables to apply to the host.
+      - See the examples for the argument format.
+"""
+
+EXAMPLES = """
+---
+- name: Create Host in Opsview
+  opsview_host:
+    username: admin
+    # Providing a token from the opsview_login module is preferred to using a
+    # password and is much faster.
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: web-uk-01
+    address: 127.214.167.12
+    host_group: web-uk
+    monitored_by: ov-cluster-uk
+    alias: Web UK 01
+    hashtags:
+      - Production
+      - Production - UK
+      - Production - UK - Web
+    host_templates:
+      - Application - Apache2
+      - OS - Opsview Agent
+      - Network - Base
+    icon: SYMBOL - Web Site
+    parents:
+      - switch-uk-01
+      - switch-uk-02
+    service_checks:
+      # Add a Service Check
+      - HTTP / SSL
+      # Add a Service Check with alternative arguments
+      - name: HTTPS Certificate Expiration Check
+        exception: -H $HOSTADDRESS$ -C 30,14
+      # Add a Service Check with a timed exception
+      - name: Unix Load Average
+        timed_exception:
+          timeperiod: nonworkhours
+          args: -H $HOSTADDRESS$ -c check_load -a '-w 5,4,3 -c 7,6,5'
+      # Remove a Service Check from an applied Host Template
+      - name: Unix Swap
+        remove_service_check: true
+    variables:
+      # Arguments 1-4 can be provided as argN
+      # Encrypted arguments 1-4 can be provided as encrypted_argN
+      - name: DISK
+        value: /
+        arg1: -w 10% -c 5%
+      - name: DISK
+        value: /var
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import string_types
+
+ARG_SPEC = {
+    "address": {
+        "required": True
+    },
+    "alias": {},
+    "check_attempts": {
+        "default": 2,
+        "type": "int"
+    },
+    "check_command": {
+        "default": "ping"
+    },
+    "check_interval": {
+        "default": 600,
+        "type": "int"
+    },
+    "check_period": {
+        "default": "24x7"
+    },
+    "description": {},
+    "enable_snmp": {
+        "type": "bool"
+    },
+    "encrypted_rancid_password": {
+        "no_log": True
+    },
+    "encrypted_snmp_community": {
+        "no_log": True
+    },
+    "encrypted_snmpv3_auth_password": {
+        "no_log": True
+    },
+    "encrypted_snmpv3_priv_password": {
+        "no_log": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "event_handler": {},
+    "event_handler_always_exec": {
+        "type": "bool"
+    },
+    "flap_detection_enabled": {
+        "default": True,
+        "type": "bool"
+    },
+    "hashtags": {
+        "type": "list"
+    },
+    "host_group": {
+        "required": True
+    },
+    "host_templates": {
+        "type": "list"
+    },
+    "icon": {},
+    "monitored_by": {
+        "default": "Master Monitoring Server"
+    },
+    "name": {
+        "required": True
+    },
+    "notification_interval": {
+        "type": "int"
+    },
+    "notification_options": {
+        "default": "u,d,r"
+    },
+    "notification_period": {
+        "default": "24x7"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "other_addresses": {},
+    "parents": {
+        "type": "list"
+    },
+    "password": {
+        "no_log": True
+    },
+    "rancid_auto_enable": {
+        "type": "bool"
+    },
+    "rancid_connection_type": {
+        "choices": ["ssh", "telnet"],
+        "default": "ssh"
+    },
+    "rancid_password": {
+        "no_log": True
+    },
+    "rancid_username": {},
+    "rancid_vendor": {},
+    "retry_check_interval": {
+        "type": "int"
+    },
+    "service_checks": {
+        "type": "list"
+    },
+    "snmp_community": {
+        "no_log": True
+    },
+    "snmp_extended_throughput_data": {
+        "type": "bool"
+    },
+    "snmp_max_msg_size": {
+        "default": 0,
+        "type": "int"
+    },
+    "snmp_port": {
+        "default": 161,
+        "type": "int"
+    },
+    "snmp_use_getnext": {
+        "type": "bool"
+    },
+    "snmp_use_ifname": {
+        "type": "bool"
+    },
+    "snmp_version": {
+        "choices": [
+            "1",
+            "2c",
+            "3"
+        ],
+        "default": "2c"
+    },
+    "snmpv3_auth_password": {
+        "no_log": True
+    },
+    "snmpv3_auth_protocol": {
+        "choices": [
+            "md5",
+            "sha"
+        ]
+    },
+    "snmpv3_priv_password": {
+        "no_log": True
+    },
+    "snmpv3_priv_protocol": {
+        "choices": [
+            "des",
+            "aes",
+            "aes128"
+        ]
+    },
+    "snmpv3_username": {},
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "tidy_ifdescr_level": {
+        "choices": [0, 1, 2, 3, 4, 5],
+        "type": "int"
+    },
+    "token": {
+        "no_log": True
+    },
+    "use_rancid": {
+        "type": "bool"
+    },
+    "username": {
+        "required": True
+    },
+    "variables": {
+        "type": "list"
+    },
+    "verify_ssl": {
+        "default": True
+    }
+}
+
+
+def hook_trans_payload(params):
+    # Ensure that the notification options are duly sorted
+    if params.get('notification_options'):
+        option_sort_order = {'u': 0, 'd': 1, 'r': 2, 'f': 3}
+        notif_opts = params['notification_options'].lower().split(',').sort(
+            key=lambda x: option_sort_order.get(x, 99)
+        )
+        params['notification_options'] = notif_opts
+
+    # Ensure that string value for icon gets passed as the icon name
+    if isinstance(params.get('icon'), string_types):
+        params['icon'] = {'name': params['icon']}
+
+    return params
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = ov.config_module_main(
+            module, 'hosts',
+            get_params={'include_encrypted': '1'},
+            pre_compare_hook=hook_trans_payload,
+            payload_finalize_hook=hook_trans_payload)
+
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_host_group.py
+++ b/lib/ansible/modules/monitoring/opsview_host_group.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_host_group
+short_description: Manages Opsview Host Groups
+description:
+  - Manages Host Groups within Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+    required: true
+  parent:
+    description:
+      - Name of the parent Host Group.
+    required: true
+"""
+
+EXAMPLES = """
+---
+- name: Create Host Group in Opsview
+  opsview_host_group:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: Production-LDN
+    parent: Production
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import string_types
+
+ARG_SPEC = {
+    "username": {
+        "required": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True
+    },
+    "token": {
+        "no_log": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "name": {
+        "required": True
+    },
+    "parent": {
+        "required": True
+    }
+}
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = ov.config_module_main(module, 'hostgroups')
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_login.py
+++ b/lib/ansible/modules/monitoring/opsview_login.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_login
+short_description: Log into Opsview
+description:
+  - Retrieves an authentication token from an Opsview API.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+"""
+
+EXAMPLES = """
+---
+- name: Log into Opsview
+  opsview_login:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+  register: ov_login
+
+- debug:
+    msg: '{{ ov_login.token }}'
+"""
+
+RETURN = """
+---
+token:
+  description: The authentication token for the Opsview server.
+  returned: success.
+  type: string
+opsview_version:
+  description: The software version for the Opsview server.
+  returned: success.
+  type: string
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+
+ARG_SPEC = {
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True,
+        "required": True
+    },
+    "username": {
+        "required": True
+    },
+    "verify_ssl": {
+        "default": True
+    }
+}
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        opsview_client = ov.new_opsview_client(
+            username=module.params['username'],
+            password=module.params['password'],
+            endpoint=module.params['endpoint'],
+            verify=module.params['verify_ssl'],
+        )
+
+        summary = {'changed': True,
+                   'token': opsview_client.token,
+                   'opsview_version': opsview_client.version}
+
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_login.py
+++ b/lib/ansible/modules/monitoring/opsview_login.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os.path
+
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -97,12 +99,17 @@ def main():
         module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
                          exception=ov.PYOV_IMPORT_EXC[1])
 
+    verify = module.params['verify_ssl']
+
+    if not os.path.exists(verify):
+        verify = module.boolean(verify)
+
     try:
         opsview_client = ov.new_opsview_client(
             username=module.params['username'],
             password=module.params['password'],
             endpoint=module.params['endpoint'],
-            verify=module.params['verify_ssl'],
+            verify=verify,
         )
 
         summary = {'changed': True,

--- a/lib/ansible/modules/monitoring/opsview_monitoring_server.py
+++ b/lib/ansible/modules/monitoring/opsview_monitoring_server.py
@@ -1,0 +1,201 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_monitoring_server
+short_description: Manages Opsview Monitoring Servers
+description:
+  - Manages Monitoring Servers within Opsview.
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  state:
+    description:
+      - C(present) and C(updated) will create the object if it doesn't exist.
+      - C(updated) will ensure that the object attributes are up to date with
+        the given options.
+      - C(absent) will ensure that the object is removed if it exists.
+      - The object is identified by C(object_id) if specified. Otherwise, it is
+        identified by C(name)
+    choices: [updated, present, absent]
+    default: updated
+  object_id:
+    description:
+      - The internal ID of the object. If specified, the object will be
+        found by ID instead of by C(name).
+      - Usually only useful for renaming objects.
+  name:
+    description:
+      - Unique name for the object. Will be used to identify existing objects
+        unless C(object_id) is specified.
+    required: true
+  nodes:
+    description:
+      - List of Opsview host names to add to this cluster.
+    required: true
+  ssh_forward:
+    description:
+      - Initiate the SSH connection on the master monitoring server rather than
+        the slave.
+    default: 'yes'
+    choices: ['yes', 'no']
+"""
+
+EXAMPLES = """
+---
+- name: Create Monitoring Server in Opsview
+  opsview_monitoring_server:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    state: updated
+    name: cluster-1
+    nodes:
+      - ov-mon-01
+      - ov-mon-02
+      - ov-mon-03
+      - ov-mon-04
+"""
+
+RETURN = """
+---
+object_id:
+  description: ID of the object in Opsview.
+  returned: When not check_mode.
+  type: int
+"""
+
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import string_types
+
+ARG_SPEC = {
+    "username": {
+        "required": True
+    },
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True
+    },
+    "token": {
+        "no_log": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "state": {
+        "choices": [
+            "updated",
+            "present",
+            "absent"
+        ],
+        "default": "updated"
+    },
+    "object_id": {
+        "type": "int"
+    },
+    "name": {
+        "required": True
+    },
+    "nodes": {
+        "required": True,
+        "type": "list",
+    },
+    "ssh_forward": {
+        "default": True,
+        "type": "bool"
+    }
+}
+
+
+def hook_trans_compare(params):
+    if params['nodes']:
+        # The API returns the nodes in a different format to the one it expects
+        nodes_full = []
+        for node in params['nodes']:
+            if isinstance(node, string_types):
+                nodes_full.append({'host': {'name': node}})
+            elif isinstance(node, dict) and 'name' in node:
+                nodes_full.append({'host': {'name': node['name']}})
+            else:
+                # Don't know what format this is... Try anyway.
+                nodes_full.append(node)
+
+        params['nodes'] = nodes_full
+
+    return params
+
+
+def hook_trans_payload(params):
+    nodes_full = []
+    for node in params.get('nodes', []):
+        if isinstance(node, string_types):
+            nodes_full.append({'name': node})
+        else:
+            nodes_full.append(node)
+
+    params['nodes'] = nodes_full
+    return params
+
+
+def main():
+    module = ov.new_module(ARG_SPEC)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = ov.config_module_main(
+            module, 'monitoringservers',
+            pre_compare_hook=hook_trans_compare,
+            payload_finalize_hook=hook_trans_payload
+        )
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_reload.py
+++ b/lib/ansible/modules/monitoring/opsview_reload.py
@@ -1,0 +1,222 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Opsview Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: opsview_reload
+short_description: Reload Opsview
+description:
+  - Reloads an Opsview Monitor system
+version_added: '2.5'
+author: Joshua Griffiths (@jpgxs)
+requirements: [pyopsview]
+options:
+  username:
+    description:
+      - Username for the Opsview API.
+    required: true
+  endpoint:
+    description:
+      - Opsview API endpoint, including schema.
+      - The C(/rest) suffix is optional.
+    required: true
+  token:
+    description:
+      - API token, usually returned by the C(opsview_login) module.
+      - Required unless C(password) is specified.
+  password:
+    description:
+      - Password for the Opsview API.
+  verify_ssl:
+    description:
+      - Enable SSL verification for HTTPS endpoints.
+      - Alternatively, a path to a CA can be provided.
+    default: 'yes'
+  force:
+    description:
+      - Force a reload even if there are no pending changes.
+    default: no
+    choices: ['yes', 'no']
+  wait:
+    description:
+      - Wait for the reload to complete.
+    default: 'yes'
+    choices: ['yes', 'no']
+"""
+
+EXAMPLES = """
+---
+- name: Reload Opsview
+  opsview_reload:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+
+- name: Force-reload Opsview without waiting
+  opsview_reload:
+    username: admin
+    password: initial
+    endpoint: https://opsview.example.com
+    force: yes
+    wait: no
+"""
+
+RETURN = """
+---
+"""
+
+import time
+import traceback
+
+from ansible.module_utils import opsview as ov
+from ansible.module_utils.basic import to_native
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.six import string_types
+
+ARG_SPEC = {
+    "endpoint": {
+        "required": True
+    },
+    "password": {
+        "no_log": True,
+    },
+    "token": {
+        "no_log": True,
+    },
+    "username": {
+        "required": True
+    },
+    "verify_ssl": {
+        "default": True
+    },
+    "force": {
+        "default": True,
+        "type": "bool",
+    },
+    "wait": {
+        "default": True,
+        "type": "bool"
+    }
+}
+
+# Used to ensure that none of the arguments are omitted
+ARG_KEYS = tuple(ARG_SPEC.keys())
+
+RELOAD_MESSAGES = {
+    0: 'Server running with no warnings',
+    1: 'Server reloading',
+    2: 'Server not running',
+    3: 'Configuration error or critical error',
+    4: 'Warnings exist',
+}
+
+
+def get_reload_status(client):
+    """Get the current reload status and convert the stringy numbers into
+    real integers.
+    """
+    status = client.reload_status()
+    for (k, v) in iteritems(status):
+        try:
+            status[k] = int(v)
+        except Exception:
+            pass
+
+    return status
+
+
+def do_reload(module, opsview_client):
+    status = get_reload_status(opsview_client)
+    reload_status = status['server_status']
+    config_status = status['configuration_status']
+
+    # Fail if a reload is not possible
+    if reload_status in (1, 2):
+        module.fail_json(
+            msg='Unable to reload Opsview: %s' % RELOAD_MESSAGES[reload_status]
+        )
+
+    # Only reload if changes are pending or 'force' was specified
+    if config_status.lower() == 'pending' or module.params.get('force'):
+        changed = True
+
+    module_status = {'changed': changed}
+
+    # noop if check mode
+    if module.check_mode or not changed:
+        return module_status
+
+    # requires a reload
+    opsview_client.reload(async=True)
+
+    # don't return additional info unless wait was specified
+    if not module.params.get('wait'):
+        return module_status
+
+    # wait loop
+    while True:
+        status = get_reload_status(opsview_client)
+        reload_status = status['server_status']
+        config_status = status['configuration_status']
+
+        if reload_status != 1:
+            break
+
+        # Must be different from the TCP keepalive seconds
+        time.sleep(3.5)
+
+    # Add warnings
+    if reload_status == 4:
+        for message in status.get('messages', []):
+            if 'detail' in message:
+                module.warn('Opsview: ' + message['detail'])
+
+    elif reload_status in (2, 3):
+        module.fail_json(msg='Failed to reload Opsview: %s' %
+                         RELOAD_MESSAGES[reload_status])
+
+    return module_status
+
+
+def module_main(module):
+    opsview_client = ov.new_opsview_client(
+        username=module.params['username'],
+        password=module.params['password'],
+        endpoint=module.params['endpoint'],
+        token=module.params['token'],
+        verify=module.params['verify_ssl'],
+    )
+
+    return do_reload(module, opsview_client)
+
+
+def main():
+    module = ov.new_module(ARG_SPEC, always_include=ARG_KEYS)
+    # Handle exception importing 'pyopsview'
+    if ov.PYOV_IMPORT_EXC is not None:
+        module.fail_json(msg=ov.PYOV_IMPORT_EXC[0],
+                         exception=ov.PYOV_IMPORT_EXC[1])
+
+    try:
+        summary = module_main(module)
+    except Exception as e:
+        module.fail_json(msg=to_native(e), exception=traceback.format_exc())
+
+    module.exit_json(**summary)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/opsview_reload.py
+++ b/lib/ansible/modules/monitoring/opsview_reload.py
@@ -8,6 +8,8 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import os.path
+
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -192,12 +194,17 @@ def do_reload(module, opsview_client):
 
 
 def module_main(module):
+    verify = module.params['verify_ssl']
+
+    if not os.path.exists(verify):
+        verify = module.boolean(verify)
+
     opsview_client = ov.new_opsview_client(
         username=module.params['username'],
         password=module.params['password'],
         endpoint=module.params['endpoint'],
         token=module.params['token'],
-        verify=module.params['verify_ssl'],
+        verify=verify,
     )
 
     return do_reload(module, opsview_client)


### PR DESCRIPTION
Add Opsview Host module

##### SUMMARY
Adds common utilities for Opsview modules.
Adds module for adding, updating and deleting hosts in Opsview.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- opsview_host

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /virtualenvs/ansible/local/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /virtualenvs/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```