### PR TITLE
Fix ansible-test default image.

### DIFF
--- a/docs/docsite/rst/dev_guide/testing/sanity/azure-requirements.rst
+++ b/docs/docsite/rst/dev_guide/testing/sanity/azure-requirements.rst
@@ -1,0 +1,10 @@
+Sanity Tests » azure-requirements
+=================================
+
+Update the Azure integration test requirements file when changes are made to the Azure packaging requirements file:
+
+.. code-block:: bash
+
+    cp packaging/requirements/requirements-azure.txt test/runner/requirements/integration.cloud.azure.txt
+
+This copy of the requirements file is used when building the ``ansible/ansible:default`` Docker container from ``test/runner/Dockerfile``.

--- a/test/integration/targets/setup_azure/tasks/main.yml
+++ b/test/integration/targets/setup_azure/tasks/main.yml
@@ -1,2 +1,0 @@
-- pip:
-    requirements: '{{ role_path }}/../../../../packaging/requirements/requirements-azure.txt'

--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -y && \
     libxslt1-dev \
     locales \
     make \
+    openssh-client \
     python2.6-dev \
     python2.7-dev \
     python3.5-dev \

--- a/test/runner/docker/requirements.sh
+++ b/test/runner/docker/requirements.sh
@@ -11,13 +11,60 @@ requirements=()
 
 for requirement in *.txt; do
     if [ "${requirement}" != "constraints.txt" ]; then
-        requirements+=("-r" "${requirement}")
+        requirements+=("${requirement}")
     fi
 done
 
 for python_version in "${python_versions[@]}"; do
+    version_requirements=()
+
+    for requirement in "${requirements[@]}"; do
+        case "${python_version}" in
+            "2.6")
+                case "${requirement}" in
+                    "integration.cloud.azure.txt") continue ;;
+                esac
+        esac
+
+        version_requirements+=("${requirement}")
+    done
+
+    echo "==> Installing pip for python ${python_version} ..."
+
     set -x
     "python${python_version}" /tmp/get-pip.py -c constraints.txt
-    "pip${python_version}" install --disable-pip-version-check -c constraints.txt "${requirements[@]}"
     set +x
+
+    echo "==> Installing requirements for python ${python_version} ..."
+
+    for requirement in "${version_requirements[@]}"; do
+        set -x
+        "pip${python_version}" install --disable-pip-version-check -c constraints.txt -r "${requirement}"
+        set +x
+    done
+
+    echo "==> Checking for requirements conflicts for ${python_version} ..."
+
+    after=$("pip${python_version}" list)
+
+    for requirement in "${version_requirements[@]}"; do
+        before="${after}"
+
+        set -x
+        "pip${python_version}" install --disable-pip-version-check -c constraints.txt -r "${requirement}"
+        set +x
+
+        after=$("pip${python_version}" list)
+
+        if [ "${before}" != "${after}" ]; then
+            echo "==> Conflicts detected in requirements for python ${python_version}: ${requirement}"
+            echo ">>> Before"
+            echo "${before}"
+            echo ">>> After"
+            echo "${after}"
+            exit 1
+        fi
+    done
+
+    echo "==> Finished with requirements for python ${python_version}."
 done

--- a/test/runner/requirements/integration.cloud.azure.txt
+++ b/test/runner/requirements/integration.cloud.azure.txt
@@ -1,0 +1,16 @@
+packaging
+requests[security]
+azure-mgmt-compute>=2.0.0,<3
+azure-mgmt-network>=1.3.0,<2
+azure-mgmt-storage>=1.2.0,<2
+azure-mgmt-resource>=1.1.0,<2
+azure-storage>=0.35.1,<0.36
+azure-cli-core>=2.0.12,<3
+msrest!=0.4.15
+msrestazure>=0.4.11,<0.5
+azure-mgmt-dns>=1.0.1,<2
+azure-mgmt-keyvault>=0.40.0,<0.41
+azure-mgmt-batch>=4.1.0,<5
+azure-mgmt-sql>=0.7.1,<0.8
+azure-mgmt-web>=0.32.0,<0.33
+azure-mgmt-containerservice>=1.0.0

--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -255,6 +255,8 @@ def parse_args():
                                      targets=walk_network_integration_targets,
                                      config=NetworkIntegrationConfig)
 
+    add_extra_docker_options(network_integration, integration=False)
+
     network_integration.add_argument('--platform',
                                      metavar='PLATFORM',
                                      action='append',
@@ -271,6 +273,8 @@ def parse_args():
     windows_integration.set_defaults(func=command_windows_integration,
                                      targets=walk_windows_integration_targets,
                                      config=WindowsIntegrationConfig)
+
+    add_extra_docker_options(windows_integration, integration=False)
 
     windows_integration.add_argument('--windows',
                                      metavar='VERSION',

--- a/test/sanity/code-smell/azure-requirements.py
+++ b/test/sanity/code-smell/azure-requirements.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+"""Make sure the Azure requirements files match."""
+
+import filecmp
+
+src = 'packaging/requirements/requirements-azure.txt'
+dst = 'test/runner/requirements/integration.cloud.azure.txt'
+
+if not filecmp.cmp(src, dst):
+    print('Update the Azure integration test requirements with the packaging test requirements:')
+    print('cp %s %s' % (src, dst))
+    exit(1)

--- a/test/sanity/code-smell/test-constraints.sh
+++ b/test/sanity/code-smell/test-constraints.sh
@@ -5,6 +5,7 @@ constraints=$(
         | grep -v '(sanity_ok)$' \
         | sed 's/ *;.*$//; s/ #.*$//' \
         | grep -v '/constraints.txt:' \
+        | grep -v '/integration.cloud.azure.txt:' \
         | grep '[<>=]'
 )
 


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test default image:

- Add openssh-client to default docker container.
- Include Azure requirements in default container.
- Add missing --docker-no-pull option.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (default-image-update ea8ea15835) last updated 2017/10/20 00:56:59 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
