### PR TITLE
Improve ios_logging log host deletion

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -148,7 +148,7 @@ def map_obj_to_commands(updates, module):
 
         if state == 'absent' and w in have:
             if dest == 'host':
-                commands.append('no logging host {}'.format(name))
+                commands.append('no logging host {} transport udp port 514'.format(name))
             elif dest:
                 commands.append('no logging {}'.format(dest))
             else:

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -59,7 +59,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - '"no logging host 172.16.0.1" in result.commands'
+      - '"no logging host 172.16.0.1 transport udp port 514" in result.commands'
 
 - name: Delete/disable host logging (idempotent)
   ios_logging:


### PR DESCRIPTION
By explicitely stating the implicit transport configuration for a log host, in
some cases unintended configuration changes can be avoided. Since in its current
state, the module only configures the log host using default transport
configuration, this should be a viable solution for the time being.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The way ios_logging currently deletes logging host commands clashes with IOS behaviour such that more configuration is deleted than intended.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/paul/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This change is motivated by the following IOS behaviour:
```
csr-test1#show run | sec logging
logging host 1.2.3.4 vrf test-vrf
logging host 1.2.3.4
! There are two logging hosts with the same IP configured, albeit in different VRFs
csr-test1#conf t
csr-test1(config)#no logging host 1.2.3.4
csr-test1(config)#end
csr-test1#show run | sec loggin
! Both logging host are deleted at this point, although the one with the VRF should still be there
csr-test1#conf t
csr-test1(config)#logging host 1.2.3.4 vrf test-vrf
csr-test1(config)#logging host 1.2.3.4
csr-test1(config)#no logging host 1.2.3.4 transport udp port 514
csr-test1#show run | sec logging
logging host 1.2.3.4 vrf test-vrf
! Only the logging host without any VRF definition is deleted
```
Tested on
```
Cisco IOS XE Software, Version 16.03.04
Cisco IOS Software [Denali], CSR1000V Software (X86_64_LINUX_IOSD-UNIVERSALK9-M), Version 16.3.4, RELEASE SOFTWARE (fc3)
```