### PR TITLE
ec2: get reserved instances matching the state specified fixes #30168

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -639,13 +639,18 @@ except ImportError:
 
 def find_running_instances_by_count_tag(module, ec2, vpc, count_tag, zone=None):
 
-    # get reservations for instances that match tag(s) and are running
-    reservations = get_reservations(module, ec2, vpc, tags=count_tag, state="running", zone=zone)
+    # get reservations for instances that match tag(s) and are in the desired state
+    state = module.params.get('state')
+    if state not in ['running', 'stopped']:
+        state = None
+    reservations = get_reservations(module, ec2, vpc, tags=count_tag, state=state, zone=zone)
 
     instances = []
     for res in reservations:
         if hasattr(res, 'instances'):
             for inst in res.instances:
+                if inst.state == 'terminated':
+                    continue
                 instances.append(inst)
 
     return reservations, instances


### PR DESCRIPTION
##### SUMMARY
Original PR: https://github.com/ansible/ansible-modules-core/pull/1484

Fixes #30168

If state is 'present' or 'stopped' rather than running, shouldn't only get reserved instances that are running. Fixes an issue where exact count would create new instances if the instance state is stopped or terminated.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.5.0
```
