### PR TITLE
Support vaulted strings in ansible-inventory --list

### DIFF
--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -23,6 +23,7 @@ from operator import attrgetter
 from ansible.cli import CLI
 from ansible.errors import AnsibleOptionsError
 from ansible.parsing.dataloader import DataLoader
+from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
 
 try:
     from __main__ import display
@@ -178,7 +179,13 @@ class InventoryCLI(CLI):
             results = yaml.dump(stuff, Dumper=AnsibleDumper, default_flow_style=False)
         else:
             import json
-            results = json.dumps(stuff, sort_keys=True, indent=4)
+
+            # yaml.objects.AnsibleVaultEncryptedUnicode is not json serializable, so add a default for dumps
+            def default(data):
+                if isinstance(data, AnsibleVaultEncryptedUnicode):
+                    return data.data
+                return json.JSONEncoder.default(data)
+            results = json.dumps(stuff, sort_keys=True, indent=4, default=default)
 
         return results
 


### PR DESCRIPTION
##### SUMMARY
Support vaulted strings in ansible-inventory --list

Add a default method to ansible-inventory's json.dumps that knows what
to do with AnsibleVaultEncryptedUnicode

Fixes #31141

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (vaulted_inventory_31141 9884565e53) last updated 2017/10/19 15:35:02 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

firstvariable is '129.168.100.32' encrypted with the password 'password'

Before:
```
[newswoop:F25:ansible (devel % u=)]$ cat vaulted_inventory.yml 
ungrouped:
  hosts:
      green.example.com:
          firstvariable: !vault |
              $ANSIBLE_VAULT;1.1;AES256
              32633234373965356537366531333238363166393039306462633137353462396335653531633637
              6335366138623264303862306535303366646630643262650a386433376130383562343037613764
              62653330643635623033323764383461613331336339336435633864303032646233393336643366
              6163383166626565660a623836303939326564346338343338346366373561623862633065613266
              6132
          anyvariable: value
[newswoop:F25:ansible (devel % u=)]$ cat password
password
[newswoop:F25:ansible (devel % u=)]$ ansible-inventory  -i vaulted_inventory.yml  --list --vault-id password -vvv
ansible-inventory 2.5.0 (devel c02173880a) last updated 2017/10/19 15:38:52 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible-inventory
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
Using /home/adrian/src/ansible/ansible.cfg as config file
Parsed /home/adrian/src/ansible/vaulted_inventory.yml inventory source with yaml plugin
ERROR! Unexpected Exception, this is probably a bug: u'191.168.100.32' is not JSON serializable
the full traceback was:

Traceback (most recent call last):
  File "/home/adrian/src/ansible/bin/ansible-inventory", line 109, in <module>
    exit_code = cli.run()
  File "/home/adrian/src/ansible/lib/ansible/cli/inventory.py", line 164, in run
    results = self.dump(results)
  File "/home/adrian/src/ansible/lib/ansible/cli/inventory.py", line 181, in dump
    results = json.dumps(stuff, sort_keys=True, indent=4)
  File "/usr/lib64/python2.7/json/__init__.py", line 251, in dumps
    sort_keys=sort_keys, **kw).encode(obj)
  File "/usr/lib64/python2.7/json/encoder.py", line 209, in encode
    chunks = list(chunks)
  File "/usr/lib64/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib64/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib64/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: u'191.168.100.32' is not JSON serializable
```

After:

```
[newswoop:F25:ansible (vaulted_inventory_31141 %)]$ ansible-inventory  -i vaulted_inventory.yml  --list --vault-id password -vvv
ansible-inventory 2.5.0 (vaulted_inventory_31141 9884565e53) last updated 2017/10/19 15:35:02 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible-inventory
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
Using /home/adrian/src/ansible/ansible.cfg as config file
Parsed /home/adrian/src/ansible/vaulted_inventory.yml inventory source with yaml plugin
{
    "_meta": {
        "hostvars": {
            "green.example.com": {
                "anyvariable": "value", 
                "firstvariable": "191.168.100.32"
            }
        }
    }, 
    "all": {}
}
```
