### PR TITLE
Add entire object lookup, allow skipping SSL verify when auth_method is used

### DIFF
--- a/lib/ansible/plugins/lookup/hashi_vault.py
+++ b/lib/ansible/plugins/lookup/hashi_vault.py
@@ -47,18 +47,24 @@ DOCUMENTATION = """
 """
 
 EXAMPLES = """
-- debug: msg="{{ lookup('hashi_vault', 'secret=secret/hello:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}"
+- debug:
+    msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}"
 
-- debug: msg="{{ lookup('hashi_vault', 'secret=secret/hello-object token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}"
+- name: Return all secrets from a path
+  debug:
+    msg: "{{ lookup('hashi_vault', 'secret=secret/hello token=c975b780-d1be-8016-866b-01d0f9b688a5 url=http://myvault:8200')}}"
 
-- name: Vault that requires authentication via ldap
-  debug: msg="{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=ldap mount_point=ldap username=myuser password=mypas url=http://myvault:8200')}}"
+- name: Vault that requires authentication via LDAP
+  debug:
+      msg: "{{ lookup('hashi_vault', 'secret=secret/hello:value auth_method=ldap mount_point=ldap username=myuser password=mypas url=http://myvault:8200')}}"
 
 - name: Using an ssl vault
-  debug: msg="{{ lookup('hashi_vault', 'secret=secret/hola:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=https://myvault:8200 validate_certs=False')}}"
+  debug:
+      msg: "{{ lookup('hashi_vault', 'secret=secret/hola:value token=c975b780-d1be-8016-866b-01d0f9b688a5 url=https://myvault:8200 validate_certs=False')}}"
 
 - name: using certificate auth
-  debug: msg="{{ lookup('hashi_vault', 'secret=secret/hi:value token=xxxx-xxx-xxx url=https://myvault:8200 validate_certs=True cacert=/cacert/path/ca.pem')}}"
+  debug:
+      msg: "{{ lookup('hashi_vault', 'secret=secret/hi:value token=xxxx-xxx-xxx url=https://myvault:8200 validate_certs=True cacert=/cacert/path/ca.pem')}}"
 """
 
 RETURN = """
@@ -102,10 +108,10 @@ class HashiVault:
         if len(s_f) >= 2:
             self.secret_field = s_f[1]
         else:
-            self.secret_field = 'ALL_OBJECT_ELEMENTS'
+            self.secret_field = ''
 
-        # if a particular backend is asked for (and its method exists) we call it, otherwise drop through to using
-        # token auth.   this means if a particular auth backend is requested and a token is also given, then we
+        # If a particular backend is asked for (and its method exists) we call it, otherwise drop through to using
+        # token auth. This means if a particular auth backend is requested and a token is also given, then we
         # ignore the token and attempt authentication against the specified backend.
         #
         # to enable a new auth backend, simply add a new 'def auth_<type>' method below.
@@ -145,7 +151,7 @@ class HashiVault:
         if data is None:
             raise AnsibleError("The secret %s doesn't seem to exist for hashi_vault lookup" % self.secret)
 
-        if self.secret_field == 'ALL_OBJECT_ELEMENTS':  # secret was specified without trailing ':'
+        if self.secret_field == '':
             return data['data']
 
         if self.secret_field not in data['data']:


### PR DESCRIPTION
Add ability to lookup entire objects in HashiCorp Vault.
When used with auth_method allow skipping SSL verify.

##### SUMMARY
Allows hashi_vault retrieve entire object from HashiCorp Vault
When auth_method is specified there was no way to disable SSL key verification.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hashi_vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel a9942353fe) last updated 2017/10/07 10:31:06 (GMT -400)
  config file = /ansible/app-name-here/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible-devel/lib/ansible
  executable location = /opt/ansible-devel/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
For my project it was essential to be able to get entire object (all key=value records)  from HC Vault and this feature was not working as expected. I also could not disable SSL key verification when hashi_vault was used with auth_method
Another small bug fix is that now auth_method=token does not return error.
