### PR TITLE
Make RPM spec compatible with RHEL 6

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -3,8 +3,6 @@
 
 %if 0%{?rhel} == 5
 %define __python2 /usr/bin/python26
-%else 0%{?rhel} == 6
-%define __python2 /usr/bin/python2
 %endif
 
 Name:      %{name}
@@ -16,6 +14,7 @@ License:   GPLv3+
 Group:     Development/Libraries
 Source:    http://releases.ansible.com/ansible/%{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
+%{!?__python2: %global __python2 /usr/bin/python2.6}
 %{!?python_sitelib: %global python_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
 
 BuildArch: noarch

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -2,7 +2,9 @@
 %define ansible_version $VERSION
 
 %if 0%{?rhel} == 5
-%define __python /usr/bin/python26
+%define __python2 /usr/bin/python26
+%else 0%{?rhel} == 6
+%define __python2 /usr/bin/python2
 %endif
 
 Name:      %{name}


### PR DESCRIPTION
##### SUMMARY
Specify location of Python2 interpreter on RHEL 6 since it is not a default RPM macro.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
packaging

##### ADDITIONAL INFORMATION
The RPM spec was changed to reference __python2, an RPM macro that points to the Python2 interpreter in RHEL 7. However, this broke RPM builds on RHEL 6 since __python2 is not a default RPM macro and was therefore undefined in the spec.
