### PR TITLE
[Docs] Network getting started example

### DIFF
--- a/docs/docsite/rst/YAMLSyntax.rst
+++ b/docs/docsite/rst/YAMLSyntax.rst
@@ -141,8 +141,8 @@ You will want to quote hash values using colons followed by a space or the end o
 
 ...and then the colon will be preserved.
 
-Further, Ansible uses ``"{{ var }}"`` for variables.  If a value after a colon starts
-with a ``"{"``, YAML will think it is a dictionary, so you must quote it, like so::
+Ansible uses ``"{{ var }}"`` for variables.  If a value after a colon starts
+with a ``"{"``, YAML will think it is a dictionary, so you must quote it. For example::
 
     foo: "{{ variable }}"
 

--- a/docs/docsite/rst/YAMLSyntax.rst
+++ b/docs/docsite/rst/YAMLSyntax.rst
@@ -117,10 +117,8 @@ This really has nothing to do with Ansible, but will give you a feel for the for
         3 A-Levels
         BSc in the Internet of Things
 
-That's all you really need to know about YAML to start writing `Ansible` playbooks.
-
-Gotchas
-=======
+Limitations and Workarounds
+===========================
 
 Colons in YAML
 --------------

--- a/docs/docsite/rst/YAMLSyntax.rst
+++ b/docs/docsite/rst/YAMLSyntax.rst
@@ -1,8 +1,11 @@
+***********
 YAML Syntax
-===========
+***********
+
+.. contents:: Topics
 
 This page provides a basic overview of correct YAML syntax, which is how Ansible
-playbooks (our configuration management language) are expressed.  
+playbooks (our configuration management language) are expressed.
 
 We use YAML because it is easier for humans to read and write than other common
 data formats like XML or JSON.  Further, there are libraries available in most
@@ -13,9 +16,9 @@ is used in practice.
 
 
 YAML Basics
------------
+===========
 
-For Ansible, nearly every YAML file starts with a list.   
+For Ansible, nearly every YAML file starts with a list.
 Each item in the list is a list of key/value pairs, commonly
 called a "hash" or a "dictionary".  So, we need to know how
 to write lists and dictionaries in YAML.
@@ -117,7 +120,10 @@ This really has nothing to do with Ansible, but will give you a feel for the for
 That's all you really need to know about YAML to start writing `Ansible` playbooks.
 
 Gotchas
--------
+=======
+
+Colons in YAML
+--------------
 
 While YAML is generally friendly, the following is going to result in a YAML syntax error::
 
@@ -132,15 +138,18 @@ While YAML is generally friendly, the following is going to result in a YAML syn
 You will want to quote hash values using colons followed by a space or the end of the line::
 
     foo: "somebody said I should put a colon here: so I did"
-    
+
     windows_drive: "c:"
 
 ...and then the colon will be preserved.
 
-Further, Ansible uses "{{ var }}" for variables.  If a value after a colon starts
-with a "{", YAML will think it is a dictionary, so you must quote it, like so::
+Further, Ansible uses ``"{{ var }}"`` for variables.  If a value after a colon starts
+with a ``"{"``, YAML will think it is a dictionary, so you must quote it, like so::
 
     foo: "{{ variable }}"
+
+Quotes in YAML
+--------------
 
 If your value starts with a quote the entire value must be quoted, not just part of it. Here are some additional examples of how to properly quote things::
 
@@ -152,9 +161,13 @@ Not valid::
 
     foo: "E:\\path\\"rest\\of\\path
 
-The same applies for strings that start or contain any YAML special characters ``[] {} : > |`` .
 
-Boolean conversion is helpful, but this can be a problem when you want a literal `yes` or other boolean values as a string.
+Escaping in YAML
+----------------
+
+As with quotes in YAML, the same applies for strings that start or contain any YAML special characters ``[] {} : > |`` .
+
+Boolean conversion is helpful, but this can be a problem when you want a literal ``yes`` or other boolean values as a string.
 In these cases just use quotes::
 
     non_boolean: "yes"
@@ -162,7 +175,7 @@ In these cases just use quotes::
 
 
 YAML converts certain strings into floating-point values, such as the string
