### PR TITLE
Avoid default inventory proccessing for pull

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -112,6 +112,7 @@ class CLI(with_metaclass(ABCMeta, object)):
     # -F (quit-if-one-screen) -R (allow raw ansi control chars)
     # -S (chop long lines) -X (disable termcap init and de-init)
     LESS_OPTS = 'FRSX'
+    SKIP_INVENTORY_DEFAULTS = False
 
     def __init__(self, args, callback=None):
         """
@@ -605,7 +606,7 @@ class CLI(with_metaclass(ABCMeta, object)):
             self.options.skip_tags = list(skip_tags)
 
         # process inventory options except for CLIs that require their own processing
-        if hasattr(self.options, 'inventory') and self.__class__.__name__ not in ('PullCLI'):
+        if hasattr(self.options, 'inventory') and not self.SKIP_INVENTORY_DEFAULTS:
 
             if self.options.inventory:
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -424,8 +424,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         if inventory_opts:
             parser.add_option('-i', '--inventory', '--inventory-file', dest='inventory', action="append",
-                              help="specify inventory host path (default=[%s]) or comma separated host list. "
-                                   "--inventory-file is deprecated" % C.DEFAULT_HOST_LIST)
+                              help="specify inventory host path or comma separated host list. --inventory-file is deprecated")
             parser.add_option('--list-hosts', dest='listhosts', action='store_true',
                               help='outputs a list of matching hosts; does not execute anything else')
             parser.add_option('-l', '--limit', default=C.DEFAULT_SUBSET, dest='subset',
@@ -605,8 +604,8 @@ class CLI(with_metaclass(ABCMeta, object)):
                     skip_tags.add(tag.strip())
             self.options.skip_tags = list(skip_tags)
 
-        # process inventory options
-        if hasattr(self.options, 'inventory'):
+        # process inventory options except for CLIs that require their own processing
+        if hasattr(self.options, 'inventory') and self.__class__.__name__ not in ('PullCLI'):
 
             if self.options.inventory:
 
@@ -616,7 +615,6 @@ class CLI(with_metaclass(ABCMeta, object)):
 
                 # Ensure full paths when needed
                 self.options.inventory = [unfrackpath(opt, follow=False) if ',' not in opt else opt for opt in self.options.inventory]
-
             else:
                 self.options.inventory = C.DEFAULT_HOST_LIST
 

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -67,6 +67,8 @@ class PullCLI(CLI):
                                  "look for a playbook based on the host's fully-qualified domain name,"
                                  'on the host hostname and finally a playbook named *local.yml*.', }
 
+    SKIP_INVENTORY_DEFAULTS = True
+
     def _get_inv_cli(self):
 
         inv_opts = ''

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -79,9 +79,6 @@ class PullCLI(CLI):
                 elif ',' in inv or os.path.exists(inv):
                     inv_opts += ' -i %s ' % inv
 
-        if not inv_opts:
-            inv_opts = " -i localhost, "
-
         return inv_opts
 
     def parse(self):
@@ -176,6 +173,8 @@ class PullCLI(CLI):
         # Attempt to use the inventory passed in as an argument
         # It might not yet have been downloaded so use localhost as default
         inv_opts = self._get_inv_cli()
+        if not inv_opts:
+            inv_opts = " -i localhost, "
 
         # FIXME: enable more repo modules hg/svn?
         if self.options.module_name == 'git':

--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -125,9 +125,6 @@ class PullCLI(CLI):
         self.parser.add_option("--check", default=False, dest='check', action='store_true',
                                help="don't make any changes; instead, try to predict some of the changes that may occur")
 
-        # for pull we don't want a default
-        self.parser.set_defaults(inventory=None)
-
         super(PullCLI, self).parse()
 
         if not self.options.dest:


### PR DESCRIPTION
##### SUMMARY

- now pull's own special inventory processing should work correctly
- also removed ineffective set_defaults

fixes #31449

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
pull
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```