### PR TITLE
Fix docker_secret integration test dependencies.

### DIFF
--- a/test/integration/targets/docker_secret/tasks/OpenSuse.yml
+++ b/test/integration/targets/docker_secret/tasks/OpenSuse.yml
@@ -5,7 +5,7 @@
 
 - name: Install docker 17
   zypper:
-    name: docker-17.04.0_ce
+    name: docker>=17
     force: yes
     disable_gpg_check: yes
     update_cache: yes

--- a/test/integration/targets/docker_secret/templates/virt.repo.j2
+++ b/test/integration/targets/docker_secret/templates/virt.repo.j2
@@ -1,7 +1,7 @@
 [Virtualization_containers]
-name=Virtualization:containers (openSUSE_Tumbleweed)
+name=Virtualization:containers (openSUSE_Leap_{{ ansible_distribution_version }})
 type=rpm-md
-baseurl=http://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Tumbleweed/
+baseurl=http://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Leap_{{ ansible_distribution_version }}/
 gpgcheck=1
-gpgkey=http://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Tumbleweed//repodata/repomd.xml.key
+gpgkey=http://download.opensuse.org/repositories/Virtualization:/containers/openSUSE_Leap_{{ ansible_distribution_version }}/repodata/repomd.xml.key
 enabled=1


### PR DESCRIPTION
##### SUMMARY

Fix docker_secret integration test dependencies.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

docker_secret integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (docker-secret-test 395cc73c8d) last updated 2017/10/18 09:55:43 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
