### PR TITLE
Adding support for macros {$ANSIBLE_HOST} and {$ANSIBLE_PORT}, provid…

### DIFF
--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -107,8 +107,8 @@ class ZabbixInventory(object):
         data['_meta'] = {'hostvars': self.meta}
 
         for host in hostsData:
-            if 0 == host['status']:
-                break
+            if host['status'] != "0":
+                continue
             hostname = host['name']
             ip = host['interfaces'][0]['ip']
             port = 22

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -165,6 +165,7 @@ class ZabbixInventory(object):
                 api.login(user=self.zabbix_username, password=self.zabbix_password)
             except BaseException as e:
                 print("Error: Could not login to Zabbix server. Check your zabbix.ini.", file=sys.stderr)
+                print("Error message was: " + str(e))
                 sys.exit(1)
 
             if self.options.host:

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -138,7 +138,7 @@ class ZabbixInventory(object):
 
     def __init__(self):
 
-    self.defaultgroup = 'group_all'
+        self.defaultgroup = 'group_all'
         self.zabbix_server = None
         self.zabbix_username = None
         self.zabbix_password = None

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # (c) 2013, Greg Buehler
-# Updates 2016 by tony@nieuwenborg.nl
+# Updates 2017 by tony@nieuwenborg.nl
 # This file is part of Ansible,
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -30,6 +30,7 @@ name, use asterisk. For example --limit="Linux*servers".
 Metadata:
 - ansible_host: IP found in host info, or macro {$ANSIBLE_HOST} if set.
 - ansible_port: macro {$ANSIBLE_PORT} if set, otherwise 22
+- user defined vars: macro {$ANSIBLE_VARS} takes json like { "foo":"bar", "num":2 }
 - templates: list of templates used by host
 
 Notes:
@@ -113,15 +114,26 @@ class ZabbixInventory(object):
             ip = host['interfaces'][0]['ip']
             port = 22
 
+            data[self.defaultgroup]['hosts'].append(hostname)
+            zabbixvars = ''
             for m in host['macros']:
                 if m['macro'] == '{$ANSIBLE_PORT}':
                     port = m['value']
-                else:
-                    if m['macro'] == '{$ANSIBLE_HOST}':
-                        ip = m['value']
+                elif m['macro'] == '{$ANSIBLE_HOST}':
+                    ip = m['value']
+                elif m['macro'] == '{$ANSIBLE_VARS}':
+                    zv = m['value']
+                    try:
+                        zabbixvars = json.loads(zv)
+                    except:
+                        print("Invalid JSON in " + hostname + ":" + "{$ANSIBLE_VARS}: " + zv)
+                        sys.exit(1)
 
-            data[self.defaultgroup]['hosts'].append(hostname)
+            # TODO maybe only add when actually (re)defined?
             data['_meta']['hostvars'][hostname] = {'ansible_host': ip, 'ansible_port': port}
+            if zabbixvars:
+                data['_meta']['hostvars'][hostname].update(zabbixvars)
+
             data['_meta']['hostvars'][hostname]['templates'] = []
             for t in host['parentTemplates']:
                 data['_meta']['hostvars'][hostname]['templates'].append(t['name'])

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -99,14 +99,14 @@ class ZabbixInventory(object):
         return data
 
     def get_list(self, api):
-        hostsData = api.host.get({'output': 'extend', 'selectGroups': 'extend',  'selectInterfaces':'extend', 'selectMacros': 'extend', 'selectParentTemplates': 'extend' })
+        hostsData = api.host.get({'output': 'extend', 'selectGroups': 'extend', 'selectInterfaces': 'extend',
+                                 'selectMacros': 'extend', 'selectParentTemplates': 'extend'})
 
         data = {}
         data[self.defaultgroup] = self.hoststub()
         data['_meta'] = {'hostvars': self.meta}
 
         for host in hostsData:
-            #print(host)
             if 0 == host['status']:
                 break
             hostname = host['name']
@@ -121,7 +121,7 @@ class ZabbixInventory(object):
                         ip = m['value']
 
             data[self.defaultgroup]['hosts'].append(hostname)
-            data['_meta']['hostvars'][hostname] = { 'ansible_host' : ip, 'ansible_port' : port } 
+            data['_meta']['hostvars'][hostname] = {'ansible_host': ip, 'ansible_port': port}
             data['_meta']['hostvars'][hostname]['templates'] = []
             for t in host['parentTemplates']:
                 data['_meta']['hostvars'][hostname]['templates'].append(t['name'])
@@ -172,4 +172,3 @@ class ZabbixInventory(object):
             sys.exit(1)
 
 ZabbixInventory()
-

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -97,7 +97,6 @@ class ZabbixInventory(object):
         }
 
     def get_host(self, api, name):
-        #data = {}
         data = api.host.get({"filter": {'name': name}})
         return data
 

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -30,7 +30,8 @@ name, use asterisk. For example --limit="Linux*servers".
 Metadata:
 - ansible_host: IP found in host info, or macro {$ANSIBLE_HOST} if set.
 - ansible_port: macro {$ANSIBLE_PORT} if set, otherwise 22
