### PR TITLE
Fix password leak in logs for provider argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,7 @@ Ansible Changes By Release
 * Include_role now complains about invalid arguments
 * Added socket conditions to ignore for wait_for, no need to error for closing already closed connection
 * Updated hostname module to work on newer RHEL7 releases
-
+* Security fix to avoid provider password leaking in logs for network modules
 
 <a id="2.3.2"></a>
 

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -64,6 +64,10 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -64,9 +64,9 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
-        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
+        provider.pop('auth_pass', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -60,6 +60,10 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -60,9 +60,9 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
-        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
+        provider.pop('auth_pass', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -64,6 +64,10 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/dellos9.py
+++ b/lib/ansible/plugins/action/dellos9.py
@@ -64,9 +64,9 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
-        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
+        provider.pop('auth_pass', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -65,9 +65,9 @@ class ActionModule(_ActionModule):
             pc.become = provider['authorize'] or False
             pc.become_pass = provider['auth_pass']
 
-            # mask no_log provider arguments
-            provider['password'] = '********' if provider['password'] else None
-            provider['auth_pass'] = '********' if provider['auth_pass'] else None
+            # remove auth from provider arguments
+            provider.pop('password', None)
+            provider.pop('auth_pass', None)
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
@@ -119,13 +119,14 @@ class ActionModule(_ActionModule):
             if provider.get('validate_certs') is None:
                 provider['validate_certs'] = ARGS_DEFAULT_VALUE['validate_certs']
 
+            # copy auth to top level module arguments to correctly handle `no_log`.
             if self._task.args.get('password') is None:
                 self._task.args['password'] = provider['password'] or self._play_context.password
 
+            # remove auth from provider arguments
             provider.pop('password', None)
 
             self._task.args['provider'] = provider
-
         result = super(ActionModule, self).run(tmp, task_vars)
 
         return result

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -62,9 +62,9 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
-        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
+        provider.pop('auth_pass', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -62,6 +62,10 @@ class ActionModule(_ActionModule):
         pc.become = provider['authorize'] or False
         pc.become_pass = provider['auth_pass']
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+        provider['auth_pass'] = '********' if provider['auth_pass'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -60,6 +60,9 @@ class ActionModule(_ActionModule):
         pc.password = provider['password'] or self._play_context.password
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -60,8 +60,8 @@ class ActionModule(_ActionModule):
         pc.password = provider['password'] or self._play_context.password
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -71,6 +71,9 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/junos.py
+++ b/lib/ansible/plugins/action/junos.py
@@ -71,8 +71,8 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -63,8 +63,8 @@ class ActionModule(_ActionModule):
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
             pc.timeout = provider['timeout'] or self._play_context.timeout
 
-            # mask no_log provider arguments
-            provider['password'] = '********' if provider['password'] else None
+            # remove auth from provider arguments
+            provider.pop('password', None)
 
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
@@ -108,9 +108,11 @@ class ActionModule(_ActionModule):
             if provider.get('username') is None:
                 provider['username'] = self._play_context.connection_user
 
+            # copy auth to top level module arguments to correctly handle `no_log`.
             if self._task.args.get('password') is None:
                 self._task.args['password'] = provider['password'] or self._play_context.password
 
+            # remove auth from provider arguments
             provider.pop('password', None)
 
             if provider.get('use_ssl') is None:

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -63,6 +63,9 @@ class ActionModule(_ActionModule):
             pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
             pc.timeout = provider['timeout'] or self._play_context.timeout
 
+            # mask no_log provider arguments
+            provider['password'] = '********' if provider['password'] else None
+
             display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
             connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 
@@ -105,8 +108,10 @@ class ActionModule(_ActionModule):
             if provider.get('username') is None:
                 provider['username'] = self._play_context.connection_user
 
-            if provider.get('password') is None:
-                provider['password'] = self._play_context.password
+            if self._task.args.get('password') is None:
+                self._task.args['password'] = provider['password'] or self._play_context.password
+
+            provider.pop('password', None)
 
             if provider.get('use_ssl') is None:
                 provider['use_ssl'] = False

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -61,8 +61,8 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/sros.py
+++ b/lib/ansible/plugins/action/sros.py
@@ -61,6 +61,9 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -59,8 +59,8 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
-        # mask no_log provider arguments
-        provider['password'] = '********' if provider['password'] else None
+        # remove auth from provider arguments
+        provider.pop('password', None)
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)

--- a/lib/ansible/plugins/action/vyos.py
+++ b/lib/ansible/plugins/action/vyos.py
@@ -59,6 +59,9 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = provider['timeout'] or self._play_context.timeout
 
+        # mask no_log provider arguments
+        provider['password'] = '********' if provider['password'] else None
+
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
         connection = self._shared_loader_obj.connection_loader.get('persistent', pc, sys.stdin)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #31906
Fixes #28724

Since provider argument is not validated against a spec
the `no_log` arguments are not handled leading to password
leaking to syslogs.

To fix this:
*  Remove password and other `no_log` provider arguments in action plugin
*  In case of `eapi` and `nxapi` as the password is used in module code,
    copy the provider password to top-level password argument which
    handles `no_log` correctly. This will, however, throw a deprecation
    warning message for password arg even if it is not given as a
    top-level argument.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/action/dellos10.py
plugins/action/dellos6.py
plugins/action/dellos9.py
plugins/action/eos.py
plugins/action/ios.py
plugins/action/iosxr.py
plugins/action/junos.py
plugins/action/nxos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
*  **For `cli` transport:**
Playbook:
```
---
- name: Fetch interface details
  hosts: vsrx1
  connection: local
  gather_facts: no
  tasks:
    - name: test
      junos_command:
          provider:
            username: root
            password: password
            host: vsrx1
          rpcs:
          - get-interface-information interface-name=em0
      register: response
```
**Before Change:**
Playbook run output:
```
$ ansible-playbook ~/targets/junos_command.yml -i hosts

PLAY [ Fetch interface details] **********************************************************************************************************************************************************

TASK [test] **********************************************************************************************************************************************************************************
ok: [vsrx1]

PLAY RECAP ***********************************************************************************************************************************************************************************
vsrx1                : ok=1    changed=0    unreachable=0    failed=0

```
Entry in syslog:
```
Oct 26 12:52:59 user ansible-junos_command: Invoked with username=None retries=10 commands=['show version'] ssh_keyfile=None rpcs=None password=NOT_LOGGING_PARAMETER interval=1 display=None host=None match=all timeout=None provider={'username': 'root', 'ssh_keyfile': None, 'host': 'vsrx1', 'timeout': None, 'password': 'password', 'port': None, 'transport': None} wait_for=None port=None transport=None
```
**After Change:**
Playbook run output:
```
$ ansible-playbook ~/targets/junos_command.yml -i hosts

PLAY [ Fetch interface details] **********************************************************************************************************************************************************

TASK [test] **********************************************************************************************************************************************************************************
ok: [vsrx1]

PLAY RECAP ***********************************************************************************************************************************************************************************
vsrx1               : ok=1    changed=0    unreachable=0    failed=0
```
Entry in syslog:
```
Oct 26 12:56:42 user ansible-junos_command: Invoked with username=None retries=10 commands=['show version'] ssh_keyfile=None rpcs=None password=NOT_LOGGING_PARAMETER interval=1 display=None host=None match=all timeout=None provider={'username': 'root', 'ssh_keyfile': None, 'host': 'vsrx1', 'timeout': None, 'port': None, 'transport': None} wait_for=None port=None transport=None
```

*  **For eos `eapi` transport:**
Playbook:
```
---
- name: Fetch facts
  hosts: veos1
  connection: local
  tasks:
    - name: Config Using Core Module
      eos_facts:
        authorize: yes
        provider:
          host: veos1
          timeout: 60
          transport: eapi
          use_ssl: False
          username: root
          password: password
      register: response
```
**Before Change:**
Playbook output run:
```
$ ansible-playbook ~/targets/eos_facts.yml -i hosts

PLAY [Fetch facts] **********************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [veos1]

TASK [Fetch facts] **************************************************************************************************************************************************************
 
ok: [veos1]

PLAY RECAP ***********************************************************************************************************************************************************************************
veos1                     : ok=2    changed=0    unreachable=0    failed=0
```
Entry in syslog:
```
Oct 26 10:53:09 user ansible-eos_facts: Invoked with authorize=True username=None ssh_keyfile=None auth_pass=NOT_LOGGING_PARAMETER host=None gather_subset=['all'] timeout=None provider={'username': 'admin', 'authorize': True, 'ssh_keyfile': None, 'auth_pass': None, 'host': 'veos1', 'timeout': 60, 'use_ssl': False, 'password': 'passwrod', 'validate_certs': True, 'port': 80, 'transport': 'eapi'} use_ssl=None password=NOT_LOGGING_PARAMETER validate_certs=None port=None transport=None
```

**After Change:**
Playbook run output
```
$ ansible-playbook ~/targets/eos_facts.yml -i hosts

PLAY [Fetch facts] **********************************************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************************************************************
ok: [veos1]

TASK [Fetch facts] **************************************************************************************************************************************************************
 [WARNING]: argument password has been deprecated and will be removed in a future version

ok: [veos1]

PLAY RECAP ***********************************************************************************************************************************************************************************
veos1                     : ok=2    changed=0    unreachable=0    failed=0
```
Entry in syslog
```
Oct 26 12:40:48 user ansible-eos_facts: Invoked with authorize=True username=None ssh_keyfile=None auth_pass=NOT_LOGGING_PARAMETER host=None gather_subset=['all'] timeout=None provider={'username': '********', 'authorize': True, 'ssh_keyfile': None, 'auth_pass': None, 'host': 'veos1', 'timeout': 60, 'use_ssl': False, 'validate_certs': True, 'port': 80, 'transport': 'eapi'} use_ssl=None password=NOT_LOGGING_PARAMETER validate_certs=None port=None transport=None
```