### PR TITLE
Move zabbix_*-modules commonly used doc fragments to central place

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix_group.py
@@ -29,43 +29,13 @@ requirements:
     - "python >= 2.6"
     - zabbix-api
 options:
-    server_url:
-        description:
-            - Url of Zabbix server, with protocol (http or https).
-              C(url) is an alias for C(server_url).
-        required: true
-        aliases: [ "url" ]
-    login_user:
-        description:
-            - Zabbix user name.
-        required: true
-    login_password:
-        description:
-            - Zabbix user password.
-        required: true
-    http_login_user:
-        description:
-            - Basic Auth login
-        required: false
-        default: None
-        version_added: "2.1"
-    http_login_password:
-        description:
-            - Basic Auth password
-        required: false
-        default: None
-        version_added: "2.1"
-    state:
+   state:
         description:
             - Create or delete host group.
         required: false
         default: "present"
         choices: [ "present", "absent" ]
-    timeout:
-        description:
-            - The timeout of API request(seconds).
-        default: 10
-    host_groups:
+   host_groups:
         description:
             - List of host groups to create or delete.
         required: true

--- a/lib/ansible/modules/monitoring/zabbix_group.py
+++ b/lib/ansible/modules/monitoring/zabbix_group.py
@@ -29,13 +29,13 @@ requirements:
     - "python >= 2.6"
     - zabbix-api
 options:
-   state:
+    state:
         description:
             - Create or delete host group.
         required: false
         default: "present"
         choices: [ "present", "absent" ]
-   host_groups:
+    host_groups:
         description:
             - List of host groups to create or delete.
         required: true

--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -29,31 +29,6 @@ requirements:
     - "python >= 2.6"
     - "zabbix-api >= 0.5.3"
 options:
-    server_url:
-        description:
-            - Url of Zabbix server, with protocol (http or https).
-        required: true
-        aliases: [ "url" ]
-    login_user:
-        description:
-            - Zabbix user name, used to authenticate against the server.
-        required: true
-    login_password:
-        description:
-            - Zabbix user password.
-        required: true
-    http_login_user:
-        description:
-            - Basic Auth login
-        required: false
-        default: None
-        version_added: "2.1"
-    http_login_password:
-        description:
-            - Basic Auth password
-        required: false
-        default: None
-        version_added: "2.1"
     host_name:
         description:
             - Name of the host in Zabbix.
@@ -99,10 +74,6 @@ options:
         required: false
         choices: ['present', 'absent']
         default: "present"
-    timeout:
-        description:
-            - The timeout of API request (seconds).
-        default: 10
     proxy:
         description:
             - The name of the Zabbix Proxy to be used

--- a/lib/ansible/modules/monitoring/zabbix_hostmacro.py
+++ b/lib/ansible/modules/monitoring/zabbix_hostmacro.py
@@ -27,31 +27,6 @@ requirements:
     - "python >= 2.6"
     - zabbix-api
 options:
-    server_url:
-        description:
-            - Url of Zabbix server, with protocol (http or https).
-        required: true
-        aliases: [ "url" ]
-    login_user:
-        description:
-            - Zabbix user name.
-        required: true
-    login_password:
-        description:
-            - Zabbix user password.
-        required: true
-    http_login_user:
-        description:
-            - Basic Auth login
-        required: false
-        default: None
-        version_added: "2.1"
-    http_login_password:
-        description:
-            - Basic Auth password
-        required: false
-        default: None
-        version_added: "2.1"
     host_name:
         description:
             - Name of the host.
@@ -72,10 +47,6 @@ options:
         required: false
         choices: ['present', 'absent']
         default: "present"
-    timeout:
-        description:
-            - The timeout of API request (seconds).
-        default: 10
 
 extends_documentation_fragment:
     - zabbix

--- a/lib/ansible/modules/monitoring/zabbix_maintenance.py
+++ b/lib/ansible/modules/monitoring/zabbix_maintenance.py
@@ -31,33 +31,6 @@ options:
         required: false
         default: present
         choices: [ "present", "absent" ]
-    server_url:
-        description:
-            - Url of Zabbix server, with protocol (http or https).
-              C(url) is an alias for C(server_url).
-        required: true
-        default: null
-        aliases: [ "url" ]
-    login_user:
-        description:
-            - Zabbix user name.
-        required: true
-    login_password:
-        description:
-            - Zabbix user password.
-        required: true
-    http_login_user:
-        description:
-            - Basic Auth login
-        required: false
-        default: None
-        version_added: "2.1"
-    http_login_password:
-        description:
-            - Basic Auth password
-        required: false
-        default: None
-        version_added: "2.1"
     host_names:
         description:
             - Hosts to manage maintenance window for.
@@ -97,12 +70,6 @@ options:
             - Type of maintenance. With data collection, or without.
         required: false
         default: "true"
-    timeout:
-        description:
-            - The timeout of API request (seconds).
-        default: 10
-        version_added: "2.1"
-        required: false
 
 extends_documentation_fragment:
     - zabbix

--- a/lib/ansible/modules/monitoring/zabbix_screen.py
+++ b/lib/ansible/modules/monitoring/zabbix_screen.py
@@ -28,35 +28,6 @@ requirements:
     - "python >= 2.6"
     - zabbix-api
 options:
-    server_url:
-        description:
-            - Url of Zabbix server, with protocol (http or https).
-        required: true
-        aliases: [ "url" ]
-    login_user:
-        description:
-            - Zabbix user name.
-        required: true
-    login_password:
-        description:
-            - Zabbix user password.
-        required: true
-    http_login_user:
-        description:
-            - Basic Auth login
-        required: false
-        default: None
-        version_added: "2.1"
-    http_login_password:
-        description:
-            - Basic Auth password
-        required: false
-        default: None
-        version_added: "2.1"
-    timeout:
-        description:
-            - The timeout of API request (seconds).
-        default: 10
     screens:
         description:
             - List of screens to be created/updated/deleted(see example).

--- a/lib/ansible/utils/module_docs_fragments/zabbix.py
+++ b/lib/ansible/utils/module_docs_fragments/zabbix.py
@@ -21,6 +21,36 @@ class ModuleDocFragment(object):
     # Standard documentation fragment
     DOCUMENTATION = '''
 options:
+    server_url:
+        description:
+            - Url of Zabbix server, with protocol (http or https).
+              C(url) is an alias for C(server_url).
+        required: true
+        aliases: [ "url" ]
+    login_user:
+        description:
+            - Zabbix user name.
+        required: true
+    login_password:
+        description:
+            - Zabbix user password.
+        required: true
+    http_login_user:
+        description:
+            - Basic Auth login
+        required: false
+        default: None
+        version_added: "2.1"
+    http_login_password:
+        description:
+            - Basic Auth password
+        required: false
+        default: None
+        version_added: "2.1"
+    timeout:
+        description:
+            - The timeout of API request(seconds).
+        default: 10
     validate_certs:
       required: false
       description:


### PR DESCRIPTION
##### SUMMARY
In zabbix_host, zabbix_hostmacro, zabbix_screen, zabbix_maintenance, and zabbix_group the parameters server_url, login_user, login_password, http_login_user, http_login_password, and timeout are the exact same. Since a centralized module_doc_fragment exists now, this PR moves the documentation for them there to reduce duplication and ease further maintenance.

There is one zabbix_-module missing from this list (zabbix_template). Once this PR is in, there will be a new PR for that one since it also needs implementation of validate_certs in order to use that module_doc_fragment. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
zabbix_*

##### ANSIBLE VERSION
2.5.0