### PR TITLE
(2.4 backport) Fix ec2_lc failing to create multi-volume configurations

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -254,7 +254,7 @@ def create_launch_config(connection, module):
     classic_link_vpc_id = module.params.get('classic_link_vpc_id')
     classic_link_vpc_security_groups = module.params.get('classic_link_vpc_security_groups')
 
-    block_device_mapping = {}
+    block_device_mapping = []
 
     convert_list = ['image_id', 'instance_type', 'instance_type', 'instance_id', 'placement_tenancy', 'key_name', 'kernel_id', 'ramdisk_id', 'spot_price']
 
@@ -273,7 +273,7 @@ def create_launch_config(connection, module):
                 module.fail_json(msg='Device name must be set for volume')
             # Minimum volume size is 1GB. We'll use volume size explicitly set to 0 to be a signal not to create this volume
             if 'volume_size' not in volume or int(volume['volume_size']) > 0:
-                block_device_mapping.update(create_block_device_meta(module, volume))
+                block_device_mapping.append(create_block_device_meta(module, volume))
 
     try:
         launch_configs = connection.describe_launch_configurations(LaunchConfigurationNames=[name]).get('LaunchConfigurations')
@@ -298,7 +298,7 @@ def create_launch_config(connection, module):
         launch_config['ClassicLinkVPCSecurityGroups'] = classic_link_vpc_security_groups
 
     if block_device_mapping:
-        launch_config['BlockDeviceMappings'] = [block_device_mapping]
+        launch_config['BlockDeviceMappings'] = block_device_mapping
 
     if instance_profile_name is not None:
         launch_config['IamInstanceProfile'] = instance_profile_name


### PR DESCRIPTION
##### SUMMARY
This pull request fixes an issue with ec2_lc where a configuration with multiple volumes would create a launch config with only one volume.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_lc

##### ANSIBLE VERSION

```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/chris/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
Backport of #32163