### PR TITLE
Remove bogus interface description

### DIFF
--- a/test/integration/targets/ios_interface/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_interface/tests/cli/basic.yaml
@@ -141,7 +141,6 @@
     that:
       - 'result.changed == true'
       - '"interface {{ test_interface }}" in result.commands'
-      - '"description test-interface-1" in result.commands'
       - '"mtu 1500" in result.commands'
       - '"interface {{ test_interface2 }}" in result.commands'
       - '"description test-interface-2" in result.commands'


### PR DESCRIPTION
The interface has already that description from a task earlier, thus that change
is not introduced susbequently and we don't have to assert for it.