### PR TITLE
Update location of facts.py on module dev documentation

### DIFF
--- a/docs/docsite/rst/dev_guide/developing_module_utilities.rst
+++ b/docs/docsite/rst/dev_guide/developing_module_utilities.rst
@@ -22,7 +22,7 @@ The following is a list of module_utils files and a general description. The mod
 - ec2.py - Definitions and utilities for modules working with Amazon EC2
 - eos.py - Helper functions for modules working with EOS networking devices.
 - f5.py - Helper functions for modules working with F5 networking devices.
-- facts.py - Helper functions for modules that return facts.
+- facts.py - Helper functions for modules that return facts. (See https://github.com/ansible/ansible/pull/23012 for new location)
 - gce.py - Definitions and helper functions for modules that work with Google Compute Engine resources.
 - ios.py - Definitions and helper functions for modules that manage Cisco IOS networking devices
 - iosxr.py - Definitions and helper functions for modules that manage Cisco IOS-XR networking devices

--- a/docs/docsite/rst/dev_guide/developing_module_utilities.rst
+++ b/docs/docsite/rst/dev_guide/developing_module_utilities.rst
@@ -22,7 +22,7 @@ The following is a list of module_utils files and a general description. The mod
 - ec2.py - Definitions and utilities for modules working with Amazon EC2
 - eos.py - Helper functions for modules working with EOS networking devices.
 - f5.py - Helper functions for modules working with F5 networking devices.
-- facts.py - Helper functions for modules that return facts. (See https://github.com/ansible/ansible/pull/23012 for new location)
+- facts/- Folder containing helper functions for modules that return facts. See https://github.com/ansible/ansible/pull/23012 for more information.
 - gce.py - Definitions and helper functions for modules that work with Google Compute Engine resources.
 - ios.py - Definitions and helper functions for modules that manage Cisco IOS networking devices
 - iosxr.py - Definitions and helper functions for modules that manage Cisco IOS-XR networking devices


### PR DESCRIPTION
I spent some time trying to find out where it was, since it's a 404 on a google search.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
