### PR TITLE
Fix #31694: running with closed stdin on python 3

### DIFF
--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -144,17 +144,17 @@ class ActionModule(ActionBase):
 
             # save the attributes on the existing (duped) stdin so
             # that we can restore them later after we set raw mode
-            if PY3:
-                stdin = self._connection._new_stdin.buffer
-            else:
-                stdin = self._connection._new_stdin
             fd = None
             try:
+                if PY3:
+                    stdin = self._connection._new_stdin.buffer
+                else:
+                    stdin = self._connection._new_stdin
                 fd = stdin.fileno()
             except (ValueError, AttributeError):
                 # ValueError: someone is using a closed file descriptor as stdin
                 # AttributeError: someone is using a null file descriptor as stdin on windoez
-                pass
+                stdin = None
             if fd is not None:
                 if isatty(fd):
                     old_settings = termios.tcgetattr(fd)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #31694.

When stdin is `/dev/null`, `self._connection._new_stdin.buffer` fails with `AttributeError`.

This amends https://github.com/ansible/ansible/pull/26495.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
./lib/ansible/plugins/action/pause.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible-playbook 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-playbook
  python version = 3.6.2 (default, Oct  2 2017, 16:51:32) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
# python3 /usr/bin/ansible-playbook -i localhost, /tmp/pause.yaml < /dev/null

PLAY [localhost] ***************************************************************

TASK [pause] *******************************************************************
Pausing for 5 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: UnboundLocalError: local variable 'stdin' referenced before assignment
fatal: [localhost]: FAILED! => {"failed": true, "msg": "Unexpected failure during module execution.", "stdout": ""}

NO MORE HOSTS LEFT *************************************************************
	to retry, use: --limit @/tmp/pause.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   

```

After:
```
# python3 /usr/bin/ansible-playbook -i localhost, /tmp/pause.yaml < /dev/null

PLAY [localhost] ***************************************************************

TASK [pause] *******************************************************************
Pausing for 5 seconds
(ctrl+C then 'C' = continue early, ctrl+C then 'A' = abort)
ok: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0   

```