### PR TITLE
Use sane mtu values on ios_interface tests

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/basic.yaml
@@ -28,7 +28,7 @@
     name: "{{ test_interface }}"
     description: test-interface-1
     speed: 1000
-    mtu: 256
+    mtu: 1500
     state: present
     authorize: yes
   register: result
@@ -63,7 +63,7 @@
   ios_interface:
     name: "{{ test_interface }}"
     description: test-interface
-    mtu: 512
+    mtu: 1600
     state: present
     authorize: yes
   register: result
@@ -73,13 +73,13 @@
       - 'result.changed == true'
       - '"interface {{ test_interface }}" in result.commands'
       - '"description test-interface" in result.commands'
-      - '"mtu 512" in result.commands'
+      - '"mtu 1600" in result.commands'
 
 - name: Change interface parameters
   ios_interface:
     name: "{{ test_interface }}"
     description: test-interface-1
-    mtu: 256
+    mtu: 1500
     state: present
     authorize: yes
   register: result
@@ -89,7 +89,7 @@
       - 'result.changed == true'
       - '"interface {{ test_interface }}" in result.commands'
       - '"description test-interface-1" in result.commands'
-      - '"mtu 256" in result.commands'
+      - '"mtu 1500" in result.commands'
 
 - name: Disable interface
   ios_interface:
@@ -122,7 +122,7 @@
     name: "{{ test_interface2 }}"
     description: test-interface-initial
     speed: 1000
-    mtu: 516
+    mtu: 1500
     state: present
     authorize: yes
   register: result
@@ -130,8 +130,8 @@
 - name: Add interface aggregate
   ios_interface:
     aggregate:
-    - "{ name: {{ test_interface }}, mtu: 256, description: test-interface-1 }"
-    - "{ name: {{ test_interface2 }}, mtu: 516, description: test-interface-2 }"
+    - { name: "{{ test_interface }}", mtu: 1500, description: test-interface-1 }
+    - { name: "{{ test_interface2 }}", mtu: 1600, description: test-interface-2 }
     speed: 1000
     state: present
     authorize: yes
@@ -142,16 +142,16 @@
       - 'result.changed == true'
       - '"interface {{ test_interface }}" in result.commands'
       - '"description test-interface-1" in result.commands'
-      - '"mtu 256" in result.commands'
+      - '"mtu 1500" in result.commands'
       - '"interface {{ test_interface2 }}" in result.commands'
       - '"description test-interface-2" in result.commands'
-      - '"mtu 516" in result.commands'
+      - '"mtu 1600" in result.commands'
 
 - name: Add interface aggregate (idempotent)
   ios_interface:
     aggregate:
-    - "{ name: {{ test_interface }}, mtu: 256, description: test-interface-1 }"
-    - "{ name: {{ test_interface2 }}, mtu: 516, description: test-interface-2 }"
+    - { name: "{{ test_interface }}", mtu: 1500, description: test-interface-1 }
+    - { name: "{{ test_interface2 }}", mtu: 1600, description: test-interface-2 }
     speed: 1000
     state: present
     authorize: yes


### PR DESCRIPTION
Anything lower than 1500 won't work on CSR nodes.