### PR TITLE
Added icinga2_host module

### DIFF
--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -130,11 +130,11 @@ EXAMPLES = '''
 
 RETURN = '''
 name:
-    description: The name used to create, modify or delete the host 
+    description: The name used to create, modify or delete the host
     type: string
     returned: always
-data: 
-    description: The data structure used for create, modify or delete of the host 
+data:
+    description: The data structure used for create, modify or delete of the host
     type: dict
     returned: always
 '''

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-module: icinga2_hosts
+module: icinga2_host
 short_description: Manage a host in Icinga2
 description:
    - "Add or remove a host to Icinga2 through the API"
@@ -21,28 +21,64 @@ description:
 version_added: "2.5"
 author: "Jurgen Brand"
 options:
-  server:
+  url:
     description:
-      - the host name or ip-address of the Icinga2 host
+      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
     required: true
-  port:
+  force:
     description:
-      - port used to connect too the Icinga2
-    required: false
-    default: 5665
-  user:
+      - If C(yes) and C(dest) is not a directory, will download the file every
+        time and replace the file if the contents change. If C(no), the file
+        will only be downloaded if the destination does not exist. Generally
+        should be C(yes) only for small local files.
+      - Prior to 0.6, this module behaved as if C(yes) was the default.
+    version_added: '0.7'
+    default: 'no'
+    type: bool
+    aliases: [ thirsty ]
+  use_proxy:
     description:
-      - the username used to authenticate with
-    required: true
-  password:
+      - if C(no), it will not use a proxy, even if one is defined in
+        an environment variable on the target hosts.
+    default: 'yes'
+    type: bool
+  validate_certs:
     description:
-      - The password used to authenticate with.
-    required: true
-  ssl_ca:
+      - If C(no), SSL certificates will not be validated. This should only be used
+        on personally controlled sites using self-signed certificates.
+    default: 'yes'
+    type: bool
+  url_username:
     description:
-      - the CA used for authenticaton
-    required: false
-    default: None
+      - The username for use in HTTP basic authentication.
+      - This parameter can be used without C(url_password) for sites that allow empty passwords.
+    version_added: '1.6'
+  url_password:
+    description:
+        - The password for use in HTTP basic authentication.
+        - If the C(url_username) parameter is not specified, the C(url_password) parameter will not be used.
+    version_added: '1.6'
+  force_basic_auth:
+    version_added: '2.0'
+    description:
+      - httplib2, the library used by the uri module only sends authentication information when a webservice
+        responds to an initial request with a 401 status. Since some basic auth services do not properly
+        send a 401, logins will fail. This option forces the sending of the Basic authentication header
+        upon initial request.
+    default: 'no'
+    type: bool
+  client_cert:
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, C(client_key) is not required.
+    version_added: '2.4'
+  client_key:
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If C(client_cert) contains both the certificate
+        and key, this option is not required.
+    version_added: '2.4'
   state:
     description:
       - Apply feature state.

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
@@ -20,20 +22,6 @@ description:
 version_added: "2.5"
 author: "Jurgen Brand"
 options:
-            server=dict(required=True),
-            port=dict(default=5665, type='int'),
-            user=dict(default=None),
-            password=dict(default=None, no_log=True),
-            ssl_ca=dict(default=None, type='path'),
-            state=dict(default="present", choices=["absent", "present"]),
-            name=dict(required=True, aliases=['host']),
-            zone=dict(default=None),
-            template=dict(default=None),
-            check_command=dict(default="hostalive"),
-            display_name=dict(default=None),
-            ip=dict(required=True),
-            variables=dict(type='dict', default=None),
-
   server:
     description:
       - the host name or ip-address of the Icinga2 host
@@ -109,7 +97,6 @@ EXAMPLES = '''
     state: present
     name: "{{ansible_fqdn }}"
     ip_address: "{{ ansible_default_ipv4.address }}"
