### PR TITLE
[aws_s3] different fail msg depending on whether version is specified

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -632,7 +632,10 @@ def main():
         # Next, we check to see if the key in the bucket exists. If it exists, it also returns key_matches md5sum check.
         keyrtn = key_check(module, s3, bucket, obj, version=version, validate=validate)
         if keyrtn is False:
-            module.fail_json(msg="Key %s with version id %s does not exist." % (obj, version))
+            if version:
+                module.fail_json(msg="Key %s with version id %s does not exist." % (obj, version))
+            else:
+                module.fail_json(msg="Key %s does not exist." % obj)
 
         # If the destination path doesn't exist or overwrite is True, no need to do the md5um etag check, so just download.
         # Compare the remote MD5 sum of the object with the local dest md5sum, if it already exists.


### PR DESCRIPTION
##### SUMMARY
Print a different failure message depending on whether version was specified as an option

If version is not specified and key does not exist, the failure message is -
_Key my/key.txt with version id None does not exist._

With this change it will be -
_Key my/key.txt does not exist._

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
`aws_s3`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```
