### PR TITLE
[ec2-ami] make examples less verbose; fix default values in docs

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -138,31 +138,21 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Basic AMI Creation
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     instance_id: i-xxxxxx
     wait: yes
     name: newtest
     tags:
       Name: newtest
       Service: TestService
-  register: image
 
 # Basic AMI Creation, without waiting
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
     instance_id: i-xxxxxx
     wait: no
     name: newtest
-  register: image
 
 # AMI Registration from EBS Snapshot
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
     name: newtest
     state: present
     architecture: x86_64
@@ -174,12 +164,9 @@ EXAMPLES = '''
         snapshot_id: snap-xxxxxxxx
         delete_on_termination: true
         volume_type: gp2
-  register: image
 
 # AMI Creation, with a custom root-device size and another EBS attached
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     instance_id: i-xxxxxx
     name: newtest
     device_mapping:
@@ -191,12 +178,9 @@ EXAMPLES = '''
           size: YYY
           delete_on_termination: false
           volume_type: gp2
-  register: image
 
 # AMI Creation, excluding a volume attached at /dev/sdb
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
     instance_id: i-xxxxxx
     name: newtest
     device_mapping:
@@ -206,31 +190,21 @@ EXAMPLES = '''
           volume_type: gp2
         - device_name: /dev/sdb
           no_device: yes
-  register: image
 
 # Deregister/Delete AMI (keep associated snapshots)
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
     image_id: "{{ instance.image_id }}"
     delete_snapshot: False
     state: absent
 
 # Deregister AMI (delete associated snapshots too)
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
     image_id: "{{ instance.image_id }}"
     delete_snapshot: True
     state: absent
 
 # Update AMI Launch Permissions, making it public
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
     image_id: "{{ instance.image_id }}"
     state: present
     launch_permissions:
@@ -238,9 +212,6 @@ EXAMPLES = '''
 
 # Allow AMI to be launched by another account
 - ec2_ami:
-    aws_access_key: xxxxxxxxxxxxxxxxxxxxxxx
-    aws_secret_key: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-    region: xxxxxx
     image_id: "{{ instance.image_id }}"
     state: present
     launch_permissions:

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -42,7 +42,7 @@ options:
     description:
       - The target architecture of the image to register
     required: false
-    default: null
+    default: x86_64
   kernel_id:
     version_added: "2.3"
     description:
@@ -54,7 +54,7 @@ options:
     description:
       - The virtualization type of the image to register
     required: false
-    default: null
+    default: hvm
   root_device_name:
     version_added: "2.3"
     description:
@@ -70,7 +70,7 @@ options:
   wait_timeout:
     description:
       - How long before wait gives up, in seconds.
-    default: 300
+    default: 900
   state:
     description:
       - Create or deregister/delete AMI.

--- a/lib/ansible/modules/cloud/amazon/ec2_ami.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami.py
@@ -136,6 +136,8 @@ extends_documentation_fragment:
 # Thank you to iAcquire for sponsoring development of this module.
 
 EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
 # Basic AMI Creation
 - ec2_ami:
     instance_id: i-xxxxxx


### PR DESCRIPTION
##### SUMMARY
Make ec2-ami examples less verbose. Fix incorrect default values in docs.

- Remove `aws_access_key`, `aws_secret_key`, `region` options. Also remove `register` parameter.
- Fix default values for `architecture `, `virtualization_type ` and `wait_timeout ` in docs to be the actual default values.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`ec2-ami`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```
