### PR TITLE
Fix Debian packaging Dockerfile and docs.

### DIFF
--- a/packaging/debian/Dockerfile
+++ b/packaging/debian/Dockerfile
@@ -7,7 +7,11 @@ RUN apt-get update && apt-get install -y \
     devscripts \
     make \
     pbuilder \
-    python-setuptools
+    python-jinja2 \
+    python-setuptools \
+    python-yaml \
+    && \
+    apt-get clean
 
 VOLUME /ansible
 WORKDIR /ansible

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -9,7 +9,6 @@ __Note__: You must run this target as root or set `PBUILDER_BIN='sudo pbuilder'`
 apt-get install asciidoc cdbs debootstrap devscripts make pbuilder python-setuptools
 git clone https://github.com/ansible/ansible.git
 cd ansible
-git submodule update --init
 DEB_DIST='xenial trusty precise' make deb
 ```
 
@@ -18,7 +17,6 @@ Building in Docker:
 ```
 git clone https://github.com/ansible/ansible.git
 cd ansible
-git submodule update --init
 docker build -t ansible-deb-builder -f packaging/debian/Dockerfile .
 docker run --privileged -e DEB_DIST='trusty' -v $(pwd):/ansible ansible-deb-builder
 ```


### PR DESCRIPTION
##### SUMMARY

Fix Debian packaging Dockerfile and docs.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

packaging/debian/Dockerfile

##### ANSIBLE VERSION

```
ansible 2.5.0 (packaging-fix 10512e2ee3) last updated 2017/10/13 12:54:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
