### PR TITLE
Lineinfile: in check mode do not fail with missing file, only warn.

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -234,7 +234,9 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
     if not os.path.exists(b_dest):
         if not create:
-            module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
+            if not module.check_mode:
+                module.fail_json(rc=257, msg='Destination %s does not exist !' % dest)
+            module.warn('Destination %s does not exist.' % dest)
         b_destpath = os.path.dirname(b_dest)
         if not os.path.exists(b_destpath) and not module.check_mode:
             os.makedirs(b_destpath)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When in **check mode** lineinfile will only warn about missing destination file.  
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lineinfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->

```
ansible 2.5.0 (lineinfile_missing_file_warn_in_check_mode 3382fbaa29) last updated 2017/10/14 14:17:08 (GMT +200)
  config file = None
  configured module search path = [u'/home/pawel/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pawel/code/ansible/lib/ansible
  executable location = /home/pawel/.virtualenvs/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Destination test.txt does not exist !", "rc": 257}
```
After
```
[WARNING]: Destination test.txt does not exist.
```