### PR TITLE
Add delayed start to win_nssm

### DIFF
--- a/lib/ansible/modules/windows/win_nssm.ps1
+++ b/lib/ansible/modules/windows/win_nssm.ps1
@@ -35,7 +35,7 @@ $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "prese
 $application = Get-AnsibleParam -obj $params -name "application" -type "str"
 $appParameters = Get-AnsibleParam -obj $params -name "app_parameters" -type "str"
 $appParametersFree  = Get-AnsibleParam -obj $params -name "app_parameters_free_form" -type "str"
-$startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset "auto","manual","disabled" -resultobj $result
+$startMode = Get-AnsibleParam -obj $params -name "start_mode" -type "str" -default "auto" -validateset "auto","delayed","manual","disabled" -resultobj $result
 
 $stdoutFile = Get-AnsibleParam -obj $params -name "stdout_file" -type "str"
 $stderrFile = Get-AnsibleParam -obj $params -name "stderr_file" -type "str"
@@ -502,7 +502,7 @@ Function Nssm-Update-StartMode
         Throw "Error updating start mode for service ""$name"""
     }
 
-    $modes=@{"auto" = "SERVICE_AUTO_START"; "manual" = "SERVICE_DEMAND_START"; "disabled" = "SERVICE_DISABLED"}
+    $modes=@{"auto" = "SERVICE_AUTO_START"; "delayed" = "SERVICE_DELAYED_AUTO_START"; "manual" = "SERVICE_DEMAND_START"; "disabled" = "SERVICE_DISABLED"}
     $mappedMode = $modes.$mode
     if ($results -cnotlike $mappedMode) {
         $cmd = "set ""$name"" Start $mappedMode"

--- a/lib/ansible/modules/windows/win_nssm.py
+++ b/lib/ansible/modules/windows/win_nssm.py
@@ -87,17 +87,21 @@ options:
       - Password to be used for service startup
   start_mode:
     description:
-      - If C(auto) is selected, the service will start at bootup. C(manual) means that the service will start only when another service needs it.
-        C(disabled) means that the service will stay off, regardless if it is needed or not.
+      - If C(auto) is selected, the service will start at bootup.
+      - C(delayed) causes a delayed but automatic start after boot (added in version 2.5).
+      - C(manual) means that the service will start only when another service needs it.
+      - C(disabled) means that the service will stay off, regardless if it is needed or not.
     default: auto
     choices:
       - auto
+      - delayed
       - manual
       - disabled
 author:
   - "Adam Keech (@smadam813)"
   - "George Frank (@georgefrank)"
   - "Hans-Joachim Kliemeck (@h0nIg)"
+  - "Michael Wild (@themiwi)"
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
##### SUMMARY
Extends the valid choices for `startup_mode` in the `win_nssm` module with the value `delayed` which translates to `Start=SERVICE_DELAYED_AUTO_START` in `nssm` (see https://nssm.cc/commands, but contrary to docs the option is *not* called `SERVICE_DELAYED_START`).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_nssm

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/add-delayed-start-to-win_nssm 39fb35817c) last updated 2017/10/22 19:05:20 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/themiwi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/themiwi/downloads/ansible/lib/ansible
  executable location = /home/themiwi/.conda/envs/conda-dev/bin/ansible
  python version = 2.7.14 | packaged by conda-forge | (default, Oct  5 2017, 14:19:56) [GCC 4.8.2 20140120 (Red Hat 4.8.2-15)]
```


##### ADDITIONAL INFORMATION
Starting a Windows service some time after boot and not during improves performance startup performance. Refer to https://blogs.technet.microsoft.com/askperf/2008/02/02/ws2008-startup-processes-and-delayed-automatic-start/ for more details.
