### PR TITLE
[ec2_vpc_subnet_facts] Add subnet_id alias for subnet_ids options

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
@@ -34,6 +34,7 @@ options:
     description:
       - A list of subnet IDs to gather facts for.
     version_added: "2.5"
+    aliases: [subnet_id]
   filters:
     description:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
@@ -223,7 +224,7 @@ def describe_subnets(connection, module):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        subnet_ids=dict(type='list', default=[]),
+        subnet_ids=dict(type='list', default=[], aliases=['subnet_id']),
         filters=dict(type='dict', default={})
     ))
 


### PR DESCRIPTION
##### SUMMARY
Add subnet_id alias for subnet_ids options

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`ec2_vpc_subnet_facts`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```