### PR TITLE
zabbix_host: fix bug introduced by earlier PR merge

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix_host.py
@@ -686,7 +686,7 @@ def main():
                     module.exit_json(changed=False)
             else:
                 if host.check_all_properties(host_id, host_groups, status, interfaces, template_ids,
-                                             exist_interfaces_copy, zabbix_host_obj, proxy_id, visible_name, host_name):
+                                             exist_interfaces_copy, zabbix_host_obj, proxy_id, visible_name, description, host_name):
                     host.update_host(host_name, group_ids, status, host_id, interfaces, exist_interfaces, proxy_id,
                                      visible_name, description, tls_connect, tls_accept, tls_psk_identity, tls_psk, tls_issuer,
                                      tls_subject)


### PR DESCRIPTION
##### SUMMARY
In zabbix_host, one of the branches does not include a required argument to check_all_properties. This leads to a backtrace if that branch is hit. This fixes the behavior.
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
2.5.0