### PR TITLE
ec2_group: do not fail on description mismatch (#31704)

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -682,8 +682,7 @@ def main():
         if group:
             # existing group
             if group['Description'] != description:
-                module.fail_json(
-                    msg="Group description does not match existing group. ec2_group does not support this case.")
+                module.warn("Group description does not match existing group.")
 
         # if the group doesn't exist, create it now
         else:

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -682,7 +682,8 @@ def main():
         if group:
             # existing group
             if group['Description'] != description:
-                module.warn("Group description does not match existing group. Descriptions cannot be changed without deleting and re-creating the security group. Try using state=absent to delete, then rerunning this task.")
+                module.warn("Group description does not match existing group. Descriptions cannot be changed without deleting "
+                            "and re-creating the security group. Try using state=absent to delete, then rerunning this task.")
 
         # if the group doesn't exist, create it now
         else:

--- a/lib/ansible/modules/cloud/amazon/ec2_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_group.py
@@ -682,7 +682,7 @@ def main():
         if group:
             # existing group
             if group['Description'] != description:
-                module.warn("Group description does not match existing group.")
+                module.warn("Group description does not match existing group. Descriptions cannot be changed without deleting and re-creating the security group. Try using state=absent to delete, then rerunning this task.")
 
         # if the group doesn't exist, create it now
         else:

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -192,7 +192,7 @@
            - 'result.group_id.startswith("sg-")'
 
     # ============================================================
-    - name: test state=present different description raises error
+    - name: test state=present different description (expected changed=false)
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}CHANGED'
@@ -204,11 +204,11 @@
       ignore_errors: true
       register: result
 
-    - name: assert matching group with non-matching description raises error
+    - name: assert state=present (expected changed=false)
       assert:
         that:
-           - 'result.failed'
-           - '"Group description does not match existing group. ec2_group does not support this case." in result.msg'
+           - 'not result.changed'
+           - 'result.group_id.startswith("sg-")'
 
     # ============================================================
     - name: test state=present (expected changed=false)


### PR DESCRIPTION
##### SUMMARY
This resolves issue #31704 AWS security group description mismatch causes module ec2_group to fail.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ANSIBLE VERSION
```
ansible 2.5.0 (ec2-group-warn 2f35157bc7) last updated 2017/10/14 13:36:01 (GMT +200)
  config file = None
  configured module search path = [u'/home/marek/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/marek/Projects/ansible/lib/ansible
  executable location = /home/marek/.virtualenvs/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
Before: ec2_group was failling when security group description didn't match existing group.
```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Group description does not match existing group. ec2_group does not support this case."}
```

After: ec2_group raises a warning.
```
[WARNING]: Group description does not match existing group.
```
