### PR TITLE
fixed .loads error for non decoded json in Python 3

### DIFF
--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -369,8 +369,7 @@ class CloudflareAPI(object):
 
         if content:
             try:
-                resp_json = content.decode('utf-8')
-                result = json.loads(resp_json)
+                result = json.loads(content.decode('utf-8'))
             except json.JSONDecodeError:
                 error_msg += "; Failed to parse API response: {0}".format(content)
 

--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -274,8 +274,9 @@ import json
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import fetch_url
+
 
 
 class CloudflareAPI(object):
@@ -369,9 +370,9 @@ class CloudflareAPI(object):
 
         if content:
             try:
-                result = json.loads(content.decode('utf-8'))
-            except json.JSONDecodeError:
-                error_msg += "; Failed to parse API response: {0}".format(content)
+                result = json.loads(to_text(content, errors='surrogate_then_strict'))
+            except (json.JSONDecodeError, UnicodeError) as e:
+                error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
 
         # received an error status but no data with details on what failed
         if (info['status'] not in [200,304]) and (result is None):

--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -369,7 +369,8 @@ class CloudflareAPI(object):
 
         if content:
             try:
-                result = json.loads(content)
+                resp_json = content.decode('utf-8')
+                result = json.loads(resp_json)
             except json.JSONDecodeError:
                 error_msg += "; Failed to parse API response: {0}".format(content)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Using Python 3 this module throws an error when parsing the JSON repsonse, as it has not been decoded from its native utf-8. 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Cloudflare DNS

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
  ansible python module location = /home/ubuntu/workspace/ansible-roles/env/lib/python3.5/site-packages/ansible
  executable location = /home/ubuntu/workspace/ansible-roles/env/bin/ansible
  python version = 3.5.1 (default, Dec 18 2015, 00:00:00) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Ansible command used:

     name: Set A record to point to this server in cloudflare
     cloudflare_dns:
         zone: "{{ domain }}"
         record: "@"
         type: A
         value: "{{ ansible_default_ipv4.address }}"
         account_email: "{{ cloudflare_email }}"
         account_api_token: "{{ cloudflare_api_key }}"

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:  
```
TASK [config-vm : Set A record to point to this server in cloudflare] 
****************************************************
--TRUNCATED--
line 372, in _cf_simple_api_call\r\n    
result = json.loads(content)\r\n  File \"/usr/lib/python3.5/json/__init__.py\", 
line 312, in loads\r\n    s.__class__.__name__))\r\n
TypeError: the JSON object must be str, not 'bytes'\r\n", "msg": "MODULE FAILURE", "rc": 0}
```

After:  
```
TASK [config-vm : Set A record to point to this server in cloudflare] ****************************************************
changed:
```
