### PR TITLE
Prefix `ssm_parameter_store` module and `ssm` lookup with aws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,13 @@ Ansible Changes By Release
   `ansible_diff_mode`, `ansible_inventory_sources`, `ansible_limit`, `ansible_run_tags` , `ansible_forks` and `ansible_skip_tags`
 * Updated the bundled copy of the six library to 1.11.0
 * Added support to `become` `NT AUTHORITY\System`, `NT AUTHORITY\LocalService`, and `NT AUTHORITY\NetworkService` on Windows hosts
+* Added `aws_ssm` lookup plugin
 
 ### New Modules
+
+#### Cloud
+
+  * aws_ssm_parameter_store
 
 #### Windows
 

--- a/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
+++ b/lib/ansible/modules/cloud/amazon/aws_ssm_parameter_store.py
@@ -1,25 +1,14 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
 
 DOCUMENTATION = '''
 ---
-module: ssm_parameter_store
+module: aws_ssm_parameter_store
 short_description: Manage key-value pairs in aws parameter store.
 description:
   - Manage key-value pairs in aws parameter store.
@@ -78,25 +67,25 @@ requirements: [ botocore, boto3 ]
 
 EXAMPLES = '''
 - name: Create or update key/value pair in aws parameter store
-  ssm_parameter_store:
+  aws_ssm_parameter_store:
     name: "Hello"
     description: "This is your first key"
     value: "World"
 
 - name: Delete the key
-  ssm_parameter_store:
+  aws_ssm_parameter_store:
     name: "Hello"
     state: absent
 
 - name: Create or update secure key/value pair with default kms key (aws/ssm)
-  ssm_parameter_store:
+  aws_ssm_parameter_store:
     name: "Hello"
     description: "This is your first key"
     string_type: "SecureString"
     value: "World"
 
 - name: Create or update secure key/value pair with nominated kms key
-  ssm_parameter_store:
+  aws_ssm_parameter_store:
     name: "Hello"
     description: "This is your first key"
     string_type: "SecureString"

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -1,19 +1,6 @@
 # (c) 2016, Bill Wang <ozbillwang(at)gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -34,22 +21,22 @@ class LookupModule(LookupBase):
         '''
         # lookup sample:
         - name: lookup ssm parameter store in the current region
-          debug: msg="{{ lookup('ssm', 'Hello' ) }}"
+          debug: msg="{{ lookup('aws_ssm', 'Hello' ) }}"
 
         - name: lookup a key which doesn't exist, return ""
-          debug: msg="{{ lookup('ssm', 'NoKey') }}"
+          debug: msg="{{ lookup('aws_ssm', 'NoKey') }}"
 
         - name: lookup ssm parameter store in nominated region
-          debug: msg="{{ lookup('ssm', 'Hello', 'region=us-east-2' ) }}"
+          debug: msg="{{ lookup('aws_ssm', 'Hello', 'region=us-east-2' ) }}"
 
         - name: lookup ssm parameter store without decrypted
-          debug: msg="{{ lookup('ssm', 'Hello', 'decrypt=False' ) }}"
+          debug: msg="{{ lookup('aws_ssm', 'Hello', 'decrypt=False' ) }}"
 
         - name: lookup ssm parameter store in nominated aws profile
-          debug: msg="{{ lookup('ssm', 'Hello', 'aws_profile=myprofile' ) }}"
+          debug: msg="{{ lookup('aws_ssm', 'Hello', 'aws_profile=myprofile' ) }}"
 
         - name: lookup ssm parameter store with all options.
-          debug: msg="{{ lookup('ssm', 'Hello', 'decrypt=false', 'region=us-east-2', 'aws_profile=myprofile') }}"
+          debug: msg="{{ lookup('aws_ssm', 'Hello', 'decrypt=false', 'region=us-east-2', 'aws_profile=myprofile') }}"
         '''
 
         ret = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aws_ssm_parameter_store

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (ssm dfb773bde8) last updated 2017/10/12 15:52:39 (GMT -400)
  config file = None
  configured module search path = [u'/home/ryansb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /tmp/ansible/lib/ansible
  executable location = /tmp/ansible/bin/ansible
  python version = 2.7.12 (default, Sep 27 2016, 18:08:33) [GCC 6.2.1 20160916 (Red Hat 6.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This module was merged with a name that's too general (ssm) and needs to be prefixed with `aws_` to be unique. 
