### PR TITLE
Hacking folder should not be excluded from Archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 CHANGELOG.md merge=union
 .github/ export-ignore
-hacking/ export-ignore
 ticket-stubs/ export-ignore


### PR DESCRIPTION
##### SUMMARY
We are using Ansible from source in our closed data centers by storing an archive of Ansible in an internal server. So far we could always just download the latest release .zip that is offered in the release section of GitHub. Unfortunately, with the latest versions that doesn't work anymore because the "hacking" folder is now excluded. This pull request includes that folder again.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

##### ANSIBLE VERSION
Starting from 2.4 onward.
