### PR TITLE
lambda: fix undefined variable and initially define account_id as None

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -225,6 +225,7 @@ def get_account_id(module, region=None, endpoint=None, **aws_connect_kwargs):
     several different ways.  Giving either IAM or STS privilages to
     the account should be enough to permit this.
     """
+    account_id = None
     try:
         sts_client = boto3_conn(module, conn_type='client', resource='sts',
                                 region=region, endpoint=endpoint, **aws_connect_kwargs)


### PR DESCRIPTION
##### SUMMARY
Previously account_id might not be defined on [line 241](https://github.com/ansible/ansible/compare/devel...s-hertel:lambda_undefined_var?expand=1#diff-76debabc50f1625c2b2497b6dba6d2f1L241).

See https://app.shippable.com/github/ansible/ansible/runs/41898/47/tests.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/lambda.py

##### ANSIBLE VERSION
```
2.5.0
```