### PR TITLE
win_dsc: link module documentation to main RST page

### DIFF
--- a/lib/ansible/modules/windows/win_dsc.py
+++ b/lib/ansible/modules/windows/win_dsc.py
@@ -33,6 +33,7 @@ short_description: Invokes a PowerShell DSC configuration
 description:
     - Invokes a PowerShell DSC Configuration. Requires PowerShell version 5 (February release or newer).
     - Most of the parameters for this module are dynamic and will vary depending on the DSC Resource.
+    - See :doc:`windows_dsc` for more information on how to use this module.
 options:
   resource_name:
     description:


### PR DESCRIPTION
##### SUMMARY
Now that the main docs have been merged, linking the win_dsc module documentation to the Windows DSC info page.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_dsc

##### ANSIBLE VERSION
```
2.5
```
