### PR TITLE
Don't start VM when state is present

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -47,7 +47,8 @@ options:
                When C(state) is I(registered) and the unregistered VM's name
                belongs to an already registered in engine VM in the same DC
                then we fail to register the unregistered template."
-            - "I(present) and I(running) are equal states."
+            - "I(present) state will create/update VM and don't change its state if it already exists."
+            - "I(running) state will create/update VM and start it."
             - "I(next_run) state updates the VM and if the VM has next run configuration it will be rebooted."
             - "Please check I(notes) to more detailed description of states."
             - "I(registered) is supported since 2.4"
@@ -1226,7 +1227,7 @@ def main():
             )
 
             # Run the VM if it was just created, else don't run it:
-            if state == 'running' or vm is None:
+            if state == 'running':
                 initialization = _get_initialization(sysprep, cloud_init, cloud_init_nics)
                 ret = vms_module.action(
                     action='start',


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR add new paramater called `start_on_create`, which can define wheter VM should be created and started, or just created in case of `state=present`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Related-to: https://github.com/ansible/ansible/issues/22189
Related-to: https://github.com/ansible/ansible/issues/27382

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
In case of `state == present` by default if user don't specify `start_on_create` parameter the VM is createad and started. If VM didn't exist VM isn't started but left in state it was. Now user can decide if VM should be started or should not with `start_on_create` parameter.

```yaml
- name: Create vm from template
      ovirt_vms:
        auth: "{{ ovirt_auth }}"
        state: present
        cluster: Default
        name: my_rhel7
        template: rhel74
        start_on_create: no
```
