### PR TITLE
Modules metadata: fix invalid GitHub ID in author field

### DIFF
--- a/lib/ansible/modules/cloud/atomic/atomic_container.py
+++ b/lib/ansible/modules/cloud/atomic/atomic_container.py
@@ -21,7 +21,7 @@ description:
     - Manage the containers on the atomic host platform
     - Allows to manage the lifecycle of a container on the atomic host platform
 version_added: "2.4"
-author: "Giuseppe Scrivano @gscrivano"
+author: "Giuseppe Scrivano (@giuseppe)"
 notes:
     - Host should support C(atomic) command
 requirements:

--- a/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_loadbalancer.py
@@ -143,7 +143,7 @@ extends_documentation_fragment:
     - azure_tags
 
 author:
-    - "Thomas Stringer (@tr_stringer)"
+    - "Thomas Stringer (@tstringer)"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_extension.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine_extension.py
@@ -81,7 +81,7 @@ extends_documentation_fragment:
 
 author:
     - "Sertac Ozercan (@sozercan)"
-    - "Julien Stroheker (@ju_stroh)"
+    - "Julien Stroheker (@julienstroheker)"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_floating_ip.py
@@ -19,7 +19,7 @@ short_description: Manage DigitalOcean Floating IPs
 description:
      - Create/delete/assign a floating IP.
 version_added: "2.4"
-author: "Patrick Marques (@patrickfmarques)"
+author: "Patrick Marques (@pmarques)"
 options:
   state:
     description:

--- a/lib/ansible/modules/monitoring/pagerduty_alert.py
+++ b/lib/ansible/modules/monitoring/pagerduty_alert.py
@@ -20,7 +20,7 @@ description:
     - This module will let you trigger, acknowledge or resolve a PagerDuty incident by sending events
 version_added: "1.9"
 author:
-    - "Amanpreet Singh (@aps-sids)"
+    - "Amanpreet Singh (@ApsOps)"
 requirements:
     - PagerDuty API access
 options:

--- a/lib/ansible/modules/network/cumulus/_cl_img_install.py
+++ b/lib/ansible/modules/network/cumulus/_cl_img_install.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
 ---
 module: cl_img_install
 version_added: "2.1"
-author: "Cumulus Networks (@CumulusLinux)"
+author: "Cumulus Networks (@CumulusNetworks)"
 short_description: Install a different Cumulus Linux version.
 deprecated: Deprecated in 2.3. The image slot system no longer exists in Cumulus Linux.
 description:

--- a/lib/ansible/modules/network/nxos/nxos_banner.py
+++ b/lib/ansible/modules/network/nxos/nxos_banner.py
@@ -27,7 +27,7 @@ DOCUMENTATION = """
 ---
 module: nxos_banner
 version_added: "2.4"
-author: "Trishna Guha (@trishnag)"
+author: "Trishna Guha (@trishnaguha)"
 short_description: Manage multiline banners on Cisco NXOS devices
 description:
   - This will configure both exec and motd banners on remote devices

--- a/lib/ansible/modules/network/nxos/nxos_logging.py
+++ b/lib/ansible/modules/network/nxos/nxos_logging.py
@@ -27,7 +27,7 @@ DOCUMENTATION = """
 ---
 module: nxos_logging
 version_added: "2.4"
-author: "Trishna Guha (@trishnag)"
+author: "Trishna Guha (@trishnaguha)"
 short_description: Manage logging on network devices
 description:
   - This module provides declarative management of logging

--- a/lib/ansible/modules/network/system/net_user.py
+++ b/lib/ansible/modules/network/system/net_user.py
@@ -16,7 +16,7 @@ DOCUMENTATION = """
 ---
 module: net_user
 version_added: "2.4"
-author: "Trishna Guha (@trishnag)"
+author: "Trishna Guha (@trishnaguha)"
 short_description: Manage the aggregate of local users on network device
 description:
   - This module provides declarative management of the local usernames

--- a/lib/ansible/modules/notification/cisco_spark.py
+++ b/lib/ansible/modules/notification/cisco_spark.py
@@ -20,7 +20,7 @@ short_description: Send a message to a Cisco Spark Room or Individual.
 description:
     - Send a message to a Cisco Spark Room or Individual with options to control the formatting.
 version_added: "2.3"
-author: Drew Rusell (@drusse11)
+author: Drew Rusell (@drew-russell)
 notes:
   - The C(recipient_id) type must be valid for the supplied C(recipient_id).
   - Full API documentation can be found at U(https://developer.ciscospark.com/endpoint-messages-post.html).

--- a/lib/ansible/modules/packaging/language/cpanm.py
+++ b/lib/ansible/modules/packaging/language/cpanm.py
@@ -80,7 +80,7 @@ options:
     version_added: "2.1"
 notes:
    - Please note that U(http://search.cpan.org/dist/App-cpanminus/bin/cpanm, cpanm) must be installed on the remote host.
-author: "Franck Cuny (@franckcuny)"
+author: "Franck Cuny (@fcuny)"
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -49,7 +49,7 @@ options:
     - disabled
 requirements:
   - This module requires Windows Management Framework 5 or later.
-author: Michael Eaton (@MichaelEaton83)
+author: Michael Eaton (@if-meaton)
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_updates.py
+++ b/lib/ansible/modules/windows/win_updates.py
@@ -65,7 +65,7 @@ options:
         description:
         - If set, C(win_updates) will append update progress to the specified file. The directory must already exist.
         required: false
-author: "Matt Davis (@mattdavispdx)"
+author: "Matt Davis (@nitzmahone)"
 notes:
 - C(win_updates) must be run by a user with membership in the local Administrators group
 - C(win_updates) will use the default update service configured for the machine (Windows Update, Microsoft Update, WSUS, etc)


### PR DESCRIPTION
##### SUMMARY
While developing a [simple webapp displaying maintainers of a namespace](http://ansiblemaint.libregerbil.fr/), I found that some GitHub ID referenced in `author` field are nonexistent (for most of them: twitter username was used instead of GitHub ID). This pull request fix these invalid Github ID.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
several modules

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0 (devel 1d14016087) last updated 2017/10/17 18:36:56 (GMT +200)
```

##### ADDITIONAL INFORMATION
It remains some fields to fix:
- inexistent @rnh556 ID (I am not sure if @rnh556 and @stealthllama are the same person): what should we do ? remove the invalid ID ?
  - https://github.com/ansible/ansible/blob/7623c2fbda6ed7f0735280242c20ff0f6d6260a2/lib/ansible/modules/network/panos/panos_nat_rule.py#L17
  - https://github.com/ansible/ansible/blob/7623c2fbda6ed7f0735280242c20ff0f6d6260a2/lib/ansible/modules/network/panos/panos_object.py#L34
  - https://github.com/ansible/ansible/blob/7623c2fbda6ed7f0735280242c20ff0f6d6260a2/lib/ansible/modules/network/panos/panos_security_rule.py#L23
- @CloudEngine-Ansible (which is a [repository](https://github.com/HuaweiSwitch/CloudEngine-Ansible)) used in [`cloudengine` modules](https://github.com/ansible/ansible/tree/7623c2fbda6ed7f0735280242c20ff0f6d6260a2/lib/ansible/modules/network/cloudengine)