### PR TITLE
Adding a regex for stderr catching.

### DIFF
--- a/lib/ansible/plugins/terminal/bigip.py
+++ b/lib/ansible/plugins/terminal/bigip.py
@@ -35,6 +35,7 @@ class TerminalModule(TerminalBase):
 
     terminal_stderr_re = [
         re.compile(br"% ?Error"),
+        re.compile(br"Syntax Error", re.I),
         re.compile(br"% User not present"),
         re.compile(br"% ?Bad secret"),
         re.compile(br"invalid input", re.I),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a new terminal plugin regex for stderr catching for bigip.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (f5/error_catch 760d05bd41) last updated 2017/10/19 12:24:42 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

