### PR TITLE
Add yaml output plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Ansible Changes By Release
 ## Lookups
 * Added `aws_ssm` lookup plugin
 * config, allows querying Ansible settings
+* Added `yaml` output plugin
 
 ### New Modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,9 +35,10 @@ Ansible Changes By Release
 ## Lookups
 * Added `aws_ssm` lookup plugin
 * config, allows querying Ansible settings
-* Added `yaml` output plugin
 
 ### New Modules
+
+* Added `yaml` output plugin
 
 #### Cloud
 

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -113,7 +113,7 @@ class CallbackModule(Default):
 
         if abridged_result:
             dumped += '\n'
-            dumped += yaml.dump(json.loads(json.dumps(abridged_result, ensure_ascii=False)), width=1000, Dumper=AnsibleDumper, default_flow_style=False)
+            dumped += yaml.dump(abridged_result, width=1000, Dumper=AnsibleDumper, default_flow_style=False)
 
         # indent by a couple of spaces
         dumped = '\n  '.join(dumped.split('\n')).rstrip()

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -1,0 +1,118 @@
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    callback: yaml
+    type: stdout
+    short_description: yaml-ized Ansible screen output
+    version_added: 2.5
+    description:
+        - Ansible output that can be quite a bit easier to read than the 
+          default JSON formatting.
+    extends_documentation_fragment:
+      - default_callback
+    requirements:
+      - set as stdout in configuration
+'''
+
+import yaml
+import json
+import re
+import string
+import sys
+from ansible.plugins.callback import CallbackBase, strip_internal_keys
+from ansible.plugins.callback.default import CallbackModule as Default
+
+
+# from http://stackoverflow.com/a/15423007/115478
+def should_use_block(value):
+    """Returns true if string should be in block format"""
+    for c in u"\u000a\u000d\u001c\u001d\u001e\u0085\u2028\u2029":
+        if c in value:
+            return True
+    return False
+
+
+def my_represent_scalar(self, tag, value, style=None):
+    """Uses block style for multi-line strings"""
+    if style is None:
+        if should_use_block(value):
+            style = '|'
+            # we care more about readable than accuracy, so...
+            # ...no trailing space
+            value = value.rstrip()
+            # ...and non-printable characters
+            value = filter(lambda x: x in string.printable, value)
+            # ...tabs prevent blocks from expanding
+            value = value.expandtabs()
+            # ...and odd bits of whitespace
+            value = re.sub(r'[\x0b\x0c\r]', '', value)
+            # ...as does trailing space
+            value = re.sub(r' +\n', '\n', value)
+        else:
+            style = self.default_style
+    node = yaml.representer.ScalarNode(tag, value, style=style)
+    if self.alias_key is not None:
+        self.represented_objects[self.alias_key] = node
+    return node
+
+
+yaml.representer.BaseRepresenter.represent_scalar = my_represent_scalar
+
+
+class CallbackModule(Default):
+
+    """
+    Variation of the Default output which uses nicely readable YAML instead
+    of JSON for printing results.
+    """
+
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'stdout'
+    CALLBACK_NAME = 'yaml'
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+
+    def _dump_results(self, result, indent=None, sort_keys=True, keep_invocation=False):
+        if result.get('_ansible_no_log', False):
+            return json.dumps(dict(censored="the output has been hidden due to the fact that 'no_log: true' was specified for this result"))
+
+        # All result keys stating with _ansible_ are internal, so remove them from the result before we output anything.
+        abridged_result = strip_internal_keys(result)
+
+        # remove invocation unless specifically wanting it
+        if not keep_invocation and self._display.verbosity < 3 and 'invocation' in result:
+            del abridged_result['invocation']
+
+        # remove diff information from screen output
+        if self._display.verbosity < 3 and 'diff' in result:
+            del abridged_result['diff']
+
+        # remove exception from screen output
+        if 'exception' in abridged_result:
+            del abridged_result['exception']
+
+        dumped = ''
+
+        # put changed and skipped into a header line
+        if 'changed' in abridged_result:
+            dumped += 'changed=' + str(abridged_result['changed']).lower() + ' '
+            del abridged_result['changed']
+
+        if 'skipped' in abridged_result:
+            dumped += 'skipped=' + str(abridged_result['skipped']).lower() + ' '
+            del abridged_result['skipped']
+
+        # if we already have stdout, we don't need stdout_lines
+        if 'stdout' in abridged_result and 'stdout_lines' in abridged_result:
+            abridged_result['stdout_lines'] = '<omitted>'
+
+        if abridged_result:
+            dumped += '\n'
+            dumped += yaml.safe_dump(json.loads(json.dumps(abridged_result, ensure_ascii=False)), width=1000, default_flow_style=False)
+
+        # indent by a couple of spaces
+        dumped = '\n  '.join(dumped.split('\n')).rstrip()
+        return dumped

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
     short_description: yaml-ized Ansible screen output
     version_added: 2.5
     description:
-        - Ansible output that can be quite a bit easier to read than the 
+        - Ansible output that can be quite a bit easier to read than the
           default JSON formatting.
     extends_documentation_fragment:
       - default_callback

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -1,3 +1,6 @@
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type

--- a/lib/ansible/plugins/callback/yaml.py
+++ b/lib/ansible/plugins/callback/yaml.py
@@ -26,6 +26,7 @@ import string
 import sys
 from ansible.plugins.callback import CallbackBase, strip_internal_keys
 from ansible.plugins.callback.default import CallbackModule as Default
+from ansible.parsing.yaml.dumper import AnsibleDumper
 
 
 # from http://stackoverflow.com/a/15423007/115478
@@ -61,9 +62,6 @@ def my_represent_scalar(self, tag, value, style=None):
     return node
 
 
-yaml.representer.BaseRepresenter.represent_scalar = my_represent_scalar
-
-
 class CallbackModule(Default):
 
     """
@@ -77,6 +75,7 @@ class CallbackModule(Default):
 
     def __init__(self):
         super(CallbackModule, self).__init__()
+        yaml.representer.BaseRepresenter.represent_scalar = my_represent_scalar
 
     def _dump_results(self, result, indent=None, sort_keys=True, keep_invocation=False):
         if result.get('_ansible_no_log', False):
@@ -114,7 +113,7 @@ class CallbackModule(Default):
 
         if abridged_result:
             dumped += '\n'
-            dumped += yaml.safe_dump(json.loads(json.dumps(abridged_result, ensure_ascii=False)), width=1000, default_flow_style=False)
+            dumped += yaml.dump(json.loads(json.dumps(abridged_result, ensure_ascii=False)), width=1000, Dumper=AnsibleDumper, default_flow_style=False)
 
         # indent by a couple of spaces
         dumped = '\n  '.join(dumped.split('\n')).rstrip()


### PR DESCRIPTION

##### SUMMARY
Using YAML instead of JSON for detailed output can (IMO) improve
readability; especially for tasks with either lots of output, or
multi-line output.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
`yaml` callback plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (yaml-output b385c7d57a) last updated 2017/10/27 07:25:14 (GMT -500)
  config file = /Users/dlee/.ansible.cfg
  configured module search path = [u'/Users/dlee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/dlee/prj/ansible/lib/ansible
  executable location = /Users/dlee/prj/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
