### PR TITLE
vmware_guest: Select only connected hosts which are not in maintenance

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1038,9 +1038,9 @@ class PyVmomiHelper(PyVmomi):
             cluster = self.cache.get_cluster(self.params['cluster'])
             if not cluster:
                 self.module.fail_json(msg='Failed to find cluster "%(cluster)s"' % self.params)
-            hostsystems = [x for x in cluster.host]
+            hostsystems = [x for x in cluster.host if x.runtime.connectionState == 'connected' and not x.runtime.inMaintenanceMode]
             if not hostsystems:
-                self.module.fail_json(msg='No hosts found in cluster "%(cluster)s. Maybe you lack the right privileges ?"' % self.params)
+                self.module.fail_json(msg='No connected (which are not in maintenance) hosts found in cluster "%(cluster)s"' % self.params)
             # TODO: add a policy to select host
             hostsystem = hostsystems[0]
         else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
To create/clone vm, the module select le first host in the cluster. But sometime, that host can be **disconnected** or in **maintenance**, so the vm creation failed.

With this change (or fix), will try to create/clone vm on **only connected hosts which are not in maintenance**.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```