### PR TITLE
ovirt: Add env variables to dynamic inventory

### DIFF
--- a/contrib/inventory/ovirt4.py
+++ b/contrib/inventory/ovirt4.py
@@ -124,10 +124,10 @@ def create_connection():
     # Create parser and add ovirt section if it doesn't exist:
     config = configparser.SafeConfigParser(
         defaults={
-            'ovirt_url': None,
-            'ovirt_username': None,
-            'ovirt_password': None,
-            'ovirt_ca_file': None,
+            'ovirt_url': os.environ.get('OVIRT_URL'),
+            'ovirt_username': os.environ.get('OVIRT_USERNAME'),
+            'ovirt_password': os.environ.get('OVIRT_PASSWORD'),
+            'ovirt_ca_file': os.environ.get('OVIRT_CAFILE'),
         }
     )
     if not config.has_section('ovirt'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This patch add new environment variables to oVirt dynamic inventory
to be consistent with all other oVirt modules:

```
 OVIRT_URL
 OVIRT_USERNAME
 OVIRT_CAFILE
 OVIRT_PASSWORD
```

Those variables are used as fallback if user don't specify a ini file,
with appropriate variables there.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt4

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
