### PR TITLE
Introspect platform before running ios tests

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/intent.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/intent.yaml
@@ -1,9 +1,23 @@
 ---
 - debug: msg="START ios_interface cli/intent.yaml"
 
+- name: Run show version
+  ios_command:
+    commands: show version
+  register: show_version_result
+
+- name: Set test interface to GigabitEthernet0/2 if we are on Cisco IOS
+  set_fact: test_interface=GigabitEthernet0/2
+  when: "'Cisco IOS' in show_version_result.stdout[0]"
+
+- name: Set test interface to GigabitEthernet2 if we are on Cisco IOS-XE
+  set_fact: test_interface=GigabitEthernet2
+  when: "'Cisco IOS-XE' in show_version_result.stdout[0]"
+
+
 - name: Check intent arguments
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     state: up
     tx_rate: ge(0)
     rx_rate: le(0)
@@ -16,7 +30,7 @@
 
 - name: Check intent arguments (failed condition)
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     state: down
     tx_rate: gt(0)
     rx_rate: lt(0)
@@ -33,7 +47,7 @@
 
 - name: Config + intent
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     enabled: False
     state: down
     authorize: yes
@@ -45,7 +59,7 @@
 
 - name: Config + intent (fail)
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     enabled: False
     authorize: yes
     state: up
@@ -98,7 +112,7 @@
 - name: Aggregate config + intent (pass)
   ios_interface:
     aggregate:
-      - name: GigabitEthernet0/2
+      - name: "{{ test_interface }}"
         enabled: True
         state: up
     authorize: yes

--- a/test/integration/targets/ios_ping/tests/cli/ping.yaml
+++ b/test/integration/targets/ios_ping/tests/cli/ping.yaml
@@ -1,10 +1,20 @@
 ---
 - debug: msg="START cli/ping.yaml"
 
-- name: Get show ip interface GigabitEthernet0/0 output
+- ios_command:
+    commands: show version
+  register: show_version_result
+
+- set_fact: management_interface=GigabitEthernet0/0
+  when: "'Cisco IOS' in show_version_result.stdout[0]"
+
+- set_fact: management_interface=GigabitEthernet1
+  when: "'Cisco IOS-XE' in show_version_result.stdout[0]"
+
+- name: Get show ip management nterface output
   ios_command:
     commands:
-      - show ip interface GigabitEthernet0/0 | include Internet address
+      - show ip interface "{{ management_interface }}" | include Internet address
     authorize: yes
   register: show_ip_interface_result
 


### PR DESCRIPTION
In some IOS tests, we can't just assume a certain interface, as
we test on IOS and IOS-XE and in our CI they scheme numbering is
different.
Introspect version on the tests where needed.