### PR TITLE
Update pamd.py to allow module path with slashes

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -200,6 +200,17 @@ EXAMPLES = """
     module_path: pam_faillock.so
     module_arguments: 'fail_interval=300'
     state: args_present
+
+- name: Add pam common-auth rule for duo
+  pamd:
+    name: common-auth
+    new_type: auth
+    new_control: '[success=1 default=ignore]'
+    new_module_path: '/lib64/security/pam_duo.so'
+    state: after
+    type: auth
+    module_path: pam_sss.so
+    control: 'requisite'
 """
 
 RETURN = '''
@@ -285,7 +296,7 @@ class PamdRule(object):
             pattern = re.compile(
                 r"""([\-A-Za-z0-9_]+)\s*         # Rule Type
                     \[([A-Za-z0-9_=\s]+)\]\s*    # Rule Control
-                    ([A-Za-z0-9_\-\.]+)\s*         # Rule Path
+                    ([A-Za-z0-9/_\-\.]+)\s*         # Rule Path
                     ([A-Za-z0-9,_=<>\-\s\./]*)""",  # Rule Args
                 re.X)
             complicated = True
@@ -293,7 +304,7 @@ class PamdRule(object):
             pattern = re.compile(
                 r"""([\-A-Za-z0-9_]+)\s*        # Rule Type
                     ([A-Za-z0-9_]+)\s*          # Rule Control
-                    ([A-Za-z0-9_\-\.]+)\s*        # Rule Path
+                    ([A-Za-z0-9/_\-\.]+)\s*        # Rule Path
                     ([A-Za-z0-9,_=<>\-\s\./]*)""",  # Rule Args
                 re.X)
 

--- a/test/units/modules/system/test_pamd.py
+++ b/test/units/modules/system/test_pamd.py
@@ -74,6 +74,20 @@ class PamdRuleTestCase(unittest.TestCase):
         module_string = re.sub(' +', ' ', str(module).replace('\t', ' '))
         self.assertEqual(rule, module_string.rstrip())
 
+    def test_slash_in_args(self):
+        rule = "auth sufficient /lib64/security/pam_duo.so".rstrip()
+        module = PamdRule.rulefromstring(stringline=rule)
+        module_string = re.sub(' +', ' ', str(module).replace('\t', ' '))
+        self.assertEqual(rule, module_string.rstrip())
+        self.assertEqual('', module.get_module_args_as_string())
+
+    def test_slash_in_args_more(self):
+        rule = "auth [success=1 default=ignore] /lib64/security/pam_duo.so".rstrip()
+        module = PamdRule.rulefromstring(stringline=rule)
+        module_string = re.sub(' +', ' ', str(module).replace('\t', ' '))
+        self.assertEqual(rule, module_string.rstrip())
+        self.assertEqual('', module.get_module_args_as_string())
+
 
 class PamdServiceTestCase(unittest.TestCase):
     def setUp(self):
@@ -141,6 +155,13 @@ session   \trequired\tpam_unix.so"""
     def test_update_rule_module_path(self):
         old_rule = PamdRule.rulefromstring('auth      	required	pam_env.so')
         new_rule = PamdRule.rulefromstring('session      	required	pam_limits.so')
+        update_rule(self.pamd, old_rule, new_rule)
+        self.assertIn(str(new_rule).rstrip(), str(self.pamd))
+        self.assertNotIn(str(old_rule).rstrip(), str(self.pamd))
+
+    def test_update_rule_module_path_slash(self):
+        old_rule = PamdRule.rulefromstring('auth      	required	pam_env.so')
+        new_rule = PamdRule.rulefromstring('auth      	required	/lib64/security/pam_duo.so')
         update_rule(self.pamd, old_rule, new_rule)
         self.assertIn(str(new_rule).rstrip(), str(self.pamd))
         self.assertNotIn(str(old_rule).rstrip(), str(self.pamd))


### PR DESCRIPTION
##### SUMMARY
When having a pam module that needs an explicit path with slashes, such as the DUO 2FA module located in `/lib64/security/` the regex match fails and the ansible task dies. This PR adds the forward slashes to the regex matches.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pamd

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Error message was as follows:
```
Using module file /usr/local/lib/python2.7/dist-packages/ansible/modules/system/pamd.py
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: root
<127.0.0.1> EXEC /bin/sh -c 'echo ~ && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759 `" && echo ansible-tmp-1509025573.18-138743905323759="` echo /root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759 `" ) && sleep 0'
<127.0.0.1> PUT /tmp/tmpf6pY6p TO /root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759/pamd.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759/ /root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759/pamd.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python /root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759/pamd.py; rm -rf "/root/.ansible/tmp/ansible-tmp-1509025573.18-138743905323759/" > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Att6gS/ansible_module_pamd.py", line 650, in <module>
    main()
  File "/tmp/ansible_Att6gS/ansible_module_pamd.py", line 605, in main
    pamd.load_rules_from_file()
  File "/tmp/ansible_Att6gS/ansible_module_pamd.py", line 327, in load_rules_from_file
    self.load_rules_from_string(stringline)
  File "/tmp/ansible_Att6gS/ansible_module_pamd.py", line 343, in load_rules_from_string
    self.rules.append(PamdRule.rulefromstring(stringline))
  File "/tmp/ansible_Att6gS/ansible_module_pamd.py", line 278, in rulefromstring
    rule_type = result.group(1)
AttributeError: 'NoneType' object has no attribute 'group'

fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_Att6gS/ansible_module_pamd.py\", line 650, in <module>\n    main()\n  File \"/tmp/ansible_Att6gS/ansible_module_pamd.py\", line 605, in main\n    pamd.load_rules_from_file()\n  File \"/tmp/ansible_Att6gS/ansible_module_pamd.py\", line 327, in load_rules_from_file\n    self.load_rules_from_string(stringline)\n  File \"/tmp/ansible_Att6gS/ansible_module_pamd.py\", line 343, in load_rules_from_string\n    self.rules.append(PamdRule.rulefromstring(stringline))\n  File \"/tmp/ansible_Att6gS/ansible_module_pamd.py\", line 278, in rulefromstring\n    rule_type = result.group(1)\nAttributeError: 'NoneType' object has no attribute 'group'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "rc": 0
}
```