-
 '''
 
 import requests

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -27,16 +27,6 @@ options:
     description:
       - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
     required: true
-  force:
-    description:
-      - If C(yes) and C(dest) is not a directory, will download the file every
-        time and replace the file if the contents change. If C(no), the file
-        will only be downloaded if the destination does not exist. Generally
-        should be C(yes) only for small local files.
-      - Prior to 0.6, this module behaved as if C(yes) was the default.
-    default: 'no'
-    type: bool
-    aliases: [ thirsty ]
   use_proxy:
     description:
       - if C(no), it will not use a proxy, even if one is defined in
@@ -230,6 +220,8 @@ class icinga2_api:
 def main():
     # use the predefined argument spec for url
     argument_spec = url_argument_spec()
+    # remove unnecessary argument 'force'
+    del argument_spec['force']
     # add our own arguments
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -99,10 +99,16 @@ EXAMPLES = '''
     ip_address: "{{ ansible_default_ipv4.address }}"
 '''
 
-import requests
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
 import json
 import warnings
 warnings.simplefilter('ignore', requests.packages.urllib3.exceptions.SecurityWarning)
+import os
 
 from ansible.module_utils.basic import AnsibleModule
 
@@ -235,6 +241,9 @@ def main():
 
     if not os.path.exists(ssl_ca):
         module.fail_json(msg="SSL ca cert can not be found")
+
+    if not HAS_REQUESTS:
+        module.fail_json(msg='requests is required for this module')
 
     try:
         icinga = icinga2_api()

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -127,7 +127,7 @@ class icinga2_api:
         if rsp:
             body = json.loads(rsp.read())
         if info['status'] >= 400:
-            {body = info['body']
+            body = info['body']
         return {'code': info['status'], 'data': body}
 
     def check_connection(self):

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -14,11 +14,10 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: icinga2_hosts
-
 short_description: Manage a host in Icinga2
 description:
-   - Add or remove a host to Icinga2 through the API
-   - ( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )
+   - "Add or remove a host to Icinga2 through the API"
+   - "( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )"
 version_added: "2.5"
 author: "Jurgen Brand"
 options:
@@ -85,7 +84,6 @@ options:
       - list of variables
     required: false
     default: None
-
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -1,0 +1,327 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+#
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: icinga2_hosts
+
+short_description: Manage a host in Icinga2
+description:
+   - Add or remove a host to Icinga2 through the API
+   - ( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )
+version_added: "2.5"
+author: "Jurgen Brand"
+options:
+            server=dict(required=True),
+            port=dict(default=5665, type='int'),
+            user=dict(default=None),
+            password=dict(default=None, no_log=True),
+            ssl_ca=dict(default=None, type='path'),
+            state=dict(default="present", choices=["absent", "present"]),
+            name=dict(required=True, aliases=['host']),
+            zone=dict(default=None),
+            template=dict(default=None),
+            check_command=dict(default="hostalive"),
+            display_name=dict(default=None),
+            ip=dict(required=True),
+            variables=dict(type='dict', default=None),
+
+  server:
+    description:
+      - the host name or ip-address of the Icinga2 host
+    required: true
+  port:
+    description:
+      - port used to connect too the Icinga2
+    required: false
+    default: 5665        
+  user:
+    description:
+      - the username used to authenticate with
+    required: true
+  password:
+    description:
+      - The password used to authenticate with.
+    required: true
+  ssl_ca:
+    description:
+      - the CA used for authenticaton 
+    required: false
+    default: None
+  state:
+    description:
+      - Apply feature state.
+    required: false
+    choices: [ "present", "absent" ]
+    default: present
+  name:
+    description:
+      - name used to create / delete the host
+      - this does not need to be the FQDN, but does needs to be uniuqe
+    required: true
+    default: null
+  zone:
+    description:
+      - ??
+    required: false
+    default: None
+  template:
+    description:
+      - the template used to define the host
+    required: false
+    default: None
+  check_command:
+    description:
+      - the command used to check if the host is alive
+    required: false
+    default "hostalive"
+  display_name:
+    description:
+      - the name used to display the host
+    required: false
+    default: <name>
+  ip:
+    description:
+      - the ip-addres of the host 
+    required: true     
+  variables:
+    description:
+      - list of variables
+    required: false
+    default: None
+    
+'''
+
+EXAMPLES = '''
+- name: Add host to icinga
+  icinga_host:
+    icinga_server: "icinga.example.com"
+    icinga_user: "anisble
+    icinga_pass: ""mypassword"
+    state: present
+    name: "{{ansible_fqdn }}"
+    ip_address: "{{ ansible_default_ipv4.address }}"
+    
+'''
+
+import requests, json
+import warnings
+warnings.simplefilter('ignore', requests.packages.urllib3.exceptions.SecurityWarning)
+
+# ===========================================
+# Icinga2 API class
+#
+class icinga2_api:
+    server = None
+    port = None
+    user = None
+    password = None
+    ssl_ca = None
+
+    def call_url (self, url, data = {}, methode = 'GET' ):
+        full_url = "https://" + self.server + ":" + str(self.port) + "/" + url
+        headers = {
+                'Accept': 'application/json',
+                'X-HTTP-Method-Override': methode,
+                }
+        r = requests.post(
+            full_url,
+            headers=headers,
+            auth=(self.user, self.password),
+            data=json.dumps(data),
+            verify=self.ssl_ca
+        )
+        return { 'code': r.status_code, 'data': r.json() }
+
+    def check_connection(self):
+        ret = self.call_url('v1/status')
+        if ret['code'] == 200:
+           return True
+        return False
+
+    def exists (self, hostname):
+        data = {
+          "filter":  "match(\"" + hostname + "\", host.name)",
+        }
+        ret = self.call_url ("v1/objects/hosts", data)
+        if ret['code'] == 200:
+           if len(ret['data']['results']) == 1:
+             return True
+        return False
+
+    def create (self, hostname, data):
+        ret = self.call_url (
+            url="v1/objects/hosts/"+ hostname,
+            data=data,
+            methode="PUT"
+        )
+        return ret
+
+    def delete (self, hostname):
+        data = { "cascade": 1 }
+        ret = self.call_url (
+            url="v1/objects/hosts/"+ hostname,
+            data=data,
+            methode="DELETE"
+        )
+        return ret
+
+    def modify (self, hostname, data):
+        ret = self.call_url (
+            url="v1/objects/hosts/"+ hostname,
+            data=data,
+            methode="POST"
+        )
+        return ret
+    
+    def diff (self, hostname, data):
+        ret = self.call_url (
+            url="v1/objects/hosts/"+ hostname,
+            data={},
+            methode="GET"
+        )
+        changed = False
+        ic_data = ret['data']['results'][0]
+        for key in data['attrs']:
+            if key not in ic_data['attrs'].keys():
+                changed = True
+            elif data['attrs'][key] != ic_data['attrs'][key]:
+                changed = True
+        return changed
+    
+# ===========================================
+# Module execution.
+#
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            server=dict(required=True),
+            port=dict(default=5665, type='int'),
+            user=dict(default=None),
+            password=dict(default=None, no_log=True),
+            ssl_ca=dict(default=None, type='path'),
+            state=dict(default="present", choices=["absent", "present"]),
+            name=dict(required=True, aliases=['host']),
+            zone=dict(default=None),
+            template=dict(default=None),
+            check_command=dict(default="hostalive"),
+            display_name=dict(default=None),
+            ip=dict(required=True),
+            variables=dict(type='dict', default=None),
+        ),
+        supports_check_mode=True
+    )
+
+    server = module.params["server"]
+    port = module.params["port"]
+    if port < 0 or port > 65535:
+        module.fail_json(msg="port must be a valid unix port number (0-65535)")
+    user = module.params["user"]
+    password = module.params["password"]
+    ssl_ca = module.params["ssl_ca"]
+    state = module.params["state"]
+    name = module.params["name"]
+    zone = module.params["zone"]
+    template=[]
+    template.append (name)
+    if module.params["template"]:
+        template.append(module.params["template"])
+    check_command = module.params["check_command"]
+    ip = module.params["ip"]
+    display_name = module.params["display_name"]
+    if not display_name:
+      display_name = name
+    variables = module.params["variables"]
+    
+    if not os.path.exists(ssl_ca):
+        module.fail_json(msg="SSL ca cert can not be found")
+
+    try:
+        icinga = icinga2_api()
+        icinga.server = server
+        icinga.port = port
+        icinga.user = user
+        icinga.password = password
+        icinga.ssl_ca = ssl_ca
+        icinga.check_connection()
+    except Exception as e:
+        module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % (e))
+
+    data = {
+        'attrs': {
+            'address': ip,
+            'check_command': check_command,
+            'zone': zone,
+            'vars': {
+                'made_by': "ansible",
+            },
+            'templates': template,
+        }
+    }
+         
+    if variables:
+        data['attrs']['vars'].upatde(variables)
+
+    changed = False
+    if icinga.exists(name):
+        if state == "absent":
+            if module.check_mode:
+                module.exit_json(changed=True, name=name, data=data)
+            else:
+                try:
+                    ret = icinga.delete(name)
+                    if ret['code'] == 200:
+                        changed = True
+                    else:
+                        module.fail_json(msg="bad return code deleting host: %s" % (ret['data']))
+                except Exception:
+                    e = get_exception()
+                    module.fail_json(msg="exception deleting host: " + str(e))
+                module.exit_json(changed=changed, name=name, data=data)
+
+        elif icinga.diff(name, data):
+            if module.check_mode:
+                module.exit_json(changed=False, name=name, data=data)
+            ret = icinga.modify(name,data)
+            if ret['code'] == 200:
+                changed = True
+            else:
+                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))        
+
+        module.exit_json(changed=changed, name=name, data=data)
+
+    else:
+        if state == "present":
+            if module.check_mode:
+                changed = True
+            else:
+                try:
+                    ret = icinga.create(name, data)
+                    if ret['code'] == 200:
+                        changed = True
+                    else:
+                        module.fail_json(msg="bad return code creating host: %s" % (ret['data']))
+                except Exception:
+                    e = get_exception()
+                    module.fail_json(msg="exception creating host: " + str(e))
+        elif icinga.diff(name, data):
+            if module.check_mode:
+                module.exit_json(changed=False, name=name, data=data)
+            ret = icinga.modify(name,data)
+            if ret['code'] == 200:
+                changed = True
+            else:
+                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))        
+
+        module.exit_json(changed=changed, name=name, data=data)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -18,8 +18,8 @@ DOCUMENTATION = '''
 module: icinga2_host
 short_description: Manage a host in Icinga2
 description:
-   - "Add or remove a host to Icinga2 through the API"
-   - "( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )"
+   - "Add or remove a host to Icinga2 through the API."
+   - "See U(https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/)"
 version_added: "2.5"
 author: "Jurgen Brand (@t794104)"
 options:
@@ -29,7 +29,7 @@ options:
     required: true
   use_proxy:
     description:
-      - if C(no), it will not use a proxy, even if one is defined in
+      - If C(no), it will not use a proxy, even if one is defined in
         an environment variable on the target hosts.
     default: 'yes'
     type: bool
@@ -73,34 +73,33 @@ options:
     default: present
   name:
     description:
-      - name used to create / delete the host
-      - this does not need to be the FQDN, but does needs to be unique
+      - Name used to create / delete the host. This does not need to be the FQDN, but does needs to be unique.
     required: true
   zone:
     description:
-      - the zone from where this host should be polled
+      - The zone from where this host should be polled.
   template:
     description:
-      - the template used to define the host
+      - The template used to define the host.
     required: false
     default: None
   check_command:
     description:
-      - the command used to check if the host is alive
+      - The command used to check if the host is alive.
     required: false
     default: "hostalive"
   display_name:
     description:
-      - the name used to display the host
+      - The name used to display the host.
     required: false
     default: if none is give it is the value of the <name> parameter
   ip:
     description:
-      - the ip-addres of the host
+      - The IP address of the host.
     required: true
   variables:
     description:
-      - list of variables
+      - List of variables.
     required: false
     default: None
 '''

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -92,7 +92,7 @@ EXAMPLES = '''
 - name: Add host to icinga
   icinga_host:
     icinga_server: "icinga.example.com"
-    icinga_user: "anisble
+    icinga_user: "anisble"
     icinga_pass: "mypassword"
     state: present
     name: "{{ansible_fqdn }}"
@@ -116,7 +116,7 @@ from ansible.module_utils.urls import fetch_url, url_argument_spec
 class icinga2_api:
     module = None
 
-    def call_url(self, path, data={}, method='GET'):
+    def call_url(self, path, data='', method='GET'):
         headers = {
             'Accept': 'application/json',
             'X-HTTP-Method-Override': method,
@@ -125,9 +125,9 @@ class icinga2_api:
         rsp, info = fetch_url(module=self.module, url=url, data=data, headers=headers, method=method)
         body = ''
         if rsp:
-          body = json.loads(rsp.read())
+            body = json.loads(rsp.read())
         if info['status'] >= 400:
-          body = info['body']
+            {body = info['body']
         return {'code': info['status'], 'data': body}
 
     def check_connection(self):
@@ -206,7 +206,7 @@ def main():
         ip=dict(required=True),
         variables=dict(type='dict', default=None),
     )
-    
+
     # Define the main module
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -305,4 +305,3 @@ def main():
 # import module snippets
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -104,6 +104,8 @@ import json
 import warnings
 warnings.simplefilter('ignore', requests.packages.urllib3.exceptions.SecurityWarning)
 
+from ansible.module_utils.basic import AnsibleModule
+
 
 # ===========================================
 # Icinga2 API class
@@ -133,7 +135,7 @@ class icinga2_api:
     def check_connection(self):
         ret = self.call_url('v1/status')
         if ret['code'] == 200:
-           return True
+            return True
         return False
 
     def exists(self, hostname):
@@ -142,8 +144,8 @@ class icinga2_api:
         }
         ret = self.call_url("v1/objects/hosts", data)
         if ret['code'] == 200:
-           if len(ret['data']['results']) == 1:
-               return True
+            if len(ret['data']['results']) == 1:
+                return True
         return False
 
     def create(self, hostname, data):
@@ -155,7 +157,7 @@ class icinga2_api:
         return ret
 
     def delete(self, hostname):
-        data = { "cascade": 1 }
+        data = {"cascade": 1}
         ret = self.call_url(
             url="v1/objects/hosts/" + hostname,
             data=data,
@@ -221,9 +223,9 @@ def main():
     name = module.params["name"]
     zone = module.params["zone"]
     template = []
-    template.append (name)
+    template.append(name)
     if module.params["template"]:
-        template.append (module.params["template"])
+        template.append(module.params["template"])
     check_command = module.params["check_command"]
     ip = module.params["ip"]
     display_name = module.params["display_name"]

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -21,7 +21,7 @@ description:
    - "Add or remove a host to Icinga2 through the API"
    - "( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )"
 version_added: "2.5"
-author: "Jurgen Brand"
+author: "Jurgen Brand (@t794104)"
 options:
   url:
     description:

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -5,9 +5,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'status': ['preview'],
-                    'supported_by': 'community',
-                    'version': '1.1'}
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
@@ -42,7 +42,7 @@ options:
     description:
       - port used to connect too the Icinga2
     required: false
-    default: 5665        
+    default: 5665
   user:
     description:
       - the username used to authenticate with
@@ -53,7 +53,7 @@ options:
     required: true
   ssl_ca:
     description:
-      - the CA used for authenticaton 
+      - the CA used for authenticaton
     required: false
     default: None
   state:
@@ -90,14 +90,14 @@ options:
     default: <name>
   ip:
     description:
-      - the ip-addres of the host 
-    required: true     
+      - the ip-addres of the host
+    required: true
   variables:
     description:
       - list of variables
     required: false
     default: None
-    
+
 '''
 
 EXAMPLES = '''
@@ -109,10 +109,11 @@ EXAMPLES = '''
     state: present
     name: "{{ansible_fqdn }}"
     ip_address: "{{ ansible_default_ipv4.address }}"
