### PR TITLE
Fix -M/--module-path option for ansible-doc and ansible-console

### DIFF
--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -126,9 +126,10 @@ class ConsoleCLI(CLI, cmd.Cmd):
 
     def list_modules(self):
         modules = set()
-        if self.options.module_path is not None:
-            for i in self.options.module_path.split(os.pathsep):
-                module_loader.add_directory(i)
+        if self.options.module_path:
+            for path in self.options.module_path:
+                if path:
+                    module_loader.add_directory(path)
 
         module_paths = module_loader._get_paths()
         for path in module_paths:

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -103,9 +103,10 @@ class DocCLI(CLI):
             loader = module_loader
 
         # add to plugin path from command line
-        if self.options.module_path is not None:
-            for i in self.options.module_path.split(os.pathsep):
-                loader.add_directory(i)
+        if self.options.module_path:
+            for path in self.options.module_path:
+                if path:
+                    loader.add_directory(path)
 
         # save only top level paths for errors
         search_paths = DocCLI.print_paths(loader)


### PR DESCRIPTION
##### SUMMARY
Fixes broken -M/--module-path options of ansible-doc and ansible-console.

Before the change I was getting the following error:
```
$ ansible-doc -M . raw -s -vvv
ERROR! Unexpected Exception, this is probably a bug: 'list' object has no attribute 'split'
the full traceback was:

Traceback (most recent call last):
  File "/home/user/ansible/ansible/bin/ansible-doc", line 109, in <module>
    exit_code = cli.run()
  File "/home/user/ansible/ansible/lib/ansible/cli/doc.py", line 107, in run
    for i in self.options.module_path.split(os.pathsep):
AttributeError: 'list' object has no attribute 'split'
```

#29663 changed the logic of the base cli parser, so options.module_path became a list.

I've copied the logic for iterating through options.module_path from the commit that changed it: https://github.com/ansible/ansible/blob/2165bac212ec916e906f6b3aa5ed845a7bfa8da4/lib/ansible/executor/task_queue_manager.py#L86-L90

fixes #31743

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cli/doc, cli/console
##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 02cd881697) last updated 2017/10/14 21:11:59 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/user/ansible/ansible/lib/ansible
  executable location = /home/user/.virtualenvs/ansible/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```