### PR TITLE
add metadata field to os_volume module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -78,7 +78,7 @@ options:
        - Metadata key/value pairs to associate with the volume.
      required: false
      default: None
-     version_added: "2.4"
+     version_added: "2.5"
 requirements:
      - "python >= 2.6"
      - "shade"

--- a/lib/ansible/modules/cloud/openstack/os_volume.py
+++ b/lib/ansible/modules/cloud/openstack/os_volume.py
@@ -73,6 +73,12 @@ options:
      required: false
      default: None
      version_added: "2.4"
+   metadata:
+     description:
+       - Metadata key/value pairs to associate with the volume.
+     required: false
+     default: None
+     version_added: "2.4"
 requirements:
      - "python >= 2.6"
      - "shade"
@@ -131,6 +137,9 @@ def _present_volume(module, cloud):
     if module.params['scheduler_hints']:
         volume_args['scheduler_hints'] = module.params['scheduler_hints']
 
+    if module.params['metadata']:
+        volume_args['metadata'] = module.params['metadata']
+
     volume = cloud.create_volume(
         wait=module.params['wait'], timeout=module.params['timeout'],
         **volume_args)
@@ -160,6 +169,7 @@ def main():
         snapshot_id=dict(default=None),
         volume=dict(default=None),
         state=dict(default='present', choices=['absent', 'present']),
+        metadata=dict(default=None, type='dict'),
         scheduler_hints=dict(default=None, type='dict')
     )
     module_kwargs = openstack_module_kwargs(


### PR DESCRIPTION
##### SUMMARY
Huawai Cloud and OTC Openstack provider support creation of encrypted volumes. To use these features, special metadata fields have to be set. This PR adds the metadata field to the os_volume module to support these features.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 - openstack/os_volume

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 0e26bfd960) last updated 2017/10/11 15:14:05 (GMT +200)
```


##### ADDITIONAL INFORMATION
The metadata field is a native field for the openstack cinder API, so this is a generic change that will support any metadata and any openstack compatible provider.