### PR TITLE
Revert "Removed a force conditional (#28851)"

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -385,8 +385,9 @@ class GalaxyCLI(CLI):
                                         (role.name, role.install_info['version'], role.version or "unspecified"))
                         continue
                 else:
-                    display.display('- %s is already installed, skipping.' % str(role))
-                    continue
+                    if not force:
+                        display.display('- %s is already installed, skipping.' % str(role))
+                        continue
 
             try:
                 installed = role.install()


### PR DESCRIPTION
This reverts commit 07acc579db839170122fc66505a886ef023d5f4f.

On closer examination of this code, the conditional that had force in it
was not a parent of this one.  So handling of force is needed i both
branches.

See the recent comments on #23391


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/cligalaxy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, 2.4
```