### PR TITLE
fix examples typo in purefa_snap

### DIFF
--- a/lib/ansible/modules/storage/purestorage/purefa_snap.py
+++ b/lib/ansible/modules/storage/purestorage/purefa_snap.py
@@ -56,7 +56,7 @@ EXAMPLES = r'''
     name: foo
     suffix: ansible
     fa_url: 10.10.10.2
-    fa_api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
     state: present
 
 - name: Create R/W clone foo_clone from snapshot foo.snap
@@ -65,7 +65,7 @@ EXAMPLES = r'''
     suffix: snap
     target: foo_clone
     fa_url: 10.10.10.2
-    fa_api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
     state: copy
 
 - name: Overwrite existing volume foo_clone with snapshot foo.snap
@@ -75,7 +75,7 @@ EXAMPLES = r'''
     target: foo_clone
     overwrite: true
     fa_url: 10.10.10.2
-    fa_api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
     state: copy
 
 - name: Delete and eradicate snapshot named foo.snap
@@ -84,7 +84,7 @@ EXAMPLES = r'''
     suffix: snap
     eradicate: true
     fa_url: 10.10.10.2
-    fa_api_token: e31060a7-21fc-e277-6240-25983c6c4592
+    api_token: e31060a7-21fc-e277-6240-25983c6c4592
     state: absent
 '''
 


### PR DESCRIPTION
##### SUMMARY
Fix issue #32138

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
purefa_snap

##### ANSIBLE VERSION
2.4

##### ADDITIONAL INFORMATION
Correct example parameter typo.
Change ```fa_api_token``` for ```api_token```