### PR TITLE
Work around cryptography 2.1 requiring pip 8.1.2+

### DIFF
--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -1,3 +1,4 @@
+cryptography>=1.3.4,<2.1  # cryptography 2.1 requires pip 8.1.2+
 packaging
 requests[security]
 azure-mgmt-compute>=2.0.0,<3


### PR DESCRIPTION
##### SUMMARY

Work around cryptography 2.1 requiring pip 8.1.2+

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

packaging/requirements/requirements-azure.txt

##### ANSIBLE VERSION

```
ansible 2.5.0 (cryptography-ci-workaround 21972b56b4) last updated 2017/10/11 15:29:03 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
