### PR TITLE
ec2_vpc_subnet: Set az to an empty string if it's None to avoid traceback

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py
@@ -124,6 +124,9 @@ def subnet_exists(conn, subnet_id):
 
 def create_subnet(conn, module, vpc_id, cidr, az, check_mode):
     try:
+        # Specifying the availability zone is optional.
+        if not az:
+            az = ''
         new_subnet = get_subnet_info(conn.create_subnet(VpcId=vpc_id, CidrBlock=cidr, AvailabilityZone=az))
         # Sometimes AWS takes its time to create a subnet and so using
         # new subnets's id to do things like create tags results in


### PR DESCRIPTION
##### SUMMARY
Backport fix for #31905. Boto3's create_subnet expects AZ to be an empty string if it doesn't exist rather than None. An availability zone will be selected if one isn't requested. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_subnet.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0 (2.4ec2_vpc_subnet_az 13e01b9b23) last updated 2017/10/26 14:13:41 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = ['/Users/shertel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 3.5.2 (default, Oct 11 2016, 04:59:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```