### PR TITLE
win_uri: fix elif to elseif

### DIFF
--- a/lib/ansible/modules/windows/win_uri.ps1
+++ b/lib/ansible/modules/windows/win_uri.ps1
@@ -114,7 +114,7 @@ if ($dest -and -not $check_mode) {
 
 if ($user -and $password) {
     $webrequest_opts.Credential = New-Object System.Management.Automation.PSCredential($user, $($password | ConvertTo-SecureString -AsPlainText -Force))
-} elif ($user -or $password) {
+} elseif ($user -or $password) {
     Add-Warning -obj $result -message "Both 'user' and 'password' parameters are required together, skipping authentication"
 }
 


### PR DESCRIPTION
##### SUMMARY
Changes usage of `elif` to `elseif` which was accidentally merged into the module recently. Without this the module will fail every time it is called.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_uri

##### ANSIBLE VERSION
```
devel
```