### PR TITLE
letsencrypt module: Force locale to "C" to properly parse days from certificate

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -166,6 +166,7 @@ import tempfile
 import textwrap
 import time
 import traceback
+import locale
 from datetime import datetime
 
 from ansible.module_utils.basic import AnsibleModule
@@ -791,6 +792,9 @@ def main():
 
     # AnsibleModule() changes the locale, so change it back to C because we rely on time.strptime() when parsing certificate dates.
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
+
+    # Force locale to "C" - if user running ansible has other locale, it can break cert days parsing
+    locale.setlocale(locale.LC_ALL, "C")
 
     cert_days = get_cert_days(module, module.params['dest'])
     if cert_days < module.params['remaining_days']:


### PR DESCRIPTION
##### SUMMARY
When user running ansible has locale other than "C" (for example: pl_PL.UTF-8), letsencrypt module fails to parse date from certificate.

Patch is based on https://github.com/ansible/ansible-modules-extras/commit/22a6449150ef451f14028e75e1ffc09d2a989a51 which wasn't moved to new repo.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
letsencrypt module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/local/lib/python2.7/dist-packages/ara/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [xxx -> 127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Failed to parse 'Not after' date of xxx.crt"}
```
After: 
```
ok: [xxx -> 127.0.0.1] => {
    "challenge": {
        "cert_days": 15,
        "changed": false,
        "failed": false
    }
}
```
