### PR TITLE
Update input parameters handlers using pgutils like postgresql_db module

### DIFF
--- a/lib/ansible/modules/database/postgresql/postgresql_ext.py
+++ b/lib/ansible/modules/database/postgresql/postgresql_ext.py
@@ -82,6 +82,7 @@ except ImportError:
 else:
     postgresqldb_found = True
 
+import ansible.module_utils.postgres as pgutils
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
@@ -120,17 +121,17 @@ def ext_create(cursor, ext):
 #
 
 def main():
+
+    argument_spec = pgutils.postgres_common_argument_spec()
+    argument_spec.update(dict(
+        db=dict(required=True),
+        ext=dict(required=True, aliases=['name']),
+        state=dict(default="present", choices=["absent", "present"]),
+    ))
+
     module = AnsibleModule(
-        argument_spec=dict(
-            login_user=dict(default="postgres"),
-            login_password=dict(default="", no_log=True),
-            login_host=dict(default=""),
-            port=dict(default="5432"),
-            db=dict(required=True),
-            ext=dict(required=True, aliases=['name']),
-            state=dict(default="present", choices=["absent", "present"]),
-        ),
-        supports_check_mode = True
+        argument_spec=argument_spec,
+        supports_check_mode=True
     )
 
     if not postgresqldb_found:


### PR DESCRIPTION
##### SUMMARY
Using pgutils function to handle common paramaters like `login_host`or `login_user`etc.
The idea is to be synchronised with the postgresql_db module on all others pg modules.

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
postgresql_ext module

##### ANSIBLE VERSION
```
2.3.1.0
```


##### ADDITIONAL INFORMATION

We are talking here about refactoring how pg modules handle common parameters.
I don't change how the module is working.
