### PR TITLE
tests:win_dsc: Run setup module before using facts to decide on whether to run tests or not

### DIFF
--- a/test/integration/targets/win_dsc/tasks/main.yml
+++ b/test/integration/targets/win_dsc/tasks/main.yml
@@ -16,12 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: run setup to ensure all checked facts are populated
+  setup: 
 
 - name: check whether servermanager module is available (windows 2008 r2 or later)
   raw: PowerShell -Command Import-Module ServerManager
   register: win_feature_has_servermanager
   ignore_errors: true
-
 
 - name: start with feature absent
   win_feature:


### PR DESCRIPTION
##### SUMMARY
Slight improvement in how we decide wether or not to run win_dsc tests


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_dsc

##### ANSIBLE VERSION
```
2.5.0
```


##### ADDITIONAL INFORMATION
I just noticed that we're checking on facts that are not guaranteed to be filled. This caused the tests for win_dsc not to be exectued, at least when the test is run "isolated" wih `ansible-test windows-integration win_dsc`. This change simply executes the setup module first to make sure that these facts are filled so that we correctly can reason about whether to run the tests or not.
