### PR TITLE
Allow module parameters of type 'list' to have choices

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1754,7 +1754,15 @@ class AnsibleModule(object):
                             if len(overlap) == 1:
                                 (param[k],) = overlap
 
-                        if param[k] not in choices:
+                        if isinstance(param[k], SEQUENCETYPE):
+                            invalid = set(param[k]).difference(choices)
+                            if invalid:
+                                choices_str = ",".join([to_native(c) for c in choices])
+                                msg = "values of %s must be one of: %s, got: %s" % (k, choices_str, ','.join(invalid))
+                                if self._options_context:
+                                    msg += " found in %s" % " -> ".join(self._options_context)
+                                self.fail_json(msg=msg)
+                        elif param[k] not in choices:
                             choices_str = ",".join([to_native(c) for c in choices])
                             msg = "value of %s must be one of: %s, got: %s" % (k, choices_str, param[k])
                             if self._options_context:

--- a/test/integration/targets/argument_spec/aliases
+++ b/test/integration/targets/argument_spec/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/argument_spec/library/wildcard.py
+++ b/test/integration/targets/argument_spec/library/wildcard.py
@@ -1,0 +1,19 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
+
+# This module accepts input directly as options to AnsibleModule,
+# allowing one to mimic every behaviour from a module directly by calling it
+
+from ansible.module_utils.basic import AnsibleModule, _load_params
+
+params = _load_params()
+
+# Add argument_spec itself
+params['argument_spec'].update(dict(argument_spec=dict(type='dict')))
+
+module = AnsibleModule(
+    argument_spec=params['argument_spec'],
+)
+
+module.exit_json(params=params)

--- a/test/integration/targets/argument_spec/tasks/main.yml
+++ b/test/integration/targets/argument_spec/tasks/main.yml
@@ -1,0 +1,58 @@
+# Copyright: (c) 2017, Dag Wieers (@dagwieers) <dag@wieers.com>
+
+- name: Single list item part of choices
+  wildcard:
+    argument_spec:
+      list_example:
+        type: list
+        choices: [ alpha, beta, gamma ]
+    list_example: alpha
+  register: list_choices_1
+
+- assert:
+    that:
+    - list_choices_1|success
+
+- name: Two list items part of choices
+  wildcard:
+    argument_spec:
+      list_example:
+        type: list
+        choices: [ alpha, beta, gamma ]
+    list_example: alpha,beta
+  register: list_choices_2
+
+- assert:
+    that:
+    - list_choices_2|success
+
+- name: Three list items part of choices
+  wildcard:
+    argument_spec:
+      list_example:
+        type: list
+        choices: [ alpha, beta, gamma ]
+    list_example:
+    - alpha
+    - beta
+    - gamma
+  register: list_choices_3
+
+- assert:
+    that:
+    - list_choices_3|success
+
+- name: One list item is not part of choices
+  wildcard:
+    argument_spec:
+      list_example:
+        type: list
+        choices: [ alpha, beta, gamma ]
+    list_example: alpha,omega
+  ignore_errors: yes
+  register: list_choices_4
+
+- assert:
+    that:
+    - list_choices_4|failed
+    - 'list_choices_4.msg == "values of list_example must be one of: alpha,beta,gamma, got: omega"'


### PR DESCRIPTION
##### SUMMARY
So some modules have parameters that allow a combination of options to be specified. Currently the argument_spec fails when one defines a parameter of type 'list' with a set of choices.

This implementation tests if the provided list of values are allowed values from the list of choices. This simplifies the argument spec of various modules.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/basic.py

##### ANSIBLE VERSION
v2.4