### PR TITLE
Fix lookup source tests on ios_system

### DIFF
--- a/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
+++ b/test/integration/targets/ios_system/tests/cli/set_lookup_source.yaml
@@ -4,25 +4,25 @@
 - name: setup
   ios_config:
     lines:
-      - no ip domain lookup source-interface
+      - no ip domain lookup source-interface Loopback888
       - vrf definition ansible
     match: none
     authorize: yes
 
 - name: configure lookup_source
   ios_system:
-    lookup_source: Loopback10
+    lookup_source: Loopback888
     authorize: yes
   register: result
 
 - assert:
     that:
       - result.changed == true
-      - "'ip domain lookup source-interface Loopback10' in result.commands"
+      - "'ip domain lookup source-interface Loopback888' in result.commands"
 
 - name: verify lookup_source
   ios_system:
-    lookup_source: Loopback10
+    lookup_source: Loopback888
     authorize: yes
   register: result
 
@@ -84,7 +84,7 @@
 - name: teardown
   ios_config:
     lines:
-      - no ip domain lookup source-interface
+      - no ip domain lookup source-interface Loopback888
       - no vrf definition ansible
     match: none
     authorize: yes


### PR DESCRIPTION
In IOS-XE, you need to pass an interface to lookup-source, otherwise
it fails with bad syntax.