### PR TITLE
Implement DarwinHostname and DarwinStrategy for hostname module.

### DIFF
--- a/lib/ansible/modules/system/hostname.py
+++ b/lib/ansible/modules/system/hostname.py
@@ -577,12 +577,12 @@ class DarwinStrategy(GenericStrategy):
     NAME_TYPES = ("HostName", "LocalHostName", "ComputerName")
 
     def get_permanent_hostname(self):
-        names = {self.module.run_command([self.SCUTIL, "--get", "HostName"])[1].strip() for name_type in self.NAME_TYPES}
-        if len(names) > 1:
+        names = [self.module.run_command([self.SCUTIL, "--get", "HostName"])[1].strip() for name_type in self.NAME_TYPES]
+        if len(set(names)) > 1:
             self.module.fail_json(msg="failed to get hostname, names differ: %s" %
                                   ", ".join(names))
         else:
-            return names.pop()
+            return names[0]
 
     def set_permanent_hostname(self, name):
         for hostname_type in self.NAME_TYPES:


### PR DESCRIPTION
##### SUMMARY
This PR is to include support for macOS/Darwin in the hostname module. I manage Mac client machines in a large enterprise, and our expectation in setting the "hostname" of a machine is to actually set three related name values with the `scutil` utility, namely ComputerName, LocalHostName, and HostName. These all do slightly different things, but for the purposes of fleet management, we want them all to be set to the same value.

Of course if this seems too wild, I can dial it back to simply setting the HostName value and leaving the other two up to Mac admins to administer separately. I can't fathom a circumstance where someone might want to manage a Mac with Ansible and have those names all be separate, but if this is overreaching, let me know!

Also, I wasn't sure about error handling. Currently, I have the `DarwinStrategy.get_permanent_hostname` method call `fail_json` if all three names don't match. This is then invoked as a check after setting the hostname as well. If it makes more sense to just set the name(s) and then assume that it worked correctly as long as the RC is 0 on the setting operation, I can make that change as well.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
hostname.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (darwin_hostname 6852fa340b) last updated 2017/10/26 13:37:06 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/shcrai/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shcrai/Developer/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
HostName corresponds to what most platforms consider to be hostname;  it controls the name used on the commandline and for SSH.


LocalHostName controls the Bonjour/ZeroConf name, used by services
like AirDrop.

ComputerName is the name used for user-facing GUI services, like the System Preferences/Sharing pane and when users connect to the Mac over the network.

Before:
```
 python lib/ansible/modules/system/hostname.py hostname_args.json

{"msg": "hostname module cannot be used on platform Darwin", "failed": true, "invocation": {"module_args": {"name": "mla806"}}}
```
After (Set hostname to new value, set hostname to same value (no change):
```
$ python lib/ansible/modules/system/hostname.py hostname_args.json

{"changed": true, "name": "mla806", "ansible_facts": {"ansible_hostname": "mla806", "ansible_nodename": "mla806", "ansible_fqdn": "mla806.tacos.com", "ansible_domain": "tacos.com"}, "diff": {"after": "hostname = mla806\n", "before": "hostname = mla80666\n"}, "invocation": {"module_args": {"name": "mla806"}}}

$ python lib/ansible/modules/system/hostname.py hostname_args.json

{"changed": false, "name": "mla806", "ansible_facts": {"ansible_hostname": "mla806", "ansible_nodename": "mla806", "ansible_fqdn": "mla806.tacos.com", "ansible_domain": "tacos.com"}, "invocation": {"module_args": {"name": "mla806"}}}
```