-    
+
 '''
 
-import requests, json
+import requests
+import json
 import warnings
 warnings.simplefilter('ignore', requests.packages.urllib3.exceptions.SecurityWarning)
 
@@ -181,7 +182,7 @@ class icinga2_api:
             methode="POST"
         )
         return ret
-    
+
     def diff (self, hostname, data):
         ret = self.call_url (
             url="v1/objects/hosts/"+ hostname,
@@ -196,7 +197,7 @@ class icinga2_api:
             elif data['attrs'][key] != ic_data['attrs'][key]:
                 changed = True
         return changed
-    
+
 # ===========================================
 # Module execution.
 #
@@ -240,7 +241,7 @@ def main():
     if not display_name:
       display_name = name
     variables = module.params["variables"]
-    
+
     if not os.path.exists(ssl_ca):
         module.fail_json(msg="SSL ca cert can not be found")
 
@@ -266,7 +267,7 @@ def main():
             'templates': template,
         }
     }
-         
+
     if variables:
         data['attrs']['vars'].upatde(variables)
 
@@ -282,8 +283,7 @@ def main():
                         changed = True
                     else:
                         module.fail_json(msg="bad return code deleting host: %s" % (ret['data']))
-                except Exception:
-                    e = get_exception()
+                except Exception as e:
                     module.fail_json(msg="exception deleting host: " + str(e))
                 module.exit_json(changed=changed, name=name, data=data)
 
@@ -294,7 +294,7 @@ def main():
             if ret['code'] == 200:
                 changed = True
             else:
-                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))        
+                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))
 
         module.exit_json(changed=changed, name=name, data=data)
 
@@ -319,12 +319,11 @@ def main():
             if ret['code'] == 200:
                 changed = True
             else:
-                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))        
+                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))
 
         module.exit_json(changed=changed, name=name, data=data)
 
 
 # import module snippets
-from ansible.module_utils.basic import *
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -117,6 +117,7 @@ import json
 import warnings
 warnings.simplefilter('ignore', requests.packages.urllib3.exceptions.SecurityWarning)
 
+
 # ===========================================
 # Icinga2 API class
 #
@@ -127,12 +128,12 @@ class icinga2_api:
     password = None
     ssl_ca = None
 
-    def call_url (self, url, data = {}, methode = 'GET' ):
+    def call_url(self, url, data={}, methode='GET'):
         full_url = "https://" + self.server + ":" + str(self.port) + "/" + url
         headers = {
-                'Accept': 'application/json',
-                'X-HTTP-Method-Override': methode,
-                }
+            'Accept': 'application/json',
+            'X-HTTP-Method-Override': methode,
+        }
         r = requests.post(
             full_url,
             headers=headers,
@@ -140,7 +141,7 @@ class icinga2_api:
             data=json.dumps(data),
             verify=self.ssl_ca
         )
-        return { 'code': r.status_code, 'data': r.json() }
+        return {'code': r.status_code, 'data': r.json()}
 
     def check_connection(self):
         ret = self.call_url('v1/status')
@@ -148,44 +149,44 @@ class icinga2_api:
            return True
         return False
 
-    def exists (self, hostname):
+    def exists(self, hostname):
         data = {
-          "filter":  "match(\"" + hostname + "\", host.name)",
+            "filter": "match(\"" + hostname + "\", host.name)",
         }
-        ret = self.call_url ("v1/objects/hosts", data)
+        ret = self.call_url("v1/objects/hosts", data)
         if ret['code'] == 200:
            if len(ret['data']['results']) == 1:
-             return True
+               return True
         return False
 
-    def create (self, hostname, data):
-        ret = self.call_url (
-            url="v1/objects/hosts/"+ hostname,
+    def create(self, hostname, data):
+        ret = self.call_url(
+            url="v1/objects/hosts/" + hostname,
             data=data,
             methode="PUT"
         )
         return ret
 
-    def delete (self, hostname):
+    def delete(self, hostname):
         data = { "cascade": 1 }
-        ret = self.call_url (
-            url="v1/objects/hosts/"+ hostname,
+        ret = self.call_url(
+            url="v1/objects/hosts/" + hostname,
             data=data,
             methode="DELETE"
         )
         return ret
 
-    def modify (self, hostname, data):
-        ret = self.call_url (
-            url="v1/objects/hosts/"+ hostname,
+    def modify(self, hostname, data):
+        ret = self.call_url(
+            url="v1/objects/hosts/" + hostname,
             data=data,
             methode="POST"
         )
         return ret
 
-    def diff (self, hostname, data):
-        ret = self.call_url (
-            url="v1/objects/hosts/"+ hostname,
+    def diff(self, hostname, data):
+        ret = self.call_url(
+            url="v1/objects/hosts/" + hostname,
             data={},
             methode="GET"
         )
@@ -198,12 +199,13 @@ class icinga2_api:
                 changed = True
         return changed
 
+
 # ===========================================
 # Module execution.
 #
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
+        argument_spec=dict(
             server=dict(required=True),
             port=dict(default=5665, type='int'),
             user=dict(default=None),
@@ -231,15 +233,15 @@ def main():
     state = module.params["state"]
     name = module.params["name"]
     zone = module.params["zone"]
-    template=[]
+    template = []
     template.append (name)
     if module.params["template"]:
-        template.append(module.params["template"])
+        template.append (module.params["template"])
     check_command = module.params["check_command"]
     ip = module.params["ip"]
     display_name = module.params["display_name"]
     if not display_name:
-      display_name = name
+        display_name = name
     variables = module.params["variables"]
 
     if not os.path.exists(ssl_ca):
@@ -290,7 +292,7 @@ def main():
         elif icinga.diff(name, data):
             if module.check_mode:
                 module.exit_json(changed=False, name=name, data=data)
-            ret = icinga.modify(name,data)
+            ret = icinga.modify(name, data)
             if ret['code'] == 200:
                 changed = True
             else:
@@ -309,13 +311,12 @@ def main():
                         changed = True
                     else:
                         module.fail_json(msg="bad return code creating host: %s" % (ret['data']))
-                except Exception:
-                    e = get_exception()
+                except Exception as e:
                     module.fail_json(msg="exception creating host: " + str(e))
         elif icinga.diff(name, data):
             if module.check_mode:
                 module.exit_json(changed=False, name=name, data=data)
-            ret = icinga.modify(name,data)
+            ret = icinga.modify(name, data)
             if ret['code'] == 200:
                 changed = True
             else:

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# This module is proudly sponsored by CGI (www.cgi.com) and
+# KPN (www.kpn.com).
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -125,12 +127,13 @@ options:
 EXAMPLES = '''
 - name: Add host to icinga
   icinga_host:
