### PR TITLE
Support domainname in docker_containers

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -100,6 +100,12 @@ options:
       - List of custom DNS search domains.
     default: null
     required: false
+  domainname:
+    description:
+      - Container domainname.
+    default: null
+    required: false
+    version_added: "2.5"
   env:
     description:
       - Dictionary of key,value pairs.
@@ -725,6 +731,7 @@ class TaskParameters(DockerBaseClass):
         self.dns_servers = None
         self.dns_opts = None
         self.dns_search_domains = None
+        self.domainname = None
         self.env = None
         self.env_file = None
         self.entrypoint = None
@@ -870,6 +877,7 @@ class TaskParameters(DockerBaseClass):
         '''
         create_params = dict(
             command='command',
+            domainname='domainname',
             hostname='hostname',
             user='user',
             detach='detach',
@@ -1290,6 +1298,7 @@ class Container(DockerBaseClass):
         config_mapping = dict(
             auto_remove=host_config.get('AutoRemove'),
             expected_cmd=config.get('Cmd'),
+            domainname=config.get('Domainname'),
             hostname=config.get('Hostname'),
             user=config.get('User'),
             detach=detach,
@@ -2052,6 +2061,7 @@ def main():
         dns_servers=dict(type='list'),
         dns_opts=dict(type='list'),
         dns_search_domains=dict(type='list'),
+        domainname=dict(type='str'),
         env=dict(type='dict'),
         env_file=dict(type='path'),
         entrypoint=dict(type='list'),


### PR DESCRIPTION
##### SUMMARY
This PR adds support for specifying a docker container's [domainname](https://github.com/docker/docker-py/blob/0d21b5b2549f013889491e02226b5facd758e514/docker/api/container.py#L239).


##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
modules/cloud/docker/docker_container


##### ANSIBLE VERSION
```
ansible-playbook 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 3.6.3 (default, Oct 10 2017, 02:29:16) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
n/a
