### PR TITLE
add support to vmware_guest for template => vm conversion

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
@@ -68,6 +68,22 @@
     that:
         - "convert_to_template.results|map(attribute='changed')|unique|list == [True]"
 
+- name: make double sure that all VMs are templates
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    folder: "{{ item|dirname }}"
+    name: "{{ item|basename }}"
+    state: present
+    is_template: True
+  with_items: "{{ vmlist['json'] }}"
+  register: still_templates
+
+- debug: var=still_templates
+
 - name: ensure that no changes were made
   assert:
     that:

--- a/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
@@ -1,0 +1,95 @@
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: "http://{{ vcsim }}:5000/killall"
+- name: start vcsim with no folders
+  uri:
+    url: "http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0"
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMs from vcsim
+  uri:
+    url: "http://{{ vcsim }}:5000/govc_find?filter=VM"
+  register: vmlist
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+
+- name: ensure that VMs are not flagged as templates
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    folder: "{{ item|dirname }}"
+    name: "{{ item|basename }}"
+    state: present
+    is_template: False
+  with_items: "{{ vmlist['json'] }}"
+  register: no_template_initial
+
+- debug: var=no_template_initial
+
+- name: ensure no changes were made
+  assert:
+    that:
+        - "no_template_initial.results|map(attribute='changed')|unique|list == [False]"
+
+- name: convert all VMs to templates
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    folder: "{{ item|dirname }}"
+    name: "{{ item|basename }}"
+    state: present
+    is_template: True
+  with_items: "{{ vmlist['json'] }}"
+  register: convert_to_template
+
+- debug: var=convert_to_template
+
+- name: ensure that changes were made
+  assert:
+    that:
+        - "convert_to_template.results|map(attribute='changed')|unique|list == [True]"
+
+- name: ensure that no changes were made
+  assert:
+    that:
+        - "still_templates.results|map(attribute='changed')|unique|list == [False]"
+
+- name: convert all templates back to VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    folder: "{{ item|dirname }}"
+    name: "{{ item|basename }}"
+    state: present
+    is_template: False
+  with_items: "{{ vmlist['json'] }}"
+  register: revert_to_vm
+
+- debug: var=revert_to_vm
+
+- name: ensure that changes were made
+  assert:
+    that:
+        - "revert_to_vm.results|map(attribute='changed')|unique|list == [True]"


### PR DESCRIPTION
##### SUMMARY
While the vmware_guest currently supports conversion of VMs to templates
using the is_template argument, it does not support the inverse:
converting templates back into VMs.  This change adds that
functionality.

When converting a template back into a VM, the extra config option
"uuid.action" is also set so that VMware will automatically create a new
UUID for the converted VM.  If the "uuid.action" setting is already
configured, it will not be modified.  Setting this prevents an
interactive question from being raised when attempting to boot the VM.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_guest