### PR TITLE
galaxy: allow access token flag for installation

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -91,6 +91,7 @@ class GalaxyCLI(CLI):
                                    help='Ignore errors and continue with the next specified role.')
             self.parser.add_option('-n', '--no-deps', dest='no_deps', action='store_true', default=False, help='Don\'t download roles listed as dependencies')
             self.parser.add_option('-r', '--role-file', dest='role_file', help='A file containing a list of roles to be imported')
+            self.parser.add_option('-t', '--token', dest='install_token', help='Token to allow installation from private repos')
         elif self.action == "remove":
             self.parser.set_usage("usage: %prog remove role1 role2 ...")
         elif self.action == "list":
@@ -389,7 +390,10 @@ class GalaxyCLI(CLI):
                     continue
 
             try:
-                installed = role.install()
+                if self.options.install_token:
+                    installed = role.install(access_token=self.options.install_token)
+                else:
+                    installed = role.install()
             except AnsibleError as e:
                 display.warning("- %s was NOT installed successfully: %s " % (role.name, str(e)))
                 self.exit_without_ignore()

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -198,11 +198,13 @@ class GalaxyRole(object):
 
         return False
 
-    def install(self):
+    def install(self, access_token=None):
         # the file is a tar, so open it that way and extract it
         # to the specified (or default) roles directory
         local_file = False
-
+        if access_token is not None:
+            parts = self.src.split("://")
+            self.src = parts[0] + "://" + access_token + "@" + parts[1]
         if self.scm:
             # create tar file from scm url
             tmp_file = RoleRequirement.scm_archive_role(**self.spec)


### PR DESCRIPTION
Specifically, private repos are a little tough to clone from in
environments where you dont have an ssh key available to you.

These changes would allow one to supply a token during an ansible-galaxy
role installation.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I encountered some difficulties earlier today when trying to install my playbook's dependencies in our CI environment. While our CI environment doesn't allow us to embed ssh keys into it, we are able to pass in environment variables and clone from our internal vcs server. As an example, the method of:
```
git clone https://${OAUTH_TOKEN}:internal.vcs/user/repo.git
```

I thought that this might be a pretty simple flag to toss together to manipulate the `src` url when provided.

I think that there is probably a more elegant way to do the token injection, so I welcome any suggestions! 

I also found https://github.com/ansible/ansible/issues/17194 which seems to be related. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
galaxy

##### ANSIBLE VERSION
```
ansible 2.5.0 (galaxy_oauth_src_injection 094bf95ce8) last updated 2017/10/12 22:39:57 (GMT -400)
  config file = /Users/rwaweber/.ansible.cfg
  configured module search path = [u/Users/rwaweber/.ansible/plugins/modules, u/usr/share/ansible/plugins/modules]
  ansible python module location = /Users/rwaweber/code/ansible/lib/ansible
  executable location = /Users/rwaweber/.virtualenvs/galaxy_debug/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]

```


##### ADDITIONAL INFORMATION
I've tested this on my own [gogs](https://github.com/gogits/gogs) instance and plan to give it a shot on GHE at some point. I'm not sure if this is supported in mercurial, and this was not tested, though I did see it listed as a support scm; I'd be happy to throw some logic in there that only does this for git.
<!--- Paste verbatim command output below, e.g. before and after your change -->
Constant:
```
# cat requirements.yml
---
# public repository
- src: http://myhome.gogs.server/rwaweber/open-role.git
  version: 0.0.1
  scm: git
# private repository
- src: http://myhome.gogs.server/rwaweber/closed-role.git
  version: 0.0.1
  scm: git
```


Before(exiting out of a username and password prompt):
```
$ ansible-galaxy install -r requirements.yml -p roles

- extracting open-role to /Users/rwaweber/automation/roles/galaxy-space/roles/open-role
- open-role (0.0.1) was installed successfully
Username for http://myhome.gogs.server: ^C [ERROR]: User interrupted execution
```
After:
```
$ ansible-galaxy install -t $GOGS_TOKEN -r requirements.yml -p roles

- extracting open-role to /Users/demos/automation/roles/galaxy-space/roles/open-role
- open-role (0.0.1) was installed successfully
- extracting closed-role to /Users/demos/automation/roles/galaxy-space/roles/closed-role
- closed-role (0.0.1) was installed successfully
```