### PR TITLE
Fix ansible can use azure-cli credentials

### DIFF
--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -74,7 +74,7 @@ Login with Azure CLI
 
 .. code-block:: bash
 
-    $ az account set -s <your-subscription-id>
+    $ az account set -s "<your-subscription-id>"
 
 Providing Credentials to Azure Modules
 ......................................

--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -70,7 +70,7 @@ Login with Azure CLI
 
     $ az login
 
-* Set your subscription:
+* Set your subscription for Azure CLI:
 
 .. code-block:: bash
 

--- a/docs/docsite/rst/guide_azure.rst
+++ b/docs/docsite/rst/guide_azure.rst
@@ -28,6 +28,7 @@ Using the Azure Resource Manager modules requires authenticating with the Azure 
 
 * Active Directory Username/Password
 * Service Principal Credentials
+* Login with Azure CLI
 
 Follow the directions for the strategy you wish to use, then proceed to `Providing Credentials to Azure Modules`_ for
 instructions on how to actually use the modules and authenticate with the Azure API.
@@ -59,6 +60,21 @@ To create an Active Directory username/password:
 * Check the checkbox of the subscription you want to test with this user.
 * Login to Azure Portal with this new user to change the temporary password to a new one. You will not be able to use the
   temporary password for OAuth login.
+  
+Login with Azure CLI
+........................................
+
+* Login Azure CLI:
+
+.. code-block:: bash
+
+    $ az login
+
+* Set your subscription:
+
+.. code-block:: bash
+
+    $ az account set -s <your-subscription-id>
 
 Providing Credentials to Azure Modules
 ......................................
@@ -83,6 +99,10 @@ To pass Active Directory username/password via the environment, define the follo
 * AZURE_AD_USER
 * AZURE_PASSWORD
 * AZURE_SUBSCRIPTION_ID
