### PR TITLE
fix legacy PEP8 violations in zabbix_*, remove test exception for them

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix_group.py
@@ -165,11 +165,11 @@ def main():
             server_url=dict(type='str', required=True, aliases=['url']),
             login_user=dict(type='str', required=True),
             login_password=dict(type='str', required=True, no_log=True),
-            http_login_user=dict(type='str',required=False, default=None),
-            http_login_password=dict(type='str',required=False, default=None, no_log=True),
-            validate_certs=dict(type='bool',required=False, default=True),
+            http_login_user=dict(type='str', required=False, default=None),
+            http_login_password=dict(type='str', required=False, default=None, no_log=True),
+            validate_certs=dict(type='bool', required=False, default=True),
             host_groups=dict(type='list', required=True, aliases=['host_group']),
-            state=dict(default="present", choices=['present','absent']),
+            state=dict(default="present", choices=['present', 'absent']),
             timeout=dict(type='int', default=10)
         ),
         supports_check_mode=True

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -226,7 +226,6 @@ import copy
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
 
-
     # Extend the ZabbixAPI
     # Since the zabbix-api python module too old (version 1.0, no higher version so far),
     # it does not support the 'hostinterface' api calls,
@@ -237,7 +236,6 @@ try:
         def __init__(self, server, timeout, user, passwd, validate_certs, **kwargs):
             ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd, validate_certs=validate_certs)
             self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
-
 
     HAS_ZABBIX_API = True
 except ImportError:

--- a/lib/ansible/modules/monitoring/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix_hostmacro.py
@@ -151,7 +151,7 @@ class HostMacro(object):
     # update host macro
     def update_host_macro(self, host_macro_obj, macro_name, macro_value):
         host_macro_id = host_macro_obj['hostmacroid']
-        if host_macro_obj['macro'] == '{$'+macro_name+'}' and host_macro_obj['value'] == macro_value:
+        if host_macro_obj['macro'] == '{$' + macro_name + '}' and host_macro_obj['value'] == macro_value:
             self._module.exit_json(changed=False, result="Host macro %s already up to date" % macro_name)
         try:
             if self._module.check_mode:
@@ -171,6 +171,7 @@ class HostMacro(object):
             self._module.exit_json(changed=True, result="Successfully deleted host macro %s " % macro_name)
         except Exception as e:
             self._module.fail_json(msg="Failed to delete host macro %s: %s" % (macro_name, e))
+
 
 def main():
     module = AnsibleModule(
@@ -200,7 +201,7 @@ def main():
     http_login_password = module.params['http_login_password']
     validate_certs = module.params['validate_certs']
     host_name = module.params['host_name']
-    macro_name  = (module.params['macro_name']).upper()
+    macro_name = (module.params['macro_name']).upper()
     macro_value = module.params['macro_value']
     state = module.params['state']
     timeout = module.params['timeout']

--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -184,7 +184,7 @@ def create_maintenance(zbx, group_ids, host_ids, start_time, maintenance_type, p
                 "active_since": str(start_time),
                 "active_till": str(end_time),
                 "description": desc,
-                "timeperiods":  [{
+                "timeperiods": [{
                     "timeperiod_type": "0",
                     "start_date": str(start_time),
                     "period": str(period),

--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -208,7 +208,7 @@ def update_maintenance(zbx, maintenance_id, group_ids, host_ids, start_time, mai
                 "active_since": str(start_time),
                 "active_till": str(end_time),
                 "description": desc,
-                "timeperiods":  [{
+                "timeperiods": [{
                     "timeperiod_type": "0",
                     "start_date": str(start_time),
                     "period": str(period),
@@ -380,11 +380,11 @@ def main():
             module.fail_json(msg="Failed to check maintenance %s existence: %s" % (name, error))
 
         if maintenance and (
-            sorted(group_ids) != sorted(maintenance["groupids"])
-            or sorted(host_ids) != sorted(maintenance["hostids"])
-            or str(maintenance_type) != maintenance["maintenance_type"]
-            or str(int(start_time)) != maintenance["active_since"]
-            or str(int(start_time + period)) != maintenance["active_till"]
+            sorted(group_ids) != sorted(maintenance["groupids"]) or
+            sorted(host_ids) != sorted(maintenance["hostids"]) or
+            str(maintenance_type) != maintenance["maintenance_type"] or
+            str(int(start_time)) != maintenance["active_since"] or
+            str(int(start_time + period)) != maintenance["active_till"]
         ):
             if module.check_mode:
                 changed = True

--- a/lib/ansible/modules/monitoring/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix_screen.py
@@ -8,7 +8,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -171,11 +171,6 @@ lib/ansible/modules/monitoring/sensu_check.py
 lib/ansible/modules/monitoring/sensu_subscription.py
 lib/ansible/modules/monitoring/stackdriver.py
 lib/ansible/modules/monitoring/uptimerobot.py
-lib/ansible/modules/monitoring/zabbix_group.py
-lib/ansible/modules/monitoring/zabbix_host.py
-lib/ansible/modules/monitoring/zabbix_hostmacro.py
-lib/ansible/modules/monitoring/zabbix_maintenance.py
-lib/ansible/modules/monitoring/zabbix_screen.py
 lib/ansible/modules/network/a10/a10_server_axapi3.py
 lib/ansible/modules/network/a10/a10_virtual_server.py
 lib/ansible/modules/network/aos/aos_asn_pool.py


### PR DESCRIPTION
##### SUMMARY
This PR fixes PEP8 errors in the zabbix_*-module-namespace and removes the test exceptions for them. This has come up in a previous PR (#25969) as a hindrance for PRs (since if code is touched which "inadvertently" fixes PEP8 errors, the test suite will fail because the exception is no longer necessary).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_*

##### ANSIBLE VERSION
2.5.0