### PR TITLE
Added more info about the overwrite option

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -101,7 +101,10 @@ options:
   overwrite:
     description:
       - Force overwrite either locally on the filesystem or remotely with the object/key. Used with PUT and GET operations.
-        Boolean or one of [always, never, different], true is equal to 'always' and false is equal to 'never', new in 2.0
+        Boolean or one of [always, never, different], true is equal to 'always' and false is equal to 'never', new in 2.0.
+        When this is set to 'different', the md5 sum of the local file is compared with the 'ETag' of the object/key in S3.
+        The ETag may or may not be an MD5 digest of the object data. See the ETag response header here
+        U(http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html)
     default: 'always'
     aliases: ['force']
     version_added: "1.2"


### PR DESCRIPTION
##### SUMMARY
Added information about how `overwrite` works when it is set to `different`.

The md5 sum of the local file is compared with the `ETag` value of the object in S3. The ETag may or may not be an MD5 digest of the object data. Whether or not it is depends on how the object was created and how it is encrypted
http://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`aws_s3`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```
