### PR TITLE
Network docs should link to network integration pages

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/avi.py
+++ b/lib/ansible/utils/module_docs_fragments/avi.py
@@ -45,4 +45,6 @@ options:
     api_version:
         description:
             - Avi API version of to use for Avi API and objects.
+notes:
+  - For more information on using Ansible to manage Avi Network devices see U(https://www.ansible.com/ansible-avi-networks).
 """

--- a/lib/ansible/utils/module_docs_fragments/cnos.py
+++ b/lib/ansible/utils/module_docs_fragments/cnos.py
@@ -85,4 +85,6 @@ options:
         choices: [g8272_cnos,g8296_cnos,g8332_cnos,NE1072T,NE1032,
          NE1032T,NE10032,NE2572]
         version_added: 2.3
+notes:
+  - For more information on using Ansible to manage Lenovo Network devices see U(https://www.ansible.com/ansible-lenovo).
 '''

--- a/lib/ansible/utils/module_docs_fragments/dellos10.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos10.py
@@ -62,4 +62,6 @@ options:
             console freezes before continuing. For example when saving
             configurations.
         default: 10
+notes:
+  - For more information on using Ansible to manage Dell EMC Network devices see U(https://www.ansible.com/ansible-dell-networking).
 """

--- a/lib/ansible/utils/module_docs_fragments/dellos6.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos6.py
@@ -62,4 +62,6 @@ options:
             console freezes before continuing. For example when saving
             configurations.
         default: 10
+notes:
+  - For more information on using Ansible to manage Dell EMC Network devices see U(https://www.ansible.com/ansible-dell-networking).
 """

--- a/lib/ansible/utils/module_docs_fragments/dellos9.py
+++ b/lib/ansible/utils/module_docs_fragments/dellos9.py
@@ -62,4 +62,6 @@ options:
             console freezes before continuing. For example when saving
             configurations.
         default: 10
+notes:
+  - For more information on using Ansible to manage Dell EMC Network devices see U(https://www.ansible.com/ansible-dell-networking).
 """

--- a/lib/ansible/utils/module_docs_fragments/eos.py
+++ b/lib/ansible/utils/module_docs_fragments/eos.py
@@ -120,6 +120,7 @@ options:
             on personally controlled sites using self-signed certificates.  If the transport
             argument is not eapi, this value is ignored.
         choices: ['yes', 'no']
-
+notes:
+  - For more information on using Ansible to manage Arista EOS devices see U(https://www.ansible.com/ansible-arista-networks).
 
 """

--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -56,4 +56,6 @@ options:
       - yes
       - no
     version_added: 2.0
+notes:
+  - For more information on using Ansible to manage F5 Networks devices see U(https://www.ansible.com/ansible-f5).
 '''

--- a/lib/ansible/utils/module_docs_fragments/ios.py
+++ b/lib/ansible/utils/module_docs_fragments/ios.py
@@ -95,4 +95,6 @@ options:
             does nothing. If the value is not specified in the task, the value of
             environment variable C(ANSIBLE_NET_AUTH_PASS) will be used instead.
         default: none
+notes:
+  - For more information on using Ansible to manage Cisco devices see U(https://www.ansible.com/ansible-cisco).
 """

--- a/lib/ansible/utils/module_docs_fragments/iosxr.py
+++ b/lib/ansible/utils/module_docs_fragments/iosxr.py
@@ -64,4 +64,6 @@ options:
             key used to authenticate the SSH session. If the value is not specified
             in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
             will be used instead.
+notes:
+  - For more information on using Ansible to manage Cisco devices see U(https://www.ansible.com/ansible-cisco).
 """

--- a/lib/ansible/utils/module_docs_fragments/junos.py
+++ b/lib/ansible/utils/module_docs_fragments/junos.py
@@ -66,4 +66,6 @@ options:
             used to authenticate the SSH session. If the value is not specified in
             the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
             will be used instead.
+notes:
+  - For more information on using Ansible to manage Juniper network devices see U(https://www.ansible.com/ansible-juniper).
 """

--- a/lib/ansible/utils/module_docs_fragments/netscaler.py
+++ b/lib/ansible/utils/module_docs_fragments/netscaler.py
@@ -49,4 +49,6 @@ options:
             - The module will not save the configuration on the netscaler node if it made no changes.
         type: bool
         default: true
+notes:
+  - For more information on using Ansible to manage Citrix NetScaler Network devices see U(https://www.ansible.com/ansible-netscaler).
 '''

--- a/lib/ansible/utils/module_docs_fragments/nxos.py
+++ b/lib/ansible/utils/module_docs_fragments/nxos.py
@@ -95,5 +95,6 @@ options:
         met either by individual arguments or values in this dict.
     required: false
     default: null
-
+notes:
+  - For more information on using Ansible to manage Cisco devices see U(https://www.ansible.com/ansible-cisco).
 """

--- a/lib/ansible/utils/module_docs_fragments/sros.py
+++ b/lib/ansible/utils/module_docs_fragments/sros.py
@@ -64,4 +64,6 @@ options:
             key used to authenticate the SSH session. If the value is not specified
             in the task, the value of environment variable C(ANSIBLE_NET_SSH_KEYFILE)
             will be used instead.
+notes:
+  - For more information on using Ansible to manage Nokia SR OS Network devices see U(https://www.ansible.com/ansible-nokia).
 """


### PR DESCRIPTION
##### SUMMARY
Make people aware of the integration pages, which contain extra network platform specific details.

Once the `network_intro` page has been refactored we may link to that from every network module

##### ISSUE TYPE
 - Docs Pull Request

