### PR TITLE
Fix include_task in include_role

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -108,8 +108,15 @@ class IncludedFile:
                                         cumulative_path = parent_include_dir
                                     include_target = templar.template(include_result['include'])
                                     if original_task._role:
-                                        new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)
-                                        include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
+                                        if os.path.isabs(cumulative_path):
+                                            # Try with original_task._role._role_path first, then with cumulative_path
+                                            new_basedir = os.path.join(original_task._role._role_path, 'tasks')
+                                            include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
+                                            if not os.path.exists(include_file):
+                                                include_file = loader.path_dwim_relative(cumulative_path, 'tasks', include_target)
+                                        else:
+                                            new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)
+                                            include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
                                     else:
                                         include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
 

--- a/test/integration/targets/includes/roles/inner/tasks/inc.yml
+++ b/test/integration/targets/includes/roles/inner/tasks/inc.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: "role ({{ role_name }}): yatta!"

--- a/test/integration/targets/includes/roles/inner/tasks/main.yml
+++ b/test/integration/targets/includes/roles/inner/tasks/main.yml
@@ -1,0 +1,3 @@
+---
+
+- include_tasks: inc.yml

--- a/test/integration/targets/includes/roles/outer/meta/main.yml
+++ b/test/integration/targets/includes/roles/outer/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - inner

--- a/test/integration/targets/includes/roles/outer/tasks/main.yml
+++ b/test/integration/targets/includes/roles/outer/tasks/main.yml
@@ -1,0 +1,2 @@
+- debug:
+    msg: "in outer role"

--- a/test/integration/targets/includes/runme.sh
+++ b/test/integration/targets/includes/runme.sh
@@ -3,3 +3,6 @@
 set -eux
 
 ansible-playbook test_includes.yml -i ../../inventory "$@"
+
+PB_OUT=$(ansible-playbook test_include_task_in_include_role.yml -i ../../inventory "$@")
+(echo "$PB_OUT" | grep -F "role (inner): yatta!") || exit 1

--- a/test/integration/targets/includes/test_include_task_in_include_role.yml
+++ b/test/integration/targets/includes/test_include_task_in_include_role.yml
@@ -1,0 +1,4 @@
+- hosts: testhost
+  tasks:
+    - include_role:
+        name: outer


### PR DESCRIPTION
##### SUMMARY
Fix when an `include_task` is used in a role which is a dependency from an included role.

Fixes #29541. Integration tests provided.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/playbook/included_file.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel e7d7a29a46) last updated 2017/10/22 10:39:44 (GMT +200)
```