### PR TITLE
(minor) fix broken link, awkward phrasing

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -351,8 +351,8 @@ This module is flagged as **@{cur_state}@** which means that @{module_states[cur
 Maintenance Info
 ~~~~~~~~~~~~~~~~
 
-For more information about Red Hat's this support of this @{ plugin_type }@,
-please refer to this `knowledge base article<https://access.redhat.com/articles/rhel-top-support-policies>_`
+For more information about Red Hat's support of this @{ plugin_type }@,
+please refer to this `knowledge base article <https://access.redhat.com/articles/rhel-top-support-policies>`_
 
 {% endif %}
 {% endif %}
@@ -360,4 +360,3 @@ please refer to this `knowledge base article<https://access.redhat.com/articles/
 
 For help in developing, should you be so inclined, please read :doc:`../../community`,
 :doc:`../../dev_guide/testing` and {% if plugin_type == 'module' %}:doc:`../../dev_guide/developing_modules`{% else %}:doc:`../../dev_guide/developing_plugins`{% endif %}.
-

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -358,5 +358,5 @@ please refer to this `knowledge base article <https://access.redhat.com/articles
 {% endif %}
 {% endif %}
 
-For help in developing, should you be so inclined, please read :doc:`../../community`,
+If you want to help with development, please read :doc:`../../community`,
 :doc:`../../dev_guide/testing` and {% if plugin_type == 'module' %}:doc:`../../dev_guide/developing_modules`{% else %}:doc:`../../dev_guide/developing_plugins`{% endif %}.


### PR DESCRIPTION
Signed-off-by: Ed Santiago <santiago@redhat.com>

##### SUMMARY

Simple transposition error was resulting in a link not
being properly htmlified.

Also clean up redundant 'this' and trailing whitespace.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
templates

##### ANSIBLE VERSION
```
ansible 2.5.0 (doc_link_fix 969c6a5ffc) last updated 2017/10/24 09:49:21 (GMT -600)                                                                            
  config file = /home/esm/.ansible.cfg
  configured module search path = [u'/home/esm/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/esm/src/net/ansible/ansible-esm/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION
