### PR TITLE
Fix Inventory Plugin Loading

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -177,7 +177,7 @@ class InventoryManager(object):
     def _setup_inventory_plugins(self):
         ''' sets up loaded inventory plugins for usage '''
 
-        inventory_loader = PluginLoader('InventoryModule', 'ansible.plugins.inventory', 'inventory_plugins', 'inventory_plugins')
+        inventory_loader = PluginLoader('InventoryModule', 'ansible.plugins.inventory', C.DEFAULT_INVENTORY_PLUGIN_PATH, 'inventory_plugins')
         display.vvvv('setting up inventory plugins')
 
         for name in C.INVENTORY_ENABLED:


### PR DESCRIPTION


##### SUMMARY
This change makes the PluginLoader use DEFAULT_INVENTORY_PLUGIN_PATH setting.
Inventory Plugins were only being loaded the 'inventory_plugins' folder of the current directory,
as well as the ansible-provided inventory plugins (e.g. `/path/to/site-packages/ansible/plugins/inventory`).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
inventory manager

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
My inventory plugin was only loading if I happened to be in the parent directory of a folder called 'inventory_plugins' that contained my plugin. I tried various configurations in ansible.cfg, but the
setting didn't seem to be used. To debug, I ended up adding this just after the InventoryManager loads the PluginLoader:
```
display.vvvv(str(inventory_loader._get_paths()))
```
That line in the output said (where cwd=`/home/ubuntu`):
```
['/home/ubuntu/inventory_plugins', '/usr/local/lib/python2.7/dist-packages/ansible/plugins/inventory']
```

Applying this change, the output matches what I set in my ansible.cfg. :)