### PR TITLE
win_regedit: fix extra info coming into stdout

### DIFF
--- a/lib/ansible/modules/windows/win_regedit.ps1
+++ b/lib/ansible/modules/windows/win_regedit.ps1
@@ -243,7 +243,7 @@ if ($state -eq "present") {
     if (-not (Test-Path -path $path)) {
         # the key doesn't exist, create it so the next steps work
         try {
-            New-Item -Path $path -Type directory -Force -WhatIf:$check_mode
+            $null = New-Item -Path $path -Type directory -Force -WhatIf:$check_mode
         } catch {
             Fail-Json $result "failed to create registry key at $($path): $($_.Exception.Message)"
         }
@@ -330,7 +330,7 @@ $key_prefix[$path]
         if ($delete_key -and $name -eq $null) {
             # the clear_key flag is set and name is null so delete the entire key
             try {
-                Remove-Item -Path $path -Force -Recurse -WhatIf:$check_mode
+                $null = Remove-Item -Path $path -Force -Recurse -WhatIf:$check_mode
             } catch {
                 Fail-Json $result "failed to delete registry key at $($path): $($_.Exception.Message)"
             }

--- a/test/integration/targets/win_regedit/tasks/tests.yml
+++ b/test/integration/targets/win_regedit/tasks/tests.yml
@@ -421,3 +421,40 @@
   assert:
     that:
     - not create_hkcr_key_again|changed
+
+# https://github.com/ansible/ansible/issues/31782
+- name: create property like a json string
+  win_regedit:
+    path: '{{test_win_regedit_local_key}}\NewKey'
+    name: '{7f51bda7-bcea-465a-9eb6-5a2bcd9cb52f}'
+    data: test data
+    type: string
+    state: present
+  register: create_prop_with_json
+
+- name: get result of create property like a json string
+  win_reg_stat:
+    path: '{{test_win_regedit_local_key}}\NewKey'
+    name: '{7f51bda7-bcea-465a-9eb6-5a2bcd9cb52f}'
+  register: create_prop_with_json_result
+
+- name: assert results of create property like a json string
+  assert:
+    that:
+    - create_prop_with_json|changed
+    - create_prop_with_json_result.exists == True
+    - create_prop_with_json_result.value == 'test data'
+
+- name: create property like a json string (idempotent)
+  win_regedit:
+    path: '{{test_win_regedit_local_key}}\NewKey'
+    name: '{7f51bda7-bcea-465a-9eb6-5a2bcd9cb52f}'
+    data: test data
+    type: string
+    state: present
+  register: create_prop_with_json_again
+
+- name: assert results of create property like a json string (idempotent)
+  assert:
+    that:
+    - not create_prop_with_json_again|changed


### PR DESCRIPTION
##### SUMMARY
`New-Item` and `Remove-Item` output into which eventually ends up in the stdout stream sent back to Ansible. Usually this isn't an issue as Ansible parses the output from when it first detects `{` but in the case of the property of data containg that character (like a guid of json string), Ansible won't be able to parse the output and it fails even though it really didn't

This change makes sure that extra data is not sent to the output/stdout stream so Ansible won't get confused in the end.

fixes https://github.com/ansible/ansible/issues/31423
fixes https://github.com/ansible/ansible/issues/31782

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_regedit

##### ANSIBLE VERSION
```
2.4
2.5
```