### PR TITLE
Resolve install warnings by setting zip_safe flag to False

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -220,5 +220,7 @@ setup(
         'bin/ansible-vault',
     ],
     data_files=[],
-    extras_require=extra_requirements
+    extras_require=extra_requirements,
+    # Installing as zip files would break due to references to __file__
+    zip_safe=False
 )


### PR DESCRIPTION
##### SUMMARY
The references to `__file__` within code base make the "zip_safe" method of installing not possible. This explicitly declares so in the setup() invocation.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
installer

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/alancoding/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /Users/alancoding/.virtualenvs/ansible/bin/ansible
  python version = 2.7.10 (default, Jul 13 2015, 12:05:58) [GCC 4.2.1 Compatible Apple LLVM 6.1.0 (clang-602.0.53)]
```


##### ADDITIONAL INFORMATION
In current `devel`, the following information is written to stderr:

```
python setup.py install > /dev/null 
no previously-included directories found matching 'ticket_stubs'
no previously-included directories found matching 'hacking'
zip_safe flag not set; analyzing archive contents...
ansible.cli.__init__: module references __file__
ansible.cli.__init__: module references __path__
ansible.config.manager: module references __file__
ansible.executor.module_common: module references __file__
ansible.galaxy.__init__: module references __file__
ansible.module_utils.basic: module references __file__
ansible.module_utils.gcp: module references __file__
ansible.module_utils.six.__init__: module references __path__
ansible.modules.cloud.amazon.ec2_elb_lb: module references __file__
ansible.modules.cloud.amazon.elb_classic_lb: module references __file__
ansible.modules.files.unarchive: module references __file__
ansible.modules.packaging.os.apt: module references __file__
ansible.modules.utilities.logic.async_wrapper: module references __file__
ansible.plugins.loader: module references __file__
ansible.plugins.callback.__init__: module references __file__
ansible.plugins.callback.osx_say: module references __file__
```

With this change, most of those warnings go away.

```
python setup.py install > /dev/null 
no previously-included directories found matching 'ticket_stubs'
no previously-included directories found matching 'hacking'
```

The warning messages about `__file__` are [because of the `zip_safe` flag](https://stackoverflow.com/a/10618900/1092940). If Ansible was installed in a zipped format, references to the current file will not work because multiple files are combined together.

You can see this if you force the zipped install method by setting the parameter to True. If you do that and then run an Ansible command, you will find that it fails.

```
ansible --version
Traceback (most recent call last):
  File "/Users/alancoding/.virtualenvs/ansible/bin/ansible", line 4, in <module>
    __import__('pkg_resources').run_script('ansible==2.5.0', 'ansible')
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/pkg_resources/__init__.py", line 742, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/pkg_resources/__init__.py", line 1510, in run_script
    exec(script_code, namespace, namespace)
  File "/Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/EGG-INFO/scripts/ansible", line 58, in <module>
    
  File "build/bdist.macosx-10.10-x86_64/egg/ansible/constants.py", line 104, in <module>
  File "build/bdist.macosx-10.10-x86_64/egg/ansible/config/manager.py", line 187, in __init__
ansible.errors.AnsibleError: Missing base configuration definition file (bad install?): /Users/alancoding/.virtualenvs/ansible/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible/config/base.yml
```