### PR TITLE
Discover ios_interface interface on basic tests

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/basic.yaml
@@ -1,9 +1,31 @@
 ---
 - debug: msg="START ios_interface cli/basic.yaml"
 
+- name: Run show version
+  ios_command:
+    commands: show version
+    authorize: yes
+  register: show_version_result
+
+- name: Set test interface to GigabitEthernet0/1 if we are on Cisco IOS
+  set_fact: test_interface=GigabitEthernet0/1
+  when: "'Cisco IOS' in show_version_result.stdout[0]"
+
+- name: Set test interface 2 to GigabitEthernet0/2 if we are on Cisco IOS
+  set_fact: test_interface2=GigabitEthernet0/2
+  when: "'Cisco IOS' in show_version_result.stdout[0]"
+
+- name: Set test interface to GigabitEthernet2 if we are on Cisco IOS-XE
+  set_fact: test_interface=GigabitEthernet2
+  when: "'Cisco IOS-XE' in show_version_result.stdout[0]"
+
+- name: Set test interface 2 to GigabitEthernet3 if we are on Cisco IOS-XE
+  set_fact: test_interface2=GigabitEthernet3
+  when: "'Cisco IOS-XE' in show_version_result.stdout[0]"
+
 - name: Configure interface (setup)
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     description: test-interface-1
     speed: 10
     duplex: full
@@ -14,7 +36,7 @@
 
 - name: Confgure interface
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     description: test-interface-initial
     state: present
     authorize: yes
@@ -28,7 +50,7 @@
 
 - name: Confgure interface (idempotent)
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     description: test-interface-initial
     state: present
     authorize: yes
@@ -40,7 +62,7 @@
 
 - name: Confgure interface parameters
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     description: test-interface
     speed: 100
     mtu: 512
@@ -51,14 +73,14 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"description test-interface" in result.commands'
       - '"speed 100" in result.commands'
       - '"mtu 512" in result.commands'
 
 - name: Change interface parameters
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     description: test-interface-1
     speed: 10
     duplex: half
@@ -70,7 +92,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"description test-interface-1" in result.commands'
       - '"speed 10" in result.commands'
       - '"duplex half" in result.commands'
@@ -78,7 +100,7 @@
 
 - name: Disable interface
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     enabled: False
     authorize: yes
   register: result
@@ -86,12 +108,12 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"shutdown" in result.commands'
 
 - name: Enable interface
   ios_interface:
-    name: GigabitEthernet0/2
+    name: "{{ test_interface }}"
     enabled: True
     authorize: yes
   register: result
@@ -99,12 +121,12 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"no shutdown" in result.commands'
 
 - name: Confgure second interface (setup)
   ios_interface:
-    name: GigabitEthernet0/1
+    name: "{{ test_interface2 }}"
     description: test-interface-initial
     speed: 100
     duplex: half
@@ -116,8 +138,8 @@
 - name: Add interface aggregate
   ios_interface:
     aggregate:
-    - { name: GigabitEthernet0/1, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/2, mtu: 516, description: test-interface-2 }
+    - "{ name: {{ test_interface }}, mtu: 256, description: test-interface-1 }"
+    - "{ name: {{ test_interface2 }}, mtu: 516, description: test-interface-2 }"
     duplex: full
     speed: 100
     state: present
@@ -127,12 +149,12 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/1" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"speed 100" in result.commands'
       - '"description test-interface-1" in result.commands'
       - '"duplex full" in result.commands'
       - '"mtu 256" in result.commands'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface2 }}" in result.commands'
       - '"speed 100" in result.commands'
       - '"description test-interface-2" in result.commands'
       - '"duplex full" in result.commands'
@@ -141,8 +163,8 @@
 - name: Add interface aggregate (idempotent)
   ios_interface:
     aggregate:
-    - { name: GigabitEthernet0/1, mtu: 256, description: test-interface-1 }
-    - { name: GigabitEthernet0/2, mtu: 516, description: test-interface-2 }
+    - "{ name: {{ test_interface }}, mtu: 256, description: test-interface-1 }"
+    - "{ name: {{ test_interface2 }}, mtu: 516, description: test-interface-2 }"
     duplex: full
     speed: 100
     state: present
@@ -156,8 +178,8 @@
 - name: Disable interface aggregate
   ios_interface:
     aggregate:
-    - name: GigabitEthernet0/1
-    - name: GigabitEthernet0/2
+    - "name: {{ test_interface }}"
+    - "name: {{ test_interface2 }}"
     enabled: False
     state: present
     authorize: yes
@@ -166,16 +188,16 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/1" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"shutdown" in result.commands'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface2 }}" in result.commands'
       - '"shutdown" in result.commands'
 
 - name: Enable interface aggregate
   ios_interface:
     aggregate:
-    - name: GigabitEthernet0/1
-    - name: GigabitEthernet0/2
+    - "name: {{ test_interface }}"
+    - "name: {{ test_interface2 }}"
     enabled: True
     state: present
     authorize: yes
@@ -184,9 +206,9 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"interface GigabitEthernet0/1" in result.commands'
+      - '"interface {{ test_interface }}" in result.commands'
       - '"no shutdown" in result.commands'
-      - '"interface GigabitEthernet0/2" in result.commands'
+      - '"interface {{ test_interface2 }}" in result.commands'
       - '"no shutdown" in result.commands'
 
 - name: loopback interface setup


### PR DESCRIPTION
We run these tests on IOS and IOS-XE, which have different interfaces
available for performing tests.