### PR TITLE
`purge_subnets` depends on `subnets` option 

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -51,7 +51,7 @@ options:
   purge_subnets:
     version_added: "2.3"
     description:
-      - "Purge existing subnets that are not found in subnets."
+      - "Purge existing subnets that are not found in subnets. Ignored unless the subnets option is supplied."
     required: false
     default: 'true'
     aliases: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

The description on the `purge_subnets` option is a little vague. It purges subnets not found in the value of the supplied `subnets` option, but does nothing unless the `subnets` option is supplied. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_vpc_route_table

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/kerk/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kerk/.pyenv/versions/2.7.11/lib/python2.7/site-packages/ansible
  executable location = /Users/kerk/.pyenv/versions/2.7.11/bin/ansible
  python version = 2.7.11 (default, Dec 29 2015, 17:39:03) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
