### PR TITLE
Allow lists and dicts as msg/var parameters to debug module

### DIFF
--- a/lib/ansible/modules/utilities/logic/debug.py
+++ b/lib/ansible/modules/utilities/logic/debug.py
@@ -27,12 +27,13 @@ options:
   msg:
     description:
       - The customized message that is printed. If omitted, prints a generic
-        message.
+        message. It may also be a list or dictionary of messages.
     required: false
     default: "Hello world!"
   var:
     description:
-      - A variable name to debug.  Mutually exclusive with the 'msg' option.
+      - A variable name to debug.  Mutually exclusive with the 'msg' option. It may also be
+        a list or dictionary of variable names
   verbosity:
     description:
       - A number that controls when the debug is run, if you set to 3 it will only run debug when -vvv or above
@@ -66,4 +67,16 @@ EXAMPLES = '''
   debug:
     var: hostvars[inventory_hostname]
     verbosity: 4
+
+- name: Display a list of messages
+  debug:
+    msg:
+    - "The default IP address is {{ ansible_default_ipv4.address }}"
+    - "The default gateway is {{ ansible_default_ipv4.gateway }}"
+
+- name: Display a dict of variables
+  debug:
+    var:
+      ip: ansible_default_ipv4.address
+      gateway: ansible_default_ipv4.gateway
 '''

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -68,9 +68,9 @@ class ActionModule(ActionBase):
             elif 'var' in self._task.args:
                 var = self._task.args['var']
                 if isinstance(var, dict):
-                    result.update((k, self._run_templar(v)) for k, v in var.items())
+                    result['var'] = dict((k, self._run_templar(v)) for k, v in var.items())
                 elif isinstance(var, list):
-                    result.update((v, self._run_templar(v)) for v in var)
+                    result['var'] = dict((v, self._run_templar(v)) for v in var)
                 else:
                     result[var] = self._run_templar(var)
             else:

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -55,7 +55,8 @@ class ActionModule(ActionBase):
             elif 'var' in self._task.args:
                 var = self._task.args['var']
                 try:
-                    templar_func = lambda v: self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
+                    def templar_func(v):
+                        return self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
                     if isinstance(var, dict):
                         results = dict((k, templar_func(v)) for k, v in var.items())
                     elif isinstance(var, list):

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -55,12 +55,13 @@ class ActionModule(ActionBase):
             elif 'var' in self._task.args:
                 var = self._task.args['var']
                 try:
+                    templar_func = lambda v: self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
                     if isinstance(var, dict):
-                        results = dict((k, self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)) for k, v in var.items())
+                        results = dict((k, templar_func(v)) for k, v in var.items())
                     elif isinstance(var, list):
-                        results = dict((v, self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)) for v in var)
+                        results = dict((v, templar_func(v)) for v in var)
                     else:
