### PR TITLE
elasticache: default zone to None - fixes #31779

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticache.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache.py
@@ -208,6 +208,8 @@ class ElastiCacheManager(object):
             else:
                 msg = "'%s' is currently deleting. Cannot create."
                 self.module.fail_json(msg=msg % self.name)
+        if self.zone is None:
+            self.zone = ''
 
         kwargs = dict(CacheClusterId=self.name,
                       NumCacheNodes=self.num_nodes,
@@ -496,7 +498,7 @@ def main():
         cache_subnet_group=dict(default=""),
         cache_security_groups=dict(default=[], type='list'),
         security_group_ids=dict(default=[], type='list'),
-        zone=dict(default=""),
+        zone=dict(),
         wait=dict(default=True, type='bool'),
         hard_modify=dict(type='bool')
     ))

--- a/lib/ansible/modules/cloud/amazon/elasticache.py
+++ b/lib/ansible/modules/cloud/amazon/elasticache.py
@@ -208,8 +208,6 @@ class ElastiCacheManager(object):
             else:
                 msg = "'%s' is currently deleting. Cannot create."
                 self.module.fail_json(msg=msg % self.name)
-        if self.zone is None:
-            self.zone = ''
 
         kwargs = dict(CacheClusterId=self.name,
                       NumCacheNodes=self.num_nodes,
@@ -219,10 +217,11 @@ class ElastiCacheManager(object):
                       CacheSecurityGroupNames=self.cache_security_groups,
                       SecurityGroupIds=self.security_group_ids,
                       CacheParameterGroupName=self.cache_parameter_group,
-                      CacheSubnetGroupName=self.cache_subnet_group,
-                      PreferredAvailabilityZone=self.zone)
+                      CacheSubnetGroupName=self.cache_subnet_group)
         if self.cache_port is not None:
             kwargs['Port'] = self.cache_port
+        if self.zone is not None:
+            kwargs['PreferredAvailabilityZone'] = self.zone
 
         try:
             self.conn.create_cache_cluster(**kwargs)


### PR DESCRIPTION
##### SUMMARY
Fixes #31779. If zone is unspecified and the cluster exists, the value for zone should appear unchanged and should not result in destroying and recreating the cluster.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/elasticache.py

##### ANSIBLE VERSION
```
2.5.0
```