### PR TITLE
Update AWS SSM lookup to support getting parameters by path (second attempt)

### DIFF
--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -1,4 +1,5 @@
 # (c) 2016, Bill Wang <ozbillwang(at)gmail.com>
+# (c) 2017, Marat Bakeev <hawara(at)gmail.com>
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
@@ -8,6 +9,7 @@ __metaclass__ = type
 from ansible.module_utils.ec2 import HAS_BOTO3
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
+from ansible.module_utils.parsing.convert_bool import boolean
 
 try:
     from botocore.exceptions import ClientError
@@ -37,18 +39,44 @@ class LookupModule(LookupBase):
 
         - name: lookup ssm parameter store with all options.
           debug: msg="{{ lookup('aws_ssm', 'Hello', 'decrypt=false', 'region=us-east-2', 'aws_profile=myprofile') }}"
+
+        - name: return a dictionary of ssm parameters from a hierarchy path
+          debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', 'region=ap-southeast-2', 'bypath', 'recursive=true' ) }}"
+
+        - name: return a dictionary of ssm parameters from a hierarchy path with shortened names (param instead of /PATH/to/param)
+          debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', 'region=ap-southeast-2', 'shortnames', 'bypath', 'recursive=true' ) }}"
+
+        - name: Iterate over a parameter hierarchy
+          debug: msg='key contains {{item.Name }} with value {{item.Value}} '
+          with_aws_ssm:
+            - '/TEST/test-list'
+            - 'region=ap-southeast-2'
+            - 'bypath'
+
         '''
 
         ret = {}
         response = {}
         session = {}
         ssm_dict = {}
+        lparams = {}
 
         if not HAS_BOTO3:
             raise AnsibleError('botocore and boto3 are required.')
 
         ssm_dict['WithDecryption'] = True
-        ssm_dict['Names'] = [terms[0]]
+
+        # check if option 'bypath' is specified, while still allowing to have a parameter with the same name
+        if 'bypath' in terms[1:]:
+            ssm_dict['Path'] = terms[0]
+            del terms[terms[1:].index('bypath') + 1]
+        else:
+            ssm_dict['Names'] = [terms[0]]
+
+        # Option to return short parameter names in by path lookups
+        if 'shortnames' in terms[1:]:
+            lparams['shortnames'] = True
+            del terms[terms[1:].index('shortnames') + 1]
 
         if len(terms) > 1:
             for param in terms[1:]:
@@ -60,8 +88,12 @@ class LookupModule(LookupBase):
                 if key == "region" or key == "aws_profile":
                     session[key] = value
 
+                # recurse or not
+                if key == "recursive" and boolean(value):
+                    ssm_dict['Recursive'] = True
+
                 # decrypt the value or not
-                if key == "decrypt" and value.lower() == "false":
+                if key == "decrypt" and boolean(value):
                     ssm_dict['WithDecryption'] = False
 
         if "aws_profile" in session:
@@ -73,13 +105,34 @@ class LookupModule(LookupBase):
             client = boto3.client('ssm')
 
         try:
-            response = client.get_parameters(**ssm_dict)
+            # Lookup by path
+            if 'Path' in ssm_dict:
+                response = client.get_parameters_by_path(**ssm_dict)
+                paramlist = list()
+                paramlist.extend(response['Parameters'])
+
+                # Manual pagination, since boto doesnt support it yet for get_parameters_by_path
+                while 'NextToken' in response:
+                    response = client.get_parameters_by_path(NextToken=response['NextToken'], **ssm_dict)
+                    paramlist.extend(response['Parameters'])
+
+                # shorten parameter names. yes, this will return duplicate names with different values.
+                if 'shortnames' in lparams:
+                    for x in paramlist:
+                        x['Name'] = x['Name'][x['Name'].rfind('/') + 1:]
+
+                if len(paramlist):
+                    return paramlist
+                else:
+                    return None
+            # Lookup by parameter name
+            else:
+                response = client.get_parameters(**ssm_dict)
+                ret.update(response)
+                if ret['Parameters']:
+                    return [ret['Parameters'][0]['Value']]
+                else:
+                    return None
+
         except ClientError as e:
             raise AnsibleError("SSM lookup exception: {0}".format(e))
-
-        ret.update(response)
-
-        if ret['Parameters']:
-            return [ret['Parameters'][0]['Value']]
-        else:
-            return None


### PR DESCRIPTION
##### SUMMARY
Update AWS SSM Parameter storage lookup plugin to support getting parameters by path

AWS SSM Parameter store lookup was added in PR https://github.com/ansible/ansible/pull/23460, but there were requests to add support to look up parameters by path. 

This is my attempt on that. This is a second PR from me, because I've screwed up the history in my original PR https://github.com/ansible/ansible/pull/31505, sorry :(

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
plugins/lookup/ssm.py

##### ANSIBLE VERSION
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 3.6.2 (default, Jul 20 2017, 03:52:27) [GCC 7.1.1 20170630]
```

##### ADDITIONAL INFORMATION
Currently, the lookup plugin only gets a single parameter as in example below:
```
- debug: msg="{{ lookup('aws_ssm', 'Hello', 'region=ap-southeast-2',  ) }}"
```

This PR adds these features:
You lookup the whole parameters hierarchy:
```
 - debug: msg="{{ lookup('aws_ssm', '/Test', 'region=ap-southeast-2', 'bypath', 'recursive=true' ) }}
```
Would return:
```
ok: [localhost] => {
    "msg": [
        {
            "Name": "/Test/secure-test", 
            "Type": "SecureString", 
            "Value": "secure-test"
        }, 
        {
            "Name": "/Test/subpath/test", 
            "Type": "String", 
            "Value": "testsubpath"
        }, 
        {
            "Name": "/Test/test-string", 
            "Type": "String", 
            "Value": "test-string"
        }
    ]
}
```

You can loop through them:
```
         - name: Getting parameters in a loop
           debug: msg='key contains an item named {{item.Name }} with value {{item.Value}}'
           with_aws_ssm:
             - '/Test'
             - 'region=ap-southeast-2'
             - 'bypath'
             - 'recursive=true'
```
would return:

```
TASK [Getting parameters in a loop] *********************************************************************
Tuesday 10 October 2017  16:22:44 +1300 (0:00:00.370)       0:00:01.035 ******* 
ok: [localhost] => (item={u'Type': u'SecureString', u'Name': u'/Test/secure-test', u'Value': u'secure-test'}) => {
    "item": {
        "Name": "/Test/secure-test", 
        "Type": "SecureString", 
        "Value": "secure-test"
    }, 
    "msg": "key contains an item named /Test/secure-test with value secure-test"
}
ok: [localhost] => (item={u'Type': u'String', u'Name': u'/Test/subpath/test', u'Value': u'testsubpath'}) => {
    "item": {
        "Name": "/Test/subpath/test", 
        "Type": "String", 
        "Value": "testsubpath"
    }, 
    "msg": "key contains an item named /Test/subpath/test with value testsubpath"
}
ok: [localhost] => (item={u'Type': u'String', u'Name': u'/Test/test-string', u'Value': u'test-string'}) => {
    "item": {
        "Name": "/Test/test-string", 
        "Type": "String", 
        "Value": "test-string"
    }, 
    "msg": "key contains an item named /Test/test-string with value test-string"
}
```

You can also ask the plugin to return short versions of parameter names (The part after the last slash, not the full path):
```
         - name: Getting parameters in a loop with names shorteting
           debug: msg='key contains an item named {{item.Name }} with value {{item.Value}}'
           with_aws_ssm:
             - '/Test'
             - 'region=ap-southeast-2'
             - 'bypath'
             - 'shortnames'
             - 'recursive=true'
```
Would return:

```
TASK [Getting parameters in a loop with names shorteting] ***********************************************
Tuesday 10 October 2017  16:22:44 +1300 (0:00:00.371)       0:00:01.406 ******* 
ok: [localhost] => (item={u'Type': u'SecureString', u'Name': u'secure-test', u'Value': u'secure-test'}) => {
    "item": {
        "Name": "secure-test", 
        "Type": "SecureString", 
        "Value": "secure-test"
    }, 
    "msg": "key contains an item named secure-test with value secure-test"
}
ok: [localhost] => (item={u'Type': u'String', u'Name': u'test', u'Value': u'testsubpath'}) => {
    "item": {
        "Name": "test", 
        "Type": "String", 
        "Value": "testsubpath"
    }, 
    "msg": "key contains an item named test with value testsubpath"
}
ok: [localhost] => (item={u'Type': u'String', u'Name': u'test-string', u'Value': u'test-string'}) => {
    "item": {
        "Name": "test-string", 
        "Type": "String", 
        "Value": "test-string"
    }, 
    "msg": "key contains an item named test-string with value test-string"
}
```

