### PR TITLE
ovirt_networks: Fix label assigment condition

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_networks.py
@@ -149,9 +149,11 @@ class NetworksModule(BaseModule):
         self._update_label_assignments(entity)
 
     def _update_label_assignments(self, entity):
+        if self.param('label') is None:
+            return
+
         labels = [lbl.id for lbl in self._connection.follow_link(entity.network_labels)]
         labels_service = self._service.service(entity.id).network_labels_service()
-
         if not self.param('label') in labels:
             if not self._module.check_mode:
                 if labels:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
#31517 has introduced an issue when comparing the label assignemnt.
We need to first check wheter user passed the label, if not don't do any check.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_networks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
