### PR TITLE
Add 'apply' state, statefulset resource to kubernetes module

### DIFF
--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -346,7 +346,7 @@ def main():
         mutually_exclusive=(('file_reference', 'inline_data'),
                             ('url_username', 'insecure'),
                             ('url_password', 'insecure')),
-        required_one_of=(('file_reference', 'inline_data')),
+        required_one_of=[['file_reference', 'inline_data']],
     )
 
     if not HAS_LIB_YAML:

--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -219,6 +219,7 @@ KIND_URL = {
     "horizontalpodautoscaler": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",  # NOQA
     "ingress": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
     "job": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
+    "statefulset": "/apis/apps/v1beta1/namespaces/{namespace}/statefulsets",
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 


### PR DESCRIPTION
##### SUMMARY
* Add apply state to kubernetes module

When using ansible for creating and updating cluster
resources, we'd like to have only one task which will
either create or update the resource.
Right now, using 'present' with a resource that already
exists will fail the task. Using 'update' with a resource
that does not exist yet will fail.
'apply' is similar to 'kubectl apply -f' and will either
create or update the resource.

* Fix required_one_of assignment

Having (()) generates the following error:

"msg": "one of the following is required: f,i,l,e,_,r,e,f,e,r,e,n,c,e"

* Add statefulset resource to kubernetes module
##### ISSUE TYPE
 - Module Pull Request
 - Module Bugfix Pull Request

##### COMPONENT NAME
kubernetes

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/<myname>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.0.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```
