### PR TITLE
vmware_vm_facts: Add error check for config.vm

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_facts.py
@@ -72,9 +72,10 @@ def get_all_virtual_machines(content):
             if _ip_address is None:
                 _ip_address = ""
         _mac_address = []
-        for dev in vm.config.hardware.device:
-            if isinstance(dev, vim.vm.device.VirtualEthernetCard):
-                _mac_address.append(dev.macAddress)
+        if vm.config is not None:
+            for dev in vm.config.hardware.device:
+                if isinstance(dev, vim.vm.device.VirtualEthernetCard):
+                    _mac_address.append(dev.macAddress)
 
         virtual_machine = {
             summary.config.name: {


### PR DESCRIPTION
Add a simple check to see if vm.config exists before looking for
vm.config.hardware

##### SUMMARY
I had a dangling inaccessible VM in my host which didn't return a mac address.
This resulted in an error:
     'NoneType' object has no attribute 'hardware'
which I traced to this section as vm.config was None.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = ['/home/zkakakhel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 17 2016, 17:05:23) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
