### PR TITLE
Remove hyphen from vmware powerstate

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -666,7 +666,7 @@ def set_vm_power_state(content, vm, state, force):
     requested states. force is forceful
     """
     facts = gather_vm_facts(content, vm)
-    expected_state = state.replace('_', '').lower()
+    expected_state = state.replace('_', '').replace('-', '').lower()
     current_state = facts['hw_power_status'].lower()
     result = dict(
         changed=False,


### PR DESCRIPTION
##### SUMMARY
This fix removes hypen while comparing to current
virtual machine's powerstate.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
```
2.5-devel
```