### PR TITLE
[WIP] globalize callbacks

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -815,4 +815,3 @@ class CLI(with_metaclass(ABCMeta, object)):
                 display.deprecated("%s stdout callback, does not support setting 'options', it will work for now, "
                                    " but this will be required in the future and should be updated,"
                                    " see the 2.4 porting guide for details." % self.callback._load_name, version="2.9")
-

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -79,6 +79,8 @@ class PlaybookCLI(CLI):
 
     def run(self):
 
+        self._load_callback()
+
         super(PlaybookCLI, self).run()
 
         # Note: slightly wrong, this is written so that implicit localhost
@@ -125,7 +127,7 @@ class PlaybookCLI(CLI):
 
         # create the playbook executor, which manages running the plays via a task queue manager
         pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options,
-                                passwords=passwords)
+                                passwords=passwords, callback=self.callback)
 
         results = pbex.run()
 

--- a/lib/ansible/executor/playbook_executor.py
+++ b/lib/ansible/executor/playbook_executor.py
@@ -45,7 +45,7 @@ class PlaybookExecutor:
     basis for bin/ansible-playbook operation.
     '''
 
-    def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords):
+    def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords, callback):
         self._playbooks = playbooks
         self._inventory = inventory
         self._variable_manager = variable_manager
@@ -53,11 +53,13 @@ class PlaybookExecutor:
         self._options = options
         self.passwords = passwords
         self._unreachable_hosts = dict()
+        self._callback = callback
 
         if options.listhosts or options.listtasks or options.listtags or options.syntax:
             self._tqm = None
         else:
-            self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader, options=options, passwords=self.passwords)
+            self._tqm = TaskQueueManager(inventory=inventory, variable_manager=variable_manager, loader=loader, options=options,
+                                         passwords=self.passwords, stdout_callback=callback)
 
         # Note: We run this here to cache whether the default ansible ssh
         # executable supports control persist.  Sometime in the future we may

--- a/lib/ansible/executor/task_queue_manager.py
+++ b/lib/ansible/executor/task_queue_manager.py
@@ -179,6 +179,7 @@ class TaskQueueManager:
                 self._stdout_callback = callback_loader.get(self._stdout_callback)
                 try:
                     self._stdout_callback.set_options(C.config.get_plugin_options('callback', self._stdout_callback._load_name))
+                    display.set_callback(self._stdout_callback)
                 except AttributeError:
                     display.deprecated("%s stdout callback, does not support setting 'options', it will work for now, "
                                        " but this will be required in the future and should be updated,"

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -54,7 +54,7 @@ class CallbackModule(CallbackBase):
             'hosts': {}
         }
 
-    def v(self, msg, host=None):
+    def verbose(self, msg, host=None, caplevel=0):
         if host:
             if not host in self._v:
                 self._v[host] = [msg]
@@ -64,7 +64,8 @@ class CallbackModule(CallbackBase):
             self._v['_global'].append(msg)
 
     def debug(self, msg):
-        self._debug.append(msg)
+        if C.DEFAULT_DEBUG:
+            self._debug.append(msg)
 
     def warning(self, msg, formatted=False):
         if msg not in self._warns:
@@ -81,8 +82,6 @@ class CallbackModule(CallbackBase):
             final = msg
         if final not in self._deprecate:
             self._deprecate.append(final)
-
-    vvvvvv = vvvvv = vvv = vv = v
 
     def v2_playbook_on_play_start(self, play):
         self.results.append(self._new_play(play))

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -18,8 +18,6 @@ DOCUMENTATION = '''
 '''
 
 import json
-import os
-import time
 
 from ansible.plugins.callback import CallbackBase
 
@@ -66,7 +64,7 @@ class CallbackModule(CallbackBase):
             self._v['_global'].append(msg)
 
     def debug(self, msg):
-        self._debug.append("%6d %0.5f: %s" % (os.getpid(), time.time(), msg))
+        self._debug.append(msg)
 
     def warning(self, msg, formatted=False):
         if msg not in self._warns:

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -19,6 +19,7 @@ DOCUMENTATION = '''
 
 import json
 
+from ansible import constants as C
 from ansible.plugins.callback import CallbackBase
 
 

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -77,12 +77,9 @@ class CallbackModule(CallbackBase):
             self._errors.append(msg)
 
     def deprecated(self, msg, version=None, removed=False):
-        if version:
-            final = msg + ' removed in %s' % version
-        else:
-            final = msg
-        if final not in self._deprecate:
-            self._deprecate.append(final)
+        dep = {'msg': msg, 'version': version, 'removed': removed}
+        if dep not in self._deprecate:
+            self._deprecate.append(dep)
 
     def v2_playbook_on_play_start(self, play):
         self.results.append(self._new_play(play))

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -18,6 +18,8 @@ DOCUMENTATION = '''
 '''
 
 import json
+import os
+import time
 
 from ansible.plugins.callback import CallbackBase
 
@@ -34,6 +36,7 @@ class CallbackModule(CallbackBase):
         self._warns = []
         self._errors = []
         self._deprecate = []
+        self._debug = []
 
     def _new_play(self, play):
         return {
@@ -61,6 +64,9 @@ class CallbackModule(CallbackBase):
                 self._v[host].append(msg)
         else:
             self._v['_global'].append(msg)
+
+    def debug(self, msg):
+        self._debug.append("%6d %0.5f: %s" % (os.getpid(), time.time(), msg))
 
     def warning(self, msg, formatted=False):
         if msg not in self._warns:
@@ -109,6 +115,7 @@ class CallbackModule(CallbackBase):
             'warnings': self._warns,
             'errors': self._errors,
             'deprecations': self._deprecate,
+            'debug': self._debug,
         }
 
         self._display.display(json.dumps(output, indent=4, sort_keys=True))

--- a/lib/ansible/plugins/callback/json.py
+++ b/lib/ansible/plugins/callback/json.py
@@ -57,7 +57,7 @@ class CallbackModule(CallbackBase):
 
     def verbose(self, msg, host=None, caplevel=0):
         if host:
-            if not host in self._v:
+            if host not in self._v:
                 self._v[host] = [msg]
             else:
                 self._v[host].append(msg)

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -73,6 +73,7 @@ class Display:
 
         self.columns = None
         self.verbosity = verbosity
+        self._callback = None
 
         # list of all deprecation messages to prevent duplicate display
         self._deprecations = {}
@@ -96,6 +97,12 @@ class Display:
                 self.b_cowsay = False
 
         self._set_column_width()
+
+    def set_callback(self, callback):
+        for override in ('v', 'vv', 'vvv', 'vvvv', 'vvvvv', 'debug', 'display', 'deprecated', 'warning', 'error'):
+            new_func = getattr(callback, override, None)
+            if new_func:
+                setattr(self, override, new_func)
 
     def set_cowsay_info(self):
         if not C.ANSIBLE_NOCOWS:

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -99,7 +99,7 @@ class Display:
         self._set_column_width()
 
     def set_callback(self, callback):
-        for override in ('v', 'vv', 'vvv', 'vvvv', 'vvvvv', 'debug', 'display', 'deprecated', 'warning', 'error'):
+        for override in ('verbose', 'v', 'vv', 'vvv', 'vvvv', 'vvvvv', 'debug', 'display', 'deprecated', 'warning', 'error'):
             new_func = getattr(callback, override, None)
             if new_func:
                 setattr(self, override, new_func)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allow callbacks to take over 'display functions' early in playbook run

update json callback as example

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
callbacks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```