### PR TITLE
firewalld: don't reference undefined variable in error case

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -751,8 +751,7 @@ def main():
 
     if import_failure:
         module.fail_json(
-            msg='firewalld and its python 2 module are required for this module, version 2.0.11 or newer required (3.0.9 or newer for offline operations) \n %s'
-            % e
+            msg='firewalld and its python 2 module are required for this module, version 2.0.11 or newer required (3.0.9 or newer for offline operations)'
         )
 
     if fw_offline:

--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -169,7 +169,7 @@ try:
         fw.start()
         fw_offline = True
 
-except ImportError as e:
+except ImportError:
     import_failure = True
 
 


### PR DESCRIPTION
Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### SUMMARY
Fixes #31927 


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
firewalld

##### ANSIBLE VERSION
```
ansible 2.4.0.0              
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']           
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible                                            
  executable location = /usr/bin/ansible                   
  python version = 2.7.14 (default, Sep 17 2017, 18:50:44) [GCC 7.2.0]  
```

