### PR TITLE
Fixes #32098 elb_target_group.py port not sent as int

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -459,7 +459,7 @@ def create_or_update_target_group(connection, module):
                     instances_to_add = []
                     for target in params['Targets']:
                         if target['Id'] in add_instances:
-                            instances_to_add.append(target)
+                            instances_to_add.append({'Id': target['Id'], 'Port': int(target['Port'])})
 
                     changed = True
                     try:


### PR DESCRIPTION
##### SUMMARY
Fixes issue #32098 where port is being submitted as string instead of as an integer to botocore validatation

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group.py

##### ANSIBLE VERSION
devel


##### ADDITIONAL INFORMATION
#32098 
