### PR TITLE
file: Mention that src supports state=hard

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -58,7 +58,7 @@ options:
     required: false
     default: null
     description:
-      - path of the file to link to (applies only to C(state=link)). Will accept absolute,
+      - path of the file to link to (applies only to C(state=link) and C(state=hard)). Will accept absolute,
         relative and nonexisting paths. Relative paths are not expanded.
   recurse:
     required: false


### PR DESCRIPTION
##### SUMMARY
The `file` module has an `src` option that’s supported both when `state=link` and `state=hard`. The documentation only mentions the former. This PR adds the latter.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
file

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = /home/baptiste/.ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Sep 27 2017, 10:33:14) [GCC 5.4.0]
```


##### ADDITIONAL INFORMATION
The Ansible version above is irrelevant because the issue is on https://docs.ansible.com/ansible/latest/file_module.html; it has nothing to do with my personal Ansible installation.