-`1.0`. If you need to specify a version number (in a requirements.yml file, for
+`1.0`. If you need to specify a version number (in a ``requirements.yml`` file, for
 example), you will need to quote the value if it looks like a floating-point
 value::
 

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -15,17 +15,19 @@ Objective
 
 I want to understand how Ansible can be used to connect to multiple network devices.
 
-This is not for production use, it's more to demonstrate the different areas that need to be considered and provide a foundation level knowledge.
+.. FIXME FUTURE Gundalow - Link to examples index once created
 
-Future examples FIXMELINK will build on this knowledge.
+.. note:: Examples, not production code
+   This is not for production use, it's more to demonstrate the different areas that need to be considered and provide a foundation level knowledge.
 
 Prerequisites
 -------------
 
 * Ansible 2.3 (or higher) installed :doc:`intro_installation`
-* One or more network device compatible with Ansible FIXMELINK
+* One or more network device compatible with Ansible
 
 .. FIXME FUTURE Gundalow - Once created we will link to the connection table here (which platforms support network_cli & credentials through inventory)
+.. FIXME FUTURE Gundalow -  Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - Once documented in above FIXME add details her
 
 Audience
 --------
@@ -81,7 +83,7 @@ Create a file called ``fetch-facts.yml`` containing the following:
           when: "'vyos' in group_names"
 
         ###
-        # Demonstrate variables
+        # Demo variables
         #
         - name: Display some facts
           debug:
@@ -158,6 +160,7 @@ Run it
    vyos01.example.net         : ok=6    changed=2    unreachable=0    failed=0
 
    cat /tmp/switch-facts
+   find /tmp/backups
 
 Details
 =======
@@ -186,12 +189,13 @@ ansible_connection
 
 Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote and execute the Python script on the network device, which would fail as Python generally isn't available on network devices.
 
+.. FIXME FUTURE Gundalow - Once the new connection types are defined (in 2.5) we will need to update this.
 
 Playbook
 --------
 
-Gathering facts
-^^^^^^^^^^^^^^^
+Collect data
+^^^^^^^^^^^^
 
 Here we use the ``_facts`` modules :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly passed via module arguments, Ansible uses the username and password from the inventory file.
 
@@ -202,18 +206,21 @@ The return values (data returned by a module) are documented in the `Return Valu
 The task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
 
 
-
-Debug
------
+Demo variables
+--------------
 
 Although these tasks are not needed to write data to disk, they are useful to demonstrate some methods of accessing facts about the given or a named host.
 
 More information on this can be found in :ref:`magic_variables_and_hostvars`.
 
-Writing to disk
----------------
+Get running configuration
+-------------------------
 
-* FIXME Link to module docs ios_facts, vyos_facts, copy, debug
+The :ref:`ios_config <ios_config>` and :ref:`vyos_config <vyos_config>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
+
+To demonstrate how we can move the backup file to a different location we ``register`` the result and use the ``backup_path`` return value as source location to move the file into ``/tmp/backups/`` directory which we have created.
+
+Note that when using variables from tasks in this way we use  double quotes (``"``) and double curly-brackets (``{{...}}`` to tell Ansible that this is a variable.
 
 Troubleshooting
 ===============
@@ -227,20 +234,3 @@ If you receive an error ``unable to open shell`` please follow the debug steps i
   * intro_inventory
   * playbooks_best_practices.html#best-practices-for-variables-and-vaults
 
-Fixme
-=====
-
-* Highlight the command to run in the console section - Look at Sphix documentation
-* Agreed: Hello world https://github.com/Dell-Networking/ansible-dellos-examples/blob/master/getfacts_os10.yaml
-
-* Add filename to code-blocks
-
-* Other examples
-
-
-* Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - What do we here?
-
-* External updates needed
-
-  * Improve vault page and link between ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``
-  * Link to network intro page table of Persistent connection and version_added table

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -217,14 +217,15 @@ Next, create a playbook file called ``fetch-facts.yml`` containing the following
 Running the playbook
 --------------------
 
-To run the playbook, run the following from a console prompt::
+To run the playbook, run the following from a console prompt:
 
 .. code-block:: console
 
    ansible-playbook -i inventory fetch-facts.yml
 
 This should return output similar to the following:
-.. code-block: console
+
+.. code-block:: console
 
    PLAY RECAP
    eos01.example.net          : ok=7    changed=2    unreachable=0    failed=0
@@ -232,13 +233,13 @@ This should return output similar to the following:
 
 Next, look at the contents of the file we created containing the switch facts:
 
-.. code-block: console
+.. code-block:: console
 
    cat /tmp/switch-facts
 
 You can also look at the backup files:
 
-.. code-block: console
+.. code-block:: console
 
    find /tmp/backups
 

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -17,7 +17,7 @@ This example shows how Ansible can be used to connect to and manage multiple net
 
 .. FIXME FUTURE Gundalow - Link to examples index once created
 
-.. note:: This example is for educational purposes only and is not intended for production use.
+.. note:: This example is for educational purposes only and is not intended for production use, for example, passwords should NEVER be stored in cleartext.
 
 Audience
 --------
@@ -39,7 +39,7 @@ This example requires the following:
 
 
 .. FIXME FUTURE Gundalow - Once created we will link to the connection table here (which platforms support network_cli & credentials through inventory)
-.. FIXME FUTURE Gundalow -  Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - Once documented in above FIXME add details her
+.. FIXME FUTURE Gundalow - Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - Once documented in above FIXME add details here
 
 Solution
 =========
@@ -69,7 +69,7 @@ Create a file called ``fetch-facts.yml`` containing the following:
 
 .. code-block:: yaml
 
-   - name: "Download switch configuration"
+   - name: "Demonstrate connecting to switches"
      hosts: switches
      gather_facts: no
 
@@ -170,14 +170,7 @@ Run the playbook
    cat /tmp/switch-facts
    find /tmp/backups
 
-If you receive an error ``unable to open shell`` ensure that the ssh fingerprints are in ``~/.ssh/known_hosts``, this can be achieved by doing using ``ssh-keyscan`` to pre-populate the ``known_hosts`` file.
-
-.. code-block:: shell
-
-   ssh-keyscan eos01.example.net
-   ssh-keyscan vyos01.example.net
-
-If `ansible-playbook` still fails, please follow the debug steps in :doc:`network_debug_troubleshooting`.
+If `ansible-playbook` fails, please follow the debug steps in :doc:`network_debug_troubleshooting`.
 
 Details
 =======
@@ -206,7 +199,7 @@ ansible_connection
 
 Setting ``ansible_connection=network_cli`` informs Ansible that the remote node is a network device with a limited execution environment. Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
 
-.. FIXME FUTURE Gundalow - Once the new connection types are defined (in 2.5) we will need to update this.
+.. FIXME FUTURE Gundalow - Link to network auth & proxy page (to be written) - in particular eapi/nxapi
 
 Playbook
 --------
@@ -216,14 +209,14 @@ Collect data
 
 Here we use the ``_facts`` modules :ref:`eos_facts <eos_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly passed via module arguments, Ansible uses the username and password from the inventory file.
 
-Ansible "Fact modules" gather information from the system and store the results in facts prefixed with ``ansible_``. The return values (data returned by a module) are documented in the `Return Values` section of the module docs, in this case :ref:`eos_facts <eos_facts>` and :ref:`vyos_facts <vyos_facts>`. We can use the facts, such as ``ansible_net_version`` late on in the "Display some facts" task.
+Ansible's "Network Fact modules" gather information from the system and store the results in facts prefixed with ``ansible_net_``. The data collected by these modules is documented in the `Return Values` section of the module docs, in this case :ref:`eos_facts <eos_facts>` and :ref:`vyos_facts <vyos_facts>`. We can use the facts, such as ``ansible_net_version`` late on in the "Display some facts" task.
 
 To ensure we call the correct mode (eos_facts or vyos_facts) the task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
 
 Privilege escalation
 ^^^^^^^^^^^^^^^^^^^^
 
-Certain network platforms, such as eos and ios, have the concept of different privilege modes. Certain network modules, such as those that modify system state including users, will only work in high privilege states. Ansible 2.5 added support for ``become`` when using ``connection=network_cli``. This allows privileges to be raised for the specific tasks that need them. Adding ``become: true`` and ``become_method: enable`` informs Ansible to go into privilege mode before executing the task, as show here:
+Certain network platforms, such as eos and ios, have the concept of different privilege modes. Certain network modules, such as those that modify system state including users, will only work in high privilege states. Ansible 2.5 added support for ``become`` when using ``connection=network_cli``. This allows privileges to be raised for the specific tasks that need them. Adding ``become: true`` and ``become_method: enable`` informs Ansible to go into privilege mode before executing the task, as shown here:
 
 .. code-block:: yaml
 
@@ -239,7 +232,7 @@ For more information see the :doc:`Ansible Privilege Escalation<become>` guide.
 Demo variables
 --------------
 
-Although these tasks are not needed to write data to disk, they are useful to demonstrate some methods of accessing facts about the given devices or a named host.
+Although these tasks are not needed to write data to disk, they are used to demonstrate some methods of accessing facts about the given devices or a named host.
 
 Ansible ``hostvars`` allows you to access variables from a named host. Without this wed return the details for the current host
 
@@ -252,12 +245,12 @@ The :ref:`eos_config <eos_config>` and :ref:`vyos_config <vyos_config>` modules 
 
 To demonstrate how we can move the backup file to a different location we ``register`` the result and use the ``backup_path`` return value as source location to move the file into ``/tmp/backups/`` directory which we have created.
 
-Note that when using variables from tasks in this way we use  double quotes (``"``) and double curly-brackets (``{{...}}`` to tell Ansible that this is a variable.
+Note that when using variables from tasks in this way we use double quotes (``"``) and double curly-brackets (``{{...}}`` to tell Ansible that this is a variable.
 
 Troubleshooting
 ===============
 
-If you receive an error ``unable to open shell`` please follow the debug steps in :doc:`network_debug_troubleshooting`.
+If you receive an connection error please double check the inventory and Playbook for typos or missing lines, if the issue still occurs follow the debug steps in :doc:`network_debug_troubleshooting`.
 
 
 .. seealso::

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -13,41 +13,40 @@ Overview
 Objective
 ---------
 
-I want to understand how Ansible can be used to connect to multiple network devices.
+This example shows how Ansible can be used to connect to and manage multiple network devices.
 
 .. FIXME FUTURE Gundalow - Link to examples index once created
 
-.. note:: Examples, not production code
-   This is not for production use, it's more to demonstrate the different areas that need to be considered and provide a foundation level knowledge.
+.. note:: This example is for educational purposes only and is not intended for production use.
+
+Audience
+--------
+
+* This example is intended for network or system administrators who want to understand how to use Ansible to manage network devices.
+
 
 Prerequisites
 -------------
 
-* Ansible 2.3 (or higher) installed :doc:`intro_installation`
-* One or more network device compatible with Ansible
-* Basic understanding of YAML :doc:`YAMLSyntax`
-* Basic understanding of Jinja2 Templates :doc:`playbooks_templating`
-* Basic Linux (comfortable on the command line)
-* Basic Network switch & router configuration knowledge
+This example requires the following:
 
+* Ansible 2.3 (or higher) installed. See :doc:`intro_installation` for more information.
+* One or more network devices that are compatible with Ansible.
+* Basic understanding of YAML :doc:`YAMLSyntax`.
+* Basic understanding of Jinja2 Templates. See :doc:`playbooks_templating` for more information.
+* Basic Linux command line use.
+* Basic knowledge of network switch & router configurations.
 
 
 .. FIXME FUTURE Gundalow - Once created we will link to the connection table here (which platforms support network_cli & credentials through inventory)
 .. FIXME FUTURE Gundalow -  Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - Once documented in above FIXME add details her
 
-Audience
---------
-
-* Network administrator or System administrator who wants to understand how to use Ansible to manage Network devices.
-
-
 Solution
 =========
 
-Create an inventory file.
+In this example, we will create an inventory file containing some network switches, then run a playbook to connect to the network devices and return some information about them.
 
-
-**Inventory file**
+**Create an inventory file**
 
 Create a file called ``inventory``, containing:
 
@@ -64,7 +63,7 @@ Create a file called ``inventory``, containing:
    vyos01.example.net ansible_connection=local ansible_user=admin ansible_ssh_pass=admin
 
 
-**Playbook**
+**Create a playbook**
 
 Create a file called ``fetch-facts.yml`` containing the following:
 
@@ -152,8 +151,8 @@ Create a file called ``fetch-facts.yml`` containing the following:
           when: "'vyos' in group_names"
 
 
-Run it
-------
+Run the playbook
+----------------
 
 .. code-block:: console
 
@@ -189,18 +188,18 @@ The above inventory file defines the groups ``ios``, ``vyos`` and a "group of gr
 Credentials
 ^^^^^^^^^^^
 
-Although there are many ways to supply credentials in Ansible in this case we are using ``ansible_user`` and ``ansible_ssh_pass`` as a simple example.
+Although there are many ways to supply credentials in Ansible, in this example we are using ``ansible_user`` and ``ansible_ssh_pass`` for simplicity.
 
 .. FIXME FUTURE Gundalow - Link to network auth & proxy page (to be written)
 
 .. warning:: Never store passwords in plain text
 
-   Passwords should never be stored in plain text. The "Vault" feature of Ansible allows keeping sensitive data such as passwords or keys in encrypted files, rather than as plaintext in your playbooks or roles. These vault files can then be distributed or placed in source control. The :doc:`playbooks_vault` contains further information.
+   Passwords should never be stored in plain text. The "Vault" feature of Ansible allows keeping sensitive data such as passwords or keys in encrypted files, rather than as plaintext in your playbooks or roles. These vault files can then be distributed or placed in source control. See :doc:`playbooks_vault` for more information.
 
 ansible_connection
 ^^^^^^^^^^^^^^^^^^
 
-Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote and execute the Python script on the network device, which would fail as Python generally isn't available on network devices.
+Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (the machine executing Ansible). Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
 
 .. FIXME FUTURE Gundalow - Once the new connection types are defined (in 2.5) we will need to update this.
 
@@ -222,7 +221,7 @@ The task is conditionally run based on the group defined in the inventory file, 
 Demo variables
 --------------
 
-Although these tasks are not needed to write data to disk, they are useful to demonstrate some methods of accessing facts about the given or a named host.
+Although these tasks are not needed to write data to disk, they are useful to demonstrate some methods of accessing facts about the given devices or a named host.
 
 More information on this can be found in :ref:`magic_variables_and_hostvars`.
 

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -50,7 +50,7 @@ In this example, we will create an inventory file containing some network switch
 
 Create a file called ``inventory``, containing:
 
-.. code-block:: none
+.. code-block:: ini
 
    [switches:children]
    eos

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -27,6 +27,10 @@ Prerequisites
 * One or more network device compatible with Ansible
 * Basic understanding of YAML :doc:`YAMLSyntax`
 * Basic understanding of Jinja2 Templates :doc:`playbooks_templating`
+* Basic Linux (comfortable on the command line)
+* Basic Network switch & router configuration knowledge
+
+
 
 .. FIXME FUTURE Gundalow - Once created we will link to the connection table here (which platforms support network_cli & credentials through inventory)
 .. FIXME FUTURE Gundalow -  Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - Once documented in above FIXME add details her
@@ -34,8 +38,7 @@ Prerequisites
 Audience
 --------
 
-* Basic Linux (comfortable on the command line)
-* Basic Network switch & router configuration knowledge
+* Network administrator or System administrator who wants to understand how to use Ansible to manage Network devices.
 
 
 Solution

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -74,12 +74,10 @@ Create a file called ``fetch-facts.yml`` containing the following:
        # Collect data
         - name: Gather facts (ios)
           ios_facts:
-          register: result_ios
           when: "'ios' in group_names"
 
         - name: Gather facts (vyos)
           vyos_facts:
-          register: result_vyos
           when: "'vyos' in group_names"
 
         ###
@@ -89,7 +87,8 @@ Create a file called ``fetch-facts.yml`` containing the following:
           debug:
             msg: "The hostname is {{ ansible_net_hostname }} and the OS is {{ ansible_net_version }}"
 
-        - debug:
+        - name: Display facts from a specific host
+          debug:
             var: hostvars['vyos01.example.net']
 
         - name: Write facts to disk using a template
@@ -123,7 +122,7 @@ Create a file called ``fetch-facts.yml`` containing the following:
           register: backup_ios
           when: "'ios' in group_names"
 
-        - name: backup switch (vyos)
+        - name: Backup switch (vyos)
           vyos_config:
             backup: yes
           register: backup_vyos
@@ -161,6 +160,15 @@ Run it
 
    cat /tmp/switch-facts
    find /tmp/backups
+
+If you receive an error ``unable to open shell`` ensure that the ssh fingerprints are in ``~/.ssh/known_hosts``, this can be achieved by doing using ``ssh-keyscan`` to pre-populate the ``known_hosts`` file.
+
+.. code-block:: shell
+
+   ssh-keyscan ios01.example.net
+   ssh-keyscan vyos01.example.net
+
+If `ansible-playbook` still fails, please follow the debug steps in :doc:`network_debug_troubleshooting`.
 
 Details
 =======

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -30,7 +30,7 @@ Prerequisites
 
 This example requires the following:
 
-* Ansible 2.3 (or higher) installed. See :doc:`intro_installation` for more information.
+* **Ansible 2.5** (or higher) installed. See :doc:`intro_installation` for more information.
 * One or more network devices that are compatible with Ansible.
 * Basic understanding of YAML :doc:`YAMLSyntax`.
 * Basic understanding of Jinja2 Templates. See :doc:`playbooks_templating` for more information.
@@ -53,14 +53,14 @@ Create a file called ``inventory``, containing:
 .. code-block::
 
    [switches:children]
-   ios
+   eos
    vyos
 
-   [ios]
-   ios01.example.net ansible_connection=local ansible_user=cisco ansible_ssh_pass=cisco
+   [eos]
+   eos01.example.net ansible_connection=network_cli ansible_network_os=eos ansible_user=myuser ansible_ssh_pass=mypassword
 
    [vyos]
-   vyos01.example.net ansible_connection=local ansible_user=admin ansible_ssh_pass=admin
+   vyos01.example.net ansible_connection=network_cli ansible_network_os=vyos ansible_user=admin ansible_ssh_pass=mypassword
 
 
 **Create a playbook**
@@ -76,80 +76,85 @@ Create a file called ``fetch-facts.yml`` containing the following:
      tasks:
        ###
        # Collect data
-        - name: Gather facts (ios)
-          ios_facts:
-          when: "'ios' in group_names"
+       #
+       - name: Gather facts (eos)
+         eos_facts:
+         become: true
+         become_method: enable
+         when: "'eos' in group_names"
 
-        - name: Gather facts (vyos)
-          vyos_facts:
-          when: "'vyos' in group_names"
+       - name: Gather facts (vyos)
+         vyos_facts:
+         when: "'vyos' in group_names"
 
-        ###
-        # Demo variables
-        #
-        - name: Display some facts
-          debug:
-            msg: "The hostname is {{ ansible_net_hostname }} and the OS is {{ ansible_net_version }}"
+       ###
+       # Demonstrate variables
+       #
+       - name: Display some facts
+         debug:
+           msg: "The hostname is {{ ansible_net_hostname }} and the OS is {{ ansible_net_version }}"
 
-        - name: Display facts from a specific host
-          debug:
-            var: hostvars['vyos01.example.net']
+       - name: Facts from a specific host
+         debug:
+           var: hostvars['vyos01.example.net']
 
-        - name: Write facts to disk using a template
-          copy:
-            content: |
-              IOS device info:
-                {% for host in groups['ios'] %}
-                Hostname: {{ hostvars[host].ansible_net_version }}
-                Version: {{ hostvars[host].ansible_net_version }}
-                Model: {{ hostvars[host].ansible_net_model }}
-                Serial: {{ hostvars[host].ansible_net_serialnum }}
-                {% endfor %}
+       - name: Write facts to disk using a template
+         copy:
+           content: |
+             #jinja2: lstrip_blocks: True
+             EOS device info:
+               {% for host in groups['eos'] %}
+               Hostname: {{ hostvars[host].ansible_net_version }}
+               Version: {{ hostvars[host].ansible_net_version }}
+               Model: {{ hostvars[host].ansible_net_model }}
+               Serial: {{ hostvars[host].ansible_net_serialnum }}
+               {% endfor %}
 
-              VyOS device info:
-                {% for host in groups['vyos'] %}
-                Hostname: {{ hostvars[host].ansible_net_version }}
-                Version: {{ hostvars[host].ansible_net_version }}
-                Model: {{ hostvars[host].ansible_net_model }}
-                Serial: {{ hostvars[host].ansible_net_serialnum }}
-                {% endfor %}
-            dest: /tmp/switch-facts
-          run_once: yes
+             VyOS device info:
+               {% for host in groups['vyos'] %}
+               Hostname: {{ hostvars[host].ansible_net_version }}
+               Version: {{ hostvars[host].ansible_net_version }}
+               Model: {{ hostvars[host].ansible_net_model }}
+               Serial: {{ hostvars[host].ansible_net_serialnum }}
+               {% endfor %}
+           dest: /tmp/switch-facts
+         run_once: yes
 
-        ###
-        # Get running configuration
-        #
+       ###
+       # Get running configuration
+       #
 
-        - name: Backup switch (ios)
-          ios_config:
-            backup: yes
-          register: backup_ios
-          when: "'ios' in group_names"
+       - name: Backup switch (eos)
+         eos_config:
+           backup: yes
+         become: true
+         become_method: enable
+         register: backup_eos
+         when: "'eos' in group_names"
 
-        - name: Backup switch (vyos)
-          vyos_config:
-            backup: yes
-          register: backup_vyos
-          when: "'vyos' in group_names"
+       - name: backup switch (vyos)
+         vyos_config:
+           backup: yes
+         register: backup_vyos
+         when: "'vyos' in group_names"
 
-        - name: Create backup dir
-          file:
-            path: "/tmp/backups/{{ inventory_hostname }}"
-            state: directory
-            recurse: yes
+       - name: Create backup dir
+         file:
+           path: "/tmp/backups/{{ inventory_hostname }}"
+           state: directory
+           recurse: yes
 
-        - name: Copy backup files into /tmp/backups/ (ios)
-          copy:
-            src: "{{ backup_ios.backup_path }}"
-            dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
-          when: "'ios' in group_names"
+       - name: Copy backup files into /tmp/backups/ (eos)
+         copy:
+           src: "{{ backup_eos.backup_path }}"
+           dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
+         when: "'eos' in group_names"
 
-        - name: Copy backup files into /tmp/backups/ (vyos)
-          copy:
-            src: "{{ backup_vyos.backup_path }}"
-            dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
-          when: "'vyos' in group_names"
-
+       - name: Copy backup files into /tmp/backups/ (vyos)
+         copy:
+           src: "{{ backup_vyos.backup_path }}"
+           dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
+         when: "'vyos' in group_names"
 
 Run the playbook
 ----------------
@@ -159,7 +164,7 @@ Run the playbook
    ansible-playbook -i inventory fetch-facts.yml
    <snip>
    PLAY RECAP
-   ios01.example.net          : ok=7    changed=2    unreachable=0    failed=0
+   eos01.example.net          : ok=7    changed=2    unreachable=0    failed=0
    vyos01.example.net         : ok=6    changed=2    unreachable=0    failed=0
 
    cat /tmp/switch-facts
@@ -169,7 +174,7 @@ If you receive an error ``unable to open shell`` ensure that the ssh fingerprint
 
 .. code-block:: shell
 
-   ssh-keyscan ios01.example.net
+   ssh-keyscan eos01.example.net
    ssh-keyscan vyos01.example.net
 
 If `ansible-playbook` still fails, please follow the debug steps in :doc:`network_debug_troubleshooting`.
@@ -182,7 +187,7 @@ Inventory
 
 The ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups.
 
-The above inventory file defines the groups ``ios``, ``vyos`` and a "group of groups" called ``switches``. Further details about subgroups and inventory files can be found in the :ref:`Ansible inventory Group documentation <subgroups>`.
+The above inventory file defines the groups ``eos``, ``vyos`` and a "group of groups" called ``switches``. Further details about subgroups and inventory files can be found in the :ref:`Ansible inventory Group documentation <subgroups>`.
 
 
 Credentials
@@ -199,7 +204,7 @@ Although there are many ways to supply credentials in Ansible, in this example w
 ansible_connection
 ^^^^^^^^^^^^^^^^^^
 
-Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (the machine executing Ansible). Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
+Setting ``ansible_connection=network_cli`` informs Ansible that the remote node is a network device with a limited execution environment. Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
 
 .. FIXME FUTURE Gundalow - Once the new connection types are defined (in 2.5) we will need to update this.
 
@@ -209,26 +214,41 @@ Playbook
 Collect data
 ^^^^^^^^^^^^
 
-Here we use the ``_facts`` modules :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly passed via module arguments, Ansible uses the username and password from the inventory file.
+Here we use the ``_facts`` modules :ref:`eos_facts <eos_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly passed via module arguments, Ansible uses the username and password from the inventory file.
 
-The data that the module returns is stored due to the use of the ``register:`` keyword into a variable called ``results_ios`` or ``results_vyos``.
+Ansible "Fact modules" gather information from the system and store the results in facts prefixed with ``ansible_``. The return values (data returned by a module) are documented in the `Return Values` section of the module docs, in this case :ref:`eos_facts <eos_facts>` and :ref:`vyos_facts <vyos_facts>`. We can use the facts, such as ``ansible_net_version`` late on in the "Display some facts" task.
 
-The return values (data returned by a module) are documented in the `Return Values` section of the module docs, in this case :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>`.
+To ensure we call the correct mode (eos_facts or vyos_facts) the task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
 
-The task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
+Privilege escalation
+^^^^^^^^^^^^^^^^^^^^
 
+Certain network platforms, such as eos and ios, have the concept of different privilege modes. Certain network modules, such as those that modify system state including users, will only work in high privilege states. Ansible 2.5 added support for ``become`` when using ``connection=network_cli``. This allows privileges to be raised for the specific tasks that need them. Adding ``become: true`` and ``become_method: enable`` informs Ansible to go into privilege mode before executing the task, as show here:
+
+.. code-block:: yaml
+
+   - name: Gather facts (eos)
+     eos_facts:
+     become: true
+     become_method: enable
+     when: "'eos' in group_names"
+
+
+For more information see the :doc:`Ansible Privilege Escalation<become>` guide.
 
 Demo variables
 --------------
 
 Although these tasks are not needed to write data to disk, they are useful to demonstrate some methods of accessing facts about the given devices or a named host.
 
+Ansible ``hostvars`` allows you to access variables from a named host. Without this wed return the details for the current host
+
 More information on this can be found in :ref:`magic_variables_and_hostvars`.
 
 Get running configuration
 -------------------------
 
-The :ref:`ios_config <ios_config>` and :ref:`vyos_config <vyos_config>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
+The :ref:`eos_config <eos_config>` and :ref:`vyos_config <vyos_config>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
 
 To demonstrate how we can move the backup file to a different location we ``register`` the result and use the ``backup_path`` return value as source location to move the file into ``/tmp/backups/`` directory which we have created.
 

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -1,4 +1,4 @@
-.. network-example-facts:
+.. network-getting-started-example:
 
 *******************************
 Network getting started example
@@ -25,6 +25,8 @@ Prerequisites
 * Ansible 2.3 (or higher) installed :doc:`intro_installation`
 * One or more network device compatible with Ansible FIXMELINK
 
+.. FIXME FUTURE Gundalow - Once created we will link to the connection table here (which platforms support network_cli & credentials through inventory)
+
 Audience
 --------
 
@@ -35,7 +37,7 @@ Audience
 Solution
 =========
 
-Create an inventory file
+Create an inventory file.
 
 
 **Inventory file**
@@ -173,6 +175,7 @@ Credentials
 
 Although there are many ways to supply credentials in Ansible in this case we are using ``ansible_user`` and ``ansible_ssh_pass`` as a simple example.
 
+.. FIXME FUTURE Gundalow - Link to network auth & proxy page (to be written)
 
 .. warning:: Never store passwords in plain text
 
@@ -241,52 +244,3 @@ Fixme
 
   * Improve vault page and link between ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``
   * Link to network intro page table of Persistent connection and version_added table
-
-
-New page: Auth & Proxy
-----------------------
-
-This section needs moving to a new page, just made notes here while I was developing this:
-
-FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere). This should just be a summary that links to the existing docs (``intro_inventory``, ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``, etc)
-
-Somewhere in the main docs we need to list the different ways of authenticating
-
-
-:Command line:
-
-  * Using ``--user`` (``-u``) and ``--ask-pass`` (``-k``).
-  * Note: This only works if all devices use the same credentials
-
-:Inventory file:
-
-  :``ansible_user``:
-
-    * Details
-    * Link to main docs
-
-  :``ansible_ssh_pass``:
-
-    * Generally used along side ``ansible_user``.
-    * Not for REST transports such as `eapi`, `nxapi`.
-    * Link to main docs
-
-  :``ansible_ssh_private_key_file``:
-
-    * Details
-    * Link to main docs
-
-:top-level module options:
-
-  * As of Ansible 2.3 this is deprecated.
-  * Link to main docs
-
-:``provider``: argument to module:
-
-  * This is OK
-  * Link to main docs
-
-:Env variables:
-
-  * ``ANSIBLE_NET_USERNAME``
-  * ``ANSIBLE_NET_PASSWORD``

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -25,6 +25,8 @@ Prerequisites
 
 * Ansible 2.3 (or higher) installed :doc:`intro_installation`
 * One or more network device compatible with Ansible
+* Basic understanding of YAML :doc:`YAMLSyntax`
+* Basic understanding of Jinja2 Templates :doc:`playbooks_templating`
 
 .. FIXME FUTURE Gundalow - Once created we will link to the connection table here (which platforms support network_cli & credentials through inventory)
 .. FIXME FUTURE Gundalow -  Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - Once documented in above FIXME add details her

--- a/docs/docsite/rst/network_getting_started.rst
+++ b/docs/docsite/rst/network_getting_started.rst
@@ -50,7 +50,7 @@ In this example, we will create an inventory file containing some network switch
 
 Create a file called ``inventory``, containing:
 
-.. code-block::
+.. code-block:: none
 
    [switches:children]
    eos

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -125,30 +125,34 @@ FIXME Link to details regarding different ways to specify credentials (this shou
   :``ansible_user``:
 
     * Details
+    * Link to main docs
 
-  : ``ansible_ssh_pass``:
-
-    * Details
-
-  : ``ansible_ssh_private_key_file``:
+  :``ansible_ssh_pass``:
 
     * Details
+    * Link to main docs
+
+  :``ansible_ssh_private_key_file``:
+
+    * Details
+    * Link to main docs
 
 :top-level:
 
-  * Details
+  * Moving away from this
+  * Link to main docs
 
 :provider:
 
-  * Details
-
+  * This is OK
+  * Link to main docs
 
 
 
 
 .. warning:: Never store passwords in plain text
 
-   FIXME Details and links to vault go here
+   FIXME Details on why this is bad, links to existing vault docs (improve that example)
 
 
 * FIXME: ``ansible_connection=local``

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -13,7 +13,24 @@ Gather facts
 Objective
 ---------
 
-I want to connect to a remote network device, download it's configuration and write it to a file
+I want to connect to a remote network device, download it's configuration and write it to a file.
+
+Prerequisites
+-------------
+
+* Ansible 2.3 (or higher) installed FIXMELINK
+* One or more network device compatible:
+
+  * Arista
+  * Cisco: ios, iosxr, nxos
+  * FIXME
+
+Audience
+--------
+
+* Basic Linux (comfortable on the command line)
+* Basic Network switch & router configuration knowledge (FIXME examples)
+
 
 Solution
 --------
@@ -128,7 +145,7 @@ Although there are many ways to supply credentials in Ansible in this case we ar
 ansible_connection
 ^^^^^^^^^^^^^^^^^^
 
-Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote 
+Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote
 
 
 Playbook

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -113,7 +113,7 @@ The above inventory file defines the groups ``ios``, ``vyos`` and a "group of gr
 
 The inventory file can be used to define the credentials to log in with, there are various ways credentials could be supplied:
 
-FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere, if not then create it, maybe using a `:fieldtable:`
+FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere). This should just be a summary that links to the existing docs (``intro_inventory``, ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``, etc)
 
 :Command line:
 
@@ -126,9 +126,21 @@ FIXME Link to details regarding different ways to specify credentials (this shou
 
     * Details
 
-  : ``ansible_ssh_pass``
-  
+  : ``ansible_ssh_pass``:
+
     * Details
+
+  : ``ansible_ssh_private_key_file``:
+
+    * Details
+
+:top-level:
+
+  * Details
+
+:provider:
+
+  * Details
 
 
 
@@ -139,19 +151,10 @@ FIXME Link to details regarding different ways to specify credentials (this shou
    FIXME Details and links to vault go here
 
 
-FIXME: ``ansible_connection=local``
-   
-   
-   This is where we explain what the above is doing
+* FIXME: ``ansible_connection=local``
 
-* FIXME Details about inventory
 
-    * What do we need to link to in main docs: ``:children``, what else?
-    * Host groups
-
-* FIXME Step though playbook
-
-  * Link to module docs for ios_facts, vyos_facts
+* FIXME Link to module docs ios_facts, vyos_facts, copy, debug
 
 Troubleshooting
 ---------------

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -45,7 +45,10 @@ Create a file called ``fetch-facts.yml`` containing the following:
 .. code-block:: yaml
 
    - name: "Download switch configuration"
+     # Which group in the inventory file this applies to
      hosts: switches
+
+     # fixme
      gather_facts: no
 
      tasks:
@@ -107,13 +110,82 @@ Details
 Inventory
 +++++++++
 
-The ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups
+The ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups:
 
 The above inventory file defines the groups ``ios``, ``vyos`` and a "group of groups" called ``switches``. Further details about subgroups and inventory files can be found in the :ref:`Ansible inventory Group documentation <subgroups>`.
 
-The inventory file can be used to define the credentials to log in with, there are various ways credentials could be supplied:
+
+Credentials
+^^^^^^^^^^^
+
+Although there are many ways to supply credentials in Ansible in this case we are using ``ansible_user`` and ``ansible_ssh_pass`` as a simple example.
+
+
+.. warning:: Never store passwords in plain text
+
+   FIXME Details on why this is bad, links to existing vault docs (improve that example)
+
+ansible_connection
+^^^^^^^^^^^^^^^^^^
+
+* FIXME: ``ansible_connection=local``
+
+
+Playbook
+++++++++
+
+Gathering facts
+^^^^^^^^^^^^^^^
+
+* Link to module
+* Not about conditional keyword - link to docs
+* ``register``
+
+
+Debug
+^^^^^^
+
+* Reference ``RETURN`` sections of docs
+* Link to docs ``hostvars`` docs
+
+Writing to disk
+^^^^^^^^^^^^^^^
+
+* FIXME Link to module docs ios_facts, vyos_facts, copy, debug
+
+Troubleshooting
+---------------
+
+If you receive an error ``unable to open shell`` please follow the debug steps in :doc:`network_debug_troubleshooting`.
+
+
+See also
+
+* Network landing page
+* intro_inventory
+* playbooks_best_practices.html#best-practices-for-variables-and-vaults
+
+Fixme
+=====
+
+* Highlight the command to run in the console section - Look at Sphix documentatiom
+* Agreed: Hello world https://github.com/Dell-Networking/ansible-dellos-examples/blob/master/getfacts_os10.yaml
+
+* Add filename to code-blocks
+
+* Other examples
+
+  * https://pynet.twb-tech.com/blog/ansible/ansible-network-backup.html
+  * https://pynet.twb-tech.com/blog/automation/cisco-ios.html
+
+  * Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - What do we here?
+
+
 
 FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere). This should just be a summary that links to the existing docs (``intro_inventory``, ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``, etc)
+
+Somewhere in the main docs we need to list the different ways of authenticating
+
 
 :Command line:
 
@@ -129,7 +201,8 @@ FIXME Link to details regarding different ways to specify credentials (this shou
 
   :``ansible_ssh_pass``:
 
-    * Details
+    * Generally used along side ``ansible_user``.
+    * Not for REST transports such as `eapi`, `nxapi`.
     * Link to main docs
 
   :``ansible_ssh_private_key_file``:
@@ -137,49 +210,13 @@ FIXME Link to details regarding different ways to specify credentials (this shou
     * Details
     * Link to main docs
 
-:top-level:
+:top-level module options:
 
-  * Moving away from this
+  * As of Ansible 2.3 this is deprecated.
   * Link to main docs
 
-:provider:
+:``provider:`` argument to module:
 
   * This is OK
   * Link to main docs
 
-
-
-
-.. warning:: Never store passwords in plain text
-
-   FIXME Details on why this is bad, links to existing vault docs (improve that example)
-
-
-* FIXME: ``ansible_connection=local``
-
-
-* FIXME Link to module docs ios_facts, vyos_facts, copy, debug
-
-Troubleshooting
----------------
-
-If you receive an error ``unable to open shell`` please follow the debug steps in :doc:`network_debug_troubleshooting`_.
-
-Fixme
-=====
-
-* Highlight the command to run in the console section - Look at Sphix documentatiom
-* Agreed: Hello world https://github.com/Dell-Networking/ansible-dellos-examples/blob/master/getfacts_os10.yaml
-
-* Add filename to code-blocks
-
-* Troubleshooting link to http://docs.ansible.com/ansible/latest/network_debug_troubleshooting.html#unable-to-open-shell
-
-
-
-
-See also
-
-* Network landing page
-* intro_inventory
-* playbooks_best_practices.html#best-practices-for-variables-and-vaults

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -1,0 +1,92 @@
+.. network-example-facts:
+
+************************************
+Gathering facts from network devices
+************************************
+
+.. contents:: Topics
+
+
+Gather facts
+============
+
+Objective
+---------
+
+I want to connect to a remote network device, download it's configuration and write it to a file
+
+Solution
+--------
+
+Create an inventory file
+
+
+Inventory file
+++++++++++++++
+
+Create a file called ``inventory``, containing:
+
+.. code-block::
+
+   [switches]
+   sw1.example.net
+
+Playbook
+++++++++
+
+Create a file called ``fetch-facts.yml`` containing the following:
+
+.. code-block:: yaml
+
+  ---
+  - name: "Download switch configuration"
+    hosts: switches
+    connection: local
+    gather_facts: no
+    vars:
+      ios_credentials:
+        username: cisco
+        password: secretpassword
+    tasks:
+      - name: Gather facts
+        ios_facts:
+          provider: "{{ ios_credentials }}"
+        register: result
+
+      - name: Display facts
+        debug:
+          msg: " {{ result }}"
+
+      - name: Write to disk
+        copy:
+          content: "{{ result | to_nice_json }}"
+          dest: "/tmp/switch-config-{{inventory_hostname}}"
+
+Run it
+++++++
+
+.. code-block:: console
+
+   ansible-playbook -i inventory fetch-facts.yml
+   <snip>
+   ios01                      : ok=3    changed=1    unreachable=0    failed=0
+   ls /tmp/switch-config-*
+   /tmp/switch-config-ios01.example.net
+   less /tmp/switch-config-ios01.example.net
+
+Details
+-------
+
+* FIXME Details about inventory
+* FIXME
+
+Fixme
+=====
+
+* Highlight the command to run in the console section - Look at Sphix documentatiom
+* Agreed: Hello world https://github.com/Dell-Networking/ansible-dellos-examples/blob/master/getfacts_os10.yaml
+
+* Add filename to code-blocks
+
+* Troubleshooting link to http://docs.ansible.com/ansible/latest/network_debug_troubleshooting.html#unable-to-open-shell
+* Duplicate for two platforms

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -21,8 +21,7 @@ Solution
 Create an inventory file
 
 
-Inventory file
-++++++++++++++
+**Inventory file**
 
 Create a file called ``inventory``, containing:
 
@@ -39,8 +38,7 @@ Create a file called ``inventory``, containing:
    vyos01.example.net ansible_connection=local ansible_user=admin ansible_ssh_pass=admin
 
 
-Playbook
-++++++++
+**Playbook**
 
 Create a file called ``fetch-facts.yml`` containing the following:
 
@@ -49,8 +47,6 @@ Create a file called ``fetch-facts.yml`` containing the following:
    - name: "Download switch configuration"
      hosts: switches
      gather_facts: no
-
-     vars:
 
      tasks:
        - name: Gather facts (ios)
@@ -67,7 +63,9 @@ Create a file called ``fetch-facts.yml`` containing the following:
          debug:
            msg: "The hostname is {{ ansible_net_hostname }} and the OS is {{ ansible_net_version }}"
 
-       - debug: var=hostvars['vyos01.example.net']
+       - name: Show how to get a fact from a specific host
+         debug:
+           var: hostvars['vyos01.example.net']
 
        - name: Write to disk
          copy:
@@ -106,9 +104,45 @@ Run it
 Details
 -------
 
+Inventory
++++++++++
+
+The ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups
+
+The above inventory file defines the groups ``ios``, ``vyos`` and a "group of groups" called ``switches``. Further details about subgroups and inventory files can be found in the :ref:`Ansible inventory Group documentation <subgroups>`.
+
+The inventory file can be used to define the credentials to log in with, there are various ways credentials could be supplied:
+
+FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere, if not then create it, maybe using a `:fieldtable:`
+
+:Command line:
+
+  * Using ``--user`` (``-u``) and ``--ask-pass`` (``-k``).
+  * Note: This only works if all devices use the same credentials
+
+:Inventory file:
+
+  :``ansible_user``:
+
+    * Details
+
+  : ``ansible_ssh_pass``
+  
+    * Details
 
 
-This is where we explain what the above is doing
+
+
+
+.. warning:: Never store passwords in plain text
+
+   FIXME Details and links to vault go here
+
+
+FIXME: ``ansible_connection=local``
+   
+   
+   This is where we explain what the above is doing
 
 * FIXME Details about inventory
 
@@ -133,3 +167,12 @@ Fixme
 * Add filename to code-blocks
 
 * Troubleshooting link to http://docs.ansible.com/ansible/latest/network_debug_troubleshooting.html#unable-to-open-shell
+
+
+
+
+See also
+
+* Network landing page
+* intro_inventory
+* playbooks_best_practices.html#best-practices-for-variables-and-vaults

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -128,7 +128,7 @@ Although there are many ways to supply credentials in Ansible in this case we ar
 ansible_connection
 ^^^^^^^^^^^^^^^^^^
 
-* FIXME: ``ansible_connection=local``
+Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote 
 
 
 Playbook
@@ -168,17 +168,15 @@ See also
 Fixme
 =====
 
-* Highlight the command to run in the console section - Look at Sphix documentatiom
+* Highlight the command to run in the console section - Look at Sphix documentation
 * Agreed: Hello world https://github.com/Dell-Networking/ansible-dellos-examples/blob/master/getfacts_os10.yaml
 
 * Add filename to code-blocks
 
 * Other examples
 
-  * https://pynet.twb-tech.com/blog/ansible/ansible-network-backup.html
-  * https://pynet.twb-tech.com/blog/automation/cisco-ios.html
 
-  * Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - What do we here?
+* Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - What do we here?
 
 
 

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -28,8 +28,16 @@ Create a file called ``inventory``, containing:
 
 .. code-block::
 
-   [switches]
-   sw1.example.net
+   [switches:children]
+   ios
+   vyos
+
+   [ios]
+   ios01.example.net ansible_connection=local ansible_user=cisco ansible_ssh_pass=cisco
+
+   [vyos]
+   vyos01.example.net ansible_connection=local ansible_user=admin ansible_ssh_pass=admin
+
 
 Playbook
 ++++++++
@@ -38,30 +46,20 @@ Create a file called ``fetch-facts.yml`` containing the following:
 
 .. code-block:: yaml
 
-   ---
    - name: "Download switch configuration"
      hosts: switches
-     connection: local
      gather_facts: no
 
      vars:
-       ios_credentials:
-         username: cisco
-         password: cisco
-       vyos_credentials:
-         username: admin
-         password: admin
 
      tasks:
        - name: Gather facts (ios)
          ios_facts:
-           provider: "{{ ios_credentials }}"
          register: result_ios
          when: "'ios' in group_names"
 
        - name: Gather facts (vyos)
          vyos_facts:
-           provider: "{{ vyos_credentials }}"
          register: result_vyos
          when: "'vyos' in group_names"
 
@@ -91,6 +89,7 @@ Create a file called ``fetch-facts.yml`` containing the following:
                {% endfor %}
            dest: /tmp/switch-facts
 
+
 Run it
 ++++++
 
@@ -115,7 +114,7 @@ This is where we explain what the above is doing
 
     * What do we need to link to in main docs: ``:children``, what else?
     * Host groups
-      
+
 * FIXME Step though playbook
 
   * Link to module docs for ios_facts, vyos_facts

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -18,14 +18,14 @@ I want to connect to a remote network device, download it's configuration and wr
 Prerequisites
 -------------
 
-* Ansible 2.3 (or higher) installed FIXMELINK
+* Ansible 2.3 (or higher) installed :doc:`intro_installation`
 * One or more network device compatible with Ansible FIXMELINK
 
 Audience
 --------
 
 * Basic Linux (comfortable on the command line)
-* Basic Network switch & router configuration knowledge (FIXME examples)
+* Basic Network switch & router configuration knowledge
 
 
 Solution
@@ -103,6 +103,8 @@ Create a file called ``fetch-facts.yml`` containing the following:
            dest: /tmp/switch-facts
 
 
+FIXME: Use ``_config`` to download full configuration and write to disk?
+
 Run it
 ------
 
@@ -135,12 +137,12 @@ Although there are many ways to supply credentials in Ansible in this case we ar
 
 .. warning:: Never store passwords in plain text
 
-   FIXME Details on why this is bad, links to existing vault docs (improve that example)
+   Passwords should never be stored in plain text. The "Vault" feature of Ansible allows keeping sensitive data such as passwords or keys in encrypted files, rather than as plaintext in your playbooks or roles. These vault files can then be distributed or placed in source control. The :doc:`playbooks_vault` contains further information.
 
 ansible_connection
 ^^^^^^^^^^^^^^^^^^
 
-Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote and execute the Python script on the network device, which would fail as Python generally isn't available.
+Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote and execute the Python script on the network device, which would fail as Python generally isn't available on network devices.
 
 
 Playbook
@@ -149,13 +151,13 @@ Playbook
 Gathering facts
 ^^^^^^^^^^^^^^^
 
-Here we use the ``_facts`` modules :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly specified Ansible uses the username and password from the inventory file.
+Here we use the ``_facts`` modules :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly passed via module arguments, Ansible uses the username and password from the inventory file.
 
 The data that the module returns is stored due to the use of the ``register:`` keyword into a variable called ``results_ios`` or ``results_vyos``.
 
 The return values (data returned by a module) are documented in the `Return Values` section of the module docs, in this case :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>`.
 
-The task is conditionally run based on the group defined in the inventory file, for more information on the use of Conditionals in Ansible Playbooks see :ref:`the_when_statement`.
+The task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
 
 
 
@@ -201,6 +203,11 @@ Fixme
   * Improve vault page and link between ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``
   * Link to network intro page table of Persistent connection and version_added table
 
+
+New page: Auth & Proxy
+----------------------
+
+This section needs moving to a new page, just made notes here while I was developing this:
 
 FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere). This should just be a summary that links to the existing docs (``intro_inventory``, ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``, etc)
 

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -242,8 +242,12 @@ Somewhere in the main docs we need to list the different ways of authenticating
   * As of Ansible 2.3 this is deprecated.
   * Link to main docs
 
-:``provider:`` argument to module:
+:``provider``: argument to module:
 
   * This is OK
   * Link to main docs
 
+:Env variables:
+
+  * ``ANSIBLE_NET_USERNAME``
+  * ``ANSIBLE_NET_PASSWORD``

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -1,8 +1,8 @@
 .. network-example-facts:
 
-************************************
-Gathering facts from network devices
-************************************
+*******************************
+Network getting started example
+*******************************
 
 .. contents:: Topics
 
@@ -13,7 +13,11 @@ Overview
 Objective
 ---------
 
-I want to connect to a remote network device, download it's configuration and write it to a file.
+I want to understand how Ansible can be used to connect to multiple network devices.
+
+This is not for production use, it's more to demonstrate the different areas that need to be considered and provide a foundation level knowledge.
+
+Future examples FIXMELINK will build on this knowledge.
 
 Prerequisites
 -------------
@@ -64,6 +68,7 @@ Create a file called ``fetch-facts.yml`` containing the following:
      gather_facts: no
 
      tasks:
+
        - name: Gather facts (ios)
          ios_facts:
          register: result_ios

--- a/docs/docsite/rst/network_use_case_facts.rst
+++ b/docs/docsite/rst/network_use_case_facts.rst
@@ -7,8 +7,8 @@ Gathering facts from network devices
 .. contents:: Topics
 
 
-Gather facts
-============
+Overview
+========
 
 Objective
 ---------
@@ -19,11 +19,7 @@ Prerequisites
 -------------
 
 * Ansible 2.3 (or higher) installed FIXMELINK
-* One or more network device compatible:
-
-  * Arista
-  * Cisco: ios, iosxr, nxos
-  * FIXME
+* One or more network device compatible with Ansible FIXMELINK
 
 Audience
 --------
@@ -33,7 +29,7 @@ Audience
 
 
 Solution
---------
+=========
 
 Create an inventory file
 
@@ -65,7 +61,6 @@ Create a file called ``fetch-facts.yml`` containing the following:
      # Which group in the inventory file this applies to
      hosts: switches
 
-     # fixme
      gather_facts: no
 
      tasks:
@@ -109,7 +104,7 @@ Create a file called ``fetch-facts.yml`` containing the following:
 
 
 Run it
-++++++
+------
 
 .. code-block:: console
 
@@ -122,12 +117,12 @@ Run it
    cat /tmp/switch-facts
 
 Details
--------
+=======
 
 Inventory
-+++++++++
+---------
 
-The ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups:
+The ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups.
 
 The above inventory file defines the groups ``ios``, ``vyos`` and a "group of groups" called ``switches``. Further details about subgroups and inventory files can be found in the :ref:`Ansible inventory Group documentation <subgroups>`.
 
@@ -145,42 +140,48 @@ Although there are many ways to supply credentials in Ansible in this case we ar
 ansible_connection
 ^^^^^^^^^^^^^^^^^^
 
-Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote
+Setting ``ansible_connection=local`` informs Ansible to execute the module on the controlling machine (i.e. the one executing Ansible). Without this Ansible would attempt to ssh onto the remote and execute the Python script on the network device, which would fail as Python generally isn't available.
 
 
 Playbook
-++++++++
+--------
 
 Gathering facts
 ^^^^^^^^^^^^^^^
 
-* Link to module
-* Not about conditional keyword - link to docs
-* ``register``
+Here we use the ``_facts`` modules :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote device. As the credentials are not explicitly specified Ansible uses the username and password from the inventory file.
+
+The data that the module returns is stored due to the use of the ``register:`` keyword into a variable called ``results_ios`` or ``results_vyos``.
+
+The return values (data returned by a module) are documented in the `Return Values` section of the module docs, in this case :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>`.
+
+The task is conditionally run based on the group defined in the inventory file, for more information on the use of Conditionals in Ansible Playbooks see :ref:`the_when_statement`.
+
 
 
 Debug
-^^^^^^
+-----
 
-* Reference ``RETURN`` sections of docs
-* Link to docs ``hostvars`` docs
+Although these tasks are not needed to write data to disk, they are useful to demonstrate some methods of accessing facts about the given or a named host.
+
+More information on this can be found in :ref:`magic_variables_and_hostvars`.
 
 Writing to disk
-^^^^^^^^^^^^^^^
+---------------
 
 * FIXME Link to module docs ios_facts, vyos_facts, copy, debug
 
 Troubleshooting
----------------
+===============
 
 If you receive an error ``unable to open shell`` please follow the debug steps in :doc:`network_debug_troubleshooting`.
 
 
-See also
+.. seealso::
 
-* Network landing page
-* intro_inventory
-* playbooks_best_practices.html#best-practices-for-variables-and-vaults
+  * Network landing page
+  * intro_inventory
+  * playbooks_best_practices.html#best-practices-for-variables-and-vaults
 
 Fixme
 =====
@@ -195,6 +196,10 @@ Fixme
 
 * Using ``ansible_ssh_pass`` will not work for REST transports such as ``eapi``, ``nxapi`` - What do we here?
 
+* External updates needed
+
+  * Improve vault page and link between ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``
+  * Link to network intro page table of Persistent connection and version_added table
 
 
 FIXME Link to details regarding different ways to specify credentials (this should be in the main docs somewhere). This should just be a summary that links to the existing docs (``intro_inventory``, ``playbooks_best_practices.html#best-practices-for-variables-and-vaults``, ``ansible-playbook.rst``, etc)


### PR DESCRIPTION
##### SUMMARY
Better view of docs: https://github.com/gundalow/ansible/blob/docs-network-use-cases/docs/docsite/rst/network_getting_started.rst (be aware that GitHub doesn't correctly render `notes` or `warnings`

**What is this**
* A "Getting started with Ansible Network Guide"
* Audience: Limited prior knowledge of Ansible or Ansible with Networking
* Explains how to connect correctly
* A pre-prerequisite for future examples (to be written)
* Examples and training were outlined at San Francisco Contributors Summit and agreed there

**Future work (separate PRs)**
* A separate document with details of how to authenticate against non-CLI transports (such as eapi, nxapi, avi, f5, etc) will be created. At that point, this page will be updated to include links - See fixme comments in the RST
* A brand new `intro_networking` page will be created.
  * New page will just be a landing/index page
  * Will contains links to this page, debug, module index, YAML, ansible.com/network, etc,e tc


_Feedback welcome, what could be clearer_

##### ISSUE TYPE
 - Docs Pull Request

