### PR TITLE
Fix YAML inventory plugin on python 3.5

### DIFF
--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -61,8 +61,7 @@ class BaseInventoryPlugin(object):
     def verify_file(self, path):
         ''' Verify if file is usable by this plugin, base does minimal accessability check '''
 
-        b_path = to_bytes(path, errors='surrogate_or_strict')
-        return (os.path.exists(b_path) and os.access(b_path, os.R_OK))
+        return (os.path.exists(path) and os.access(path, os.R_OK))
 
     def get_cache_prefix(self, path):
         ''' create predictable unique prefix for plugin/inventory '''


### PR DESCRIPTION
##### SUMMARY
Without this fix, Ansible v2.4.0.0-1 (and later) fail to verify a YAML file using python 3.5, where python 2.7 works perfectly fine.

It seems the **os.path.exists** and **os.access** translate to **False** when used with **b_path** on python 3.5 for even simply values like `/tmp/demo.yaml`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
yaml inventory plugin

##### ANSIBLE VERSION
v2.4.0.0-1 and newer