### PR TITLE
Handle bad options syntax in validate-modules.

### DIFF
--- a/test/sanity/validate-modules/main.py
+++ b/test/sanity/validate-modules/main.py
@@ -987,7 +987,11 @@ class ModuleValidator(Validator):
         strict_ansible_version = StrictVersion(should_be)
 
         for option, details in options.items():
-            names = [option] + details.get('aliases', [])
+            try:
+                names = [option] + details.get('aliases', [])
+            except AttributeError:
+                # Reporting of this syntax error will be handled by schema validation.
+                continue
 
             if any(name in existing_options for name in names):
                 continue


### PR DESCRIPTION
##### SUMMARY

Handle bad options syntax in validate-modules.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Module Validator

##### ANSIBLE VERSION

```
ansible 2.5.0 (validate-fix aa39e65355) last updated 2017/10/16 10:42:18 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
