### PR TITLE
Included ansible_distribution_major_version #29561

### DIFF
--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -469,6 +469,7 @@ class Distribution(object):
         aix_facts = {}
         rc, out, err = self.module.run_command("/usr/bin/oslevel")
         data = out.split('.')
+        aix_facts['distribution_major_version'] = data[0]
         aix_facts['distribution_version'] = data[0]
         aix_facts['distribution_release'] = data[1]
         return aix_facts


### PR DESCRIPTION
##### SUMMARY
Included ansible_distribution_major_version according with
issue #29561

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/system/distribution.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (fix_29561 c61f5fe8cf) last updated 2017/10/15 13:28:35 (GMT +200)
  config file = None
  configured module search path = ['/Users/kairo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kairo/Dev/Ansible/bug_fixes/fix_29561/ansible/lib/ansible
  executable location = /Users/kairo/Dev/Ansible/bug_fixes/fix_29561/ansible/bin/ansible
  python version = 3.6.3 (v3.6.3:2c5fed86e0, Oct  3 2017, 00:32:08) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```

##### ADDITIONAL INFORMATION
Was added ansible_distribution_major_version as mentioned on Issue #29561


```
# ansible -I ../inventory all -m setup -a 'filter=*distribution*'
linux4 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "RedHat",
        "ansible_distribution_file_parsed": true,
        "ansible_distribution_file_path": "/etc/redhat-release",
        "ansible_distribution_file_variety": "RedHat",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_release": "Maipo",
        "ansible_distribution_version": "7.1"
    },
    "changed": false,
    "failed": false
}
lpar24 | SUCCESS => {
    "ansible_facts": {
        "ansible_distribution": "AIX",
        "ansible_distribution_major_version": "7",
        "ansible_distribution_release": "1",
        "ansible_distribution_version": "7"
    },
    "changed": false,
    "failed": false
}
```