### PR TITLE
Add some --no-* options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ansible Changes By Release
 * boundary_meter: There was no deprecation period for this but the hosted
   service it relied on has gone away so the module has been removed.
   https://github.com/ansible/ansible/issues/29387
+* Added `--no-ask-vault-pass`, `--no-become`, `--no-ask-become-pass` command line options
 
 ### New Plugins
 

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -342,7 +342,7 @@ class CLI(with_metaclass(ABCMeta, object)):
 
     def normalize_become_options(self):
         ''' this keeps backwards compatibility with sudo/su self.options '''
-        self.options.become_ask_pass = self.options.become_ask_pass or self.options.ask_sudo_pass or self.options.ask_su_pass or C.DEFAULT_BECOME_ASK_PASS
+        self.options.become_ask_pass = self.options.become_ask_pass or self.options.ask_sudo_pass or self.options.ask_su_pass
         self.options.become_user = self.options.become_user or self.options.sudo_user or self.options.su_user or C.DEFAULT_BECOME_USER
 
         def _dep(which):
@@ -444,6 +444,8 @@ class CLI(with_metaclass(ABCMeta, object)):
         if vault_opts:
             parser.add_option('--ask-vault-pass', default=C.DEFAULT_ASK_VAULT_PASS, dest='ask_vault_pass', action='store_true',
                               help='ask for vault password')
+            parser.add_option('--no-ask-vault-pass', dest='ask_vault_pass', action='store_false',
+                              help='do not ask for vault password')
             parser.add_option('--vault-password-file', default=[], dest='vault_password_files',
                               help="vault password file", action="callback", callback=CLI.unfrack_paths, type='string')
             parser.add_option('--new-vault-password-file', default=[], dest='new_vault_password_files',
@@ -505,6 +507,8 @@ class CLI(with_metaclass(ABCMeta, object)):
             # consolidated privilege escalation (become)
             runas_group.add_option("-b", "--become", default=C.DEFAULT_BECOME, action="store_true", dest='become',
                                    help="run operations with become (does not imply password prompting)")
+            runas_group.add_option("--no-become", action="store_false", dest='become',
+                                   help="run operations without become")
             runas_group.add_option('--become-method', dest='become_method', default=C.DEFAULT_BECOME_METHOD, type='choice', choices=C.BECOME_METHODS,
                                    help="privilege escalation method to use (default=%s), valid choices: [ %s ]" %
                                    (C.DEFAULT_BECOME_METHOD, ' | '.join(C.BECOME_METHODS)))
@@ -518,8 +522,10 @@ class CLI(with_metaclass(ABCMeta, object)):
                                    help='ask for sudo password (deprecated, use become)')
             runas_group.add_option('--ask-su-pass', default=C.DEFAULT_ASK_SU_PASS, dest='ask_su_pass', action='store_true',
                                    help='ask for su password (deprecated, use become)')
-            runas_group.add_option('-K', '--ask-become-pass', default=False, dest='become_ask_pass', action='store_true',
+            runas_group.add_option('-K', '--ask-become-pass', default=C.DEFAULT_BECOME_ASK_PASS, dest='become_ask_pass', action='store_true',
                                    help='ask for privilege escalation password')
+            runas_group.add_option('--no-ask-become-pass', dest='become_ask_pass', action='store_false',
+                                   help='do not ask for privilege escalation password')
 
         if runas_group:
             parser.add_option_group(runas_group)


### PR DESCRIPTION
##### SUMMARY

There are some defaults that can be set in `ansible.cfg` that cannot be
currently undone with command line options. This commit adds
`--no-ask-vault-pass`, `--no-become`, `--no-ask-become-pass` allowing
the corresponding `ansible.cfg` options to be overridden.

Fixes #14150
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.4.0.0
  config file = /Users/dlee/.ansible.cfg
  configured module search path = [u'/Users/dlee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.0.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
