### PR TITLE
Improve python 2/3 ABC fallback for pylint.

### DIFF
--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -2,7 +2,6 @@
 
 from __future__ import absolute_import, print_function
 
-import abc
 import errno
 import inspect
 import os
@@ -14,7 +13,11 @@ import re
 import sys
 import time
 
-ABC = abc.ABCMeta('ABC', (object,), {'__slots__': ()})  # compatible with Python 2 *and* 3
+try:
+    from abc import ABC
+except ImportError:
+    from abc import ABCMeta
+    ABC = ABCMeta('ABC', (), {})
 
 
 def is_shippable():

--- a/test/sanity/code-smell/pylint-ansible-test.sh
+++ b/test/sanity/code-smell/pylint-ansible-test.sh
@@ -6,6 +6,7 @@ pylint --max-line-length=160 --reports=n ./*.py ./*/*.py ./*/*/*.py \
     --jobs 2 \
     --rcfile /dev/null \
     --function-rgx '[a-z_][a-z0-9_]{2,40}$' \
+    --method-rgx '[a-z_][a-z0-9_]{2,40}$' \
     -d unused-import \
     -d too-few-public-methods \
     -d too-many-arguments \


### PR DESCRIPTION
##### SUMMARY

Improve python 2/3 ABC fallback for pylint. Also allow longer method names in ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-abc ac03ef059b) last updated 2017/10/17 12:09:09 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
