### PR TITLE
composer: return skipped if command has no --dry-run

### DIFF
--- a/lib/ansible/modules/packaging/language/composer.py
+++ b/lib/ansible/modules/packaging/language/composer.py
@@ -31,89 +31,74 @@ options:
         version_added: "1.8"
         description:
             - Composer command like "install", "update" and so on.
-        required: false
         default: install
     arguments:
         version_added: "2.0"
         description:
             - Composer arguments like required package, version and so on.
-        required: false
-        default: null
     executable:
         version_added: "2.4"
         description:
-            - Path to PHP Executable on the remote host, if PHP is not in PATH
-        required: false
-        default: null
-        aliases: [ "php_path" ]
+            - Path to PHP Executable on the remote host, if PHP is not in PATH.
+        aliases: [ php_path ]
     working_dir:
         description:
             - Directory of your project (see --working-dir). This is required when
               the command is not run globally.
             - Will be ignored if C(global_command=true).
-        required: false
-        default: null
-        aliases: [ "working-dir" ]
+        aliases: [ working-dir ]
     global_command:
         version_added: "2.4"
         description:
             - Runs the specified command globally.
-        required: false
         choices: [ true, false]
         default: false
-        aliases: [ "global-command" ]
+        aliases: [ global-command ]
     prefer_source:
         description:
             - Forces installation from package sources when possible (see --prefer-source).
-        required: false
         default: false
         choices: [ true, false]
-        aliases: [ "prefer-source" ]
+        aliases: [ prefer-source ]
     prefer_dist:
         description:
             - Forces installation from package dist even for dev versions (see --prefer-dist).
-        required: false
         default: false
         choices: [ true, false]
-        aliases: [ "prefer-dist" ]
+        aliases: [ prefer-dist ]
     no_dev:
         description:
             - Disables installation of require-dev packages (see --no-dev).
-        required: false
         default: true
         choices: [ true, false]
-        aliases: [ "no-dev" ]
+        aliases: [ no-dev ]
     no_scripts:
         description:
             - Skips the execution of all scripts defined in composer.json (see --no-scripts).
-        required: false
         default: false
         choices: [ true, false]
-        aliases: [ "no-scripts" ]
+        aliases: [ no-scripts ]
     no_plugins:
         description:
             - Disables all plugins ( see --no-plugins ).
-        required: false
         default: false
         choices: [ true, false]
-        aliases: [ "no-plugins" ]
+        aliases: [ no-plugin ]
     optimize_autoloader:
         description:
             - Optimize autoloader during autoloader dump (see --optimize-autoloader).
             - Convert PSR-0/4 autoloading to classmap to get a faster autoloader.
             - Recommended especially for production, but can take a bit of time to run.
-        required: false
         default: true
         choices: [ true, false]
-        aliases: [ "optimize-autoloader" ]
+        aliases: [ optimize-autoloader ]
     ignore_platform_reqs:
         version_added: "2.0"
         description:
             - Ignore php, hhvm, lib-* and ext-* requirements and force the installation even if the local machine does not fulfill these.
-        required: false
         default: false
         choices: [ true, false]
-        aliases: [ "ignore-platform-reqs" ]
+        aliases: [ ignore-platform-reqs ]
 requirements:
     - php
     - composer installed in bin path (recommended /usr/local/bin)
@@ -148,7 +133,6 @@ EXAMPLES = '''
 '''
 
 import re
-
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -188,9 +172,9 @@ def composer_command(module, command, arguments="", options=None, global_command
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            command=dict(default="install", type="str", required=False),
-            arguments=dict(default="", type="str", required=False),
-            executable=dict(type="path", required=False, aliases=["php_path"]),
+            command=dict(default="install", type="str"),
+            arguments=dict(default="", type="str"),
+            executable=dict(type="path", aliases=["php_path"]),
             working_dir=dict(type="path", aliases=["working-dir"]),
             global_command=dict(default=False, type="bool", aliases=["global-command"]),
             prefer_source=dict(default=False, type="bool", aliases=["prefer-source"]),
@@ -247,7 +231,10 @@ def main():
             options.append(option)
 
     if module.check_mode:
-        options.append('--dry-run')
+        if 'dry-run' in available_options:
+            options.append('--dry-run')
+        else:
+            module.exit_json(skipped=True, msg="command '%s' does not support check mode, skipping" % command)
 
     rc, out, err = composer_command(module, command, arguments, options, global_command)
 


### PR DESCRIPTION
##### SUMMARY
Some commands in composer does not support check mode. Identify those and return skipped. Fixes #31816 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
composer

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
 $ ansible-playbook test.yml --check -v 

PLAY [localhost] *****************************************************************************************************************************************************************

TASK [composer] ******************************************************************************************************************************************************************
skipping: [localhost] => {"msg": "command 'config' does not support check mode, skipping"}

PLAY RECAP ***********************************************************************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=0  
```
