### PR TITLE
ovirt_templates: wait for OK state when importing

### DIFF
--- a/lib/ansible/module_utils/ovirt.py
+++ b/lib/ansible/module_utils/ovirt.py
@@ -746,14 +746,14 @@ class BaseModule(object):
             'diff': self._diff,
         }
 
-    def wait_for_import(self):
+    def wait_for_import(self, condition=lambda e: True):
         if self._module.params['wait']:
             start = time.time()
             timeout = self._module.params['timeout']
             poll_interval = self._module.params['poll_interval']
             while time.time() < start + timeout:
                 entity = self.search_entity()
-                if entity:
+                if entity and condition(entity):
                     return entity
                 time.sleep(poll_interval)
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -351,7 +351,10 @@ def main():
                     ) if module.params['cluster'] else None,
                     **kwargs
                 )
-                template = templates_module.wait_for_import()
+                # Wait for template to appear in system:
+                template = templates_module.wait_for_import(
+                    condition=lambda t: t.status == otypes.TemplateStatus.OK
+                )
                 ret = {
                     'changed': True,
                     'id': template.id,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When importing a template we didn't waited for OK state of the template. This PR fixes it.
Fixes #31589

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_templates

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
