### PR TITLE
Add reference option for file based modules

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -198,6 +198,7 @@ FILE_COMMON_ARGUMENTS = dict(
     mode=dict(type='raw'),
     owner=dict(),
     group=dict(),
+    reference=dict(type='path'),
     seuser=dict(),
     serole=dict(),
     selevel=dict(),
@@ -894,6 +895,7 @@ class AnsibleModule(object):
         mode = params.get('mode', None)
         owner = params.get('owner', None)
         group = params.get('group', None)
+        reference = params.get('reference', None)
 
         # selinux related options
         seuser = params.get('seuser', None)
@@ -915,6 +917,7 @@ class AnsibleModule(object):
             path=path, mode=mode, owner=owner, group=group,
             seuser=seuser, serole=serole, setype=setype,
             selevel=selevel, secontext=secontext, attributes=attributes,
+            reference=reference,
         )
 
     # Detect whether using selinux that is MLS-aware.
@@ -1145,6 +1148,37 @@ class AnsibleModule(object):
             except OSError:
                 path = to_text(b_path)
                 self.fail_json(path=path, msg='chgrp failed')
+            changed = True
+        return changed
+
+    def set_owner_and_group_from_reference_if_different(self, path, reference_path, changed, diff=None, expand=True):
+        b_path = to_bytes(path, errors='surrogate_or_strict')
+        if expand:
+            b_path = os.path.expanduser(os.path.expandvars(b_path))
+        if reference_path is None:
+            return changed
+        b_reference_path = to_bytes(reference_path, errors='surrogate_or_strict')
+        orig_uid, orig_gid = self.user_and_group(b_path, expand)
+        reference_uid, reference_gid = self.user_and_group(b_reference_path, expand)
+
+        if orig_uid != reference_uid or orig_gid != reference_gid:
+            if diff is not None:
+                if 'before' not in diff:
+                    diff['before'] = {}
+                diff['before']['owner'] = orig_uid
+                diff['before']['group'] = orig_gid
+                if 'after' not in diff:
+                    diff['after'] = {}
+                diff['after']['owner'] = reference_uid
+                diff['after']['group'] = reference_gid
+
+            if self.check_mode:
+                return True
+            try:
+                os.lchown(b_path, reference_uid, reference_gid)
+            except (IOError, OSError) as e:
+                path = to_text(b_path)
+                self.fail_json(path=path, msg='chown failed: %s' % (to_text(e)))
             changed = True
         return changed
 
@@ -1414,12 +1448,17 @@ class AnsibleModule(object):
         changed = self.set_context_if_different(
             file_args['path'], file_args['secontext'], changed, diff
         )
-        changed = self.set_owner_if_different(
-            file_args['path'], file_args['owner'], changed, diff, expand
-        )
-        changed = self.set_group_if_different(
-            file_args['path'], file_args['group'], changed, diff, expand
-        )
+        if file_args['owner'] or file_args['group']:
+            changed = self.set_owner_if_different(
+                file_args['path'], file_args['owner'], changed, diff, expand
+            )
+            changed = self.set_group_if_different(
+                file_args['path'], file_args['group'], changed, diff, expand
+            )
+        elif file_args['reference']:
+            changed = self.set_owner_and_group_from_reference_if_different(
+                file_args['path'], file_args['reference'], changed, diff, expand
+            )
         changed = self.set_mode_if_different(
             file_args['path'], file_args['mode'], changed, diff, expand
         )

--- a/lib/ansible/modules/files/copy.py
+++ b/lib/ansible/modules/files/copy.py
@@ -121,6 +121,14 @@ EXAMPLES = r'''
     group: foo
     mode: u+rw,g-wx,o-rwx
 
+# Copy a new "ntp.conf file into place, keeping the ownership (user and group) of the original file.
+- copy:
+    src: /mine/ntp.conf
+    dest: /etc/ntp.conf
+    reference: /mine/ntp.conf
+    mode: 0644
+    backup: yes
+
 # Copy a new "ntp.conf file into place, backing up the original if it differs from the copied version
 - copy:
     src: /mine/ntp.conf

--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -117,6 +117,12 @@ EXAMPLES = '''
     state: touch
     mode: "u+rw,g-wx,o-rwx"
 
+# touch the same file, but copy the ownership (user and group) of another file
+- file:
+    path: /etc/foo.conf
+    state: touch
+    reference: /etc/bar.conf
+
 # create a directory if it doesn't exist
 - file:
     path: /etc/some_directory

--- a/lib/ansible/utils/module_docs_fragments/files.py
+++ b/lib/ansible/utils/module_docs_fragments/files.py
@@ -38,6 +38,12 @@ options:
     default: null
     description:
       - Name of the group that should own the file/directory, as would be fed to I(chown).
+  reference:
+    required: false
+    default: null
+    description:
+      - Path to the file/directory for which the user and group will be taken
+        as reference. These will be passed to I(chown).
   seuser:
     required: false
     default: null


### PR DESCRIPTION
##### SUMMARY
 Similar to the --reference parameter of the chown command. The reference option will take the ownership (user and group) from the referenced file and use these two set the ownership for the target file.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/basic

##### ANSIBLE VERSION
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/josorior/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/josorior/development/ansible/.tox/py35/lib/python3.5/site-packages/ansible
  executable location = /home/josorior/development/ansible/.tox/py35/bin/ansible
  python version = 3.5.3 (default, Jun 26 2017, 10:36:28) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]


##### ADDITIONAL INFORMATION
This will be included in all modules that inherit from module_utils basic. Including the copy and file modules.
