### PR TITLE
fix the order commands are sent in eos_user fixes #31680

### DIFF
--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -180,7 +180,7 @@ def map_obj_to_commands(updates, module):
         if want['state'] == 'absent':
             commands.append('no username %s' % want['name'])
             continue
-        
+
         if needs_update('configured_password'):
             if update_password == 'always' or not have:
                 add('secret %s' % want['configured_password'])
@@ -190,7 +190,7 @@ def map_obj_to_commands(updates, module):
 
         if needs_update('privilege'):
             add('privilege %s' % want['privilege'])
-        
+
         if needs_update('sshkey'):
             add('sshkey %s' % want['sshkey'])
 

--- a/lib/ansible/modules/network/eos/eos_user.py
+++ b/lib/ansible/modules/network/eos/eos_user.py
@@ -180,17 +180,17 @@ def map_obj_to_commands(updates, module):
         if want['state'] == 'absent':
             commands.append('no username %s' % want['name'])
             continue
+        
+        if needs_update('configured_password'):
+            if update_password == 'always' or not have:
+                add('secret %s' % want['configured_password'])
 
         if needs_update('role'):
             add('role %s' % want['role'])
 
         if needs_update('privilege'):
             add('privilege %s' % want['privilege'])
-
-        if needs_update('configured_password'):
-            if update_password == 'always' or not have:
-                add('secret %s' % want['configured_password'])
-
+        
         if needs_update('sshkey'):
             add('sshkey %s' % want['sshkey'])
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When using the eos_user module to create a new user and setting the privilege level the play would fail because the privilege level would set before the user would be created.  This fix insures the correct order of commands

