### PR TITLE
Relicense convert_bool to 2-clause BSD

### DIFF
--- a/lib/ansible/module_utils/parsing/convert_bool.py
+++ b/lib/ansible/module_utils/parsing/convert_bool.py
@@ -1,5 +1,5 @@
 # Copyright: 2017, Ansible Project
-# License: GNU General Public License v3 or later (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt )
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause )
 
 from ansible.module_utils.six import binary_type, text_type
 from ansible.module_utils._text import to_text


### PR DESCRIPTION
This code originated in module_utils/basic.py which was BSD licensed.
In moving it and making it aplicable to other pieces of code that were
using similar functions, I added onto it a little.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/parsing/convert_bool.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
i, Toshio Kuratomi, give permission to relicense the code I've contributed in lib/ansible/module_utils/parsing/convert_bool.py from the GPLv3+ to the simplified BSD license ( as shown here https://opensource.org/licenses/BSD-2-Clause ).

Also need permission from @bcoca who is the only other person to have modified  this file while it was listed as GPLv3+ licensed.