### PR TITLE
Add addtional fact gathering to vmware modules

### DIFF
--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -42,6 +42,13 @@
 
 - set_fact: dc1="{{ datacenters['json'][0] }}"
 
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
+
+- set_fact: h1="{{ hosts['json'][0] }}"
+
 - name: get a list of virtual machines from vcsim
   uri:
     url: http://{{ vcsim }}:5000/govc_find?filter=VM
@@ -68,6 +75,8 @@
       - "guest_facts_0001['instance']['hw_name'] == vm1 | basename"
       - "guest_facts_0001['instance']['hw_product_uuid'] is defined"
       - "guest_facts_0001['instance']['hw_cores_per_socket'] is defined"
+      - "guest_facts_0001['instance']['hw_datastores'] is defined"
+      - "guest_facts_0001['instance']['hw_esxi_host'] == h1 | basename"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
 
@@ -154,3 +163,4 @@
       - "guest_facts_0004['instance']['snapshots'][0]['name'] == 'snap1'"
       - "guest_facts_0004['instance']['snapshots'][1]['name'] == 'snap2'"
       - "guest_facts_0004['instance']['current_snapshot']['name'] == 'snap2'"
+      - "guest_facts_0002['instance']['hw_folder'] == vm1 | dirname"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add more facts to the fact gathering.  datastores, esxi_host, vm files,
ha state, question, is_template, consolidation status and folder path to VM.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vmware_facts_enhance 2c63a9d9be) last updated 2017/10/12 12:56:09 (GMT +000)
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible/lib/ansible
  executable location = /home/ec2-user/ansible/bin/ansible
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
In addition to the below, hw_files will contain a list of files that comprise the vm, such as the .vmdk, .vmsd, snapshots, logs, etc.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ok: [testhost] => {
    "msg": {
        "changed": false, 
        "failed": false, 
        "instance": {
            "annotation": null, 
            "current_snapshot": null, 
            "customvalues": {}, 
            "guest_consolidation_needed": false, 
            "guest_question": null, 
            "guest_tools_status": null, 
            "guest_tools_version": null, 
            "hw_datastores": [
                "LocalDS_0"
            ], 
            "hw_esxi_host": "DC0_H0", 
            "hw_eth0": {
                "addresstype": "generated", 
                "ipaddresses": null, 
                "label": "ethernet-0", 
                "macaddress": "00:0c:29:12:f4:4c", 
                "macaddress_dash": "00-0c-29-12-f4-4c", 
                "summary": "DVSwitch: 2030c00a-9cbc-4d32-8a49-8c43b588b13d"
            }, 
            "hw_files": [], 
            "hw_folder": "/DC0/vm", 
            "hw_guest_full_name": null, 
            "hw_guest_ha_state": null, 
            "hw_guest_id": "otherGuest", 
            "hw_interfaces": [
                "eth0"
            ], 
            "hw_is_template": false, 
            "hw_memtotal_mb": 32, 
            "hw_name": "DC0_H0_VM0", 
            "hw_power_status": "poweredOff", 
            "hw_processor_count": 1, 
            "hw_product_uuid": "451ff635-d89a-44f0-bc11-0c8eb1980755", 
            "ipv4": null, 
            "ipv6": null, 
            "module_hw": true, 
            "snapshots": []
        }
    }
}
```
