### PR TITLE
Fixes documentation related bugs

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_partition.py
+++ b/lib/ansible/modules/network/f5/bigip_partition.py
@@ -4,14 +4,18 @@
 # Copyright (c) 2017 F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: bigip_partition
-short_description: Manage BIG-IP partitions.
+short_description: Manage BIG-IP partitions
 description:
   - Manage BIG-IP partitions.
 version_added: "2.5"
@@ -42,70 +46,70 @@ author:
   - Tim Rupp (@caphrim007)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create partition "foo" using the default route domain
   bigip_partition:
-      name: "foo"
-      password: "secret"
-      server: "lb.mydomain.com"
-      user: "admin"
+    name: foo
+    password: secret
+    server: lb.mydomain.com
+    user: admin
   delegate_to: localhost
 
 - name: Create partition "bar" using a custom route domain
   bigip_partition:
-      name: "bar"
-      route_domain: 3
-      password: "secret"
-      server: "lb.mydomain.com"
-      user: "admin"
+    name: bar
+    route_domain: 3
+    password: secret
+    server: lb.mydomain.com
+    user: admin
   delegate_to: localhost
 
 - name: Change route domain of partition "foo"
   bigip_partition:
-      name: "foo"
-      route_domain: 8
-      password: "secret"
-      server: "lb.mydomain.com"
-      user: "admin"
+    name: foo
+    route_domain: 8
+    password: secret
+    server: lb.mydomain.com
+    user: admin
   delegate_to: localhost
 
 - name: Set a description for partition "foo"
   bigip_partition:
-      name: "foo"
-      description: "Tenant CompanyA"
-      password: "secret"
-      server: "lb.mydomain.com"
-      user: "admin"
+    name: foo
+    description: Tenant CompanyA
+    password: secret
+    server: lb.mydomain.com
+    user: admin
   delegate_to: localhost
 
 - name: Delete the "foo" partition
   bigip_partition:
-      name: "foo"
-      password: "secret"
-      server: "lb.mydomain.com"
-      user: "admin"
-      state: "absent"
+    name: foo
+    password: secret
+    server: lb.mydomain.com
+    user: admin
+    state: absent
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 route_domain:
-    description: Name of the route domain associated with the partition.
-    returned: changed and success
-    type: int
-    sample: 0
+  description: Name of the route domain associated with the partition.
+  returned: changed and success
+  type: int
+  sample: 0
 description:
-    description: The description of the partition.
-    returned: changed and success
-    type: string
-    sample: "Example partition"
+  description: The description of the partition.
+  returned: changed and success
+  type: string
+  sample: Example partition
 '''
 
 from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import AnsibleF5Parameters
 from ansible.module_utils.f5_utils import F5ModuleError
-from ansible.module_utils.f5_utils import iteritems
-from ansible.module_utils.f5_utils import defaultdict
+from ansible.module_utils.six import iteritems
+from collections import defaultdict
 
 try:
     from ansible.module_utils.f5_utils import HAS_F5SDK

--- a/test/units/modules/network/f5/test_bigip_partition.py
+++ b/test/units/modules/network/f5/test_bigip_partition.py
@@ -38,11 +38,13 @@ try:
     from library.bigip_partition import Parameters
     from library.bigip_partition import ModuleManager
     from library.bigip_partition import ArgumentSpec
+    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_partition import Parameters
         from ansible.modules.network.f5.bigip_partition import ModuleManager
         from ansible.modules.network.f5.bigip_partition import ArgumentSpec
+        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
New conventions for ansible warrant fixes to accomodate those
in bigip_partition.

This patch also includes an import fix that can raise an error when
Ansible unit tests run

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_partition

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.4 (default, Sep 13 2017, 14:38:38) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
