### PR TITLE
Introspect the management IP on ios_ping

### DIFF
--- a/test/integration/targets/ios_ping/tests/cli/ping.yaml
+++ b/test/integration/targets/ios_ping/tests/cli/ping.yaml
@@ -1,9 +1,19 @@
 ---
 - debug: msg="START cli/ping.yaml"
 
+- name: Get show ip interface GigabitEthernet0/0 output
+  ios_command:
+    commands:
+      - show ip interface GigabitEthernet0/0 | include Internet address
+    authorize: yes
+  register: show_ip_interface_result
+
+- name: Extract the IP address from registered output
+  set_fact: management_ip="{{ show_ip_interface_result.stdout[0].split()[-1].split('/')[0] }}"
+
 - name: expected successful ping
   ios_ping: &valid_ip
-    dest: '8.8.8.8'
+    dest: '{{ management_ip }}'
     authorize: yes
   register: esp
   
@@ -13,6 +23,7 @@
     timeout: 45
     authorize: yes
   register: uup
+  ignore_errors: yes
 
 - name: unexpected successful ping
   ios_ping:
@@ -20,6 +31,7 @@
     state: 'absent'
     authorize: yes
   register: usp
+  ignore_errors: yes
 
 - name: expected unsuccessful ping
   ios_ping:


### PR DESCRIPTION
On our CI we don't have external connectivity, so let's ping to
the management interface IP.
Also, ignore errors on the expected failures tests.