### PR TITLE
Add adhoc callbacks to mirror playbook start/stats

### DIFF
--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -28,6 +28,7 @@ from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.executor.task_queue_manager import TaskQueueManager
 from ansible.module_utils._text import to_text
 from ansible.parsing.splitter import parse_kv
+from ansible.playbook import Playbook
 from ansible.playbook.play import Play
 from ansible.plugins.loader import get_all_plugin_loaders
 
@@ -144,6 +145,11 @@ class AdHocCLI(CLI):
         play_ds = self._play_ds(pattern, self.options.seconds, self.options.poll_interval)
         play = Play().load(play_ds, variable_manager=variable_manager, loader=loader)
 
+        # used in start callback
+        playbook = Playbook(loader)
+        playbook._entries.append(play)
+        playbook._file_name = '__adhoc_playbook__'
+
         if self.callback:
             cb = self.callback
         elif self.options.one_line:
@@ -174,7 +180,11 @@ class AdHocCLI(CLI):
                 run_tree=run_tree,
             )
 
+            self._tqm.send_callback('v2_playbook_on_start', playbook)
+
             result = self._tqm.run(play)
+
+            self._tqm.send_callback('v2_playbook_on_stats', self._tqm._stats)
         finally:
             if self._tqm:
                 self._tqm.cleanup()


### PR DESCRIPTION
##### SUMMARY
Use playbook callbacks for adhoc commands too

This makes adhoc mirror playbook callback functionality by running a
callback before and after all tasks have run. Adhoc commands now call:
    
- `v2_playbook_on_start`
- `v2_playbook_on_stats`
  
NOTE: When `v2_playbook_on_start` is called, a dummy playbook is provided
that says its `_file_name` is `__adhoc_playbook__`. All callback plugins
that provide `v2_playbook_on_start` access the `_file_name` attribute, so
this should maintain backward compatibility when those plugins are
called with adhoc commands even though they would not have been called
previously. The adhoc play is also added to _entries for any private
callback plugins that might be using this callback.

_edit: this now reuses the playbook callbacks instead of adding new adhoc callbacks_

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
adhoc cli
~callbacks base~

##### ANSIBLE VERSION
devel

##### ADDITIONAL INFORMATION
I want to make the JSON callback work for adhoc commands. However, with the current callbacks, the only way to handle output is to print a stream of objects (triggered via `v2_runner_on_*`. Though a `json_stream` callback could be cool, that's not how the `json` callback functions for playbook, so it shouldn't  send a stream for adhoc either. In order to print the output only after the last host has finished it's task, the callback needs to know when the adhoc "play" has finished. ~So, I added these two callbacks to signal start and end of the adhoc run.~

This has the bonus effect of supplying stats at the end of the adhoc tasks. :)

Though this is a new feature, it feels like a very minor addition to me, and it should be backwards compatible. The only difference is that callback plugins will start working with adhoc commands where they may have only worked with playbook output before. These ansible-provided callback plugins might show additional output if used with adhoc:

* uses `on_start` and `on_stats`
** `default`
** `logstash`
** `junit`
** `slack`

* uses `on_start` only
** `mail`

* uses `on_stats` only
** `dense`
** `foreman`
** `json`
** `selective`
** `timer`

So, could this, perhaps, be considered for a 2.4.* release?