### PR TITLE
Add support for Cloudformation's parameter attribute UsePreviousValue

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -33,7 +33,8 @@ options:
     choices: [ "true", "false" ]
   template_parameters:
     description:
-      - a list of hashes of all the template variables for the stack
+      - a list of hashes of all the template variables for the stack. The value can be a string or a dict.
+        Dict can be used to set additional template parameter attributes like UsePreviousValue (see example)
     required: false
     default: {}
   state:
@@ -197,6 +198,24 @@ EXAMPLES = '''
       ClusterSize: 3
     tags:
       Stack: ansible-cloudformation
+
+# Pass a template parameter which uses Cloudformation's UsePreviousValue attribute
+# When use_previous_value is set to True, the given value will be ignored and
+# Cloudformation will use the value from a previously submitted template.
+# If use_previous_value is set to False (default) the given value is used.
+  cloudformation:
+    stack_name: "ansible-cloudformation"
+    state: "present"
+    region: "us-east-1"
+    template: "files/cloudformation-example.json"
+    template_parameters:
+      DBSnapshotIdentifier:
+        use_previous_value: True
+        value: arn:aws:rds:es-east-1:000000000000:snapshot:rds:my-db-snapshot
+      DBName:
+        use_previous_value: True
+    tags:
+      Stack: "ansible-cloudformation"
 
 # Enable termination protection on a stack.
 # If the stack already exists, this will update its termination protection
@@ -586,7 +605,24 @@ def main():
         stack_params['StackPolicyBody'] = open(module.params['stack_policy'], 'r').read()
 
     template_parameters = module.params['template_parameters']
-    stack_params['Parameters'] = [{'ParameterKey': k, 'ParameterValue': str(v)} for k, v in template_parameters.items()]
+
+    stack_params['Parameters'] = []
+    for k, v in template_parameters.items():
+        if isinstance(v, dict):
+            # set parameter based on a dict to allow additional CFN Parameter Attributes
+            param = dict(ParameterKey=k)
+
+            if 'value' in v:
+                param['ParameterValue'] = str(v['value'])
+
+            if 'use_previous_value' in v and bool(v['use_previous_value']):
+                param['UsePreviousValue'] = True
+                param.pop('ParameterValue', None)
+
+            stack_params['Parameters'].append(param)
+        else:
+            # allow default k/v configuration to set a template parameter
+            stack_params['Parameters'].append({'ParameterKey': k, 'ParameterValue': str(v)})
 
     if isinstance(module.params.get('tags'), dict):
         stack_params['Tags'] = ansible.module_utils.ec2.ansible_dict_to_boto3_tag_list(module.params['tags'])

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -203,7 +203,7 @@ EXAMPLES = '''
 # When use_previous_value is set to True, the given value will be ignored and
 # Cloudformation will use the value from a previously submitted template.
 # If use_previous_value is set to False (default) the given value is used.
-  cloudformation:
+- cloudformation:
     stack_name: "ansible-cloudformation"
     state: "present"
     region: "us-east-1"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add support for Cloudformation's UsePreviousValue

Ansible allows a single value (k/v) as a CFN parameter. While CFN's Parameter datatype allows three attributes (http://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_Parameter.html):

  1) ParameterKey
  2) ParameterValue
  3) UsePreviousValue

ParameterKey / ParameterValue are mapped with the k/v provided in Ansible. UsePreviousValue is not usable via the cloudformation Ansible module.

When the module is able to handle a dict as a value, more attributes can be passed to the Parameter Datatype.

Handle **use_previous_value** and **value** as k/v pairs in a 'dict' passed as the value of a template_variable. Map these k/v's to the corresponding CFN Parameter Attribute. For backwards compatibility Ansible will default to the regular behavior except when a dict is provided as a value.

```
---
- cloudformation:
    template_parameters:
      NormalVariable: "value"

      DictVariable:
        value: "value"
        use_previous_value: false

      ExtraVariable:
        value: ""
        use_previous_value: true
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloudformation.py (module cloud/amazon)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```