### PR TITLE
Remove ip nameservers on ios_system/set_name_servers teardown

### DIFF
--- a/test/integration/targets/ios_system/tests/cli/set_name_servers.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_name_servers.yaml
@@ -84,7 +84,7 @@
 - name: teardown
   ios_config:
     lines:
-      - no ip domain lookup source-interface
+      - no ip name-server
     match: none
     authorize: yes
 


### PR DESCRIPTION
Not sure why lookup source-interface, the only thing tested on that
file is adding/removing name servers, no lookup is set.