### PR TITLE
windows: add #AnsibleRequires for Windows modules

### DIFF
--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -794,7 +794,6 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
         min_os_version = None
         min_ps_version = None
 
-
         requires_module_list = re.compile(to_bytes(r'(?i)^#\s*requires\s+\-module(?:s?)\s*(Ansible\.ModuleUtils\..+)'))
         requires_become = re.compile(to_bytes('(?i)^#\s*ansiblerequires.*\-become'))
         requires_os_version = re.compile(to_bytes('(?i)^#\s*ansiblerequires.*\-osversion\s*(([0-9]+)\.([0-9]+))$'))

--- a/lib/ansible/executor/module_common.py
+++ b/lib/ansible/executor/module_common.py
@@ -626,9 +626,10 @@ def _find_module_utils(module_name, b_module_data, module_path, module_args, tas
     elif REPLACER_WINDOWS in b_module_data:
         module_style = 'new'
         module_substyle = 'powershell'
-        b_module_data = b_module_data.replace(REPLACER_WINDOWS, b'#Requires -Module Ansible.ModuleUtils.Legacy.psm1')
-    elif re.search(b'#Requires \-Module', b_module_data, re.IGNORECASE)\
-            or re.search(b'#AnsibleRequires \-', b_module_data, re.IGNORECASE):
+        b_module_data = b_module_data.replace(REPLACER_WINDOWS, b'#Requires -Module Ansible.ModuleUtils.Legacy')
+    elif re.search(b'#Requires \-Module', b_module_data, re.IGNORECASE) \
+            or re.search(b'#Requires \-Version', b_module_data, re.IGNORECASE)\
+            or re.search(b'#AnsibleRequires \-OSVersion', b_module_data, re.IGNORECASE):
         module_style = 'new'
         module_substyle = 'powershell'
     elif REPLACER_JSONARGS in b_module_data:

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -70,6 +70,26 @@ end {
 
     # TODO: handle binary modules
     # TODO: handle persistence
+    
+    $min_os_version = [version]$payload.min_os_version
+    if ($min_os_version -ne $null) {
+        $actual_os_version = [System.Environment]::OSVersion.Version
+        if ($actual_os_version -lt $min_os_version) {
+            $msg = "This module cannot run on this OS as it requires a minimum version of $min_os_version, actual was $actual_os_version"
+            Write-Output (ConvertTo-Json @{failed=$true;msg=$msg})
+            exit 1        
+        }    
+    }
+    
+    $min_ps_version = [version]$payload.min_ps_version
+    if ($min_ps_version -ne $null) {
+        $actual_ps_version = $PSVersionTable.PSVersion
+        if ($actual_ps_version -lt $min_ps_version) {
+            $msg = "This module cannot run as it requires a minimum PowerShell version of $min_ps_version, actual was $actual_ps_version"
+            Write-Output (ConvertTo-Json @{failed=$true;msg=$msg})
+            exit 1
+        }
+    }
 
     $actions = $payload.actions
 

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -70,17 +70,17 @@ end {
 
     # TODO: handle binary modules
     # TODO: handle persistence
-    
+
     $min_os_version = [version]$payload.min_os_version
     if ($min_os_version -ne $null) {
         $actual_os_version = [System.Environment]::OSVersion.Version
         if ($actual_os_version -lt $min_os_version) {
             $msg = "This module cannot run on this OS as it requires a minimum version of $min_os_version, actual was $actual_os_version"
             Write-Output (ConvertTo-Json @{failed=$true;msg=$msg})
-            exit 1        
-        }    
+            exit 1
+        }
     }
-    
+
     $min_ps_version = [version]$payload.min_ps_version
     if ($min_ps_version -ne $null) {
         $actual_ps_version = $PSVersionTable.PSVersion

--- a/test/integration/targets/win_exec_wrapper/aliases
+++ b/test/integration/targets/win_exec_wrapper/aliases
@@ -1,0 +1,1 @@
+windows/ci/group3

--- a/test/integration/targets/win_exec_wrapper/library/test_all_options.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_all_options.ps1
@@ -1,7 +1,7 @@
 #!powershell
 
-#Requires -Module Ansible.ModuleUtils.Legacy.psm1
-#Requires -Module Ansible.ModuleUtils.SID.psm1
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.SID
 #Requires -Version 3.0
 #AnsibleRequires -OSVersion 6
 #AnsibleRequires -Become

--- a/test/integration/targets/win_exec_wrapper/library/test_all_options.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_all_options.ps1
@@ -1,0 +1,12 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#Requires -Module Ansible.ModuleUtils.SID.psm1
+#AnsibleRequires -Become
+#AnsibleRequires -OSVersion 6.0
+#AnsibleRequires -PSVersion 3.0
+
+$output = &whoami.exe
+$sid = Convert-ToSID -account_name $output.Trim()
+
+Exit-Json -obj @{ output = $sid; changed = $false }

--- a/test/integration/targets/win_exec_wrapper/library/test_all_options.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_all_options.ps1
@@ -2,9 +2,9 @@
 
 #Requires -Module Ansible.ModuleUtils.Legacy.psm1
 #Requires -Module Ansible.ModuleUtils.SID.psm1
+#Requires -Version 3.0
+#AnsibleRequires -OSVersion 6
 #AnsibleRequires -Become
-#AnsibleRequires -OSVersion 6.0
-#AnsibleRequires -PSVersion 3.0
 
 $output = &whoami.exe
 $sid = Convert-ToSID -account_name $output.Trim()

--- a/test/integration/targets/win_exec_wrapper/library/test_invalid_requires.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_invalid_requires.ps1
@@ -1,9 +1,9 @@
 #!powershell
 
 #Requires -Module Ansible.ModuleUtils.Legacy.psm1
-#AnsibleRequires -OSVersion 20
-#AnsibleRequires -PSVersion 20.0.0
+# Requires -Version 20
+# AnsibleRequires -OSVersion 20
 
-# a version must be only major.minor, this module won't fail
+# requires statement must be straight after the original # with now space, this module won't fail
 
 Exit-Json -obj @{ output = "output"; changed = $false }

--- a/test/integration/targets/win_exec_wrapper/library/test_invalid_requires.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_invalid_requires.ps1
@@ -1,6 +1,6 @@
 #!powershell
 
-#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#Requires -Module Ansible.ModuleUtils.Legacy
 # Requires -Version 20
 # AnsibleRequires -OSVersion 20
 

--- a/test/integration/targets/win_exec_wrapper/library/test_invalid_requires.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_invalid_requires.ps1
@@ -1,0 +1,9 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#AnsibleRequires -OSVersion 20
+#AnsibleRequires -PSVersion 20.0.0
+
+# a version must be only major.minor, this module won't fail
+
+Exit-Json -obj @{ output = "output"; changed = $false }

--- a/test/integration/targets/win_exec_wrapper/library/test_min_os_version.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_min_os_version.ps1
@@ -1,6 +1,6 @@
 #!powershell
 
-#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#Requires -Module Ansible.ModuleUtils.Legacy
 #AnsibleRequires -OSVersion 20.0
 
 # this shouldn't run as no Windows OS will meet the version of 20.0

--- a/test/integration/targets/win_exec_wrapper/library/test_min_os_version.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_min_os_version.ps1
@@ -1,0 +1,8 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#AnsibleRequires -OSVersion 20.0
+
+# this shouldn't run as no Windows OS will meet the version of 20.0
+
+Exit-Json -obj @{ output = "output"; changed = $false }

--- a/test/integration/targets/win_exec_wrapper/library/test_min_ps_version.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_min_ps_version.ps1
@@ -1,0 +1,8 @@
+#!powershell
+
+#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#AnsibleRequires -PSVersion 20.0
+
+# this shouldn't run as no PS Version will be at 20.0 in the near future
+
+Exit-Json -obj @{ output = "output"; changed = $false }

--- a/test/integration/targets/win_exec_wrapper/library/test_min_ps_version.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_min_ps_version.ps1
@@ -1,8 +1,8 @@
 #!powershell
 
 #Requires -Module Ansible.ModuleUtils.Legacy.psm1
-#AnsibleRequires -PSVersion 20.0
+#Requires -Version 20.0.0.0
 
-# this shouldn't run as no PS Version will be at 20.0 in the near future
+# this shouldn't run as no PS Version will be at 20 in the near future
 
 Exit-Json -obj @{ output = "output"; changed = $false }

--- a/test/integration/targets/win_exec_wrapper/library/test_min_ps_version.ps1
+++ b/test/integration/targets/win_exec_wrapper/library/test_min_ps_version.ps1
@@ -1,6 +1,6 @@
 #!powershell
 
-#Requires -Module Ansible.ModuleUtils.Legacy.psm1
+#Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Version 20.0.0.0
 
 # this shouldn't run as no PS Version will be at 20 in the near future

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -29,7 +29,7 @@
   assert:
     that:
     - invalid_ps_version|failed
-    - '"This module cannot run as it requires a minimum PowerShell version of 20.0, actual was " in invalid_ps_version.msg'
+    - '"This module cannot run as it requires a minimum PowerShell version of 20.0.0.0, actual was " in invalid_ps_version.msg'
 
 - name: test out become requires without become_user set
   test_all_options:

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -1,0 +1,103 @@
+---
+- name: test out invalid options
+  test_invalid_requires:
+  register: invalid_options
+
+- name: assert test out invalid options
+  assert:
+    that:
+    - invalid_options|success
+    - invalid_options.output == "output"
+
+- name: test out invalid os version
+  test_min_os_version:
+  register: invalid_os_version
+  ignore_errors: yes
+
+- name: assert test out invalid os version
+  assert:
+    that:
+    - invalid_os_version|failed
+    - '"This module cannot run on this OS as it requires a minimum version of 20.0, actual was " in invalid_os_version.msg'
+
+- name: test out invalid powershell version
+  test_min_ps_version:
+  register: invalid_ps_version
+  ignore_errors: yes
+
+- name: assert test out invalid powershell version
+  assert:
+    that:
+    - invalid_ps_version|failed
+    - '"This module cannot run as it requires a minimum PowerShell version of 20.0, actual was " in invalid_ps_version.msg'
+
+- name: test out become requires without become_user set
+  test_all_options:
+  register: become_system
+
+- name: assert become requires without become_user set
+  assert:
+    that:
+    - become_system|success
+    - become_system.output == "S-1-5-18"
+
+- set_fact:
+    become_test_username: ansible_become_test
+    gen_pw: password123! + {{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}
+
+- name: create unprivileged user
+  win_user:
+    name: "{{ become_test_username }}"
+    password: "{{ gen_pw }}"
+    update_password: always
+    groups: Users
+  register: become_test_user_result
+
+- name: execute tests and ensure that test user is deleted regardless of success/failure
+  block:
+  - name: ensure current user is not the become user
+    win_shell: whoami
+    register: whoami_out
+
+  - name: verify output
+    assert:
+      that:
+      - not whoami_out.stdout_lines[0].endswith(become_test_username)
+
+  - name: get become user profile dir so we can clean it up later
+    vars: &become_vars
+      ansible_become_user: "{{ become_test_username }}"
+      ansible_become_password: "{{ gen_pw }}"
+      ansible_become_method: runas
+      ansible_become: yes
+    win_shell: $env:USERPROFILE
+    register: profile_dir_out
+
+  - name: ensure profile dir contains test username (eg, if become fails silently, prevent deletion of real user profile)
+    assert:
+      that:
+      - become_test_username in profile_dir_out.stdout_lines[0]
+
+  - name: test out become requires when become_user set
+    test_all_options:
+    vars: *become_vars
+    register: become_system
+
+  - name: assert become requires when become_user set
+    assert:
+      that:
+      - become_system|success
+      - become_system.output == become_test_user_result.sid
+
+  always:
+  - name: ensure test user is deleted
+    win_user:
+      name: "{{ become_test_username }}"
+      state: absent
+
+  - name: ensure test user profile is deleted
+    # NB: have to work around powershell limitation of long filenames until win_file fixes it
+    win_shell: rmdir /S /Q {{ profile_dir_out.stdout_lines[0] }}
+    args:
+      executable: cmd.exe
+    when: become_test_username in profile_dir_out.stdout_lines[0]


### PR DESCRIPTION
##### SUMMARY
This PR adds in the functionality to use `#AnsibleRequires` to state whether a module requires

* to be run in become mode, bypassing WinRM restrictions like Windows Updates. If `become: yes` isn't set on this task then Ansible will become the `SYSTEM` account
* The minimum OS version based on the major.minor. Useful for things like win_share that require a minimum OS version for it to work
* The minimum PS version based on the major.minor, self explanatory

Once the format is done and this is merged in, I will create a separate PR to update the docs.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
windows

##### ANSIBLE VERSION
```
2.5
```