### PR TITLE
galaxy: enable specifying remote path for git/hg

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -101,6 +101,9 @@ Each role in the file will have one or more of the following attributes:
    name:
      Download the role to a specific name. Defaults to the Galaxy name when downloading from Galaxy, otherwise it defaults
      to the name of the repository.
+   remote_path:
+     Within the given repository, download the role found at this path. If not specified, will download from the root
+     directory of the repository.
 
 Use the following example as a guide for specifying roles in *requirements.yml*:
 
@@ -116,6 +119,12 @@ Use the following example as a guide for specifying roles in *requirements.yml*:
     - src: https://github.com/bennojoy/nginx
       version: master
       name: nginx_role
+
+    # from GitHub, downloading from a specific directory within the repository
+    - src: https://github.com/example/monolith
+      version: master
+      name: special-role
+      remote_path: roles/special-role
 
     # from a webserver, where the role is packaged in a tar.gz
     - src: https://some.webserver.example.com/files/master.tar.gz

--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -49,7 +49,7 @@ class GalaxyRole(object):
     META_INSTALL = os.path.join('meta', '.galaxy_install_info')
     ROLE_DIRS = ('defaults', 'files', 'handlers', 'meta', 'tasks', 'templates', 'vars', 'tests')
 
-    def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None):
+    def __init__(self, galaxy, name, src=None, version=None, scm=None, path=None, remote_path=None):
 
         self._metadata = None
         self._install_info = None
@@ -64,6 +64,7 @@ class GalaxyRole(object):
         self.version = version
         self.src = src or name
         self.scm = scm
+        self.remote_path = remote_path
 
         if path is not None:
             if self.name not in path:
@@ -353,7 +354,8 @@ class GalaxyRole(object):
            'scm': 'git',
            'src': 'http://git.example.com/repos/repo.git',
            'version': 'v1.0',
-           'name': 'repo'
+           'name': 'repo',
+           'remote_path': 'roles'
         }
         """
-        return dict(scm=self.scm, src=self.src, version=self.version, name=self.name)
+        return dict(scm=self.scm, src=self.src, version=self.version, name=self.name, remote_path=self.remote_path)


### PR DESCRIPTION
It's common to have multiple roles in a single repository.
Specifying a remote path will allow galaxy to install from
a single subdirectory within that given repository.

Fixes #11418
##### SUMMARY
Allows specifying a remote path that tells galaxy where it should look for roles in the given repository. Before it would always consider the repository as a whole and yield varying results depending on its structure.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
galaxy

##### ANSIBLE VERSION
```
ansible 2.5.0 (remote_path 11aecf9b87) last updated 2017/10/24 15:21:50 (GMT -700)
  config file = /home/victor/.ansible.cfg
  configured module search path = [u'/home/victor/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/victor/dev/ansible/lib/ansible
  executable location = /home/victor/dev/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
Requirements file:
```
- src: ssh://git@github.com/stevepereira/ansible-example.git
  version: master
  name: keepalived
  scm: git
  remote_path: playbooks/roles/keepalived/
```

Before:
```
victor@vsilva:~/dev/b3/ansible$ ansible-galaxy install -r requirements.yml --roles-path external_roles/
- extracting keepalived to /home/victor/dev/b3/ansible/external_roles/keepalived
- keepalived (master) was installed successfully

victor@vsilva:~/dev/b3/ansible/external_roles$ tree                                                      
.
└── keepalived
    ├── handlers
    │   └── main.yml
    ├── keepalived
    │   ├── ansible.cfg
    │   ├── Brewfile
    │   ├── btsync-wip
    │   ├── playbooks
    │   │   ├── alpha-inventory
    │   │   ├── ansible.cfg
    │   │   ├── callback_plugins
    │   │   │   ├── profile_tasks.py
    │   │   │   └── profile_tasks.pyc
    │   │   ├── cluster-appserver.yml
    │   │   ├── cluster-loadbalancer.yml
    │   │   ├── cluster-webserver.yml
    │   │   ├── cluster.yml
    │   │   ├── common
    │   │   │   └── handlers
    │   │   │       ├── haproxy.yml
    │   │   │       ├── iptables.yml
    │   │   │       ├── jetty.yml
    │   │   │       ├── main.yml
    │   │   │       ├── nginx.yml
    │   │   │       └── salt
    │   │   ├── connection-test.yml
    │   │   ├── deploy.yml
    │   │   ├── doc
    │   │   │   ├── code-structure.md
    │   │   │   ├── local-development.md
    │   │   │   ├── local-installation.md
    │   │   │   └── README.md
    │   │   ├── group_vars
    │   │   │   └── all
    │   │   ├── roles
    │   │   │   ├── clamav
    │   │   │   │   ├── tasks
    │   │   │   │   │   └── main.yml
    │   │   │   │   ├── templates
    │   │   │   │   │   ├── daily.j2
    │   │   │   │   │   └── hourly.j2
    │   │   │   │   └── tests
    │   │   │   │       ├── inventory
    │   │   │   │       └── test.yml
    │   │   │   ├── common
    │   │   │   │   ├── handlers
    │   │   │   │   │   └── main.yml
    │   │   │   │   ├── tasks
    │   │   │   │   │   ├── base.yml
    │   │   │   │   │   ├── harden.yml
    │   │   │   │   │   ├── localactions.yml
    │   │   │   │   │   ├── main.yml
    │   │   │   │   │   ├── packages.yml
    │   │   │   │   │   ├── salt
    │   │   │   │   │   ├── ssh_config.yml
    │   │   │   │   │   └── timezone.yml
    │   │   │   │   ├── templates
    │   │   │   │   │   ├── environment.j2
    │   │   │   │   │   ├── hostname.j2
    │   │   │   │   │   ├── postfix_selections.j2
    │   │   │   │   │   ├── sources.list.j2
    │   │   │   │   │   ├── ssh_config.j2
    │   │   │   │   │   └── timezone.j2
    │   │   │   │   ├── tests
    │   │   │   │   │   ├── inventory
    │   │   │   │   │   └── test.yml
    │   │   │   │   └── vars
    │   │   │   │       ├── main.yml
    │   │   │   │       └── salt
    │   │   │   ├── deploy
    │   │   │   │   ├── handlers
    │   │   │   │   │   └── main.yml
    │   │   │   │   ├── tasks
    │   │   │   │   │   └── main.yml
    │   │   │   │   └── tests
    │   │   │   │       ├── inventory
    │   │   │   │       └── test.yml
...
```

After:
```
victor@vsilva:~/dev/b3/ansible$ ansible-galaxy install -r requirements.yml --roles-path external_roles/
- extracting keepalived to /home/victor/dev/b3/ansible/external_roles/keepalived
- keepalived (master) was installed successfully

victor@vsilva:~/dev/b3/ansible/external_roles$ tree
.
└── keepalived
    ├── handlers
    │   └── main.yml
    ├── meta
    │   └── main.yml
    ├── README.md
    ├── tasks
    │   └── main.yml
    └── templates
        └── etc_keepalived_keepalived_conf
```
