### PR TITLE
Enable ECHO in pause module

### DIFF
--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -144,16 +144,14 @@ class ActionModule(ActionBase):
                     # ICANON -> Allows characters to be deleted and hides things like ^M.
                     # ICRNL -> Makes the return key work when ICANON is enabled, otherwise
                     #          you get stuck at the prompt with no way to get out of it.
+                    # ECHO -> Echos input back to stdout
+                    #
                     # See man termios for details on these flags
                     if not seconds:
                         new_settings = termios.tcgetattr(fd)
                         new_settings[0] = new_settings[0] | termios.ICRNL
-                        new_settings[3] = new_settings[3] | termios.ICANON
+                        new_settings[3] = new_settings[3] | (termios.ICANON | termios.ECHO)
                         termios.tcsetattr(fd, termios.TCSANOW, new_settings)
-
-                        # Enable ECHO since tty.setraw() disables it
-                        new_settings = termios.tcgetattr(fd)
-                        new_settings[3] = new_settings[3] | termios.ECHO
                         termios.tcsetattr(fd, termios.TCSANOW, new_settings)
 
                     # flush the buffer to make sure no previous key presses

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -140,10 +140,21 @@ class ActionModule(ActionBase):
                     old_settings = termios.tcgetattr(fd)
                     tty.setraw(fd)
 
-                    # Enable ECHO since tty.setraw() disables it
-                    new_settings = termios.tcgetattr(fd)
-                    new_settings[3] = new_settings[3] | termios.ECHO
-                    termios.tcsetattr(fd, termios.TCSANOW, new_settings)
+                    # Enable a few things turned off by tty.setraw()
+                    # ICANON -> Allows characters to be deleted and hides things like ^M.
+                    # ICRNL -> Makes the return key work when ICANON is enabled, otherwise
+                    #          you get stuck at the prompt with no way to get out of it.
+                    # See man termios for details on these flags
+                    if not seconds:
+                        new_settings = termios.tcgetattr(fd)
+                        new_settings[0] = new_settings[0] | termios.ICRNL
+                        new_settings[3] = new_settings[3] | termios.ICANON
+                        termios.tcsetattr(fd, termios.TCSANOW, new_settings)
+
+                        # Enable ECHO since tty.setraw() disables it
+                        new_settings = termios.tcgetattr(fd)
+                        new_settings[3] = new_settings[3] | termios.ECHO
+                        termios.tcsetattr(fd, termios.TCSANOW, new_settings)
 
                     # flush the buffer to make sure no previous key presses
                     # are read in below

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -140,6 +140,11 @@ class ActionModule(ActionBase):
                     old_settings = termios.tcgetattr(fd)
                     tty.setraw(fd)
 
+                    # Enable ECHO since tty.setraw() disables it
+                    new_settings = termios.tcgetattr(fd)
+                    new_settings[3] = new_settings[3] | termios.ECHO
+                    termios.tcsetattr(fd, termios.TCSANOW, new_settings)
+
                     # flush the buffer to make sure no previous key presses
                     # are read in below
                     termios.tcflush(stdin, termios.TCIFLUSH)


### PR DESCRIPTION

##### SUMMARY
When `pause.py` terminal input code was rewritten, it disabled echo output. This PR flips some bits set my `tty.setraw()`, reenabling echo output for the `prompt` module as well as allowing the input to be edited interactively. 

Fixes #14160

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
`lib/ansible/plugins/action/pause.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
##### ADDITIONAL INFORMATION

Tested with Python 2.7.14 and Python 3.6.3

