### PR TITLE
vmware_guest - Apply fix to allow the root resource pool of a cluster to be chosen

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1198,17 +1198,24 @@ class PyVmomiHelper(PyVmomi):
         return root
 
     def get_resource_pool(self):
-
         resource_pool = None
-
-        if self.params['esxi_hostname']:
+        # highest priority, resource_pool given.
+        if self.params['resource_pool']:
+            resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
+        # next priority, esxi hostname given.
+        elif self.params['esxi_hostname']:
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
+        # next priority, cluster given, take the root of the pool
+        elif self.params['cluster']:
+            cluster = self.cache.get_cluster(self.params['cluster'])
+            resource_pool = cluster.resourcePool
+        # fallback, pick any RP
         else:
             resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
 
         if resource_pool is None:
-            self.module.fail_json(msg='Unable to find resource pool "%(resource_pool)s"' % self.params)
+            self.module.fail_json(msg='Unable to find resource pool, need esxi_hostname, resource_pool, or cluster')
 
         return resource_pool
 

--- a/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -1,0 +1,259 @@
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=2&pool=2&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of VMS from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vmlist
+
+- name: get a list of clusters from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=CCR
+  register: clusts
+
+- name: get a list of resource pools from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=RP
+  register: res_pools
+
+- name: get a list of hosts from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=H
+  register: hosts
+
+- debug: var=vcsim_instance
+- debug: var=vmlist
+- debug: var=res_pools
+- debug: var=clusts
+- debug: var=hosts
+
+# Create one with the defaults
+- name: create new VM with default resource pool
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rp_d1_c1_f0
+
+- debug: var=clone_rp_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "clone_rp_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+- name: delete the new VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    #guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    state: absent
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rp_d1_c1_f0_delete
+
+- debug: var=clone_rp_d1_c1_f0_delete
+
+- name: assert that changes were made with deletion
+  assert:
+    that:
+        - "clone_rp_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+
+# now create with just a cluster
+- name: create new VM with default resource pool in cluster
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    cluster: "{{ clusts['json'][0]|basename }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rpc_d1_c1_f0
+
+- debug: var=clone_rpc_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "clone_rpc_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+- name: delete the new VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    #guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    cluster: "{{ clusts['json'][0]|basename }}"
+    state: absent
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rpc_d1_c1_f0_delete
+
+- debug: var=clone_rpc_d1_c1_f0_delete
+
+- name: assert that changes were made with deletion
+  assert:
+    that:
+        - "clone_rpc_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+
+# now create with a specific resource pool
+- name: create new VM with specific resource pool in cluster
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    cluster: "{{ clusts['json'][0]|basename }}"
+    resource_pool: "{{ res_pools['json'][2]|basename }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rpcp_d1_c1_f0
+
+- debug: var=clone_rpcp_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "clone_rpcp_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+- name: delete the new VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    #guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    cluster: "{{ clusts['json'][0]|basename }}"
+    state: absent
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rpcp_d1_c1_f0_delete
+
+- debug: var=clone_rpcp_d1_c1_f0_delete
+
+- name: assert that changes were made with deletion
+  assert:
+    that:
+        - "clone_rpcp_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"
+
+# now create with a specific host
+- name: create new VM with specific host
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    esxi_hostname: "{{ hosts['json'][0]|basename }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    state: poweredoff
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rph_d1_c1_f0
+
+- debug: var=clone_rph_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+      - "clone_rph_d1_c1_f0.results|map(attribute='changed')|unique|list == [true]"
+
+- name: delete the new VMs
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ 'newvm_' + item|basename }}"
+    #template: "{{ item|basename }}"
+    #guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    state: absent
+    folder: "{{ item|dirname }}"
+  with_items: "{{ vmlist['json'][0] }}"
+  register: clone_rph_d1_c1_f0_delete
+
+- debug: var=clone_rph_d1_c1_f0_delete
+
+- name: assert that changes were made with deletion
+  assert:
+    that:
+        - "clone_rph_d1_c1_f0_delete.results|map(attribute='changed')|unique|list == [true]"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -14,3 +14,4 @@
 - include: clone_d1_c1_f0.yml
 - include: create_d1_c1_f0.yml
 - include: cdrom_d1_c1_f0.yml
+- include: create_rp_d1_c1_f0.yml


### PR DESCRIPTION
vmware_guest - Apply fix to allow the root resource pool of a cluster to be chosen. Fixes #28394 Fixes #30879 

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Implements the following behavior when picking a resource pool:

  1)  if a resource pool is specified by name, use that
  2)  If esxi_hostname is given, pick resource pool from that.
  3)  if cluster is given, pick the root resource pool of that cluster
  4)  if all else fails, fall back to the current behavior and just pick a resource pool

Includes integration test for resource pool selection

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vmware_guest_set_rp 49494d06a1) last updated 2017/10/12 15:00:13 (GMT +000)
  config file = None
  configured module search path = [u'/home/ec2-user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ec2-user/ansible/lib/ansible
  executable location = /home/ec2-user/ansible/bin/ansible
  python version = 2.7.12 (default, Sep  1 2016, 22:14:00) [GCC 4.8.3 20140911 (Red Hat 4.8.3-9)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Replaces the following PRs:  #31136 #31257 #31139
See also: https://github.com/ansible/community/issues/233

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
