### PR TITLE
add user agent for Azure cloud shell

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -30,9 +30,9 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves import configparser
 import ansible.module_utils.six.moves.urllib.parse as urlparse
 try:
-    from ansible.release import __version__ as ansible_version
+    from ansible.release import __version__ as ANSIBLE_VERSION
 except ImportError:
-    ansible_version = 'unknown'
+    ANSIBLE_VERSION = 'unknown'
 
 AZURE_COMMON_ARGS = dict(
     cli_default_profile=dict(type='bool'),
@@ -68,7 +68,8 @@ AZURE_COMMON_REQUIRED_IF = [
     ('log_mode', 'file', ['log_path'])
 ]
 
-ANSIBLE_USER_AGENT = 'Ansible/{0}'.format(ansible_version)
+ANSIBLE_USER_AGENT = 'Ansible/{0}'.format(ANSIBLE_VERSION)
+CLOUDSHELL_USER_AGENT_KEY = 'AZURE_HTTP_USER_AGENT'
 
 CIDR_PATTERN = re.compile("(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1"
                           "[0-9]{2}|2[0-4][0-9]|25[0-5])(\/([0-9]|[1-2][0-9]|3[0-2]))")
@@ -723,7 +724,11 @@ class AzureRMModuleBase(object):
                                  self.subscription_id,
                                  base_url=base_url)
 
+        # Add user agent for Ansible
         client.config.add_user_agent(ANSIBLE_USER_AGENT)
+        # Add user agent when running from Cloud Shell
+        if CLOUDSHELL_USER_AGENT_KEY in os.environ:
+            client.config.add_user_agent(os.environ[CLOUDSHELL_USER_AGENT_KEY])
 
         return client
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Right now, we are integrating Ansible with [Azure Cloud Shell](https://docs.microsoft.com/en-us/azure/cloud-shell/overview), meaning users will be able to directly run Ansible CLI from Cloud Shell without any extra setup.
This fix enables Ansible Azure Modules to pick up User Agent string from Cloud Shell's environment variables.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`azure_rm_common`
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (cloudshell 1f99f3674a) last updated 2017/10/30 10:43:30 (GMT +800)
  config file = None
  configured module search path = [u'/Users/kevinzha/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kevinzha/workspace/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
