### PR TITLE
Default ansible_ssh_port to 22 on ios_user tests

### DIFF
--- a/test/integration/targets/ios_user/tests/cli/auth.yaml
+++ b/test/integration/targets/ios_user/tests/cli/auth.yaml
@@ -11,13 +11,13 @@
 
   - name: test login
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
         (?i)password: "pass123"
 
   - name: test login with invalid password (should fail)
     expect:
-      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
+      command: "ssh auth_user@{{ ansible_ssh_host }} -p {{ ansible_ssh_port|default(22) }} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o PubkeyAuthentication=no show version"
       responses:
         (?i)password: "badpass"
     ignore_errors: yes


### PR DESCRIPTION
The csr nodes do not have ansible_ssh_port on group_vars, as it uses
standard 22 port, therefore default to it on tests needing it.