### PR TITLE
ec2: use instance for warning before turning into a dict

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -989,11 +989,11 @@ def enforce_count(module, ec2, vpc):
     # ensure all instances are dictionaries
     all_instances = []
     for inst in instances:
+        warn_if_public_ip_assignment_changed(module, inst)
+
         if not isinstance(inst, dict):
             inst = get_instance_info(inst)
         all_instances.append(inst)
-
-        warn_if_public_ip_assignment_changed(module, inst)
 
     return (all_instances, instance_dict_array, changed_instance_ids, changed)
 


### PR DESCRIPTION
##### SUMMARY
Alternative to #31835.

On this code path inst is turned into a dict and the warning fails since the dictionary won't have an id attribute.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.5.0
```