### PR TITLE
Add module ldap_attrs; deprecate ldap_attr

### DIFF
--- a/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/_ldap_attr.py
@@ -36,7 +36,10 @@ notes:
     possible to see spurious changes when target and actual values are
     semantically identical but lexically distinct.
 version_added: '2.3'
-deprecated: Deprecated in 2.9. Use M(ldap_attrs) instead.
+deprecated:
+  removed_in: '2.12'
+  why: 'The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies..'
+  alternative: 'Use M(ldap_attrs) instead. Deprecated in 2.9. Use M(ldap_attrs) instead.'
 author:
   - Jiri Tyr (@jtyr)
 requirements:

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright: (c) 2017, Alexander Korinek <noles@a3k.net>
 # Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
@@ -8,18 +9,20 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['deprecated'],
+    'status': ['preview'],
     'supported_by': 'community'
 }
 
+
 DOCUMENTATION = r'''
 ---
-module: ldap_attr
-short_description: Add or remove LDAP attribute values
+module: ldap_attrs
+short_description: Add or remove multiple LDAP attribute values.
 description:
-  - Add or remove LDAP attribute values.
+  - Add or remove multiple LDAP attribute values.
 notes:
   - This only deals with attributes on existing entries. To add or remove
     whole entries, see M(ldap_entry).
@@ -35,34 +38,29 @@ notes:
     rules. This should work out in most cases, but it is theoretically
     possible to see spurious changes when target and actual values are
     semantically identical but lexically distinct.
-version_added: '2.3'
-deprecated: Deprecated in 2.9. Use M(ldap_attrs) instead.
+version_added: '2.9'
 author:
   - Jiri Tyr (@jtyr)
+  - Alexander Korinek (@noles)
 requirements:
   - python-ldap
 options:
-  name:
-    description:
-      - The name of the attribute to modify.
-    type: str
-    required: true
   state:
-    description:
-      - The state of the attribute values.
-      - If C(present), all given values will be added if they're missing.
-      - If C(absent), all given values will be removed if present.
-      - If C(exact), the set of values will be forced to exactly those provided and no others.
-      - If I(state=exact) and I(value) is an empty list, all values for this attribute will be removed.
-    choices: [ absent, exact, present ]
+    required: false
+    choices: [present, absent, exact]
     default: present
-  values:
     description:
-      - The value(s) to add or remove. This can be a string or a list of
-        strings. The complex argument format is required in order to pass
-        a list of strings (see examples).
-    type: raw
+      - The state of the attribute values. If C(present), all given
+        values will be added if they're missing. If C(absent), all given
+        values will be removed if present. If C(exact), the set of values
+        will be forced to exactly those provided and no others. If
+        I(state=exact) and I(value) is empty, all values for this
+        attribute will be removed.
+  attributes:
     required: true
+    description:
+      - The attribute(s) and value(s) to add or remove. The complex argument format is required in order to pass
+        a list of strings (see examples).
   params:
     description:
     - Additional module parameters.
@@ -71,56 +69,54 @@ extends_documentation_fragment:
 - ldap.documentation
 '''
 
