### PR TITLE
Set region correctly for efs and efs_facts

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -230,7 +230,7 @@ def get_aws_connection_info(module, boto3=False):
                     module.fail_json(msg="boto is required for this module. Please install boto and try again")
             elif HAS_BOTO3:
                 # here we don't need to make an additional call, will default to 'us-east-1' if the below evaluates to None.
-                region = botocore.session.get_session().get_config_variable('region')
+                region = botocore.session.Session(profile=profile_name).get_config_variable('region')
             else:
                 module.fail_json(msg="Boto3 is required for this module. Please install boto3 and try again")
 


### PR DESCRIPTION
##### SUMMARY

Set `EFSConnection`'s `region` correctly by using whatever
region boto3 detects - this will either be from parameter,
environment variables or boto3 configuration file.

Without this, the `mount_point` gets incorrectly set to
include `None` in its path, because `region` is unset but
the connection has worked fine

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
efs
efs_facts

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel b058b8e653) last updated 2017/10/16 09:15:28 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```