### PR TITLE
Run var_prec tests with/without fact caching

### DIFF
--- a/test/integration/targets/var_precedence/runme.sh
+++ b/test/integration/targets/var_precedence/runme.sh
@@ -2,6 +2,23 @@
 
 set -eux
 
+MYTMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
+trap 'rm -rf "${MYTMPDIR}"' EXIT
+
+# no fact caching
 ansible-playbook test_var_precedence.yml -i ../../inventory -v "$@" \
     -e 'extra_var=extra_var' \
-    -e 'extra_var_override=extra_var_override'
+    -e 'extra_var_override=extra_var_override' \
+    -e '{ write_cache: False }'
+
+# use fact cache, and invoke set_fact with 'cacheable=true' so we can test it across plays in a playbook
+ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansible-playbook test_var_precedence.yml -i ../../inventory -v "$@" \
+    -e 'extra_var=extra_var' \
+    -e 'extra_var_override=extra_var_override' \
+    -e '{ write_cache: True }'
+
+# use fact cache, but do not use set_fact with 'cacheable=true' so no set_fact calls should persist across plays in a playbook
+ANSIBLE_CACHE_PLUGIN=jsonfile ANSIBLE_CACHE_PLUGIN_CONNECTION="${MYTMPDIR}" ansible-playbook test_var_precedence.yml -i ../../inventory -v "$@" \
+    -e 'extra_var=extra_var' \
+    -e 'extra_var_override=extra_var_override' \
+    -e '{ write_cache: False }'

--- a/test/integration/targets/var_precedence/test_var_precedence.yml
+++ b/test/integration/targets/var_precedence/test_var_precedence.yml
@@ -2,11 +2,14 @@
 - hosts: testhost
   vars:
     - ansible_hostname: "BAD!"
+    - ansible_nodename: "nodename_from_play_vars"
     - vars_var: "vars_var"
     - param_var: "BAD!"
     - vars_files_var: "BAD!"
     - extra_var_override_once_removed: "{{ extra_var_override }}"
     - from_inventory_once_removed: "{{ inven_var | default('BAD!') }}"
+    - set_fact_cacheable_var: "set_fact_cacheable_from_play_vars"
+
   vars_files:
     - vars/test_var_precedence.yml
   roles:
@@ -17,6 +20,17 @@
       register: registered_var
     - name: use set_fact to override the registered_var
       set_fact: registered_var="this is from set_fact"
+      # set fact cacheable so it persists across plays
+    - name: use set_fact with cacheable to override set_facts_cacheable_var
+      set_fact:
+        set_fact_cacheable_var: "set_fact_cacheable_from_set_fact_cacheable"
+        cacheable: true
+      when: write_cache
+    - name: use set_fact with cacheable to persist the gather fact nodename
+      set_fact:
+        set_fact_cacheable_machine_id: "{{ hostvars[inventory_hostname]['ansible_machine_id'] }}"
+        cacheable: true
+      when: write_cache
     - debug: var=extra_var
     - debug: var=extra_var_override_once_removed
     - debug: var=vars_var
@@ -24,9 +38,15 @@
     - debug: var=vars_files_var_role
     - debug: var=registered_var
     - debug: var=from_inventory_once_removed
+    - debug: var=ansible_hostname
+    - debug: var=ansible_machine_id
+    - debug: var=set_fact_cacheable_var
+    - debug: var=write_cache
     - assert:
         that: item
       with_items:
+          - 'ansible_hostname == "BAD!"'
+          - 'ansible_nodename == "nodename_from_play_vars"'
           - 'extra_var == "extra_var"'
           - 'extra_var_override == "extra_var_override"'
           - 'extra_var_override_once_removed == "extra_var_override"'
@@ -36,9 +56,57 @@
           - 'registered_var == "this is from set_fact"'
           - 'from_inventory_once_removed == "inventory_var"'
 
+    - name: assert that set_fact_cacheable_var if write_cache is true
+      assert:
+        that:
+          - 'set_fact_cacheable_var == "set_fact_cacheable_from_set_fact_cacheable"'
+      when: write_cache
+
+    - name: assert that set_fact_cacheable_var is from play_vars if write_cache is false
+      assert:
+        that:
+          - 'set_fact_cacheable_var == "set_fact_cacheable_from_play_vars"'
+      when: not write_cache
+
 - hosts: inven_overridehosts
   vars_files:
     - "test_var_precedence.yml"
   roles:
     - role: test_var_precedence_inven_override
       foo: bar
+
+- name: verify set_fact cacheable persists across plays
+  hosts: testhost
+  gather_facts: smart
+  vars:
+    - set_fact_cacheable_var: "set_fact_cacheable_from_play_vars_other_play"
+  tasks:
+    - debug: var=ansible_hostname
+    - debug: var=ansible_machine_id
+    - debug: var=set_fact_cacheable_var
+    - debug: var=write_cache
+
+    - assert:
+        that: item
+      with_items:
+          - 'ansible_hostname != "BAD!"'
+          - 'extra_var == "extra_var"'
+          - 'extra_var_override == "extra_var_override"'
+
+    - name: assert that ansible_machine_id matches set_fact_cacheable_machine_id
+      assert:
+        that:
+          - 'ansible_machine_id == set_fact_cacheable_machine_id'
+      when: write_cache
+
+    - name: assert that set_fact_cacheable_var if write_cache is true in another play
+      assert:
+        that:
+          - 'set_fact_cacheable_var == "set_fact_cacheable_from_set_fact_cacheable"'
+      when: write_cache
+
+    - name: assert that set_fact_cacheable_var is from play_vars if write_cache is false in another play
+      assert:
+        that:
+          - 'set_fact_cacheable_var == "set_fact_cacheable_from_play_vars_other_play"'
+      when: not write_cache


### PR DESCRIPTION
Run var_prec tests with/without fact caching
and test set_fact with cacheable:true persists facts
across plays in a playbook and the var_prec is correct.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Tests Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/var_precedence

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (set_fact_prec_intg_tests_32302 610885cfd1) last updated 2017/10/30 15:31:17 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
