### PR TITLE
Fix bad syntax in test_infra integration test.

### DIFF
--- a/test/integration/targets/test_infra/runme.sh
+++ b/test/integration/targets/test_infra/runme.sh
@@ -7,7 +7,7 @@ PB_OUT=$(ansible-playbook -i inventory.local test_test_infra.yml)
 APB_RC=$?
 echo "$PB_OUT"
 echo "rc was $APB_RC (must be non-zero)"
-[ $$APB_RC -ne 0 ]
+[ ${APB_RC} -ne 0 ]
 echo "ensure playbook output shows assert/fail works (True)"
 echo "$PB_OUT" | grep -F "fail works (True)" || exit 1
 echo "$PB_OUT" | grep -F "assert works (True)" || exit 1
@@ -17,7 +17,7 @@ PB_OUT=$(ansible-playbook -i ../../inventory test_test_infra.yml "$@")
 APB_RC=$?
 echo "$PB_OUT"
 echo "rc was $APB_RC (must be non-zero)"
-[ $$APB_RC -ne 0 ]
+[ ${APB_RC} -ne 0 ]
 echo "ensure playbook output shows assert/fail works (True)"
 echo "$PB_OUT" | grep -F "fail works (True)" || exit 1
 echo "$PB_OUT" | grep -F "assert works (True)" || exit 1


### PR DESCRIPTION
##### SUMMARY

Fix bad syntax in test_infra integration test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test_infra integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-infra-fix 1bdc38a5a5) last updated 2017/10/17 09:37:18 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
