### PR TITLE
Update index.rst to point to new community guide

### DIFF
--- a/docs/docsite/rst/index.rst
+++ b/docs/docsite/rst/index.rst
@@ -37,7 +37,7 @@ Ansible, Inc. releases a new major release of Ansible approximately every two mo
    guides
    dev_guide/index
    tower
-   community
+   community/index
    galaxy
    test_strategies
    faq


### PR DESCRIPTION
##### SUMMARY
We made this change a couple of months ago, deprecating community.html in favor of community/index.html and its full guide, but the change was never made here in the index.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
n/a

##### ANSIBLE VERSION
n/a

##### ADDITIONAL INFORMATION
n/a