### PR TITLE
inserts enable cmd hash with auth_pass used

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -296,7 +296,7 @@ class Eapi:
         commands = to_list(commands)
 
         if self._enable:
-            commands.insert(0, 'enable')
+            commands.insert(0, self._enable)
 
         body = self._request_builder(commands, output)
         data = self._module.jsonify(body)


### PR DESCRIPTION
eapi transport was not passing the auth_pass to the remote device with
it was provided.  this fix will now insert the correct command hash into
the jsonrpc request.

fixes #30802

