### PR TITLE
Add ansible_distribution_major_version to macOS

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -487,7 +487,9 @@ class Distribution(object):
         darwin_facts['distribution'] = 'MacOSX'
         rc, out, err = self.module.run_command("/usr/bin/sw_vers -productVersion")
         data = out.split()[-1]
-        darwin_facts['distribution_version'] = data
+        if data:
+            darwin_facts['distribution_major_version'] = data.split('.')[0]
+            darwin_facts['distribution_version'] = data
         return darwin_facts
 
     def get_distribution_FreeBSD(self):


### PR DESCRIPTION
##### SUMMARY

Add `ansible_distribution_major_version` to macOS facts.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
`module_utils/facts/system/distribution.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
