### PR TITLE
Catch AttributeError when accessing _new_stdin.buffer

### DIFF
--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -124,9 +124,9 @@ class ActionModule(ActionBase):
 
             # save the attributes on the existing (duped) stdin so
             # that we can restore them later after we set raw mode
-            if PY3:
+            try:
                 stdin = self._connection._new_stdin.buffer
-            else:
+            except AttributeError:
                 stdin = self._connection._new_stdin
             fd = None
             try:


### PR DESCRIPTION
##### SUMMARY

According to https://docs.python.org/3/library/sys.html#sys.stdin, one
cannot assume that a stream has a buffer attribute. Without catching
AttributeError, this module will crash when run in an environment
where stdin is not available (such as executing Ansible on a CI
service).

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

pause

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```