### PR TITLE
Remove cryptography install from CI other test.

### DIFF
--- a/test/utils/shippable/other.sh
+++ b/test/utils/shippable/other.sh
@@ -7,10 +7,6 @@ shippable.py
 retry.py apt-get update -qq
 retry.py apt-get install -qq \
     shellcheck \
-    libssl-dev \
-    libffi-dev \
-
-pip install cryptography
 
 retry.py pip install tox --disable-pip-version-check
 


### PR DESCRIPTION
##### SUMMARY

Remove cryptography install from CI other test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.5.0 (ci-fix 9630630bdb) last updated 2017/10/11 23:47:08 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
