### PR TITLE
eos_eapi: adding the desired state config to the new vrf fixes #32111

### DIFF
--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -260,7 +260,7 @@ def map_obj_to_commands(updates, module, warnings):
         else:
             add('protocol unix-socket')
 
-    if needs_update('state'):
+    if needs_update('state') and not needs_update('vrf'):
         if want['state'] == 'stopped':
             add('shutdown')
         elif want['state'] == 'started':

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -260,11 +260,17 @@ def map_obj_to_commands(updates, module, warnings):
         else:
             add('protocol unix-socket')
 
+    if needs_update('state'):
+        if want['state'] == 'stopped':
+            add('shutdown')
+        elif want['state'] == 'started':
+            add('no shutdown')
+
 
     if needs_update('vrf'):
         add('vrf %s' % want['vrf'])
-
-    if needs_update('state'):
+        # switching operational vrfs here
+        # need to add the desired state as well
         if want['state'] == 'stopped':
             add('shutdown')
         elif want['state'] == 'started':

--- a/test/units/modules/network/eos/test_eos_eapi.py
+++ b/test/units/modules/network/eos/test_eos_eapi.py
@@ -134,6 +134,11 @@ class TestEosEapiModule(TestEosModule):
         commands = ['management api http-commands', 'vrf test', 'no shutdown']
         self.start_unconfigured(changed=True, commands=commands)
 
+    def test_eos_eapi_change_from_default_vrf(self):
+        set_module_args(dict(vrf='test'))
+        commands = ['management api http-commands', 'vrf test', 'no shutdown']
+        self.start_configured(changed=True, commands=commands)
+
     def test_eos_eapi_vrf_missing(self):
         set_module_args(dict(vrf='missing'))
         self.start_unconfigured(failed=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes #32111
Adding the final shut/no shut to the newly minted  eapi operational vrf.  eapi can only run in one vrf at at time, so we need add the state commands to the new vrf even if they are present for the default running config
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_eapi
##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/dt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.11 (default, Nov 13 2016, 20:35:45) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```



