### PR TITLE
facts: Fix duplicate IPs in ipv4_secondaries

### DIFF
--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -206,12 +206,13 @@ class LinuxNetwork(Network):
                         if secondary:
                             if "ipv4_secondaries" not in interfaces[device]:
                                 interfaces[device]["ipv4_secondaries"] = []
-                            interfaces[device]["ipv4_secondaries"].append({
-                                'address': address,
-                                'broadcast': broadcast,
-                                'netmask': netmask,
-                                'network': network,
-                            })
+                            if device != iface:
+                                interfaces[device]["ipv4_secondaries"].append({
+                                    'address': address,
+                                    'broadcast': broadcast,
+                                    'netmask': netmask,
+                                    'network': network,
+                                })
 
                         # NOTE: default_ipv4 is ref to outside scope
                         # If this is the default address, update default_ipv4


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix duplicate IPs in ipv4_secondaries. For example lo interface/device.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
facts.py / facts/network/linux.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (duplicate_ipv4_secondaries 776a330f69) last updated 2017/10/23 14:46:54 (GMT +200)
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The IPs of the lo interfaces are twice in "ipv4_secondaries" fact of ansible_lo

Steps to reproduce - Add further IPs to the lo device
```
sudo ip a a 127.0.0.2/8 brd 127.255.255.255 dev lo
sudo ip a a 127.0.0.3/8 dev lo
run the setup module
ansible -m setup localhost -a "filter=ansible_lo*"
```

Before:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible -m setup localhost -a "filter=ansible_lo*"
...
            "ipv4_secondaries": [
                {
                    "address": "127.0.0.2",
                    "broadcast": "127.255.255.255",
                    "netmask": "255.0.0.0",
                    "network": "127.0.0.0"
                },
                {
                    "address": "127.0.0.2",
                    "broadcast": "127.255.255.255",
                    "netmask": "255.0.0.0",
                    "network": "127.0.0.0"
                },
                {
                    "address": "127.0.0.3",
                    "broadcast": "host",
                    "netmask": "255.0.0.0",
                    "network": "127.0.0.0"
                },
                {
                    "address": "127.0.0.3",
                    "broadcast": "host",
                    "netmask": "255.0.0.0",
                    "network": "127.0.0.0"
                }
            ],

```
After:
```
...
            "ipv4_secondaries": [
                {
                    "address": "127.0.0.2",
                    "broadcast": "127.255.255.255",
                    "netmask": "255.0.0.0",
                    "network": "127.0.0.0"
                },
                {
                    "address": "127.0.0.3",
                    "broadcast": "host",
                    "netmask": "255.0.0.0",
                    "network": "127.0.0.0"
                }
            ],

```
