### PR TITLE
Documentation update about dashes in subnet names

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -40,8 +40,9 @@ options:
       - The list of subnets that should be associated with the network ACL.
       - Must be specified as a list
       - Each subnet can be specified as subnet ID, or its tagged name.
-        If names are used, they must not contain dashes '-'. Otherwise
-        the new or updated NACLs won't be associated with the(se) subnets.
+        If names are used, they must not contain dashes '-', or
+        the new or updated NACLs won't be associated with the subnet or
+        subnets.
     required: false
   egress:
     description:

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py
@@ -40,6 +40,8 @@ options:
       - The list of subnets that should be associated with the network ACL.
       - Must be specified as a list
       - Each subnet can be specified as subnet ID, or its tagged name.
+        If names are used, they must not contain dashes '-'. Otherwise
+        the new or updated NACLs won't be associated with the(se) subnets.
     required: false
   egress:
     description:
@@ -76,7 +78,7 @@ EXAMPLES = '''
     vpc_id: vpc-12345678
     name: prod-dmz-nacl
     region: ap-southeast-2
-    subnets: ['prod-dmz-1', 'prod-dmz-2']
+    subnets: ['prod_dmz_1', 'prod_dmz_2']
     tags:
       CostCode: CC1234
       Project: phoenix
@@ -99,8 +101,8 @@ EXAMPLES = '''
     name: prod-dmz-nacl
     region: ap-southeast-2
     subnets:
-      - prod-dmz-1
-      - prod-dmz-2
+      - prod_dmz_1
+      - prod_dmz_2
     tags:
       CostCode: CC1234
       Project: phoenix


### PR DESCRIPTION
Subnets whose names contain dashes don't get associated to newly created or updated NACLs. Therefore I updated the documentation of this module.

##### SUMMARY
I ran into the behavior that subnets with dashes in their names don't get associated with NACLs. 
Since this seems to be a yaml-behavior that I wasn't aware of, I had to change my subnet names. In the module's documentation dashes are used. My pull request changes and corrects the module documentation accordingly.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
~/lib/ansible/modules/cloud/amazon/ec2_vpc_nacl.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/ABC/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```
