### PR TITLE
Fix "route" has to be the first option in ufw command

### DIFF
--- a/lib/ansible/modules/system/ufw.py
+++ b/lib/ansible/modules/system/ufw.py
@@ -332,11 +332,11 @@ def main():
         elif command == 'rule':
             # Rules are constructed according to the long format
             #
-            # ufw [--dry-run] [delete] [insert NUM] [route] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
+            # ufw [--dry-run] [route] [delete] [insert NUM] allow|deny|reject|limit [in|out on INTERFACE] [log|log-all] \
             #     [from ADDRESS [port PORT]] [to ADDRESS [port PORT]] \
             #     [proto protocol] [app application] [comment COMMENT]
-            cmd.append([module.boolean(params['delete']), 'delete'])
             cmd.append([module.boolean(params['route']), 'route'])
+            cmd.append([module.boolean(params['delete']), 'delete'])
             cmd.append([params['insert'], "insert %s" % params['insert']])
             cmd.append([value])
             cmd.append([params['direction'], "%s" % params['direction']])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
For supporting deletion of ufw routes, route option has to be placed before delete option

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ufw module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
example task:
```yaml
- name: "delete allowed input for forwarted port {{ item.port }}"
    ufw:
      rule: allow
      interface: "{{ ansible_default_ipv4.interface }}"
      direction: in
      route: yes
      to_port: "{{ item.port }}"
      dest: "{{ item.dest }}"
      delete: yes
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
FAILED! => {"changed": false, "failed": true, "msg": "ERROR: Invalid syntax\n"}
```
