### PR TITLE
Add ansible_ssh_port to iosxr_user auth tests

### DIFF
--- a/test/integration/targets/iosxr_user/tests/cli/auth.yaml
+++ b/test/integration/targets/iosxr_user/tests/cli/auth.yaml
@@ -8,13 +8,13 @@
 
   - name: test login
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "pass123"
 
   - name: test login with invalid password (should fail)
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no show version"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes


### PR DESCRIPTION
The CI nodes listen on port 8022, we need to plumb that to avoid
test failures.