### PR TITLE
fixes [Errno 13] Permission denied: ./cloudforms.hosts in tower 3.2.1…

### DIFF
--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -186,7 +186,7 @@ class CloudFormsInventory(object):
         try:
             cache_path = os.path.expanduser(config.get('cache', 'path'))
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
-            cache_path = '.'
+            cache_path = '/tmp'
         (script, ext) = os.path.splitext(os.path.basename(__file__))
         self.cache_path_hosts = cache_path + "/%s.hosts" % script
         self.cache_path_inventory = cache_path + "/%s.inventory" % script


### PR DESCRIPTION
In the latest Tower release the cloudforms sync breaks with IOError: [Errno 13] Permission denied: './cloudforms.hosts' as the cache_path is set to "."
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
changed cache_path = /tmp
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
cloudforms.py
##### ANSIBLE VERSION
2.3 - 2.4
```

```


##### ADDITIONAL INFORMATION
<!---

  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
Before change: 
ERROR! Could not parse inventory source /var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py with available plugins:
Plugin script failed: Inventory script (/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py) had an execution error: /var/lib/awx/venv/ansible/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/var/lib/awx/venv/ansible/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/var/lib/awx/venv/ansible/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
/var/lib/awx/venv/ansible/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:852: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
Traceback (most recent call last):
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py", line 461, in <module>
    CloudFormsInventory()
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py", line 55, in __init__
    self.update_cache()
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py", line 382, in update_cache
    self.write_to_cache(self.hosts, self.cache_path_hosts)
  File "/var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py", line 438, in write_to_cache
    cache = open(filename, 'w')
IOError: [Errno 13] Permission denied: './cloudforms.hosts'

 
Plugin ini failed: /var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py:23: Expected key=value host variable assignment, got: __future__


After the change: 
  2.664 INFO     Updating inventory 6: cfmetower
    2.685 INFO     Reading Ansible inventory source: /var/lib/awx/venv/awx/lib/python2.7/site-packages/awx/plugins/inventory/cloudforms.py
   25.600 INFO     Processing JSON output...
   25.608 INFO     Loaded 101 groups, 93 hosts
   25.618 WARNING  Host "CF45_DB" has no "id" variable
   25.618 WARNING  Host "cfmedb" has no "id" variable
   25.618 WARNING  Host "demo-rhel7" has no "id" variable
   25.618 WARNING  Host "Coke-ami" has no "id" variable
   25.618 WARNING  Host "osenode1" has no "id" variable
   25.619 WARNING  Host "osenode2" has no "id" variable```
