### PR TITLE
Changing regex for ansible_net_model fact in ios_facts.py

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -194,7 +194,7 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_model(self, data):
-        match = re.search(r'^Cisco (.+) \(revision', data, re.M)
+        match = re.search(r'^[cC]isco\s+(?P<product>\S+).+?with .+? bytes of.+?memory', data, re.M)
         if match:
             return match.group(1)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Could you please review changed regex for ansible_net_model. Previous regex was showing "null" output almost everytime

Fixes #19615 
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_facts module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/']
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
New regex was tested on different IOS systems, such as Denali, IOS12,IOS15,IOS-XE and different platforms including 6509E,4500x, 4507R, ISR4451x and ASR1K as well.

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before, pay attention to ansible_net_model output
```
Using /etc/ansible/ansible.cfg as config file

PLAYBOOK: test2.yaml ******************************************************************************************************************************************
1 plays in test2.yaml

PLAY [Get_Cisco_Inventory_Data] *******************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************
ok: [lgb-rtcore]
META: ran handlers

TASK [Facts] **************************************************************************************************************************************************
task path: /opt/NetAutomation/ansible/cisco/test2.yaml:16
ok: [lgb-rtcore] => {"ansible_facts": {"ansible_net_gather_subset": ["default"], "ansible_net_hostname": "lgb-rtcore-a", "ansible_net_image": "bootflash:cat4500-entservicesk9-mz.150-2.SG11.bin", "ansible_net_model": null, "ansible_net_serialnum": "FOX094202Z5", "ansible_net_version": "15.0(2)SG11"}, "changed": false}
META: ran handlers
META: ran handlers

PLAY RECAP ****************************************************************************************************************************************************
lgb-rtcore                 : ok=2    changed=0    unreachable=0    failed=0   

```
After

```
Using /etc/ansible/ansible.cfg as config file

PLAYBOOK: test2.yaml ******************************************************************************************************************************************
1 plays in test2.yaml

PLAY [Get_Cisco_Inventory_Data] *******************************************************************************************************************************

TASK [Gathering Facts] ****************************************************************************************************************************************
ok: [lgb-rtcore]
META: ran handlers

TASK [Facts] **************************************************************************************************************************************************
task path: /opt/NetAutomation/ansible/cisco/test2.yaml:16
ok: [lgb-rtcore] => {"ansible_facts": {"ansible_net_gather_subset": ["default"], "ansible_net_hostname": "lgb-rtcore-a", "ansible_net_image": "bootflash:cat4500-entservicesk9-mz.150-2.SG11.bin", "ansible_net_model": "WS-C4507R", "ansible_net_serialnum": "FOX094202Z5", "ansible_net_version": "15.0(2)SG11"}, "changed": false}
META: ran handlers
META: ran handlers

PLAY RECAP ****************************************************************************************************************************************************
lgb-rtcore                 : ok=2    changed=0    unreachable=0    failed=0   
```