-    icinga_server: "icinga.example.com"
-    icinga_user: "anisble"
-    icinga_pass: "mypassword"
+    url: "https://icinga2.example.co,m"
+    url_username: "ansible"
+    url_password: "a_secret"
     state: present
-    name: "{{ansible_fqdn }}"
-    ip_address: "{{ ansible_default_ipv4.address }}"
+    name: "{{ ansible_fqdn }}"
+    ip: "{{ ansible_default_ipv4.address }}"
+  delegate_to: 127.0.0.1
 '''
 
 RETURN = '''
@@ -298,7 +301,6 @@ def main():
                         module.fail_json(msg="bad return code deleting host: %s" % (ret['data']))
                 except Exception as e:
                     module.fail_json(msg="exception deleting host: " + str(e))
-                module.exit_json(changed=changed, name=name, data=data)
 
         elif icinga.diff(name, data):
             if module.check_mode:
@@ -308,8 +310,6 @@ def main():
                 changed = True
             else:
                 module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))
-
-        module.exit_json(changed=changed, name=name, data=data)
 
     else:
         if state == "present":
@@ -324,16 +324,8 @@ def main():
                         module.fail_json(msg="bad return code creating host: %s" % (ret['data']))
                 except Exception as e:
                     module.fail_json(msg="exception creating host: " + str(e))
