### PR TITLE
Fixed mange to say manage

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift_subnet_group.py
+++ b/lib/ansible/modules/cloud/amazon/redshift_subnet_group.py
@@ -18,7 +18,7 @@ author:
   - "Jens Carl (@j-carl), Hothead Games Inc."
 module: redshift_subnet_group
 version_added: "2.2"
-short_description: mange Redshift cluster subnet groups
+short_description: manage Redshift cluster subnet groups
 description:
   - Create, modifies, and deletes Redshift cluster subnet groups.
 options:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
There is a typo in the documentation about managing Redshift cluster subnet groups. Found at [http://docs.ansible.com/ansible/latest/redshift_subnet_group_module.html](url) . It says "mange" instead of "manage".
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
redshift_subnet_group
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
