### PR TITLE
win_reboot: change to sample system uptime instead of checking port status

### DIFF
--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -31,6 +31,7 @@ options:
     description:
     - Maximum seconds to wait for shutdown to occur
     - Increase this timeout for very slow hardware, large update applications, etc
+    - This option has been removed since Ansible 2.5 as the win_reboot behaviour has changed
     default: 600
     aliases: [ shutdown_timeout_sec ]
   reboot_timeout:
@@ -42,6 +43,7 @@ options:
   connect_timeout:
     description:
     - Maximum seconds to wait for a single successful TCP connection to the WinRM endpoint before trying again
+    - This option has been deprecated in Ansible 2.5 as the win_reboot behaviour has changed
     default: 5
     aliases: [ connect_timeout_sec ]
   test_command:
@@ -70,7 +72,6 @@ EXAMPLES = r'''
 
 # Reboot a slow machine that might have lots of updates to apply
 - win_reboot:
-    shutdown_timeout: 3600
     reboot_timeout: 3600
 '''
 

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -43,7 +43,6 @@ options:
   connect_timeout:
     description:
     - Maximum seconds to wait for a single successful TCP connection to the WinRM endpoint before trying again
-    - This option has been deprecated in Ansible 2.5 as the win_reboot behaviour has changed
     default: 5
     aliases: [ connect_timeout_sec ]
   test_command:

--- a/lib/ansible/modules/windows/win_reboot.py
+++ b/lib/ansible/modules/windows/win_reboot.py
@@ -31,7 +31,7 @@ options:
     description:
     - Maximum seconds to wait for shutdown to occur
     - Increase this timeout for very slow hardware, large update applications, etc
-    - This option has been removed since Ansible 2.5 as the win_reboot behaviour has changed
+    - This option has been removed since Ansible 2.5 as the win_reboot behavior has changed
     default: 600
     aliases: [ shutdown_timeout_sec ]
   reboot_timeout:

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -155,7 +155,6 @@ class ActionModule(ActionBase):
                     self._connection._set_connection_timeout_override(connect_timeout)
                 except AttributeError:
                     display.warning("Connection plugin does not allow the connection timeout to be overridden")
-                    pass
 
                 # try and get uptime
                 try:

--- a/lib/ansible/plugins/action/win_reboot.py
+++ b/lib/ansible/plugins/action/win_reboot.py
@@ -52,7 +52,7 @@ class ActionModule(ActionBase):
     def do_until_success_or_timeout(self, what, timeout, what_desc, fail_sleep=1):
         max_end_time = datetime.utcnow() + timedelta(seconds=timeout)
 
-        e = None
+        e = ""
         while datetime.utcnow() < max_end_time:
             try:
                 what()

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -263,7 +263,7 @@ class Connection(ConnectionBase):
             display.vvvvv('WINRM CONNECT: transport=%s endpoint=%s' % (transport, endpoint), host=self._winrm_host)
             try:
                 winrm_kwargs = self._winrm_kwargs.copy()
-                if self.connection_timeout: # allows plugins like win_reboot to override the timeout
+                if self.connection_timeout:  # allows plugins like win_reboot to override the timeout
                     winrm_kwargs['operation_timeout_sec'] = self.connection_timeout
                     winrm_kwargs['read_timeout_sec'] = self.connection_timeout + 1
                     self.connection_timeout = None


### PR DESCRIPTION
##### SUMMARY
One issue with win_reboot is that it checks if the port is offline and the online before continuing. This is an issue when using a VM with forwarded ports as Ansible never sees them as going offline and so timing out. This change samples the system uptime ticks and keeps on waiting until the system uptime is less than before.

Still need to solve the connection timeout and somehow pass that through to WinRM

Fixes https://github.com/ansible/ansible/issues/19825
Fixes https://github.com/ansible/ansible/issues/18108
Fixes https://github.com/ansible/ansible/issues/16826

I also want to try and fix https://github.com/ansible/ansible/issues/28389 but not sure if I can do it, trying to find out more info as `(New-Object -ComObject Microsoft.Update.Session).CreateUpdateInstaller().IsBusy` does not return `true` during the post reboot install phase

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
win_reboot

##### ANSIBLE VERSION
```
2.5
```
