### PR TITLE
Support 'termination protection' for cloudformation stacks

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -382,12 +382,8 @@ def update_termination_protection(module, cfn, stack_name, desired_termination_p
                 cfn.update_termination_protection(
                     EnableTerminationProtection=desired_termination_protection_state,
                     StackName=stack_name)
-                module.exit_json(msg="Termination protection on stack {0} updated.".format(stack_name), changed=True)
             except botocore.exceptions.ClientError as e:
                 module.fail_json(msg=boto_exception(e), exception=traceback.format_exc())
-        else:
-            module.exit_json(msg="Termination protection on stack {0} is already the requested value".format(stack_name),
-                changed=False)
 
 
 def boto_supports_termination_protection(cfn):
@@ -601,9 +597,10 @@ def main():
             result = create_stack(module, stack_params, cfn)
         elif module.params.get('create_changeset'):
             result = create_changeset(module, stack_params, cfn)
-        elif module.params.get('termination_protection') is not None:
-            update_termination_protection(module, cfn, stack_params['StackName'], bool(module.params.get('termination_protection')))
         else:
+            if module.params.get('termination_protection') is not None:
+                update_termination_protection(module, cfn, stack_params['StackName'],
+                                              bool(module.params.get('termination_protection')))
             result = update_stack(module, stack_params, cfn)
 
         # format the stack output

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -380,7 +380,7 @@ def update_termination_protection(module, stack_params, cfn):
                 module.exit_json(
                     msg="Termination protection on stack {0} updated.".format(stack_params['StackName']), changed=True)
             except botocore.exceptions.ClientError as e:
-                module.fail_json(msg=to_native(e))
+                module.fail_json(msg=boto_exception(e), exception=traceback.format_exc())
         else:
             module.exit_json(msg="Termination protection setting on stack {0} is already the requested value"
                 .format(stack_params['StackName']), changed=False)

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -297,7 +297,7 @@ def create_stack(module, stack_params, cfn):
     # 'disablerollback' and 'EnableTerminationProtection' only
     # apply on creation, not update.
     stack_params['DisableRollback'] = module.params['disable_rollback']
-    stack_params['EnableTerminationProtection'] = bool(module.params['termination_protection'])
+    stack_params['EnableTerminationProtection'] = bool(module.params.get('termination_protection'))
 
     try:
         cfn.create_stack(**stack_params)
@@ -589,8 +589,8 @@ def main():
             result = create_stack(module, stack_params, cfn)
         elif module.params.get('create_changeset'):
             result = create_changeset(module, stack_params, cfn)
-        elif module.params['termination_protection'] is not None:
-            update_termination_protection(module, cfn, stack_params['StackName'], module.params['termination_protection'])
+        elif module.params.get('termination_protection') is not None:
+            update_termination_protection(module, cfn, stack_params['StackName'], bool(module.params.get('termination_protection')))
         else:
             result = update_stack(module, stack_params, cfn)
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -392,11 +392,7 @@ def update_termination_protection(module, cfn, stack_name, desired_termination_p
 
 def boto_supports_termination_protection(cfn):
     '''termination protection was added in botocore 1.7.18'''
-    try:
-        getattr(cfn, "update_termination_protection")
-        return True
-    except AttributeError:
-        return False
+    return hasattr(cfn, "update_termination_protection")
 
 
 def stack_operation(cfn, stack_name, operation):


### PR DESCRIPTION
##### SUMMARY
Add support for Cloudformation stack termination protection

Fixes #31462

https://aws.amazon.com/blogs/mt/use-aws-cloudformation-stack-termination-protection-and-rollback-triggers-to-maintain-infrastructure-availability/
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
`cloudformation`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
  -->
This PR adds support for enabling/disabling `Termination Protection` for cloudformation stacks.
It adds a new option called `termination_protection`, which is a boolean value.

Termination protection can be enabled during stack creation for new stacks. For existing stacks, the option can be used to enable/disable termination protection. When this option is used for existing stacks, the task will only be used to change this particular setting. 

Stack deletion tasks do not read this option. That is, you can't disable the termination protection and delete the stack in the same task.