fix the order commands are sent allowing for user attributes to be se…
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_user
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/dt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.11 (default, Nov 13 2016, 20:35:45) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before the change
```
fatal: [mn100]: FAILED! => {
    "changed": false,
    "code": 1000,
    "failed": true,
    "invocation": {
        "module_args": {
            "aggregate": null,
            "auth_pass": null,
            "authorize": false,
            "configured_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "host": "mn100",
            "name": "dt",
            "nopassword": null,
            "password": "",
            "port": 443,
            "privilege": 15,
            "provider": {
                "auth_pass": null,
                "authorize": false,
                "host": "mn100",
                "password": "",
                "port": 443,
                "ssh_keyfile": null,
                "timeout": 10,
                "transport": "eapi",
                "use_ssl": true,
                "username": "admin",
                "validate_certs": false
            },
            "purge": false,
            "role": null,
            "ssh_keyfile": null,
            "sshkey": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCUoCOc+YSyGj9/5K1dYDodwzNJ+7wFkgTyZ3NppTyBiQ96XqmjyEMI/mX58mfS8rm/1W4uPqUZiGmgPSPxmOOE5C9w5q3RRFoIMwrlmoEYFkax5Rn5A3egRrPg1SG2Ybi4lSikpzjLuA/fhGH5915AtApSM57r4v7mYyYrQuqdBGA+h8FlemfWrHqm5LkJMO+fD22A8yXNCS0Rzoo9mL0ZzQY/n5isp1giKJQjvqd2ONl7IohWTAQ7ZHmq9t8294FdepIzund6Iv3akbJ59PkGak1e1VF7jTYMX3bDoYUvA1zFl9YEHkQbgJIei2K1jFRFBZ+pTR8z/nTxT6+VECMZWW5vq25LQqLAqyH/tuXRDN8NLWV1Hkn984wX4UY9nbnjOrLih4gcMpeCHOxgFJmr6OUP6+CEJGi07tTFg1p9NQnCkq8zBEIxzT89ayS1EWutF4dbXMj5N1EEkffwQakGVMDDeqFZIEc98OajJRGf6xREUOMimvxLKCwHQeTVocHl7oTR8Ku2Tsjr5Kugf9X7gcH9tn4UTIS/oSAA/2rxFGww7ViUrBHNrnQDpFgRlZD4eTr8X4BhHvoFMhH94xz7R68BIwYq7HPudyKR01iWLWvnpvGv21/xcNDE8c9Qr0mqtJbdrGMNGNyCEPe55Z6ZU1/GmT4LcNzpM3W44Js7HQ== mcroff@wish.com",
            "state": "present",
            "timeout": 10,
            "transport": "cli",
            "update_password": "on_create",
            "url_password": "",
            "url_username": "admin",
  1 ---
            "use_ssl": true,
            "username": "admin",
            "validate_certs": false
        }
    },
    "msg": "CLI command 3 of 5 'username  willfail  privilege 15' failed: could not run command"
}
```
After the change
```
23:36:20 [dt:~/eosplus/cloud-deployment/ansible] develop(+6/-6)+* ± ansible-playbook -i hosts user.yaml  -vvvvv
ansible-playbook 2.4.0.0
  config file = None
  configured module search path = [u'/Users/dt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.11 (default, Nov 13 2016, 20:35:45) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
No config file found; using defaults
setting up inventory plugins
Parsed /Users/dt/eosplus/cloud-deployment/ansible/hosts inventory source with ini plugin
Loading callback plugin default of type stdout, v2.0 from /usr/local/lib/python2.7/site-packages/ansible/plugins/callback/__init__.pyc

PLAYBOOK: user.yaml *********************************************************************************************************************************************************************************
1 plays in user.yaml

PLAY [mn100] ****************************************************************************************************************************************************************************************
META: ran handlers

TASK [new user] *************************************************************************************************************************************************************************************
task path: /Users/dt/eosplus/cloud-deployment/ansible/user.yaml:7
<mn100> connection transport is eapi
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/basic.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/network_common.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/eos.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/six/__init__.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/_text.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/parsing/convert_bool.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/parsing/__init__.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/pycompat24.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/connection.py
Using module_utils file /usr/local/lib/python2.7/site-packages/ansible/module_utils/urls.py
Using module file /usr/local/lib/python2.7/site-packages/ansible/modules/network/eos/eos_user.py
<mn100> ESTABLISH LOCAL CONNECTION FOR USER: dt
<mn100> EXEC /bin/sh -c 'echo ~ && sleep 0'
<mn100> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304 `" && echo ansible-tmp-1507865782.98-129193525012304="` echo /Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304 `" ) && sleep 0'
<mn100> PUT /var/folders/vw/2_f0pb_s40z3gxbzqs3s55980000gp/T/tmpJJS2DD TO /Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304/eos_user.py
<mn100> EXEC /bin/sh -c 'chmod u+x /Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304/ /Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304/eos_user.py && sleep 0'
<mn100> EXEC /bin/sh -c '/usr/bin/python /Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304/eos_user.py; rm -rf "/Users/dt/.ansible/tmp/ansible-tmp-1507865782.98-129193525012304/" > /dev/null 2>&1 && sleep 0'
changed: [mn100] => {
    "changed": true,
    "commands": [
        "username willfail secret ********",
        "username willfail privilege 15"
    ],
    "failed": false,
    "invocation": {
        "module_args": {
            "aggregate": null,
            "auth_pass": null,
            "authorize": false,
            "configured_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "host": "mn100",
            "name": "willfail",
            "nopassword": null,
            "password": "",
            "port": 443,
            "privilege": 15,
            "provider": {
                "auth_pass": null,
                "authorize": false,
                "host": "mn100",
                "password": "",
                "port": 443,
                "ssh_keyfile": null,
                "timeout": 10,
                "transport": "eapi",
                "use_ssl": true,
                "username": "admin",
                "validate_certs": false
            },
            "purge": false,
            "role": null,
            "ssh_keyfile": null,
            "sshkey": null,
            "state": "present",
            "timeout": 10,
            "transport": "cli",
            "update_password": "on_create",
            "url_password": "",
            "url_username": "admin",
            "use_ssl": true,
            "username": "admin",
            "validate_certs": false
        }
    },
    "session_name": "ansible_1507865786"
```
