### PR TITLE
Update file module to accept backup=yes, fixes #31594

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -219,7 +219,7 @@ def main():
                 appears_binary = True
         except:
             pass
-        res_args = dict( path=path, changed=False, appears_binary=appears_binary )
+        res_args = dict(path=path, changed=False, appears_binary=appears_binary)
 
     prev_state = get_state(b_path)
 
@@ -283,17 +283,6 @@ def main():
             if os.path.islink(b_path):
                 os.unlink(b_path)
                 open(b_path, 'w').close()
-            if validate:
-                # if we have a mode, make sure we set it on the temporary
-                # file source as some validations may require it
-                # FIXME: should we do the same for owner/group here too?
-                if mode is not None:
-                    module.set_mode_if_different(src, mode, False)
-                if "%s" not in validate:
-                    module.fail_json(msg="validate must contain %%s: %s" % (validate))
-                (rc, out, err) = module.run_command(validate % src)
-                if rc != 0:
-                    module.fail_json(msg="failed to validate", exit_status=rc, stdout=out, stderr=err)
 
     if state == 'absent':
         if state_change:
@@ -308,9 +297,9 @@ def main():
                         os.unlink(b_path)
                     except Exception as e:
                         module.fail_json(path=path, msg="unlinking failed: %s " % to_native(e))
-            res_args = dict( path=path, changed=True, diff=diff )
+            res_args = dict(path=path, changed=True, diff=diff)
         else:
-            res_args = dict( path=path, changed=False )
+            res_args = dict(path=path, changed=False)
 
     elif state == 'file':
 
@@ -327,7 +316,7 @@ def main():
             module.fail_json(path=path, msg='file (%s) is %s, cannot continue' % (path, prev_state))
 
         changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
-        res_args = dict( path=path, changed=changed, diff=diff )
+        res_args = dict(path=path, changed=changed, diff=diff)
 
     elif state == 'directory':
         if follow and prev_state == 'link':
@@ -337,7 +326,7 @@ def main():
 
         if prev_state == 'absent':
             if module.check_mode:
-                res_args = dict( changed=True, diff=diff )
+                res_args = dict(changed=True, diff=diff)
             changed = True
             curpath = ''
 
@@ -375,7 +364,7 @@ def main():
         if recurse:
             changed |= recursive_set_attributes(module, to_bytes(file_args['path'], errors='surrogate_or_strict'), follow, file_args)
 
-        res_args = dict( path=path, changed=changed, diff=diff )
+        res_args = dict(path=path, changed=changed, diff=diff)
 
     elif state in ('link', 'hard'):
 
@@ -423,7 +412,7 @@ def main():
             changed = True
             if os.path.exists(b_path):
                 if state == 'hard' and os.stat(b_path).st_ino == os.stat(b_src).st_ino:
-                    res_args = dict( path=path, changed=False )
+                    res_args = dict(path=path, changed=False)
                 elif not force:
                     module.fail_json(dest=path, src=src, msg='Cannot link, different hard link exists at destination')
         else:
@@ -460,10 +449,10 @@ def main():
                     module.fail_json(path=path, msg='Error while linking: %s' % to_native(e, nonstring='simplerepr'))
 
         if module.check_mode and not os.path.exists(b_path):
-            res_args = dict( dest=path, src=src, changed=changed, diff=diff )
+            res_args = dict(dest=path, src=src, changed=changed, diff=diff)
 
         changed = module.set_fs_attributes_if_different(file_args, changed, diff, expand=False)
-        res_args = dict( dest=path, src=src, changed=changed, diff=diff )
+        res_args = dict(dest=path, src=src, changed=changed, diff=diff)
 
     elif state == 'touch':
         if not module.check_mode:
@@ -491,7 +480,7 @@ def main():
                         os.remove(b_path)
                 raise e
 
-        res_args = dict( dest=path, changed=True, diff=diff )
+        res_args = dict(dest=path, changed=True, diff=diff)
 
     if backup_file:
         res_args['backup_file'] = backup_file


### PR DESCRIPTION
This currently only works with files (not links or directories), and will fail for other types.  When backup=no (or undefined) the same functionality is available.  Fixes #31594

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #31594
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
File module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 89428a40b3) last updated 2017/10/13 10:25:45 (GMT -600)
  config file = None
  configured module search path = [u'/opt/ansible/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible/source/lib/ansible
  executable location = /opt/ansible/source/bin/ansible
  python version = 2.7.9 (default, Nov 18 2015, 13:07:23) [GCC 4.4.7 20120313 (Red Hat 4.4.7-16)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
See #31594
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```