### PR TITLE
Add check for sv binary

### DIFF
--- a/lib/ansible/modules/system/runit.py
+++ b/lib/ansible/modules/system/runit.py
@@ -265,6 +265,9 @@ def main():
     changed = False
     orig_state = sv.report()
 
+    if not sv.svc_cmd:
+        module.fail_json(msg="Could not find sv binary. Please ensure it is installed.")
+
     if enabled is not None and enabled != sv.enabled:
         changed = True
         if not module.check_mode:

--- a/lib/ansible/modules/system/runit.py
+++ b/lib/ansible/modules/system/runit.py
@@ -141,7 +141,7 @@ class Sv(object):
         self.pid            = None
         self.duration       = None
 
-        self.svc_cmd        = module.get_bin_path('sv', opt_dirs=self.extra_paths)
+        self.svc_cmd        = module.get_bin_path('sv', opt_dirs=self.extra_paths, required=True)
         self.svstat_cmd     = module.get_bin_path('sv', opt_dirs=self.extra_paths)
         self.svc_full = '/'.join([ self.service_dir, self.name ])
         self.src_full = '/'.join([ self.service_src, self.name ])
@@ -264,9 +264,6 @@ def main():
     sv = Sv(module)
     changed = False
     orig_state = sv.report()
-
-    if not sv.svc_cmd:
-        module.fail_json(msg="Could not find sv binary. Please ensure it is installed.")
 
     if enabled is not None and enabled != sv.enabled:
         changed = True


### PR DESCRIPTION
##### SUMMARY
This commit adds a check for the sv binary. If the binary is not present
then the module will fail.

Fixes #32248

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
runit

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/jsumners/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible
  executable location = /opt/local/Library/Frameworks/Python.framework/Versions/2.7/bin//ansible
  python version = 2.7.14 (default, Sep 27 2017, 12:15:00) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```
