### PR TITLE
Add integration tests for some of the issues in 32302

### DIFF
--- a/test/integration/targets/set_fact/set_fact_cached_1.yml
+++ b/test/integration/targets/set_fact/set_fact_cached_1.yml
@@ -8,7 +8,7 @@
 
     - name: set a persistent fact foobar
       set_fact:
-        ansible_foobar: 'blippy'
+        ansible_foobar: 'foobar_from_set_fact_cacheable'
         cacheable: true
 
     - name: show foobar fact after
@@ -18,7 +18,7 @@
     - name: assert ansible_foobar is correct value
       assert:
         that:
-          - ansible_foobar == 'blippy'
+          - ansible_foobar == 'foobar_from_set_fact_cacheable'
 
     - name: set a non persistent fact that will not be cached
       set_fact:
@@ -43,4 +43,129 @@
     - name: assert ansible_foobar is correct value
       assert:
         that:
-          - ansible_foobar == 'blippy'
+          - ansible_foobar == 'foobar_from_set_fact_cacheable'
+
+- name: show ansible_nodename
+  hosts: localhost
+  tasks:
+    - name: show nodename fact after second play
+      debug:
+        var: ansible_nodename
+
+- name: show ansible_nodename overridden with var
+  hosts: localhost
+  vars:
+    ansible_nodename: 'nodename_from_play_vars'
+  tasks:
+    - name: show nodename fact after second play
+      debug:
+        var: ansible_nodename
+
+- name: verify ansible_nodename from vars overrides the fact
+  hosts: localhost
+  vars:
+    ansible_nodename: 'nodename_from_play_vars'
+  tasks:
+    - name: show nodename fact
+      debug:
+        var: ansible_nodename
+
+    - name: assert ansible_nodename is correct value
+      assert:
+        that:
+          - ansible_nodename == 'nodename_from_play_vars'
+
+- name: set_fact ansible_nodename
+  hosts: localhost
+  tasks:
+    - name: set a persistent fact nodename
+      set_fact:
+        ansible_nodename: 'nodename_from_set_fact_cacheable'
+
+    - name: show nodename fact
+      debug:
+        var: ansible_nodename
+
+    - name: assert ansible_nodename is correct value
+      assert:
+        that:
+          - ansible_nodename == 'nodename_from_set_fact_cacheable'
+
+- name: verify that set_fact ansible_nodename non_cacheable overrides ansible_nodename in vars
+  hosts: localhost
+  vars:
+    ansible_nodename: 'nodename_from_play_vars'
+  tasks:
+    - name: show nodename fact
+      debug:
+        var: ansible_nodename
+
+    - name: assert ansible_nodename is correct value
+      assert:
+        that:
+          - ansible_nodename == 'nodename_from_set_fact_cacheable'
+
+- name: verify that set_fact_cacheable in previous play overrides ansible_nodename in vars
+  hosts: localhost
+  vars:
+    ansible_nodename: 'nodename_from_play_vars'
+  tasks:
+    - name: show nodename fact
+      debug:
+        var: ansible_nodename
+
+    - name: assert ansible_nodename is correct value
+      assert:
+        that:
+          - ansible_nodename == 'nodename_from_set_fact_cacheable'
+
+- name: set_fact ansible_nodename cacheable
+  hosts: localhost
+  tasks:
+    - name: set a persistent fact nodename
+      set_fact:
+        ansible_nodename: 'nodename_from_set_fact_cacheable'
+        cacheable: true
+
+    - name: show nodename fact
+      debug:
+        var: ansible_nodename
+
+    - name: assert ansible_nodename is correct value
+      assert:
+        that:
+          - ansible_nodename == 'nodename_from_set_fact_cacheable'
+
+
+- name: verify that set_fact_cacheable in previous play overrides ansible_nodename in vars
+  hosts: localhost
+  vars:
+    ansible_nodename: 'nodename_from_play_vars'
+  tasks:
+    - name: show nodename fact
+      debug:
+        var: ansible_nodename
+
+    - name: assert ansible_nodename is correct value
+      assert:
+        that:
+          - ansible_nodename == 'nodename_from_set_fact_cacheable'
+
+- name: the fourth play
+  hosts: localhost
+  vars:
+    ansible_foobar: 'foobar_from_play_vars'
+  tasks:
+    - name: show example fact
+      debug:
+        var: ansible_example
+
+    - name: set a persistent fact example
+      set_fact:
+        ansible_example: 'foobar_from_set_fact_cacheable'
+        cacheable: true
+
+    - name: assert ansible_example is correct value
+      assert:
+        that:
+          - ansible_example == 'foobar_from_set_fact_cacheable'

--- a/test/integration/targets/set_fact/set_fact_cached_2.yml
+++ b/test/integration/targets/set_fact/set_fact_cached_2.yml
@@ -9,7 +9,7 @@
     - name: assert ansible_foobar is correct value when read from cache
       assert:
         that:
-          - ansible_foobar == 'blippy'
+          - ansible_foobar == 'foobar_from_set_fact_cacheable'
 
     - name: show ansible_foobar_not_cached fact
       debug:


### PR DESCRIPTION
Add intg tests for some of the issues in 32302

Verify that set_fact's var_prec is correct and that
regular facts var_prec is correct (ie, that play_vars
can override them)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Tests Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
test/integration/targets/set_fact

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (set_fact_prec_intg_tests_32302 610885cfd1) last updated 2017/10/30 15:31:17 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
