### PR TITLE
add user-agent to Azure API calls

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -26,6 +26,7 @@ import traceback
 
 from os.path import expanduser
 
+from ansible.release import __version__ as ansible_version
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import configparser
 import ansible.module_utils.six.moves.urllib.parse as urlparse
@@ -64,7 +65,7 @@ AZURE_COMMON_REQUIRED_IF = [
     ('log_mode', 'file', ['log_path'])
 ]
 
-ANSIBLE_USER_AGENT = 'Ansible-Deploy'
+ANSIBLE_USER_AGENT = 'Ansible/{}'.format(ansible_version)
 
 CIDR_PATTERN = re.compile("(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1"
                           "[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))")
@@ -146,20 +147,44 @@ def azure_id_to_dict(id):
     return result
 
 
-AZURE_EXPECTED_VERSIONS = dict(
-    storage_client_version="1.0.0",
-    compute_client_version="1.0.0",
-    network_client_version="1.0.0",
-    resource_client_version="1.1.0",
-    dns_client_version="1.0.1",
-    web_client_version="0.32.0"
-)
+AZURE_PKG_VERSIONS = {
+    StorageManagementClient.__name__: {
+        'package_name': 'storage',
+        'expected_version': '1.0.0',
+        'installed_version': storage_client_version
+    },
+    ComputeManagementClient.__name__: {
+        'package_name': 'compute',
+        'expected_version': '1.0.0',
+        'installed_version': compute_client_version
+    },
+    NetworkManagementClient.__name__: {
+        'package_name': 'network',
+        'expected_version': '1.0.0',
+        'installed_version': network_client_version
+    },
+    ResourceManagementClient.__name__: {
+        'package_name': 'resource',
+        'expected_version': '1.1.0',
+        'installed_version': resource_client_version
+    },
+    DnsManagementClient.__name__: {
+        'package_name': 'dns',
+        'expected_version': '1.0.1',
+        'installed_version': dns_client_version
+    },
+    WebSiteManagementClient.__name__: {
+        'package_name': 'web',
+        'expected_version': '0.32.0',
+        'installed_version': web_client_version
+    },
+}
+
 
 AZURE_MIN_RELEASE = '2.0.0'
 
 
 class AzureRMModuleBase(object):
