### PR TITLE
bigip terminal plugin changes for local password

### DIFF
--- a/lib/ansible/plugins/terminal/bigip.py
+++ b/lib/ansible/plugins/terminal/bigip.py
@@ -30,7 +30,8 @@ class TerminalModule(TerminalBase):
     terminal_stdout_re = [
         re.compile(br"[\r\n]?(?:\([^\)]+\)){,5}(?:>|#) ?$"),
         re.compile(br"[\r\n]?[\w+\-\.:\/\[\]]+(?:\([^\)]+\)){,3}(?:>|#) ?$"),
-        re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$")
+        re.compile(br"\[\w+\@[\w\-\.]+(?: [^\]])\] ?[>#\$] ?$"),
+        re.compile(br"(?:new|confirm) password:")
     ]
 
     terminal_stderr_re = [
@@ -40,6 +41,7 @@ class TerminalModule(TerminalBase):
         re.compile(br"invalid input", re.I),
         re.compile(br"(?:incomplete|ambiguous) command", re.I),
         re.compile(br"connection timed out", re.I),
+        re.compile(br"the new password was not confirmed", re.I),
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
         re.compile(br"[^\r\n]\/bin\/(?:ba)?sh")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adds regex for stdout needed for changing root password and regex for stderr catching problems with the password. Running `modify auth password root` prompts with `new password: ` and `confirm password: `. If they don't match it responds with `the new password was not confirmed`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (f5/local_password_regex 590ed0181a) last updated 2017/10/19 14:57:18 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


