### PR TITLE
Avoid re.split as it's a bit less efficient and a bit harder to read.

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -91,7 +91,7 @@ def split_host_pattern(pattern):
     # If it's got commas in it, we'll treat it as a straightforward
     # comma-separated list of patterns.
     if ',' in pattern:
-        patterns = re.split('\s*,\s*', pattern)
+        patterns = pattern.split(',')
 
     # If it doesn't, it could still be a single pattern. This accounts for
     # non-separator uses of colons: IPv6 addresses and [x:y] host ranges.


### PR DESCRIPTION
##### SUMMARY
Minor change.  just avoids an re.split() as regexes are slower and harder to read than string functions.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```