### PR TITLE
Fix a crash when the volume_size for an EBS volume is not an int

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -216,7 +216,7 @@ def create_block_device_meta(module, volume):
         return_object['Ebs']['SnapshotId'] = volume.get('snapshot')
 
     if 'volume_size' in volume:
-        return_object['Ebs']['VolumeSize'] = volume.get('volume_size')
+        return_object['Ebs']['VolumeSize'] = int(volume.get('volume_size', 0))
 
     if 'volume_type' in volume:
         return_object['Ebs']['VolumeType'] = volume.get('volume_type')


### PR DESCRIPTION
 (because of templating for example)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
boto3 added type validation to many methods. Similar to  #18999, the ec2_lc module didn't cast the volume_size parameter to int before passing it to boto. This was fine if the yaml used an integer value, but if a string was used (because of templating, or variable substitution mostly), a type error was raised.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_lc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (boto3-non-int-volume-size-crash e4f6b8a5cb) last updated 2017/10/28 07:05:08 (GMT -400)
  config file = None
  configured module search path = [u'/home/jtate/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jtate/Work/crunch.io/misc/ansible/lib/ansible
  executable location = /home/jtate/Work/crunch.io/misc/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```
Broken in 6d402de25e32373298cd021007ec676eb77b51f5 all the way to current devel HEAD.

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Imagine a task as follows:
```
- name: set up the launch configuration
  ec2_lc:
    name: blargh
    volumes:
      - device_name: /dev/sda1
        volume_size: "{{ebs_vol_size|int}}"
        device_type: gp2
        delete_on_termination: true
# ... etc
```

Because of the forced use of quotes, volume_size is passed to the module as a string.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_Ip2uRQ/ansible_module_ec2_lc.py", line 426, in <module>
    main()
  File "/tmp/ansible_Ip2uRQ/ansible_module_ec2_lc.py", line 420, in main
    create_launch_config(connection, module)
  File "/tmp/ansible_Ip2uRQ/ansible_module_ec2_lc.py", line 317, in create_launch_config
    connection.create_launch_configuration(**launch_config)
  File "/home/jtate/.virtualenvs/ansible2/lib/python2.7/site-packages/botocore/client.py", line 312, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/jtate/.virtualenvs/ansible2/lib/python2.7/site-packages/botocore/client.py", line 579, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/home/jtate/.virtualenvs/ansible2/lib/python2.7/site-packages/botocore/client.py", line 634, in _convert_to_request_dict
    api_params, operation_model)
  File "/home/jtate/.virtualenvs/ansible2/lib/python2.7/site-packages/botocore/validate.py", line 291, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter BlockDeviceMappings[0].Ebs.VolumeSize, value: 100, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>

After applying this change, the command succeeds.
```
