### PR TITLE
fixes #31543 - any_errors_fatal should take effect on tasks after failure in block/rescue/always

### DIFF
--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -382,9 +382,10 @@ class StrategyModule(StrategyBase):
                 failed_hosts = []
                 unreachable_hosts = []
                 for res in results:
+                    current_state = iterator.get_host_state(res._host)
                     if res.is_failed() and iterator.is_failed(res._host):
                         failed_hosts.append(res._host.name)
-                    elif any_errors_fatal and iterator.get_host_state(res._host).did_rescue:
+                    elif any_errors_fatal and current_state.cur_always_task >= len(current_state._blocks[current_state.cur_block].always) and current_state != iterator.FAILED_NONE:
                         failed_hosts.append(res._host.name)
                     elif res.is_unreachable():
                         unreachable_hosts.append(res._host.name)

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -385,10 +385,13 @@ class StrategyModule(StrategyBase):
                     current_state = iterator.get_host_state(res._host)
                     if res.is_failed() and iterator.is_failed(res._host):
                         failed_hosts.append(res._host.name)
-                    elif any_errors_fatal and current_state.cur_always_task >= len(current_state._blocks[current_state.cur_block].always) and current_state != iterator.FAILED_NONE:
-                        failed_hosts.append(res._host.name)
                     elif res.is_unreachable():
                         unreachable_hosts.append(res._host.name)
+                    elif (any_errors_fatal and
+                          current_state.cur_always_task >= len(current_state._blocks[current_state.cur_block].always) and
+                          current_state != iterator.FAILED_NONE and
+                          not current_state.did_rescue):
+                        failed_hosts.append(res._host.name)
 
                 # if any_errors_fatal and we had an error, mark all hosts as failed
                 if any_errors_fatal and (len(failed_hosts) > 0 or len(unreachable_hosts) > 0):

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -384,6 +384,8 @@ class StrategyModule(StrategyBase):
                 for res in results:
                     if res.is_failed() and iterator.is_failed(res._host):
                         failed_hosts.append(res._host.name)
+                    elif any_errors_fatal and iterator.get_host_state(res._host).did_rescue:
+                        failed_hosts.append(res._host.name)
                     elif res.is_unreachable():
                         unreachable_hosts.append(res._host.name)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #31543.
any_errors_fatal should stop tasks after failure in block/rescue/always.

Failure in block + no rescue section + any_errors_fatal means subsequent tasks don't run.
Failure in block + failed rescue section + any_errors_fatal means subsequent tasks don't run.
Failure in block + successful rescue section + any_errors_fatal means subsequent tasks run.

Example:
```
---
- hosts: host0:host1
  gather_facts: no
  tasks:
  - block:
    - name: fail host0
      fail:
      when: inventory_hostname=="host0"
    - debug: msg="still executing in block for one host"
    always:
    - debug: msg="executing in always for both hosts"
    any_errors_fatal: true

  - name: an error here
    debug: msg="Should not execute since host0 failed and was not rescued."
```
On devel this results in:
```
PLAYBOOK: any_err_fatal_task_after_block.yml *****************************************************************************************
1 plays in my_playbooks/any_err_fatal_task_after_block.yml

PLAY [host0:host1] *******************************************************************************************************************
META: ran handlers

TASK [fail host0] ********************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:6
skipping: [host1] => {
    "changed": false,
    "skip_reason": "Conditional result was False",
    "skipped": true
}
fatal: [host0]: FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Failed as requested from task"
}
META: noop

TASK [debug] *************************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:9
ok: [host1] => {
    "msg": "still executing in block for one host"
}

TASK [debug] *************************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:11
ok: [host0] => {
    "msg": "executing in always for both hosts"
}
ok: [host1] => {
    "msg": "executing in always for both hosts"
}

TASK [an error here] *****************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:14
ok: [host1] => {
    "msg": "Should not execute since host0 failed and was not rescued."
}
META: ran handlers
META: ran handlers
	to retry, use: --limit @/Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.retry

PLAY RECAP ***************************************************************************************************************************
host0                      : ok=1    changed=0    unreachable=0    failed=1
host1                      : ok=3    changed=0    unreachable=0    failed=0
```
After this fix:
```
PLAYBOOK: any_err_fatal_task_after_block.yml *****************************************************************************************
1 plays in my_playbooks/any_err_fatal_task_after_block.yml

PLAY [host0:host1] *******************************************************************************************************************
META: ran handlers

TASK [fail host0] ********************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:6
skipping: [host1] => {
    "changed": false,
    "skip_reason": "Conditional result was False",
    "skipped": true
}
fatal: [host0]: FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Failed as requested from task"
}
META: noop

TASK [debug] *************************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:9
ok: [host1] => {
    "msg": "still executing in block for one host"
}

TASK [debug] *************************************************************************************************************************
task path: /Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.yml:11
ok: [host0] => {
    "msg": "executing in always for both hosts"
}
ok: [host1] => {
    "msg": "executing in always for both hosts"
}

NO MORE HOSTS LEFT *******************************************************************************************************************
	to retry, use: --limit @/Users/shertel/Workspace/ansible/my_playbooks/any_err_fatal_task_after_block.retry

PLAY RECAP ***************************************************************************************************************************
host0                      : ok=1    changed=0    unreachable=0    failed=1
host1                      : ok=2    changed=0    unreachable=0    failed=0
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/strategy/linear.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```