-        elif icinga.diff(name, data):
-            if module.check_mode:
-                module.exit_json(changed=False, name=name, data=data)
-            ret = icinga.modify(name, data)
-            if ret['code'] == 200:
-                changed = True
-            else:
-                module.fail_json(msg="bad return code modifying host: %s" % (ret['data']))
 
-        module.exit_json(changed=changed, name=name, data=data)
+    module.exit_json(changed=changed, name=name, data=data)
 
 
 # import module snippets

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -54,14 +54,11 @@ options:
     description:
       - The username for use in HTTP basic authentication.
       - This parameter can be used without C(url_password) for sites that allow empty passwords.
-    version_added: '1.6'
   url_password:
     description:
         - The password for use in HTTP basic authentication.
         - If the C(url_username) parameter is not specified, the C(url_password) parameter will not be used.
-    version_added: '1.6'
   force_basic_auth:
-    version_added: '2.0'
     description:
       - httplib2, the library used by the uri module only sends authentication information when a webservice
         responds to an initial request with a 401 status. Since some basic auth services do not properly
@@ -74,13 +71,11 @@ options:
       - PEM formatted certificate chain file to be used for SSL client
         authentication. This file can also include the key as well, and if
         the key is included, C(client_key) is not required.
-    version_added: '2.4'
   client_key:
     description:
       - PEM formatted file that contains your private key to be used for SSL
         client authentication. If C(client_cert) contains both the certificate
         and key, this option is not required.
