### PR TITLE
use to_str instead of json.dumps when serializing k8s object for logging

### DIFF
--- a/lib/ansible/module_utils/k8s_common.py
+++ b/lib/ansible/module_utils/k8s_common.py
@@ -226,7 +226,7 @@ class KubernetesAnsibleModule(AnsibleModule):
                 self.exit_json(**return_attributes)
             else:
                 self.helper.log('Existing:')
-                self.helper.log(existing.to_str(), indent=4)
+                self.helper.log(existing.to_str())
                 self.helper.log('\nDifferences:')
                 self.helper.log(json.dumps(diff, indent=4))
             # Differences exist between the existing obj and requested params

--- a/lib/ansible/module_utils/k8s_common.py
+++ b/lib/ansible/module_utils/k8s_common.py
@@ -226,7 +226,7 @@ class KubernetesAnsibleModule(AnsibleModule):
                 self.exit_json(**return_attributes)
             else:
                 self.helper.log('Existing:')
-                self.helper.log(json.dumps(existing.to_dict(), indent=4))
+                self.helper.log(existing.to_str(), indent=4)
                 self.helper.log('\nDifferences:')
                 self.helper.log(json.dumps(diff, indent=4))
             # Differences exist between the existing obj and requested params


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Modules that use the k8s_common module will fail during a logging statement if the object retrieved from the k8s API has datetime objects in it, because `json.dumps` cannot serialize datetime objects. If `obj.to_str` is used instead of `json.dumps(obj.to_dict())`, `pprint.pformat` is used to serialize it and it handles datetime objects fine. This should only affect the logging output of the k8s_common module.


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
k8s_common