### PR TITLE
Keep newlines when reading LXC container config file

### DIFF
--- a/lib/ansible/modules/cloud/lxc/lxc_container.py
+++ b/lib/ansible/modules/cloud/lxc/lxc_container.py
@@ -723,7 +723,7 @@ class LxcContainerManagement(object):
 
         container_config_file = self.container.config_file_name
         with open(container_config_file, 'rb') as f:
-            container_config = to_text(f.read(), errors='surrogate_or_strict').splitlines()
+            container_config = to_text(f.read(), errors='surrogate_or_strict').splitlines(True)
 
         # Note used ast literal_eval because AnsibleModule does not provide for
         # adequate dictionary parsing.


### PR DESCRIPTION
##### SUMMARY

This fixes a regression in #30572 where newlines are stripped on the creation of LXC containers when the `container_config` parameter is defined, preventing LXC containers from starting.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

modules/cloud/lxc/lxc_container.py

##### ANSIBLE VERSION
```
$ ansible --version
ansible 2.4.1.0
  config file = /home/lae/ansible-role-travis-lxc/ansible.cfg
  configured module search path = [u'/home/lae/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lae/travis/local/lib/python2.7/site-packages/ansible
  executable location = /home/lae/travis/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION

See this comment: https://github.com/lae/ansible-role-travis-lxc/issues/10#issuecomment-339786164