### PR TITLE
Make ec2_vpc_endpoint policy_path usable

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_endpoint.py
@@ -39,7 +39,7 @@ options:
       - Option when creating an endpoint. If not provided AWS will
         utilise a default policy which provides full access to the service.
     required: false
-  policy_path:
+  policy_file:
     description:
       - The path to the properly json formatted policy file, see
         U(https://github.com/ansible/ansible/issues/7005#issuecomment-42894813)
@@ -47,6 +47,7 @@ options:
       - Option when creating an endpoint. If not provided AWS will
         utilise a default policy which provides full access to the service.
     required: false
+    aliases: [ "policy_path" ]
   state:
     description:
         - present to ensure resource is created.
@@ -262,7 +263,7 @@ def create_vpc_endpoint(client, module):
 
     elif module.params.get('policy_file'):
         try:
-            with open(module.params.get('policy'), 'r') as json_data:
+            with open(module.params.get('policy_file'), 'r') as json_data:
                 policy = json.load(json_data)
         except Exception as e:
             module.fail_json(msg=str(e), exception=traceback.format_exc(),
@@ -330,7 +331,7 @@ def main():
             vpc_id=dict(),
             service=dict(),
             policy=dict(type='json'),
-            policy_file=dict(type='path'),
+            policy_file=dict(type='path', aliases=['policy_path']),
             state=dict(default='present', choices=['present', 'absent']),
             wait=dict(type='bool', default=False),
             wait_timeout=dict(type='int', default=320, required=False),


### PR DESCRIPTION
##### SUMMARY
The current code flow precludes the use of the policy_path module
parameter that's documented.  It's actually called policy_file in the
code.

What's worse is that the policy_file branch actually tries to open the
file named by the policy parameter, even though policy and policy_file
are marked as mutually-exclusive.

This change fixes the logic error in policy_file and renames all
instances of policy_file to policy_path.

I'm fine with changing the doc to reference `policy_file` instead of 
`policy_path` if changing the doc to align with the code is preferable to 
my approach. The parameter is effectively unusable right now, so there
aren't any backwards-compatibility issues I don't think.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_endpoint

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/u/en/fennm/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
To reproduce, try creating a VPC endpoint with example in the documentation and observe that it falls into the except block here:

```
    elif module.params.get('policy_file'):
        try:
            with open(module.params.get('policy'), 'r') as json_data:
                policy = json.load(json_data)
        except Exception as e:
            module.fail_json(msg=str(e), exception=traceback.format_exc(),
                             **camel_dict_to_snake_dict(e.response))
```