### PR TITLE
Fun with callbacks

### DIFF
--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -1,0 +1,199 @@
+# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.plugins.callback import CallbackBase
+from ansible.utils.color import colorize, hostcolor
+from ansible import constants as C
+from os.path import basename
+
+
+class CallbackModule(CallbackBase):
+
+    '''
+    Print consolidated output that looks like a *NIX startup log
+    Always dump full, pretty-printed result on failures
+    '''
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'unixy'
+
+    #def _get_task_banner(self, task):
+
+
+    def _get_task_display_name(self, task):
+        display_name = task.get_name().strip().split(" : ")
+
+        if len(task_display_name) > 1:
+            display_name_index = 1
+        else:
+            display_name_index = 0
+
+        self.task_display_name = task_display_name[display_name_index].capitalize()
+
+    def v2_playbook_on_task_start(self, task, is_conditional):
+        # TODO only display task if it will not be skipped for any hosts
+        # Should be able to achieve this by only running display on ok, changed, and failed
+        self._get_task_display_name(task)
+        self._display.display("%s..." % self.task_display_name)
+
+    def v2_playbook_on_handler_task_start(self, task):
+        self._get_task_display_name(task)
+        self._display.display("%s (via handler)... " % self.task_display_name)
+
+    def v2_playbook_on_play_start(self, play):
+        # TODO display name of play and list of play hosts
+        # TODO don't display play name if no hosts in play
+        name = play.get_name().strip()
+        if not name:
+            msg = u"---"
+        else:
+            msg = u"\n- %s -" % name
+
+        self._display.display(msg)
+
+    def v2_runner_on_failed(self, result, ignore_errors=False):
+        self._handle_exception(result._result)
+        self._handle_warnings(result._result)
+
+        self._display.display("%s failed: %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_ERROR)
+
+    def v2_runner_on_ok(self, result):
+        self._clean_results(result._result, result._task.action)
+        self._handle_warnings(result._result)
+        # TODO: handle delegated tasks
+
+        result_was_changed = ('changed' in result._result
+                                and result._result['changed'])
+
+        run_is_verbose = ((self._display.verbosity > 0
+                            or '_ansible_verbose_always' in result._result)
+                            and '_ansible_verbose_override' not in result._result)
+
+        if result_was_changed:
+            msg = "done"
+            display_color = C.COLOR_CHANGED
+        else:
+            msg = "ok"
+            display_color = C.COLOR_OK
+
+        if run_is_verbose:
+            self._display.display("  %s %s: %s" % (result._host.get_name(), msg, self._dump_results(result._result, indent=4)), color=display_color)
+        else:
+            self._display.display("  %s %s" % (result._host.get_name(), msg), color=display_color)
+
+    def v2_runner_on_skipped(self, result):
+        run_is_verbose = ((self._display.verbosity > 0
+                            or '_ansible_verbose_always' in result._result)
+                            and '_ansible_verbose_override' not in result._result)
+
+        if run_is_verbose:
+            if self._display.verbosity > 1:
+                skip_detail = self._dump_results(result._result, indent=4)
+
+            elif self._display.verbosity == 1:
+                skip_detail = result._result.get('skipped_reason')
+
+            self._display.display("  %s skipped: %s" % (result._host.get_name(), skip_detail), color=C.COLOR_SKIP)
+
+    def v2_runner_on_unreachable(self, result):
+        self._display.display("  %s unreachable: %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_UNREACHABLE)
+
+    def v2_on_file_diff(self, result):
+        if result._task.loop and 'results' in result._result:
+            for res in result._result['results']:
+                if 'diff' in res and res['diff'] and res.get('changed', False):
+                    diff = self._get_diff(res['diff'])
+                    if diff:
+                        self._display.display(diff)
+        elif 'diff' in result._result and result._result['diff'] and result._result.get('changed', False):
+            diff = self._get_diff(result._result['diff'])
+            if diff:
+                self._display.display(diff)
+
+    def v2_playbook_on_stats(self, stats):
+        self._display.display("\n- Play recap -", screen_only=True)
+
+        hosts = sorted(stats.processed.keys())
+        for h in hosts:
+            # TODO how else can we display these?
+            t = stats.summarize(h)
+
+            self._display.display(u"  %s : %s %s %s %s" % (
+                hostcolor(h, t),
+                colorize(u'ok', t['ok'], C.COLOR_OK),
+                colorize(u'changed', t['changed'], C.COLOR_CHANGED),
+                colorize(u'unreachable', t['unreachable'], C.COLOR_UNREACHABLE),
+                colorize(u'failed', t['failures'], C.COLOR_ERROR)),
+                screen_only=True
+            )
+
+            self._display.display(u"  %s : %s %s %s %s" % (
+                hostcolor(h, t, False),
+                colorize(u'ok', t['ok'], None),
+                colorize(u'changed', t['changed'], None),
+                colorize(u'unreachable', t['unreachable'], None),
+                colorize(u'failed', t['failures'], None)),
+                log_only=True
+            )
+
+        # print custom stats
+        if C.SHOW_CUSTOM_STATS and stats.custom:
+            self._display.banner("Custom Stats: ")
+            # per host
+            # TODO: come up with 'pretty format'
+            for k in sorted(stats.custom.keys()):
+                if k == '_run':
+                    continue
+                self._display.display('\t%s: %s' % (k, self._dump_results(stats.custom[k], indent=1).replace('\n', '')))
+
+            # print per run custom stats
+            if '_run' in stats.custom:
+                self._display.display("", screen_only=True)
+                self._display.display('\tRun: %s' % self._dump_results(stats.custom['_run'], indent=1).replace('\n', ''))
+            self._display.display("", screen_only=True)
+
+    def v2_playbook_on_no_hosts_matched(self):
+        self._display.display("  No hosts found!", color=C.COLOR_DEBUG)
+        return
+
+    def v2_playbook_on_no_hosts_remaining(self):
+        self._display.display("Ran out of hosts!", color=C.COLOR_ERROR)
+
+    def v2_playbook_on_start(self, playbook):
+        # TODO display whether this run is happening in check mode
+        self._display.display("Executing playbook %s" % basename(playbook._file_name))
+
+        if self._display.verbosity > 3:
+            if self._options is not None:
+                for option in dir(self._options):
+                    if option.startswith('_') or option in ['read_file', 'ensure_value', 'read_module']:
+                        continue
+                    val = getattr(self._options, option)
+                    if val:
+                        self._display.vvvv('%s: %s' % (option, val))
+
+    def v2_runner_retry(self, result):
+        msg = "Retrying... (%d of %d)" % (result._result['attempts'], result._result['retries'])
+        if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
+            msg += "Result was: %s" % self._dump_results(result._result)
+        self._display.display(msg, color=C.COLOR_DEBUG)
+

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -1,23 +1,23 @@
-# (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017, Allyson Bowles <@akatch>
+# Copyright: (c) 2012-2014, Michael DeHaan <michael.dehaan@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: unixy
+    type: stdout
+    short_description: condensed Ansible output
+    version_added: 2.5
+    description:
+      - Consolidated Ansible output in the style of *NIX startup logs
+    extends_documentation_fragment:
+      - default_callback
+    requirements:
+      - set as stdout in configuration
+'''
 
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.color import colorize, hostcolor
@@ -44,12 +44,8 @@ class CallbackModule(CallbackBase):
     CALLBACK_TYPE = 'stdout'
     CALLBACK_NAME = 'unixy'
 
-    #def _get_task_banner(self, task):
-
     def _run_is_verbose(self, result):
-        return ((self._display.verbosity > 0
-                or '_ansible_verbose_always' in result._result)
-                and '_ansible_verbose_override' not in result._result)
+        return ((self._display.verbosity > 0 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result)
 
     def _get_task_display_name(self, task):
         self.task_display_name = None
@@ -200,4 +196,3 @@ class CallbackModule(CallbackBase):
         if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)
-

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -42,12 +42,12 @@ class CallbackModule(CallbackBase):
     def _get_task_display_name(self, task):
         display_name = task.get_name().strip().split(" : ")
 
-        if len(task_display_name) > 1:
+        if len(display_name) > 1:
             display_name_index = 1
         else:
             display_name_index = 0
 
-        self.task_display_name = task_display_name[display_name_index].capitalize()
+        self.task_display_name = display_name[display_name_index].capitalize()
 
     def v2_playbook_on_task_start(self, task, is_conditional):
         # TODO only display task if it will not be skipped for any hosts

--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -28,8 +28,16 @@ from os.path import basename
 class CallbackModule(CallbackBase):
 
     '''
-    Print consolidated output that looks like a *NIX startup log
-    Always dump full, pretty-printed result on failures
+    Design goals:
+    - Print consolidated output that looks like a *NIX startup log
+    - Defaults should avoid displaying unnecessary information wherever possible
+
+    TODOs:
+    - Only display task names if the task runs on at least one host
+    - Add option to display all hostnames on a single line in the appropriate result color (failures may have a separate line)
+    - Consolidate stats display
+    - Display whether run is in --check mode
+    - Don't show play name if no hosts found
     '''
 
     CALLBACK_VERSION = 2.0
@@ -38,89 +46,97 @@ class CallbackModule(CallbackBase):
 
     #def _get_task_banner(self, task):
 
+    def _run_is_verbose(self, result):
+        return ((self._display.verbosity > 0
+                or '_ansible_verbose_always' in result._result)
+                and '_ansible_verbose_override' not in result._result)
 
     def _get_task_display_name(self, task):
         self.task_display_name = None
         display_name = task.get_name().strip().split(" : ")
 
-        if len(display_name) > 1:
-            display_name_index = 1
-        else:
-            display_name_index = 0
-        task_display_name = display_name[display_name_index]
-        if task_display_name == "include" or task_display_name == "include_vars":
+        task_display_name = display_name[-1]
+        if task_display_name.startswith("include"):
             return
         else:
             self.task_display_name = task_display_name
 
+    def _preprocess_result(self, result):
+        self.delegated_vars = result._result.get('_ansible_delegated_vars', None)
+        self._handle_exception(result._result)
+        self._handle_warnings(result._result)
+
+    def _process_result_output(self, result, msg):
+        task_host = result._host.get_name()
+        task_result = "%s %s" % (task_host, msg)
+
+        if self._run_is_verbose(result):
+            task_result = "%s %s: %s" % (task_host, msg, self._dump_results(result._result, indent=4))
+
+        if self.delegated_vars:
+            task_delegate_host = self.delegated_vars['ansible_host']
+            task_result = "%s -> %s %s" % (task_host, task_delegate_host, msg)
+
+        if result._result.get('msg') and result._result.get('msg') != "All items completed":
+            task_result += " | msg: " + result._result.get('msg')
+
+        if result._result.get('stdout'):
+            task_result += " | stdout: " + result._result.get('stdout')
+
+        if result._result.get('stderr'):
+            task_result += " | stderr: " + result._result.get('stderr')
+
+        return task_result
+
     def v2_playbook_on_task_start(self, task, is_conditional):
-        # TODO only display task if it will not be skipped for any hosts
-        # Should be able to achieve this by only running display on ok, changed, and failed
         self._get_task_display_name(task)
         if self.task_display_name is not None:
             self._display.display("%s..." % self.task_display_name)
 
     def v2_playbook_on_handler_task_start(self, task):
         self._get_task_display_name(task)
-        self._display.display("%s (via handler)... " % self.task_display_name)
+        if self.task_display_name is not None:
+            self._display.display("%s (via handler)... " % self.task_display_name)
 
     def v2_playbook_on_play_start(self, play):
         # TODO display name of play and list of play hosts
         # TODO don't display play name if no hosts in play
         name = play.get_name().strip()
-        if not name:
-            msg = u"---"
-        else:
+        if name:
             msg = u"\n- %s -" % name
+        else:
+            msg = u"---"
 
         self._display.display(msg)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self._handle_exception(result._result)
-        self._handle_warnings(result._result)
+        self._preprocess_result(result)
+        display_color = C.COLOR_ERROR
+        msg = "failed"
 
-        self._display.display("%s failed: %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_ERROR)
+        task_result = self._process_result_output(result, msg)
+        self._display.display("  " + task_result, display_color)
 
-    def v2_runner_on_ok(self, result):
-        self._clean_results(result._result, result._task.action)
-        self._handle_warnings(result._result)
-        # TODO: handle delegated tasks
+    def v2_runner_on_ok(self, result, msg="ok", display_color=C.COLOR_OK):
+        self._preprocess_result(result)
 
-        result_was_changed = ('changed' in result._result
-                                and result._result['changed'])
-
-        run_is_verbose = ((self._display.verbosity > 0
-                            or '_ansible_verbose_always' in result._result)
-                            and '_ansible_verbose_override' not in result._result)
-
+        result_was_changed = ('changed' in result._result and result._result['changed'])
         if result_was_changed:
             msg = "done"
             display_color = C.COLOR_CHANGED
-        else:
-            msg = "ok"
-            display_color = C.COLOR_OK
 
-        if run_is_verbose:
-            self._display.display("  %s %s: %s" % (result._host.get_name(), msg, self._dump_results(result._result, indent=4)), color=display_color)
-        else:
-            self._display.display("  %s %s" % (result._host.get_name(), msg), color=display_color)
+        task_result = self._process_result_output(result, msg)
+        self._display.display("  " + task_result, display_color)
 
-    def v2_runner_on_skipped(self, result):
-        run_is_verbose = ((self._display.verbosity > 0
-                            or '_ansible_verbose_always' in result._result)
-                            and '_ansible_verbose_override' not in result._result)
-
-        if run_is_verbose:
-            if self._display.verbosity > 1:
-                skip_detail = self._dump_results(result._result, indent=4)
-
-            elif self._display.verbosity == 1:
-                skip_detail = result._result.get('skipped_reason')
-
-            self._display.display("  %s skipped: %s" % (result._host.get_name(), skip_detail), color=C.COLOR_SKIP)
+    def v2_runner_item_on_failed(self, result):
+        self.v2_runner_on_failed(result)
 
     def v2_runner_on_unreachable(self, result):
-        self._display.display("  %s unreachable: %s" % (result._host.get_name(), self._dump_results(result._result, indent=4)), color=C.COLOR_UNREACHABLE)
+        msg = "unreachable"
+        display_color = C.COLOR_UNREACHABLE
+        task_result = self._process_result_output(result, msg)
+
+        self._display.display("  " + task_result, display_color)
 
     def v2_on_file_diff(self, result):
         if result._task.loop and 'results' in result._result:
@@ -160,28 +176,11 @@ class CallbackModule(CallbackBase):
                 log_only=True
             )
 
-        # print custom stats
-        if C.SHOW_CUSTOM_STATS and stats.custom:
-            self._display.banner("Custom Stats: ")
-            # per host
-            # TODO: come up with 'pretty format'
-            for k in sorted(stats.custom.keys()):
-                if k == '_run':
-                    continue
-                self._display.display('\t%s: %s' % (k, self._dump_results(stats.custom[k], indent=1).replace('\n', '')))
-
-            # print per run custom stats
-            if '_run' in stats.custom:
-                self._display.display("", screen_only=True)
-                self._display.display('\tRun: %s' % self._dump_results(stats.custom['_run'], indent=1).replace('\n', ''))
-            self._display.display("", screen_only=True)
-
     def v2_playbook_on_no_hosts_matched(self):
         self._display.display("  No hosts found!", color=C.COLOR_DEBUG)
-        return
 
     def v2_playbook_on_no_hosts_remaining(self):
-        self._display.display("Ran out of hosts!", color=C.COLOR_ERROR)
+        self._display.display("  Ran out of hosts!", color=C.COLOR_ERROR)
 
     def v2_playbook_on_start(self, playbook):
         # TODO display whether this run is happening in check mode


### PR DESCRIPTION
##### SUMMARY
A callback plugin featuring condensed output similar to a *NIX startup log

Design goals:
- Provide friendlier output for less experienced users
- Strike a good balance between hiding unnecessary screen output and providing useful information to the operator
- Easily display full result dumps with -v

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
unixy

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ally/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```

##### ADDITIONAL INFORMATION
Example output:
```
Executing playbook test.yml

- localhost -
Gathering Facts...
  localhost ok
debug...
  localhost ok: {
    "ansible_default_ipv4": {
        "address": "10.0.0.5",
        "alias": "enp5s0",
        "broadcast": "10.0.0.255",
        "gateway": "10.0.0.1",
        "interface": "enp5s0",
        "macaddress": "aa:bb:cc:11:22:33",
        "mtu": 1500,
        "netmask": "255.255.255.0",
        "network": "10.0.0.0",
        "type": "ether"
    },
    "changed": false,
    "failed": false
}
apt...
  localhost failed | msg: No package matching 'notarealpkg' is available
  localhost failed
wait_for...
  localhost -> localhost ok
command...
  localhost failed | msg: [Errno 2] No such file or directory
command...
  localhost done | stdout:  01:59:07 up 18 days,  4:10, 22 users,  load average: 0.36, 0.45, 0.55

- Play recap -
  localhost                  : ok=6    changed=1    unreachable=0    failed=0
```

Critique greatly appreciated!