### PR TITLE
fix syntax error

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -1626,7 +1626,7 @@ def warn_if_public_ip_assignment_changed(module, instance):
     public_dns_name = getattr(instance, 'public_dns_name', None)
     if (assign_public_ip or public_dns_name) and (not public_dns_name or not assign_public_ip):
         module.warn("Unable to modify public ip assignment to {0} for instance {1}. "
-                    "Whether or not to assign a public IP is determined during instance creation.".format(assign_public_ip, instance.id))
+                    "Whether or not to assign a public IP is determined during instance creation.".format(assign_public_ip, instance['id']))
 
 
 def main():


### PR DESCRIPTION
* failed with: AttributeError: 'dict' object has no attribute 'id'

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloud/amazon/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/blomkim/.ansible.cfg
  configured module search path = [u'/home/blomkim/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python2.7/site-packages/ansible
  executable location = /usr/lib/python-exec/python2.7/ansible
  python version = 2.7.12 (default, Jun  2 2017, 15:18:54) [GCC 4.9.4]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Failed with:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_NxtU2Q/ansible_module_ec2.py", line 1742, in <module>
    main()
  File "/tmp/ansible_NxtU2Q/ansible_module_ec2.py", line 1736, in main
    (tagged_instances, instance_dict_array, new_instance_ids, changed) = enforce_count(module, ec2, vpc)
  File "/tmp/ansible_NxtU2Q/ansible_module_ec2.py", line 991, in enforce_count
    warn_if_public_ip_assignment_changed(module, inst)
  File "/tmp/ansible_NxtU2Q/ansible_module_ec2.py", line 1624, in warn_if_public_ip_assignment_changed
    "Whether or not to assign a public IP is determined during instance creation.".format(assign_public_ip, instance.id))
AttributeError: 'dict' object has no attribute 'id'
```
