### PR TITLE
Fix header for direct_connect module_utils

### DIFF
--- a/lib/ansible/module_utils/aws/direct_connect.py
+++ b/lib/ansible/module_utils/aws/direct_connect.py
@@ -1,12 +1,10 @@
+# Copyright (c) 2017 Ansible Project
+#
 # This code is part of Ansible, but is an independent component.
 # This particular file snippet, and this file snippet only, is BSD licensed.
 # Modules you write using this snippet, which is embedded dynamically by Ansible
 # still belong to the author of the module, and may assign their own license
 # to the complete work.
-#
-# Copyright (c) 2017 Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-# All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
 # are permitted provided that the following conditions are met:


### PR DESCRIPTION
##### SUMMARY
Removing the GPLv3+ statement and moving the copyright to the top.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/aws/direct_connect.py

##### ANSIBLE VERSION
```
2.5.0
```