### PR TITLE
Move asa provider to suboptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,7 @@ Ansible Changes By Release
   https://github.com/ansible/ansible/issues/31786
 * Fix ansible-doc and ansible-console module-path option (https://github.com/ansible/ansible/pull/31744)
 * Fix for hostname module on RHEL 7.5 (https://github.com/ansible/ansible/issues/31811)
+* Fix provider password leak in logs for asa modules (https://github.com/ansible/ansible/issues/32343)
 
 ### Known Bugs
 * Implicit localhost is getting ansible_connection from all:vars instead of

--- a/lib/ansible/module_utils/asa.py
+++ b/lib/ansible/module_utils/asa.py
@@ -33,7 +33,7 @@ from ansible.module_utils.connection import Connection, exec_command
 _DEVICE_CONFIGS = {}
 _CONNECTION = None
 
-asa_argument_spec = {
+asa_provider_spec = {
     'host': dict(),
     'port': dict(type='int'),
     'username': dict(fallback=(env_fallback, ['ANSIBLE_NET_USERNAME'])),
@@ -42,10 +42,14 @@ asa_argument_spec = {
     'authorize': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTHORIZE']), type='bool'),
     'auth_pass': dict(fallback=(env_fallback, ['ANSIBLE_NET_AUTH_PASS']), no_log=True),
     'timeout': dict(type='int'),
-    'provider': dict(type='dict'),
     'context': dict(),
     'passwords': dict()
 }
+
+asa_argument_spec = {
+    'provider': dict(type='dict', options=asa_provider_spec),
+}
+asa_argument_spec.update(asa_provider_spec)
 
 command_spec = {
     'command': dict(key=True),
@@ -59,16 +63,9 @@ def get_argspec():
 
 
 def check_args(module):
-    provider = module.params['provider'] or {}
-
     for key in asa_argument_spec:
         if key not in ['context', 'passwords', 'provider', 'authorize'] and module.params[key]:
             module.warn('argument %s has been deprecated and will be removed in a future version' % key)
-
-    if provider:
-        for param in ('auth_pass', 'password'):
-            if provider.get(param):
-                module.no_log_values.update(return_values(provider[param]))
 
 
 def get_connection(module):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #32343

* Move provider arg spec as part of suboptions
  to validate input args against provider spec.
* This handles `no_log` for password arg correctly.

Merged to devel PR #28984
( cherry picked from commit 599fe23 )
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aos_*
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