-    version_added: '2.4'
   state:
     description:
       - Apply feature state.
@@ -92,12 +87,9 @@ options:
       - name used to create / delete the host
       - this does not need to be the FQDN, but does needs to be uniuqe
     required: true
-    default: null
   zone:
     description:
-      - ??
-    required: false
-    default: None
+      - the zone from where this host should be polled
   template:
     description:
       - the template used to define the host
@@ -137,7 +129,14 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-#
+name:
+    description: The name used to create, modify or delete the host 
+    type: string
+    returned: always
+data: 
+    description: The data structure used for create, modify or delete of the host 
+    type: dict
+    returned: always
 '''
 
 import json
@@ -236,7 +235,7 @@ def main():
     argument_spec.update(
         state=dict(default="present", choices=["absent", "present"]),
         name=dict(required=True, aliases=['host']),
-        zone=dict(default=None),
+        zone=dict(),
         template=dict(default=None),
         check_command=dict(default="hostalive"),
         display_name=dict(default=None),

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -34,7 +34,6 @@ options:
         will only be downloaded if the destination does not exist. Generally
         should be C(yes) only for small local files.
       - Prior to 0.6, this module behaved as if C(yes) was the default.
-    version_added: '0.7'
     default: 'no'
     type: bool
     aliases: [ thirsty ]
@@ -85,7 +84,7 @@ options:
   name:
     description:
       - name used to create / delete the host
-      - this does not need to be the FQDN, but does needs to be uniuqe
+      - this does not need to be the FQDN, but does needs to be unique
     required: true
   zone:
     description:
@@ -104,7 +103,7 @@ options:
     description:
       - the name used to display the host
     required: false
-    default: <name>
+    default: if none is give it is the value of the <name> parameter
   ip:
     description:
       - the ip-addres of the host

--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -1,7 +1,10 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-#
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'version': '1.1'}


### PR DESCRIPTION
SUMMARY

This module (icinga2_host) allows the use of the Icinga2 REST API (https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/) to manage a host definition in Icinga2.

ISSUE TYPE

    New Module Pull Request

COMPONENT NAME

    icinga2_host

ANSIBLE VERSION

    2.5.0

ADDITIONAL INFORMATION

modules to follow are
 - icinga2_service (manage services to monitor)
 - icinga2_downtime (manage downtime for hosts)

All 3 modules together will make it possible for a playbook to make sure the host(s) are monitored, they are down while running the playbook (no alarms are send) and manage the services that need to be monitored.

Please let me know if I can improve / help this along in any way.