+
+To use Azure CLI, set the following varibale to true:
+
+* AZURE_CLI_DEFAULT_PROFILE
 
 Storing in a File
 `````````````````
@@ -118,6 +138,9 @@ Or, pass the following parameters for Active Directory username/password:
 * password
 * subscription_id
 
+Or, set the following parameter to true for login with Azure CLI:
+
+* cli_default_profile
 
 Other Cloud Environments
 ------------------------

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -289,7 +289,7 @@ class AzureRMModuleBase(object):
                                                          self.credentials['password'],
                                                          tenant=tenant,
                                                          cloud_environment=self._cloud_environment)
-        
+
         elif self.credentials.get('credentials') is not None:
             self.azure_credentials = self.credentials.get('credentials')
 

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -289,7 +289,11 @@ class AzureRMModuleBase(object):
                                                          self.credentials['password'],
                                                          tenant=tenant,
                                                          cloud_environment=self._cloud_environment)
-        else:
+        
+        elif self.credentials.get('credentials') is not None:
+            self.azure_credentials = self.credentials.get('credentials')
+
+        if not self.azure_credentials:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password or "
                       "be logged using AzureCLI.")

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -296,7 +296,7 @@ class AzureRMModuleBase(object):
         if not self.azure_credentials:
             self.fail("Failed to authenticate with provided credentials. Some attributes were missing. "
                       "Credentials must include client_id, secret and tenant or ad_user and password or "
-                      "be logged using AzureCLI.")
+                      "be logged in using AzureCLI.")
 
         # common parameter validation
         if self.module.params.get('tags'):

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -69,7 +69,7 @@ options:
         default: AzureCloud
     cli_default_profile:
         description:
-            - Set to C(true), when login with Azure CLI
+            - Whether login with Azure CLI.
         required: false
         default: null
 requirements:

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -83,5 +83,5 @@ notes:
       a [default] section and the following keys: subscription_id, client_id, secret and tenant or
       subscription_id, ad_user and password. It is also possible to add additional profiles. Specify the profile
       by passing profile or setting AZURE_PROFILE in the environment."
-    - Use 'az login' to login your Azure CLI.
+    - Use 'az login' to login with Azure CLI.
     '''

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -73,7 +73,7 @@ requirements:
 
 notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
-      in ~/.azure/credentials or login with Azure CLI. 
+      in ~/.azure/credentials or login with Azure CLI.
       Authentication is possible using a service principal or Active Directory user.
       To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -67,6 +67,11 @@ options:
               C(AzureUSGovernment)), or a metadata discovery endpoint URL (required for Azure Stack). Can also be set via credential file profile or
               the C(AZURE_CLOUD_ENVIRONMENT) environment variable.
         default: AzureCloud
+    cli_default_profile:
+        description:
+            - Set to C(true), when login with Azure CLI
+        required: false
+        default: null
 requirements:
     - "python >= 2.7"
     - "azure >= 2.0.0"
@@ -83,5 +88,6 @@ notes:
       a [default] section and the following keys: C(subscription_id), C(client_id), C(secret) and C(tenant) or
       C(subscription_id), C(ad_user) and C(password). It is also possible to add additional profiles. Specify the profile
       by passing profile or setting C(AZURE_PROFILE) in the environment."
-    - Use 'az login' to login with Azure CLI.
+    - Use 'az login' to login with Azure CLI. Set the I(cli_default_profile) flag to C(true) in the playbook, the azure resource module
+      can use Azure CLI credentials.
     '''

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -38,7 +38,7 @@ options:
         default: null
     profile:
         description:
-            - Security profile found in ~/.azure/credentials file.
+            - Security profile found in C(~/.azure/credentials) file.
         required: false
         default: null
     subscription_id:
@@ -73,15 +73,15 @@ requirements:
 
 notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
-      in ~/.azure/credentials or login with Azure CLI.
+      in C(~/.azure/credentials) or login with Azure CLI.
       Authentication is possible using a service principal or Active Directory user.
-      To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
-      variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
-    - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and
-      AZURE_PASSWORD in the environment.
-    - "Alternatively, credentials can be stored in ~/.azure/credentials. This is an ini file containing
-      a [default] section and the following keys: subscription_id, client_id, secret and tenant or
-      subscription_id, ad_user and password. It is also possible to add additional profiles. Specify the profile
-      by passing profile or setting AZURE_PROFILE in the environment."
+      To authenticate via service principal, pass C(subscription_id), C(client_id), C(secret) and C(tenant) or set environment
+      variables C(AZURE_SUBSCRIPTION_ID), C(AZURE_CLIENT_ID), C(AZURE_SECRET) and C(AZURE_TENANT).
+    - To authenticate via Active Directory user, pass C(ad_user) and C(password), or set C(AZURE_AD_USER) and
+      C(AZURE_PASSWORD) in the environment.
+    - "Alternatively, credentials can be stored in C(~/.azure/credentials). This is an ini file containing
+      a [default] section and the following keys: C(subscription_id), C(client_id), C(secret) and C(tenant) or
+      C(subscription_id), C(ad_user) and C(password). It is also possible to add additional profiles. Specify the profile
+      by passing profile or setting C(AZURE_PROFILE) in the environment."
     - Use 'az login' to login with Azure CLI.
     '''

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -73,7 +73,7 @@ requirements:
 
 notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
-      in ~/.azure/credentials or login your AzureCLI. 
+      in ~/.azure/credentials or login with Azure CLI. 
       Authentication is possible using a service principal or Active Directory user.
       To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
@@ -83,5 +83,5 @@ notes:
       a [default] section and the following keys: subscription_id, client_id, secret and tenant or
       subscription_id, ad_user and password. It is also possible to add additional profiles. Specify the profile
       by passing profile or setting AZURE_PROFILE in the environment."
-    - Use 'az login' to login your AzureCLI.
+    - Use 'az login' to login your Azure CLI.
     '''

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -72,8 +72,9 @@ requirements:
     - "azure >= 2.0.0"
 
 notes:
-    - For authentication with Azure you can pass parameters, set environment variables or use a profile stored
-      in ~/.azure/credentials. Authentication is possible using a service principal or Active Directory user.
+    - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
+      in ~/.azure/credentials or be logged using AzureCLI. 
+      Authentication is possible using a service principal or Active Directory user.
       To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.
     - To authenticate via Active Directory user, pass ad_user and password, or set AZURE_AD_USER and
@@ -82,4 +83,5 @@ notes:
       a [default] section and the following keys: subscription_id, client_id, secret and tenant or
       subscription_id, ad_user and password. It is also possible to add additional profiles. Specify the profile
       by passing profile or setting AZURE_PROFILE in the environment."
+    - Use 'az login' to login your AzureCLI.
     '''

--- a/lib/ansible/utils/module_docs_fragments/azure.py
+++ b/lib/ansible/utils/module_docs_fragments/azure.py
@@ -73,7 +73,7 @@ requirements:
 
 notes:
     - For authentication with Azure you can pass parameters, set environment variables, use a profile stored
-      in ~/.azure/credentials or be logged using AzureCLI. 
+      in ~/.azure/credentials or login your AzureCLI. 
       Authentication is possible using a service principal or Active Directory user.
       To authenticate via service principal, pass subscription_id, client_id, secret and tenant or set environment
       variables AZURE_SUBSCRIPTION_ID, AZURE_CLIENT_ID, AZURE_SECRET and AZURE_TENANT.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Ansible can use Azure-CLI's credential to manage azure resources.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
azure_rm_common

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
User can login the AzureCLI and select the subscription via the following command. Then if the playbook hasn't specific the credentials, it will use AzureCLI's credential to manage the Azure resources.
```
az login
az account set -s <subscriptionId>
```
