### PR TITLE
Fix documentation bug for asa_config

### DIFF
--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -93,28 +93,6 @@ options:
     required: false
     default: line
     choices: ['line', 'block']
-  update:
-    description:
-      - The I(update) argument controls how the configuration statements
-        are processed on the remote device.  Valid choices for the I(update)
-        argument are I(merge) and I(check).  When the argument is set to
-        I(merge), the configuration changes are merged with the current
-        device running configuration.  When the argument is set to I(check)
-        the configuration updates are determined but not actually configured
-        on the remote device.
-    required: false
-    default: merge
-    choices: ['merge', 'check']
-  commit:
-    description:
-      - This argument specifies the update method to use when applying the
-        configuration changes to the remote node.  If the value is set to
-        I(merge) the configuration updates are merged with the running-
-        config.  If the value is set to I(check), no changes are made to
-        the remote host.
-    required: false
-    default: merge
-    choices: ['merge', 'check']
   backup:
     description:
       - This argument will cause the module to create a full backup of


### PR DESCRIPTION
The documentation mentioned the "commit" and "update" parameters which
didn't exist.

##### SUMMARY
Documentation bug, fixes #31609. Should also be backported to the 2.4 branch.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- asa_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/patrick/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/patrick/.virtualenvs/prod/lib/python2.7/site-packages/ansible
  executable location = /Users/patrick/.virtualenvs/prod/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```
