### PR TITLE
Only install pyvmomi if user is root

### DIFF
--- a/test/integration/targets/vmware_cluster/tasks/main.yml
+++ b/test/integration/targets/vmware_cluster/tasks/main.yml
@@ -20,6 +20,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_datacenter/tasks/main.yml
+++ b/test/integration/targets/vmware_datacenter/tasks/main.yml
@@ -20,6 +20,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -20,6 +20,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -20,6 +20,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_guest_find/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_find/tasks/main.yml
@@ -6,6 +6,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -7,6 +7,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_host/tasks/main.yml
+++ b/test/integration/targets/vmware_host/tasks/main.yml
@@ -20,6 +20,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_maintenancemode/tasks/main.yml
+++ b/test/integration/targets/vmware_maintenancemode/tasks/main.yml
@@ -7,6 +7,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/test/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -20,6 +20,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -21,6 +21,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:

--- a/test/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/test/integration/targets/vmware_vswitch/tasks/main.yml
@@ -7,6 +7,7 @@
   pip:
     name: pyvmomi
     state: latest
+  when: "{{ ansible_user_id == 'root' }}"
 
 - name: store the vcenter container ip
   set_fact:


### PR DESCRIPTION
##### SUMMARY
Makes testing the vmware targets outside of docker much easier.

```shell
ansible-test integration -vvvv --allow-destructive vmware_.*
```

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
vmware test targets

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


