### PR TITLE
Added regex to recognize prompt

### DIFF
--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -31,7 +31,8 @@ class TerminalModule(TerminalBase):
 
     terminal_stdout_re = [
         re.compile(br"[\r\n]?[\w]*\(.+\) ?#(?:\s*)$"),
-        re.compile(br"[pP]assword:$")
+        re.compile(br"[pP]assword:$"),
+        re.compile(br"(?<=\s)[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?\s*#\s*$"),
     ]
 
     terminal_stderr_re = [


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Added an additional regex for recognizing prompt. Some prompts do not include parentheses, so the existing regex was not good enough.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aruba_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = <home>/ansible/ansible.cfg
  configured module search path = [u'<home>/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
