### PR TITLE
fix eos terminal plugin to recognize ospf error message

### DIFF
--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -44,7 +44,8 @@ class TerminalModule(TerminalBase):
         re.compile(br"connection timed out", re.I),
         re.compile(br"[^\r\n]+ not found", re.I),
         re.compile(br"'[^']' +returned error code: ?\d+"),
-        re.compile(br"[^\r\n]\/bin\/(?:ba)?sh")
+        re.compile(br"[^\r\n]\/bin\/(?:ba)?sh"),
+        re.compile(br"% More than \d+ OSPF instance", re.I)
     ]
 
     def on_open_shell(self):


### PR DESCRIPTION
The eos terminal plugin did not correctly catch the error message
returned with trying to configure more than one ospf instance.  This
change updates the terminal plugin to catch that scenario