-                        results = self._templar.template(var, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
+                        results = templar_func(var)
                         if results == var:
                             # if results is not str/unicode type, raise an exception
                             if not isinstance(results, string_types):

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -53,9 +53,10 @@ class ActionModule(ActionBase):
                 result['msg'] = self._task.args['msg']
 
             elif 'var' in self._task.args:
+                var = self._task.args['var']
                 try:
-                    results = self._templar.template(self._task.args['var'], convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
-                    if results == self._task.args['var']:
+                    results = self._templar.template(var, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
+                    if results == var:
                         # if results is not str/unicode type, raise an exception
                         if not isinstance(results, string_types):
                             raise AnsibleUndefinedVariable
@@ -64,11 +65,11 @@ class ActionModule(ActionBase):
                 except AnsibleUndefinedVariable:
                     results = "VARIABLE IS NOT DEFINED!"
 
-                if isinstance(self._task.args['var'], (list, dict)):
+                if isinstance(var, (list, dict)):
                     # If var is a list or dict, use the type as key to display
-                    result[to_text(type(self._task.args['var']))] = results
+                    result[to_text(type(var))] = results
                 else:
-                    result[self._task.args['var']] = results
+                    result[var] = results
             else:
                 result['msg'] = 'Hello world!'
 

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -58,9 +58,9 @@ class ActionModule(ActionBase):
                     def templar_func(v):
                         return self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
                     if isinstance(var, dict):
-                        results = dict((k, templar_func(v)) for k, v in var.items())
+                        result.update((k, templar_func(v)) for k, v in var.items())
                     elif isinstance(var, list):
-                        results = dict((v, templar_func(v)) for v in var)
+                        result.update((v, templar_func(v)) for v in var)
                     else:
                         results = templar_func(var)
                         if results == var:
@@ -69,14 +69,15 @@ class ActionModule(ActionBase):
                                 raise AnsibleUndefinedVariable
                             # If var name is same as result, try to template it
                             results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
+                        result[var] = results
                 except AnsibleUndefinedVariable:
                     results = "VARIABLE IS NOT DEFINED!"
 
-                if isinstance(var, (list, dict)):
-                    # If var is a list or dict, use the type as key to display
-                    result[to_text(type(var).__name__)] = results
-                else:
-                    result[var] = results
+                    if isinstance(var, (list, dict)):
+                        # If var is a list or dict, use the type as key to display
+                        result[to_text(type(var).__name__)] = results
+                    else:
+                        result[var] = results
             else:
                 result['msg'] = 'Hello world!'
 

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -55,13 +55,18 @@ class ActionModule(ActionBase):
             elif 'var' in self._task.args:
                 var = self._task.args['var']
                 try:
-                    results = self._templar.template(var, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
-                    if results == var:
-                        # if results is not str/unicode type, raise an exception
-                        if not isinstance(results, string_types):
-                            raise AnsibleUndefinedVariable
-                        # If var name is same as result, try to template it
-                        results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
+                    if isinstance(var, dict):
+                        results = dict((k, self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)) for k, v in var.items())
+                    elif isinstance(var, list):
+                        results = dict((v, self._templar.template(v, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)) for v in var)
+                    else:
+                        results = self._templar.template(var, convert_bare=True, fail_on_undefined=True, bare_deprecated=False)
+                        if results == var:
+                            # if results is not str/unicode type, raise an exception
+                            if not isinstance(results, string_types):
+                                raise AnsibleUndefinedVariable
+                            # If var name is same as result, try to template it
+                            results = self._templar.template("{{" + results + "}}", convert_bare=True, fail_on_undefined=True)
                 except AnsibleUndefinedVariable:
                     results = "VARIABLE IS NOT DEFINED!"
 

--- a/lib/ansible/plugins/action/debug.py
+++ b/lib/ansible/plugins/action/debug.py
@@ -67,7 +67,7 @@ class ActionModule(ActionBase):
 
                 if isinstance(var, (list, dict)):
                     # If var is a list or dict, use the type as key to display
-                    result[to_text(type(var))] = results
+                    result[to_text(type(var).__name__)] = results
                 else:
                     result[var] = results
             else:

--- a/test/integration/targets/ipify_facts/tasks/main.yml
+++ b/test/integration/targets/ipify_facts/tasks/main.yml
@@ -29,7 +29,7 @@
     timeout: 30
     validate_certs: "{{ validate_certs }}"
   register: external_ip
-- debug: var="{{ external_ip }}"
+- debug: var=external_ip
 
 - name: check if task was successful
   assert:

--- a/test/integration/targets/vmware_vm_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_vm_facts/tasks/main.yml
@@ -59,7 +59,7 @@
     password: "{{ vcsim_instance['json']['password'] }}"
   register: vm_facts_0001
 
-- debug: var="{{ vm_facts_0001['virtual_machines'].keys() }}"
+- debug: msg="{{ vm_facts_0001['virtual_machines'].keys() }}"
 
 - name: get all VMs
   uri:


### PR DESCRIPTION
##### SUMMARY
This pull request allows lists and dicts to be passed as values of the `debug` module. Strictly speaking, a similar effect may be achieved using `with_items`, but the output is clearer when implemented natively. Please see additional information for before/after comparison:

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`plugins/action/debug.py`

##### ANSIBLE VERSION
```
ansible 2.5.0 (debug-list 4b50d22be3) last updated 2017/10/14 12:09:47 (GMT +200)
  config file = None
  configured module search path = [u'/Users/blackfire/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/blackfire/src/ansible/lib/ansible
  executable location = /Users/blackfire/src/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 14 2015, 19:46:27) [GCC 4.2.1 Compatible Apple LLVM 6.0 (clang-600.0.39)]
```


##### ADDITIONAL INFORMATION

Before:
```
  - debug:
      var: "{{ item }}"
    with_items:
    - str1_var
    - str2_var
```
```
ok: [localhost] => (item=str1_var) => {
    "item": "str1_var",
    "str1_var": "string variable 1"
}
ok: [localhost] => (item=str2_var) => {
    "item": "str2_var",
    "str2_var": "string variable 2"
}
```

After:
```
  - debug:
      var:
      - str1_var
      - str2_var
```
```
ok: [localhost] => {
    "var": {
        "str1_var": "string variable 1",
        "str2_var": "string variable 2"
    }
}
```
