### PR TITLE
git: remove duplicate ssh_wrapper cleanup

### DIFF
--- a/lib/ansible/modules/source_control/git.py
+++ b/lib/ansible/modules/source_control/git.py
@@ -1161,14 +1161,6 @@ def main():
 
         create_archive(git_path, module, dest, archive, version, repo, result)
 
-    # cleanup the wrapper script
-    if ssh_wrapper:
-        try:
-            os.remove(ssh_wrapper)
-        except OSError:
-            # No need to fail if the file already doesn't exist
-            pass
-
     module.exit_json(**result)
 
 


### PR DESCRIPTION
##### SUMMARY
Already removed by `module.add_cleanup_file(path=ssh_wrapper)`

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
git

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION