### PR TITLE
Issue 30829: change file lookup plugin strip behavior

### DIFF
--- a/lib/ansible/plugins/lookup/file.py
+++ b/lib/ansible/plugins/lookup/file.py
@@ -15,6 +15,16 @@ DOCUMENTATION = """
       _terms:
         description: path(s) of files to read
         required: True
+      rstrip:
+        description: whether or not to remove whitespace from the ending of the looked-up file
+        type: bool
+        required: False
+        default: True
+      lstrip:
+        description: whether or not to remove whitespace from the beginning of the looked-up file
+        type: bool
+        required: False
+        default: False
     notes:
       - if read in variable context, the file can be interpreted as YAML if the content is valid to the parser.
       - this lookup does not understand 'globing', use the fileglob lookup instead.
@@ -64,7 +74,11 @@ class LookupModule(LookupBase):
                 if lookupfile:
                     b_contents, show_data = self._loader._get_file_contents(lookupfile)
                     contents = to_text(b_contents, errors='surrogate_or_strict')
-                    ret.append(contents.rstrip())
+                    if kwargs.get('lstrip', False):
+                        contents = contents.lstrip()
+                    if kwargs.get('rstrip', True):
+                        contents = contents.rstrip()
+                    ret.append(contents)
                 else:
                     raise AnsibleParserError()
             except AnsibleParserError:


### PR DESCRIPTION
##### SUMMARY
This PR adds two optional flags to the file lookup plugin. 
By default the plugin rstrips the content, with rstrip=False the content will be kept as the exact file's contents.
With lstrip=True, whitespace will be truncated from the beginning of the buffered content.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lookup

##### ANSIBLE VERSION
```
ansible 2.5.0 (30829-file-lookup-strip b0b855279e) last updated 2017/10/14 15:32:03 (GMT +200)
  config file = None
  configured module search path = [u'/home/tomo/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/tomo/PycharmProjects/ansible/lib/ansible
  executable location = /home/tomo/PycharmProjects/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```