### PR TITLE
Remove toLower on source in win_chocolatey module

### DIFF
--- a/lib/ansible/modules/windows/win_chocolatey.ps1
+++ b/lib/ansible/modules/windows/win_chocolatey.ps1
@@ -39,10 +39,6 @@ $result = @{
     changed = $false
 }
 
-if ($source) {
-    $source = $source.Tolower()
-}
-
 if ($upgrade)
 {
     Add-DeprecationWarning -obj $result -message "Parameter upgrade=yes is replaced with state=latest" -version 2.6


### PR DESCRIPTION
Having this here breaks any source URLs that require case sensitivity.

##### SUMMARY
Removes the .toLower from the chocolatey source because it breaks source URLs that may be case sensitive. 

For example some private nuget repos use a mixed case string as an identifier that is required to match casing exactly. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
windows/win_chocolatey

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```
