### PR TITLE
iptables: chain creation and deletion

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -608,7 +608,7 @@ def main():
                         insert_rule(iptables_path, module, module.params)
                     else:
                         append_rule(iptables_path, module, module.params)
-                elif:
+                else:
                     insert = (module.params['action'] == 'insert')
                     rule_is_present = check_present(iptables_path, module, module.params)
                     should_be_present = (args['state'] == 'present')

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -41,7 +41,9 @@ options:
   state:
     description:
       - Whether the rule or chain should be absent or present.
-      - If absent, the chain is deleted only if the other other parameters used are chain and (optionally) table. If there are parameters other than these used, only the rule will be deleted.
+      - If absent, the chain is deleted only if the other parameters
+        used are chain and (optionally) table. If there are parameters
+        other than these used, only the rule will be deleted.
       - If present, the chain is created if it does not exist.
     choices: [ absent, present ]
     default: present


### PR DESCRIPTION
##### SUMMARY

This change adds the functionality of creating or deleting user-defined chains in iptables.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

modules/system/iptables

##### ANSIBLE VERSION

```
ansible 2.3.2.0
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION

The functionality is purposefully limited: chains must be deleted individually and cannot be deleted while deleting the last rule in the chain. However, new chains can be created while creating a new rule, not requiring separately creating the chain beforehand.