### PR TITLE
Add echo option to pause module

### DIFF
--- a/lib/ansible/modules/utilities/logic/pause.py
+++ b/lib/ansible/modules/utilities/logic/pause.py
@@ -40,6 +40,12 @@ options:
       - Optional text to use for the prompt message.
     required: false
     default: null
+  echo:
+    description:
+      - Contols whether or not keyboard input is shown when typing.
+    required: false
+    default: 'yes'
+    choices: ['yes', 'no']
 author: "Tim Bielawa (@tbielawa)"
 notes:
       - Starting in 2.2,  if you specify 0 or negative for minutes or seconds, it will wait for 1 second, previously it would wait indefinitely.
@@ -57,6 +63,11 @@ EXAMPLES = '''
 # A helpful reminder of what to look out for post-update.
 - pause:
     prompt: "Make sure org.foo.FooOverload exception is not present"
+
+# Do not echo output
+- pause:
+    prompt: "Enter a secret"
+    echo: no
 '''
 
 RETURN = '''
@@ -85,4 +96,9 @@ stdout:
   returned: always
   type: string
   sample: Paused for 0.04 minutes
+echo:
+  description: Value of echo setting
+  returned: always
+  type: bool
+  sample: true
 '''

--- a/lib/ansible/modules/utilities/logic/pause.py
+++ b/lib/ansible/modules/utilities/logic/pause.py
@@ -43,14 +43,16 @@ options:
   echo:
     description:
       - Contols whether or not keyboard input is shown when typing.
+      - Has no effect if 'seconds' or 'minutes' is set.
     required: false
     default: 'yes'
     choices: ['yes', 'no']
-    version_added: 2.4
+    version_added: 2.5
 author: "Tim Bielawa (@tbielawa)"
 notes:
       - Starting in 2.2,  if you specify 0 or negative for minutes or seconds, it will wait for 1 second, previously it would wait indefinitely.
       - This module is also supported for Windows targets.
+      - User input is not captured or echoed, regardless of echo setting, when minutes or seconds is specified.
 '''
 
 EXAMPLES = '''
@@ -65,7 +67,7 @@ EXAMPLES = '''
 - pause:
     prompt: "Make sure org.foo.FooOverload exception is not present"
 
-# Do not echo output
+# Pause to get some sensitive input.
 - pause:
     prompt: "Enter a secret"
     echo: no

--- a/lib/ansible/modules/utilities/logic/pause.py
+++ b/lib/ansible/modules/utilities/logic/pause.py
@@ -46,6 +46,7 @@ options:
     required: false
     default: 'yes'
     choices: ['yes', 'no']
+    version_added: 2.4
 author: "Tim Bielawa (@tbielawa)"
 notes:
       - Starting in 2.2,  if you specify 0 or negative for minutes or seconds, it will wait for 1 second, previously it would wait indefinitely.

--- a/lib/ansible/plugins/action/pause.py
+++ b/lib/ansible/plugins/action/pause.py
@@ -140,19 +140,10 @@ class ActionModule(ActionBase):
                     old_settings = termios.tcgetattr(fd)
                     tty.setraw(fd)
 
-                    # Enable a few things turned off by tty.setraw()
-                    # ICANON -> Allows characters to be deleted and hides things like ^M.
-                    # ICRNL -> Makes the return key work when ICANON is enabled, otherwise
-                    #          you get stuck at the prompt with no way to get out of it.
-                    # ECHO -> Echos input back to stdout
-                    #
-                    # See man termios for details on these flags
-                    if not seconds:
-                        new_settings = termios.tcgetattr(fd)
-                        new_settings[0] = new_settings[0] | termios.ICRNL
-                        new_settings[3] = new_settings[3] | (termios.ICANON | termios.ECHO)
-                        termios.tcsetattr(fd, termios.TCSANOW, new_settings)
-                        termios.tcsetattr(fd, termios.TCSANOW, new_settings)
+                    # Enable ECHO since tty.setraw() disables it
+                    new_settings = termios.tcgetattr(fd)
+                    new_settings[3] = new_settings[3] | termios.ECHO
+                    termios.tcsetattr(fd, termios.TCSANOW, new_settings)
 
                     # flush the buffer to make sure no previous key presses
                     # are read in below


### PR DESCRIPTION
##### SUMMARY

Add option to control whether or not output is echoed to pause module.
Change logic around options so they can be used in varying combinations.
Add input validation to options.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
`pause.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```

#### ADDITIONAL INFORMATION

This will have a conflict with `devel` after the bugfix for returning echo is merged. I'll rebase once that is merged.
