### PR TITLE
Wait for VM state to reach poweredoff when state: shutdownguest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -156,6 +156,13 @@ options:
     - "vmware-tools needs to be installed on given virtual machine in order to work with this parameter."
     default: 'no'
     type: bool
+  state_change_timeout:
+    description:
+    - If the C(state) is set to C(shutdownguest), by default the module will return immediately after sending the shutdown signal.
+    - If this argument is set to a positive integer, the module will instead wait for the VM to reach the poweredoff state.
+    - The value sets a timeout in seconds for the module to wait for the state change.
+    default: 0
+    version_added: '2.6'
   snapshot_src:
     description:
     - Name of the existing snapshot to use to create a clone of a VM.
@@ -1887,6 +1894,7 @@ def main():
         esxi_hostname=dict(type='str'),
         cluster=dict(type='str'),
         wait_for_ip_address=dict(type='bool', default=False),
+        state_change_timeout=dict(type='int', default=0),
         snapshot_src=dict(type='str'),
         linked_clone=dict(type='bool', default=False),
         networks=dict(type='list', default=[]),
@@ -1946,7 +1954,7 @@ def main():
                 )
                 module.exit_json(**result)
             # set powerstate
-            tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'])
+            tmp_result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
             if tmp_result['changed']:
                 result["changed"] = True
             if not tmp_result["failed"]:


### PR DESCRIPTION
##### SUMMARY
The vmware_guest module supports the shutdownguest state, but the
vCenter API simply issues the shutdown guest command and immediately
terminates.  This poses a problem when attempting to follow up the
shutdown with a vCenter command that requires the VM to be off, as the
shutdown procedure may not have completed.

This change modifies the set_vm_powerstate method to wait for the power
state of the VM to update to poweredoff when using the shutdownguest
state.

Fixes issue #28498.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/vmware.py
vmware_guest

##### ANSIBLE VERSION
devel