### PR TITLE
Retry flakey rabbitmq install during test.

### DIFF
--- a/test/integration/targets/win_rabbitmq_plugin/tasks/tests.yml
+++ b/test/integration/targets/win_rabbitmq_plugin/tasks/tests.yml
@@ -2,6 +2,10 @@
   win_chocolatey:
     name: rabbitmq
     state: present
+  retries: 3
+  delay: 3
+  register: result
+  until: result.rc == 0
 
 - name: Ensure that rabbitmq_management plugin disabled
   win_rabbitmq_plugin:


### PR DESCRIPTION
##### SUMMARY

Retry flakey rabbitmq install during test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_rabbitmq integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-win-rabbitmq e795c92a00) last updated 2017/10/17 09:46:49 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
