### PR TITLE
Add ca_path parameter to fetch_url to support custom CA certificate

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -601,7 +601,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
     '''
     CONNECT_COMMAND = "CONNECT %s:%s HTTP/1.0\r\nConnection: close\r\n"
 
-    def __init__(self, hostname, port, ca_path):
+    def __init__(self, hostname, port, ca_path=None):
         self.hostname = hostname
         self.port = port
         self.ca_path = ca_path
@@ -792,7 +792,7 @@ class SSLValidationHandler(urllib_request.BaseHandler):
     https_request = http_request
 
 
-def maybe_add_ssl_handler(url, validate_certs, ca_path):
+def maybe_add_ssl_handler(url, validate_certs, ca_path=None):
     # FIXME: change the following to use the generic_urlparse function
     #        to remove the indexed references for 'parsed'
     parsed = urlparse(url)


### PR DESCRIPTION
##### SUMMARY
Add support for using custom CA certificate for https calls.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/urls

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
This is a ground to allow modules to use custom CAs, this is important in use cases when don't want to install CA certs permanently in the system or you want to enforce specific CA cert for validation for increased security.