### PR TITLE
Fix #24964 comparison string vs integer

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -331,7 +331,7 @@ class Host(object):
                     flag = False
                     interface_str = interface
                     for exist_interface in exist_interface_list:
-                        interface_type = interface['type']
+                        interface_type = int(interface['type'])
                         exist_interface_type = int(exist_interface['type'])
                         if interface_type == exist_interface_type:
                             # update


### PR DESCRIPTION
##### SUMMARY
Cherry-pick fix for #24964 from #28442
Fixes #24964

This forces a comparison between ints (and not int/string), yielding a more robust idempotency for the zabbix_host module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
2.5.0

##### ADDITIONAL INFORMATION
This is a single cherry-picked commit from helldorado's PR #28442 (which contains multiple separate module changes). They fixed it, I'm just trying to get it merged :-)