+
 EXAMPLES = r'''
 - name: Configure directory number 1 for example.com
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: olcSuffix
-    values: dc=example,dc=com
+    attributes:
+        olcSuffix: dc=example,dc=com
     state: exact
 
 # The complex argument format is required here to pass a list of ACL strings.
 - name: Set up the ACL
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: olcAccess
-    values:
-      - >-
-        {0}to attrs=userPassword,shadowLastChange
-        by self write
-        by anonymous auth
-        by dn="cn=admin,dc=example,dc=com" write
-        by * none'
-      - >-
-        {1}to dn.base="dc=example,dc=com"
-        by dn="cn=admin,dc=example,dc=com" write
-        by * read
+    attributes:
+        olcAccess:
+          - >-
+            {0}to attrs=userPassword,shadowLastChange
+            by self write
+            by anonymous auth
+            by dn="cn=admin,dc=example,dc=com" write
+            by * none'
+          - >-
+            {1}to dn.base="dc=example,dc=com"
+            by dn="cn=admin,dc=example,dc=com" write
+            by * read
     state: exact
 
 - name: Declare some indexes
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: olcDbIndex
-    values: "{{ item }}"
-  with_items:
-    - objectClass eq
-    - uid eq
+    attributes:
+        olcDbIndex:
+            - objectClass eq
+            - uid eq
 
 - name: Set up a root user, which we can use later to bootstrap the directory
-  ldap_attr:
+  ldap_attrs:
     dn: olcDatabase={1}hdb,cn=config
-    name: "{{ item.key }}"
-    values: "{{ item.value }}"
+    attributes:
+        olcRootDN: cn=root,dc=example,dc=com
+        olcRootPW: "{SSHA}tabyipcHzhwESzRaGA7oQ/SDoBZQOGND"
     state: exact
-  with_dict:
-    olcRootDN: cn=root,dc=example,dc=com
-    olcRootPW: "{SSHA}tabyipcHzhwESzRaGA7oQ/SDoBZQOGND"
 
 - name: Get rid of an unneeded attribute
-  ldap_attr:
+  ldap_attrs:
     dn: uid=jdoe,ou=people,dc=example,dc=com
-    name: shadowExpire
-    values: []
+    attributes:
+        shadowExpire: ""
     state: exact
     server_uri: ldap://localhost/
     bind_dn: cn=admin,dc=example,dc=com
@@ -135,13 +131,14 @@ EXAMPLES = r'''
 #   bind_dn: cn=admin,dc=example,dc=com
 #   bind_pw: password
 - name: Get rid of an unneeded attribute
-  ldap_attr:
+  ldap_attrs:
     dn: uid=jdoe,ou=people,dc=example,dc=com
-    name: shadowExpire
-    values: []
+    attributes:
+        shadowExpire: ""
     state: exact
     params: "{{ ldap_auth }}"
 '''
+
 
 RETURN = r'''
 modlist:
@@ -167,82 +164,91 @@ except ImportError:
     HAS_LDAP = False
 
 
-class LdapAttr(LdapGeneric):
+class LdapAttrs(LdapGeneric):
     def __init__(self, module):
         LdapGeneric.__init__(self, module)
 
         # Shortcuts
-        self.name = self.module.params['name']
+        self.attrs = self.module.params['attributes']
         self.state = self.module.params['state']
 
-        # Normalize values
-        if isinstance(self.module.params['values'], list):
-            self.values = list(map(to_bytes, self.module.params['values']))
+
+        # Establish connection
+        self.connection = self._connect_to_ldap()
+
+    def _normalize_values(self, values):
+        """ Normalize attribute's values. """
+        norm_values = []
+
+        if isinstance(values, list):
+            norm_values = list(map(to_bytes, values))
         else:
-            self.values = [to_bytes(self.module.params['values'])]
+            norm_values = [to_bytes(values)]
+
+        return norm_values
 
     def add(self):
-        values_to_add = list(filter(self._is_value_absent, self.values))
-
-        if len(values_to_add) > 0:
-            modlist = [(ldap.MOD_ADD, self.name, values_to_add)]
-        else:
-            modlist = []
+        modlist = []
+        for name, values in self.module.params['attributes'].items():
+            norm_values = self._normalize_values(values)
+            for value in norm_values:
+                if self._is_value_absent(name, value):
+                    modlist.append((ldap.MOD_ADD, name, value))
 
         return modlist
 
     def delete(self):
-        values_to_delete = list(filter(self._is_value_present, self.values))
-
-        if len(values_to_delete) > 0:
-            modlist = [(ldap.MOD_DELETE, self.name, values_to_delete)]
-        else:
-            modlist = []
+        modlist = []
+        for name, values in self.module.params['attributes'].items():
+            norm_values = self._normalize_values(values)
+            for value in norm_values:
+                if self._is_value_present(name, value):
+                    modlist.append((ldap.MOD_DELETE, name, value))
 
         return modlist
 
     def exact(self):
-        try:
-            results = self.connection.search_s(
-                self.dn, ldap.SCOPE_BASE, attrlist=[self.name])
-        except ldap.LDAPError as e:
-            self.fail("Cannot search for attribute %s" % self.name, e)
-
-        current = results[0][1].get(self.name, [])
         modlist = []
+        for name, values in self.module.params['attributes'].items():
+            norm_values = self._normalize_values(values)
+            try:
+                results = self.connection.search_s(
+                    self.dn, ldap.SCOPE_BASE, attrlist=[name])
+            except ldap.LDAPError as e:
+                self.fail("Cannot search for attribute %s" % self.name, e)
 
