### PR TITLE
docker_image: Fix idempotency of pull

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -338,8 +338,8 @@ class ImageManager(DockerBaseClass):
                 self.results['actions'].append('Pulled image %s:%s' % (self.name, self.tag))
                 self.results['changed'] = True
                 if not self.check_mode:
-                    self.results['image'] = self.client.pull_image(self.name, tag=self.tag)
-                    if image and image == self.results['image']:
+                    self.results['image'], already_latest = self.client.pull_image(self.name, tag=self.tag)
+                    if already_latest:
                         self.results['changed'] = False
 
         if self.archive_path:


### PR DESCRIPTION
##### SUMMARY
when pulling an image with force=yes the task was marked as changed
everytime even when the image hasn't changed.

This was due to a bad comparison of the image tag before the pull
and after the pull.

Fixes #22596

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_image.py

##### ANSIBLE VERSION
```
➜  Desktop ansible --version
ansible 2.5.0 (docker_image e2f329500a) last updated 2017/10/19 17:06:49 (GMT -500)
  config file = None
  configured module search path = [u'/Users/albertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/albertom/github/ansible/lib/ansible
  executable location = /Users/albertom/github/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```

##### ADDITIONAL INFORMATION
test_docker_image.yml
```yaml
---
- hosts: localhost
  connection: local
  tasks:
    - docker_image:
        name: tomcat:latest
        pull: yes
        force: yes
```
Before the fix
```
➜  Desktop ansible-playbook test_docker_image.yml
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: Could not match supplied host pattern, ignoring: all

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] *****************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
ok: [localhost]

TASK [docker_image] **************************************************************************************************************************************************************************************
changed: [localhost]

PLAY RECAP ***********************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0

```

After the fix
```
➜  Desktop ansible-playbook test_docker_image.yml
 [WARNING]: Unable to parse /etc/ansible/hosts as an inventory source

 [WARNING]: No inventory was parsed, only implicit localhost is available

 [WARNING]: Could not match supplied host pattern, ignoring: all

 [WARNING]: provided hosts list is empty, only localhost is available


PLAY [localhost] *****************************************************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************************
ok: [localhost]

TASK [docker_image] **************************************************************************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=0

