### PR TITLE
Deleted api_version from compute_client

### DIFF
--- a/contrib/inventory/azure_rm.py
+++ b/contrib/inventory/azure_rm.py
@@ -444,8 +444,7 @@ class AzureRM(object):
             self._compute_client = ComputeManagementClient(
                 self.azure_credentials,
                 self.subscription_id,
-                base_url=self._cloud_environment.endpoints.resource_manager,
-                api_version='2017-03-30'
+                base_url=self._cloud_environment.endpoints.resource_manager
             )
             self._register('Microsoft.Compute')
         return self._compute_client


### PR DESCRIPTION
##### SUMMARY

compute_client does not accept api_version as argument parameter.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
```
$ python ./ansible/contrib/inventory/azure_rm.py --list | jq
Traceback (most recent call last):
  File "./ansible/contrib/inventory/azure_rm.py", line 859, in <module>
    main()
  File "./ansible/contrib/inventory/azure_rm.py", line 855, in main
    AzureInventory()
  File "./ansible/contrib/inventory/azure_rm.py", line 465, in __init__
    self._compute_client = rm.compute_client
  File "./ansible/contrib/inventory/azure_rm.py", line 448, in compute_client
    api_version = '2017-03-30'
TypeError: __init__() got an unexpected keyword argument 'api_version'
```