-        if frozenset(self.values) != frozenset(current):
-            if len(current) == 0:
-                modlist = [(ldap.MOD_ADD, self.name, self.values)]
-            elif len(self.values) == 0:
-                modlist = [(ldap.MOD_DELETE, self.name, None)]
-            else:
-                modlist = [(ldap.MOD_REPLACE, self.name, self.values)]
+            current = results[0][1].get(name, [])
+
+            if frozenset(norm_values) != frozenset(current):
+                if len(current) == 0:
+                    modlist.append((ldap.MOD_ADD, name, norm_values))
+                elif len(norm_values) == 0:
+                    modlist.append((ldap.MOD_DELETE, name, None))
+                else:
+                    modlist.append((ldap.MOD_REPLACE, name, norm_values))
 
         return modlist
 
-    def _is_value_present(self, value):
+    def _is_value_present(self, name, value):
         """ True if the target attribute has the given value. """
         try:
             is_present = bool(
-                self.connection.compare_s(self.dn, self.name, value))
+                self.connection.compare_s(self.dn, name, value))
         except ldap.NO_SUCH_ATTRIBUTE:
             is_present = False
 
         return is_present
 
-    def _is_value_absent(self, value):
+    def _is_value_absent(self, name, value):
         """ True if the target attribute doesn't have the given value. """
-        return not self._is_value_present(value)
-
+        return not self._is_value_present(name, value)
 
 def main():
     module = AnsibleModule(
         argument_spec=gen_specs(
-            name=dict(type='str', required=True),
             params=dict(type='dict'),
+            attributes=dict(type='dict', required=True),
             state=dict(type='str', default='present', choices=['absent', 'exact', 'present']),
-            values=dict(type='raw', required=True),
         ),
         supports_check_mode=True,
     )
@@ -258,7 +264,7 @@ def main():
         module.params.pop('params', None)
 
     # Instantiate the LdapAttr object
-    ldap = LdapAttr(module)
+    ldap = LdapAttrs(module)
 
     state = module.params['state']
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attrs.py
@@ -172,10 +172,6 @@ class LdapAttrs(LdapGeneric):
         self.attrs = self.module.params['attributes']
         self.state = self.module.params['state']
 
-
-        # Establish connection
-        self.connection = self._connect_to_ldap()
-
     def _normalize_values(self, values):
         """ Normalize attribute's values. """
         norm_values = []
@@ -242,6 +238,7 @@ class LdapAttrs(LdapGeneric):
     def _is_value_absent(self, name, value):
         """ True if the target attribute doesn't have the given value. """
         return not self._is_value_present(name, value)
+
 
 def main():
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
The current "ldap_attr" module does not support ldap attribute insertations or deletions with objectClass dependencies.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
ldap_attrs


##### ANSIBLE VERSION
```
ansible 2.8.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/akorinek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
For example, if you have the following ldap entry:
```
dn: dc=test,dc=local
o: test.local
dc: test
objectClass: top
objectClass: dcObject
objectClass: organization
```
and you like to add:
```
gosaAclEntry: 0:subtree:Y249YWRtaW4sb3U9YWxjcm9sZXMsZGM9dGVzdCxkYz1sb2NhbAo=
 :dWlkPWZkLWFkbWluLG91PXBlb3BsZSxkYz10ZXN0LGRjPWxvY2FsCg==
```
you need the additional objectClass `gosaAcl`.

But because of the schema definition:
```
objectclass ( 1.3.6.1.4.1.10098.1.2.1.19.18 NAME 'gosaAcl'
  DESC 'GOsa - ACL container to define single ACLs'
  SUP top AUXILIARY
  MUST ( gosaAclEntry  ))
```

`gosaAclEntry` must be added on `gosaAcl` add as well.

With the `ldap_attr` module these insertation is not possible because every entry will be added one by one and can not be combined in one run. 
This results in:
`OBJECT_CLASS_VIOLATION: {'info': "object class 'gosaAcl' requires attribute 'gosaAclEntry'", 'desc': 'Object class violation'}`
and
`OBJECT_CLASS_VIOLATION: {'info': "attribute 'gosaAclEntry' not allowed", 'desc': 'Object class violation'}`

For backward compatibility I created a new module with different configuration parameters.