### PR TITLE
Disable flakey win_rabbitmq_plugin test.

### DIFF
--- a/test/integration/targets/win_rabbitmq_plugin/aliases
+++ b/test/integration/targets/win_rabbitmq_plugin/aliases
@@ -1,1 +1,0 @@
-windows/ci/group3


### PR DESCRIPTION
##### SUMMARY

Disable flakey win_rabbitmq_plugin test.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME

win_rabbitmq_plugin integration test

##### ANSIBLE VERSION

```
nsible 2.5.0 (disable-test 6c510cda3d) last updated 2017/10/17 13:54:01 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
