### PR TITLE
Remove cryptography version limit in Azure tests.

### DIFF
--- a/test/integration/targets/setup_azure/tasks/main.yml
+++ b/test/integration/targets/setup_azure/tasks/main.yml
@@ -1,8 +1,2 @@
-- name: install cryptography requirement
-  # preempt the installation of cryptography from requirements-azure.txt to limit the version installed
-  # requests[security] requires cryptography >= 1.3.4
-  # cryptography 2.1 requires pip 8.1.2+
-  command: pip install cryptography>=1.3.4,<2.1
-
 - pip:
     requirements: '{{ role_path }}/../../../../packaging/requirements/requirements-azure.txt'


### PR DESCRIPTION
##### SUMMARY

Remove cryptography version limit in Azure tests.

No longer needed now that cryptography 2.1.1 has been released.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Azure integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (azure-test 899ff681d7) last updated 2017/10/12 14:35:03 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
