### PR TITLE
Add a cloudformation_facts example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation_facts.py
@@ -69,6 +69,17 @@ EXAMPLES = '''
 - debug:
     msg: "{{ ansible_facts['cloudformation']['my-cloudformation-stack'] }}"
 
+# Get stack outputs, when you have the stack name available as a fact
+- set_fact:
+    stack_name: my-awesome-stack
+
+- cloudformation_facts:
+    stack_name: "{{ stack_name }}"
+  register: my_stack
+
+- debug:
+    msg: "{{ my_stack.ansible_facts.cloudformation[stack_name].stack_outputs }}"
+
 # Get all stack information about a stack
 - cloudformation_facts:
     stack_name: my-cloudformation-stack


### PR DESCRIPTION
##### SUMMARY
Added an example of `cloudformation_facts`, where you get the `stack_ouputs` using the stack name available to you as a fact.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`cloudformation`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```


##### ADDITIONAL INFORMATION
In this example, we have the stack name available as a fact. We pass the `stack_name` to `cloudformation_facts` and register its output. Using this registered variable, we get the `stack_outputs`.

