### PR TITLE
fix ios_interface test unsupported param

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/intent.yaml
@@ -8,7 +8,6 @@
     tx_rate: ge(0)
     rx_rate: le(0)
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -22,7 +21,6 @@
     tx_rate: gt(0)
     rx_rate: lt(0)
     authorize: yes
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -39,7 +37,6 @@
     enabled: False
     state: down
     authorize: yes
-    provider: "{{ cli }}"
   register: result
 
 - assert:
@@ -52,7 +49,6 @@
     enabled: False
     authorize: yes
     state: up
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -76,7 +72,6 @@
           - port: eth0
             host: netdev
         authorize: yes
-        provider: "{{ cli }}"
       register: result
 
     - assert:
@@ -90,7 +85,6 @@
           - port: dummy_port
             host: dummy_host
         authorize: yes
-        provider: "{{ cli }}"
       ignore_errors: yes
       register: result
 
@@ -108,7 +102,6 @@
         enabled: True
         state: up
     authorize: yes
-    provider: "{{ cli }}"
   ignore_errors: yes
   register: result
 
@@ -125,7 +118,6 @@
               - port: eth0
                 host: netdev
         authorize: yes
-        provider: "{{ cli }}"
       ignore_errors: yes
       register: result
 
@@ -143,7 +135,6 @@
           - port: dummy_port
             host: dummy_host
         authorize: yes
-        provider: "{{ cli }}"
       ignore_errors: yes
       register: result
 


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/ios_interface/tests/cli/intent.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```