### PR TITLE
Fix exception upon display.warn()

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -133,7 +133,7 @@ class InventoryModule(BaseFileInventoryPlugin):
                         hosts, port = self._parse_host(host_pattern)
                         self.populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
                 else:
-                    self.display.warn('Skipping unexpected key (%s) in group (%s), only "vars", "children" and "hosts" are valid' % (key, group))
+                    self.display.warning('Skipping unexpected key (%s) in group (%s), only "vars", "children" and "hosts" are valid' % (key, group))
 
     def _parse_host(self, host_pattern):
         '''


### PR DESCRIPTION
##### SUMMARY
Fixes #31875

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
YAML inventory

##### ANSIBLE VERSION
ansible 2.5.0
  config file = /mnt/c/Users/user/Projects/ansible/ansible.cfg
  configured module search path = [u'/home/zanglang/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]


##### ADDITIONAL INFORMATION
Should fix https://github.com/ansible/ansible/issues/31875