### PR TITLE
aws_s3: require src when mode is 'put' - fixes #30223

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -598,6 +598,7 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=[('mode', 'put', ('src',))],
     )
 
     if module._name == 's3':


### PR DESCRIPTION
##### SUMMARY
Fixes #30223.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
2.5.0
```
