### PR TITLE
Enable use of empty manageiq arguments

### DIFF
--- a/lib/ansible/module_utils/manageiq.py
+++ b/lib/ansible/module_utils/manageiq.py
@@ -37,13 +37,19 @@ except ImportError:
 
 
 def manageiq_argument_spec():
-    return dict(
+    options = dict(
         url=dict(default=os.environ.get('MIQ_URL', None)),
         username=dict(default=os.environ.get('MIQ_USERNAME', None)),
         password=dict(default=os.environ.get('MIQ_PASSWORD', None), no_log=True),
         token=dict(default=os.environ.get('MIQ_TOKEN', None), no_log=True),
         verify_ssl=dict(default=True, type='bool'),
         ca_bundle_path=dict(required=False, default=None),
+    )
+
+    return dict(
+        manageiq_connection=dict(type='dict',
+                                 default=dict(verify_ssl=False),
+                                 options=options),
     )
 
 

--- a/lib/ansible/module_utils/manageiq.py
+++ b/lib/ansible/module_utils/manageiq.py
@@ -48,7 +48,7 @@ def manageiq_argument_spec():
 
     return dict(
         manageiq_connection=dict(type='dict',
-                                 default=dict(verify_ssl=False),
+                                 default=dict(verify_ssl=True),
                                  options=options),
     )
 

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -548,14 +548,14 @@ def main():
     zone_id = None
     endpoints = []
     argument_spec = dict(
-        manageiq_connection=dict(required=True, type='dict',
-                                 options=manageiq_argument_spec()),
         state=dict(choices=['absent', 'present'], default='present'),
         name=dict(required=True),
         zone=dict(default='default'),
         provider_region=dict(),
         type=dict(choices=supported_providers().keys()),
     )
+    # add the manageiq connection arguments to the arguments
+    argument_spec.update(manageiq_argument_spec())
     # add the endpoint arguments to the arguments
     argument_spec.update(endpoint_list_spec())
 

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_tags.py
@@ -246,18 +246,19 @@ class ManageIQTags(object):
 
 def main():
     actions = {'present': 'assign', 'absent': 'unassign', 'list': 'list'}
+    argument_spec = dict(
+        tags=dict(type='list'),
+        resource_name=dict(required=True, type='str'),
+        resource_type=dict(required=True, type='str',
+                           choices=manageiq_entities().keys()),
+        state=dict(required=False, type='str',
+                   choices=['present', 'absent', 'list'], default='present'),
+    )
+    # add the manageiq connection arguments to the arguments
+    argument_spec.update(manageiq_argument_spec())
 
     module = AnsibleModule(
-        argument_spec=dict(
-            manageiq_connection=dict(required=True, type='dict',
-                                     options=manageiq_argument_spec()),
-            tags=dict(type='list'),
-            resource_name=dict(required=True, type='str'),
-            resource_type=dict(required=True, type='str',
-                               choices=manageiq_entities().keys()),
-            state=dict(required=False, type='str',
-                       choices=['present', 'absent', 'list'], default='present'),
-        ),
+        argument_spec=argument_spec,
         required_if=[
             ('state', 'present', ['tags']),
             ('state', 'absent', ['tags'])

--- a/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_user.py
@@ -283,19 +283,21 @@ class ManageIQUser(object):
 
 
 def main():
+    argument_spec = dict(
+        userid=dict(required=True, type='str'),
+        name=dict(),
+        password=dict(no_log=True),
+        group=dict(),
+        email=dict(),
+        state=dict(choices=['absent', 'present'], default='present'),
+        update_password=dict(choices=['always', 'on_create'],
+                             default='always'),
+    )
+    # add the manageiq connection arguments to the arguments
+    argument_spec.update(manageiq_argument_spec())
+
     module = AnsibleModule(
-        argument_spec=dict(
-            manageiq_connection=dict(required=True, type='dict',
-                                     options=manageiq_argument_spec()),
-            userid=dict(required=True, type='str'),
-            name=dict(),
-            password=dict(no_log=True),
-            group=dict(),
-            email=dict(),
-            state=dict(choices=['absent', 'present'], default='present'),
-            update_password=dict(choices=['always', 'on_create'],
-                                 default='always'),
-        ),
+        argument_spec=argument_spec,
     )
 
     userid = module.params['userid']


### PR DESCRIPTION
##### SUMMARY
Currently we can not omit the managiq arguments:

Bug: If example.yaml does not have the `manageiq_connection` argument, we will get `"missing required arguments: manageiq_connection"` error:

##### Example
Without this fix we can not use the system variables:

    MIQ_URL=http://127.0.0.1:3000 MIQ_USERNAME=admin MIQ_PASSWORD=smartvm ansible-playbook example.yaml

will give:

    "msg": "missing required arguments: manageiq_connection"

With this bug fix, the above line will work.

This change is adding:

    manageiq module_utils, responsible for management of ManageIQ

All the modules, including docs, tests and usage examples can be found here

Currently, the only requirement for the modules is manageiq-api-client-python

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
manageiq.py (module_utils)

##### ANSIBLE VERSION
ansible 2.5.0.0


