### PR TITLE
Upgrade pip to support cryptography 2.1 and later.

### DIFF
--- a/test/utils/shippable/remote.sh
+++ b/test/utils/shippable/remote.sh
@@ -86,6 +86,7 @@ if [ ${start_instance} ]; then
         start --id "${instance_id}" "${test_auth}" "${test_platform}" "${test_version}" ${args}
 fi
 
+pip install pip --upgrade
 pip install "${source_root}" --upgrade
 pip install -r "${source_root}/test/utils/shippable/remote-requirements.txt" --upgrade
 pip list


### PR DESCRIPTION
##### SUMMARY

Upgrade pip to support cryptography 2.1 and later.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

CI

##### ANSIBLE VERSION

```
ansible 2.2.3.0 (ci-2.2 1f6066fd88) last updated 2017/10/13 15:40:43 (GMT -700)
  lib/ansible/modules/core: (detached HEAD ebdd66c2b6) last updated 2017/05/10 02:01:03 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 0cfb1c4c34) last updated 2017/05/10 02:01:05 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
