### PR TITLE
Add additional deps to support all filters/tests

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,7 +8,7 @@ Homepage: http://ansible.github.com/
 
 Package: ansible
 Architecture: all
-Depends: python-jinja2, python-yaml, python-paramiko, python-httplib2, python-six, python-crypto (>= 2.6), python-setuptools, sshpass, ${misc:Depends}, ${python:Depends}
+Depends: python-jinja2, python-yaml, python-paramiko, python-requests, python-six, python-crypto (>= 2.6), python-setuptools, python-netaddr, python-jmespath, python-dns, sshpass, ${misc:Depends}, ${python:Depends}
 Description: Ansible IT Automation
  A radically simple IT automation platform that makes your applications and
  systems easier to deploy. Avoid writing scripts or custom code to deploy and

--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -1,10 +1,6 @@
 %define name ansible
 %define ansible_version $VERSION
 
-%if 0%{?rhel} == 5
-%define __python /usr/bin/python26
-%endif
-
 Name:      %{name}
 Version:   %{ansible_version}
 Release:   1%{?dist}
@@ -18,19 +14,6 @@ BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 
 BuildArch: noarch
 
-# RHEL <=5
-%if 0%{?rhel} && 0%{?rhel} <= 5
-BuildRequires: python26-devel
-BuildRequires: python26-setuptools
-Requires: python26-PyYAML
-Requires: python26-paramiko
-Requires: python26-jinja2
-Requires: python26-keyczar
-Requires: python26-httplib2
-Requires: python26-setuptools
-Requires: python26-six
-%endif
-
 # RHEL == 6
 %if 0%{?rhel} == 6
 Requires: python-crypto
@@ -41,15 +24,19 @@ Requires: python-crypto
 Requires: python2-cryptography
 %endif
 
-# RHEL > 5
-%if 0%{?rhel} && 0%{?rhel} > 5
+# RHEL => 6
+%if 0%{?rhel} && 0%{?rhel} >= 6
 BuildRequires: python2-devel
 BuildRequires: python-setuptools
 Requires: PyYAML
 Requires: python-paramiko
 Requires: python-jinja2
+Requires: python-requests
 Requires: python-setuptools
 Requires: python-six
+Requires: python-jmespath
+Requires: python-netaddr
+Requires: python-dns
 %endif
 
 # FEDORA > 17
@@ -59,10 +46,12 @@ BuildRequires: python-setuptools
 Requires: PyYAML
 Requires: python-paramiko
 Requires: python-jinja2
-Requires: python-keyczar
-Requires: python-httplib2
+Requires: python-requests
 Requires: python-setuptools
 Requires: python-six
+Requires: python-jmespath
+Requires: python-netaddr
+Requires: python-dns
 %endif
 
 # SuSE/openSuSE
@@ -71,11 +60,13 @@ BuildRequires: python-devel
 BuildRequires: python-setuptools
 Requires: python-paramiko
 Requires: python-jinja2
-Requires: python-keyczar
 Requires: python-yaml
-Requires: python-httplib2
+Requires: python-requests
 Requires: python-setuptools
 Requires: python-six
+Requires: python-jmespath
+Requires: python-netaddr
+Requires: python-dns
 %endif
 
 Requires: sshpass


### PR DESCRIPTION
##### SUMMARY
Ansible has a few useful filters and tests which require additional packages to be installed on the control machine to work, because Ansible RPM and DEB packages don't install them by default. There is also a lot of modules that are usually run on the controller (especially cloud and network) which require e.g. `python-requests`, which also isn't installed by default so you always have to do it manually. The most interesting thing is that the needed packages are available in the official repositories or EPEL, so it would be convenient if Ansible package just installed them as dependencies.

This PR adds the following dependencies to RPM and DEB packages:
  * `python-netaddr` - to support `ipaddr` filter
  * `python-jmespath` - to support `json_query`
  * `python-dns` - to support `dig` lookup
  * `python-requests` - to support some lookups and a lot of modules which are run locally on the controller (like cloud and network)

It also removes support for RHEL 5.

##### ISSUE TYPE
 - Improvement Pull Request

##### COMPONENT NAME
RPM/DEB packages

##### ANSIBLE VERSION
```
devel
```