### PR TITLE
Fix service_mgr fact collection

### DIFF
--- a/lib/ansible/module_utils/facts/system/service_mgr.py
+++ b/lib/ansible/module_utils/facts/system/service_mgr.py
@@ -105,22 +105,22 @@ class ServiceMgrFactCollector(BaseFactCollector):
 
         # FIXME: replace with a system->service_mgr_name map?
         # start with the easy ones
-        elif collected_facts.get('distribution', None) == 'MacOSX':
+        elif collected_facts.get('ansible_distribution', None) == 'MacOSX':
             # FIXME: find way to query executable, version matching is not ideal
             if LooseVersion(platform.mac_ver()[0]) >= LooseVersion('10.4'):
                 service_mgr_name = 'launchd'
             else:
                 service_mgr_name = 'systemstarter'
-        elif 'BSD' in collected_facts.get('system', '') or collected_facts.get('system') in ['Bitrig', 'DragonFly']:
+        elif 'BSD' in collected_facts.get('ansible_system', '') or collected_facts.get('ansible_system') in ['Bitrig', 'DragonFly']:
             # FIXME: we might want to break out to individual BSDs or 'rc'
             service_mgr_name = 'bsdinit'
-        elif collected_facts.get('system') == 'AIX':
+        elif collected_facts.get('ansible_system') == 'AIX':
             service_mgr_name = 'src'
-        elif collected_facts.get('system') == 'SunOS':
+        elif collected_facts.get('ansible_system') == 'SunOS':
             service_mgr_name = 'smf'
-        elif collected_facts.get('distribution') == 'OpenWrt':
+        elif collected_facts.get('ansible_distribution') == 'OpenWrt':
             service_mgr_name = 'openwrt_init'
-        elif collected_facts.get('system') == 'Linux':
+        elif collected_facts.get('ansible_system') == 'Linux':
             # FIXME: mv is_systemd_managed
             if self.is_systemd_managed(module=module):
                 service_mgr_name = 'systemd'


### PR DESCRIPTION
The platform/distro/etc facts were being passed in
correctly, but service_mgr.py was looking up the
wrong names ('system' vs 'ansible_system')

Fixes #30753, #31095

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts/system/service_mgr.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (service_mgr_fact_30753 62d0f6c8c8) last updated 2017/10/24 12:04:28 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
