### PR TITLE
Remove default value for 'value' option in route53 module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -458,7 +458,7 @@ def main():
     ttl_in = module.params.get('ttl')
     record_in = module.params.get('record').lower()
     type_in = module.params.get('type')
-    value_in = module.params.get('value')
+    value_in = module.params.get('value') or []
     alias_in = module.params.get('alias')
     alias_hosted_zone_id_in = module.params.get('alias_hosted_zone_id')
     alias_evaluate_target_health_in = module.params.get('alias_evaluate_target_health')

--- a/lib/ansible/modules/cloud/amazon/route53.py
+++ b/lib/ansible/modules/cloud/amazon/route53.py
@@ -413,7 +413,7 @@ def main():
         alias=dict(required=False, type='bool'),
         alias_hosted_zone_id=dict(required=False),
         alias_evaluate_target_health=dict(required=False, type='bool', default=False),
-        value=dict(required=False, type='list', default=[]),
+        value=dict(required=False, type='list'),
         overwrite=dict(required=False, type='bool'),
         retry_interval=dict(required=False, default=500),
         private_zone=dict(required=False, type='bool', default=False),


### PR DESCRIPTION
##### SUMMARY
Remove the default value for `value` option.

Fixes #32296.

In route53 module, the option value is required when state is 'present' or 'absent'. This is not enforced right now as there is a bug in the module. The value option has a default value of [], therefore the required_if statements are not taking effect. This PR is for fixing that.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`route53`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```
