### PR TITLE
dont add all group vars to implicit on create

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -75,23 +75,18 @@ class InventoryData(object):
         else:
             new_host = Host(pattern)
 
-            # use 'all' vars but not part of all group
-            new_host.vars = self.groups['all'].get_vars()
-
             new_host.address = "127.0.0.1"
             new_host.implicit = True
 
-            if "ansible_python_interpreter" not in new_host.vars:
-                py_interp = sys.executable
-                if not py_interp:
-                    # sys.executable is not set in some cornercases.  #13585
-                    py_interp = '/usr/bin/python'
-                    display.warning('Unable to determine python interpreter from sys.executable. Using /usr/bin/python default. '
-                                    'You can correct this by setting ansible_python_interpreter for localhost')
-                new_host.set_variable("ansible_python_interpreter", py_interp)
-
-            if "ansible_connection" not in new_host.vars:
-                new_host.set_variable("ansible_connection", 'local')
+            # set localhost defaults
+            py_interp = sys.executable
+            if not py_interp:
+                # sys.executable is not set in some cornercases. see issue #13585
+                py_interp = '/usr/bin/python'
+                display.warning('Unable to determine python interpreter from sys.executable. Using /usr/bin/python default. '
+                                'You can correct this by setting ansible_python_interpreter for localhost')
+            new_host.set_variable("ansible_python_interpreter", py_interp)
+            new_host.set_variable("ansible_connection", 'local')
 
             self.localhost = new_host
 


### PR DESCRIPTION
##### SUMMARY
they already get added in vars manager on use.
fixes #31420
this fixes the precedence issue that allowed connection/interpreter to be overriden w/o defining the host in inventory.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
localhost
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```