### PR TITLE
ec2_vpc_route_table: fix returning routes after creating them

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -642,6 +642,15 @@ def ensure_route_table_present(connection, module):
                 error_traceback=traceback.format_exc()
             )
 
+    # make sure the route table represents the current state
+    try:
+        route_table = get_route_table_by_id(connection, vpc_id, route_table.id)
+    except EC2ResponseError as e:
+        raise AnsibleRouteTableException(
+            message="Failed to get the latest state for route table {0}: {1}"
+            .format(route_table.id, str(e)),
+            error_traceback=traceback.format_exc())
+
     module.exit_json(changed=changed, route_table=get_route_table_info(route_table))
 
 


### PR DESCRIPTION
##### SUMMARY
Get the latest route table state before exiting.

See: https://gist.github.com/s-hertel/bd3176bacc9afbe6c03a3e472fd9394b for behavior without this patch.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py

##### ANSIBLE VERSION
```
2.5.0
```