### PR TITLE
Add missing packages to default docker image.

### DIFF
--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F23C5A6CF475977595C
 
 RUN apt-get update -y && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
     gcc \
     git \
     libffi-dev \
@@ -14,6 +16,7 @@ RUN apt-get update -y && \
     locales \
     make \
     openssh-client \
+    openssl \
     python2.6-dev \
     python2.7-dev \
     python3.5-dev \


### PR DESCRIPTION
##### SUMMARY

Add missing packages to default docker image.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

default docker container for ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (default-container-update 6ca923d79c) last updated 2017/10/24 13:58:28 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
