### PR TITLE
Fix typo in ipa_user module documentation example.

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
     - pinky@acme.com
     telephonenumber:
     - '+555123456'
-    sshpubkeyfp:
+    sshpubkey:
     - ssh-rsa ....
     - ssh-dsa ....
     ipa_host: ipa.example.com


### PR DESCRIPTION
##### SUMMARY
ipa_user module accepts sshpubkey parameter, as it is described in the documentation, but example used sshpubkeyfp instead.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ipa_user.py

##### ANSIBLE VERSION
```
2.5.0
```

##### ADDITIONAL INFORMATION
None.