### PR TITLE
Use the new Parallels servers for OS X in CI.

### DIFF
--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -40,7 +40,9 @@ case "${test_platform}" in
         ci_endpoint="https://14blg63h2i.execute-api.us-east-1.amazonaws.com"
         ;;
     "osx")
-        ci_endpoint="https://osx.testing.ansible.com"
+        ci_endpoint=$(curl -s 'https://s3.amazonaws.com/ansible-ci-files/ansible-test/parallels-endpoints.txt' \
+                    | python -c "import random, sys; print(random.choice(sys.stdin.read().splitlines()))")
+
         ;;
     *)
         echo "unsupported platform: ${test_platform}"


### PR DESCRIPTION
##### SUMMARY

Use the new Parallels servers for OS X in CI. The old server will soon be decommissioned.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.2.3.0 (ci-update-2.2 432303dace) last updated 2017/10/12 15:33:45 (GMT -700)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```
