### PR TITLE
Fix issue-32019: [Python 3] znode fails to create node (It uses string value instead of bytes value)

### DIFF
--- a/lib/ansible/modules/clustering/znode.py
+++ b/lib/ansible/modules/clustering/znode.py
@@ -111,7 +111,7 @@ except ImportError:
     KAZOO_INSTALLED = False
 
 from ansible.module_utils.basic import AnsibleModule
-
+from ansible.module_utils._text import to_bytes
 
 def main():
     module = AnsibleModule(
@@ -238,7 +238,7 @@ class KazooCommandProxy():
             else:
                 return True, {'changed': False, 'msg': 'No changes were necessary.', 'znode': path, 'value': value}
         else:
-            self.zk.create(path, value, makepath=True)
+            self.zk.create(path, to_bytes(value), makepath=True)
             return True, {'changed': True, 'msg': 'Created a new znode.', 'znode': path, 'value': value}
 
     def _wait(self, path, timeout, interval=5):

--- a/lib/ansible/modules/clustering/znode.py
+++ b/lib/ansible/modules/clustering/znode.py
@@ -113,6 +113,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes
 
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(


### PR DESCRIPTION
##### DESCRIPTION
The module znode doens't work for python 3 when trying to publish some value to zookeeper, It is because of  KazooClient.create requires a byte string in python 3 like `b'value'` instead of `'value'`. This PR changes `ansible/modules/clustering/znode.py:242` to consume the proper message either for python2 or 3 by using `from ansible.module_utils._text import to_bytes`.

##### ISSUE TYPE
 - Bug Report (Fixes [32019](https://github.com/ansible/ansible/issues/32019))

##### COMPONENT NAME
znode

##### ANSIBLE VERSION

```
ansible 2.5.0 [] last updated 2017/10/19 20:28:31 (GMT +100)
...
python version = 3.5.2 (v3.5.2:4def2a2901a5, Jun 26 2016, 10:47:25) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```

##### CONFIGURATION

##### OS / ENVIRONMENT
"N/A"

##### SUMMARY
In python 3, kazoo client requires bytes and not string, in order to solve the issue:

1.- include in znode.py:
```
from ansible.module_utils._text import to_bytes
```

2.- Replace znode.py line 241:
```
 - self.zk.create(path, value, makepath=True)
 + self.zk.create(path, to_bytes(value), makepath=True)
```

This solve the issue and is backward compatible (I already tested and will create the proper PR if I have time, I'm actually working on other future PRs).

##### STEPS TO REPRODUCE
- tested with: Python 2.7.13, Python 3.5.2
- kazoo (2.4.0)
- playbook:
```yaml
- name: test my new module
  connection: local
  hosts: localhost
  - name: publish to zookeeper
    znode:
      hosts: "localhost:2181"
      name: "/mynode"
      value: "myvalue"
      state: present
```

##### EXPECTED RESULTS

```
TASK [testmod : publish to zookeeper] ************************************************************************************************************
ok: [localhost]
```

##### ACTUAL RESULTS

```
TASK [testmod : publish to zookeeper] ************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Invalid type for 'value' (must be a byte string)
```