-
     def __init__(self, derived_arg_spec, bypass_checks=False, no_log=False,
                  check_invalid_arguments=True, mutually_exclusive=None, required_together=None,
                  required_one_of=None, add_file_common_args=False, supports_check_mode=False,
@@ -274,12 +299,17 @@ class AzureRMModuleBase(object):
             res = self.exec_module(**self.module.params)
             self.module.exit_json(**res)
 
-    def check_client_version(self, client_name, client_version, expected_version):
+    def check_client_version(self, client_type):
         # Ensure Azure modules are at least 2.0.0rc5.
-        if Version(client_version) < Version(expected_version):
-            self.fail("Installed {0} client version is {1}. The supported version is {2}. Try "
-                      "`pip install azure>={3} --upgrade`".format(client_name, client_version, expected_version,
-                                                                  AZURE_MIN_RELEASE))
+        package_version = AZURE_PKG_VERSIONS[client_type.__name__]
+        if package_version:
+            client_name = package_version['package_name']
+            client_version = package_version['installed_version']
+            expected_version = package_version['expected_version']
+            if Version(client_version) < Version(expected_version):
+                self.fail("Installed {0} client version is {1}. The supported version is {2}. Try "
+                          "`pip install azure>={3} --upgrade`".format(client_name, client_version, expected_version,
+                                                                      AZURE_MIN_RELEASE))
 
     def exec_module(self, **kwargs):
         self.fail("Error: {0} failed to implement exec_module method.".format(self.__class__.__name__))
@@ -677,88 +707,77 @@ class AzureRMModuleBase(object):
 
         return self.get_poller_result(poller)
 
+    def get_mgmt_svc_client(self, client_type, base_url=None, api_version=None):
+        self.log('Getting management service client {0}'.format(client_type.__name__))
+        self.check_client_version(client_type)
+        if api_version:
+            client = client_type(self.azure_credentials,
+                                 self.subscription_id,
+                                 api_version,
+                                 base_url)
+        else:
+            client = client_type(self.azure_credentials,
+                                 self.subscription_id,
+                                 base_url=base_url)
+
+        client.config.add_user_agent(ANSIBLE_USER_AGENT)
+
+        return client
+
     @property
     def storage_client(self):
         self.log('Getting storage client...')
         if not self._storage_client:
-            self.check_client_version('storage', storage_client_version, AZURE_EXPECTED_VERSIONS['storage_client_version'])
-            self._storage_client = StorageManagementClient(
-                self.azure_credentials,
-                self.subscription_id,
-                base_url=self._cloud_environment.endpoints.resource_manager,
-                api_version='2017-06-01'
-            )
+            self._storage_client = self.get_mgmt_svc_client(StorageManagementClient,
+                                                            self._cloud_environment.endpoints.resource_manager,
+                                                            '2017-06-01')
         return self._storage_client
 
     @property
     def network_client(self):
         self.log('Getting network client')
         if not self._network_client:
-            self.check_client_version('network', network_client_version, AZURE_EXPECTED_VERSIONS['network_client_version'])
-            self._network_client = NetworkManagementClient(
-                self.azure_credentials,
-                self.subscription_id,
-                base_url=self._cloud_environment.endpoints.resource_manager,
-                api_version='2017-06-01'
-            )
+            self._network_client = self.get_mgmt_svc_client(NetworkManagementClient,
+                                                            self._cloud_environment.endpoints.resource_manager,
+                                                            '2017-06-01')
         return self._network_client
 
     @property
     def rm_client(self):
         self.log('Getting resource manager client')
         if not self._resource_client:
-            self.check_client_version('resource', resource_client_version, AZURE_EXPECTED_VERSIONS['resource_client_version'])
-            self._resource_client = ResourceManagementClient(
-                self.azure_credentials,
-                self.subscription_id,
-                base_url=self._cloud_environment.endpoints.resource_manager,
-                api_version='2017-05-10'
-            )
+            self._resource_client = self.get_mgmt_svc_client(ResourceManagementClient,
+                                                             self._cloud_environment.endpoints.resource_manager,
+                                                             '2017-05-10')
         return self._resource_client
 
     @property
     def compute_client(self):
         self.log('Getting compute client')
         if not self._compute_client:
-            self.check_client_version('compute', compute_client_version, AZURE_EXPECTED_VERSIONS['compute_client_version'])
-            self._compute_client = ComputeManagementClient(
-                self.azure_credentials,
-                self.subscription_id,
-                base_url=self._cloud_environment.endpoints.resource_manager,
-                api_version='2017-03-30'
-            )
+            self._compute_client = self.get_mgmt_svc_client(ComputeManagementClient,
+                                                            self._cloud_environment.endpoints.resource_manager,
+                                                            '2017-03-30')
         return self._compute_client
 
     @property
     def dns_client(self):
         self.log('Getting dns client')
         if not self._dns_client:
-            self.check_client_version('dns', dns_client_version, AZURE_EXPECTED_VERSIONS['dns_client_version'])
-            self._dns_client = DnsManagementClient(
-                self.azure_credentials,
-                self.subscription_id,
-                base_url=self._cloud_environment.endpoints.resource_manager,
-            )
+            self._dns_client = self.get_mgmt_svc_client(DnsManagementClient,
+                                                        self._cloud_environment.endpoints.resource_manager)
         return self._dns_client
 
     @property
     def web_client(self):
         self.log('Getting web client')
         if not self._web_client:
-            self.check_client_version('web', web_client_version, AZURE_EXPECTED_VERSIONS['web_client_version'])
-            self._web_client = WebSiteManagementClient(
-                credentials=self.azure_credentials,
-                subscription_id=self.subscription_id,
-                base_url=self.base_url
-            )
+            self._web_client = self.get_mgmt_svc_client(WebSiteManagementClient, self.base_url)
         return self._web_client
 
     @property
     def containerservice_client(self):
         self.log('Getting container service client')
         if not self._containerservice_client:
-            self._containerservice_client = ContainerServiceClient(
-                self.azure_credentials,
-                self.subscription_id
-            )
+            self._containerservice_client = self.get_mgmt_svc_client(ContainerServiceClient)
         return self._containerservice_client


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

- Add Ansible `user-agent` back in Azure API calls. It was removed in this [commit](https://github.com/ansible/ansible/commit/d1b611a730387ae0a9a31060d60281150a60ddba#diff-2b622fe76a39bb9004ac394693b03853L600).
- Minor refactor for required package version check.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

`azure_rm_common`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (user-agent 7f350f6ed0) last updated 2017/10/18 15:14:09 (GMT +800)
  config file = None
  configured module search path = [u'/Users/kevinzha/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kevinzha/workspace/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
