### PR TITLE
ovirt_host_networks: Fix label assignment

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_networks.py
@@ -194,6 +194,7 @@ class HostNetworksModule(BaseModule):
         update = False
         bond = self._module.params['bond']
         networks = self._module.params['networks']
+        labels = self._module.params['labels']
         nic = get_entity(nic_service)
 
         if nic is None:
@@ -208,6 +209,12 @@ class HostNetworksModule(BaseModule):
                     sorted(get_link_name(self._connection, s) for s in nic.bonding.slaves)
                 )
             )
+
+        # Check if labels need to be updated on interface/bond:
+        if labels:
+            net_labels = nic_service.network_labels_service().list()
+            if sorted(labels) != sorted([lbl.id for lbl in net_labels]):
+                return True
 
         if not networks:
             return update
@@ -307,7 +314,7 @@ def main():
                 ] if bond else None,
                 modified_labels=[
                     otypes.NetworkLabel(
-                        name=str(name),
+                        id=str(name),
                         host_nic=otypes.HostNic(
                             name=bond.get('name') if bond else interface
                         ),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes the label assigment on network interface or bond.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_host_networks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.3.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Now user can assign labels to interface, by executing following task, previously just network assignment worked and was checked:
```yaml
- name: Assign VLAN to eth1 on host1
    ovirt_host_networks:
      auth: "{{ ovirt_auth }}"
      name: host1
      interface: eth1
      labels:
        - INT
        - PRD
      save: true
      check: true
```
