### PR TITLE
Delete AWS CloudFormation stack using role ARN if set

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -629,7 +629,10 @@ def main():
             if not stack:
                 result = {'changed': False, 'output': 'Stack not found.'}
             else:
-                cfn.delete_stack(StackName=stack_params['StackName'])
+                if stack_params.get('RoleARN') is None:
+                    cfn.delete_stack(StackName=stack_params['StackName'])
+                else:
+                    cfn.delete_stack(StackName=stack_params['StackName'], RoleARN=stack_params['RoleARN'])
                 result = stack_operation(cfn, stack_params['StackName'], 'DELETE', stack_params['ClientRequestToken'])
         except Exception as err:
             module.fail_json(msg=boto_exception(err), exception=traceback.format_exc())


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes an issue where the cloudformation module does not currently pass a service role when deleting a stack.  

The delete stack operation should always pass a service role if configured, as there are scenarios where this is useful.

For example, if a service role previously used to create a stack has been deleted, you must pass a service role to the delete stack operation otherwise the operation will fail indicating the previous service role could not be found.  This scenario cannot even be resolved from the AWS console, and with the cloudformation module not supporting passing a service role, I could only overcome this issue via the AWS CLI.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloudformation module
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/jmenga/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```