### PR TITLE
ec2_elb: make ec2_elb idempotent when deregistering instances - fixes #30230

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_elb.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_elb.py
@@ -133,6 +133,10 @@ class ElbManager:
                 # balancer. Ignore it and try the next one.
                 continue
 
+            # The instance is not associated with any load balancer so nothing to do
+            if not self._get_instance_lbs():
+                return
+
             lb.deregister_instances([self.instance_id])
 
             # The ELB is changing state in some way. Either an instance that's


### PR DESCRIPTION
##### SUMMARY
Fixes #30230.

Don't try to deregister and instance unless it is registered to a load balancer. Fixes change always True when deregistering non-registered instances.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_elb

##### ANSIBLE VERSION
```
2.5.0
```