### PR TITLE
fix the handling of empty auth_key

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -443,7 +443,7 @@ class ManageIQProvider(object):
                 # get role and authtype
                 role = endpoint.get('role') or provider_defaults.get(endpoint_key + '_role', 'default')
                 if role == 'default':
-                    authtype = provider_defaults.get('authtype', role)
+                    authtype = provider_defaults.get('authtype') or role
                 else:
                     authtype = role
 
@@ -461,7 +461,7 @@ class ManageIQProvider(object):
                         'authtype': authtype,
                         'userid': endpoint.get('userid'),
                         'password': endpoint.get('password'),
-                        'auth_key': endpoint.get('auth_key', default_auth_key),
+                        'auth_key': endpoint.get('auth_key') or default_auth_key,
                     }
                 })
 


### PR DESCRIPTION
**SUMMARY**

ManageIQ is an open source management platform for Hybrid IT.

This change is fixing:

The handling of missing `authtype` argument, currently if the argument is not given, it gets the value of an empty string ( e.g. "" ), we want to replace it with the default auth type.

For example, if authtype is not defined in the playbook:
`authtype = provider_defaults.get('authtype', role)` will return => "" while
`authtype = provider_defaults.get('authtype') or role` will return => role



**ISSUE TYPE**

    Bug fix

**COMPONENT NAME**

manageiq_provider.py (module)

**ANSIBLE VERSION**

ansible 2.5.0.0
