### PR TITLE
Playbook dir option

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -415,7 +415,7 @@ class CLI(with_metaclass(ABCMeta, object)):
     @staticmethod
     def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
                     async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
-                    runas_prompt_opts=False, desc=None):
+                    runas_prompt_opts=False, desc=None, basedir_opts=False):
         ''' create an options parser for most ansible scripts '''
 
         # base opts
@@ -546,6 +546,10 @@ class CLI(with_metaclass(ABCMeta, object)):
             parser.add_option('--flush-cache', dest='flush_cache', action='store_true',
                               help="clear the fact cache")
 
+        if basedir_opts:
+            parser.add_option('--playbook-dir', default=None, dest='basedir', action='store',
+                              help="Since this tool does not use playbooks, use this as a subsitute playbook directory."
+                                   "This sets the relative path for many features including roles/ group_vars/ etc.")
         return parser
 
     @abstractmethod
@@ -774,6 +778,10 @@ class CLI(with_metaclass(ABCMeta, object)):
 
         # all needs loader
         loader = DataLoader()
+
+        basedir = getattr(options, 'basedir')
+        if basedir:
+            loader.set_basedir(basedir)
 
         vault_ids = options.vault_ids
         default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST

--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -779,7 +779,7 @@ class CLI(with_metaclass(ABCMeta, object)):
         # all needs loader
         loader = DataLoader()
 
-        basedir = getattr(options, 'basedir')
+        basedir = getattr(options, 'basedir', False)
         if basedir:
             loader.set_basedir(basedir)
 

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -60,6 +60,7 @@ class AdHocCLI(CLI):
             vault_opts=True,
             fork_opts=True,
             module_opts=True,
+            basedir_opts=True,
             desc="Define and run a single task 'playbook' against a set of hosts",
             epilog="Some modules do not make sense in Ad-Hoc (include, meta, etc)",
         )

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -88,6 +88,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
             vault_opts=True,
             fork_opts=True,
             module_opts=True,
+            basedir_opts=True,
             desc="REPL console for executing Ansible tasks.",
             epilog="This is not a live session/connection, each task executes in the background and returns it's results."
         )

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -71,7 +71,7 @@ class InventoryCLI(CLI):
             epilog='Show Ansible inventory information, by default it uses the inventory script JSON format',
             inventory_opts=True,
             vault_opts=True,
-            basdir_opts=True,
+            basedir_opts=True,
         )
 
         # Actions

--- a/lib/ansible/cli/inventory.py
+++ b/lib/ansible/cli/inventory.py
@@ -70,7 +70,8 @@ class InventoryCLI(CLI):
             usage='usage: %prog [options] [host|group]',
             epilog='Show Ansible inventory information, by default it uses the inventory script JSON format',
             inventory_opts=True,
-            vault_opts=True
+            vault_opts=True,
+            basdir_opts=True,
         )
 
         # Actions


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows you to set a 'playbook dir' for adhoc, inventory and console to allow for 'relative path loading'

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
adhoc, console
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
