### PR TITLE
Allow health_check_port to be a string

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -32,6 +32,7 @@ options:
   health_check_port:
     description:
       - The port the load balancer uses when performing health checks on targets.
+        Can be set to 'traffic-port' to match target port.
     required: false
     default: "The port on which each target receives traffic from the load balancer."
   health_check_path:
@@ -360,7 +361,7 @@ def create_or_update_target_group(connection, module):
             params['HealthCheckProtocol'] = module.params.get("health_check_protocol").upper()
 
         if module.params.get("health_check_port") is not None:
-            params['HealthCheckPort'] = str(module.params.get("health_check_port"))
+            params['HealthCheckPort'] = module.params.get("health_check_port")
 
         if module.params.get("health_check_interval") is not None:
             params['HealthCheckIntervalSeconds'] = module.params.get("health_check_interval")
@@ -622,7 +623,7 @@ def main():
         dict(
             deregistration_delay_timeout=dict(type='int'),
             health_check_protocol=dict(choices=['http', 'https', 'tcp', 'HTTP', 'HTTPS', 'TCP'], type='str'),
-            health_check_port=dict(type='int'),
+            health_check_port=dict(),
             health_check_path=dict(default=None, type='str'),
             health_check_interval=dict(type='int'),
             health_check_timeout=dict(type='int'),


### PR DESCRIPTION
##### SUMMARY

Setting health_check_port to 'traffic-port' allows the health
check to use the target's traffic port. This needs a minor change
to the argument spec. Needed for changing an existing health_check_port
to 'traffic-port' (not setting health_check_port when creating a new
TG would have similar effect, I think)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel d088b7ab93) last updated 2017/10/27 14:17:48 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```