### PR TITLE
Fix include_role unit tests

### DIFF
--- a/test/units/playbook/role/test_include_role.py
+++ b/test/units/playbook/role/test_include_role.py
@@ -122,9 +122,12 @@ class TestIncludeRole(unittest.TestCase):
         ), loader=self.loader, variable_manager=self.var_manager)
 
         tasks = play.compile()
+        tested = False
         for role, task_vars in self.get_tasks_vars(play, tasks):
+            tested = True
             self.assertEqual(task_vars.get('l3_variable'), 'l3-main')
             self.assertEqual(task_vars.get('test_variable'), 'l3-main')
+        self.assertTrue(tested)
 
     @patch('ansible.playbook.role.definition.unfrackpath',
            mock_unfrackpath_noop)
@@ -140,9 +143,12 @@ class TestIncludeRole(unittest.TestCase):
             loader=self.loader, variable_manager=self.var_manager)
 
         tasks = play.compile()
+        tested = False
         for role, task_vars in self.get_tasks_vars(play, tasks):
+            tested = True
             self.assertEqual(task_vars.get('l3_variable'), 'l3-alt')
             self.assertEqual(task_vars.get('test_variable'), 'l3-alt')
+        self.assertTrue(tested)
 
     @patch('ansible.playbook.role.definition.unfrackpath',
            mock_unfrackpath_noop)
@@ -165,7 +171,9 @@ class TestIncludeRole(unittest.TestCase):
         ), loader=self.loader, variable_manager=self.var_manager)
 
         tasks = play.compile()
+        expected_roles = ['l1', 'l2', 'l3']
         for role, task_vars in self.get_tasks_vars(play, tasks):
+            expected_roles.remove(role)
             # Outer-most role must not have variables from inner roles yet
             if role == 'l1':
                 self.assertEqual(task_vars.get('l1_variable'), 'l1-main')
@@ -184,6 +192,9 @@ class TestIncludeRole(unittest.TestCase):
                 self.assertEqual(task_vars.get('l2_variable'), 'l2-main')
                 self.assertEqual(task_vars.get('l3_variable'), 'l3-main')
                 self.assertEqual(task_vars.get('test_variable'), 'l3-main')
+            else:
+                self.fail()
+        self.assertFalse(expected_roles)
 
     @patch('ansible.playbook.role.definition.unfrackpath',
            mock_unfrackpath_noop)
@@ -206,7 +217,9 @@ class TestIncludeRole(unittest.TestCase):
         ), loader=self.loader, variable_manager=self.var_manager)
 
         tasks = play.compile()
+        expected_roles = ['l1', 'l2', 'l3']
         for role, task_vars in self.get_tasks_vars(play, tasks):
+            expected_roles.remove(role)
             # Outer-most role must not have variables from inner roles yet
             if role == 'l1':
                 self.assertEqual(task_vars.get('l1_variable'), 'l1-alt')
@@ -225,3 +238,6 @@ class TestIncludeRole(unittest.TestCase):
                 self.assertEqual(task_vars.get('l2_variable'), 'l2-alt')
                 self.assertEqual(task_vars.get('l3_variable'), 'l3-alt')
                 self.assertEqual(task_vars.get('test_variable'), 'l3-alt')
+            else:
+                self.fail()
+        self.assertFalse(expected_roles)


### PR DESCRIPTION
##### SUMMARY

Fix `include_role` unit tests. Since e609618274db6a7e3c273abde457f53de8c9976c:
- `include_role` can not be static anymore
- `include_role` unit tests don't test anything because `get_tasks_vars` never yield.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
include_role

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel b9223cdc89) last updated 2017/10/18 16:39:11 (GMT +200)
```