### PR TITLE
Add ansible.cfg setting to suppress duplicate group host warnings

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -153,6 +153,12 @@
 # safely set this to True to get more informative messages.
 #display_args_to_stdout = False
 
+# by default, if the target host name is the same as its groupname
+# ansible-playbook will display a warning notifying you of this.
+# In some environments, this may be an intended configuration, and if so
+# you can set this to False to suppress such warnings
+#display_duplicate_group_host_warnings = True
+
 # by default (as of 1.3), Ansible will raise errors when attempting to dereference
 # Jinja2 variables that are not set in templates or action lines. Uncomment this line
 # to revert the behavior to pre-1.3.

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1179,6 +1179,15 @@ DISPLAY_SKIPPED_HOSTS:
   ini:
   - {key: display_skipped_hosts, section: defaults}
   type: boolean
+DISPLAY_DUPLICATE_GROUP_HOST_WARNINGS:
+  name: Display inventory warnings
+  default: True
+  description: Display warning when inventory host name is the same as group name
+  env: [{name: DISPLAY_DUPLICATE_GROUP_HOST_WARNINGS}]
+  ini:
+  - {key: display_duplicate_group_host_warnings, section: defaults}
+  type: boolean
+  version_added: "2.5"
 ERROR_ON_MISSING_HANDLER:
   name: Missing handler error
   default: True

--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -145,8 +145,9 @@ class InventoryData(object):
                 host.vars = combine_vars(self.groups['all'].get_vars(), host.vars)
 
         # warn if overloading identifier as both group and host
-        for conflict in group_names.intersection(host_names):
-            display.warning("Found both group and host with same name: %s" % conflict)
+        if C.DISPLAY_DUPLICATE_GROUP_HOST_WARNINGS:
+            for conflict in group_names.intersection(host_names):
+                display.warning("Found both group and host with same name: %s" % conflict)
 
         self._groups_dict_cache = {}
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR adds a setting called `display_duplicate_group_host_warnings` to the ansible.cfg file which can be used to display/suppress warnings with the target host name is the same as the group name.

For example, currently with the following inventory file:

```
[dev]
dev ansible_connection=local
```

If you run an ansible playbook you will get the following warning:

```
 [WARNING]: Found both group and host with same name: dev
```

This warning was introduced in Ansible 2.3 (#22519).

In some use cases, this configuration is normal.  For example, if you are performing cloud deployments and want to target a specific "environment", setting the host and group name to the same value allows you to define your "environment" settings in `group_vars`.  Note there are comments on #22519 indicating this is an issue for docker.py dynamic inventory as well.

With this PR users now have the option to suppress the above warning by adding the following configuration to `ansible.cfg`:

```
[defaults]
...
...
display_duplicate_group_host_warnings = False
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/jmenga/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```