-- user defined vars: macro {$ANSIBLE_VARS} takes json like { "foo":"bar", "num":2 }
+- user defined vars: macro {$ANSIBLE_VARS} takes json like:
+  { "foo":"bar", "num":2 }
 - templates: list of templates used by host
 
 Notes:
@@ -55,7 +56,7 @@ except ImportError:
 try:
     from zabbix_api import ZabbixAPI
 except:
-    print("Error: Zabbix API library must be installed: pip install zabbix-api.",
+    print("Error: Zabbix API library must be installed.",
           file=sys.stderr)
     sys.exit(1)
 
@@ -96,12 +97,16 @@ class ZabbixInventory(object):
         }
 
     def get_host(self, api, name):
-        data = {}
+        #data = {}
+        data = api.host.get({"filter": {'name': name}})
         return data
 
     def get_list(self, api):
-        hostsData = api.host.get({'output': 'extend', 'selectGroups': 'extend', 'selectInterfaces': 'extend',
-                                 'selectMacros': 'extend', 'selectParentTemplates': 'extend'})
+        hostsData = api.host.get({'output': 'extend',
+                                  'selectGroups': 'extend',
+                                  'selectInterfaces': 'extend',
+                                  'selectMacros': 'extend',
+                                  'selectParentTemplates': 'extend'})
 
         data = {}
         data[self.defaultgroup] = self.hoststub()
@@ -126,11 +131,14 @@ class ZabbixInventory(object):
                     try:
                         zabbixvars = json.loads(zv)
                     except:
-                        print("Invalid JSON in " + hostname + ":" + "{$ANSIBLE_VARS}: " + zv)
+                        print("Invalid JSON in "
+                              + hostname + ":"
+                              + "{$ANSIBLE_VARS}: " + zv)
                         sys.exit(1)
 
             # TODO maybe only add when actually (re)defined?
-            data['_meta']['hostvars'][hostname] = {'ansible_host': ip, 'ansible_port': port}
+            data['_meta']['hostvars'][hostname] = {'ansible_host': ip,
+                                                   'ansible_port': port}
             if zabbixvars:
                 data['_meta']['hostvars'][hostname].update(zabbixvars)
 
@@ -162,9 +170,11 @@ class ZabbixInventory(object):
         if self.zabbix_server and self.zabbix_username:
             try:
                 api = ZabbixAPI(server=self.zabbix_server)
-                api.login(user=self.zabbix_username, password=self.zabbix_password)
+                api.login(user=self.zabbix_username,
+                          password=self.zabbix_password)
             except BaseException as e:
-                print("Error: Could not login to Zabbix server. Check your zabbix.ini.", file=sys.stderr)
+                print("Error: Could not login to Zabbix server. Check your zabbix.ini.",
+                      file=sys.stderr)
                 print("Error message was: " + str(e))
                 sys.exit(1)
 
@@ -177,11 +187,13 @@ class ZabbixInventory(object):
                 print(json.dumps(data, indent=2))
 
             else:
-                print("usage: --list  ..OR.. --host <hostname>", file=sys.stderr)
+                print("usage: --list  ..OR.. --host <hostname>",
+                      file=sys.stderr)
                 sys.exit(1)
 
         else:
-            print("Error: Configuration of server and credentials are required. See zabbix.ini.", file=sys.stderr)
+            print("Error: Configuration of server and credentials are required. See zabbix.ini.",
+                  file=sys.stderr)
             sys.exit(1)
 
 ZabbixInventory()

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -168,7 +168,7 @@ class ZabbixInventory(object):
 
         if self.zabbix_server and self.zabbix_username:
             try:
-                api = ZabbixAPI(server=self.zabbix_server)
+                api = ZabbixAPI(server=self.zabbix_server, validate_certs=self.validate_certs)
                 api.login(user=self.zabbix_username,
                           password=self.zabbix_password)
             except BaseException as e:

--- a/contrib/inventory/zabbix.py
+++ b/contrib/inventory/zabbix.py
@@ -169,8 +169,7 @@ class ZabbixInventory(object):
         if self.zabbix_server and self.zabbix_username:
             try:
                 api = ZabbixAPI(server=self.zabbix_server, validate_certs=self.validate_certs)
-                api.login(user=self.zabbix_username,
-                          password=self.zabbix_password)
+                api.login(user=self.zabbix_username, password=self.zabbix_password)
             except BaseException as e:
                 print("Error: Could not login to Zabbix server. Check your zabbix.ini.",
                       file=sys.stderr)


### PR DESCRIPTION
…ing meta data

##### SUMMARY
<!--- Fetches IP address to ssh to from host info, optionally gets address from macro {$ANSIBLE_HOST}. For non-standard ports there's macro {$ANSIBLE_PORT. Provides ansible_host and ansible_port in metadata, together with a list of templates used by each host -->



##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- ansible.py -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
