### PR TITLE
[aws fragment] Update note about configuration files

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -74,8 +74,9 @@ notes:
     C(AWS_SECRET_ACCESS_KEY) or C(AWS_SECRET_KEY) or C(EC2_SECRET_KEY),
     C(AWS_SECURITY_TOKEN) or C(EC2_SECURITY_TOKEN),
     C(AWS_REGION) or C(EC2_REGION)
-  - Ansible uses the boto configuration file (typically ~/.boto) if no
-    credentials are provided. See http://boto.readthedocs.org/en/latest/boto_config_tut.html
+  - Ansible uses the boto configuration files if no credentials are provided.
+    For boto, see http://boto.readthedocs.io/en/latest/boto_config_tut.html#credentials.
+    For boto3, see http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials.
   - C(AWS_REGION) or C(EC2_REGION) can be typically be used to specify the
     AWS region, when required, but this can also be configured in the boto config file
 """

--- a/lib/ansible/utils/module_docs_fragments/aws.py
+++ b/lib/ansible/utils/module_docs_fragments/aws.py
@@ -75,8 +75,8 @@ notes:
     C(AWS_SECURITY_TOKEN) or C(EC2_SECURITY_TOKEN),
     C(AWS_REGION) or C(EC2_REGION)
   - Ansible uses the boto configuration files if no credentials are provided.
-    For boto, see http://boto.readthedocs.io/en/latest/boto_config_tut.html#credentials.
-    For boto3, see http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials.
+    For boto, see U(http://boto.readthedocs.io/en/latest/boto_config_tut.html#credentials).
+    For boto3, see U(http://boto3.readthedocs.io/en/latest/guide/configuration.html#configuring-credentials).
   - C(AWS_REGION) or C(EC2_REGION) can be typically be used to specify the
     AWS region, when required, but this can also be configured in the boto config file
 """


### PR DESCRIPTION
##### SUMMARY
Updated note about how ansible reads credentials if they are not passed in as parameters to the module. Added a link to boto3 'Configuring Credentials' doc.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`utils/module_docs_fragments/aws.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```