### PR TITLE
Add a validate example to blockinfile.

### DIFF
--- a/lib/ansible/modules/files/blockinfile.py
+++ b/lib/ansible/modules/files/blockinfile.py
@@ -117,11 +117,12 @@ EXAMPLES = r"""
           address 192.0.2.23
           netmask 255.255.255.0
 
-- name: insert/update configuration using a local file
+- name: insert/update configuration using a local file and validate it
   blockinfile:
     block: "{{ lookup('file', './local/ssh_config') }}"
     dest: "/etc/ssh/ssh_config"
     backup: yes
+    validate: "/usr/sbin/sshd -T -f %s"
 
 - name: insert/update HTML surrounded by custom markers after <body> line
   blockinfile:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The blockinfile documentation must have been copied from lineinfile.  The "validate" option references "the example below" but there is no example.  I added a validate example to one of the existing examples for the sshd config file.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
blockinfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
