### PR TITLE
Parameterize the ssh port on ios_user tests

### DIFF
--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -11,13 +11,13 @@
 
   - name: test login
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
         (?i)password: "pass123"
 
   - name: test login with invalid password (should fail)
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes


### PR DESCRIPTION
On CI we use 8022 for SSH, thus we need to explicitly pass
ansible_ssh_port to the ssh command to work.