### PR TITLE
-Fixes JSON parsing(use JSON object instead of string) for facts module

### DIFF
--- a/lib/ansible/modules/network/junos/junos_facts.py
+++ b/lib/ansible/modules/network/junos/junos_facts.py
@@ -56,6 +56,7 @@ requirements:
 notes:
   - Ensure I(config_format) used to retrieve configuration from device
     is supported by junos version running on device.
+  - With I(config_format = json), configuration in the results will be a dictionary(and not a JSON string)
   - This module requires the netconf system service be enabled on
     the remote device being managed.
   - Tested against vSRX JUNOS version 15.1X49-D15.4, vqfx-10000 JUNOS Version 15.1X53-D60.4.
@@ -155,7 +156,7 @@ class Config(FactsBase):
             config = self.get_text(reply, 'configuration-text')
 
         elif config_format == 'json':
-            config = str(reply.text).strip()
+            config = self.module.from_json(reply.text.strip())
 
         elif config_format == 'set':
             config = self.get_text(reply, 'configuration-set')
@@ -370,7 +371,6 @@ def main():
         else:
             warnings += ['junos-eznc is required to gather old style facts but does not appear to be installed. '
                          'It can be installed using `pip  install junos-eznc`']
-
     module.exit_json(ansible_facts=ansible_facts, warnings=warnings)
 
 

--- a/test/integration/targets/junos_facts/tests/netconf/facts.yaml
+++ b/test/integration/targets/junos_facts/tests/netconf/facts.yaml
@@ -86,7 +86,7 @@
 - assert:
     that:
       - "result.changed == false"
-      - "'\"data\" : \"{{ inventory_hostname_short }}\"' in result['ansible_facts']['ansible_net_config']"
+      - "'{{ inventory_hostname_short }}' == '{{ result['ansible_facts']['ansible_net_config']['configuration'][0]['system'][0]['host-name'][0]['data'] }}' "
 
 - name: Collect config facts from device in text format
   junos_facts:

--- a/test/units/modules/network/junos/fixtures/get_configuration_rpc_reply_json.txt
+++ b/test/units/modules/network/junos/fixtures/get_configuration_rpc_reply_json.txt
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8"?><rpc-reply message-id="urn:uuid:72c481b8">
+{
+    "configuration" : [
+    {
+        "system" : [
+        {
+            "host-name" : [
+            {
+                "data" : "vsrx01"
+            }
+            ],
+            "domain-name" : [
+            {
+                "data" : "junos.com"
+            }
+            ],
+            "name-server" : [
+            {
+                "name" :
+                {
+                    "data" : "172.26.1.1"
+                }
+            },
+            {
+                "name" :
+                {
+                    "data" : "8.8.8.8"
+                }
+            }
+            ],
+            "services" : [
+            {
+                "ssh" : [
+                {
+                }
+                ],
+                "telnet" : [
+                {
+                }
+                ],
+                "netconf" : [
+                {
+                    "ssh" : [
+                    {
+                        "port" : [
+                        {
+                            "data" : "830"
+                        }
+                        ]
+                    }
+                    ],
+                    "traceoptions" : [
+                    {
+                        "file" : [
+                        {
+                            "filename" : [
+                            {
+                                "data" : "netconf-ops.log"
+                            }
+                            ]
+                        }
+                        ],
+                        "flag" : [
+                        {
+                            "name" :
+                            {
+                                "data" : "all"
+                            }
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ],
+                "web-management" : [
+                {
+                    "http" : [
+                    {
+                        "interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ],
+            "syslog" : [
+            {
+                "user" : [
+                {
+                    "name" :
+                    {
+                        "data" : "*"
+                    },
+                    "contents" : [
+                    {
+                        "name" :
+                        {
+                            "data" : "any"
+                        },
+                        "emergency" : [
+                        {
+                            "data" : null
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ],
+                "file" : [
+                {
+                    "name" :
+                    {
+                        "data" : "messages"
+                    },
+                    "contents" : [
+                    {
+                        "name" :
+                        {
+                            "data" : "any"
+                        },
+                        "any" : [
+                        {
+                            "data" : null
+                        }
+                        ]
+                    },
+                    {
+                        "name" :
+                        {
+                            "data" : "authorization"
+                        },
+                        "info" : [
+                        {
+                            "data" : null
+                        }
+                        ]
+                    }
+                    ]
+                },
+                {
+                    "name" :
+                    {
+                        "data" : "interactive-commands"
+                    },
+                    "contents" : [
+                    {
+                        "name" :
+                        {
+                            "data" : "interactive-commands"
+                        },
+                        "any" : [
+                        {
+                            "data" : null
+                        }
+                        ]
+                    }
+                    ]
+                },
+                {
+                    "name" :
+                    {
+                        "data" : "test1"
+                    },
+                    "contents" : [
+                    {
+                        "name" :
+                        {
+                            "data" : "any"
+                        },
+                        "any" : [
+                        {
+                            "data" : null
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+	]
+    }
+    ]
+}
+</rpc-reply>

--- a/test/units/modules/network/junos/test_junos_facts.py
+++ b/test/units/modules/network/junos/test_junos_facts.py
@@ -88,6 +88,17 @@ class TestJunosCommandModule(TestJunosModule):
         self.assertEqual(facts['ansible_net_hostname'], 'vsrx01')
         self.assertTrue('ansible_net_interfaces' not in facts)
 
+    def test_junos_get_facts_subset_config_json(self):
+        self.get_config.return_value = load_fixture('get_configuration_rpc_reply_json.txt')
+        set_module_args(dict(gather_subset='config', config_format='json'))
+        result = self.execute_module(format='xml')
+        facts = result['ansible_facts']
+
+        self.assertTrue('ansible_net_config' in facts)
+        self.assertTrue('configuration' in facts['ansible_net_config'])
+        self.assertEqual(facts['ansible_net_hostname'], 'vsrx01')
+        self.assertTrue('ansible_net_interfaces' not in facts)
+
     def test_junos_get_facts_subset_list(self):
         set_module_args(dict(gather_subset=['hardware', 'interfaces']))
         result = self.execute_module(format='xml')


### PR DESCRIPTION
##### SUMMARY
Fixes output parsing for junos facts to use JSON object instead of a string

Fixes #31489 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/network/junos

##### ANSIBLE VERSION
```
2.5.0 (devel)
```
