### PR TITLE
Fix for #31855

### DIFF
--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -48,6 +48,6 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command(b'no paging')
+            self._exec_cli_command(b'no pag')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')


### PR DESCRIPTION
Fix for #31855. Using shorthand for disabling paging to avoid the syntax difference between versions.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In newer versions of Aruba the command to disable paging changed from `no paging` to `no page`. This commit changes the command sent from the terminal plugin to send the shorthand version which works for both, which is `no pag`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aruba_command
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (aruba/paging b16f6dab14) last updated 2017/10/18 10:34:21 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


