### PR TITLE
Deprecate tests used as filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Ansible Changes By Release
 
 ### Deprecations
 * Previously deprecated 'hostfile' config settings have been 're-deprecated' as previously code did not warn about deprecated configuration settings.
+* Using Ansible provided Jinja tests as filters is deprecated and will be removed in Ansible 2.9
 
 ### Minor Changes
 * added a few new magic vars corresponding to configuration/command line options:

--- a/docs/docsite/rst/become.rst
+++ b/docs/docsite/rst/become.rst
@@ -296,7 +296,7 @@ If running on a version of Ansible that is older than 2.5 or the normal
     
     - name: reboot after disabling UAC
       win_reboot:
-      when: uac_result|changed
+      when: uac_result is changed
 
 .. Note:: Granting the ``SeTcbPrivilege`` or turning UAC off can cause Windows
     security vulnerabilities and care should be given if these steps are taken.

--- a/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
+++ b/docs/docsite/rst/dev_guide/developing_modules_general_windows.rst
@@ -252,7 +252,7 @@ idempotent and does not report changes. For example:
     - name: assert remove a file (check mode)
       assert:
         that:
-        - remove_file_check|changed
+        - remove_file_check is changed
         - remove_file_actual_check.stdout == 'true\r\n'
 
     - name: remove a file
@@ -268,7 +268,7 @@ idempotent and does not report changes. For example:
     - name: assert remove a file
       assert:
         that:
-        - remove_file|changed
+        - remove_file is changed
         - remove_file_actual.stdout == 'false\r\n'
 
     - name: remove a file (idempotent)
@@ -280,7 +280,7 @@ idempotent and does not report changes. For example:
     - name: assert remove a file (idempotent)
       assert:
         that:
-        - not remove_file_again|changed
+        - not remove_file_again is changed
 
 
 Windows communication and development support

--- a/docs/docsite/rst/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbooks_conditionals.rst
@@ -57,14 +57,14 @@ decide to do something conditionally based on success or failure::
         ignore_errors: True
 
       - command: /bin/something
-        when: result|failed
+        when: result is failed
 
-      # In older versions of ansible use |success, now both are valid but succeeded uses the correct tense.
+      # In older versions of ansible use ``success``, now both are valid but succeeded uses the correct tense.
       - command: /bin/something_else
-        when: result|succeeded
+        when: result is succeeded
 
       - command: /bin/still/something_else
-        when: result|skipped
+        when: result is skipped
 
 
 .. note:: both `success` and `succeeded` work (`fail`/`failed`, etc).

--- a/docs/docsite/rst/playbooks_tests.rst
+++ b/docs/docsite/rst/playbooks_tests.rst
@@ -17,7 +17,7 @@ In addition to those Jinja2 tests, Ansible supplies a few more and users can eas
 Test syntax
 ```````````
 
-`Test syntax<http://jinja.pocoo.org/docs/dev/templates/#tests>`_ varies from `filter syntax <http://jinja.pocoo.org/docs/dev/templates/#filters>`_ (``variable | filter``). Historically Ansible has registered tests as both jinja tests and jinja filters, allowing for them to be referenced using filter syntax.
+`Test syntax <http://jinja.pocoo.org/docs/dev/templates/#tests>`_ varies from `filter syntax <http://jinja.pocoo.org/docs/dev/templates/#filters>`_ (``variable | filter``). Historically Ansible has registered tests as both jinja tests and jinja filters, allowing for them to be referenced using filter syntax.
 
 As of Ansible 2.5, using a jinja test as a filter will generate a warning.
 

--- a/docs/docsite/rst/playbooks_tests.rst
+++ b/docs/docsite/rst/playbooks_tests.rst
@@ -133,7 +133,7 @@ Testing paths
 The following tests can provide information about a path on the controller::
 
     - debug: msg="path is a directory"
-      when: mypath is dir
+      when: mypath is directory
 
     - debug: msg="path is a file"
       when: mypath is file

--- a/docs/docsite/rst/playbooks_tests.rst
+++ b/docs/docsite/rst/playbooks_tests.rst
@@ -4,9 +4,10 @@ Tests
 .. contents:: Topics
 
 
-`Tests <http://jinja.pocoo.org/docs/dev/templates/#tests>`_ in Jinja2 are a way of evaluating template expressions and returning True or False.
-Jinja2 ships with many of these. See `builtin tests`_ in the official Jinja2 template documentation.
-Tests are very similar to filters and are used mostly the same way, but they can also be used in list processing filters, like C(map()) and C(select()) to choose items in the list.
+`Tests <http://jinja.pocoo.org/docs/dev/templates/#tests>`_ in Jinja are a way of evaluating template expressions and returning True or False.
+Jinja ships with many of these. See `builtin tests`_ in the official Jinja template documentation.
+
+The main difference between tests and filters are that Jinja tests are used for comparisons, whereas filters are used for data manipulation, and have different applications in jinja. Tests can also be used in list processing filters, like C(map()) and C(select()) to choose items in the list.
 
 Like all templating, tests always execute on the Ansible controller, **not** on the target of a task, as they test local data.
 

--- a/docs/docsite/rst/playbooks_tests.rst
+++ b/docs/docsite/rst/playbooks_tests.rst
@@ -4,13 +4,30 @@ Tests
 .. contents:: Topics
 
 
-Tests in Jinja2 are a way of evaluating template expressions and returning True or False.
+`Tests <http://jinja.pocoo.org/docs/dev/templates/#tests>`_ in Jinja2 are a way of evaluating template expressions and returning True or False.
 Jinja2 ships with many of these. See `builtin tests`_ in the official Jinja2 template documentation.
 Tests are very similar to filters and are used mostly the same way, but they can also be used in list processing filters, like C(map()) and C(select()) to choose items in the list.
 
 Like all templating, tests always execute on the Ansible controller, **not** on the target of a task, as they test local data.
 
 In addition to those Jinja2 tests, Ansible supplies a few more and users can easily create their own.
+
+.. _test_syntax:
+
+Test syntax
+```````````
+
+`Test syntax<http://jinja.pocoo.org/docs/dev/templates/#tests>`_ varies from `filter syntax <http://jinja.pocoo.org/docs/dev/templates/#filters>`_ (``variable | filter``). Historically Ansible has registered tests as both jinja tests and jinja filters, allowing for them to be referenced using filter syntax.
+
+As of Ansible 2.5, using a jinja test as a filter will generate a warning.
+
+The syntax for using a jinja test is as follows::
+
+    variable is test_name
+
+Such as::
+
+    result is failed
 
 .. _testing_strings:
 
@@ -24,13 +41,13 @@ To match strings against a substring or a regex, use the "match" or "search" fil
 
     tasks:
         - debug: "msg='matched pattern 1'"
-          when: url | match("http://example.com/users/.*/resources/.*")
+          when: url is match("http://example.com/users/.*/resources/.*")
 
         - debug: "msg='matched pattern 2'"
-          when: url | search("/users/.*/resources/.*")
+          when: url is search("/users/.*/resources/.*")
 
         - debug: "msg='matched pattern 3'"
-          when: url | search("/users/")
+          when: url is search("/users/")
 
 'match' requires a complete match in the string, while 'search' only requires matching a subset of the string.
 
@@ -42,23 +59,25 @@ Version Comparison
 
 .. versionadded:: 1.6
 
+.. note:: In 2.5 ``version_compare`` was renamed to ``version``
+
 To compare a version number, such as checking if the ``ansible_distribution_version``
-version is greater than or equal to '12.04', you can use the ``version_compare`` filter.
+version is greater than or equal to '12.04', you can use the ``version`` test.
 
-The ``version_compare`` filter can also be used to evaluate the ``ansible_distribution_version``::
+The ``version`` test can also be used to evaluate the ``ansible_distribution_version``::
 
-    {{ ansible_distribution_version | version_compare('12.04', '>=') }}
+    {{ ansible_distribution_version is version('12.04', '>=') }}
 
-If ``ansible_distribution_version`` is greater than or equal to 12, this filter returns True, otherwise False.
+If ``ansible_distribution_version`` is greater than or equal to 12, this test returns True, otherwise False.
 
-The ``version_compare`` filter accepts the following operators::
+The ``version`` test accepts the following operators::
 
     <, lt, <=, le, >, gt, >=, ge, ==, =, eq, !=, <>, ne
 
 This test also accepts a 3rd parameter, ``strict`` which defines if strict version parsing should
 be used.  The default is ``False``, but this setting as ``True`` uses more strict version parsing::
 
-    {{ sample_version_var | version_compare('1.0', operator='lt', strict=True) }}
+    {{ sample_version_var is version('1.0', operator='lt', strict=True) }}
 
 
 .. _math_tests:
@@ -68,17 +87,19 @@ Group theory tests
 
 .. versionadded:: 2.1
 
-To see if a list includes or is included by another list, you can use 'issubset' and 'issuperset'::
+.. note:: In 2.5 ``issubset`` and ``issuperset`` were renamed to ``subset`` and ``superset``
+
+To see if a list includes or is included by another list, you can use 'subset' and 'superset'::
 
     vars:
         a: [1,2,3,4,5]
         b: [2,3]
     tasks:
         - debug: msg="A includes B"
-          when: a|issuperset(b)
+          when: a is superset(b)
 
         - debug: msg="B is included in A"
-          when: b|issubset(a)
+          when: b is subset(a)
 
 
 .. _path_tests:
@@ -101,33 +122,35 @@ You can use `any` and `all` to check if any or all elements in a list are true o
       when: mylist is all
 
     - debug: msg="at least one is true"
-      when: myotherlist|any
+      when: myotherlist is any
 
 
 Testing paths
 `````````````
 
+.. note:: In 2.5 the follwing tests were renamed to remove the ``is_`` prefix
+
 The following tests can provide information about a path on the controller::
 
     - debug: msg="path is a directory"
-      when: mypath|is_dir
+      when: mypath is dir
 
     - debug: msg="path is a file"
-      when: mypath|is_file
+      when: mypath is file
 
     - debug: msg="path is a symlink"
-      when: mypath|is_link
+      when: mypath is link
 
     - debug: msg="path already exists"
-      when: mypath|exists
+      when: mypath is exists
 
-    - debug: msg="path is {{ (mypath|is_abs)|ternary('absolute','relative')}}"
+    - debug: msg="path is {{ (mypath is abs)|ternary('absolute','relative')}}"
 
     - debug: msg="path is the same file as path2"
-      when: mypath|samefile(path2)
+      when: mypath is same_file(path2)
 
     - debug: msg="path is a mount"
-      when: mypath|is_mount
+      when: mypath is mount
 
 
 .. _test_task_results:
@@ -144,20 +167,20 @@ The following tasks are illustrative of the tests meant to check the status of t
         ignore_errors: True
 
       - debug: msg="it failed"
-        when: result|failed
+        when: result is failed
 
       # in most cases you'll want a handler, but if you want to do something right now, this is nice
       - debug: msg="it changed"
-        when: result|changed
+        when: result is changed
 
       - debug: msg="it succeeded in Ansible >= 2.1"
-        when: result|succeeded
+        when: result is succeeded
 
       - debug: msg="it succeeded"
-        when: result|success
+        when: result is success
 
       - debug: msg="it was skipped"
-        when: result|skipped
+        when: result is skipped
 
 .. note:: From 2.1, you can also use success, failure, change, and skip so that the grammar matches, for those who need to be strict about it.
 

--- a/docs/docsite/rst/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guide_2.5.rst
@@ -22,7 +22,42 @@ No notable changes.
 Deprecated
 ==========
 
-No notable changes.
+Jinja tests used as filters
+---------------------------
+
+Using Ansible provided jinja tests as filters will be removed in Ansible 2.9.
+
+Prior to Ansible 2.5, jinja tests included within Ansible were most often used as filters. The large difference in use is that filters are referenced as ``variable | filter_name`` where as jinja tests are refereced as ``variable is test_name``.
+
+Jinja tests are used for comparisons, whereas filters are used for data manipulation, and have different applications in jinja. This change is to help differentiate the concepts for a better understanding of jinja, and where each can be appropriately used.
+
+As of Ansible 2.5 using an Ansible provided jinja test with filter syntax, will display a deprecation error.
+
+**OLD** In Ansible 2.4 (and earlier) the use of an Ansible included jinja test would likely look like this:
+
+.. code-block:: yaml
+
+    when:
+        - result | failed
+        - not result | success
+
+**NEW** In Ansible 2.5 it should be changed to look like this:
+
+.. code-block:: yaml
+
+    when:
+        - result is failed
+        - results is not successful
+
+In addition to the deprecation warnings, many new tests have been introduced that are aliases of the old tests, that make more sense grammatically with the jinja test syntax such as the new ``successful`` test which aliases ``success``
+
+.. code-block:: yaml
+
+    when: result is successful
+
+See :ref:`The Ansible Tests Documentation <playbooks_tests>` for more information.
+
+Additionally, a script was created to assist in the conversion for tests using filter syntax to proper jinja test syntax. This script has been used to convert all of the Ansible integration tests to the correct format. There are a few limitations documented, and all changes made by this script should be evaluated for correctness before executing the modified playbooks. The script can be found at `https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py <https://github.com/ansible/ansible/blob/devel/hacking/fix_test_syntax.py>`_.
 
 Modules
 =======
@@ -41,7 +76,7 @@ The following modules no longer exist:
 Deprecation notices
 -------------------
 
-The following modules will be removed in Ansible 2.8. Please update update your playbooks accordingly.
+The following modules will be removed in Ansible 2.9. Please update update your playbooks accordingly.
 
 * :ref:`fixme <fixme>`
 

--- a/hacking/README.md
+++ b/hacking/README.md
@@ -62,6 +62,11 @@ The module formatter is a script used to generate manpages and online
 module documentation.  This is used by the system makefiles and rarely
 needs to be run directly.
 
+fix_test_syntax.py
+------------------
+
+A script to assist in the conversion for tests using filter syntax to proper jinja test syntax. This script has been used to convert all of the Ansible integration tests to the correct format for the 2.5 release. There are a few limitations documented, and all changes made by this script should be evaluated for correctness before executing the modified playbooks.
+
 Authors
 -------
 'authors' is a simple script that generates a list of everyone who has

--- a/hacking/fix_test_syntax.py
+++ b/hacking/fix_test_syntax.py
@@ -72,7 +72,7 @@ parser.add_argument(
 )
 args = parser.parse_args()
 
-for root, _, filenames in os.walk(args.path):
+for root, dirs, filenames in os.walk(args.path):
     for name in filenames:
         if os.path.splitext(name)[1] not in ('.yml', '.yaml'):
             continue

--- a/hacking/fix_test_syntax.py
+++ b/hacking/fix_test_syntax.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# (c) 2017, Michael DeHaan <matt@sivel.net>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Purpose:
+# The purpose of this script is to convert uses of tests as filters to proper jinja test syntax
+# as part of https://github.com/ansible/proposals/issues/83
+
+# Notes:
+# This script is imperfect, but was close enough to "fix" all integration tests
+# with the exception of:
+#
+# 1. One file needed manual remediation, where \\\\ was ultimately replace with \\ in 8 locations.
+# 2. Multiple filter pipeline is unsupported. Example:
+#        var|string|search('foo')
+#    Which should be converted to:
+#        var|string is search('foo')
+
+import argparse
+import os
+import re
+
+from ansible.plugins.test import core, files, mathstuff
+
+
+TESTS = list(core.TestModule().tests().keys()) + list(files.TestModule().tests().keys()) + list(mathstuff.TestModule().tests().keys())
+
+
+TEST_MAP = {
+    'version_compare': 'version',
+    'is_dir': 'directory',
+    'is_file': 'file',
+    'is_link': 'link',
+    'is_abs': 'abs',
+    'is_same_file': 'same_file',
+    'is_mount': 'mount',
+    'issubset': 'subset',
+    'issuperset': 'superset',
+    'isnan': 'nan',
+    'succeeded': 'successful',
+    'success': 'successful',
+    'change': 'changed',
+    'skip': 'skipped',
+}
+
+
+FILTER_RE = re.compile(r'((.+?)\s*([\w \.\'"]+)(\s*)\|(\s*)(\w+))')
+NOT_RE = re.compile(r'( ?)not ')
+ASSERT_SPACE_RE = re.compile(r'- ([\'"])\s+')
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'path',
+    help='Path to a directory that will be recursively walked. All .yml and .yaml files will be evaluated '
+         'and uses of tests as filters will be conveted to proper jinja test syntax files to have test syntax '
+         'fixed'
+)
+args = parser.parse_args()
+
+for root, _, filenames in os.walk(args.path):
+    for name in filenames:
+        if os.path.splitext(name)[1] not in ('.yml', '.yaml'):
+            continue
+        path = os.path.join(root, name)
+
+        print(path)
+        with open(path) as f:
+            text = f.read()
+
+        for match in FILTER_RE.findall(text):
+            filter_name = match[5]
+
+            is_not = match[2].strip(' "\'').startswith('not ')
+
+            try:
+                test_name = TEST_MAP[filter_name]
+            except KeyError:
+                test_name = filter_name
+
+            if test_name not in TESTS:
+                continue
+
+            if is_not:
+                before = NOT_RE.sub(r'\1', match[2]).rstrip()
+                text = re.sub(
+                    re.escape(match[0]),
+                    '%s %s is not %s' % (match[1], before, test_name,),
+                    text
+                )
+            else:
+                text = re.sub(
+                    re.escape(match[0]),
+                    '%s %s is %s' % (match[1], match[2].rstrip(), test_name,),
+                    text
+                )
+
+        with open(path, 'w+') as f:
+            f.write(text)

--- a/lib/ansible/modules/network/f5/bigip_iapp_service.py
+++ b/lib/ansible/modules/network/f5/bigip_iapp_service.py
@@ -161,7 +161,7 @@ EXAMPLES = r'''
     state: absent
   register: result
   failed_when:
-    - not result|success
+    - result is not successful
     - "'referenced by one or more applications' not in result.msg"
 
 - name: Configure a service using more complicated parameters

--- a/lib/ansible/modules/network/nuage/nuage_vspk.py
+++ b/lib/ansible/modules/network/nuage/nuage_vspk.py
@@ -185,7 +185,7 @@ EXAMPLES = '''
     state: present
     properties:
       name: "{{ enterprise_new_name }}-basic"
-  when: nuage_check_enterprise | failed
+  when: nuage_check_enterprise is failed
 
 # Creating a User in an Enterprise
 - name: Create admin user

--- a/lib/ansible/modules/network/panos/panos_admpwd.py
+++ b/lib/ansible/modules/network/panos/panos_admpwd.py
@@ -60,7 +60,7 @@ EXAMPLES = '''
     key_filename: "/tmp/ssh.key"
     newpassword: "badpassword"
   register: result
-  until: not result|failed
+  until: result is not failed
   retries: 10
   delay: 30
 '''

--- a/lib/ansible/modules/network/panos/panos_check.py
+++ b/lib/ansible/modules/network/panos/panos_check.py
@@ -70,7 +70,7 @@ EXAMPLES = '''
     ip_address: "192.168.1.1"
     password: "admin"
   register: result
-  until: not result|failed
+  until: result is not failed
   retries: 10
   delay: 30
 '''

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -110,7 +110,7 @@ EXAMPLES = '''
 # - copy:
 #     dest: /var/www/html/{{ sample_com_challenge['challenge_data']['sample.com']['http-01']['resource'] }}
 #     content: "{{ sample_com_challenge['challenge_data']['sample.com']['http-01']['resource_value'] }}"
-#     when: sample_com_challenge|changed
+#     when: sample_com_challenge is changed
 
 - letsencrypt:
     account_key: /etc/pki/cert/private/account.key

--- a/lib/ansible/plugins/test/__init__.py
+++ b/lib/ansible/plugins/test/__init__.py
@@ -1,3 +1,23 @@
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
+
+from functools import wraps
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+
+def renamed_deprecation(func, new, version):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        display.deprecated(
+            'The `%s` test was renamed to fit better gramatically with the switch to proper test syntax. '
+            'Please use `%s` as a replacement' % (func.__name__, new),
+            version=version
+        )
+        return func(*args, **kwargs)
+    return wrapper

--- a/lib/ansible/plugins/test/__init__.py
+++ b/lib/ansible/plugins/test/__init__.py
@@ -1,23 +1,3 @@
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
-
-from functools import wraps
-
-try:
-    from __main__ import display
-except ImportError:
-    from ansible.utils.display import Display
-    display = Display()
-
-
-def renamed_deprecation(func, new, version):
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        display.deprecated(
-            'The `%s` test was renamed to fit better gramatically with the switch to proper test syntax. '
-            'Please use `%s` as a replacement' % (func.__name__, new),
-            version=version
-        )
-        return func(*args, **kwargs)
-    return wrapper

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -30,7 +30,7 @@ from ansible import errors
 def failed(result):
     ''' Test if task result yields failed '''
     if not isinstance(result, MutableMapping):
-        raise errors.AnsibleFilterError("|failed expects a dictionary")
+        raise errors.AnsibleFilterError("The failed test expects a dictionary")
     return result.get('failed', False)
 
 
@@ -42,7 +42,7 @@ def success(result):
 def changed(result):
     ''' Test if task result yields changed '''
     if not isinstance(result, MutableMapping):
-        raise errors.AnsibleFilterError("|changed expects a dictionary")
+        raise errors.AnsibleFilterError("The changed test expects a dictionary")
     if 'changed' not in result:
         changed = False
         if (
@@ -62,7 +62,7 @@ def changed(result):
 def skipped(result):
     ''' Test if task result yields skipped '''
     if not isinstance(result, MutableMapping):
-        raise errors.AnsibleFilterError("|skipped expects a dictionary")
+        raise errors.AnsibleFilterError("The skipped test expects a dictionary")
     return result.get('skipped', False)
 
 

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -25,6 +25,7 @@ from collections import MutableMapping, MutableSequence
 from distutils.version import LooseVersion, StrictVersion
 
 from ansible import errors
+from ansible.plugins.test import renamed_deprecation
 
 
 def failed(result):
@@ -144,7 +145,8 @@ class TestModule(object):
             'regex': regex,
 
             # version comparison
-            'version_compare': version_compare,
+            'version_compare': renamed_deprecation(version_compare, 'version', '2.9'),
+            'version': version_compare,
 
             # lists
             'any': any,

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -130,6 +130,7 @@ class TestModule(object):
             'failure': failed,
             'succeeded': success,
             'success': success,
+            'successful': success,
 
             # changed testing
             'changed': changed,

--- a/lib/ansible/plugins/test/core.py
+++ b/lib/ansible/plugins/test/core.py
@@ -25,7 +25,6 @@ from collections import MutableMapping, MutableSequence
 from distutils.version import LooseVersion, StrictVersion
 
 from ansible import errors
-from ansible.plugins.test import renamed_deprecation
 
 
 def failed(result):
@@ -146,7 +145,7 @@ class TestModule(object):
             'regex': regex,
 
             # version comparison
-            'version_compare': renamed_deprecation(version_compare, 'version', '2.9'),
+            'version_compare': version_compare,
             'version': version_compare,
 
             # lists

--- a/lib/ansible/plugins/test/files.py
+++ b/lib/ansible/plugins/test/files.py
@@ -21,6 +21,7 @@ __metaclass__ = type
 
 from os.path import isdir, isfile, isabs, exists, lexists, islink, samefile, ismount
 from ansible import errors
+from ansible.plugins.test import renamed_deprecation
 
 
 class TestModule(object):
@@ -29,14 +30,20 @@ class TestModule(object):
     def tests(self):
         return {
             # file testing
-            'is_dir': isdir,
-            'is_file': isfile,
-            'is_link': islink,
+            'is_dir': renamed_deprecation(isdir, 'dir', '2.9'),
+            'dir': isdir,
+            'is_file': renamed_deprecation(isfile, 'file', '2.9'),
+            'file': isfile,
+            'is_link': renamed_deprecation(islink, 'link', '2.9'),
+            'link': islink,
             'exists': exists,
             'link_exists': lexists,
 
             # path testing
-            'is_abs': isabs,
-            'is_same_file': samefile,
-            'is_mount': ismount,
+            'is_abs': renamed_deprecation(isabs, 'abs', '2.9'),
+            'abs': isabs,
+            'is_same_file': renamed_deprecation(samefile, 'same_file', '2.9'),
+            'same_file': samefile,
+            'is_mount': renamed_deprecation(ismount, 'mount', '2.9'),
+            'mount': ismount,
         }

--- a/lib/ansible/plugins/test/files.py
+++ b/lib/ansible/plugins/test/files.py
@@ -30,7 +30,7 @@ class TestModule(object):
         return {
             # file testing
             'is_dir': isdir,
-            'dir': isdir,
+            'directory': isdir,
             'is_file': isfile,
             'file': isfile,
             'is_link': islink,

--- a/lib/ansible/plugins/test/files.py
+++ b/lib/ansible/plugins/test/files.py
@@ -21,7 +21,6 @@ __metaclass__ = type
 
 from os.path import isdir, isfile, isabs, exists, lexists, islink, samefile, ismount
 from ansible import errors
-from ansible.plugins.test import renamed_deprecation
 
 
 class TestModule(object):
@@ -30,20 +29,20 @@ class TestModule(object):
     def tests(self):
         return {
             # file testing
-            'is_dir': renamed_deprecation(isdir, 'dir', '2.9'),
+            'is_dir': isdir,
             'dir': isdir,
-            'is_file': renamed_deprecation(isfile, 'file', '2.9'),
+            'is_file': isfile,
             'file': isfile,
-            'is_link': renamed_deprecation(islink, 'link', '2.9'),
+            'is_link': islink,
             'link': islink,
             'exists': exists,
             'link_exists': lexists,
 
             # path testing
-            'is_abs': renamed_deprecation(isabs, 'abs', '2.9'),
+            'is_abs': isabs,
             'abs': isabs,
-            'is_same_file': renamed_deprecation(samefile, 'same_file', '2.9'),
+            'is_same_file': samefile,
             'same_file': samefile,
-            'is_mount': renamed_deprecation(ismount, 'mount', '2.9'),
+            'is_mount': ismount,
             'mount': ismount,
         }

--- a/lib/ansible/plugins/test/mathstuff.py
+++ b/lib/ansible/plugins/test/mathstuff.py
@@ -20,8 +20,6 @@ __metaclass__ = type
 
 import math
 
-from ansible.plugins.test import renamed_deprecation
-
 
 def issubset(a, b):
     return set(a) <= set(b)
@@ -44,10 +42,10 @@ class TestModule:
     def tests(self):
         return {
             # set theory
-            'issubset': renamed_deprecation(issubset, 'subset', '2.9'),
+            'issubset': issubset,
             'subset': issubset,
-            'issuperset': renamed_deprecation(issuperset, 'superset', '2.9'),
+            'issuperset': issuperset,
             'superset': issuperset,
-            'isnan': renamed_deprecation(isnotanumber, 'nan', '2.9'),
+            'isnan': isnotanumber,
             'nan': isnotanumber,
         }

--- a/lib/ansible/plugins/test/mathstuff.py
+++ b/lib/ansible/plugins/test/mathstuff.py
@@ -20,6 +20,8 @@ __metaclass__ = type
 
 import math
 
+from ansible.plugins.test import renamed_deprecation
+
 
 def issubset(a, b):
     return set(a) <= set(b)
@@ -42,7 +44,10 @@ class TestModule:
     def tests(self):
         return {
             # set theory
-            'issubset': issubset,
-            'issuperset': issuperset,
-            'isnan': isnotanumber,
+            'issubset': renamed_deprecation(issubset, 'subset', '2.9'),
+            'subset': issubset,
+            'issuperset': renamed_deprecation(issuperset, 'superset', '2.9'),
+            'superset': issuperset,
+            'isnan': renamed_deprecation(isnotanumber, 'nan', '2.9'),
+            'nan': isnotanumber,
         }

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -27,6 +27,7 @@ import pwd
 import re
 import time
 
+from functools import wraps
 from io import StringIO
 from numbers import Number
 
@@ -158,6 +159,7 @@ def _count_newlines_from_end(in_str):
 
 
 def tests_as_filters_warning(func):
+    @wraps(func)
     def wrapper(*args, **kwargs):
         display.deprecated(
             'Using tests as filters is deprecated. Instead of using `result|%(name)s` instead use '

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -157,6 +157,17 @@ def _count_newlines_from_end(in_str):
         return i
 
 
+def tests_as_filters_warning(func):
+    def wrapper(*args, **kwargs):
+        display.deprecated(
+            'Using tests as filters is deprecated. Instead of using `result|%(name)s` instead use '
+            '`result is %(name)s`' % dict(name=func.__name__),
+            version='2.9'
+        )
+        return func(*args, **kwargs)
+    return wrapper
+
+
 class AnsibleContext(Context):
     '''
     A custom context, which intercepts resolve() calls and sets a flag
@@ -283,7 +294,9 @@ class Templar:
         self._filters = dict()
         for fp in plugins:
             self._filters.update(fp.filters())
-        self._filters.update(self._get_tests())
+
+        for name, func in self._get_tests().items():
+            self._filters[name] = tests_as_filters_warning(func)
 
         return self._filters.copy()
 

--- a/lib/ansible/template/__init__.py
+++ b/lib/ansible/template/__init__.py
@@ -158,12 +158,20 @@ def _count_newlines_from_end(in_str):
         return i
 
 
-def tests_as_filters_warning(func):
+def tests_as_filters_warning(name, func):
+    '''
+    Closure to enable displaying a deprecation warning when tests are used as a filter
+
+    This closure is only used when registering ansible provided tests as filters
+
+    This function should be removed in 2.9 along with registering ansible provided tests as filters
+    in Templar._get_filters
+    '''
     @wraps(func)
     def wrapper(*args, **kwargs):
         display.deprecated(
             'Using tests as filters is deprecated. Instead of using `result|%(name)s` instead use '
-            '`result is %(name)s`' % dict(name=func.__name__),
+            '`result is %(name)s`' % dict(name=name),
             version='2.9'
         )
         return func(*args, **kwargs)
@@ -297,8 +305,9 @@ class Templar:
         for fp in plugins:
             self._filters.update(fp.filters())
 
+        # TODO: Remove registering tests as filters in 2.9
         for name, func in self._get_tests().items():
-            self._filters[name] = tests_as_filters_warning(func)
+            self._filters[name] = tests_as_filters_warning(name, func)
 
         return self._filters.copy()
 

--- a/packaging/release/release.yml
+++ b/packaging/release/release.yml
@@ -81,7 +81,7 @@
   - name: "assert the specified version ({{new_version}}) is greater than the latest version ({{latest_version.stdout}})"
     assert:
       that:
-      - new_version|version_compare(latest_version.stdout, "gt")
+      - new_version is version(latest_version.stdout, "gt")
     ignore_errors: yes
 
   - name: Update the VERSION file for the main repo

--- a/test/integration/targets/acl/tasks/acl.yml
+++ b/test/integration/targets/acl/tasks/acl.yml
@@ -55,8 +55,8 @@
 - name: verify output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - "'user:{{ ansible_user }}:r--' in output.acl"
       - "'user:{{ ansible_user }}:r--' in getfacl_output.stdout_lines"
 ##############################################################################
@@ -72,8 +72,8 @@
 - name: verify output
   assert:
     that:
-      - not output|changed
-      - not output|failed
+      - output is not changed
+      - output is not failed
       - "'user::rw-' in output.acl"
       - "'user:{{ ansible_user }}:r--' in output.acl"
       - "'group::r--' in output.acl"
@@ -100,8 +100,8 @@
 - name: verify output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - "'user:{{ ansible_user }}:r--' not in output.acl"
       - "'user:{{ ansible_user }}:r--' not in getfacl_output.stdout_lines"
 ##############################################################################
@@ -122,8 +122,8 @@
 - name: verify output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - "'user:{{ ansible_user }}:rw-' in output.acl"
       - "'default:user:{{ ansible_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
@@ -145,8 +145,8 @@
 - name: verify output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - "'user:{{ ansible_user }}:rw-' in output.acl"
       - "'default:user:{{ ansible_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
@@ -165,8 +165,8 @@
 - name: verify output
   assert:
     that:
-      - not output|changed
-      - not output|failed
+      - output is not changed
+      - output is not failed
       - "'user:{{ ansible_user }}:rw-' in output.acl"
       - "'default:user:{{ ansible_user }}:rw-' in getfacl_output.stdout_lines"
 ##############################################################################
@@ -198,8 +198,8 @@
 - name: verify output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - "'user::rwx' in getfacl_output.stdout_lines"
       - "'group::r-x' in getfacl_output.stdout_lines"
       - "'other::r-x' in getfacl_output.stdout_lines"

--- a/test/integration/targets/alternatives/tasks/path_is_checked.yml
+++ b/test/integration/targets/alternatives/tasks/path_is_checked.yml
@@ -9,4 +9,4 @@
 - name: Check previous task failed
   assert:
     that:
-      - 'alternative|failed'
+      - 'alternative is failed'

--- a/test/integration/targets/alternatives/tasks/test.yml
+++ b/test/integration/targets/alternatives/tasks/test.yml
@@ -12,8 +12,8 @@
   - name: check expected command was executed
     assert:
       that:
-        - 'alternative|success'
-        - 'alternative|changed'
+        - 'alternative is successful'
+        - 'alternative is changed'
   when: with_link
 
 - block:
@@ -26,8 +26,8 @@
   - name: check expected command was executed
     assert:
       that:
-        - 'alternative|success'
-        - 'alternative|changed'
+        - 'alternative is successful'
+        - 'alternative is changed'
   when: not with_link
 
 - name: execute dummy command

--- a/test/integration/targets/alternatives/tasks/tests_set_priority.yml
+++ b/test/integration/targets/alternatives/tasks/tests_set_priority.yml
@@ -16,7 +16,7 @@
 - name: check expected command was executed
   assert:
     that:
-      - 'alternative|changed'
+      - 'alternative is changed'
       - 'cmd.stdout == "dummy{{ item }}"'
 
 - name: check that alternative has been updated

--- a/test/integration/targets/apt/tasks/apt-builddep.yml
+++ b/test/integration/targets/apt/tasks/apt-builddep.yml
@@ -26,7 +26,7 @@
 - name: uninstall quilt with apt
   apt: pkg=quilt state=absent purge=yes
   register: apt_result
-  when: dpkg_result|success
+  when: dpkg_result is successful
   tags: ['test_apt_builddep']
 
 # install build-dep for netcat

--- a/test/integration/targets/apt/tasks/apt.yml
+++ b/test/integration/targets/apt/tasks/apt.yml
@@ -4,12 +4,12 @@
 - name: use python-apt
   set_fact:
     python_apt: python-apt
-  when: ansible_python_version | version_compare('3', '<')
+  when: ansible_python_version is version('3', '<')
 
 - name: use python3-apt
   set_fact:
     python_apt: python3-apt
-  when: ansible_python_version | version_compare('3', '>=')
+  when: ansible_python_version is version('3', '>=')
 
 # UNINSTALL 'python-apt'
 #  The `apt` module has the smarts to auto-install `python-apt`.  To test, we
@@ -22,7 +22,7 @@
 - name: uninstall {{ python_apt }} with apt
   apt: pkg={{ python_apt }} state=absent purge=yes
   register: apt_result
-  when: dpkg_result|success
+  when: dpkg_result is successful
 
 # UNINSTALL 'hello'
 #   With 'python-apt' uninstalled, the first call to 'apt' should install

--- a/test/integration/targets/apt_repository/tasks/apt.yml
+++ b/test/integration/targets/apt_repository/tasks/apt.yml
@@ -12,12 +12,12 @@
 - name: use python-apt
   set_fact:
     python_apt: python-apt
-  when: ansible_python_version | version_compare('3', '<')
+  when: ansible_python_version is version('3', '<')
 
 - name: use python3-apt
   set_fact:
     python_apt: python3-apt
-  when: ansible_python_version | version_compare('3', '>=')
+  when: ansible_python_version is version('3', '>=')
 
 # UNINSTALL 'python-apt'
 #  The `apt_repository` module has the smarts to auto-install `python-apt`.  To
@@ -30,7 +30,7 @@
 - name: uninstall {{ python_apt }} with apt
   apt: pkg={{ python_apt }} state=absent purge=yes
   register: apt_result
-  when: dpkg_result|success
+  when: dpkg_result is successful
 
 #
 # TEST: apt_repository: repo=<name>

--- a/test/integration/targets/async/tasks/main.yml
+++ b/test/integration/targets/async/tasks/main.yml
@@ -101,8 +101,8 @@
     that:
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
-    - async_result | changed == false
-    - async_result | failed
+    - async_result is changed == false
+    - async_result is failed
     - async_result.msg == 'failed gracefully'
 
 - name: test exception module failure
@@ -119,7 +119,7 @@
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
     - async_result.changed == false
-    - async_result | failed == true
+    - async_result is failed == true
     - async_result.stderr is search('failing via exception', multiline=True)
 
 - name: test leading junk before JSON
@@ -135,7 +135,7 @@
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
     - async_result.changed == true
-    - async_result | success
+    - async_result is successful
 
 - name: test trailing junk after JSON
   async_test:
@@ -150,5 +150,5 @@
     - async_result.ansible_job_id is match('\d+\.\d+')
     - async_result.finished == 1
     - async_result.changed == true
-    - async_result | success
+    - async_result is successful
     - async_result.warnings[0] is search('trailing junk after module output')

--- a/test/integration/targets/aws_api_gateway/tasks/main.yml
+++ b/test/integration/targets/aws_api_gateway/tasks/main.yml
@@ -106,7 +106,7 @@
     - name: assert 
       assert:
         that:
-          - bad_uri_result|failed
+          - bad_uri_result is failed
 
     # ============================================================
 

--- a/test/integration/targets/aws_lambda/tasks/main.yml
+++ b/test/integration/targets/aws_lambda/tasks/main.yml
@@ -115,7 +115,7 @@
     - name: assert lambda upload succeeded
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
 
     - name: test lambda works
       execute_lambda:
@@ -131,7 +131,7 @@
     - name: assert lambda manages to respond as expected
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
            - 'result.result.output.message == "hello Mr Ansible Tests"'
 
     # ============================================================
@@ -157,7 +157,7 @@
     - name: assert lambda fails with proper message
       assert:
         that:
-           - 'result|failed'
+           - 'result is failed'
            - 'result.msg != "MODULE FAILURE"'
            - 'result.changed == False'
            - '"requires at least one security group and one subnet" in result.msg'
@@ -188,7 +188,7 @@
     - name: assert lambda remains as before
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
            - 'result.changed == False'
 
 
@@ -212,7 +212,7 @@
     - name: assert lambda upload succeeded
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
            - 'result.changed == True'
 
     - name: test lambda works
@@ -229,7 +229,7 @@
     - name: assert lambda manages to respond as expected
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
            - 'result.result.output.message == "hello Mr Ansible Tests. I think you are great!!"'
 
     # ============================================================
@@ -250,7 +250,7 @@
     - name: assert lambda manages to respond as expected
       assert:
         that:
-           - 'result|failed'
+           - 'result is failed'
            - 'result.changed == False'
 
     # ============================================================
@@ -267,7 +267,7 @@
     - name: assert state=absent
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
            - 'result.changed == True'
 
     # ============================================================
@@ -331,7 +331,7 @@
     - name: assert lambda manages to respond as expected
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
 
     - name: wait for async job 1
       async_status: jid={{ async_1.ansible_job_id }}
@@ -402,7 +402,7 @@
     - name: assert lambda creation has succeeded
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
 
     - name: wait for async job 1
       async_status: jid={{ async_1.ansible_job_id }}
@@ -446,5 +446,5 @@
     - name: assert state=absent
       assert:
         that:
-           - 'not result|failed'
+           - 'result is not failed'
            - 'result.changed == False'

--- a/test/integration/targets/binary_modules/roles/test_binary_modules/tasks/main.yml
+++ b/test/integration/targets/binary_modules/roles/test_binary_modules/tasks/main.yml
@@ -36,7 +36,7 @@
 - assert:
     that:
       - 'async_hello_world.msg == "Hello, World!"'
-  when: not async_hello_world|skipped
+  when: async_hello_world is not skipped
 
 - name: Async Hello, Ansible!
   action: "helloworld_{{ ansible_system|lower }}"
@@ -50,4 +50,4 @@
 - assert:
     that:
       - 'async_hello_ansible.msg == "Hello, Ansible!"'
-  when: not async_hello_ansible|skipped
+  when: async_hello_ansible is not skipped

--- a/test/integration/targets/check_mode/roles/test_check_mode/tasks/main.yml
+++ b/test/integration/targets/check_mode/roles/test_check_mode/tasks/main.yml
@@ -27,7 +27,7 @@
 - name: verify that the file was marked as changed in check mode
   assert: 
     that: 
-      - "template_result|changed"
+      - "template_result is changed"
       - "not foo.stat.exists"
 
 - name: Actually create the file, disable check mode
@@ -46,5 +46,5 @@
 - name: verify that the file was not changed
   assert: 
     that: 
-      - "checkmode_disabled|changed"
-      - "not template_result2|changed"
+      - "checkmode_disabled is changed"
+      - "template_result2 is not changed"

--- a/test/integration/targets/connection/test_connection.yml
+++ b/test/integration/targets/connection/test_connection.yml
@@ -12,7 +12,7 @@
     assert:
       that:
       - "'汉语' in command.stdout"
-      - command | changed # as of 2.2, raw should default to changed: true for consistency w/ shell/command/script modules
+      - command is changed # as of 2.2, raw should default to changed: true for consistency w/ shell/command/script modules
 
   ### copy local file with unicode filename and content
 

--- a/test/integration/targets/copy/tasks/dest_in_non_existent_directories.yml
+++ b/test/integration/targets/copy/tasks/dest_in_non_existent_directories.yml
@@ -14,8 +14,8 @@
 - name: assert copy worked
   assert:
     that:
-      - 'copy_result|success'
-      - 'copy_result|changed'
+      - 'copy_result is successful'
+      - 'copy_result is changed'
 
 - name: stat copied file
   stat:

--- a/test/integration/targets/copy/tasks/src_file_dest_file_in_non_existent_dir.yml
+++ b/test/integration/targets/copy/tasks/src_file_dest_file_in_non_existent_dir.yml
@@ -13,7 +13,7 @@
 - name: Assert copy failed
   assert:
     that:
-      - 'copy_result|failed'
+      - 'copy_result is failed'
 
 - name: Stat dest path
   stat:

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -108,7 +108,7 @@
 - name: Assert that the file was not changed
   assert:
     that:
-      - "not copy_result2|changed"
+      - "copy_result2 is not changed"
 
 - name: Overwrite the file using the content system
   copy:
@@ -129,7 +129,7 @@
 - name: Assert that the file has changed
   assert:
      that:
-       - "copy_result3|changed"
+       - "copy_result3 is changed"
        - "'content' not in copy_result3"
        - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
        - "stat_results.stat.mode != '0700'"
@@ -154,7 +154,7 @@
 - name: Assert that the file has changed
   assert:
      that:
-       - "copy_result3|changed"
+       - "copy_result3 is changed"
        - "'content' not in copy_result3"
        - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
        - "stat_results.stat.mode == '0700'"
@@ -269,7 +269,7 @@
 - name: Assert that empty source failed
   assert:
     that:
-      - failed_copy | failed
+      - failed_copy is failed
       - "'src (or content) is required' in failed_copy.msg"
 
 - name: Try without destination to ensure it fails
@@ -285,7 +285,7 @@
 - name: Assert that missing destination failed
   assert:
     that:
-      - failed_copy | failed
+      - failed_copy is failed
       - "'dest is required' in failed_copy.msg"
 
 - name: Try without source to ensure it fails
@@ -301,7 +301,7 @@
 - name: Assert that missing source failed
   assert:
     that:
-      - failed_copy | failed
+      - failed_copy is failed
       - "'src (or content) is required' in failed_copy.msg"
 
 - name: Try with both src and content to ensure it fails
@@ -315,7 +315,7 @@
 - name: Assert that mutually exclusive parameters failed
   assert:
     that:
-      - failed_copy | failed
+      - failed_copy is failed
       - "'mutually exclusive' in failed_copy.msg"
 
 - name: Try with content and directory as destination to ensure it fails
@@ -332,7 +332,7 @@
 - name: Assert that content and directory as destination failed
   assert:
     that:
-      - failed_copy | failed
+      - failed_copy is failed
       - "'can not use content with a dir as dest' in failed_copy.msg"
 
 - name: Clean up
@@ -359,7 +359,7 @@
 - name: Assert that the file has changed
   assert:
      that:
-       - "copy_results|changed"
+       - "copy_results is changed"
        - "stat_results.stat.checksum == ('foo.txt\n'|hash('sha1'))"
        - "stat_results.stat.mode == '0500'"
 
@@ -386,7 +386,7 @@
 - name: Assert that the file has changed and has correct mode
   assert:
      that:
-       - "copy_results|changed"
+       - "copy_results is changed"
        - "copy_results.mode == '0547'"
        - "stat_results.stat.checksum == ('foo.txt\n'|hash('sha1'))"
        - "stat_results.stat.mode == '0547'"
@@ -437,7 +437,7 @@
 - name: Assert that the recursive copy did something
   assert:
     that:
-      - "recursive_copy_result|changed"
+      - "recursive_copy_result is changed"
 
 - name: Check that a file in a directory was transferred
   stat:
@@ -547,7 +547,7 @@
 - name: Assert that the second copy did not change anything
   assert:
     that:
-      - "not recursive_copy_result|changed"
+      - "recursive_copy_result is not changed"
 
 - name: Cleanup the recursive copy subdir
   file:
@@ -594,7 +594,7 @@
 - name: Assert that the recursive copy did something
   assert:
     that:
-      - "recursive_copy_result|changed"
+      - "recursive_copy_result is changed"
 
 - name: Check that a file in a directory was transferred
   stat:
@@ -702,7 +702,7 @@
 - name: Assert that the second copy did not change anything
   assert:
     that:
-      - "not recursive_copy_result|changed"
+      - "recursive_copy_result is not changed"
 
 - name: Cleanup the recursive copy subdir
   file:
@@ -749,7 +749,7 @@
 - name: Assert that the recursive copy did something
   assert:
     that:
-      - "recursive_copy_result|changed"
+      - "recursive_copy_result is changed"
 
 - name: Check that a file in a directory was transferred
   stat:
@@ -867,7 +867,7 @@
 - name: Assert that the second copy did not change anything
   assert:
     that:
-      - "not recursive_copy_result|changed"
+      - "recursive_copy_result is not changed"
 
 - name: Cleanup the recursive copy subdir
   file:
@@ -1153,7 +1153,7 @@
 - name: Assert that the file has changed and is not a link
   assert:
      that:
-       - "copy_results|changed"
+       - "copy_results is changed"
        - "'content' not in copy_results"
        - "stat_results.stat.checksum == ('modified'|hash('sha1'))"
        - "not stat_results.stat.islnk"

--- a/test/integration/targets/cs_account/tasks/main.yml
+++ b/test/integration/targets/cs_account/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup
   assert:
     that:
-    - acc|success
+    - acc is successful
 
 - name: test fail if missing name
   action: cs_account
@@ -14,7 +14,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - acc|failed
+    - acc is failed
     - 'acc.msg == "missing required arguments: name"'
 
 - name: test fail if missing params if state=present
@@ -25,7 +25,7 @@
 - name: verify results of fail if missing params if state=present
   assert:
     that:
-    - acc|failed
+    - acc is failed
     - 'acc.msg == "missing required arguments: email, username, password, first_name, last_name"'
 
 - name: test create user account in check mode
@@ -42,8 +42,8 @@
 - name: verify results of create account in check mode
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
 
 - name: test create user account
   cs_account:
@@ -58,8 +58,8 @@
 - name: verify results of create account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -79,8 +79,8 @@
 - name: verify results of create account idempotence
   assert:
     that:
-    - acc|success
-    - not acc|changed
+    - acc is successful
+    - acc is not changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -96,8 +96,8 @@
 - name: verify results of lock user account in check mode
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -112,8 +112,8 @@
 - name: verify results of lock user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -128,8 +128,8 @@
 - name: verify results of lock user account idempotence
   assert:
     that:
-    - acc|success
-    - not acc|changed
+    - acc is successful
+    - acc is not changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -145,8 +145,8 @@
 - name: verify results of disable user account in check mode
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -161,8 +161,8 @@
 - name: verify results of disable user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -177,8 +177,8 @@
 - name: verify results of disable user account idempotence
   assert:
     that:
-    - acc|success
-    - not acc|changed
+    - acc is successful
+    - acc is not changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -194,8 +194,8 @@
 - name: verify results of lock disabled user account in check mode
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -210,8 +210,8 @@
 - name: verify results of lock disabled user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -226,8 +226,8 @@
 - name: verify results of lock disabled user account idempotence
   assert:
     that:
-    - acc|success
-    - not acc|changed
+    - acc is successful
+    - acc is not changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -243,8 +243,8 @@
 - name: verify results of enable user account in check mode
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -259,8 +259,8 @@
 - name: verify results of enable user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -275,8 +275,8 @@
 - name: verify results of enable user account idempotence
   assert:
     that:
-    - acc|success
-    - not acc|changed
+    - acc is successful
+    - acc is not changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -292,8 +292,8 @@
 - name: verify results of remove user account in check mode
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -308,8 +308,8 @@
 - name: verify results of remove user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -324,8 +324,8 @@
 - name: verify results of remove user account idempotence
   assert:
     that:
-    - acc|success
-    - not acc|changed
+    - acc is successful
+    - acc is not changed
 
 - name: test create user disabled account
   cs_account:
@@ -341,8 +341,8 @@
 - name: verify results of create disabled account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -357,8 +357,8 @@
 - name: verify results of remove disabled user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -379,8 +379,8 @@
 - name: verify results of create locked account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -395,8 +395,8 @@
 - name: verify results of remove locked user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -417,8 +417,8 @@
 - name: verify results of create unlocked/enabled account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
@@ -433,8 +433,8 @@
 - name: verify results of remove unlocked/enabled user account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_user"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"

--- a/test/integration/targets/cs_affinitygroup/tasks/main.yml
+++ b/test/integration/targets/cs_affinitygroup/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup
   assert:
     that:
-    - ag|success
+    - ag is successful
 
 - name: test fail if missing name
   cs_affinitygroup:
@@ -16,7 +16,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-    - ag|failed
+    - ag is failed
     - "ag.msg == 'missing required arguments: name'"
 
 - name: test fail unknown affinity type
@@ -28,7 +28,7 @@
 - name: verify test fail unknown affinity type
   assert:
     that:
-    - ag|failed
+    - ag is failed
     - "ag.msg == 'affinity group type not found: unexistent affinity type'"
 
 - name: test present affinity group in check mode
@@ -38,8 +38,8 @@
 - name: verify results of create affinity group in check mode
   assert:
     that:
-    - ag|success
-    - ag|changed
+    - ag is successful
+    - ag is changed
 
 - name: test present affinity group
   cs_affinitygroup: name={{ cs_resource_prefix }}_ag
@@ -47,8 +47,8 @@
 - name: verify results of create affinity group
   assert:
     that:
-    - ag|success
-    - ag|changed
+    - ag is successful
+    - ag is changed
     - ag.name == "{{ cs_resource_prefix }}_ag"
 
 - name: test present affinity group is idempotence
@@ -57,8 +57,8 @@
 - name: verify results present affinity group is idempotence
   assert:
     that:
-    - ag|success
-    - not ag|changed
+    - ag is successful
+    - ag is not changed
     - ag.name == "{{ cs_resource_prefix }}_ag"
 
 - name: test absent affinity group in check mode
@@ -68,8 +68,8 @@
 - name: verify results of absent affinity group in check mode
   assert:
     that:
-    - ag|success
-    - ag|changed
+    - ag is successful
+    - ag is changed
     - ag.name == "{{ cs_resource_prefix }}_ag"
 
 - name: test absent affinity group
@@ -78,8 +78,8 @@
 - name: verify results of absent affinity group
   assert:
     that:
-    - ag|success
-    - ag|changed
+    - ag is successful
+    - ag is changed
     - ag.name == "{{ cs_resource_prefix }}_ag"
 
 - name: test absent affinity group is idempotence
@@ -88,6 +88,6 @@
 - name: verify results of absent affinity group is idempotence
   assert:
     that:
-    - ag|success
-    - not ag|changed
+    - ag is successful
+    - ag is not changed
     - ag.name is undefined

--- a/test/integration/targets/cs_cluster/tasks/main.yml
+++ b/test/integration/targets/cs_cluster/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup cluster is absent
   assert:
     that:
-      - cluster|success
+      - cluster is successful
 
 - name: setup zone is present
   cs_zone:
@@ -19,7 +19,7 @@
 - name: verify setup zone is present
   assert:
     that:
-      - zone|success
+      - zone is successful
 
 - name: setup pod is present
   cs_pod:
@@ -32,7 +32,7 @@
 - name: verify setup pod is present
   assert:
     that:
-      - pod|success
+      - pod is successful
 
 - name: test fail if missing name
   cs_cluster:
@@ -41,7 +41,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-      - cluster|failed
+      - cluster is failed
       - "cluster.msg == 'missing required arguments: name'"
 
 - name: test fail if pod not found
@@ -56,7 +56,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-      - cluster|failed
+      - cluster is failed
       - "cluster.msg == 'Pod unexistent not found in zone {{ cs_resource_prefix }}-zone'"
 
 - name: test create cluster in check mode
@@ -71,7 +71,7 @@
 - name: verify test create cluster in check mode
   assert:
     that:
-      - cluster_origin|changed
+      - cluster_origin is changed
 
 - name: test create cluster
   cs_cluster:
@@ -84,7 +84,7 @@
 - name: verify test create cluster
   assert:
     that:
-      - cluster_origin|changed
+      - cluster_origin is changed
       - cluster_origin.name == "{{ cs_resource_prefix }}-cluster"
       - cluster_origin.zone == "{{ cs_resource_prefix }}-zone"
       - cluster_origin.allocation_state == "Enabled"
@@ -102,7 +102,7 @@
   assert:
     that:
       - cluster.id == cluster_origin.id
-      - not cluster|changed
+      - cluster is not changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -120,7 +120,7 @@
 - name: verify test update cluster in check mode
   assert:
     that:
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -138,7 +138,7 @@
 - name: verify test update cluster
   assert:
     that:
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -156,7 +156,7 @@
 - name: verify test update cluster idempotence
   assert:
     that:
-      - not cluster|changed
+      - cluster is not changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -173,7 +173,7 @@
 - name: verify test disable cluster in check mode
   assert:
     that:
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -189,7 +189,7 @@
 - name: verify test disable cluster
   assert:
     that:
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Disabled"
@@ -205,7 +205,7 @@
 - name: verify test disable cluster idempotence
   assert:
     that:
-      - not cluster|changed
+      - cluster is not changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Disabled"
@@ -221,7 +221,7 @@
 - name: verify test enable cluster in check mode
   assert:
     that:
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Disabled"
@@ -237,7 +237,7 @@
 - name: verify test enable cluster
   assert:
     that:
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -253,7 +253,7 @@
 - name: verify test enable cluster idempotence
   assert:
     that:
-      - not cluster|changed
+      - cluster is not changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -272,7 +272,7 @@
   assert:
     that:
       - cluster.id == cluster_origin.id
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -288,7 +288,7 @@
   assert:
     that:
       - cluster.id == cluster_origin.id
-      - cluster|changed
+      - cluster is changed
       - cluster.name == "{{ cs_resource_prefix }}-cluster"
       - cluster.zone == "{{ cs_resource_prefix }}-zone"
       - cluster.allocation_state == "Enabled"
@@ -303,4 +303,4 @@
 - name: verify test remove cluster idempotence
   assert:
     that:
-      - not cluster|changed
+      - cluster is not changed

--- a/test/integration/targets/cs_configuration/tasks/account.yml
+++ b/test/integration/targets/cs_configuration/tasks/account.yml
@@ -8,7 +8,7 @@
 - name: verify test configuration storage
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration account in check mode
   cs_configuration:
@@ -20,8 +20,8 @@
 - name: verify update configuration account in check mode
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "true"
     - config.name == "allow.public.user.templates"
     - config.scope == "account"
@@ -36,8 +36,8 @@
 - name: verify update configuration account
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "false"
     - config.name == "allow.public.user.templates"
     - config.scope == "account"
@@ -52,8 +52,8 @@
 - name: verify update configuration account idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "false"
     - config.name == "allow.public.user.templates"
     - config.scope == "account"
@@ -68,8 +68,8 @@
 - name: verify update configuration account
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "true"
     - config.name == "allow.public.user.templates"
     - config.scope == "account"

--- a/test/integration/targets/cs_configuration/tasks/cluster.yml
+++ b/test/integration/targets/cs_configuration/tasks/cluster.yml
@@ -8,7 +8,7 @@
 - name: verify test configuration cluster
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration cluster in check mode
   cs_configuration:
@@ -20,8 +20,8 @@
 - name: verify update configuration cluster in check mode
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "1.0"
     - config.name == "cpu.overprovisioning.factor"
     - config.scope == "cluster"
@@ -36,8 +36,8 @@
 - name: verify update configuration cluster
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "2.0"
     - config.name == "cpu.overprovisioning.factor"
     - config.scope == "cluster"
@@ -52,8 +52,8 @@
 - name: verify update configuration cluster idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "2.0"
     - config.name == "cpu.overprovisioning.factor"
     - config.scope == "cluster"
@@ -68,8 +68,8 @@
 - name: verify reset configuration cluster
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "1.0"
     - config.name == "cpu.overprovisioning.factor"
     - config.scope == "cluster"

--- a/test/integration/targets/cs_configuration/tasks/main.yml
+++ b/test/integration/targets/cs_configuration/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: verify results of fail if missing arguments
   assert:
     that:
-      - config|failed
+      - config is failed
       - "config.msg.startswith('missing required arguments: ')"
 
 - name: test configuration
@@ -17,7 +17,7 @@
 - name: verify test configuration
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration string in check mode
   cs_configuration:
@@ -28,8 +28,8 @@
 - name: verify test update configuration string in check mode
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "global"
     - config.name == "network.loadbalancer.haproxy.stats.visibility"
 
@@ -41,8 +41,8 @@
 - name: verify test update configuration string
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "all"
     - config.name == "network.loadbalancer.haproxy.stats.visibility"
 
@@ -54,8 +54,8 @@
 - name: verify test update configuration string idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "all"
     - config.name == "network.loadbalancer.haproxy.stats.visibility"
 
@@ -67,8 +67,8 @@
 - name: verify test reset configuration string
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "global"
     - config.name == "network.loadbalancer.haproxy.stats.visibility"
 
@@ -80,7 +80,7 @@
 - name: verify test configuration
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration bool in check mode
   cs_configuration:
@@ -91,8 +91,8 @@
 - name: verify test update configuration bool in check mode
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "false"
     - config.name == "vmware.recycle.hung.wokervm"
 
@@ -104,8 +104,8 @@
 - name: verify test update configuration bool
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "true"
     - config.name == "vmware.recycle.hung.wokervm"
 
@@ -117,8 +117,8 @@
 - name: verify test update configuration bool idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "true"
     - config.name == "vmware.recycle.hung.wokervm"
 
@@ -130,8 +130,8 @@
 - name: verify test reset configuration bool
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "false"
     - config.name == "vmware.recycle.hung.wokervm"
 
@@ -143,7 +143,7 @@
 - name: verify test configuration
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration float in check mode
   cs_configuration:
@@ -154,8 +154,8 @@
 - name: verify update configuration float in check mode
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "0.7"
     - config.name == "agent.load.threshold"
 
@@ -167,8 +167,8 @@
 - name: verify update configuration float
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "0.81"
     - config.name == "agent.load.threshold"
 
@@ -180,8 +180,8 @@
 - name: verify update configuration float idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "0.81"
     - config.name == "agent.load.threshold"
 
@@ -193,8 +193,8 @@
 - name: verify reset configuration float
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "0.7"
     - config.name == "agent.load.threshold"
 

--- a/test/integration/targets/cs_configuration/tasks/storage.yml
+++ b/test/integration/targets/cs_configuration/tasks/storage.yml
@@ -8,7 +8,7 @@
 - name: verify test configuration storage
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration storage in check mode
   cs_configuration:
@@ -20,8 +20,8 @@
 - name: verify update configuration storage in check mode
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "2.0"
     - config.name == "storage.overprovisioning.factor"
     - config.scope == "storagepool"
@@ -36,8 +36,8 @@
 - name: verify update configuration storage
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "3.0"
     - config.name == "storage.overprovisioning.factor"
     - config.scope == "storagepool"
@@ -52,8 +52,8 @@
 - name: verify update configuration storage idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "3.0"
     - config.name == "storage.overprovisioning.factor"
     - config.scope == "storagepool"
@@ -68,8 +68,8 @@
 - name: verify reset configuration storage
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "2.0"
     - config.name == "storage.overprovisioning.factor"
     - config.scope == "storagepool"

--- a/test/integration/targets/cs_configuration/tasks/zone.yml
+++ b/test/integration/targets/cs_configuration/tasks/zone.yml
@@ -8,7 +8,7 @@
 - name: verify test configuration zone
   assert:
     that:
-    - config|success
+    - config is successful
 
 - name: test update configuration zone
   cs_configuration:
@@ -19,8 +19,8 @@
 - name: verify update configuration zone
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "true"
     - config.name == "use.external.dns"
     - config.scope == "zone"
@@ -35,8 +35,8 @@
 - name: verify update configuration zone idempotence
   assert:
     that:
-    - config|success
-    - not config|changed
+    - config is successful
+    - config is not changed
     - config.value == "true"
     - config.name == "use.external.dns"
     - config.scope == "zone"
@@ -51,8 +51,8 @@
 - name: verify reset configuration zone
   assert:
     that:
-    - config|success
-    - config|changed
+    - config is successful
+    - config is changed
     - config.value == "false"
     - config.name == "use.external.dns"
     - config.scope == "zone"

--- a/test/integration/targets/cs_domain/tasks/main.yml
+++ b/test/integration/targets/cs_domain/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup
   assert:
     that:
-    - dom|success
+    - dom is successful
 
 - name: test fail if missing name
   action: cs_domain
@@ -16,7 +16,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - dom|failed
+    - dom is failed
     - 'dom.msg == "missing required arguments: path"'
 
 - name: test fail if ends with /
@@ -27,7 +27,7 @@
 - name: verify results of fail if ends with /
   assert:
     that:
-    - dom|failed
+    - dom is failed
     - dom.msg == "Path '{{ cs_resource_prefix }}_domain/' must not end with /"
 
 - name: test create a domain in check mode
@@ -38,7 +38,7 @@
 - name: verify results of test create a domain in check mode
   assert:
     that:
-    - dom|changed
+    - dom is changed
 
 - name: test create a domain
   cs_domain:
@@ -47,7 +47,7 @@
 - name: verify results of test create a domain
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain"
     - dom.name == "{{ cs_resource_prefix }}_domain"
 
@@ -58,7 +58,7 @@
 - name: verify results of test create a domain idempotence
   assert:
     that:
-    - not dom|changed
+    - dom is not changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain"
     - dom.name == "{{ cs_resource_prefix }}_domain"
 
@@ -69,7 +69,7 @@
 - name: verify results of test create a domain idempotence2
   assert:
     that:
-    - not dom|changed
+    - dom is not changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain"
     - dom.name == "{{ cs_resource_prefix }}_domain"
 
@@ -81,7 +81,7 @@
 - name: test fail to create a subdomain for inexistent domain
   assert:
     that:
-    - dom|failed
+    - dom is failed
     - dom.msg == "Parent domain path ROOT/inexistent does not exist"
 
 - name: test create a subdomain in check mode
@@ -92,7 +92,7 @@
 - name: verify results of test create a domain in check mode
   assert:
     that:
-    - dom|changed
+    - dom is changed
 
 - name: test create a subdomain
   cs_domain:
@@ -101,7 +101,7 @@
 - name: verify results of test create a domain
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
 
@@ -112,7 +112,7 @@
 - name: verify results of test create a subdomain idempotence
   assert:
     that:
-    - not dom|changed
+    - dom is not changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
 
@@ -125,7 +125,7 @@
 - name: verify results of test update a subdomain in check mode
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.network_domain is undefined
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
@@ -138,7 +138,7 @@
 - name: verify results of test update a subdomain
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.network_domain == "domain.example.com"
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
@@ -151,7 +151,7 @@
 - name: verify results of test update a subdomain idempotence
   assert:
     that:
-    - not dom|changed
+    - dom is not changed
     - dom.network_domain == "domain.example.com"
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
@@ -165,7 +165,7 @@
 - name: verify results of test delete a subdomain in check mode
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
 
@@ -177,7 +177,7 @@
 - name: verify results of test delete a subdomain
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
 
@@ -189,7 +189,7 @@
 - name: verify results of test delete a subdomain idempotence
   assert:
     that:
-    - not dom|changed
+    - dom is not changed
 
 - name: test create a subdomain 2
   cs_domain:
@@ -198,7 +198,7 @@
 - name: verify results of test create a subdomain 2
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain/{{ cs_resource_prefix }}_subdomain"
     - dom.name == "{{ cs_resource_prefix }}_subdomain"
 
@@ -212,7 +212,7 @@
 - name: verify results of test delete a domain with clean up in check mode
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain"
     - dom.name == "{{ cs_resource_prefix }}_domain"
 
@@ -225,7 +225,7 @@
 - name: verify results of test delete a domain with clean up
   assert:
     that:
-    - dom|changed
+    - dom is changed
     - dom.path == "ROOT/{{ cs_resource_prefix }}_domain"
     - dom.name == "{{ cs_resource_prefix }}_domain"
 
@@ -238,4 +238,4 @@
 - name: verify results of test delete a domain with clean up idempotence
   assert:
     that:
-    - not dom|changed
+    - dom is not changed

--- a/test/integration/targets/cs_firewall/tasks/main.yml
+++ b/test/integration/targets/cs_firewall/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify network setup
   assert:
     that:
-    - net|success
+    - net is successful
 
 - name: public ip address setup
   cs_ip_address:
@@ -19,7 +19,7 @@
 - name: verify public ip address setup
   assert:
     that:
-    - ip_address|success
+    - ip_address is successful
 
 - name: set ip address as fact
   set_fact:
@@ -35,7 +35,7 @@
 - name: verify setup
   assert:
     that:
-    - fw|success
+    - fw is successful
 
 - name: setup 5300
   cs_firewall:
@@ -52,7 +52,7 @@
 - name: verify setup
   assert:
     that:
-    - fw|success
+    - fw is successful
 
 - name: setup all
   cs_firewall:
@@ -65,7 +65,7 @@
 - name: verify setup
   assert:
     that:
-    - fw|success
+    - fw is successful
 
 - name: test fail if missing params
   action: cs_firewall
@@ -74,7 +74,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - fw|failed
+    - fw is failed
     - "fw.msg == 'one of the following is required: ip_address, network'"
 
 - name: test fail if missing params
@@ -86,7 +86,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - fw|failed
+    - fw is failed
     - "fw.msg == \"missing required argument for protocol 'tcp': start_port or end_port\""
 
 - name: test fail if missing params network egress
@@ -98,7 +98,7 @@
 - name: verify results of fail if missing params ip_address
   assert:
     that:
-    - fw|failed
+    - fw is failed
     - "fw.msg == 'one of the following is required: ip_address, network'"
 
 - name: test present firewall rule ingress 80 in check mode
@@ -111,8 +111,8 @@
 - name: verify results of present firewall rule ingress 80 in check mode
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
 
 - name: test present firewall rule ingress 80
   cs_firewall:
@@ -123,8 +123,8 @@
 - name: verify results of present firewall rule ingress 80
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -142,8 +142,8 @@
 - name: verify results of present firewall rule ingress 80 idempotence
   assert:
     that:
-    - fw|success
-    - not fw|changed
+    - fw is successful
+    - fw is not changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -167,8 +167,8 @@
 - name: verify results of present firewall rule ingress 5300 in check mode
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
 
 - name: test present firewall rule ingress 5300
   cs_firewall:
@@ -184,8 +184,8 @@
 - name: verify results of present firewall rule ingress 5300
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "1.2.3.0/24,4.5.6.0/24"
     - fw.cidrs == [ '1.2.3.0/24', '4.5.6.0/24' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -208,8 +208,8 @@
 - name: verify results of present firewall rule ingress 5300 idempotence
   assert:
     that:
-    - fw|success
-    - not fw|changed
+    - fw is successful
+    - fw is not changed
     - fw.cidr == "1.2.3.0/24,4.5.6.0/24"
     - fw.cidrs == [ '1.2.3.0/24', '4.5.6.0/24' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -229,8 +229,8 @@
 - name: verify results of present firewall rule egress all in check mode
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
 
 - name: test present firewall rule egress all
   cs_firewall:
@@ -242,8 +242,8 @@
 - name: verify results of present firewall rule egress all
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.network == "{{ cs_firewall_network }}"
@@ -260,8 +260,8 @@
 - name: verify results of present firewall rule egress all idempotence
   assert:
     that:
-    - fw|success
-    - not fw|changed
+    - fw is successful
+    - fw is not changed
     - fw.cidr == "0.0.0.0/0"
     - fw.network == "{{ cs_firewall_network }}"
     - fw.protocol == "all"
@@ -278,8 +278,8 @@
 - name: verify results of absent firewall rule ingress 80 in check mode
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -298,8 +298,8 @@
 - name: verify results of absent firewall rule ingress 80
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -318,8 +318,8 @@
 - name: verify results of absent firewall rule ingress 80 idempotence
   assert:
     that:
-    - fw|success
-    - not fw|changed
+    - fw is successful
+    - fw is not changed
 
 - name: test absent firewall rule ingress 5300 in check mode
   cs_firewall:
@@ -337,8 +337,8 @@
 - name: verify results of absent firewall rule ingress 5300 in check mode
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "1.2.3.0/24,4.5.6.0/24"
     - fw.cidrs == [ '1.2.3.0/24', '4.5.6.0/24' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -362,8 +362,8 @@
 - name: verify results of absent firewall rule ingress 5300
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "1.2.3.0/24,4.5.6.0/24"
     - fw.cidrs == [ '1.2.3.0/24', '4.5.6.0/24' ]
     - fw.ip_address == "{{ cs_firewall_ip_address }}"
@@ -387,8 +387,8 @@
 - name: verify results of absent firewall rule ingress 5300 idempotence
   assert:
     that:
-    - fw|success
-    - not fw|changed
+    - fw is successful
+    - fw is not changed
 
 - name: test absent firewall rule egress all in check mode
   cs_firewall:
@@ -402,8 +402,8 @@
 - name: verify results of absent firewall rule egress all in check mode
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.network == "{{ cs_firewall_network }}"
@@ -421,8 +421,8 @@
 - name: verify results of absent firewall rule egress all
   assert:
     that:
-    - fw|success
-    - fw|changed
+    - fw is successful
+    - fw is changed
     - fw.cidr == "0.0.0.0/0"
     - fw.cidrs == [ '0.0.0.0/0' ]
     - fw.network == "{{ cs_firewall_network }}"
@@ -440,8 +440,8 @@
 - name: verify results of absent firewall rule egress all idempotence
   assert:
     that:
-    - fw|success
-    - not fw|changed
+    - fw is successful
+    - fw is not changed
 
 - name: network cleanup
   cs_network:
@@ -452,4 +452,4 @@
 - name: verify network cleanup
   assert:
     that:
-    - net|success
+    - net is successful

--- a/test/integration/targets/cs_host/tasks/main.yml
+++ b/test/integration/targets/cs_host/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: verify test fail missing url if host is not existent
   assert:
     that:
-      - host|failed
+      - host is failed
       - 'host.msg == "missing required arguments: name"'
 
 - name: test fail missing params if host is not existent
@@ -17,7 +17,7 @@
 - name: verify test fail missing params if host is not existent
   assert:
     that:
-      - host|failed
+      - host is failed
       - 'host.msg == "missing required arguments: password, username, hypervisor, pod"'
 
 - name: test create a host in check mode
@@ -38,7 +38,7 @@
 - name: verify test create a host in check mode
   assert:
     that:
-      - host|changed
+      - host is changed
 
 - name: test create a host
   cs_host:
@@ -57,7 +57,7 @@
 - name: verify test create a host
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -91,7 +91,7 @@
 - name: verify test create a host idempotence
   assert:
     that:
-      - not host|changed
+      - host is not changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -120,7 +120,7 @@
 - name: verify test update a host in check mode
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -148,7 +148,7 @@
 - name: verify test update a host in check mode
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -176,7 +176,7 @@
 - name: verify test update a host idempotence
   assert:
     that:
-      - not host|changed
+      - host is not changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -203,7 +203,7 @@
 - name: verify test update host remove host_tags
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.host_tags|length == 0
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
@@ -231,7 +231,7 @@
 - name: verify test update host remove host_tags idempotence
   assert:
     that:
-      - not host|changed
+      - host is not changed
       - len(host.host_tags) == 0
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
@@ -254,7 +254,7 @@
 - name: verify test put host in maintenance in check mode
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -274,7 +274,7 @@
 - name: verify test put host in maintenance
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -294,7 +294,7 @@
 - name: verify test put host in maintenance idempotence
   assert:
     that:
-      - not host|changed
+      - host is not changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -315,7 +315,7 @@
 - name: verify test put host out of maintenance in check mode
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -335,7 +335,7 @@
 - name: verify test put host out of maintenance
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -355,7 +355,7 @@
 - name: verify test put host out of maintenance idempotence
   assert:
     that:
-      - not host|changed
+      - host is not changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -376,7 +376,7 @@
 - name: verify test remove a host in check mode
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -396,7 +396,7 @@
 - name: verify test remove a host
   assert:
     that:
-      - host|changed
+      - host is changed
       - host.cluster == 'C0-basic'
       - host.pod == 'POD0-basic'
       - host.hypervisor == 'Simulator'
@@ -416,4 +416,4 @@
 - name: verify test remove a host idempotenc
   assert:
     that:
-      - not host|changed
+      - host is not changed

--- a/test/integration/targets/cs_instance/tasks/absent.yml
+++ b/test/integration/targets/cs_instance/tasks/absent.yml
@@ -8,8 +8,8 @@
 - name: verify destroy instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state != "Destroyed"
 
 - name: test destroy instance
@@ -20,8 +20,8 @@
 - name: verify destroy instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Destroyed"
 
 - name: test destroy instance idempotence
@@ -32,8 +32,8 @@
 - name: verify destroy instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
 
 - name: test recover to stopped state and update a deleted instance in check mode
   cs_instance:
@@ -45,8 +45,8 @@
 - name: verify test recover to stopped state and update a deleted instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
 
 - name: test recover to stopped state and update a deleted instance
   cs_instance:
@@ -57,8 +57,8 @@
 - name: verify test recover to stopped state and update a deleted instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -71,8 +71,8 @@
 - name: verify test recover to stopped state and update a deleted instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -85,8 +85,8 @@
 - name: verify test expunge instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -98,8 +98,8 @@
 - name: verify test expunge instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -111,5 +111,5 @@
 - name: verify test expunge instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed

--- a/test/integration/targets/cs_instance/tasks/absent_display_name.yml
+++ b/test/integration/targets/cs_instance/tasks/absent_display_name.yml
@@ -7,8 +7,8 @@
 - name: verify destroy instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Destroyed"
 
 - name: test destroy instance with display_name idempotence
@@ -19,8 +19,8 @@
 - name: verify destroy instance with display_name idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
 
 - name: test recover to stopped state and update a deleted instance with display_name
   cs_instance:
@@ -31,8 +31,8 @@
 - name: verify test recover to stopped state and update a deleted instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 

--- a/test/integration/targets/cs_instance/tasks/cleanup.yml
+++ b/test/integration/targets/cs_instance/tasks/cleanup.yml
@@ -5,26 +5,26 @@
 - name: verify cleanup ssh key
   assert:
     that:
-    - sshkey|success
+    - sshkey is successful
 
 - name: cleanup affinity group
   cs_affinitygroup: name={{ cs_resource_prefix }}-ag state=absent
   register: ag
-  until: ag|success
+  until: ag is successful
   retries: 20
   delay: 5
 - name: verify cleanup affinity group
   assert:
     that:
-    - ag|success
+    - ag is successful
 
 - name: cleanup security group ...take a while unless instance is expunged
   cs_securitygroup: name={{ cs_resource_prefix }}-sg state=absent
   register: sg
-  until: sg|success
+  until: sg is successful
   retries: 100
   delay: 10
 - name: verify cleanup security group
   assert:
     that:
-    - sg|success
+    - sg is successful

--- a/test/integration/targets/cs_instance/tasks/present.yml
+++ b/test/integration/targets/cs_instance/tasks/present.yml
@@ -5,7 +5,7 @@
 - name: verify instance to be absent
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: test create instance in check mode
   cs_instance:
@@ -21,8 +21,8 @@
 - name: verify create instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
 
 - name: test create instance
   cs_instance:
@@ -37,8 +37,8 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -59,8 +59,8 @@
 - name: verify create instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -77,8 +77,8 @@
 - name: verify running instance not updated in check mode
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -93,8 +93,8 @@
 - name: verify running instance not updated
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -109,8 +109,8 @@
 - name: verify stopping instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -124,8 +124,8 @@
 - name: verify stopping instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -139,8 +139,8 @@
 - name: verify stopping instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.state == "Stopped"
 
 - name: test updating stopped instance in check mode
@@ -153,8 +153,8 @@
 - name: verify updating stopped instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -169,8 +169,8 @@
 - name: verify updating stopped instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
@@ -185,8 +185,8 @@
 - name: verify updating stopped instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
@@ -201,8 +201,8 @@
 - name: verify starting instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
@@ -216,8 +216,8 @@
 - name: verify starting instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
@@ -231,8 +231,8 @@
 - name: verify starting instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
@@ -248,8 +248,8 @@
 - name: verify force update running instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
@@ -264,8 +264,8 @@
 - name: verify force update running instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -280,8 +280,8 @@
 - name: verify force update running instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -297,8 +297,8 @@
 - name: verify restore instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
@@ -312,8 +312,8 @@
 - name: verify restore instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"

--- a/test/integration/targets/cs_instance/tasks/present_display_name.yml
+++ b/test/integration/targets/cs_instance/tasks/present_display_name.yml
@@ -5,7 +5,7 @@
 - name: verify instance with display_name to be absent
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: test create instance with display_name
   cs_instance:
@@ -20,8 +20,8 @@
 - name: verify create instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
@@ -41,8 +41,8 @@
 - name: verify create instance with display_name idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
@@ -57,8 +57,8 @@
 - name: verify running instance with display_name not updated
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
@@ -71,8 +71,8 @@
 - name: verify stopping instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Stopped"
@@ -85,8 +85,8 @@
 - name: verify stopping instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.state == "Stopped"
 
 - name: test updating stopped instance with display_name
@@ -97,8 +97,8 @@
 - name: verify updating stopped instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
     - instance.state == "Stopped"
@@ -111,8 +111,8 @@
 - name: verify starting instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
     - instance.state == "Running"
@@ -125,8 +125,8 @@
 - name: verify starting instance with display_name idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_2 }}"
     - instance.state == "Running"
@@ -140,8 +140,8 @@
 - name: verify force update running instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
@@ -155,8 +155,8 @@
 - name: verify force update running instance with display_name idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
     - instance.state == "Running"
@@ -170,7 +170,7 @@
 - name: verify restore instance with display_name
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"

--- a/test/integration/targets/cs_instance/tasks/project.yml
+++ b/test/integration/targets/cs_instance/tasks/project.yml
@@ -6,7 +6,7 @@
 - name: verify test create project
   assert:
     that:
-    - prj|success
+    - prj is successful
 
 - name: setup instance in project to be absent
   cs_instance:
@@ -17,7 +17,7 @@
 - name: verify instance in project to be absent
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: setup ssh key in project
   cs_sshkeypair:
@@ -27,7 +27,7 @@
 - name: verify setup ssh key in project
   assert:
     that:
-    - sshkey|success
+    - sshkey is successful
 
 - name: setup affinity group in project
   cs_affinitygroup:
@@ -37,7 +37,7 @@
 - name: verify setup affinity group in project
   assert:
     that:
-    - ag|success
+    - ag is successful
 
 - name: setup security group in project
   cs_securitygroup:
@@ -47,7 +47,7 @@
 - name: verify setup security group in project
   assert:
     that:
-    - sg|success
+    - sg is successful
 
 - name: test create instance in project in check mode
   cs_instance:
@@ -64,8 +64,8 @@
 - name: verify create instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
 
 - name: test create instance in project
   cs_instance:
@@ -81,8 +81,8 @@
 - name: verify create instance in project
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -105,8 +105,8 @@
 - name: verify create instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -125,8 +125,8 @@
 - name: verify running instance in project not updated in check mode
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -143,8 +143,8 @@
 - name: verify running instance in project not updated
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -161,8 +161,8 @@
 - name: verify stopping instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -178,8 +178,8 @@
 - name: verify stopping instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -195,8 +195,8 @@
 - name: verify stopping instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.state == "Stopped"
 
 - name: test updating stopped instance in project in check mode
@@ -210,8 +210,8 @@
 - name: verify updating stopped instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
@@ -228,8 +228,8 @@
 - name: verify updating stopped instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -246,8 +246,8 @@
 - name: verify updating stopped instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -264,8 +264,8 @@
 - name: verify starting instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -281,8 +281,8 @@
 - name: verify starting instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -298,8 +298,8 @@
 - name: verify starting instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -317,8 +317,8 @@
 - name: verify force update running instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -335,8 +335,8 @@
 - name: verify force update running instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -353,8 +353,8 @@
 - name: verify force update running instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -372,8 +372,8 @@
 - name: verify restore instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -389,8 +389,8 @@
 - name: verify restore instance in project
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-{{ instance_number }}"
     - instance.project == "{{ cs_resource_prefix }}-prj"
     - instance.display_name == "{{ cs_resource_prefix }}-display-{{ instance_number }}"
@@ -406,8 +406,8 @@
 - name: verify destroy instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state != "Destroyed"
 
 - name: test destroy instance in project
@@ -419,8 +419,8 @@
 - name: verify destroy instance in project
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Destroyed"
 
 - name: test destroy instance in project idempotence
@@ -432,8 +432,8 @@
 - name: verify destroy instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
 
 - name: test recover in project to stopped state and update a deleted instance in project in check mode
   cs_instance:
@@ -446,8 +446,8 @@
 - name: verify test recover to stopped state and update a deleted instance in project in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
 
 - name: test recover to stopped state and update a deleted instance in project
   cs_instance:
@@ -459,8 +459,8 @@
 - name: verify test recover to stopped state and update a deleted instance in project
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -474,8 +474,8 @@
 - name: verify test recover to stopped state and update a deleted instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -489,8 +489,8 @@
 - name: verify test expunge instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -503,8 +503,8 @@
 - name: verify test expunge instance in project
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.state == "Stopped"
     - instance.service_offering == "{{ test_cs_instance_offering_1 }}"
 
@@ -517,8 +517,8 @@
 - name: verify test expunge instance in project idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
 
 - name: cleanup ssh key in project
   cs_sshkeypair:
@@ -529,7 +529,7 @@
 - name: verify cleanup ssh key in project
   assert:
     that:
-    - sshkey|success
+    - sshkey is successful
 
 - name: cleanup affinity group in project
   cs_affinitygroup:
@@ -537,13 +537,13 @@
     project: "{{ cs_resource_prefix }}-prj"
     state: absent
   register: ag
-  until: ag|success
+  until: ag is successful
   retries: 20
   delay: 5
 - name: verify cleanup affinity group in project
   assert:
     that:
-    - ag|success
+    - ag is successful
 
 - name: cleanup security group in project ...take a while unless instance in project is expunged
   cs_securitygroup:
@@ -551,10 +551,10 @@
     project: "{{ cs_resource_prefix }}-prj"
     state: absent
   register: sg
-  until: sg|success
+  until: sg is successful
   retries: 100
   delay: 10
 - name: verify cleanup security group in project
   assert:
     that:
-    - sg|success
+    - sg is successful

--- a/test/integration/targets/cs_instance/tasks/setup.yml
+++ b/test/integration/targets/cs_instance/tasks/setup.yml
@@ -5,7 +5,7 @@
 - name: verify setup ssh key
   assert:
     that:
-    - sshkey|success
+    - sshkey is successful
 
 - name: setup affinity group
   cs_affinitygroup: name={{ cs_resource_prefix }}-ag
@@ -13,7 +13,7 @@
 - name: verify setup affinity group
   assert:
     that:
-    - ag|success
+    - ag is successful
 
 - name: setup security group
   cs_securitygroup: name={{ cs_resource_prefix }}-sg
@@ -21,4 +21,4 @@
 - name: verify setup security group
   assert:
     that:
-    - sg|success
+    - sg is successful

--- a/test/integration/targets/cs_instance/tasks/sshkeys.yml
+++ b/test/integration/targets/cs_instance/tasks/sshkeys.yml
@@ -10,7 +10,7 @@
 - name: verify  update instance ssh key non existent
   assert:
     that:
-    - instance|failed
+    - instance is failed
     - 'instance.msg == "SSH key not found: {{ cs_resource_prefix }}-sshkey2"'
 
 - name: test create instance without keypair in check mode
@@ -23,8 +23,8 @@
 - name: verify create instance without keypair in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
 
 - name: test create instance without keypair
   cs_instance:
@@ -35,8 +35,8 @@
 - name: verify create instance without keypair
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.ssh_key is not defined
 
 - name: test create instance without keypair idempotence
@@ -48,8 +48,8 @@
 - name: verify create instance without keypair idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.ssh_key is not defined
 
 - name: setup ssh key2
@@ -58,7 +58,7 @@
 - name: verify setup ssh key2
   assert:
     that:
-    - sshkey|success
+    - sshkey is successful
 
 - name: test update instance ssh key2 in check mode
   cs_instance:
@@ -70,7 +70,7 @@
 - name: verify update instance ssh key2 in check mode
   assert:
     that:
-    - instance|changed
+    - instance is changed
     - instance.ssh_key is not defined
 
 - name: test update instance ssh key2
@@ -82,7 +82,7 @@
 - name: verify update instance ssh key2
   assert:
     that:
-    - instance|changed
+    - instance is changed
     - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey2"
 
 - name: test update instance ssh key2 idempotence
@@ -94,7 +94,7 @@
 - name: verify update instance ssh key2 idempotence
   assert:
     that:
-    - not instance|changed
+    - instance is not changed
     - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey2"
 
 - name: cleanup ssh key2
@@ -105,7 +105,7 @@
 - name: verify cleanup ssh key2
   assert:
     that:
-    - sshkey2|success
+    - sshkey2 is successful
 
 - name: test update instance ssh key2 idempotence2
   cs_instance:
@@ -117,7 +117,7 @@
 - name: verify update instance ssh key2 idempotence2
   assert:
     that:
-    - instance|failed
+    - instance is failed
     - 'instance.msg == "SSH key not found: {{ cs_resource_prefix }}-sshkey2"'
 
 - name: test update instance ssh key in check mode
@@ -130,7 +130,7 @@
 - name: verify update instance ssh key in check mode
   assert:
     that:
-    - instance|changed
+    - instance is changed
     - instance.ssh_key is not defined
 
 - name: test update instance ssh key
@@ -142,7 +142,7 @@
 - name: verify update instance ssh key
   assert:
     that:
-    - instance|changed
+    - instance is changed
     - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey"
 
 - name: test update instance ssh key idempotence
@@ -154,7 +154,7 @@
 - name: verify update instance ssh key idempotence
   assert:
     that:
-    - not instance|changed
+    - instance is not changed
     - instance.ssh_key == "{{ cs_resource_prefix }}-sshkey"
 
 - name: cleanup expunge instance
@@ -165,4 +165,4 @@
 - name: verify cleanup expunge instance
   assert:
     that:
-    - instance|success
+    - instance is successful

--- a/test/integration/targets/cs_instance/tasks/tags.yml
+++ b/test/integration/targets/cs_instance/tasks/tags.yml
@@ -12,8 +12,8 @@
 - name: verify add tags to instance in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - not instance.tags
 
 - name: test add tags to instance
@@ -28,8 +28,8 @@
 - name: verify add tags to instance
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.tags|length == 2
     - "instance.tags[0]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag1' ]"
     - "instance.tags[1]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag1' ]"
@@ -46,8 +46,8 @@
 - name: verify tags to instance idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.tags|length == 2
     - "instance.tags[0]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag1' ]"
     - "instance.tags[1]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag1' ]"
@@ -65,8 +65,8 @@
 - name: verify tags to instance idempotence in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.tags|length == 2
     - "instance.tags[0]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag1' ]"
     - "instance.tags[1]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag1' ]"
@@ -83,8 +83,8 @@
 - name: verify tags to instance idempotence
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.tags|length == 2
     - "instance.tags[0]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag3' ]"
     - "instance.tags[1]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag3' ]"
@@ -98,8 +98,8 @@
 - name: verify not touch tags of instance if no param tags
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.tags|length == 2
     - "instance.tags[0]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag3' ]"
     - "instance.tags[1]['key'] in [ '{{ cs_resource_prefix }}-tag2', '{{ cs_resource_prefix }}-tag3' ]"
@@ -115,8 +115,8 @@
 - name: verify remove tags in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.tags|length != 0
 
 - name: test remove tags
@@ -127,6 +127,6 @@
 - name: verify remove tags
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.tags|length == 0

--- a/test/integration/targets/cs_instance_facts/tasks/main.yml
+++ b/test/integration/targets/cs_instance_facts/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup ssh key
   assert:
     that:
-    - sshkey|success
+    - sshkey is successful
 
 - name: setup affinity group
   cs_affinitygroup: name={{ cs_resource_prefix }}-ag
@@ -13,7 +13,7 @@
 - name: verify setup affinity group
   assert:
     that:
-    - ag|success
+    - ag is successful
 
 - name: setup security group
   cs_securitygroup: name={{ cs_resource_prefix }}-sg
@@ -21,7 +21,7 @@
 - name: verify setup security group
   assert:
     that:
-    - sg|success
+    - sg is successful
 
 - name: setup instance
   cs_instance:
@@ -36,7 +36,7 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: test instance facts in check mode
   cs_instance_facts:
@@ -46,8 +46,8 @@
 - name: verify test instance facts in check mode
   assert:
     that:
-    - instance_facts|success
-    - not instance_facts|changed
+    - instance_facts is successful
+    - instance_facts is not changed
     - cloudstack_instance.id == instance.id
     - cloudstack_instance.domain == instance.domain
     - cloudstack_instance.account == instance.account
@@ -62,8 +62,8 @@
 - name: verify test instance facts
   assert:
     that:
-    - instance_facts|success
-    - not instance_facts|changed
+    - instance_facts is successful
+    - instance_facts is not changed
     - cloudstack_instance.id == instance.id
     - cloudstack_instance.domain == instance.domain
     - cloudstack_instance.account == instance.account

--- a/test/integration/targets/cs_instance_nic/tasks/main.yml
+++ b/test/integration/targets/cs_instance_nic/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: verify setup network
   assert:
     that:
-    - net|success
+    - net is successful
     - net.name == "net_nic"
 
 - name: setup instance
@@ -29,7 +29,7 @@
 - name: verify setup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
     - instance.name == "instance-nic-vm"
     - instance.state == "Stopped"
 
@@ -48,7 +48,7 @@
 - name: verify setup network 2
   assert:
     that:
-    - net|success
+    - net is successful
     - net.name == "net_nic2"
 
 - name: setup absent nic
@@ -61,7 +61,7 @@
 - name: verify setup absent nic
   assert:
     that:
-    - nic|success
+    - nic is successful
 
 - name: test fail missing params
   cs_instance_nic:
@@ -70,7 +70,7 @@
 - name: verify test fail missing params
   assert:
     that:
-    - nic|failed
+    - nic is failed
     - "nic.msg.startswith('missing required arguments: ')"
 
 - name: test create nic in check mode
@@ -83,8 +83,8 @@
 - name: verify test create nic in check mode
   assert:
     that:
-    - nic|success
-    - nic|changed
+    - nic is successful
+    - nic is changed
     - nic.network == "net_nic2"
     - nic.vm == "instance-nic-vm"
     - nic.zone == "{{ cs_common_zone_adv }}"
@@ -99,8 +99,8 @@
 - name: verify test create nic
   assert:
     that:
-    - nic|success
-    - nic|changed
+    - nic is successful
+    - nic is changed
     - nic.ip_address == "10.100.124.42"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -118,8 +118,8 @@
 - name: verify test create nic idempotence
   assert:
     that:
-    - nic|success
-    - not nic|changed
+    - nic is successful
+    - nic is not changed
     - nic.ip_address == "10.100.124.42"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -136,8 +136,8 @@
 - name: verify test create nic without ip address idempotence
   assert:
     that:
-    - nic|success
-    - not nic|changed
+    - nic is successful
+    - nic is not changed
     - nic.ip_address == "10.100.124.42"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -156,8 +156,8 @@
 - name: verify test update nic in check mode
   assert:
     that:
-    - nic|success
-    - nic|changed
+    - nic is successful
+    - nic is changed
     - nic.ip_address == "10.100.124.42"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -175,8 +175,8 @@
 - name: verify test update nic
   assert:
     that:
-    - nic|success
-    - nic|changed
+    - nic is successful
+    - nic is changed
     - nic.ip_address == "10.100.124.23"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -194,8 +194,8 @@
 - name: verify test update nic idempotence
   assert:
     that:
-    - nic|success
-    - not nic|changed
+    - nic is successful
+    - nic is not changed
     - nic.ip_address == "10.100.124.23"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -212,8 +212,8 @@
 - name: verify test update nic without ip address idempotence
   assert:
     that:
-    - nic|success
-    - not nic|changed
+    - nic is successful
+    - nic is not changed
     - nic.ip_address == "10.100.124.23"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -232,8 +232,8 @@
 - name: verify test remove nic in check mode
   assert:
     that:
-    - nic|success
-    - nic|changed
+    - nic is successful
+    - nic is changed
     - nic.ip_address == "10.100.124.23"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -251,8 +251,8 @@
 - name: verify test remove nic
   assert:
     that:
-    - nic|success
-    - nic|changed
+    - nic is successful
+    - nic is changed
     - nic.ip_address == "10.100.124.23"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -270,8 +270,8 @@
 - name: verify test remove nic idempotence
   assert:
     that:
-    - nic|success
-    - not nic|changed
+    - nic is successful
+    - nic is not changed
 
 - name: cleanup instance
   cs_instance:
@@ -281,7 +281,7 @@
 - name: verify cleanup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: cleanup network
   cs_network:
@@ -292,7 +292,7 @@
 - name: verify cleanup network
   assert:
     that:
-    - net|success
+    - net is successful
 
 - name: cleanup network 2
   cs_network:
@@ -303,4 +303,4 @@
 - name: verify cleanup network 2
   assert:
     that:
-    - net|success
+    - net is successful

--- a/test/integration/targets/cs_instance_nic_secondaryip/tasks/main.yml
+++ b/test/integration/targets/cs_instance_nic_secondaryip/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: verify setup network
   assert:
     that:
-    - net|success
+    - net is successful
     - net.name == "net_nic"
 
 - name: setup instance
@@ -29,7 +29,7 @@
 - name: verify setup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
     - instance.name == "instance-nic-vm"
     - instance.state == "Stopped"
 
@@ -48,7 +48,7 @@
 - name: verify setup network 2
   assert:
     that:
-    - net|success
+    - net is successful
     - net.name == "net_nic2"
 
 - name: setup nic
@@ -61,7 +61,7 @@
 - name: verify test create nic
   assert:
     that:
-    - nic|success
+    - nic is successful
     - nic.ip_address == "10.100.124.42"
     - nic.netmask == "255.255.255.0"
     - nic.network == "net_nic2"
@@ -80,7 +80,7 @@
 - name: verify setup remove secondary ip
   assert:
     that:
-    - sip|success
+    - sip is successful
 
 - name: test add secondary ip in check mode
   cs_instance_nic_secondaryip:
@@ -93,8 +93,8 @@
 - name: verify test add secondary ip in check mode
   assert:
     that:
-    - sip|success
-    - sip|changed
+    - sip is successful
+    - sip is changed
     - sip.network == "net_nic2"
     - sip.vm == "instance-nic-vm"
     - sip.zone == "{{ cs_common_zone_adv }}"
@@ -109,8 +109,8 @@
 - name: verify test add secondary ip
   assert:
     that:
-    - sip|success
-    - sip|changed
+    - sip is successful
+    - sip is changed
     - sip.vm_guest_ip == "10.100.124.43"
     - sip.network == "net_nic2"
     - sip.vm == "instance-nic-vm"
@@ -126,8 +126,8 @@
 - name: verify test add secondary ip idempotence
   assert:
     that:
-    - sip|success
-    - not sip|changed
+    - sip is successful
+    - sip is not changed
     - sip.vm_guest_ip == "10.100.124.43"
     - sip.network == "net_nic2"
     - sip.vm == "instance-nic-vm"
@@ -145,8 +145,8 @@
 - name: verify test remove secondary ip in check mode
   assert:
     that:
-    - sip|success
-    - sip|changed
+    - sip is successful
+    - sip is changed
     - sip.vm_guest_ip == "10.100.124.43"
     - sip.network == "net_nic2"
     - sip.vm == "instance-nic-vm"
@@ -163,8 +163,8 @@
 - name: verify test remove secondary ip
   assert:
     that:
-    - sip|success
-    - sip|changed
+    - sip is successful
+    - sip is changed
     - sip.vm_guest_ip == "10.100.124.43"
     - sip.network == "net_nic2"
     - sip.vm == "instance-nic-vm"
@@ -181,8 +181,8 @@
 - name: verify test remove secondary ip idempotence
   assert:
     that:
-    - sip|success
-    - not sip|changed
+    - sip is successful
+    - sip is not changed
     - sip.network == "net_nic2"
     - sip.vm == "instance-nic-vm"
     - sip.zone == "{{ cs_common_zone_adv }}"
@@ -195,7 +195,7 @@
 - name: verify cleanup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: cleanup network
   cs_network:
@@ -206,7 +206,7 @@
 - name: verify cleanup network
   assert:
     that:
-    - net|success
+    - net is successful
 
 - name: cleanup network 2
   cs_network:
@@ -217,4 +217,4 @@
 - name: verify cleanup network 2
   assert:
     that:
-    - net|success
+    - net is successful

--- a/test/integration/targets/cs_instancegroup/tasks/main.yml
+++ b/test/integration/targets/cs_instancegroup/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup
   assert:
     that:
-    - ig|success
+    - ig is successful
 
 - name: test fail if missing name
   action: cs_instancegroup
@@ -14,7 +14,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-    - ig|failed
+    - ig is failed
     - "ig.msg == 'missing required arguments: name'"
 
 - name: test present instance group in check mode
@@ -24,8 +24,8 @@
 - name: verify results of create instance group in check mode
   assert:
     that:
-    - ig|success
-    - ig|changed
+    - ig is successful
+    - ig is changed
 
 - name: test present instance group
   cs_instancegroup: name={{ cs_resource_prefix }}_ig
@@ -33,8 +33,8 @@
 - name: verify results of create instance group
   assert:
     that:
-    - ig|success
-    - ig|changed
+    - ig is successful
+    - ig is changed
     - ig.name == "{{ cs_resource_prefix }}_ig"
 
 - name: test present instance group is idempotence
@@ -43,8 +43,8 @@
 - name: verify results present instance group is idempotence
   assert:
     that:
-    - ig|success
-    - not ig|changed
+    - ig is successful
+    - ig is not changed
     - ig.name == "{{ cs_resource_prefix }}_ig"
 
 - name: test absent instance group in check mode
@@ -54,8 +54,8 @@
 - name: verify results of absent instance group in check mode
   assert:
     that:
-    - ig|success
-    - ig|changed
+    - ig is successful
+    - ig is changed
     - ig.name == "{{ cs_resource_prefix }}_ig"
 
 - name: test absent instance group
@@ -64,8 +64,8 @@
 - name: verify results of absent instance group
   assert:
     that:
-    - ig|success
-    - ig|changed
+    - ig is successful
+    - ig is changed
     - ig.name == "{{ cs_resource_prefix }}_ig"
 
 - name: test absent instance group is idempotence
@@ -74,6 +74,6 @@
 - name: verify results of absent instance group is idempotence
   assert:
     that:
-    - ig|success
-    - not ig|changed
+    - ig is successful
+    - ig is not changed
     - ig.name is undefined

--- a/test/integration/targets/cs_iso/tasks/main.yml
+++ b/test/integration/targets/cs_iso/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup iso
   assert:
     that:
-    - iso|success
+    - iso is successful
 
 - name: test download iso in check mode
   cs_iso:
@@ -20,7 +20,7 @@
 - name: verify test download iso in check mode
   assert:
     that:
-    - iso|changed
+    - iso is changed
 
 - name: test download iso
   cs_iso:
@@ -32,7 +32,7 @@
 - name: verify test download iso
   assert:
     that:
-    - iso|changed
+    - iso is changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso"
     - iso.cross_zones == true
@@ -47,7 +47,7 @@
 - name: verify test download iso idempotence
   assert:
     that:
-    - not iso|changed
+    - iso is not changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso"
     - iso.cross_zones == true
@@ -64,7 +64,7 @@
 - name: verify test update iso in check mode
   assert:
     that:
-    - iso|changed
+    - iso is changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso"
     - iso.cross_zones == true
@@ -80,7 +80,7 @@
 - name: verify test update iso
   assert:
     that:
-    - iso|changed
+    - iso is changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso display_text"
     - iso.cross_zones == true
@@ -96,7 +96,7 @@
 - name: verify test update iso idempotence
   assert:
     that:
-    - not iso|changed
+    - iso is not changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso display_text"
     - iso.cross_zones == true
@@ -111,7 +111,7 @@
 - name: verify test remove iso in check mode
   assert:
     that:
-    - iso|changed
+    - iso is changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso display_text"
     - iso.cross_zones == true
@@ -125,7 +125,7 @@
 - name: verify test remove iso
   assert:
     that:
-    - iso|changed
+    - iso is changed
     - iso.name == "{{ cs_resource_prefix }}-iso"
     - iso.display_text == "{{ cs_resource_prefix }}-iso display_text"
     - iso.cross_zones == true
@@ -139,4 +139,4 @@
 - name: verify test remove iso idempotence
   assert:
     that:
-    - not iso|changed
+    - iso is not changed

--- a/test/integration/targets/cs_loadbalancer_rule/tasks/main.yml
+++ b/test/integration/targets/cs_loadbalancer_rule/tasks/main.yml
@@ -8,8 +8,8 @@
 - name: verify test create network for lb
   assert:
     that:
-    - lb_net|success
-    - lb_net|changed
+    - lb_net is successful
+    - lb_net is changed
     - lb_net.name == "{{ cs_resource_prefix }}_net_lb"
 
 - name: setup instance in lb
@@ -23,8 +23,8 @@
 - name: verify setup instance in lb
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-lb"
     - instance.state == "Running"
 
@@ -36,7 +36,7 @@
 - name: verify setup instance in lb
   assert:
     that:
-    - ip_address|success
+    - ip_address is successful
 
 - name: setup lb rule absent
   cs_loadbalancer_rule:
@@ -47,7 +47,7 @@
 - name: verify setup lb rule absent
   assert:
     that:
-    - lb|success
+    - lb is successful
 
 - name: test rule requires params
   cs_loadbalancer_rule:
@@ -56,7 +56,7 @@
 - name: verify test rule requires params
   assert:
     that:
-    - lb|failed
+    - lb is failed
     - "lb.msg.startswith('missing required arguments: ')"
 
 
@@ -72,8 +72,8 @@
 - name: verify test create rule in check mode
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
 
 - name: test create rule
   cs_loadbalancer_rule:
@@ -86,8 +86,8 @@
 - name: verify test create rule
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "roundrobin"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -105,8 +105,8 @@
 - name: verify test create rule idempotence
   assert:
     that:
-    - lb|success
-    - not lb|changed
+    - lb is successful
+    - lb is not changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "roundrobin"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -125,8 +125,8 @@
 - name: verify  test update rule in check mode
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "roundrobin"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -144,8 +144,8 @@
 - name: verify  test update rule
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -163,8 +163,8 @@
 - name: verify  test update rule idempotence
   assert:
     that:
-    - lb|success
-    - not lb|changed
+    - lb is successful
+    - lb is not changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -178,7 +178,7 @@
 - name: verify test rule requires params
   assert:
     that:
-    - lb|failed
+    - lb is failed
     - "lb.msg.startswith('missing required arguments: ')"
 
 - name: test add members to rule in check mode
@@ -190,8 +190,8 @@
 - name: verify add members to rule in check mode
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -207,8 +207,8 @@
 - name: verify add members to rule
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -224,8 +224,8 @@
 - name: verify add members to rule idempotence
   assert:
     that:
-    - lb|success
-    - not lb|changed
+    - lb is successful
+    - lb is not changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -243,8 +243,8 @@
 - name: verify remove members to rule in check mode
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -261,8 +261,8 @@
 - name: verify remove members to rule
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -279,8 +279,8 @@
 - name: verify remove members to rule
   assert:
     that:
-    - lb|success
-    - not lb|changed
+    - lb is successful
+    - lb is not changed
 
 - name: test remove rule in check mode
   cs_loadbalancer_rule:
@@ -292,8 +292,8 @@
 - name: verify remove rule in check mode
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -309,8 +309,8 @@
 - name: verify remove rule
   assert:
     that:
-    - lb|success
-    - lb|changed
+    - lb is successful
+    - lb is changed
     - lb.name == "{{ cs_resource_prefix }}_lb"
     - lb.algorithm == "source"
     - lb.public_ip == "{{ ip_address.ip_address }}"
@@ -326,5 +326,5 @@
 - name: verify remove rule idempotence
   assert:
     that:
-    - lb|success
-    - not lb|changed
+    - lb is successful
+    - lb is not changed

--- a/test/integration/targets/cs_network_acl/tasks/main.yml
+++ b/test/integration/targets/cs_network_acl/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify setup vpc
   assert:
     that:
-    - vpc|success
+    - vpc is successful
 
 - name: setup network acl absent
   cs_network_acl:
@@ -21,7 +21,7 @@
 - name: verify setup network acl absent
   assert:
     that:
-    - acl|success
+    - acl is successful
 
 - name: test fail missing param name and vpc for network acl
   cs_network_acl:
@@ -30,7 +30,7 @@
 - name: verify test fail missing param name and vpc for network acl
   assert:
     that:
-    - acl|failed
+    - acl is failed
     - "acl.msg.startswith('missing required arguments: ')"
 
 - name: test create network acl in check mode
@@ -43,8 +43,8 @@
 - name: verify test create network acl in check mode
   assert:
     that:
-    - acl|success
-    - acl|changed
+    - acl is successful
+    - acl is changed
 
 - name: test create network acl
   cs_network_acl:
@@ -55,8 +55,8 @@
 - name: verify test create network acl
   assert:
     that:
-    - acl|success
-    - acl|changed
+    - acl is successful
+    - acl is changed
     - acl.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl.name == "{{ cs_resource_prefix }}_acl"
 
@@ -69,8 +69,8 @@
 - name: verify test create network acl idempotence
   assert:
     that:
-    - acl|success
-    - not acl|changed
+    - acl is successful
+    - acl is not changed
     - acl.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl.name == "{{ cs_resource_prefix }}_acl"
 
@@ -85,8 +85,8 @@
 - name: verify test remove network acl in check mode
   assert:
     that:
-    - acl|success
-    - acl|changed
+    - acl is successful
+    - acl is changed
     - acl.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl.name == "{{ cs_resource_prefix }}_acl"
 
@@ -100,8 +100,8 @@
 - name: verify test remove network acl
   assert:
     that:
-    - acl|success
-    - acl|changed
+    - acl is successful
+    - acl is changed
     - acl.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl.name == "{{ cs_resource_prefix }}_acl"
 
@@ -115,5 +115,5 @@
 - name: verify test remove network acl idempotence
   assert:
     that:
-    - acl|success
-    - not acl|changed
+    - acl is successful
+    - acl is not changed

--- a/test/integration/targets/cs_network_acl_rule/tasks/main.yml
+++ b/test/integration/targets/cs_network_acl_rule/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify setup vpc
   assert:
     that:
-    - vpc|success
+    - vpc is successful
 
 - name: setup network acl
   cs_network_acl:
@@ -20,7 +20,7 @@
 - name: verify setup network acl
   assert:
     that:
-    - acl|success
+    - acl is successful
 
 - name: setup network acl rule
   cs_network_acl_rule:
@@ -33,7 +33,7 @@
 - name: verify setup network acl rule
   assert:
     that:
-    - acl_rule|success
+    - acl_rule is successful
 
 - name: test fail missing params
   cs_network_acl_rule:
@@ -42,7 +42,7 @@
 - name: verify test fail missing param
   assert:
     that:
-    - acl_rule|failed
+    - acl_rule is failed
     - "acl_rule.msg.startswith('missing required arguments: ')"
 
 - name: test fail missing params for tcp
@@ -59,7 +59,7 @@
 - name: verify test fail missing param for tcp
   assert:
     that:
-    - acl_rule|failed
+    - acl_rule is failed
     - "acl_rule.msg == 'protocol is tcp but the following are missing: start_port, end_port'"
 
 - name: test fail missing params for icmp
@@ -77,7 +77,7 @@
 - name: verify test fail missing param for icmp
   assert:
     that:
-    - acl_rule|failed
+    - acl_rule is failed
     - "acl_rule.msg == 'protocol is icmp but the following are missing: icmp_type, icmp_code'"
 
 - name: test fail missing params for by number
@@ -95,7 +95,7 @@
 - name: verify test fail missing param for by number
   assert:
     that:
-    - acl_rule|failed
+    - acl_rule is failed
     - "acl_rule.msg == 'protocol is by_number but the following are missing: protocol_number'"
 
 - name: test create network acl rule in check mode
@@ -113,8 +113,8 @@
 - name: verify test create network acl rule in check mode
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
 
 - name: test create network acl rule
   cs_network_acl_rule:
@@ -130,8 +130,8 @@
 - name: verify test create network acl rule
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 80
@@ -155,8 +155,8 @@
 - name: verify test create network acl idempotence
   assert:
     that:
-    - acl_rule|success
-    - not acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is not changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 80
@@ -181,8 +181,8 @@
 - name: verify test change network acl rule in check mode
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 80
@@ -207,8 +207,8 @@
 - name: verify test change network acl rule
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -234,8 +234,8 @@
 - name: verify test change network acl idempotence
   assert:
     that:
-    - acl_rule|success
-    - not acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is not changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -263,8 +263,8 @@
 - name: verify test change network acl by protocol number in check mode
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -291,8 +291,8 @@
 - name: verify test change network acl by protocol number
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -320,8 +320,8 @@
 - name: verify test change network acl by protocol number idempotence
   assert:
     that:
-    - acl_rule|success
-    - not acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is not changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -349,8 +349,8 @@
 - name: verify test create 2nd network acl rule in check mode
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
 
 - name: test create 2nd network acl rule
   cs_network_acl_rule:
@@ -366,8 +366,8 @@
 - name: verify test create 2nd network acl rule
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.action_policy == "allow"
@@ -390,8 +390,8 @@
 - name: verify test create 2nd network acl rule idempotence
   assert:
     that:
-    - acl_rule|success
-    - not acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is not changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.action_policy == "allow"
@@ -416,8 +416,8 @@
 - name: verify test create 2nd network acl rule
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.action_policy == "allow"
@@ -444,8 +444,8 @@
 - name: verify test create 2nd network acl rule idempotence
   assert:
     that:
-    - acl_rule|success
-    - not acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is not changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.action_policy == "allow"
@@ -468,8 +468,8 @@
 - name: verify test absent network acl rule in check mode
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -490,8 +490,8 @@
 - name: verify test absent network acl rule
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.start_port == 81
@@ -512,8 +512,8 @@
 - name: verify test absent network acl rule idempotence
   assert:
     that:
-    - acl_rule|success
-    - not acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is not changed
 
 - name: test absent 2nd network acl rule
   cs_network_acl_rule:
@@ -526,8 +526,8 @@
 - name: verify test absent 2nd network acl rule
   assert:
     that:
-    - acl_rule|success
-    - acl_rule|changed
+    - acl_rule is successful
+    - acl_rule is changed
     - acl_rule.vpc == "{{ cs_resource_prefix }}_vpc"
     - acl_rule.network_acl == "{{ cs_resource_prefix }}_acl"
     - acl_rule.action_policy == "allow"

--- a/test/integration/targets/cs_pod/tasks/main.yml
+++ b/test/integration/targets/cs_pod/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify setup zone is present
   assert:
     that:
-      - zone|success
+      - zone is successful
 
 - name: setup pod is absent
   cs_pod:
@@ -20,7 +20,7 @@
 - name: verify setup pod is absent
   assert:
     that:
-      - pod|success
+      - pod is successful
 
 - name: test fail if missing name
   cs_pod:
@@ -29,7 +29,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-      - pod|failed
+      - pod is failed
       - "pod.msg == 'missing required arguments: name'"
 
 
@@ -45,7 +45,7 @@
 - name: verify test create pod  in check mode
   assert:
     that:
-      - pod_origin|changed
+      - pod_origin is changed
       - pod_origin.zone == "{{ cs_resource_prefix }}-zone"
 
 - name: test create pod
@@ -59,7 +59,7 @@
 - name: verify test create pod
   assert:
     that:
-      - pod_origin|changed
+      - pod_origin is changed
       - pod_origin.allocation_state == "Enabled"
       - pod_origin.start_ip == "10.100.10.101"
       - pod_origin.end_ip == "10.100.10.254"
@@ -78,7 +78,7 @@
 - name: verify test create pod idempotence
   assert:
     that:
-      - not pod|changed
+      - pod is not changed
       - pod.allocation_state == "Enabled"
       - pod.start_ip == "10.100.10.101"
       - pod.end_ip == "10.100.10.254"
@@ -98,7 +98,7 @@
 - name: verify test update pod in check mode
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.allocation_state == "Enabled"
       - pod.start_ip == "10.100.10.101"
       - pod.end_ip == "10.100.10.254"
@@ -117,7 +117,7 @@
 - name: verify test update pod
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.allocation_state == "Enabled"
       - pod.start_ip == "10.100.10.102"
       - pod.end_ip == "10.100.10.254"
@@ -136,7 +136,7 @@
 - name: verify test update pod idempotence
   assert:
     that:
-      - not pod|changed
+      - pod is not changed
       - pod.allocation_state == "Enabled"
       - pod.start_ip == "10.100.10.102"
       - pod.end_ip == "10.100.10.254"
@@ -154,7 +154,7 @@
 - name: verify test enable pod in check mode
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.allocation_state == "Enabled"
       - pod.id == pod_origin.id
       - pod.start_ip == "10.100.10.102"
@@ -172,7 +172,7 @@
 - name: verify test enable pod
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.allocation_state == "Disabled"
       - pod.id == pod_origin.id
       - pod.start_ip == "10.100.10.102"
@@ -190,7 +190,7 @@
 - name: verify test enable pod idempotence
   assert:
     that:
-      - not pod|changed
+      - pod is not changed
       - pod.allocation_state == "Disabled"
       - pod.id == pod_origin.id
       - pod.start_ip == "10.100.10.102"
@@ -209,7 +209,7 @@
 - name: verify test disable pod in check mode
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.allocation_state == "Disabled"
       - pod.id == pod_origin.id
       - pod.start_ip == "10.100.10.102"
@@ -227,7 +227,7 @@
 - name: verify test disable pod
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.allocation_state == "Enabled"
       - pod.id == pod_origin.id
       - pod.start_ip == "10.100.10.102"
@@ -246,7 +246,7 @@
 - name: verify test enabled pod idempotence
   assert:
     that:
-      - not pod|changed
+      - pod is not changed
       - pod.allocation_state == "Enabled"
       - pod.id == pod_origin.id
       - pod.start_ip == "10.100.10.102"
@@ -265,7 +265,7 @@
 - name: verify test create pod in check mode
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.id == pod_origin.id
       - pod.allocation_state == "Enabled"
       - pod.start_ip == "10.100.10.102"
@@ -283,7 +283,7 @@
 - name: verify test create pod
   assert:
     that:
-      - pod|changed
+      - pod is changed
       - pod.id == pod_origin.id
       - pod.allocation_state == "Enabled"
       - pod.start_ip == "10.100.10.102"
@@ -301,4 +301,4 @@
 - name: verify test absent pod idempotence
   assert:
     that:
-      - not pod|changed
+      - pod is not changed

--- a/test/integration/targets/cs_portforward/tasks/main.yml
+++ b/test/integration/targets/cs_portforward/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify network setup
   assert:
     that:
-    - net|success
+    - net is successful
 
 - name: instance setup
   cs_instance:
@@ -22,7 +22,7 @@
 - name: verify instance setup
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: public ip address setup
   cs_ip_address:
@@ -32,7 +32,7 @@
 - name: verify public ip address setup
   assert:
     that:
-    - ip_address|success
+    - ip_address is successful
 
 - name: set ip address as fact
   set_fact:
@@ -49,7 +49,7 @@
 - name: verify  clear existing port forwarding
   assert:
     that:
-    - pf|success
+    - pf is successful
 
 - name: test fail if missing params
   action: cs_portforward
@@ -58,7 +58,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - pf|failed
+    - pf is failed
     - 'pf.msg.startswith("missing required arguments: ")'
 
 - name: test present port forwarding in check mode
@@ -73,8 +73,8 @@
 - name: verify results of present port forwarding in check mode
   assert:
     that:
-    - pf|success
-    - pf|changed
+    - pf is successful
+    - pf is changed
 
 - name: test present port forwarding
   cs_portforward:
@@ -87,8 +87,8 @@
 - name: verify results of present port forwarding
   assert:
     that:
-    - pf|success
-    - pf|changed
+    - pf is successful
+    - pf is changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -107,8 +107,8 @@
 - name: verify results of present port forwarding idempotence
   assert:
     that:
-    - pf|success
-    - not pf|changed
+    - pf is successful
+    - pf is not changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -128,8 +128,8 @@
 - name: verify results of change port forwarding in check mode
   assert:
     that:
-    - pf|success
-    - pf|changed
+    - pf is successful
+    - pf is changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -148,8 +148,8 @@
 - name: verify results of change port forwarding
   assert:
     that:
-    - pf|success
-    - pf|changed
+    - pf is successful
+    - pf is changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -168,8 +168,8 @@
 - name: verify results of change port forwarding idempotence
   assert:
     that:
-    - pf|success
-    - not pf|changed
+    - pf is successful
+    - pf is not changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -189,8 +189,8 @@
 - name: verify results of absent port forwarding in check mode
   assert:
     that:
-    - pf|success
-    - pf|changed
+    - pf is successful
+    - pf is changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -209,8 +209,8 @@
 - name: verify results of absent port forwarding
   assert:
     that:
-    - pf|success
-    - pf|changed
+    - pf is successful
+    - pf is changed
     - pf.vm_name == "{{ cs_portforward_vm }}"
     - pf.ip_address == "{{ cs_portforward_public_ip }}"
     - pf.public_port == 80
@@ -229,8 +229,8 @@
 - name: verify results of absent port forwarding idempotence
   assert:
     that:
-    - pf|success
-    - not pf|changed
+    - pf is successful
+    - pf is not changed
 
 - name: instance cleanup
   cs_instance:
@@ -241,7 +241,7 @@
 - name: verify instance cleanup
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: network cleanup
   cs_network:
@@ -252,4 +252,4 @@
 - name: verify network cleanup
   assert:
     that:
-    - net|success
+    - net is successful

--- a/test/integration/targets/cs_project/tasks/main.yml
+++ b/test/integration/targets/cs_project/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify project did not exist
   assert:
     that:
-    - prj|success
+    - prj is successful
 
 - name: test create project in check mode
   cs_project:
@@ -17,7 +17,7 @@
 - name: verify test create project in check mode
   assert:
     that:
-    - prj|changed
+    - prj is changed
 
 - name: test create project
   cs_project:
@@ -26,7 +26,7 @@
 - name: verify test create project
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
 
 - name: test create project idempotence
@@ -36,7 +36,7 @@
 - name: verify test create project idempotence
   assert:
     that:
-    - not prj|changed
+    - prj is not changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
 
 - name: test suspend project in check mode
@@ -48,7 +48,7 @@
 - name: verify test suspend project in check mode
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state != "Suspended"
 
@@ -60,7 +60,7 @@
 - name: verify test suspend project
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state == "Suspended"
 
@@ -72,7 +72,7 @@
 - name: verify test suspend project idempotence
   assert:
     that:
-    - not prj|changed
+    - prj is not changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state == "Suspended"
 
@@ -85,7 +85,7 @@
 - name: verify test activate project in check mode
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state != "Active"
 
@@ -97,7 +97,7 @@
 - name: verify test activate project
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state == "Active"
 
@@ -109,7 +109,7 @@
 - name: verify test activate project idempotence
   assert:
     that:
-    - not prj|changed
+    - prj is not changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state == "Active"
 
@@ -122,7 +122,7 @@
 - name: verify test delete project in check mode
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state == "Active"
 
@@ -134,7 +134,7 @@
 - name: verify test delete project
   assert:
     that:
-    - prj|changed
+    - prj is changed
     - prj.name == "{{ cs_resource_prefix }}-prj"
     - prj.state == "Active"
 
@@ -146,4 +146,4 @@
 - name: verify test delete project idempotence
   assert:
     that:
-    - not prj|changed
+    - prj is not changed

--- a/test/integration/targets/cs_region/tasks/main.yml
+++ b/test/integration/targets/cs_region/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup
   assert:
     that:
-    - region|success
+    - region is successful
 
 - name: test fail if missing params
   cs_region:
@@ -16,7 +16,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-    - region|failed
+    - region is failed
     - "region.msg.startswith('missing required arguments: ')"
 
 - name: test create region in check mode
@@ -29,7 +29,7 @@
 - name: verify test create region in check mode
   assert:
     that:
-    - region|changed
+    - region is changed
 
 - name: test create region in check mode
   cs_region:
@@ -40,7 +40,7 @@
 - name: verify test create region in check mode
   assert:
     that:
-    - region|changed
+    - region is changed
     - region.name == 'geneva'
     - region.id == 2
     - region.endpoint == 'https://cloud.gva.example.com'
@@ -56,7 +56,7 @@
 - name: verify test create region idempotence
   assert:
     that:
-    - not region|changed
+    - region is not changed
     - region.name == 'geneva'
     - region.id == 2
     - region.endpoint == 'https://cloud.gva.example.com'
@@ -73,7 +73,7 @@
 - name: verify test update region in check mode
   assert:
     that:
-    - region|changed
+    - region is changed
     - region.name == 'geneva'
     - region.id == 2
     - region.endpoint == 'https://cloud.gva.example.com'
@@ -89,7 +89,7 @@
 - name: verify test update region
   assert:
     that:
-    - region|changed
+    - region is changed
     - region.name == 'zuerich'
     - region.id == 2
     - region.endpoint == 'https://cloud.zrh.example.com'
@@ -105,7 +105,7 @@
 - name: verify test update region idempotence
   assert:
     that:
-    - not region|changed
+    - region is not changed
     - region.name == 'zuerich'
     - region.id == 2
     - region.endpoint == 'https://cloud.zrh.example.com'
@@ -121,7 +121,7 @@
 - name: verify test remove region in check mode
   assert:
     that:
-    - region|changed
+    - region is changed
     - region.name == 'zuerich'
     - region.id == 2
     - region.endpoint == 'https://cloud.zrh.example.com'
@@ -136,7 +136,7 @@
 - name: verify test remove region
   assert:
     that:
-    - region|changed
+    - region is changed
     - region.name == 'zuerich'
     - region.id == 2
     - region.endpoint == 'https://cloud.zrh.example.com'
@@ -151,4 +151,4 @@
 - name: verify test remove region idempotence
   assert:
     that:
-    - not region|changed
+    - region is not changed

--- a/test/integration/targets/cs_resourcelimit/tasks/cpu.yml
+++ b/test/integration/targets/cs_resourcelimit/tasks/cpu.yml
@@ -9,7 +9,7 @@
 - name: verify setup cpu limits account
   assert:
     that:
-    - rl|success
+    - rl is successful
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 20
@@ -24,7 +24,7 @@
 - name: verify setup cpu limits for domain
   assert:
     that:
-    - rl|success
+    - rl is successful
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == -1
     - rl.resource_type == "cpu"
@@ -39,7 +39,7 @@
 - name: verify set cpu limits for domain in check mode
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == -1
     - rl.resource_type == "cpu"
@@ -53,7 +53,7 @@
 - name: verify set cpu limits for domain
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 12
     - rl.resource_type == "cpu"
@@ -67,7 +67,7 @@
 - name: verify set cpu limits for domain
   assert:
     that:
-    - not rl|changed
+    - rl is not changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 12
     - rl.resource_type == "cpu"
@@ -83,7 +83,7 @@
 - name: verify set cpu limits for account in check mode
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 20
@@ -99,7 +99,7 @@
 - name: verify set cpu limits for account
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 10
@@ -115,7 +115,7 @@
 - name: verify set cpu limits for account idempotence
   assert:
     that:
-    - not rl|changed
+    - rl is not changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 10

--- a/test/integration/targets/cs_resourcelimit/tasks/instance.yml
+++ b/test/integration/targets/cs_resourcelimit/tasks/instance.yml
@@ -9,7 +9,7 @@
 - name: verify setup instance limits account
   assert:
     that:
-    - rl|success
+    - rl is successful
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 20
@@ -25,7 +25,7 @@
 - name: verify set instance limits for domain in check mode
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 20
     - rl.resource_type == "instance"
@@ -39,7 +39,7 @@
 - name: verify set instance limits for domain
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 12
     - rl.resource_type == "instance"
@@ -53,7 +53,7 @@
 - name: verify set instance limits for domain
   assert:
     that:
-    - not rl|changed
+    - rl is not changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 12
     - rl.resource_type == "instance"
@@ -69,7 +69,7 @@
 - name: verify set instance limits for account in check mode
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit != 10
@@ -85,7 +85,7 @@
 - name: verify set instance limits for account
   assert:
     that:
-    - rl|changed
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 10
@@ -101,7 +101,7 @@
 - name: verify set instance limits for account idempotence
   assert:
     that:
-    - not rl|changed
+    - rl is not changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.account == "{{ cs_resource_prefix }}_user"
     - rl.limit == 10

--- a/test/integration/targets/cs_resourcelimit/tasks/main.yml
+++ b/test/integration/targets/cs_resourcelimit/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup domain
   assert:
     that:
-    - dom|success
+    - dom is successful
 
 - name: setup account
   cs_account:
@@ -21,7 +21,7 @@
 - name: verify setup account
   assert:
     that:
-    - acc|success
+    - acc is successful
 
 - name: test failed unkonwn type
   cs_resourcelimit:
@@ -33,7 +33,7 @@
 - name: verify test failed unkonwn type
   assert:
     that:
-    - rl|failed
+    - rl is failed
 
 - name: test failed missing type
   cs_resourcelimit:
@@ -42,7 +42,7 @@
 - name: verify test failed missing type
   assert:
     that:
-    - rl|failed
+    - rl is failed
 
 - name: setup resource limits domain
   cs_resourcelimit:
@@ -53,7 +53,7 @@
 - name: verify setup resource limits domain
   assert:
     that:
-    - rl|success
+    - rl is successful
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 10
 
@@ -67,8 +67,8 @@
 - name: verify setup resource limits domain to 20 in check mode
   assert:
     that:
-    - rl|success
-    - rl|changed
+    - rl is successful
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 10
 
@@ -81,8 +81,8 @@
 - name: verify setup resource limits domain to 20
   assert:
     that:
-    - rl|success
-    - rl|changed
+    - rl is successful
+    - rl is changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 20
 
@@ -95,8 +95,8 @@
 - name: verify setup resource limits domain to 20 idempotence
   assert:
     that:
-    - rl|success
-    - not rl|changed
+    - rl is successful
+    - rl is not changed
     - rl.domain == "{{ cs_resource_prefix }}-domain"
     - rl.limit == 20
 

--- a/test/integration/targets/cs_role/tasks/main.yml
+++ b/test/integration/targets/cs_role/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup
   assert:
     that:
-    - role|success
+    - role is successful
 
 - name: test fail if missing params
   cs_role:
@@ -16,7 +16,7 @@
 - name: verifytest fail if missing params
   assert:
     that:
-    - role|failed
+    - role is failed
     - "role.msg.startswith('missing required arguments: ')"
 
 - name: test create role in check mode
@@ -28,7 +28,7 @@
 - name: verify test create role in check mode
   assert:
     that:
-    - role|changed
+    - role is changed
 
 - name: test create role
   cs_role:
@@ -38,7 +38,7 @@
 - name: verify test create role
   assert:
     that:
-    - role|changed
+    - role is changed
     - role.name == '{{ cs_resource_prefix }}-role'
     - role.role_type == 'DomainAdmin'
 
@@ -50,7 +50,7 @@
 - name: verify test create role idempotence
   assert:
     that:
-    - not role|changed
+    - role is not changed
     - role.name == '{{ cs_resource_prefix }}-role'
     - role.role_type == 'DomainAdmin'
 
@@ -64,7 +64,7 @@
 - name: verify test update role in check mode
   assert:
     that:
-    - role|changed
+    - role is changed
     - role.name == '{{ cs_resource_prefix }}-role'
     - "role.description is not defined"
     - role.role_type == 'DomainAdmin'
@@ -78,7 +78,7 @@
 - name: verify test update role
   assert:
     that:
-    - role|changed
+    - role is changed
     - role.name == '{{ cs_resource_prefix }}-role'
     - role.description == '{{ cs_resource_prefix }}-role-description'
     - role.role_type == 'DomainAdmin'
@@ -91,7 +91,7 @@
 - name: verify test update role idempotence
   assert:
     that:
-    - not role|changed
+    - role is not changed
     - role.name == '{{ cs_resource_prefix }}-role'
     - role.description == '{{ cs_resource_prefix }}-role-description'
     - role.role_type == 'DomainAdmin'
@@ -105,7 +105,7 @@
 - name: verify test remove role in check mode
   assert:
     that:
-    - role|changed
+    - role is changed
     - role.name == '{{ cs_resource_prefix }}-role'
     - role.role_type == 'DomainAdmin'
 
@@ -117,7 +117,7 @@
 - name: verify test remove role
   assert:
     that:
-    - role|changed
+    - role is changed
 
 - name: test remove role idempotence
   cs_role:
@@ -127,4 +127,4 @@
 - name: verify test remove role idempotence
   assert:
     that:
-    - not role|changed
+    - role is not changed

--- a/test/integration/targets/cs_router/tasks/main.yml
+++ b/test/integration/targets/cs_router/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: verify setup network
   assert:
     that:
-    - net|success
+    - net is successful
     - net.name == "net_router"
 
 - name: setup instance
@@ -29,7 +29,7 @@
 - name: verify setup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
     - instance.name == "instance-vm"
     - instance.state == "Running"
 
@@ -45,7 +45,7 @@
 - name: verify setup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
     - instance.name == "instance-vm"
     - instance.state == "Running"
 
@@ -73,7 +73,7 @@
 - name: verify test router started
   assert:
     that:
-    - router|success
+    - router is successful
 
 - name: test stop router in check mode
   cs_router:
@@ -85,7 +85,7 @@
 - name: verify test stop router in check mode
   assert:
     that:
-    - router|changed
+    - router is changed
     - router.state == "Running"
     - router.service_offering == "System Offering For Software Router"
 
@@ -98,7 +98,7 @@
 - name: verify test stop router
   assert:
     that:
-    - router|changed
+    - router is changed
     - router.state == "Stopped"
     - router.service_offering == "System Offering For Software Router"
 
@@ -111,7 +111,7 @@
 - name: verify test stop router idempotence
   assert:
     that:
-    - not router|changed
+    - router is not changed
     - router.state == "Stopped"
     - router.service_offering == "System Offering For Software Router"
 
@@ -125,7 +125,7 @@
 - name: verify test start router in check mode
   assert:
     that:
-    - router|changed
+    - router is changed
     - router.state == "Stopped"
     - router.service_offering == "System Offering For Software Router"
 
@@ -138,7 +138,7 @@
 - name: verify test start router
   assert:
     that:
-    - router|changed
+    - router is changed
     - router.state == "Running"
     - router.service_offering == "System Offering For Software Router"
 
@@ -151,7 +151,7 @@
 - name: verify test start router idempotence
   assert:
     that:
-    - not router|changed
+    - router is not changed
     - router.state == "Running"
     - router.service_offering == "System Offering For Software Router"
 
@@ -165,7 +165,7 @@
 - name: verify test restart router in check mode
   assert:
     that:
-    - router|changed
+    - router is changed
     - router.state == "Running"
     - router.service_offering == "System Offering For Software Router"
 
@@ -178,6 +178,6 @@
 - name: verify test restart router
   assert:
     that:
-    - router|changed
+    - router is changed
     - router.state == "Running"
     - router.service_offering == "System Offering For Software Router"

--- a/test/integration/targets/cs_securitygroup/tasks/main.yml
+++ b/test/integration/targets/cs_securitygroup/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup
   assert:
     that:
-    - sg|success
+    - sg is successful
 
 - name: test fail if missing name
   action: cs_securitygroup
@@ -14,7 +14,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-    - sg|failed
+    - sg is failed
     - "sg.msg == 'missing required arguments: name'"
 
 - name: test present security group in check mode
@@ -24,8 +24,8 @@
 - name: verify results of create security group in check mode
   assert:
     that:
-    - sg|success
-    - sg|changed
+    - sg is successful
+    - sg is changed
 
 - name: test present security group
   cs_securitygroup: name={{ cs_resource_prefix }}_sg
@@ -33,8 +33,8 @@
 - name: verify results of create security group
   assert:
     that:
-    - sg|success
-    - sg|changed
+    - sg is successful
+    - sg is changed
     - sg.name == "{{ cs_resource_prefix }}_sg"
 
 - name: test present security group is idempotence
@@ -43,8 +43,8 @@
 - name: verify results present security group is idempotence
   assert:
     that:
-    - sg|success
-    - not sg|changed
+    - sg is successful
+    - sg is not changed
     - sg.name == "{{ cs_resource_prefix }}_sg"
 
 - name: test absent security group in check mode
@@ -54,8 +54,8 @@
 - name: verify results of absent security group in check mode
   assert:
     that:
-    - sg|success
-    - sg|changed
+    - sg is successful
+    - sg is changed
     - sg.name == "{{ cs_resource_prefix }}_sg"
 
 - name: test absent security group
@@ -64,8 +64,8 @@
 - name: verify results of absent security group
   assert:
     that:
-    - sg|success
-    - sg|changed
+    - sg is successful
+    - sg is changed
     - sg.name == "{{ cs_resource_prefix }}_sg"
 
 - name: test absent security group is idempotence
@@ -74,6 +74,6 @@
 - name: verify results of absent security group is idempotence
   assert:
     that:
-    - sg|success
-    - not sg|changed
+    - sg is successful
+    - sg is not changed
     - sg.name is undefined

--- a/test/integration/targets/cs_securitygroup_rule/tasks/absent.yml
+++ b/test/integration/targets/cs_securitygroup_rule/tasks/absent.yml
@@ -11,8 +11,8 @@
 - name: verify create http range rule in check mode
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'tcp'
@@ -31,8 +31,8 @@
 - name: verify create http range rule
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'tcp'
@@ -51,8 +51,8 @@
 - name: verify create http range rule idempotence
   assert:
     that:
-    - sg_rule|success
-    - not sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is not changed
 
 - name: test remove single port udp rule in check mode
   cs_securitygroup_rule:
@@ -67,8 +67,8 @@
 - name: verify remove single port udp rule in check mode
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'egress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'udp'
@@ -88,8 +88,8 @@
 - name: verify remove single port udp rule
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'egress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'udp'
@@ -109,8 +109,8 @@
 - name: verify remove single port udp rule idempotence
   assert:
     that:
-    - sg_rule|success
-    - not sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is not changed
 
 - name: test remove icmp rule in check mode
   cs_securitygroup_rule:
@@ -125,8 +125,8 @@
 - name: verify icmp rule in check mode
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.cidr == '0.0.0.0/0'
@@ -146,8 +146,8 @@
 - name: verify icmp rule
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.cidr == '0.0.0.0/0'
@@ -167,5 +167,5 @@
 - name: verify icmp rule idempotence
   assert:
     that:
-    - sg_rule|success
-    - not sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is not changed

--- a/test/integration/targets/cs_securitygroup_rule/tasks/cleanup.yml
+++ b/test/integration/targets/cs_securitygroup_rule/tasks/cleanup.yml
@@ -4,4 +4,4 @@
 - name: verify setup
   assert:
     that:
-    - sg|success
+    - sg is successful

--- a/test/integration/targets/cs_securitygroup_rule/tasks/present.yml
+++ b/test/integration/targets/cs_securitygroup_rule/tasks/present.yml
@@ -10,8 +10,8 @@
 - name: verify create http range rule in check mode
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
 
 - name: test create http range rule
   cs_securitygroup_rule:
@@ -23,8 +23,8 @@
 - name: verify create http range rule
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'tcp'
@@ -42,8 +42,8 @@
 - name: verify create http range rule idempotence
   assert:
     that:
-    - sg_rule|success
-    - not sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is not changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'tcp'
@@ -63,8 +63,8 @@
 - name: verify create single port udp rule in check mode
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
 
 - name: test create single port udp rule
   cs_securitygroup_rule:
@@ -77,8 +77,8 @@
 - name: verify create single port udp rule
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'egress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'udp'
@@ -98,8 +98,8 @@
 - name: verify single port udp rule idempotence
   assert:
     that:
-    - sg_rule|success
-    - not sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is not changed
     - sg_rule.type == 'egress'
     - sg_rule.security_group == 'default'
     - sg_rule.protocol == 'udp'
@@ -119,8 +119,8 @@
 - name: verify icmp rule in check mode
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
 
 - name: test icmp rule
   cs_securitygroup_rule:
@@ -133,8 +133,8 @@
 - name: verify icmp rule
   assert:
     that:
-    - sg_rule|success
-    - sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.cidr == '0.0.0.0/0'
@@ -153,8 +153,8 @@
 - name: verify icmp rule idempotence
   assert:
     that:
-    - sg_rule|success
-    - not sg_rule|changed
+    - sg_rule is successful
+    - sg_rule is not changed
     - sg_rule.type == 'ingress'
     - sg_rule.security_group == 'default'
     - sg_rule.cidr == '0.0.0.0/0'

--- a/test/integration/targets/cs_securitygroup_rule/tasks/setup.yml
+++ b/test/integration/targets/cs_securitygroup_rule/tasks/setup.yml
@@ -4,7 +4,7 @@
 - name: verify setup
   assert:
     that:
-    - sg|success
+    - sg is successful
 
 - name: setup default security group
   cs_securitygroup: name=default
@@ -12,7 +12,7 @@
 - name: verify setup
   assert:
     that:
-    - sg|success
+    - sg is successful
 
 - name: setup remove icmp rule
   cs_securitygroup_rule:
@@ -26,7 +26,7 @@
 - name: verify remove icmp rule
   assert:
     that:
-    - sg_rule|success
+    - sg_rule is successful
 
 - name: setup remove http range rule
   cs_securitygroup_rule:
@@ -39,7 +39,7 @@
 - name: verify remove http range rule
   assert:
     that:
-    - sg_rule|success
+    - sg_rule is successful
 
 - name: setup remove single port udp rule
   cs_securitygroup_rule:
@@ -53,4 +53,4 @@
 - name: verify remove single port udp rule
   assert:
     that:
-    - sg_rule|success
+    - sg_rule is successful

--- a/test/integration/targets/cs_serviceoffer/tasks/guest_vm_service_offering.yml
+++ b/test/integration/targets/cs_serviceoffer/tasks/guest_vm_service_offering.yml
@@ -7,7 +7,7 @@
 - name: verify setup service offering
   assert:
     that:
-    - so|success
+    - so is successful
 
 - name: create service offering in check mode
   cs_serviceoffer:
@@ -26,7 +26,7 @@
 - name: verify create service offering in check mode
   assert:
     that:
-    - so|changed
+    - so is changed
 
 - name: create service offering
   cs_serviceoffer:
@@ -44,7 +44,7 @@
 - name: verify create service offering
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "Micro"
     - so.display_text == "Micro 512mb 1cpu"
     - so.cpu_number == 1
@@ -70,7 +70,7 @@
 - name: verify create service offering idempotence
   assert:
     that:
-    - not so|changed
+    - so is not changed
     - so.name == "Micro"
     - so.display_text == "Micro 512mb 1cpu"
     - so.cpu_number == 1
@@ -89,7 +89,7 @@
 - name: verify create update offering in check mode
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "Micro"
     - so.display_text == "Micro 512mb 1cpu"
     - so.cpu_number == 1
@@ -107,7 +107,7 @@
 - name: verify update service offerin
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "Micro"
     - so.display_text == "Micro RAM 512MB 1vCPU"
     - so.cpu_number == 1
@@ -125,7 +125,7 @@
 - name: verify update service offering idempotence
   assert:
     that:
-    - not so|changed
+    - so is not changed
     - so.name == "Micro"
     - so.display_text == "Micro RAM 512MB 1vCPU"
     - so.cpu_number == 1
@@ -144,7 +144,7 @@
 - name: verify remove service offering in check mode
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "Micro"
     - so.display_text == "Micro RAM 512MB 1vCPU"
     - so.cpu_number == 1
@@ -162,7 +162,7 @@
 - name: verify remove service offering
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "Micro"
     - so.display_text == "Micro RAM 512MB 1vCPU"
     - so.cpu_number == 1
@@ -180,4 +180,4 @@
 - name: verify remove service offering idempotence
   assert:
     that:
-    - not so|changed
+    - so is not changed

--- a/test/integration/targets/cs_serviceoffer/tasks/system_vm_service_offering.yml
+++ b/test/integration/targets/cs_serviceoffer/tasks/system_vm_service_offering.yml
@@ -27,7 +27,7 @@
 - name: verify create system service offering in check mode
   assert:
     that:
-    - so|failed
+    - so is failed
     - so.msg.startswith('missing required arguments:')
 
 - name: create system service offering in check mode

--- a/test/integration/targets/cs_serviceoffer/tasks/system_vm_service_offering.yml
+++ b/test/integration/targets/cs_serviceoffer/tasks/system_vm_service_offering.yml
@@ -8,7 +8,7 @@
 - name: verify setup system offering
   assert:
     that:
-    - so|success
+    - so is successful
 
 - name: fail missing storage type and is_system
   cs_serviceoffer:
@@ -48,7 +48,7 @@
 - name: verify create system service offering in check mode
   assert:
     that:
-    - so|changed
+    - so is changed
 
 - name: create system service offering
   cs_serviceoffer:
@@ -67,7 +67,7 @@
 - name: verify create system service offering
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "System Offering for Ansible"
     - so.display_text == "System Offering for Ansible"
     - so.cpu_number == 1
@@ -98,7 +98,7 @@
 - name: verify create system service offering idempotence
   assert:
     that:
-    - not so|changed
+    - so is not changed
     - so.name == "System Offering for Ansible"
     - so.display_text == "System Offering for Ansible"
     - so.cpu_number == 1
@@ -122,7 +122,7 @@
 - name: verify remove system service offering in check mode
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "System Offering for Ansible"
     - so.is_system == true
 
@@ -135,7 +135,7 @@
 - name: verify remove system service offering
   assert:
     that:
-    - so|changed
+    - so is changed
     - so.name == "System Offering for Ansible"
     - so.is_system == true
 
@@ -148,4 +148,4 @@
 - name: verify remove system service offering idempotence
   assert:
     that:
-    - not so|changed
+    - so is not changed

--- a/test/integration/targets/cs_snapshot_policy/tasks/main.yml
+++ b/test/integration/targets/cs_snapshot_policy/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify setup instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: setup snapshot policy absent
   cs_snapshot_policy:
@@ -20,7 +20,7 @@
 - name: verify setup snapshot policy absent
   assert:
     that:
-    - snapshot|success
+    - snapshot is successful
 
 - name: create snapshot policy in check mode
   cs_snapshot_policy:
@@ -32,7 +32,7 @@
 - name: verify  create snapshot policy in check mode
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
 
 - name: create snapshot policy
   cs_snapshot_policy:
@@ -43,7 +43,7 @@
 - name: verify  create snapshot policy
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
     - snapshot.schedule == "5"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -57,7 +57,7 @@
 - name: verify create snapshot policy idempotence
   assert:
     that:
-    - not snapshot|changed
+    - snapshot is not changed
     - snapshot.schedule == "5"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -72,7 +72,7 @@
 - name: verify update snapshot policy
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
     - snapshot.schedule == "5"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -89,7 +89,7 @@
 - name: verify update snapshot policy in check mode
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
     - snapshot.schedule == "5"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -107,7 +107,7 @@
 - name: verify update snapshot policy
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
     - snapshot.schedule == "6"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -125,7 +125,7 @@
 - name: verify update snapshot policy idempotence
   assert:
     that:
-    - not snapshot|changed
+    - snapshot is not changed
     - snapshot.schedule == "6"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -142,7 +142,7 @@
 - name: verify remove snapshot policy in check mode
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
     - snapshot.schedule == "6"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -158,7 +158,7 @@
 - name: verify remove snapshot policy
   assert:
     that:
-    - snapshot|changed
+    - snapshot is changed
     - snapshot.schedule == "6"
     - snapshot.interval_type == "hourly"
     - snapshot.volume != ""
@@ -174,4 +174,4 @@
 - name: verify remove snapshot policy idempotence
   assert:
     that:
-    - not snapshot|changed
+    - snapshot is not changed

--- a/test/integration/targets/cs_sshkeypair/tasks/main.yml
+++ b/test/integration/targets/cs_sshkeypair/tasks/main.yml
@@ -12,7 +12,7 @@
 - name: verify results of fail on missing name
   assert:
     that:
-    - sshkey|failed
+    - sshkey is failed
     - "sshkey.msg == 'missing required arguments: name'"
 
 - name: test ssh key creation in check mode
@@ -23,8 +23,8 @@
 - name: verify results of ssh key creation in check mode
   assert:
     that:
-    - sshkey|success
-    - sshkey|changed
+    - sshkey is successful
+    - sshkey is changed
 
 - name: test ssh key creation
   cs_sshkeypair:
@@ -33,8 +33,8 @@
 - name: verify results of ssh key creation
   assert:
     that:
-    - sshkey|success
-    - sshkey|changed
+    - sshkey is successful
+    - sshkey is changed
     - sshkey.fingerprint is defined and sshkey.fingerprint != ""
     - sshkey.private_key is defined and sshkey.private_key != ""
     - sshkey.name == "first-sshkey"
@@ -46,8 +46,8 @@
 - name: verify results of ssh key creation idempotence
   assert:
     that:
-    - sshkey2|success
-    - not sshkey2|changed
+    - sshkey2 is successful
+    - sshkey2 is not changed
     - sshkey2.fingerprint is defined and sshkey2.fingerprint == sshkey.fingerprint
     - sshkey2.private_key is not defined
     - sshkey2.name == "first-sshkey"
@@ -61,8 +61,8 @@
 - name: verify results of replace ssh public key in check mode
   assert:
     that:
-    - sshkey2|success
-    - sshkey2|changed
+    - sshkey2 is successful
+    - sshkey2 is changed
     - sshkey2.fingerprint is defined and sshkey2.fingerprint == sshkey.fingerprint
     - sshkey2.private_key is not defined
     - sshkey2.name == "first-sshkey"
@@ -75,8 +75,8 @@
 - name: verify results of replace ssh public key
   assert:
     that:
-    - sshkey3|success
-    - sshkey3|changed
+    - sshkey3 is successful
+    - sshkey3 is changed
     - sshkey3.fingerprint is defined and sshkey3.fingerprint != sshkey2.fingerprint
     - sshkey3.private_key is not defined
     - sshkey3.name == "first-sshkey"
@@ -89,8 +89,8 @@
 - name: verify results of ssh public key idempotence
   assert:
     that:
-    - sshkey4|success
-    - not sshkey4|changed
+    - sshkey4 is successful
+    - sshkey4 is not changed
     - sshkey4.fingerprint is defined and sshkey4.fingerprint == sshkey3.fingerprint
     - sshkey4.private_key is not defined
     - sshkey4.name == "first-sshkey"
@@ -107,8 +107,8 @@
 - name: verify test different but exisitng name but same ssh public key as first-sshkey
   assert:
     that:
-    - sshkey|success
-    - sshkey|changed
+    - sshkey is successful
+    - sshkey is changed
     - sshkey.fingerprint is defined and sshkey.fingerprint == sshkey4.fingerprint
     - sshkey.private_key is not defined
     - sshkey.name == "second-sshkey"
@@ -120,8 +120,8 @@
 - name: verify result of key absent in check mode
   assert:
     that:
-    - sshkey5|success
-    - sshkey5|changed
+    - sshkey5 is successful
+    - sshkey5 is changed
     - sshkey5.fingerprint is defined and sshkey5.fingerprint == sshkey3.fingerprint
     - sshkey5.private_key is not defined
     - sshkey5.name == "second-sshkey"
@@ -132,8 +132,8 @@
 - name: verify result of key absent
   assert:
     that:
-    - sshkey5|success
-    - sshkey5|changed
+    - sshkey5 is successful
+    - sshkey5 is changed
     - sshkey5.fingerprint is defined and sshkey5.fingerprint == sshkey3.fingerprint
     - sshkey5.private_key is not defined
     - sshkey5.name == "second-sshkey"
@@ -144,8 +144,8 @@
 - name: verify result of ssh key absent idempotence
   assert:
     that:
-    - sshkey6|success
-    - not sshkey6|changed
+    - sshkey6 is successful
+    - sshkey6 is not changed
     - sshkey6.fingerprint is not defined
     - sshkey6.private_key is not defined
     - sshkey6.name is not defined

--- a/test/integration/targets/cs_storage_pool/tasks/main.yml
+++ b/test/integration/targets/cs_storage_pool/tasks/main.yml
@@ -14,7 +14,7 @@
 - name: verify setup host is present
   assert:
     that:
-      - host|success
+      - host is successful
 
 - name: setup storage pool is absent
   cs_storage_pool:
@@ -25,7 +25,7 @@
 - name: verify setup storage pool is absent
   assert:
     that:
-      - sp|success
+      - sp is successful
 
 - name: test fail if missing params
   cs_storage_pool:
@@ -34,7 +34,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-      - sp|failed
+      - sp is failed
       - "sp.msg == 'missing required arguments: name'"
 
 - name: test fail if provider unknown
@@ -51,7 +51,7 @@
 - name: verify test fail if provider unknown
   assert:
     that:
-      - sp|failed
+      - sp is failed
       - "sp.msg == 'Storage provider DNE not found'"
 
 - name: test fail if cluster unknown
@@ -67,7 +67,7 @@
 - name: verify test fail if cluster unknown
   assert:
     that:
-      - sp|failed
+      - sp is failed
       - "sp.msg == 'Cluster DNE not found'"
 
 - name: test fail if pod unknown
@@ -83,7 +83,7 @@
 - name: verify test fail if pod unknown
   assert:
     that:
-      - sp|failed
+      - sp is failed
       - "sp.msg == 'Pod DNE not found'"
 
 - name: create storage pool in check mode
@@ -99,8 +99,8 @@
 - name: verify create storage pool in check mode
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
 
 - name: create storage pool
   cs_storage_pool:
@@ -114,8 +114,8 @@
 - name: verify create storage pool
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
       - sp.storage_url == "RBD://ceph-mons.domain/poolname"
@@ -131,8 +131,8 @@
 - name: verify create storage pool idempotence
   assert:
     that:
-      - sp|success
-      - not sp|changed
+      - sp is successful
+      - sp is not changed
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
       - sp.storage_url == "RBD://ceph-mons.domain/poolname"
@@ -150,8 +150,8 @@
 - name: verify disable storage pool in check mode
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'enabled'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -170,8 +170,8 @@
 - name: verify disable storage pool
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'disabled'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -190,8 +190,8 @@
 - name: verify disable storage pool idempotence
   assert:
     that:
-      - sp|success
-      - not sp|changed
+      - sp is successful
+      - sp is not changed
       - sp.allocation_state == 'disabled'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -213,8 +213,8 @@
 - name: verify update while storage pool disabled in check mode
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'disabled'
       - sp.storage_tags == []
       - sp.cluster == "C0-adv"
@@ -236,8 +236,8 @@
 - name: verify update while storage pool disabled
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'disabled'
       - sp.storage_tags == ['eco', 'ssd']
       - sp.cluster == "C0-adv"
@@ -259,8 +259,8 @@
 - name: verify update while storage pool disabled idempotence
   assert:
     that:
-      - sp|success
-      - not sp|changed
+      - sp is successful
+      - sp is not changed
       - sp.allocation_state == 'disabled'
       - sp.storage_tags == ['eco', 'ssd']
       - sp.cluster == "C0-adv"
@@ -281,8 +281,8 @@
 - name: verify put storage in maintenance pool in check mode
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'disabled'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -301,8 +301,8 @@
 - name: verify put storage in maintenance pool
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'maintenance'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -321,8 +321,8 @@
 - name: verify put storage in maintenance pool idempotence
   assert:
     that:
-      - sp|success
-      - not sp|changed
+      - sp is successful
+      - sp is not changed
       - sp.allocation_state == 'maintenance'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -341,8 +341,8 @@
 - name: verify update while in maintenance pool
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'maintenance'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -359,8 +359,8 @@
 - name: verify remove storage pool in check mode
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
       - sp.storage_url == "RBD://ceph-mons.domain/poolname"
@@ -374,8 +374,8 @@
 - name: verify remove storage pool
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
       - sp.storage_url == "RBD://ceph-mons.domain/poolname"
@@ -389,8 +389,8 @@
 - name: verify remove storage pool idempotence
   assert:
     that:
-      - sp|success
-      - not sp|changed
+      - sp is successful
+      - sp is not changed
 
 - name: create storage pool in maintenance
   cs_storage_pool:
@@ -405,8 +405,8 @@
 - name: verify create storage pool in maintenance
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'maintenance'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -421,8 +421,8 @@
 - name: verify storage pool in maintenance
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'maintenance'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -441,8 +441,8 @@
 - name: verify create storage pool in disabled
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'disabled'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"
@@ -457,8 +457,8 @@
 - name: verify remove disabled storage pool
   assert:
     that:
-      - sp|success
-      - sp|changed
+      - sp is successful
+      - sp is changed
       - sp.allocation_state == 'disabled'
       - sp.cluster == "C0-adv"
       - sp.pod == "POD0-adv"

--- a/test/integration/targets/cs_user/tasks/main.yml
+++ b/test/integration/targets/cs_user/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup
   assert:
     that:
-    - user|success
+    - user is successful
 
 - name: test fail if missing username
   action: cs_user
@@ -14,7 +14,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - user|failed
+    - user is failed
     - 'user.msg == "missing required arguments: username"'
 
 - name: test fail if missing params if state=present
@@ -25,7 +25,7 @@
 - name: verify results of fail if missing params if state=present
   assert:
     that:
-    - user|failed
+    - user is failed
     - 'user.msg == "missing required arguments: account, email, password, first_name, last_name"'
 
 - name: test create user in check mode
@@ -41,8 +41,8 @@
 - name: verify results of create user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
 
 - name: test create user
   cs_user:
@@ -56,8 +56,8 @@
 - name: verify results of create user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name"
     - user.last_name == "{{ cs_resource_prefix }}_last_name"
@@ -80,8 +80,8 @@
 - name: verify results of create user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name"
     - user.last_name == "{{ cs_resource_prefix }}_last_name"
@@ -105,14 +105,14 @@
 - name: verify results of create account
   assert:
     that:
-    - acc|success
-    - acc|changed
+    - acc is successful
+    - acc is changed
     - acc.name == "{{ cs_resource_prefix }}_acc"
     - acc.network_domain == "example.com"
     - acc.account_type == "user"
     - acc.state == "enabled"
     - acc.domain == "ROOT"
-    - acc|changed
+    - acc is changed
 
 - name: test create user2 in check mode
   cs_user:
@@ -128,8 +128,8 @@
 - name: verify results of create user idempotence
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
 
 - name: test create user2
   cs_user:
@@ -144,8 +144,8 @@
 - name: verify results of create user idempotence
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user2"
     - user.first_name == "{{ cs_resource_prefix }}_first_name2"
     - user.last_name == "{{ cs_resource_prefix }}_last_name2"
@@ -169,8 +169,8 @@
 - name: verify results of create user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user2"
     - user.first_name == "{{ cs_resource_prefix }}_first_name2"
     - user.last_name == "{{ cs_resource_prefix }}_last_name2"
@@ -195,8 +195,8 @@
 - name: verify results of update user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name"
     - user.last_name == "{{ cs_resource_prefix }}_last_name"
@@ -220,8 +220,8 @@
 - name: verify results of update user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name1"
     - user.last_name == "{{ cs_resource_prefix }}_last_name1"
@@ -245,8 +245,8 @@
 - name: verify results of update user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name1"
     - user.last_name == "{{ cs_resource_prefix }}_last_name1"
@@ -266,8 +266,8 @@
 - name: verify results of lock user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -282,8 +282,8 @@
 - name: verify results of lock user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -298,8 +298,8 @@
 - name: verify results of lock user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -315,8 +315,8 @@
 - name: verify results of disable user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -331,8 +331,8 @@
 - name: verify results of disable user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -347,8 +347,8 @@
 - name: verify results of disable user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -364,8 +364,8 @@
 - name: verify results of lock disabled user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -380,8 +380,8 @@
 - name: verify results of lock disabled user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -396,8 +396,8 @@
 - name: verify results of lock disabled user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -413,8 +413,8 @@
 - name: verify results of enable user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -429,8 +429,8 @@
 - name: verify results of enable user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -445,8 +445,8 @@
 - name: verify results of enable user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -462,8 +462,8 @@
 - name: verify results of remove user in check mode
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -478,8 +478,8 @@
 - name: verify results of remove user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -494,8 +494,8 @@
 - name: verify results of remove user idempotence
   assert:
     that:
-    - user|success
-    - not user|changed
+    - user is successful
+    - user is not changed
 
 - name: test create locked user
   cs_user:
@@ -510,8 +510,8 @@
 - name: verify results of create locked user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name"
     - user.last_name == "{{ cs_resource_prefix }}_last_name"
@@ -529,8 +529,8 @@
 - name: verify results of remove locked user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -550,8 +550,8 @@
 - name: verify results of create disabled user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name"
     - user.last_name == "{{ cs_resource_prefix }}_last_name"
@@ -569,8 +569,8 @@
 - name: verify results of remove disabled user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"
@@ -590,8 +590,8 @@
 - name: verify results of create enabled user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.first_name == "{{ cs_resource_prefix }}_first_name"
     - user.last_name == "{{ cs_resource_prefix }}_last_name"
@@ -609,8 +609,8 @@
 - name: verify results of remove enabled user
   assert:
     that:
-    - user|success
-    - user|changed
+    - user is successful
+    - user is changed
     - user.username == "{{ cs_resource_prefix }}_user"
     - user.account_type == "root_admin"
     - user.account == "admin"

--- a/test/integration/targets/cs_vmsnapshot/tasks/main.yml
+++ b/test/integration/targets/cs_vmsnapshot/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: ensure no snapshot exists
   cs_vmsnapshot:
@@ -19,7 +19,7 @@
 - name: verify setup
   assert:
     that:
-    - snap|success
+    - snap is successful
 
 - name: test fail if missing name
   action: cs_vmsnapshot
@@ -28,7 +28,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - snap|failed
+    - snap is failed
     - 'snap.msg.startswith("missing required arguments: ")'
 
 - name: test create snapshot in check mode
@@ -41,7 +41,7 @@
 - name: verify test create snapshot in check mode
   assert:
     that:
-    - snap|changed
+    - snap is changed
 
 - name: test create snapshot
   cs_vmsnapshot:
@@ -52,7 +52,7 @@
 - name: verify test create snapshot
   assert:
     that:
-    - snap|changed
+    - snap is changed
     - snap.display_name == "{{ cs_resource_prefix }}_snapshot"
 
 - name: test create snapshot idempotence
@@ -64,7 +64,7 @@
 - name: verify test create snapshot idempotence
   assert:
     that:
-    - not snap|changed
+    - snap is not changed
     - snap.display_name == "{{ cs_resource_prefix }}_snapshot"
 
 - name: test revert snapshot in check mode
@@ -77,7 +77,7 @@
 - name: verify test revert snapshot in check mode
   assert:
     that:
-    - snap|changed
+    - snap is changed
     - snap.display_name == "{{ cs_resource_prefix }}_snapshot"
 
 - name: test fail revert unknown snapshot
@@ -90,7 +90,7 @@
 - name: verify test fail revert unknown snapshot
   assert:
     that:
-    - snap|failed
+    - snap is failed
     - snap.msg == "snapshot not found, could not revert VM"
 
 - name: test revert snapshot
@@ -102,7 +102,7 @@
 - name: verify test revert snapshot
   assert:
     that:
-    - snap|changed
+    - snap is changed
     - snap.display_name == "{{ cs_resource_prefix }}_snapshot"
 
 - name: test remove snapshot in check mode
@@ -115,7 +115,7 @@
 - name: verify test remove snapshot in check mode
   assert:
     that:
-    - snap|changed
+    - snap is changed
     - snap.display_name == "{{ cs_resource_prefix }}_snapshot"
 
 - name: test remove snapshot
@@ -127,7 +127,7 @@
 - name: verify test remove snapshot
   assert:
     that:
-    - snap|changed
+    - snap is changed
     - snap.display_name == "{{ cs_resource_prefix }}_snapshot"
 
 - name: test remove snapshot idempotence
@@ -139,7 +139,7 @@
 - name: verify test remove snapshot idempotence
   assert:
     that:
-    - not snap|changed
+    - snap is not changed
 
 - name: cleanup instance
   cs_instance:
@@ -149,4 +149,4 @@
 - name: verify destroy instance
   assert:
     that:
-    - instance|success
+    - instance is successful

--- a/test/integration/targets/cs_volume/tasks/main.yml
+++ b/test/integration/targets/cs_volume/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: verify setup
   assert:
     that:
-    - vol|success
+    - vol is successful
 
 - name: setup instance 1
   cs_instance:
@@ -16,7 +16,7 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: setup instance 2
   cs_instance:
@@ -27,7 +27,7 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: test fail if missing name
   action: cs_volume
@@ -36,7 +36,7 @@
 - name: verify results of fail if missing name
   assert:
     that:
-    - vol|failed
+    - vol is failed
     - "vol.msg == 'missing required arguments: name'"
 
 - name: test create volume in check mode
@@ -49,7 +49,7 @@
 - name: verify results test create volume in check mode
   assert:
     that:
-    - vol|changed
+    - vol is changed
 
 - name: test create volume
   cs_volume:
@@ -60,7 +60,7 @@
 - name: verify results test create volume
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.size == 20 * 1024 ** 3
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
@@ -73,7 +73,7 @@
 - name: verify results test create volume idempotence
   assert:
     that:
-    - not vol|changed
+    - vol is not changed
     - vol.size == 20 * 1024 ** 3
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
@@ -88,7 +88,7 @@
 - name: verify results test create volume in check mode
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.size == 20 * 1024 ** 3
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
@@ -102,7 +102,7 @@
 - name: verify results test create volume
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.size == 10 * 1024 ** 3
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
@@ -116,7 +116,7 @@
 - name: verify results test create volume
   assert:
     that:
-    - not vol|changed
+    - vol is not changed
     - vol.size == 10 * 1024 ** 3
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
@@ -130,7 +130,7 @@
 - name: verify results test attach volume in check mode
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.attached is not defined
 
@@ -143,7 +143,7 @@
 - name: verify results test attach volume
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.vm == "{{ test_cs_instance_1 }}"
     - vol.attached is defined
@@ -157,7 +157,7 @@
 - name: verify results test attach volume idempotence
   assert:
     that:
-    - not vol|changed
+    - vol is not changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.vm == "{{ test_cs_instance_1 }}"
     - vol.attached is defined
@@ -172,7 +172,7 @@
 - name: verify results test attach attached volume to another vm in check mode
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.vm == "{{ test_cs_instance_1 }}"
     - vol.attached is defined
@@ -186,7 +186,7 @@
 - name: verify results test attach attached volume to another vm
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.vm == "{{ test_cs_instance_2 }}"
     - vol.attached is defined
@@ -200,7 +200,7 @@
 - name: verify results test attach attached volume to another vm idempotence
   assert:
     that:
-    - not vol|changed
+    - vol is not changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.vm == "{{ test_cs_instance_2 }}"
     - vol.attached is defined
@@ -214,7 +214,7 @@
 - name: verify results test detach volume in check mdoe
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.attached is defined
 
@@ -226,7 +226,7 @@
 - name: verify results test detach volume
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.attached is undefined
 
@@ -238,7 +238,7 @@
 - name: verify results test detach volume idempotence
   assert:
     that:
-    - not vol|changed
+    - vol is not changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
     - vol.attached is undefined
 
@@ -251,7 +251,7 @@
 - name: verify results test create volume in check mode
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
 - name: test delete volume
@@ -262,7 +262,7 @@
 - name: verify results test create volume
   assert:
     that:
-    - vol|changed
+    - vol is changed
     - vol.name == "{{ cs_resource_prefix }}_vol"
 
 - name: test delete volume idempotence
@@ -273,7 +273,7 @@
 - name: verify results test delete volume idempotence
   assert:
     that:
-    - not vol|changed
+    - vol is not changed
 
 - name: cleanup instance 1
   cs_instance:
@@ -283,7 +283,7 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
+    - instance is successful
 
 - name: cleanup instance 2
   cs_instance:
@@ -293,4 +293,4 @@
 - name: verify create instance
   assert:
     that:
-    - instance|success
+    - instance is successful

--- a/test/integration/targets/cs_vpc/tasks/main.yml
+++ b/test/integration/targets/cs_vpc/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: verify setup
   assert:
     that:
-    - vpc|success
+    - vpc is successful
 
 - name: test fail missing name of vpc
   cs_vpc:
@@ -18,7 +18,7 @@
 - name: verify test fail missing name of vpc
   assert:
     that:
-    - vpc|failed
+    - vpc is failed
     - "vpc.msg.startswith('missing required arguments: ')"
 
 - name: test fail missing cidr for vpc
@@ -30,7 +30,7 @@
 - name: verify test fail missing cidr for vpc
   assert:
     that:
-    - vpc|failed
+    - vpc is failed
     - 'vpc.msg == "state is present but all of the following are missing: cidr"'
 
 - name: test fail missing vpc offering not found
@@ -44,7 +44,7 @@
 - name: verify test fail missing cidr for vpc
   assert:
     that:
-    - vpc|failed
+    - vpc is failed
     - 'vpc.msg == "VPC offering not found: does_not_exist"'
 
 - name: test create vpc with custom offering in check mode
@@ -59,8 +59,8 @@
 - name: verify test create vpc with custom offering in check mode
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
 
 - name: test create vpc with custom offering
   cs_vpc:
@@ -73,8 +73,8 @@
 - name: verify test create vpc with custom offering
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc_custom"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text_custom"
     - vpc.cidr == "10.10.1.0/16"
@@ -90,8 +90,8 @@
 - name: verify test create vpc with custom offering idempotence
   assert:
     that:
-    - vpc|success
-    - not vpc|changed
+    - vpc is successful
+    - vpc is not changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc_custom"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text_custom"
     - vpc.cidr == "10.10.1.0/16"
@@ -107,8 +107,8 @@
 - name: verify test create vpc with default offering in check mode
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
 
 - name: test create vpc with default offering
   cs_vpc:
@@ -120,8 +120,8 @@
 - name: verify test create vpc with default offering
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text"
     - vpc.cidr == "10.10.0.0/16"
@@ -136,8 +136,8 @@
 - name: verify test create vpc with default offering idempotence
   assert:
     that:
-    - vpc|success
-    - not vpc|changed
+    - vpc is successful
+    - vpc is not changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text"
     - vpc.cidr == "10.10.0.0/16"
@@ -151,8 +151,8 @@
 - name: verify test create vpc idempotence2
   assert:
     that:
-    - vpc|success
-    - not vpc|changed
+    - vpc is successful
+    - vpc is not changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text"
     - vpc.cidr == "10.10.0.0/16"
@@ -168,8 +168,8 @@
 - name: verify test update vpc with default offering in check mode
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text"
     - vpc.cidr == "10.10.0.0/16"
@@ -184,8 +184,8 @@
 - name: verify test update vpc with default offering
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -200,8 +200,8 @@
 - name: verify test update vpc idempotence
   assert:
     that:
-    - vpc|success
-    - not vpc|changed
+    - vpc is successful
+    - vpc is not changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -219,8 +219,8 @@
 - name: verify test restart vpc with default offering with clean up in check mode
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -237,8 +237,8 @@
 - name: verify test restart vpc with default offering with clean up
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -254,8 +254,8 @@
 - name: verify test restart vpc with default offering without clean up
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -273,8 +273,8 @@
 - name: verify test create network in vpc in check mode
   assert:
     that:
-    - vpc_net|success
-    - vpc_net|changed
+    - vpc_net is successful
+    - vpc_net is changed
 
 - name: test create network in vpc
   cs_network:
@@ -288,8 +288,8 @@
 - name: verify test create network in vpc
   assert:
     that:
-    - vpc_net|success
-    - vpc_net|changed
+    - vpc_net is successful
+    - vpc_net is changed
     - vpc_net.name == "{{ cs_resource_prefix }}_net_vpc"
 
 - name: test create network in vpc idempotence
@@ -304,8 +304,8 @@
 - name: verify test create network in vpc idempotence
   assert:
     that:
-    - vpc_net|success
-    - not vpc_net|changed
+    - vpc_net is successful
+    - vpc_net is not changed
     - vpc_net.name == "{{ cs_resource_prefix }}_net_vpc"
 
 - name: test create instance in vpc in check mode
@@ -320,8 +320,8 @@
 - name: verify test create instance in vpc in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
 
 - name: test create instance in vpc
   cs_instance:
@@ -334,8 +334,8 @@
 - name: verify test create instance in vpc
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-vpc"
     - instance.state == "Running"
 
@@ -350,8 +350,8 @@
 - name: verify test create instance in vpc idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
     - instance.name == "{{ cs_resource_prefix }}-vm-vpc"
     - instance.state == "Running"
 
@@ -375,8 +375,8 @@
 - name: verify test static nat in vpc in check mode
   assert:
     that:
-    - static_nat|success
-    - static_nat|changed
+    - static_nat is successful
+    - static_nat is changed
 
 - name: test static nat in vpc
   cs_staticnat:
@@ -389,8 +389,8 @@
 - name: verify test static nat in vpc
   assert:
     that:
-    - static_nat|success
-    - static_nat|changed
+    - static_nat is successful
+    - static_nat is changed
 
 - name: test static nat in vpc idempotence
   cs_staticnat:
@@ -403,8 +403,8 @@
 - name: verify test static nat in vpc idempotence
   assert:
     that:
-    - static_nat|success
-    - not static_nat|changed
+    - static_nat is successful
+    - static_nat is not changed
 
 - name: test remove static nat in vpc in check mode
   cs_staticnat:
@@ -419,8 +419,8 @@
 - name: verify test remove static nat in vpc in check mode
   assert:
     that:
-    - static_nat|success
-    - static_nat|changed
+    - static_nat is successful
+    - static_nat is changed
 
 - name: test remove static nat in vpc
   cs_staticnat:
@@ -434,8 +434,8 @@
 - name: verify test remove static nat in vpc
   assert:
     that:
-    - static_nat|success
-    - static_nat|changed
+    - static_nat is successful
+    - static_nat is changed
 
 - name: test remove static nat in vpc idempotence
   cs_staticnat:
@@ -449,8 +449,8 @@
 - name: verify test remove static nat in vpc idempotence
   assert:
     that:
-    - static_nat|success
-    - not static_nat|changed
+    - static_nat is successful
+    - static_nat is not changed
 
 - name: test create port forwarding in vpc in check mode
   cs_portforward:
@@ -466,8 +466,8 @@
 - name: verify test create port forwarding in vpc in check mode
   assert:
     that:
-    - port_forward|success
-    - port_forward|changed
+    - port_forward is successful
+    - port_forward is changed
 
 - name: test create port forwarding in vpc
   cs_portforward:
@@ -482,8 +482,8 @@
 - name: verify test create port forwarding in vpc
   assert:
     that:
-    - port_forward|success
-    - port_forward|changed
+    - port_forward is successful
+    - port_forward is changed
 
 - name: test create port forwarding in vpc idempotence
   cs_portforward:
@@ -498,8 +498,8 @@
 - name: verify test create port forwarding in vpc idempotence
   assert:
     that:
-    - port_forward|success
-    - not port_forward|changed
+    - port_forward is successful
+    - port_forward is not changed
 
 - name: test remove port forwarding in vpc in check mode
   cs_portforward:
@@ -516,8 +516,8 @@
 - name: verify test remove port forwarding in vpc in check mode
   assert:
     that:
-    - port_forward|success
-    - port_forward|changed
+    - port_forward is successful
+    - port_forward is changed
 
 - name: test remove port forwarding in vpc
   cs_portforward:
@@ -533,8 +533,8 @@
 - name: verify test remove port forwarding in vpc
   assert:
     that:
-    - port_forward|success
-    - port_forward|changed
+    - port_forward is successful
+    - port_forward is changed
 
 - name: test remove port forwarding in vpc idempotence
   cs_portforward:
@@ -550,8 +550,8 @@
 - name: verify test remove port forwarding in vpc idempotence
   assert:
     that:
-    - port_forward|success
-    - not port_forward|changed
+    - port_forward is successful
+    - port_forward is not changed
 
 - name: test remove ip address from vpc
   cs_ip_address:
@@ -564,8 +564,8 @@
 - name: verify test remove ip address from vpc
   assert:
     that:
-    - ip_address_removed|success
-    - ip_address_removed|changed
+    - ip_address_removed is successful
+    - ip_address_removed is changed
 
 - name: test remove instance in vpc in check mdoe
   cs_instance:
@@ -577,8 +577,8 @@
 - name: verify test remove instance in vpc in check mode
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-vpc"
     - instance.state == "Running"
 
@@ -591,8 +591,8 @@
 - name: verify test remove instance in vpc
   assert:
     that:
-    - instance|success
-    - instance|changed
+    - instance is successful
+    - instance is changed
     - instance.name == "{{ cs_resource_prefix }}-vm-vpc"
     - instance.state == "Running"
 
@@ -605,8 +605,8 @@
 - name: verify test remove instance in vpc idempotence
   assert:
     that:
-    - instance|success
-    - not instance|changed
+    - instance is successful
+    - instance is not changed
 
 - name: test remove network in vpc in check mode
   cs_network:
@@ -619,8 +619,8 @@
 - name: verify test remove network in vpc in check mode
   assert:
     that:
-    - vpc_net|success
-    - vpc_net|changed
+    - vpc_net is successful
+    - vpc_net is changed
     - vpc_net.name == "{{ cs_resource_prefix }}_net_vpc"
 
 - name: test remove network in vpc
@@ -633,8 +633,8 @@
 - name: verify test remove network in vpc
   assert:
     that:
-    - vpc_net|success
-    - vpc_net|changed
+    - vpc_net is successful
+    - vpc_net is changed
     - vpc_net.name == "{{ cs_resource_prefix }}_net_vpc"
 
 - name: test remove network in vpc idempotence
@@ -647,8 +647,8 @@
 - name: verify test remove network in vpc idempotence
   assert:
     that:
-    - vpc_net|success
-    - not vpc_net|changed
+    - vpc_net is successful
+    - vpc_net is not changed
 
 - name: test remove vpc with default offering in check mode
   cs_vpc:
@@ -660,8 +660,8 @@
 - name: verify test remove vpc with default offering in check mode
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -675,8 +675,8 @@
 - name: verify test remove vpc with default offering
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc"
     - vpc.display_text == "{{ cs_resource_prefix }}_display_text2"
     - vpc.cidr == "10.10.0.0/16"
@@ -689,8 +689,8 @@
 - name: verify test remove vpc idempotence
   assert:
     that:
-    - vpc|success
-    - not vpc|changed
+    - vpc is successful
+    - vpc is not changed
 
 - name: test remove vpc with custom offering
   cs_vpc:
@@ -701,7 +701,7 @@
 - name: verify test remove vpc with custom offering
   assert:
     that:
-    - vpc|success
-    - vpc|changed
+    - vpc is successful
+    - vpc is changed
     - vpc.name == "{{ cs_resource_prefix }}_vpc_custom"
     - vpc.cidr == "10.10.1.0/16"

--- a/test/integration/targets/cs_vpn_gateway/tasks/main.yml
+++ b/test/integration/targets/cs_vpn_gateway/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify setup vpc
   assert:
     that:
-    - vpc|success
+    - vpc is successful
 
 - name: setup vpn gateway absent
   cs_vpn_gateway:
@@ -20,7 +20,7 @@
 - name: verify setup vpn gateway absent
   assert:
     that:
-    - vpn_gateway|success
+    - vpn_gateway is successful
 
 - name: test fail missing param vpc for vpn gateway
   cs_vpn_gateway:
@@ -29,7 +29,7 @@
 - name: verify test fail missing param vpc for vpn gateway
   assert:
     that:
-    - vpn_gateway|failed
+    - vpn_gateway is failed
     - "vpn_gateway.msg.startswith('missing required arguments: ')"
 
 - name: test create vpn gateway in check mode
@@ -41,8 +41,8 @@
 - name: verify test create vpn gateway in check mode
   assert:
     that:
-    - vpn_gateway|success
-    - vpn_gateway|changed
+    - vpn_gateway is successful
+    - vpn_gateway is changed
 
 - name: test create vpn gateway
   cs_vpn_gateway:
@@ -52,8 +52,8 @@
 - name: verify test create vpn gateway
   assert:
     that:
-    - vpn_gateway|success
-    - vpn_gateway|changed
+    - vpn_gateway is successful
+    - vpn_gateway is changed
     - vpn_gateway.vpc == "{{ cs_resource_prefix }}_vpc"
 
 - name: test create vpn gateway idempotence
@@ -64,8 +64,8 @@
 - name: verify test create vpn gateway idempotence
   assert:
     that:
-    - vpn_gateway|success
-    - not vpn_gateway|changed
+    - vpn_gateway is successful
+    - vpn_gateway is not changed
     - vpn_gateway.vpc == "{{ cs_resource_prefix }}_vpc"
 
 - name: test remove vpn gateway in check mode
@@ -78,8 +78,8 @@
 - name: verify test remove vpn gateway in check mode
   assert:
     that:
-    - vpn_gateway|success
-    - vpn_gateway|changed
+    - vpn_gateway is successful
+    - vpn_gateway is changed
     - vpn_gateway.vpc == "{{ cs_resource_prefix }}_vpc"
 
 - name: test remove vpn gateway
@@ -91,8 +91,8 @@
 - name: verify test remove vpn gateway
   assert:
     that:
-    - vpn_gateway|success
-    - vpn_gateway|changed
+    - vpn_gateway is successful
+    - vpn_gateway is changed
     - vpn_gateway.vpc == "{{ cs_resource_prefix }}_vpc"
 
 - name: test remove vpn gateway idempotence
@@ -104,5 +104,5 @@
 - name: verify test remove vpn gateway idempotence
   assert:
     that:
-    - vpn_gateway|success
-    - not vpn_gateway|changed
+    - vpn_gateway is successful
+    - vpn_gateway is not changed

--- a/test/integration/targets/cs_zone/tasks/main.yml
+++ b/test/integration/targets/cs_zone/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: verify setup zone absent
   assert:
     that:
-      - zone|success
+      - zone is successful
 
 - name: test fail missing param
   cs_zone:
@@ -17,7 +17,7 @@
 - name: verify test fail missing param
   assert:
     that:
-      - zone|failed
+      - zone is failed
       - "zone.msg == 'missing required arguments: dns1'"
 
 - name: test create zone in check mode
@@ -31,8 +31,8 @@
 - name: verify test create zone in check mode
   assert:
     that:
-      - zone|success
-      - zone|changed
+      - zone is successful
+      - zone is changed
 
 - name: test create zone
   cs_zone:
@@ -44,8 +44,8 @@
 - name: verify test create zone
   assert:
     that:
-      - zone|success
-      - zone|changed
+      - zone is successful
+      - zone is changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "8.8.8.8"
@@ -66,8 +66,8 @@
 - name: verify test create zone idempotency
   assert:
     that:
-      - zone|success
-      - not zone|changed
+      - zone is successful
+      - zone is not changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "8.8.8.8"
@@ -92,8 +92,8 @@
 - name: verify test update zone in check mode
   assert:
     that:
-      - zone|success
-      - zone|changed
+      - zone is successful
+      - zone is changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "8.8.8.8"
@@ -117,8 +117,8 @@
 - name: verify test update zone
   assert:
     that:
-      - zone|success
-      - zone|changed
+      - zone is successful
+      - zone is changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "10.10.1.100"
@@ -142,8 +142,8 @@
 - name: verify test update zone idempotency
   assert:
     that:
-      - zone|success
-      - not zone|changed
+      - zone is successful
+      - zone is not changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "10.10.1.100"
@@ -163,8 +163,8 @@
 - name: verify test absent zone in check mode
   assert:
     that:
-      - zone|success
-      - zone|changed
+      - zone is successful
+      - zone is changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "10.10.1.100"
@@ -182,8 +182,8 @@
 - name: verify test absent zone
   assert:
     that:
-      - zone|success
-      - zone|changed
+      - zone is successful
+      - zone is changed
       - zone.dns1 == "8.8.8.8"
       - zone.dns2 == "8.8.4.4"
       - zone.internal_dns1 == "10.10.1.100"
@@ -201,5 +201,5 @@
 - name: verify test absent zone idempotency
   assert:
     that:
-      - zone|success
-      - not zone|changed
+      - zone is successful
+      - zone is not changed

--- a/test/integration/targets/cs_zone_facts/tasks/main.yml
+++ b/test/integration/targets/cs_zone_facts/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: verify setup zone is present
   assert:
     that:
-      - zone|success
+      - zone is successful
 
 - name: get facts from zone in check mode
   cs_zone_facts:
@@ -19,8 +19,8 @@
 - name: verify  get facts from zone in check mode
   assert:
     that:
-      - zone|success
-      - not zone|changed
+      - zone is successful
+      - zone is not changed
       - cloudstack_zone.dns1 == "8.8.8.8"
       - cloudstack_zone.dns2 == "8.8.4.4"
       - cloudstack_zone.internal_dns1 == "8.8.8.8"
@@ -39,8 +39,8 @@
 - name: verify get facts from zone
   assert:
     that:
-      - zone|success
-      - not zone|changed
+      - zone is successful
+      - zone is not changed
       - cloudstack_zone.dns1 == "8.8.8.8"
       - cloudstack_zone.dns2 == "8.8.4.4"
       - cloudstack_zone.internal_dns1 == "8.8.8.8"

--- a/test/integration/targets/dnf/tasks/dnf.yml
+++ b/test/integration/targets/dnf/tasks/dnf.yml
@@ -11,7 +11,7 @@
 # some dnf python files after the package is uninstalled.
 - name: uninstall python2-dnf with shell
   shell: dnf -y remove python2-dnf
-  when: rpm_result|success
+  when: rpm_result is successful
 
 # UNINSTALL
 #   With 'python2-dnf' uninstalled, the first call to 'dnf' should install
@@ -203,7 +203,7 @@
 - name: check non-existent rpm install failed
   assert:
     that:
-      - non_existent_rpm|failed
+      - non_existent_rpm is failed
 
 # Install in installroot='/'.  This should be identical to default
 - name: install sos in /
@@ -345,7 +345,7 @@
   assert:
     that:
         - "not dnf_result.changed"
-        - "dnf_result|failed"
+        - "dnf_result is failed"
 
 - name: verify dnf module outputs
   assert:
@@ -363,7 +363,7 @@
 - name: verify installation failed
   assert:
     that:
-        - "dnf_result|failed"
+        - "dnf_result is failed"
         - "not dnf_result.changed"
 
 - name: verify dnf module outputs
@@ -382,7 +382,7 @@
 - name: verify installation failed
   assert:
     that:
-        - "dnf_result|failed"
+        - "dnf_result is failed"
         - "not dnf_result.changed"
 
 - name: verify dnf module outputs

--- a/test/integration/targets/docker/tasks/docker-setup-rht.yml
+++ b/test/integration/targets/docker/tasks/docker-setup-rht.yml
@@ -7,10 +7,10 @@
   package:
     state: present
     name: nmap-ncat
-  when: ansible_distribution == 'Fedora' or (ansible_os_family == 'RedHat' and ansible_distribution_version|version_compare(7, '>='))
+  when: ansible_distribution == 'Fedora' or (ansible_os_family == 'RedHat' and ansible_distribution_version is version(7, '>='))
 
 - name: Install netcat (RHEL)
   package:
     state: present
     name: nc
-  when: ansible_distribution != 'Fedora' and (ansible_os_family == 'RedHat' and ansible_distribution_version|version_compare(7, '<'))
+  when: ansible_distribution != 'Fedora' and (ansible_os_family == 'RedHat' and ansible_distribution_version is version(7, '<'))

--- a/test/integration/targets/ecs_ecr/tasks/main.yml
+++ b/test/integration/targets/ecs_ecr/tasks/main.yml
@@ -17,8 +17,8 @@
     - name: it should skip, change and create
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - result.created
 
 
@@ -36,7 +36,7 @@
     - name: it should fail with an AccessDeniedException
       assert:
         that:
-          - result|failed
+          - result is failed
           - '"AccessDeniedException" in result.msg'
 
 
@@ -52,7 +52,7 @@
     - name: it should change and create
       assert:
         that:
-          - result|changed
+          - result is changed
           - result.created
 
 
@@ -69,8 +69,8 @@
     - name: it should not skip, should not change
       assert:
         that:
-          - not result|skipped
-          - not result|changed
+          - result is not skipped
+          - result is not changed
 
 
     - name: When creating a repository that already exists
@@ -85,7 +85,7 @@
     - name: it should not change
       assert:
         that:
-          - not result|changed
+          - result is not changed
 
 
     - name: When in check mode, and deleting a policy that does not exists
@@ -102,8 +102,8 @@
     - name: it should not skip and not change
       assert:
         that:
-          - not result|skipped
-          - not result|changed
+          - result is not skipped
+          - result is not changed
 
 
     - name: When in check mode, setting policy on a repository that has no policy
@@ -120,8 +120,8 @@
     - name: it should skip, change and not create
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - not result.created
 
 
@@ -138,7 +138,7 @@
     - name: it should change and not create
       assert:
         that:
-          - result|changed
+          - result is changed
           - not result.created
 
 
@@ -156,8 +156,8 @@
     - name: it should skip, change but not create
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - not result.created
 
 
@@ -174,7 +174,7 @@
     - name: it should change and not create
       assert:
         that:
-          - result|changed
+          - result is changed
           - not result.created
 
 
@@ -191,7 +191,7 @@
     - name: it should change and not create
       assert:
         that:
-          - result|changed
+          - result is changed
           - not result.created
 
 
@@ -208,7 +208,7 @@
     - name: it should not change
       assert:
         that:
-          - not result|changed
+          - result is not changed
 
 
     - name: When omitting policy on a repository that has a policy
@@ -223,7 +223,7 @@
     - name: it should not change
       assert:
         that:
-          - not result|changed
+          - result is not changed
 
 
     - name: When specifying both policy and delete_policy
@@ -241,7 +241,7 @@
     - name: it should fail
       assert:
         that:
-          - result|failed
+          - result is failed
 
 
     - name: When specifying invalid JSON for policy
@@ -258,7 +258,7 @@
     - name: it should fail
       assert:
         that:
-          - result|failed
+          - result is failed
 
 
     - name: When in check mode, deleting a policy that exists
@@ -275,8 +275,8 @@
     - name: it should skip, change and not create
       assert:
         that:
-          - result|skipped
-          - result|changed
+          - result is skipped
+          - result is changed
           - not result.created
 
 
@@ -293,7 +293,7 @@
     - name: it should change
       assert:
         that:
-          - result|changed
+          - result is changed
 
 
     - name: When in check mode, deleting a policy that does not exist
@@ -310,8 +310,8 @@
     - name: it should not change
       assert:
         that:
-          - not result|skipped
-          - not result|changed
+          - result is not skipped
+          - result is not changed
 
 
     - name: When deleting a policy that does not exist
@@ -327,7 +327,7 @@
     - name: it should not change
       assert:
         that:
-          - not result|changed
+          - result is not changed
 
   always:
 

--- a/test/integration/targets/fetch/tasks/main.yml
+++ b/test/integration/targets/fetch/tasks/main.yml
@@ -63,7 +63,7 @@
   assert:
     that:
       - "fetch_missing_nofail.msg"
-      - "not fetch_missing_nofail|changed"
+      - "fetch_missing_nofail is not changed"
 
 - name: attempt to fetch a non-existent file - fail on missing
   fetch: src={{ output_dir }}/doesnotexist dest={{ output_dir }}/fetched fail_on_missing=yes
@@ -73,9 +73,9 @@
 - name: check fetch missing with failure
   assert:
     that:
-      - "fetch_missing|failed"
+      - "fetch_missing is failed"
       - "fetch_missing.msg"
-      - "not fetch_missing|changed"
+      - "fetch_missing is not changed"
 
 - name: attempt to fetch a directory - should not fail but return a message
   fetch: src={{ output_dir }} dest={{ output_dir }}/somedir fail_on_missing=False
@@ -84,7 +84,7 @@
 - name: check fetch directory result
   assert:
     that:
-      - "not fetch_dir|changed"
+      - "fetch_dir is not changed"
       - "fetch_dir.msg"
 
 - name: attempt to fetch a directory - should fail
@@ -95,7 +95,7 @@
 - name: check fetch directory result
   assert:
     that:
-      - "failed_fetch_dir|failed"
+      - "failed_fetch_dir is failed"
       - "fetch_dir.msg"
 
 - name: create symlink to a file that we can fetch
@@ -134,5 +134,5 @@
 - name: check that it indeed failed
   assert:
     that:
-      - "failed_fetch_dest_dir|failed"
+      - "failed_fetch_dest_dir is failed"
       - "failed_fetch_dest_dir.msg"

--- a/test/integration/targets/filters/files/foo.txt
+++ b/test/integration/targets/filters/files/foo.txt
@@ -20,7 +20,7 @@ Dumping the same structure to YAML, but don't pretty print
 
 
 From a recorded task, the changed, failed, success, and skipped
-filters are shortcuts to ask if those tasks produced changes, failed,
+tests are shortcuts to ask if those tasks produced changes, failed,
 succeeded, or skipped (as one might guess).
 
 Changed = True

--- a/test/integration/targets/filters/tasks/main.yml
+++ b/test/integration/targets/filters/tasks/main.yml
@@ -124,8 +124,7 @@
       - "'local' == ['localhost']|map('extract',hostvars,'ansible_connection')|list|first"
       - "'local' == ['localhost']|map('extract',hostvars,['ansible_connection'])|list|first"
   # map was added to jinja2 in version 2.7
-  when: "{{ ( lookup('pipe', '{{ ansible_python[\"executable\"] }} -c \"import jinja2; print(jinja2.__version__)\"') |
-              version_compare('2.7', '>=') ) }}"
+  when: "{{ ( lookup('pipe', '{{ ansible_python[\"executable\"] }} -c \"import jinja2; print(jinja2.__version__)\"')  is version('2.7', '>=') ) }}"
 
 - name: Test json_query filter
   assert:
@@ -167,5 +166,5 @@
 - name: Verify urlsplit filter showed an error message
   assert:
     that:
-      - _bad_urlsplit_filter | failed
+      - _bad_urlsplit_filter is failed
       - "'unknown URL component' in _bad_urlsplit_filter.msg"

--- a/test/integration/targets/filters/templates/foo.j2
+++ b/test/integration/targets/filters/templates/foo.j2
@@ -14,13 +14,13 @@ Dumping the same structure to YAML, but don't pretty print
 {{ some_structure | to_yaml }}
 
 From a recorded task, the changed, failed, success, and skipped
-filters are shortcuts to ask if those tasks produced changes, failed,
+tests are shortcuts to ask if those tasks produced changes, failed,
 succeeded, or skipped (as one might guess).
 
-Changed = {{ some_registered_var | changed }}
-Failed  = {{ some_registered_var | failed }}
-Success = {{ some_registered_var | success }}
-Skipped = {{ some_registered_var | skipped }}
+Changed = {{ some_registered_var is changed }}
+Failed  = {{ some_registered_var is failed }}
+Success = {{ some_registered_var is successful }}
+Skipped = {{ some_registered_var is skipped }}
 
 The mandatory filter fails if a variable is not defined and returns the value.
 To avoid breaking this test, this variable is already defined.

--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -111,8 +111,8 @@
 - name: Assert that the file was not downloaded
   assert:
     that:
-      - "result|failed"
-      - "'Failed to validate the SSL certificate' in result.msg or (result.msg | match('hostname .* doesn.t match .*'))"
+      - "result is failed"
+      - "'Failed to validate the SSL certificate' in result.msg or ( result.msg is match('hostname .* doesn.t match .*'))"
       - "stat_result.stat.exists == false"
 
 - name: test https fetch to a site with mismatched hostname and certificate and validate_certs=no
@@ -156,7 +156,7 @@
 - name: Assert that hostname verification failed because SNI is not supported on this version of python
   assert:
     that:
-      - 'get_url_result|failed'
+      - 'get_url_result is failed'
   when: "{{ not python_has_ssl_context }}"
 
 # These tests are just side effects of how the site is hosted.  It's not
@@ -177,14 +177,14 @@
   assert:
     that:
       - 'data_result.rc == 0'
-      - 'not get_url_result|failed'
+      - 'get_url_result is not failed'
   when: "{{ python_has_ssl_context }}"
 
 # If the client doesn't support SNI then get_url should have failed with a certificate mismatch
 - name: Assert that hostname verification failed because SNI is not supported on this version of python
   assert:
     that:
-      - 'get_url_result|failed'
+      - 'get_url_result is failed'
   when: "{{ not python_has_ssl_context }}"
 # End hacky SNI test section
 

--- a/test/integration/targets/git/tasks/archive.yml
+++ b/test/integration/targets/git/tasks/archive.yml
@@ -18,7 +18,7 @@
     that: (git_archive.results | map(attribute='changed') | unique | list)[0]
   when:
     - "ansible_os_family == 'RedHat'"
-    - ansible_distribution_major_version | version_compare('7', '>=')
+    - ansible_distribution_major_version is version('7', '>=')
 
 - name: ARCHIVE | Check if archive file is created or not
   stat:
@@ -31,7 +31,7 @@
     that: (archive_check.results | map(attribute='stat.exists') | unique | list)[0]
   when:
     - "ansible_os_family == 'RedHat'"
-    - ansible_distribution_major_version | version_compare('7', '>=')
+    - ansible_distribution_major_version is version('7', '>=')
 
 - name: ARCHIVE | Clear checkout_dir               
   file:                  
@@ -60,7 +60,7 @@
     that: (git_archive.results | map(attribute='changed') | unique | list)[0]
   when:
     - "ansible_os_family == 'RedHat'"
-    - ansible_distribution_major_version | version_compare('7', '>=')
+    - ansible_distribution_major_version is version('7', '>=')
 
 - name: ARCHIVE | Check if archive file is created or not
   stat:
@@ -73,4 +73,4 @@
     that: (archive_check.results | map(attribute='stat.exists') | unique | list)[0]
   when:
     - "ansible_os_family == 'RedHat'"
-    - ansible_distribution_major_version | version_compare('7', '>=')
+    - ansible_distribution_major_version is version('7', '>=')

--- a/test/integration/targets/git/tasks/change-repo-url.yml
+++ b/test/integration/targets/git/tasks/change-repo-url.yml
@@ -18,7 +18,7 @@
   register: clone2
 
 - assert:
-    that: "clone2|success"
+    that: "clone2 is successful"
 
 - name: CHANGE-REPO-URL | check url updated
   shell: git remote show origin | grep Fetch
@@ -63,7 +63,7 @@
 - name: CHANGE-REPO-URL | check repo not changed
   assert:
     that:
-      - not checkout_same_url|changed
+      - checkout_same_url is not changed
 
 
 - name: CHANGE-REPO-URL | clone repo with new url to same destination
@@ -75,7 +75,7 @@
 - name: CHANGE-REPO-URL | check repo changed
   assert:
     that:
-      - checkout_new_url|changed
+      - checkout_new_url is changed
 
 
 - name: CHANGE-REPO-URL | clone repo with new url in check mode
@@ -88,8 +88,8 @@
 - name: CHANGE-REPO-URL | check repo reported changed in check mode
   assert:
     that:
-      - checkout_new_url_check_mode | changed
-  when: git_version.stdout | version_compare(git_version_supporting_ls_remote, '>=')
+      - checkout_new_url_check_mode is changed
+  when: git_version.stdout is version(git_version_supporting_ls_remote, '>=')
 
 - name: CHANGE-REPO-URL | clone repo with new url after check mode
   git:
@@ -100,7 +100,7 @@
 - name: CHANGE-REPO-URL | check repo still changed after check mode
   assert:
     that:
-      - checkout_new_url_after_check_mode|changed
+      - checkout_new_url_after_check_mode is changed
 
 
 # Test that checkout by branch works when the branch is not in our current repo but the sha is

--- a/test/integration/targets/git/tasks/checkout-new-tag.yml
+++ b/test/integration/targets/git/tasks/checkout-new-tag.yml
@@ -44,7 +44,7 @@
 - name: check new head
   assert:
     that:
-      - not update_new_tag|changed
+      - update_new_tag is not changed
       - "'newtag' in listoftags.stdout_lines"
 
 

--- a/test/integration/targets/git/tasks/depth.yml
+++ b/test/integration/targets/git/tasks/depth.yml
@@ -21,7 +21,7 @@
 - name: DEPTH | make sure the old commit was not fetched
   assert:
     that: 'checkout_early.rc != 0'
-  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
 # tests https://github.com/ansible/ansible/issues/14954
 - name: DEPTH | fetch repo again with depth=1
@@ -32,8 +32,8 @@
   register: checkout2
 
 - assert:
-    that: "not checkout2|changed"
-  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
+    that: "checkout2 is not changed"
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
 - name: DEPTH | again try to access earlier commit
   shell: "git checkout {{git_shallow_head_1.stdout}}"
@@ -45,7 +45,7 @@
 - name: DEPTH | again make sure the old commit was not fetched
   assert:
     that: 'checkout_early.rc != 0'
-  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
 # make sure we are still able to fetch other versions
 - name: DEPTH | Clone same repo with older version
@@ -57,7 +57,7 @@
   register: cloneold
 
 - assert:
-    that: cloneold | success
+    that: cloneold is successful
 
 - name: DEPTH | try to access earlier commit
   shell: "git checkout {{git_shallow_head_1.stdout}}"
@@ -79,7 +79,7 @@
   register: cloneold
 
 - assert:
-    that: cloneold | success
+    that: cloneold is successful
 
 - name: DEPTH | clear checkout_dir
   file:
@@ -107,7 +107,7 @@
 
 - name: DEPTH | ensure the fetch succeeded
   assert:
-    that: git_fetch | success
+    that: git_fetch is successful
 
 
 - name: DEPTH | clear checkout_dir
@@ -132,7 +132,7 @@
 
 - name: DEPTH | ensure the fetch succeeded
   assert:
-    that: git_fetch | success
+    that: git_fetch is successful
 
 - name: DEPTH | clear checkout_dir
   file:
@@ -165,7 +165,7 @@
   assert:
     that:
       - "{{ lookup('file', checkout_dir+'/a' )}} == 3"
-      - git_fetch | changed
+      - git_fetch is changed
 
 - name: DEPTH | clear checkout_dir
   file:

--- a/test/integration/targets/git/tasks/gpg-verification.yml
+++ b/test/integration/targets/git/tasks/gpg-verification.yml
@@ -99,8 +99,8 @@
 - name: GPG-VERIFICATION | Check that unsigned lightweight tag verification failed
   assert:
     that:
-      - git_verify|failed
-      - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
+      - git_verify is failed
+      - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
 
 - name: GPG-VERIFICATION | Clone repo and verify a signed commit
   environment:
@@ -125,8 +125,8 @@
 - name: GPG-VERIFICATION | Check that unsigned commit verification failed
   assert:
     that:
-      - git_verify|failed
-      - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
+      - git_verify is failed
+      - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
 
 - name: GPG-VERIFICATION | Clone repo and verify a signed annotated tag
   environment:
@@ -151,8 +151,8 @@
 - name: GPG-VERIFICATION | Check that unsigned annotated tag verification failed
   assert:
     that:
-      - git_verify|failed
-      - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
+      - git_verify is failed
+      - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
 
 - name: GPG-VERIFICATION | Clone repo and verify a signed branch
   environment:
@@ -177,8 +177,8 @@
 - name: GPG-VERIFICATION | Check that unsigned branch verification failed
   assert:
     that:
-      - git_verify|failed
-      - git_verify.msg|match("Failed to verify GPG signature of commit/tag.+")
+      - git_verify is failed
+      - git_verify.msg is match("Failed to verify GPG signature of commit/tag.+")
 
 - name: GPG-VERIFICATION | Remove GnuPG verification workdir
   file:

--- a/test/integration/targets/git/tasks/localmods.yml
+++ b/test/integration/targets/git/tasks/localmods.yml
@@ -29,7 +29,7 @@
 - name: LOCALMODS | check fetch with localmods failed
   assert:
     that:
-      - git_fetch|failed
+      - git_fetch is failed
 
 - name: LOCALMODS | fetch with local mods with force
   git:
@@ -43,7 +43,7 @@
   assert:
     that:
       - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
-      - git_fetch_force|changed
+      - git_fetch_force is changed
 
 - name: LOCALMODS | clear checkout_dir
   file: state=absent path={{ checkout_dir }}
@@ -81,7 +81,7 @@
 - name: LOCALMODS | check fetch with localmods failed
   assert:
     that:
-      - git_fetch|failed
+      - git_fetch is failed
 
 - name: LOCALMODS | fetch with local mods with force
   git:
@@ -96,7 +96,7 @@
   assert:
     that:
       - "{{ lookup('file', checkout_dir+'/a' )}} == 2"
-      - git_fetch_force|changed
+      - git_fetch_force is changed
 
 - name: LOCALMODS | clear checkout_dir
   file: state=absent path={{ checkout_dir }}

--- a/test/integration/targets/git/tasks/main.yml
+++ b/test/integration/targets/git/tasks/main.yml
@@ -31,7 +31,7 @@
   when:
     - not gpg_version.stderr
     - gpg_version.stdout
-    - git_version.stdout | version_compare("2.1.0", '>=')
+    - git_version.stdout is version("2.1.0", '>=')
 - include_tasks: localmods.yml
 - include_tasks: reset-origin.yml
 - include_tasks: ambiguous-ref.yml

--- a/test/integration/targets/git/tasks/missing_hostkey.yml
+++ b/test/integration/targets/git/tasks/missing_hostkey.yml
@@ -8,7 +8,7 @@
 
 - assert:
     that:
-      - git_result | failed
+      - git_result is failed
 
 - name: MISSING-HOSTKEY | checkout git@github.com repo with accept_hostkey (expected pass)
   git:
@@ -22,7 +22,7 @@
 
 - assert:
     that:
-      - git_result | changed
+      - git_result is changed
   when: github_ssh_private_key is defined
 
 - name: MISSING-HOSTKEY | clear checkout_dir
@@ -44,5 +44,5 @@
 
 - assert:
     that:
-      - git_result | changed
+      - git_result is changed
   when: github_ssh_private_key is defined

--- a/test/integration/targets/git/tasks/no-destination.yml
+++ b/test/integration/targets/git/tasks/no-destination.yml
@@ -10,4 +10,4 @@
 
 - assert:
     that:
-      - git_result | changed
+      - git_result is changed

--- a/test/integration/targets/git/tasks/specific-revision.yml
+++ b/test/integration/targets/git/tasks/specific-revision.yml
@@ -30,7 +30,7 @@
 
 - assert:
     that:
-      - git_result | changed
+      - git_result is changed
 
 - name: SPECIFIC-REVISION | check HEAD after update to revision
   command: git rev-parse HEAD
@@ -54,7 +54,7 @@
 
 - assert:
     that:
-      - git_result | failed
+      - git_result is failed
 
 # Same as the previous test, but this time we specify which ref
 # contains the SHA1
@@ -110,8 +110,8 @@
   assert:
     that:
       - checkout_shallow.rc != 0
-      - checkout_shallow | success
-  when: git_version.stdout | version_compare(git_version_supporting_depth, '>=')
+      - checkout_shallow is successful
+  when: git_version.stdout is version(git_version_supporting_depth, '>=')
 
 - name: SPECIFIC-REVISION | clear checkout_dir
   file:

--- a/test/integration/targets/group/tasks/main.yml
+++ b/test/integration/targets/group/tasks/main.yml
@@ -66,7 +66,7 @@
       that:
           - "group_test1.results|map(attribute='changed')|unique|list == [False]"
           - "group_test1.results|map(attribute='state')|unique|list == ['present']"
-  when: "jinja2_version.stdout|version_compare('2.6', '>=')"
+  when: "jinja2_version.stdout is version('2.6', '>=')"
 
 - name: validate change results for testcase 1 (jinja2 < 2.6)
   assert:
@@ -76,7 +76,7 @@
           - "not group_test1.results[2]['changed']"
           - "not group_test1.results[3]['changed']"
           - "not group_test1.results[4]['changed']"
-  when: "jinja2_version.stdout|version_compare('2.6', '<')"
+  when: "jinja2_version.stdout is version('2.6', '<')"
 
 
 

--- a/test/integration/targets/iso_extract/tasks/tests.yml
+++ b/test/integration/targets/iso_extract/tasks/tests.yml
@@ -28,7 +28,7 @@
 
 - assert:
     that:
-    - iso_extract_test0|changed == true
+    - iso_extract_test0 is changed == true
 
 - name: Extract the iso again
   iso_extract:
@@ -42,11 +42,11 @@
 - name: Test iso_extract_test0_again (normal mode)
   assert:
     that:
-    - iso_extract_test0_again|changed == false
+    - iso_extract_test0_again is changed == false
   when: not in_check_mode
 
 - name: Test iso_extract_test0_again (check-mode)
   assert:
     that:
-    - iso_extract_test0_again|changed == true
+    - iso_extract_test0_again is changed == true
   when: in_check_mode

--- a/test/integration/targets/iterators/tasks/main.yml
+++ b/test/integration/targets/iterators/tasks/main.yml
@@ -93,9 +93,9 @@
 
 - assert:
     that:
-        - not start_equal_end| skipped
-        - count_of_zero | skipped
-        - not count_of_one | skipped
+        - start_equal_end is not skipped
+        - count_of_zero is skipped
+        - count_of_one is not skipped
 
 - name: test with_sequence shortcut syntax (end)
   set_fact: "{{ 'ws_z_' + item }}={{ item }}"

--- a/test/integration/targets/java_cert/tasks/main.yml
+++ b/test/integration/targets/java_cert/tasks/main.yml
@@ -17,7 +17,7 @@
 - name: verify success
   assert:
     that:
-    - result_success|success
+    - result_success is successful
 
 - name: import pkcs12 with wrong password
   local_action:
@@ -36,7 +36,7 @@
 - name: verify fail with wrong import password
   assert:
     that:
-    - result_wrong_pass|failed
+    - result_wrong_pass is failed
 
 - name: test fail on mutually exclusive params
   local_action:
@@ -53,4 +53,4 @@
 - name: verify failed exclusive params
   assert:
     that:
-    - result_excl_params|failed
+    - result_excl_params is failed

--- a/test/integration/targets/junos_config/tests/netconf/single.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/single.yaml
@@ -57,8 +57,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *file test1")
-      - result.diff.prepared | search("\+ *any any")
+      - result.diff.prepared is search("\+ *file test1")
+      - result.diff.prepared is search("\+ *any any")
 
 - name: Rollback junos config
   junos_config:
@@ -69,8 +69,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *file test1")
-      - result.diff.prepared | search("\+ *any any")
+      - result.diff.prepared is search("\+ *file test1")
+      - result.diff.prepared is search("\+ *any any")
 
 - name: teardown
   junos_config:

--- a/test/integration/targets/junos_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_interface/tests/netconf/basic.yaml
@@ -118,7 +118,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable interface
   junos_interface:
@@ -131,7 +131,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Delete interface
   junos_interface:
@@ -178,15 +178,15 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *ge-0/0/1")
-      - result.diff.prepared | search("\+ *description test-interface-1")
-      - result.diff.prepared | search("\+ *speed 1g")
-      - result.diff.prepared | search("\+ *mtu 512")
-      - result.diff.prepared | search("\+ *link-mode full-duplex")
-      - result.diff.prepared | search("\+ *description test-interface-2")
-      - result.diff.prepared | search("\+ *speed 10m")
-      - result.diff.prepared | search("\+ * mtu 256")
-      - result.diff.prepared | search("\+ *link-mode full-duplex")
+      - result.diff.prepared is search("\+ *ge-0/0/1")
+      - result.diff.prepared is search("\+ *description test-interface-1")
+      - result.diff.prepared is search("\+ *speed 1g")
+      - result.diff.prepared is search("\+ *mtu 512")
+      - result.diff.prepared is search("\+ *link-mode full-duplex")
+      - result.diff.prepared is search("\+ *description test-interface-2")
+      - result.diff.prepared is search("\+ *speed 10m")
+      - result.diff.prepared is search("\+ * mtu 256")
+      - result.diff.prepared is search("\+ *link-mode full-duplex")
 
 - name: Set interface on aggregate (idempotent)
   junos_interface:
@@ -213,7 +213,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable interface on aggregate
   junos_interface:
@@ -227,7 +227,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Deactivate interface configuration on aggregate
   junos_interface:
@@ -242,8 +242,8 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *inactive[:] ge-0/0/1")
-      - result.diff.prepared | search("! *inactive[:] ge-0/0/2")
+      - result.diff.prepared is search("! *inactive[:] ge-0/0/1")
+      - result.diff.prepared is search("! *inactive[:] ge-0/0/2")
 
 - name: Activate interface configuration on aggregate
   junos_interface:
@@ -258,8 +258,8 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *active[:] ge-0/0/1")
-      - result.diff.prepared | search("! *active[:] ge-0/0/2")
+      - result.diff.prepared is search("! *active[:] ge-0/0/1")
+      - result.diff.prepared is search("! *active[:] ge-0/0/2")
 
 - name: Delete interface on aggregate
   junos_interface:
@@ -273,15 +273,15 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *ge-0/0/1")
-      - result.diff.prepared | search("\- *description test-interface-1")
-      - result.diff.prepared | search("\- *speed 1g")
-      - result.diff.prepared | search("\- *mtu 512")
-      - result.diff.prepared | search("\- *link-mode full-duplex")
-      - result.diff.prepared | search("\- *description test-interface-2")
-      - result.diff.prepared | search("\- *speed 10m")
-      - result.diff.prepared | search("\- * mtu 256")
-      - result.diff.prepared | search("\- *link-mode full-duplex")
+      - result.diff.prepared is search("\- *ge-0/0/1")
+      - result.diff.prepared is search("\- *description test-interface-1")
+      - result.diff.prepared is search("\- *speed 1g")
+      - result.diff.prepared is search("\- *mtu 512")
+      - result.diff.prepared is search("\- *link-mode full-duplex")
+      - result.diff.prepared is search("\- *description test-interface-2")
+      - result.diff.prepared is search("\- *speed 10m")
+      - result.diff.prepared is search("\- * mtu 256")
+      - result.diff.prepared is search("\- *link-mode full-duplex")
 
 - name: Delete interface on aggregate (idempotent)
   junos_interface:

--- a/test/integration/targets/junos_interface/tests/netconf/intent.yaml
+++ b/test/integration/targets/junos_interface/tests/netconf/intent.yaml
@@ -10,17 +10,17 @@
 - name: Define interface name for vSRX
   set_fact:
     intf_name: pp0
-  when: result['ansible_facts']['ansible_net_model'] | search("vSRX*")
+  when: result['ansible_facts']['ansible_net_model']  is search("vSRX*")
 
 - name: Define interface name for vsrx
   set_fact:
     intf_name: pp0
-  when: result['ansible_facts']['ansible_net_model'] | search("vsrx")
+  when: result['ansible_facts']['ansible_net_model']  is search("vsrx")
 
 - name: Define interface name for vQFX
   set_fact:
     intf_name: gr-0/0/0
-  when: result['ansible_facts']['ansible_net_model'] | search("vqfx*")
+  when: result['ansible_facts']['ansible_net_model']  is search("vqfx*")
 
 - name: Check intent arguments
   junos_interface:
@@ -63,7 +63,7 @@
 - assert:
     that:
       - "result.failed == false"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Config + intent (fail)
   junos_interface:

--- a/test/integration/targets/junos_l3_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_l3_interface/tests/netconf/basic.yaml
@@ -29,8 +29,8 @@
       - "result.changed == true"
       - "'<name>1.1.1.1/32</name>' in config.xml"
       - "'<name>fd5d:12c9:2201:1::1/128</name>' in config.xml"
-      - result.diff.prepared | search("\+ *address 1.1.1.1/32")
-      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\+ *address 1.1.1.1/32")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:1::1/128")
 
 - name: Configure interface address (idempotent)
   junos_l3_interface:
@@ -65,8 +65,8 @@
     that:
       - "result.changed == true"
       - "'<address inactive=\"inactive\">' in config.xml"
-      - result.diff.prepared | search("! *inactive[:] address 1.1.1.1/32")
-      - result.diff.prepared | search("! *inactive[:] address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("! *inactive[:] address 1.1.1.1/32")
+      - result.diff.prepared is search("! *inactive[:] address fd5d:12c9:2201:1::1/128")
 
 - name: Activate interface address
   junos_l3_interface:
@@ -81,8 +81,8 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("! *active[:] address 1.1.1.1/32")
-      - result.diff.prepared | search("! *active[:] address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("! *active[:] address 1.1.1.1/32")
+      - result.diff.prepared is search("! *active[:] address fd5d:12c9:2201:1::1/128")
 
 - name: Delete interface address
   junos_l3_interface:
@@ -95,8 +95,8 @@
 
 - assert:
     that:
-      - result.diff.prepared | search("\- *address 1.1.1.1/32")
-      - result.diff.prepared | search("\- *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\- *address 1.1.1.1/32")
+      - result.diff.prepared is search("\- *address fd5d:12c9:2201:1::1/128")
 
 - name: Delete interface address (idempotent)
   junos_l3_interface:
@@ -145,13 +145,13 @@
     that:
       - 'result.changed == true'
       - "'edit interfaces ge-0/0/1 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address 1.1.1.1/32")
+      - result.diff.prepared is search("\+ *address 1.1.1.1/32")
       - "'edit interfaces ge-0/0/1 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:1::1/128")
       - "'edit interfaces ge-0/0/2 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address 2.2.2.2/32")
+      - result.diff.prepared is search("\+ *address 2.2.2.2/32")
       - "'edit interfaces ge-0/0/2 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:2::2/128")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:2::2/128")
 
 - name: Configure l3 interface in aggregate (idempotent)
   junos_l3_interface:
@@ -186,10 +186,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *inactive[:] address 1.1.1.1/32")
-      - result.diff.prepared | search("! *inactive[:] address fd5d:12c9:2201:1::1/128")
-      - result.diff.prepared | search("! *inactive[:] address 2.2.2.2/32")
-      - result.diff.prepared | search("! *inactive[:] address fd5d:12c9:2201:2::2/128")
+      - result.diff.prepared is search("! *inactive[:] address 1.1.1.1/32")
+      - result.diff.prepared is search("! *inactive[:] address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("! *inactive[:] address 2.2.2.2/32")
+      - result.diff.prepared is search("! *inactive[:] address fd5d:12c9:2201:2::2/128")
 
 - name: Activate l3 interface configuration
   junos_l3_interface:
@@ -207,10 +207,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *active[:] address 1.1.1.1/32")
-      - result.diff.prepared | search("! *active[:] address fd5d:12c9:2201:1::1/128")
-      - result.diff.prepared | search("! *active[:] address 2.2.2.2/32")
-      - result.diff.prepared | search("! *active[:] address fd5d:12c9:2201:2::2/128")
+      - result.diff.prepared is search("! *active[:] address 1.1.1.1/32")
+      - result.diff.prepared is search("! *active[:] address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("! *active[:] address 2.2.2.2/32")
+      - result.diff.prepared is search("! *active[:] address fd5d:12c9:2201:2::2/128")
 
 - name: Delete l3 interface configuration
   junos_l3_interface:
@@ -229,13 +229,13 @@
     that:
       - 'result.changed == true'
       - "'edit interfaces ge-0/0/1 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address 1.1.1.1/32")
+      - result.diff.prepared is search("\- *address 1.1.1.1/32")
       - "'edit interfaces ge-0/0/1 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\- *address fd5d:12c9:2201:1::1/128")
       - "'edit interfaces ge-0/0/2 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address 2.2.2.2/32")
+      - result.diff.prepared is search("\- *address 2.2.2.2/32")
       - "'edit interfaces ge-0/0/2 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address fd5d:12c9:2201:2::2/128")
+      - result.diff.prepared is search("\- *address fd5d:12c9:2201:2::2/128")
 
 - name: Delete l3 interface configuration (idempotent)
   junos_l3_interface:

--- a/test/integration/targets/junos_linkagg/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_linkagg/tests/netconf/basic.yaml
@@ -128,7 +128,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable linkagg interface
   junos_linkagg:
@@ -140,7 +140,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Deactivate linkagg
   junos_linkagg:

--- a/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
@@ -38,9 +38,9 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *advertisement-interval 10")
-      - result.diff.prepared | search("\+ *transmit-delay 2")
-      - result.diff.prepared | search("\+ *hold-multiplier 5")
+      - result.diff.prepared is search("\+ *advertisement-interval 10")
+      - result.diff.prepared is search("\+ *transmit-delay 2")
+      - result.diff.prepared is search("\+ *hold-multiplier 5")
 
 - name: configure lldp parameters and enable lldp(idempotent)
   junos_lldp:
@@ -67,7 +67,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
       - "'advertisement-interval 10;' not in result.diff.prepared"
       - "'transmit-delay 2;' not in result.diff.prepared"
       - "'hold-multiplier 5;' not in result.diff.prepared"
@@ -84,7 +84,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
       - "'advertisement-interval 10;' not in result.diff.prepared"
       - "'transmit-delay 2;' not in result.diff.prepared"
       - "'hold-multiplier 5;' not in result.diff.prepared"
@@ -101,10 +101,10 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
-      - result.diff.prepared | search("\- *advertisement-interval 10")
-      - result.diff.prepared | search("\- *transmit-delay 2")
-      - result.diff.prepared | search("\- *hold-multiplier 5")
+      - result.diff.prepared is search("\+ *disable")
+      - result.diff.prepared is search("\- *advertisement-interval 10")
+      - result.diff.prepared is search("\- *transmit-delay 2")
+      - result.diff.prepared is search("\- *hold-multiplier 5")
 
 - name: Remove lldp (idempotent)
   junos_lldp:

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
@@ -17,7 +17,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *interface ge-0/0/5")
+      - result.diff.prepared is search("\+ *interface ge-0/0/5")
 
 - name: lldp interface configuration (idempotent)
   junos_lldp_interface:
@@ -41,7 +41,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/5")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5")
 
 - name: Activate lldp interface configuration
   junos_lldp_interface:
@@ -54,7 +54,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/5")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/5")
 
 - name: Disable lldp on particular interface
   junos_lldp_interface:
@@ -66,7 +66,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable lldp on particular interface
   junos_lldp_interface:
@@ -78,7 +78,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Delete lldp on particular interface
   junos_lldp_interface:
@@ -90,7 +90,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *interface ge-0/0/5")
+      - result.diff.prepared is search("\- *interface ge-0/0/5")
 
 - name: Delete lldp on particular interface (idempotent)
   junos_lldp_interface:

--- a/test/integration/targets/junos_logging/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_logging/tests/netconf/basic.yaml
@@ -316,10 +316,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *file test-1")
-      - result.diff.prepared | search("\+ *pfe critical")
-      - result.diff.prepared | search("\+ *file test-2")
-      - result.diff.prepared | search("\+ *kernel emergency")
+      - result.diff.prepared is search("\+ *file test-1")
+      - result.diff.prepared is search("\+ *pfe critical")
+      - result.diff.prepared is search("\+ *file test-2")
+      - result.diff.prepared is search("\+ *kernel emergency")
 
 - name: Deactivate file logging configuration using aggregate
   junos_logging:
@@ -339,10 +339,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *inactive[:] file test-1")
-      - result.diff.prepared | search("! *inactive[:] pfe")
-      - result.diff.prepared | search("! *inactive[:] file test-2")
-      - result.diff.prepared | search("! *inactive[:] kernel")
+      - result.diff.prepared is search("! *inactive[:] file test-1")
+      - result.diff.prepared is search("! *inactive[:] pfe")
+      - result.diff.prepared is search("! *inactive[:] file test-2")
+      - result.diff.prepared is search("! *inactive[:] kernel")
 
 - name: activate file logging configuration using aggregate
   junos_logging:
@@ -356,10 +356,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *active[:] file test-1")
-      - result.diff.prepared | search("! *active[:] pfe")
-      - result.diff.prepared | search("! *active[:] file test-2")
-      - result.diff.prepared | search("! *active[:] kernel")
+      - result.diff.prepared is search("! *active[:] file test-1")
+      - result.diff.prepared is search("! *active[:] pfe")
+      - result.diff.prepared is search("! *active[:] file test-2")
+      - result.diff.prepared is search("! *active[:] kernel")
 
 - name: Delete file logging using aggregate
   junos_logging:
@@ -373,10 +373,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *file test-1")
-      - result.diff.prepared | search("\- *pfe critical")
-      - result.diff.prepared | search("\- *file test-2")
-      - result.diff.prepared | search("\- *kernel emergency")
+      - result.diff.prepared is search("\- *file test-1")
+      - result.diff.prepared is search("\- *pfe critical")
+      - result.diff.prepared is search("\- *file test-2")
+      - result.diff.prepared is search("\- *kernel emergency")
 
 - name: Delete file logging using aggregate (idempotent)
   junos_logging:

--- a/test/integration/targets/junos_static_route/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_static_route/tests/netconf/basic.yaml
@@ -161,16 +161,16 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *route 4.4.4.0/24")
-      - result.diff.prepared | search("\+ *next-hop 3.3.3.3")
-      - result.diff.prepared | search("\+ *qualified-next-hop 5.5.5.5")
-      - result.diff.prepared | search("\+ *preference 30")
-      - result.diff.prepared | search("\+ *preference 10")
-      - result.diff.prepared | search("\+ *route 5.5.5.0/24")
-      - result.diff.prepared | search("\+ *next-hop 6.6.6.6")
-      - result.diff.prepared | search("\+ *qualified-next-hop 7.7.7.7")
-      - result.diff.prepared | search("\+ *preference 30")
-      - result.diff.prepared | search("\+ *preference 11")
+      - result.diff.prepared is search("\+ *route 4.4.4.0/24")
+      - result.diff.prepared is search("\+ *next-hop 3.3.3.3")
+      - result.diff.prepared is search("\+ *qualified-next-hop 5.5.5.5")
+      - result.diff.prepared is search("\+ *preference 30")
+      - result.diff.prepared is search("\+ *preference 10")
+      - result.diff.prepared is search("\+ *route 5.5.5.0/24")
+      - result.diff.prepared is search("\+ *next-hop 6.6.6.6")
+      - result.diff.prepared is search("\+ *qualified-next-hop 7.7.7.7")
+      - result.diff.prepared is search("\+ *preference 30")
+      - result.diff.prepared is search("\+ *preference 11")
 
 - name: Deactivate static route configuration using aggegrate
   junos_static_route:
@@ -185,12 +185,12 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *inactive[:] route 4.4.4.0/24")
-      - result.diff.prepared | search("! *inactive[:] qualified-next-hop 5.5.5.5")
-      - result.diff.prepared | search("! *inactive[:] preference")
-      - result.diff.prepared | search("! *inactive[:] route 5.5.5.0/24")
-      - result.diff.prepared | search("! *inactive[:] qualified-next-hop 7.7.7.7")
-      - result.diff.prepared | search("! *inactive[:] preference")
+      - result.diff.prepared is search("! *inactive[:] route 4.4.4.0/24")
+      - result.diff.prepared is search("! *inactive[:] qualified-next-hop 5.5.5.5")
+      - result.diff.prepared is search("! *inactive[:] preference")
+      - result.diff.prepared is search("! *inactive[:] route 5.5.5.0/24")
+      - result.diff.prepared is search("! *inactive[:] qualified-next-hop 7.7.7.7")
+      - result.diff.prepared is search("! *inactive[:] preference")
 
 - name: Activate static route configuration using aggegrate
   junos_static_route:
@@ -205,12 +205,12 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *active[:] route 4.4.4.0/24")
-      - result.diff.prepared | search("! *active[:] qualified-next-hop 5.5.5.5")
-      - result.diff.prepared | search("! *active[:] preference")
-      - result.diff.prepared | search("! *active[:] route 5.5.5.0/24")
-      - result.diff.prepared | search("! *active[:] qualified-next-hop 7.7.7.7")
-      - result.diff.prepared | search("! *active[:] preference")
+      - result.diff.prepared is search("! *active[:] route 4.4.4.0/24")
+      - result.diff.prepared is search("! *active[:] qualified-next-hop 5.5.5.5")
+      - result.diff.prepared is search("! *active[:] preference")
+      - result.diff.prepared is search("! *active[:] route 5.5.5.0/24")
+      - result.diff.prepared is search("! *active[:] qualified-next-hop 7.7.7.7")
+      - result.diff.prepared is search("! *active[:] preference")
 
 - name: Delete static route configuration using aggegrate
   junos_static_route:
@@ -224,16 +224,16 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *route 4.4.4.0/24")
-      - result.diff.prepared | search("\- *next-hop 3.3.3.3")
-      - result.diff.prepared | search("\- *qualified-next-hop 5.5.5.5")
-      - result.diff.prepared | search("\- *preference 30")
-      - result.diff.prepared | search("\- *preference 10")
-      - result.diff.prepared | search("\- *route 5.5.5.0/24")
-      - result.diff.prepared | search("\- *next-hop 6.6.6.6")
-      - result.diff.prepared | search("\- *qualified-next-hop 7.7.7.7")
-      - result.diff.prepared | search("\- *preference 30")
-      - result.diff.prepared | search("\- *preference 11")
+      - result.diff.prepared is search("\- *route 4.4.4.0/24")
+      - result.diff.prepared is search("\- *next-hop 3.3.3.3")
+      - result.diff.prepared is search("\- *qualified-next-hop 5.5.5.5")
+      - result.diff.prepared is search("\- *preference 30")
+      - result.diff.prepared is search("\- *preference 10")
+      - result.diff.prepared is search("\- *route 5.5.5.0/24")
+      - result.diff.prepared is search("\- *next-hop 6.6.6.6")
+      - result.diff.prepared is search("\- *qualified-next-hop 7.7.7.7")
+      - result.diff.prepared is search("\- *preference 30")
+      - result.diff.prepared is search("\- *preference 11")
 
 - name: Delete static route configuration using aggegrate (idempotent)
   junos_static_route:

--- a/test/integration/targets/junos_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_user/tests/netconf/basic.yaml
@@ -189,5 +189,5 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *user test_user1")
-      - result.diff.prepared | search("\- *user test_user2")
+      - result.diff.prepared is search("\- *user test_user1")
+      - result.diff.prepared is search("\- *user test_user2")

--- a/test/integration/targets/junos_vlan/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_vlan/tests/netconf/basic.yaml
@@ -124,10 +124,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *test_vlan_1")
-      - result.diff.prepared | search("\+ *vlan-id 159")
-      - result.diff.prepared | search("\+ *vlan-id 161")
-      - result.diff.prepared | search("\+ *description \"test vlan\"")
+      - result.diff.prepared is search("\+ *test_vlan_1")
+      - result.diff.prepared is search("\+ *vlan-id 159")
+      - result.diff.prepared is search("\+ *vlan-id 161")
+      - result.diff.prepared is search("\+ *description \"test vlan\"")
 
 - name: Deactivate vlan configuration using aggregate
   junos_vlan:
@@ -141,8 +141,8 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *inactive[:] test_vlan_1")
-      - result.diff.prepared | search("! *inactive[:] test_vlan_2")
+      - result.diff.prepared is search("! *inactive[:] test_vlan_1")
+      - result.diff.prepared is search("! *inactive[:] test_vlan_2")
 
 - name: activate vlan configuration using aggregate
   junos_vlan:
@@ -156,8 +156,8 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *active[:] test_vlan_1")
-      - result.diff.prepared | search("! *active[:] test_vlan_2")
+      - result.diff.prepared is search("! *active[:] test_vlan_1")
+      - result.diff.prepared is search("! *active[:] test_vlan_2")
 
 - name: Delete vlan configuration using aggregate
   junos_vlan:
@@ -172,9 +172,9 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *test_vlan_1")
-      - result.diff.prepared | search("\- *vlan-id 159")
-      - result.diff.prepared | search("\- *test_vlan_2")
+      - result.diff.prepared is search("\- *test_vlan_1")
+      - result.diff.prepared is search("\- *vlan-id 159")
+      - result.diff.prepared is search("\- *test_vlan_2")
 
 - name: Delete vlan configuration using aggregate (idempotent)
   junos_vlan:

--- a/test/integration/targets/junos_vrf/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_vrf/tests/netconf/basic.yaml
@@ -23,13 +23,13 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *test-1")
-      - result.diff.prepared | search("\+ *description test-vrf-1")
-      - result.diff.prepared | search("\+ *instance-type vrf")
-      - result.diff.prepared | search("\+ *interface ge-0/0/5.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/6.0")
-      - result.diff.prepared | search("\+ *route-distinguisher 3.3.3.3:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65513:111")
+      - result.diff.prepared is search("\+ *test-1")
+      - result.diff.prepared is search("\+ *description test-vrf-1")
+      - result.diff.prepared is search("\+ *instance-type vrf")
+      - result.diff.prepared is search("\+ *interface ge-0/0/5.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/6.0")
+      - result.diff.prepared is search("\+ *route-distinguisher 3.3.3.3:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65513:111")
 
 - name: Configure vrf and its parameter (idempotent)
   junos_vrf:
@@ -65,11 +65,11 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/3.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65514:113")
+      - result.diff.prepared is search("\+ *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65514:113")
 
 - name: Deactivate vrf
   junos_vrf:
@@ -89,13 +89,13 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances]' in result.diff.prepared"
-      - result.diff.prepared | search("! *inactive[:] test-1")
+      - result.diff.prepared is search("! *inactive[:] test-1")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/2.0")
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/3.0")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/2.0")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/3.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("! *inactive[:] route-distinguisher")
-      - result.diff.prepared | search("! *inactive[:] vrf-target")
+      - result.diff.prepared is search("! *inactive[:] route-distinguisher")
+      - result.diff.prepared is search("! *inactive[:] vrf-target")
 
 - name: Activate vrf
   junos_vrf:
@@ -115,13 +115,13 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances]' in result.diff.prepared"
-      - result.diff.prepared | search("! *active[:] test-1")
+      - result.diff.prepared is search("! *active[:] test-1")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/2.0")
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/3.0")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/2.0")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/3.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("! *active[:] route-distinguisher")
-      - result.diff.prepared | search("! *active[:] vrf-target")
+      - result.diff.prepared is search("! *active[:] route-distinguisher")
+      - result.diff.prepared is search("! *active[:] vrf-target")
 
 - name: Delete vrf
   junos_vrf:
@@ -139,13 +139,13 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *test-1")
-      - result.diff.prepared | search("\- *description test-vrf-1")
-      - result.diff.prepared | search("\- *instance-type vrf")
-      - result.diff.prepared | search("\- *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\- *interface ge-0/0/3.0")
-      - result.diff.prepared | search("\- *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\- *vrf-target target:65514:113")
+      - result.diff.prepared is search("\- *test-1")
+      - result.diff.prepared is search("\- *description test-vrf-1")
+      - result.diff.prepared is search("\- *instance-type vrf")
+      - result.diff.prepared is search("\- *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\- *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\- *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\- *vrf-target target:65514:113")
 
 - name: Delete vrf (idempotent)
   junos_vrf:
@@ -196,20 +196,20 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *test-1")
-      - result.diff.prepared | search("\+ *description test-vrf-1")
-      - result.diff.prepared | search("\+ *instance-type vrf")
-      - result.diff.prepared | search("\+ *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/3.0")
-      - result.diff.prepared | search("\+ *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65514:113")
-      - result.diff.prepared | search("\+ *test-2")
-      - result.diff.prepared | search("\+ *description test-vrf-2")
-      - result.diff.prepared | search("\+ *instance-type vrf")
-      - result.diff.prepared | search("\+ *interface ge-0/0/4.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/5.0")
-      - result.diff.prepared | search("\+ *route-distinguisher 2.2.2.2:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65515:114")
+      - result.diff.prepared is search("\+ *test-1")
+      - result.diff.prepared is search("\+ *description test-vrf-1")
+      - result.diff.prepared is search("\+ *instance-type vrf")
+      - result.diff.prepared is search("\+ *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\+ *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65514:113")
+      - result.diff.prepared is search("\+ *test-2")
+      - result.diff.prepared is search("\+ *description test-vrf-2")
+      - result.diff.prepared is search("\+ *instance-type vrf")
+      - result.diff.prepared is search("\+ *interface ge-0/0/4.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/5.0")
+      - result.diff.prepared is search("\+ *route-distinguisher 2.2.2.2:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65515:114")
 
 - name: Deactivate vrf configuration using aggregate
   junos_vrf:
@@ -236,15 +236,15 @@
     that:
       - "result.changed == true"
       - "'edit routing-instances test-1' in result.diff.prepared"
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/2.0")
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/3.0")
-      - result.diff.prepared | search("! *inactive[:] route-distinguisher")
-      - result.diff.prepared | search("! *inactive[:] vrf-target")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/2.0")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/3.0")
+      - result.diff.prepared is search("! *inactive[:] route-distinguisher")
+      - result.diff.prepared is search("! *inactive[:] vrf-target")
       - "'edit routing-instances test-2' in result.diff.prepared"
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/4.0")
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/5.0")
-      - result.diff.prepared | search("! *inactive[:] route-distinguisher")
-      - result.diff.prepared | search("! *inactive[:] vrf-target")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/4.0")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5.0")
+      - result.diff.prepared is search("! *inactive[:] route-distinguisher")
+      - result.diff.prepared is search("! *inactive[:] vrf-target")
 
 - name: Deactivate vrf configuration using aggregate
   junos_vrf:
@@ -271,15 +271,15 @@
     that:
       - "result.changed == true"
       - "'edit routing-instances test-1' in result.diff.prepared"
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/2.0")
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/3.0")
-      - result.diff.prepared | search("! *active[:] route-distinguisher")
-      - result.diff.prepared | search("! *active[:] vrf-target")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/2.0")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/3.0")
+      - result.diff.prepared is search("! *active[:] route-distinguisher")
+      - result.diff.prepared is search("! *active[:] vrf-target")
       - "'edit routing-instances test-2' in result.diff.prepared"
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/4.0")
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/5.0")
-      - result.diff.prepared | search("! *active[:] route-distinguisher")
-      - result.diff.prepared | search("! *active[:] vrf-target")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/4.0")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/5.0")
+      - result.diff.prepared is search("! *active[:] route-distinguisher")
+      - result.diff.prepared is search("! *active[:] vrf-target")
 
 - name: Delete vrf configuration using aggregate
   junos_vrf:
@@ -293,20 +293,20 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *test-1")
-      - result.diff.prepared | search("\- *description test-vrf-1")
-      - result.diff.prepared | search("\- *instance-type vrf")
-      - result.diff.prepared | search("\- *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\- *interface ge-0/0/3.0")
-      - result.diff.prepared | search("\- *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\- *vrf-target target:65514:113")
-      - result.diff.prepared | search("\- *test-2")
-      - result.diff.prepared | search("\- *description test-vrf-2")
-      - result.diff.prepared | search("\- *instance-type vrf")
-      - result.diff.prepared | search("\- *interface ge-0/0/4.0")
-      - result.diff.prepared | search("\- *interface ge-0/0/5.0")
-      - result.diff.prepared | search("\- *route-distinguisher 2.2.2.2:10")
-      - result.diff.prepared | search("\- *vrf-target target:65515:114")
+      - result.diff.prepared is search("\- *test-1")
+      - result.diff.prepared is search("\- *description test-vrf-1")
+      - result.diff.prepared is search("\- *instance-type vrf")
+      - result.diff.prepared is search("\- *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\- *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\- *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\- *vrf-target target:65514:113")
+      - result.diff.prepared is search("\- *test-2")
+      - result.diff.prepared is search("\- *description test-vrf-2")
+      - result.diff.prepared is search("\- *instance-type vrf")
+      - result.diff.prepared is search("\- *interface ge-0/0/4.0")
+      - result.diff.prepared is search("\- *interface ge-0/0/5.0")
+      - result.diff.prepared is search("\- *route-distinguisher 2.2.2.2:10")
+      - result.diff.prepared is search("\- *vrf-target target:65515:114")
 
 - name: Delete vrf configuration using aggregate (idempotent)
   junos_vrf:

--- a/test/integration/targets/lambda_policy/tasks/main.yml
+++ b/test/integration/targets/lambda_policy/tasks/main.yml
@@ -71,7 +71,7 @@
     - name: assert lambda manages to respond as expected
       assert:
         that:
-           - 'result|failed'
+           - 'result is failed'
            - 'result.msg != "MODULE FAILURE"'
            - 'result.changed == False'
 
@@ -150,7 +150,7 @@
     - name: assert internal server error due to permissions
       assert:
         that:
-          - unauth_uri_result|failed
+          - unauth_uri_result is failed
           - 'unauth_uri_result.status == 500'
 
     - name: give api gateway execute permissions on lambda
@@ -215,4 +215,4 @@
       assert:
         that:
            - 'destroy_result.changed == True'
-           - 'not result|failed'
+           - 'result is not failed'

--- a/test/integration/targets/lookup_passwordstore/tasks/tests.yml
+++ b/test/integration/targets/lookup_passwordstore/tasks/tests.yml
@@ -5,7 +5,7 @@
 
 - name: "set gpg2 binary name"
   set_fact:
-    gpg2_bin: '{{ "gpg2" if gpg2_check|success else "gpg" }}'
+    gpg2_bin: '{{ "gpg2" if gpg2_check is successful else "gpg" }}'
 
 - name: "remove previous password files and directory"
   file: dest={{item}} state=absent

--- a/test/integration/targets/lookups/tasks/main.yml
+++ b/test/integration/targets/lookups/tasks/main.yml
@@ -245,7 +245,7 @@
 - assert:
     that:
       - "url_invalid_cert.failed"
-      - "'Error validating the server' in url_invalid_cert.msg or (url_invalid_cert.msg | search('hostname .* doesn.t match .*'))"
+      - "'Error validating the server' in url_invalid_cert.msg or ( url_invalid_cert.msg is search('hostname .* doesn.t match .*'))"
 
 - name: Test that retrieving a url with invalid cert with validate_certs=False works
   set_fact:

--- a/test/integration/targets/module_utils/module_utils_test.yml
+++ b/test/integration/targets/module_utils/module_utils_test.yml
@@ -47,5 +47,5 @@
   - name: Make sure we failed in AnsiBallZ
     assert:
       that:
-        - result|failed
+        - result is failed
         - result['msg'] == "Could not find imported module support code for test_failure.  Looked for either foo.py or zebra.py"

--- a/test/integration/targets/mysql_user/tasks/user_password_update_test.yml
+++ b/test/integration/targets/mysql_user/tasks/user_password_update_test.yml
@@ -34,7 +34,7 @@
 - name: store user2 grants with old password  (mysql 5.7.5 and older)
   command: mysql "-e SHOW GRANTS FOR '{{ user_name_2 }}'@'localhost';"
   register: user_password_old  
-  when: user_password_old_create|failed
+  when: user_password_old_create is failed
 
 # FIXME: not sure why this is failing, but it looks like it should expect changed=true
 #- name: update user2 state=present with same password (expect changed=false)
@@ -60,15 +60,15 @@
 - name: store user2 grants with new password 
   command: mysql "-e SHOW GRANTS FOR '{{ user_name_2 }}'@'localhost';"
   register: user_password_new 
-  when: user_password_new_create|failed
+  when: user_password_new_create is failed
 
 - name: assert output message password was update for user2 (mysql 5.7.6 and newer)
   assert: { that: "user_password_old_create.stdout != user_password_new_create.stdout" }
-  when: not user_password_new_create|failed
+  when: user_password_new_create is not failed
 
 - name: assert output message password was update for user2 (mysql 5.7.5 and older)
   assert: { that: "user_password_old.stdout != user_password_new.stdout" }
-  when: user_password_new_create|failed
+  when: user_password_new_create is failed
 
 - name: create database using user2 and old password
   mysql_db: name={{ db_name }} state=present login_user={{ user_name_2 }} login_password={{ user_password_2 }}

--- a/test/integration/targets/net_interface/tests/junos/basic.yaml
+++ b/test/integration/targets/net_interface/tests/junos/basic.yaml
@@ -77,7 +77,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable interface
   net_interface:
@@ -90,7 +90,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Delete interface
   net_interface:
@@ -137,15 +137,15 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *ge-0/0/1")
-      - result.diff.prepared | search("\+ *description test-interface-1")
-      - result.diff.prepared | search("\+ *speed 1g")
-      - result.diff.prepared | search("\+ *mtu 512")
-      - result.diff.prepared | search("\+ *link-mode full-duplex")
-      - result.diff.prepared | search("\+ *description test-interface-2")
-      - result.diff.prepared | search("\+ *speed 10m")
-      - result.diff.prepared | search("\+ * mtu 256")
-      - result.diff.prepared | search("\+ *link-mode full-duplex")
+      - result.diff.prepared is search("\+ *ge-0/0/1")
+      - result.diff.prepared is search("\+ *description test-interface-1")
+      - result.diff.prepared is search("\+ *speed 1g")
+      - result.diff.prepared is search("\+ *mtu 512")
+      - result.diff.prepared is search("\+ *link-mode full-duplex")
+      - result.diff.prepared is search("\+ *description test-interface-2")
+      - result.diff.prepared is search("\+ *speed 10m")
+      - result.diff.prepared is search("\+ * mtu 256")
+      - result.diff.prepared is search("\+ *link-mode full-duplex")
 
 - name: Set interface on aggregate (idempotent)
   net_interface:
@@ -172,7 +172,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable interface on aggregate
   net_interface:
@@ -186,7 +186,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Delete interface on aggregate
   net_interface:
@@ -200,15 +200,15 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *ge-0/0/1")
-      - result.diff.prepared | search("\- *description test-interface-1")
-      - result.diff.prepared | search("\- *speed 1g")
-      - result.diff.prepared | search("\- *mtu 512")
-      - result.diff.prepared | search("\- *link-mode full-duplex")
-      - result.diff.prepared | search("\- *description test-interface-2")
-      - result.diff.prepared | search("\- *speed 10m")
-      - result.diff.prepared | search("\- * mtu 256")
-      - result.diff.prepared | search("\- *link-mode full-duplex")
+      - result.diff.prepared is search("\- *ge-0/0/1")
+      - result.diff.prepared is search("\- *description test-interface-1")
+      - result.diff.prepared is search("\- *speed 1g")
+      - result.diff.prepared is search("\- *mtu 512")
+      - result.diff.prepared is search("\- *link-mode full-duplex")
+      - result.diff.prepared is search("\- *description test-interface-2")
+      - result.diff.prepared is search("\- *speed 10m")
+      - result.diff.prepared is search("\- * mtu 256")
+      - result.diff.prepared is search("\- *link-mode full-duplex")
 
 - name: Delete interface on aggregate (idempotent)
   net_interface:

--- a/test/integration/targets/net_interface/tests/junos/intent.yaml
+++ b/test/integration/targets/net_interface/tests/junos/intent.yaml
@@ -10,12 +10,12 @@
 - name: Define interface name for vSRX
   set_fact:
     name: pp0
-  when: result['ansible_facts']['ansible_net_model'] | search("vSRX*")
+  when: result['ansible_facts']['ansible_net_model']  is search("vSRX*")
 
 - name: Define interface name for vQFX
   set_fact:
     name: gr-0/0/0
-  when: result['ansible_facts']['ansible_net_model'] | search("vqfx*")
+  when: result['ansible_facts']['ansible_net_model']  is search("vqfx*")
 
 - name: Check intent arguments
   net_interface:
@@ -58,7 +58,7 @@
 - assert:
     that:
       - "result.failed == false"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Config + intent (fail)
   net_interface:

--- a/test/integration/targets/net_l3_interface/tests/junos/basic.yaml
+++ b/test/integration/targets/net_l3_interface/tests/junos/basic.yaml
@@ -29,8 +29,8 @@
       - "result.changed == true"
       - "'<name>1.1.1.1/32</name>' in config.xml"
       - "'<name>fd5d:12c9:2201:1::1/128</name>' in config.xml"
-      - result.diff.prepared | search("\+ *address 1.1.1.1/32")
-      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\+ *address 1.1.1.1/32")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:1::1/128")
 
 - name: Configure interface address (idempotent)
   net_l3_interface:
@@ -65,8 +65,8 @@
       - "result.changed == true"
       - "'<name>1.1.1.1/32</name>' not in config.xml"
       - "'<name>fd5d:12c9:2201:1::1/128</name>' not in config.xml"
-      - result.diff.prepared | search("\- *address 1.1.1.1/32")
-      - result.diff.prepared | search("\- *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\- *address 1.1.1.1/32")
+      - result.diff.prepared is search("\- *address fd5d:12c9:2201:1::1/128")
 
 - name: Delete interface address (idempotent)
   net_l3_interface:
@@ -115,13 +115,13 @@
     that:
       - 'result.changed == true'
       - "'edit interfaces ge-0/0/1 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address 1.1.1.1/32")
+      - result.diff.prepared is search("\+ *address 1.1.1.1/32")
       - "'edit interfaces ge-0/0/1 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:1::1/128")
       - "'edit interfaces ge-0/0/2 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address 2.2.2.2/32")
+      - result.diff.prepared is search("\+ *address 2.2.2.2/32")
       - "'edit interfaces ge-0/0/2 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *address fd5d:12c9:2201:2::2/128")
+      - result.diff.prepared is search("\+ *address fd5d:12c9:2201:2::2/128")
 
 - name: Configure l3 interface in aggregate (idempotent)
   net_l3_interface:
@@ -157,13 +157,13 @@
     that:
       - 'result.changed == true'
       - "'edit interfaces ge-0/0/1 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address 1.1.1.1/32")
+      - result.diff.prepared is search("\- *address 1.1.1.1/32")
       - "'edit interfaces ge-0/0/1 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address fd5d:12c9:2201:1::1/128")
+      - result.diff.prepared is search("\- *address fd5d:12c9:2201:1::1/128")
       - "'edit interfaces ge-0/0/2 unit 0 family inet' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address 2.2.2.2/32")
+      - result.diff.prepared is search("\- *address 2.2.2.2/32")
       - "'edit interfaces ge-0/0/2 unit 0 family inet6' in result.diff.prepared"
-      - result.diff.prepared | search("\- *address fd5d:12c9:2201:2::2/128")
+      - result.diff.prepared is search("\- *address fd5d:12c9:2201:2::2/128")
 
 - name: Delete l3 interface configuration (idempotent)
   net_l3_interface:

--- a/test/integration/targets/net_linkagg/tests/junos/basic.yaml
+++ b/test/integration/targets/net_linkagg/tests/junos/basic.yaml
@@ -128,7 +128,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable linkagg interface
   net_linkagg:
@@ -140,7 +140,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Deactivate linkagg
   net_linkagg:

--- a/test/integration/targets/net_lldp/tests/junos/basic.yaml
+++ b/test/integration/targets/net_lldp/tests/junos/basic.yaml
@@ -38,9 +38,9 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *advertisement-interval 10")
-      - result.diff.prepared | search("\+ *transmit-delay 2")
-      - result.diff.prepared | search("\+ *hold-multiplier 5")
+      - result.diff.prepared is search("\+ *advertisement-interval 10")
+      - result.diff.prepared is search("\+ *transmit-delay 2")
+      - result.diff.prepared is search("\+ *hold-multiplier 5")
 
 - name: configure lldp parameters and enable lldp(idempotent)
   net_lldp:
@@ -67,7 +67,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
       - "'advertisement-interval 10;' not in result.diff.prepared"
       - "'transmit-delay 2;' not in result.diff.prepared"
       - "'hold-multiplier 5;' not in result.diff.prepared"
@@ -84,7 +84,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
       - "'advertisement-interval 10;' not in result.diff.prepared"
       - "'transmit-delay 2;' not in result.diff.prepared"
       - "'hold-multiplier 5;' not in result.diff.prepared"
@@ -101,10 +101,10 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
-      - result.diff.prepared | search("\- *advertisement-interval 10")
-      - result.diff.prepared | search("\- *transmit-delay 2")
-      - result.diff.prepared | search("\- *hold-multiplier 5")
+      - result.diff.prepared is search("\+ *disable")
+      - result.diff.prepared is search("\- *advertisement-interval 10")
+      - result.diff.prepared is search("\- *transmit-delay 2")
+      - result.diff.prepared is search("\- *hold-multiplier 5")
 
 - name: Remove lldp (idempotent)
   net_lldp:

--- a/test/integration/targets/net_lldp_interface/tests/junos/basic.yaml
+++ b/test/integration/targets/net_lldp_interface/tests/junos/basic.yaml
@@ -17,7 +17,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *interface ge-0/0/5")
+      - result.diff.prepared is search("\+ *interface ge-0/0/5")
 
 - name: lldp interface configuration (idempotent)
   net_lldp_interface:
@@ -41,7 +41,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("! *inactive[:] interface ge-0/0/5")
+      - result.diff.prepared is search("! *inactive[:] interface ge-0/0/5")
 
 - name: Activate lldp interface configuration
   net_lldp_interface:
@@ -54,7 +54,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("! *active[:] interface ge-0/0/5")
+      - result.diff.prepared is search("! *active[:] interface ge-0/0/5")
 
 - name: Disable lldp on particular interface
   net_lldp_interface:
@@ -66,7 +66,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *disable")
+      - result.diff.prepared is search("\+ *disable")
 
 - name: Enable lldp on particular interface
   net_lldp_interface:
@@ -78,7 +78,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *disable")
+      - result.diff.prepared is search("\- *disable")
 
 - name: Delete lldp on particular interface
   net_lldp_interface:
@@ -90,7 +90,7 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *interface ge-0/0/5")
+      - result.diff.prepared is search("\- *interface ge-0/0/5")
 
 - name: Delete lldp on particular interface (idempotent)
   net_lldp_interface:

--- a/test/integration/targets/net_logging/tests/junos/basic.yaml
+++ b/test/integration/targets/net_logging/tests/junos/basic.yaml
@@ -316,10 +316,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *file test-1")
-      - result.diff.prepared | search("\+ *pfe critical")
-      - result.diff.prepared | search("\+ *file test-2")
-      - result.diff.prepared | search("\+ *kernel emergency")
+      - result.diff.prepared is search("\+ *file test-1")
+      - result.diff.prepared is search("\+ *pfe critical")
+      - result.diff.prepared is search("\+ *file test-2")
+      - result.diff.prepared is search("\+ *kernel emergency")
 
 - name: Deactivate file logging configuration using aggregate
   net_logging:
@@ -339,10 +339,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *inactive[:] file test-1")
-      - result.diff.prepared | search("! *inactive[:] pfe")
-      - result.diff.prepared | search("! *inactive[:] file test-2")
-      - result.diff.prepared | search("! *inactive[:] kernel")
+      - result.diff.prepared is search("! *inactive[:] file test-1")
+      - result.diff.prepared is search("! *inactive[:] pfe")
+      - result.diff.prepared is search("! *inactive[:] file test-2")
+      - result.diff.prepared is search("! *inactive[:] kernel")
 
 - name: activate file logging configuration using aggregate
   net_logging:
@@ -356,10 +356,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("! *active[:] file test-1")
-      - result.diff.prepared | search("! *active[:] pfe")
-      - result.diff.prepared | search("! *active[:] file test-2")
-      - result.diff.prepared | search("! *active[:] kernel")
+      - result.diff.prepared is search("! *active[:] file test-1")
+      - result.diff.prepared is search("! *active[:] pfe")
+      - result.diff.prepared is search("! *active[:] file test-2")
+      - result.diff.prepared is search("! *active[:] kernel")
 
 - name: Delete file logging using aggregate
   net_logging:
@@ -373,10 +373,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *file test-1")
-      - result.diff.prepared | search("\- *pfe critical")
-      - result.diff.prepared | search("\- *file test-2")
-      - result.diff.prepared | search("\- *kernel emergency")
+      - result.diff.prepared is search("\- *file test-1")
+      - result.diff.prepared is search("\- *pfe critical")
+      - result.diff.prepared is search("\- *file test-2")
+      - result.diff.prepared is search("\- *kernel emergency")
 
 - name: Delete file logging using aggregate (idempotent)
   net_logging:

--- a/test/integration/targets/net_static_route/tests/junos/basic.yaml
+++ b/test/integration/targets/net_static_route/tests/junos/basic.yaml
@@ -88,16 +88,16 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *route 4.4.4.0/24")
-      - result.diff.prepared | search("\+ *next-hop 3.3.3.3")
-      - result.diff.prepared | search("\+ *qualified-next-hop 5.5.5.5")
-      - result.diff.prepared | search("\+ *preference 30")
-      - result.diff.prepared | search("\+ *preference 10")
-      - result.diff.prepared | search("\+ *route 5.5.5.0/24")
-      - result.diff.prepared | search("\+ *next-hop 6.6.6.6")
-      - result.diff.prepared | search("\+ *qualified-next-hop 7.7.7.7")
-      - result.diff.prepared | search("\+ *preference 12")
-      - result.diff.prepared | search("\+ *preference 11")
+      - result.diff.prepared is search("\+ *route 4.4.4.0/24")
+      - result.diff.prepared is search("\+ *next-hop 3.3.3.3")
+      - result.diff.prepared is search("\+ *qualified-next-hop 5.5.5.5")
+      - result.diff.prepared is search("\+ *preference 30")
+      - result.diff.prepared is search("\+ *preference 10")
+      - result.diff.prepared is search("\+ *route 5.5.5.0/24")
+      - result.diff.prepared is search("\+ *next-hop 6.6.6.6")
+      - result.diff.prepared is search("\+ *qualified-next-hop 7.7.7.7")
+      - result.diff.prepared is search("\+ *preference 12")
+      - result.diff.prepared is search("\+ *preference 11")
 
 - name: Delete static route configuration using aggegrate
   net_static_route:
@@ -110,16 +110,16 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *route 4.4.4.0/24")
-      - result.diff.prepared | search("\- *next-hop 3.3.3.3")
-      - result.diff.prepared | search("\- *qualified-next-hop 5.5.5.5")
-      - result.diff.prepared | search("\- *preference 30")
-      - result.diff.prepared | search("\- *preference 10")
-      - result.diff.prepared | search("\- *route 5.5.5.0/24")
-      - result.diff.prepared | search("\- *next-hop 6.6.6.6")
-      - result.diff.prepared | search("\- *qualified-next-hop 7.7.7.7")
-      - result.diff.prepared | search("\- *preference 12")
-      - result.diff.prepared | search("\- *preference 11")
+      - result.diff.prepared is search("\- *route 4.4.4.0/24")
+      - result.diff.prepared is search("\- *next-hop 3.3.3.3")
+      - result.diff.prepared is search("\- *qualified-next-hop 5.5.5.5")
+      - result.diff.prepared is search("\- *preference 30")
+      - result.diff.prepared is search("\- *preference 10")
+      - result.diff.prepared is search("\- *route 5.5.5.0/24")
+      - result.diff.prepared is search("\- *next-hop 6.6.6.6")
+      - result.diff.prepared is search("\- *qualified-next-hop 7.7.7.7")
+      - result.diff.prepared is search("\- *preference 12")
+      - result.diff.prepared is search("\- *preference 11")
 
 - name: Delete static route configuration using aggegrate (idempotent)
   net_static_route:

--- a/test/integration/targets/net_system/tests/vyos/set_name_servers.yaml
+++ b/test/integration/targets/net_system/tests/vyos/set_name_servers.yaml
@@ -21,9 +21,9 @@
     that:
       - result.changed == true
       - result.commands|length == 3
-      - result.commands[0] | search("set system name-server '1.1.1.1'")
-      - result.commands[1] | search("set system name-server '2.2.2.2'")
-      - result.commands[2] | search("set system name-server '3.3.3.3'")
+      - result.commands[0]  is search("set system name-server '1.1.1.1'")
+      - result.commands[1]  is search("set system name-server '2.2.2.2'")
+      - result.commands[2]  is search("set system name-server '3.3.3.3'")
 
 - name: verify name_servers
   net_system:
@@ -48,7 +48,7 @@
     that:
       - result.changed == true
       - result.commands|length == 1
-      - result.commands[0] | search("delete system name-server '3.3.3.3'")
+      - result.commands[0]  is search("delete system name-server '3.3.3.3'")
 
 - name: teardown
   vyos_config:

--- a/test/integration/targets/net_vlan/tests/junos/basic.yaml
+++ b/test/integration/targets/net_vlan/tests/junos/basic.yaml
@@ -80,10 +80,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\+ *test_vlan_1")
-      - result.diff.prepared | search("\+ *vlan-id 159")
-      - result.diff.prepared | search("\+ *test_vlan_2")
-      - result.diff.prepared | search("\+ *vlan-id 160")
+      - result.diff.prepared is search("\+ *test_vlan_1")
+      - result.diff.prepared is search("\+ *vlan-id 159")
+      - result.diff.prepared is search("\+ *test_vlan_2")
+      - result.diff.prepared is search("\+ *vlan-id 160")
 
 - name: Delete vlan configuration using aggregate
   net_vlan:
@@ -99,10 +99,10 @@
 - assert:
     that:
       - 'result.changed == true'
-      - result.diff.prepared | search("\- *test_vlan_1")
-      - result.diff.prepared | search("\- *vlan-id 159")
-      - result.diff.prepared | search("\- *test_vlan_2")
-      - result.diff.prepared | search("\- *vlan-id 160")
+      - result.diff.prepared is search("\- *test_vlan_1")
+      - result.diff.prepared is search("\- *vlan-id 159")
+      - result.diff.prepared is search("\- *test_vlan_2")
+      - result.diff.prepared is search("\- *vlan-id 160")
 
 - name: Delete vlan configuration using aggregate (idempotent)
   net_vlan:

--- a/test/integration/targets/net_vrf/tests/junos/basic.yaml
+++ b/test/integration/targets/net_vrf/tests/junos/basic.yaml
@@ -23,13 +23,13 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *test-1")
-      - result.diff.prepared | search("\+ *description test-vrf-1")
-      - result.diff.prepared | search("\+ *instance-type vrf")
-      - result.diff.prepared | search("\+ *interface ge-0/0/5.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/6.0")
-      - result.diff.prepared | search("\+ *route-distinguisher 3.3.3.3:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65513:111")
+      - result.diff.prepared is search("\+ *test-1")
+      - result.diff.prepared is search("\+ *description test-vrf-1")
+      - result.diff.prepared is search("\+ *instance-type vrf")
+      - result.diff.prepared is search("\+ *interface ge-0/0/5.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/6.0")
+      - result.diff.prepared is search("\+ *route-distinguisher 3.3.3.3:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65513:111")
 
 - name: Configure vrf and its parameter (idempotent)
   net_vrf:
@@ -65,11 +65,11 @@
     that:
       - "result.changed == true"
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/3.0")
       - "'[edit routing-instances test-1]' in result.diff.prepared"
-      - result.diff.prepared | search("\+ *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65514:113")
+      - result.diff.prepared is search("\+ *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65514:113")
 
 
 - name: Delete vrf
@@ -88,13 +88,13 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *test-1")
-      - result.diff.prepared | search("\- *description test-vrf-1")
-      - result.diff.prepared | search("\- *instance-type vrf")
-      - result.diff.prepared | search("\- *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\- *interface ge-0/0/3.0")
-      - result.diff.prepared | search("\- *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\- *vrf-target target:65514:113")
+      - result.diff.prepared is search("\- *test-1")
+      - result.diff.prepared is search("\- *description test-vrf-1")
+      - result.diff.prepared is search("\- *instance-type vrf")
+      - result.diff.prepared is search("\- *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\- *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\- *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\- *vrf-target target:65514:113")
 
 - name: Delete vrf (idempotent)
   net_vrf:
@@ -145,20 +145,20 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\+ *test-1")
-      - result.diff.prepared | search("\+ *description test-vrf-1")
-      - result.diff.prepared | search("\+ *instance-type vrf")
-      - result.diff.prepared | search("\+ *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/3.0")
-      - result.diff.prepared | search("\+ *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65514:113")
-      - result.diff.prepared | search("\+ *test-2")
-      - result.diff.prepared | search("\+ *description test-vrf-2")
-      - result.diff.prepared | search("\+ *instance-type vrf")
-      - result.diff.prepared | search("\+ *interface ge-0/0/4.0")
-      - result.diff.prepared | search("\+ *interface ge-0/0/5.0")
-      - result.diff.prepared | search("\+ *route-distinguisher 2.2.2.2:10")
-      - result.diff.prepared | search("\+ *vrf-target target:65515:114")
+      - result.diff.prepared is search("\+ *test-1")
+      - result.diff.prepared is search("\+ *description test-vrf-1")
+      - result.diff.prepared is search("\+ *instance-type vrf")
+      - result.diff.prepared is search("\+ *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\+ *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65514:113")
+      - result.diff.prepared is search("\+ *test-2")
+      - result.diff.prepared is search("\+ *description test-vrf-2")
+      - result.diff.prepared is search("\+ *instance-type vrf")
+      - result.diff.prepared is search("\+ *interface ge-0/0/4.0")
+      - result.diff.prepared is search("\+ *interface ge-0/0/5.0")
+      - result.diff.prepared is search("\+ *route-distinguisher 2.2.2.2:10")
+      - result.diff.prepared is search("\+ *vrf-target target:65515:114")
 
 - name: Delete vrf configuration using aggregate
   net_vrf:
@@ -172,20 +172,20 @@
 - assert:
     that:
       - "result.changed == true"
-      - result.diff.prepared | search("\- *test-1")
-      - result.diff.prepared | search("\- *description test-vrf-1")
-      - result.diff.prepared | search("\- *instance-type vrf")
-      - result.diff.prepared | search("\- *interface ge-0/0/2.0")
-      - result.diff.prepared | search("\- *interface ge-0/0/3.0")
-      - result.diff.prepared | search("\- *route-distinguisher 1.1.1.1:10")
-      - result.diff.prepared | search("\- *vrf-target target:65514:113")
-      - result.diff.prepared | search("\- *test-2")
-      - result.diff.prepared | search("\- *description test-vrf-2")
-      - result.diff.prepared | search("\- *instance-type vrf")
-      - result.diff.prepared | search("\- *interface ge-0/0/4.0")
-      - result.diff.prepared | search("\- *interface ge-0/0/5.0")
-      - result.diff.prepared | search("\- *route-distinguisher 2.2.2.2:10")
-      - result.diff.prepared | search("\- *vrf-target target:65515:114")
+      - result.diff.prepared is search("\- *test-1")
+      - result.diff.prepared is search("\- *description test-vrf-1")
+      - result.diff.prepared is search("\- *instance-type vrf")
+      - result.diff.prepared is search("\- *interface ge-0/0/2.0")
+      - result.diff.prepared is search("\- *interface ge-0/0/3.0")
+      - result.diff.prepared is search("\- *route-distinguisher 1.1.1.1:10")
+      - result.diff.prepared is search("\- *vrf-target target:65514:113")
+      - result.diff.prepared is search("\- *test-2")
+      - result.diff.prepared is search("\- *description test-vrf-2")
+      - result.diff.prepared is search("\- *instance-type vrf")
+      - result.diff.prepared is search("\- *interface ge-0/0/4.0")
+      - result.diff.prepared is search("\- *interface ge-0/0/5.0")
+      - result.diff.prepared is search("\- *route-distinguisher 2.2.2.2:10")
+      - result.diff.prepared is search("\- *vrf-target target:65515:114")
 
 - name: Delete vrf configuration using aggregate (idempotent)
   net_vrf:

--- a/test/integration/targets/nxos_acl/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_acl/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - debug: msg="START TRANSPORT:{{ connection.transport }} nxos_acl sanity test"
 
 - set_fact: time_range="ans-range"
-  when: not (platform | match("N5K"))
+  when: not ( platform is match("N5K"))
 
 - name: "Setup: Cleanup possibly existing acl."
   nxos_acl: &remove

--- a/test/integration/targets/nxos_banner/tests/common/basic-exec.yaml
+++ b/test/integration/targets/nxos_banner/tests/common/basic-exec.yaml
@@ -33,7 +33,7 @@
           - "result.changed == false"
           - "result.commands | length == 0"
 
-  when: platform | match("N7K")
+  when: platform is match("N7K")
 
 - debug: msg="END nxos_banner exec test"
 

--- a/test/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_bgp_af/tests/common/sanity.yaml
@@ -2,7 +2,7 @@
 - debug: msg="START TRANSPORT:{{ connection.transport }} nxos_bgp_af sanity test"
 
 - set_fact: advertise_l2vpn_evpn="true"
-  when: platform | search('N9K')
+  when: platform is search('N9K')
 
 - name: "Enable feature BGP"
   nxos_feature:
@@ -31,7 +31,7 @@
       lines:
         - nv overlay evpn
       provider: "{{ connection }}"
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - name: "Configure BGP_AF defaults"
     nxos_bgp_af: &configure_default
@@ -144,6 +144,6 @@
       lines:
         - no nv overlay evpn
       provider: "{{ connection }}"
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - debug: msg="END TRANSPORT:{{ connection.transport }} nxos_bgp_af sanity test"

--- a/test/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_evpn_global/tests/common/sanity.yaml
@@ -55,7 +55,7 @@
 
   - assert: *false
 
-  when: not (platform | search('N3K'))
+  when: not ( platform is search('N3K'))
 
   rescue:
   - debug: msg="TRANSPORT:{{ connection.transport }} nxos_evpn_global sanity test - FALURE ENCOUNTERED"

--- a/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
@@ -3,5 +3,5 @@
   assert:
     that:
       - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port
-      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port | string | search("9443")
+      - result.stdout[0]['TABLE_listen_on_port']['ROW_listen_on_port'].l_port|string is search("9443")
       - result.stdout[0]['operation_status'].o_status == 'nxapi enabled'

--- a/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
+++ b/test/integration/targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
@@ -3,5 +3,5 @@
   assert:
     that:
       - result.stdout[0].http_port is not defined
-      - result.stdout[0].https_port | string | search("9443")
+      - result.stdout[0].https_port|string is search("9443")
       - result.stdout[0].sandbox_status == 'Enabled'

--- a/test/integration/targets/nxos_nxapi/tests/cli/badtransport.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/badtransport.yaml
@@ -12,6 +12,6 @@
 
 - assert:
      that:
-        - result.failed and result.msg | search('transport')
+        - result.failed and result.msg is search('transport')
 
 - debug: msg="END cli/badtransport.yaml"

--- a/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml
@@ -2,7 +2,7 @@
 - debug: msg="START cli/configure.yaml"
 
 - set_fact: nxapi_sandbox_option="yes"
-  when: platform | search('N7K')
+  when: platform is search('N7K')
 
 - name: Setup - put NXAPI in stopped state
   nxos_nxapi:
@@ -25,10 +25,10 @@
   register: result
 
 - include: targets/nxos_nxapi/tasks/platform/n7k/assert_changes.yaml
-  when: platform | match('N7K')
+  when: platform is match('N7K')
 
 - include: targets/nxos_nxapi/tasks/platform/default/assert_changes.yaml
-  when: not (platform | search('N7K'))
+  when: not ( platform is search('N7K'))
 
 - name: Configure NXAPI again
   nxos_nxapi:

--- a/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/disable.yaml
@@ -25,7 +25,7 @@
 - name: Assert NXAPI is disabled
   assert:
     that:
-      result.stdout[0] | search('disabled')
+      result.stdout[0]  is search('disabled')
 
 - name: Disable NXAPI again
   nxos_nxapi:

--- a/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
+++ b/test/integration/targets/nxos_nxapi/tests/cli/enable.yaml
@@ -22,7 +22,7 @@
 
 - name: Assert NXAPI is enabled
   assert:
-      that: result.stdout[0] | search('enabled')
+      that: result.stdout[0]  is search('enabled')
 
 - name: Enable NXAPI again
   nxos_nxapi:

--- a/test/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_overlay_global/tests/common/sanity.yaml
@@ -3,8 +3,8 @@
 
 - set_fact: overlay_global_supported="false"
 - set_fact: overlay_global_supported="true"
-  when: platform | search("N35NG|N7K|^N9K$") or
-        (platform | match("N9k-F") and imagetag | version_compare('F3', 'ne'))
+  when: platform is search("N35NG|N7K|^N9K$") or
+        ( platform is match("N9k-F") and imagetag is version('F3', 'ne'))
 
 - debug: msg="Platform {{ platform }} running Image version {{ image_version }} supports nxos_overlay_global"
   when: overlay_global_supported
@@ -18,7 +18,7 @@
 
   - name: "Apply N7K specific setup config"
     include: targets/nxos_overlay_global/tasks/platform/n7k/setup.yaml
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: "Configure Additional N7K requiste features"
     nxos_config:
@@ -27,7 +27,7 @@
         - feature fabric forwarding
       match: none
       provider: "{{ connection }}"
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: "Remove possibly existing mac"
     nxos_overlay_global:
@@ -92,7 +92,7 @@
   always:
   - name: "Apply N7K specific cleanup config"
     include: targets/nxos_overlay_global/tasks/platform/n7k/cleanup.yaml
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: "Disable nv overlay evpn"
     nxos_evpn_global: &disable_evpn

--- a/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
+++ b/test/integration/targets/nxos_pim_rp_address/tests/common/configure.yaml
@@ -2,11 +2,11 @@
 - debug: msg="START {{ connection.transport }} nxos_pim_rp_address sanity"
 
 - set_fact: bidir="false" 
-  when: platform | search('N3K')
+  when: platform is search('N3K')
 
 - set_fact: bidircfg='bidir'
 - set_fact: bidircfg=''
-  when: platform | search('N3K')
+  when: platform is search('N3K')
 
 - block:
   - name: "Disable feature PIM"

--- a/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_snapshot/tests/common/sanity.yaml
@@ -3,7 +3,7 @@
 
 - set_fact: snapshot_run="true"
 - set_fact: snapshot_run="false"
-  when: titanium and (connection.transport | match('nxapi'))
+  when: titanium and ( connection.transport is match('nxapi'))
 
 - block:
   - name: create snapshot

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_trap.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v2_trap.yaml
@@ -6,7 +6,7 @@
 
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
-  when: not (platform | match("N5K"))
+  when: not (platform is match("N5K"))
 
 - name: Setup - Remove snmp_host if configured
   nxos_snmp_host: &remove

--- a/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
+++ b/test/integration/targets/nxos_snmp_host/tests/common/sanity_snmp_v3_inform.yaml
@@ -7,7 +7,7 @@
 
 # Select interface for test
 - set_fact: intname="{{ nxos_int1 }}"
-  when: not (platform | match("N5K"))
+  when: not (platform is match("N5K"))
 
 - name: Setup - Remove snmp_host if configured
   nxos_snmp_host: &remove
@@ -51,7 +51,7 @@
       that:
         - "result.changed == false"
 
-  when: not (platform | match('N35'))
+  when: not (platform is match('N35'))
 
   always:
   - name: Cleanup

--- a/test/integration/targets/nxos_udld/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld/tests/common/sanity.yaml
@@ -3,7 +3,7 @@
 
 - set_fact: udld_run="true"
 - set_fact: udld_run="false"
-  when: ((platform | search('N9K-F')) and (imagetag and (imagetag | version_compare('F3', 'lt'))))
+  when: (( platform is search('N9K-F')) and (imagetag and ( imagetag is version('F3', 'lt'))))
 - set_fact: udld_run="false"
   when: titanium
 

--- a/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_udld_interface/tests/common/sanity.yaml
@@ -3,7 +3,7 @@
 
 - set_fact: udld_run="true"
 - set_fact: udld_run="false"
-  when: ((platform | search('N9K-F')) and (imagetag and (imagetag | version_compare('F3', 'lt'))))
+  when: ((platform is search('N9K-F')) and (imagetag and (imagetag is version('F3', 'lt'))))
 - set_fact: udld_run="false"
   when: titanium
 

--- a/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vlan/tests/common/sanity.yaml
@@ -8,7 +8,7 @@
         - feature vn-segment-vlan-based
       provider: "{{ connection }}"
       match: none
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - name: Ensure a range of VLANs are present on the switch
     nxos_vlan: &conf_vlan
@@ -37,18 +37,18 @@
       mapped_vni: 5555
       provider: "{{ connection }}"
     register: result
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - assert: *true
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - name: "web Idempotence"
     nxos_vlan: *web1
     register: result
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - assert: *false
-    when: platform | search('N9K')
+    when: platform is search('N9K')
 
   - name: Ensure VLAN 50 exists with the name WEB and is in the shutdown state
     nxos_vlan: &web2
@@ -58,18 +58,18 @@
       name: WEB
       provider: "{{ connection }}"
     register: result
-    when: platform | search('N3K|N7K')
+    when: platform is search('N3K|N7K')
 
   - assert: *true
-    when: platform | search('N3K|N7K')
+    when: platform is search('N3K|N7K')
 
   - name: "web Idempotence"
     nxos_vlan: *web2
     register: result
-    when: platform | search('N3K|N7K')
+    when: platform is search('N3K|N7K')
 
   - assert: *false
-    when: platform | search('N3K|N7K')
+    when: platform is search('N3K|N7K')
 
   - name: Ensure VLAN is NOT on the device
     nxos_vlan: &no_vlan
@@ -100,6 +100,6 @@
         state: disabled
         provider: "{{ connection }}"
       ignore_errors: yes
-      when: platform | search('N9K')
+      when: platform is search('N9K')
 
 - debug: msg="END TRANSPORT:{{ connection.transport }} nxos_vlan sanity test"

--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
 - block:
   - name: "Apply N7K specific setup config"
     include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: "Enable feature nv overlay"
     nxos_config: 
@@ -37,7 +37,7 @@
         that:
           - "result.changed == false"
 
-    when: (platform | search('N9K'))
+    when: (platform is search('N9K'))
 
   - block:
     - name: configure vxlan_vtep
@@ -62,7 +62,7 @@
         that:
           - "result.changed == false"
 
-    when: (platform | search('N7K'))
+    when: (platform is search('N7K'))
 
   - name: remove vxlan_vtep
     nxos_vxlan_vtep: &remove
@@ -93,7 +93,7 @@
   always:
   - name: "Apply N7K specific cleanup config"
     include: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: "Disable feature nv overlay"
     nxos_feature: 

--- a/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep/tests/common/sanity.yaml
@@ -88,7 +88,7 @@
       that:
         - "result.changed == false"
 
-  when: (platform | search("N7K|N9K"))
+  when: (platform is search("N7K|N9K"))
 
   always:
   - name: "Apply N7K specific cleanup config"

--- a/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
+++ b/test/integration/targets/nxos_vxlan_vtep_vni/tests/common/sanity.yaml
@@ -4,7 +4,7 @@
 - block:
   - name: "Apply N7K specific setup config"
     include: targets/nxos_vxlan_vtep/tasks/platform/n7k/setup.yaml
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: "Enable feature nv overlay"
     nxos_config: 
@@ -110,14 +110,14 @@
 
     - assert: *false
 
-    when: (platform | search('N9K'))
+    when: (platform is search('N9K'))
 
-  when: (platform | search("N7K|N9K"))
+  when: (platform is search("N7K|N9K"))
 
   always:
   - name: "Apply N7K specific cleanup config"
     include: targets/nxos_vxlan_vtep/tasks/platform/n7k/cleanup.yaml
-    when: platform | match('N7K')
+    when: platform is match('N7K')
 
   - name: remove vxlan_vtep
     nxos_vxlan_vtep:

--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -90,4 +90,4 @@
 
     - import_tasks: ../tests/validate.yml
 
-  when: pyopenssl_version.stdout|version_compare('0.15', '>=')
+  when: pyopenssl_version.stdout is version('0.15', '>=')

--- a/test/integration/targets/openssl_csr/tasks/main.yml
+++ b/test/integration/targets/openssl_csr/tasks/main.yml
@@ -44,4 +44,4 @@
 
     - import_tasks: ../tests/validate.yml
 
-  when: pyopenssl_version.stdout|version_compare('0.15', '>=')
+  when: pyopenssl_version.stdout is version('0.15', '>=')

--- a/test/integration/targets/openssl_privatekey/tests/validate.yml
+++ b/test/integration/targets/openssl_privatekey/tests/validate.yml
@@ -44,27 +44,27 @@
   register: privatekey5
   # Current version of OS/X that runs in the CI (10.11) does not have an up to date version of the OpenSSL library
   # leading to this test to fail when run in the CI. However, this test has been run for 10.12 and has returned succesfully.
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate privatekey5 (assert - Passphrase protected key + idempotence)
   assert:
     that:
       - privatekey5.stdout == '4096'
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate privatekey5 idempotence (assert - Passphrase protected key + idempotence)
   assert:
     that:
-      - not privatekey5_idempotence|changed
+      - privatekey5_idempotence is not changed
 
 
 - name: Validate privatekey6 (test - Passphrase protected key with non ascii character)
   shell: "openssl rsa -noout -text -in {{ output_dir }}/privatekey6.pem -passin pass:ànsïblé | grep Private | sed 's/Private-Key: (\\(.*\\) bit)/\\1/'"
   register: privatekey6
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate privatekey6 (assert - Passphrase protected key with non ascii character)
   assert:
     that:
       - privatekey6.stdout == '4096'
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')

--- a/test/integration/targets/openssl_publickey/tasks/main.yml
+++ b/test/integration/targets/openssl_publickey/tasks/main.yml
@@ -16,7 +16,7 @@
       # cryptography.hazmat.primitives import serialization.Encoding.OpenSSH and
       # cryptography.hazmat.primitives import serialization.PublicFormat.OpenSSH constants
       # appeared in version 1.4 of cryptography
-      when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+      when: cryptography_version.stdout is version('1.4.0', '>=')
 
     - name: Generate publickey2 - standard
       openssl_publickey:
@@ -60,4 +60,4 @@
 
     - import_tasks: ../tests/validate.yml
 
-  when: pyopenssl_version.stdout|version_compare('16.0.0', '>=')
+  when: pyopenssl_version.stdout is version('16.0.0', '>=')

--- a/test/integration/targets/openssl_publickey/tests/validate.yml
+++ b/test/integration/targets/openssl_publickey/tests/validate.yml
@@ -14,19 +14,19 @@
 - name: Validate public key - OpenSSH format (test - privatekey's publickey)
   shell: 'ssh-keygen -y -f {{ output_dir }}/privatekey.pem'
   register: privatekey_publickey
-  when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+  when: cryptography_version.stdout is version('1.4.0', '>=')
 
 - name: Validate public key - OpenSSH format  (test - publickey)
   slurp:
     src: '{{ output_dir }}/publickey-ssh.pub'
   register: publickey
-  when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+  when: cryptography_version.stdout is version('1.4.0', '>=')
 
 - name: Validate public key - OpenSSH format (assert)
   assert:
     that:
       - privatekey_publickey.stdout == '{{ publickey.content|b64decode }}'
-  when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+  when: cryptography_version.stdout is version('1.4.0', '>=')
 
 - name: Validate publickey2 (test - Ensure key has been removed)
   stat:
@@ -42,36 +42,36 @@
 - name: Validate publickey3 (test - privatekey modulus)
   shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey3.pem -passin pass:ansible | openssl md5'
   register: privatekey3_modulus
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey3 (test - publickey modulus)
   shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey3.pub  | openssl md5'
   register: publickey3_modulus
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey3 (assert)
   assert:
     that:
       - publickey3_modulus.stdout == privatekey3_modulus.stdout
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey3 idempotence (assert)
   assert:
     that:
-      - not publickey3_idempotence|changed
+      - publickey3_idempotence is not changed
 
 - name: Validate publickey4 (test - privatekey modulus)
   shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
   register: privatekey4_modulus
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey4 (test - publickey modulus)
   shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey4.pub  | openssl md5'
   register: publickey4_modulus
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')
 
 - name: Validate publickey4 (assert)
   assert:
     that:
       - publickey4_modulus.stdout == privatekey4_modulus.stdout
-  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+  when: openssl_version.stdout is version('0.9.8zh', '>=')

--- a/test/integration/targets/parsing/roles/test_bad_parsing/tasks/main.yml
+++ b/test/integration/targets/parsing/roles/test_bad_parsing/tasks/main.yml
@@ -57,4 +57,4 @@
 
 - assert:
     that:
-     - filter_fail|failed
+     - filter_fail is failed

--- a/test/integration/targets/ping/tasks/main.yml
+++ b/test/integration/targets/ping/tasks/main.yml
@@ -23,8 +23,8 @@
 - name: assert the ping worked
   assert:
     that:
-    - not result|failed
-    - not result|changed
+    - result is not failed
+    - result is not changed
     - result.ping == 'pong'
 
 - name: ping with data
@@ -35,8 +35,8 @@
 - name: assert the ping worked with data
   assert:
     that:
-    - not result|failed
-    - not result|changed
+    - result is not failed
+    - result is not changed
     - result.ping == 'testing'
 
 - name: ping with data=crash
@@ -48,6 +48,6 @@
 - name: assert the ping failed with data=boom
   assert:
     that:
-    - result|failed
-    - not result|changed
+    - result is failed
+    - result is not changed
     - "'Exception: boom' in result.module_stderr"

--- a/test/integration/targets/postgresql/tasks/main.yml
+++ b/test/integration/targets/postgresql/tasks/main.yml
@@ -208,7 +208,7 @@
     msg: "{{ postgres_version_resp.stdout }}"
 
 - set_fact:
-    bypassrls_supported: "{{ postgres_version_resp.stdout | version_compare('9.5.0', '>=') }}"
+    bypassrls_supported: "{{ postgres_version_resp.stdout is version('9.5.0', '>=') }}"
 
 # test 'no_password_change' and 'role_attr_flags' parameters
 - include: test_no_password_change.yml

--- a/test/integration/targets/postgresql/tasks/pg_authid_not_readable.yml
+++ b/test/integration/targets/postgresql/tasks/pg_authid_not_readable.yml
@@ -13,9 +13,9 @@
 - name: "Check that task succeeded without any change"
   assert:
     that:
-      - 'not redo_as_admin|failed'
-      - 'not redo_as_admin|changed'
-      - 'redo_as_admin|success'
+      - 'redo_as_admin is not failed'
+      - 'redo_as_admin is not changed'
+      - 'redo_as_admin is successful'
 
 - name: "Check that normal user isn't allowed to access pg_authid"
   shell: 'psql -c "select * from pg_authid;" {{ db_name }} {{ db_user1 }}'
@@ -26,7 +26,7 @@
 
 - assert:
     that:
-      - 'pg_authid|failed'
+      - 'pg_authid is failed'
       - '"permission denied for relation pg_authid" in pg_authid.stderr'
 
 - name: "Normal user isn't allowed to access pg_authid relation: password comparison will fail, password will be updated"
@@ -45,6 +45,6 @@
 - name: "Check that task succeeded and that result is changed"
   assert:
     that:
-      - 'not redo_as_normal_user|failed'
-      - 'redo_as_normal_user|changed'
-      - 'redo_as_normal_user|success'
+      - 'redo_as_normal_user is not failed'
+      - 'redo_as_normal_user is changed'
+      - 'redo_as_normal_user is successful'

--- a/test/integration/targets/postgresql/tasks/test_no_password_change.yml
+++ b/test/integration/targets/postgresql/tasks/test_no_password_change.yml
@@ -126,7 +126,7 @@
 
       - assert:
           that:
-            - "(postgres_version_resp.stdout | version_compare('9.5.0', '<')) or 'bypassrls:f' in result.stdout_lines[-2]"
+            - "( postgres_version_resp.stdout is version('9.5.0', '<')) or 'bypassrls:f' in result.stdout_lines[-2]"
     when: bypassrls_supported
 
   - name: Check that using same attribute a second time does nothing

--- a/test/integration/targets/postgresql/tasks/test_password.yml
+++ b/test/integration/targets/postgresql/tasks/test_password.yml
@@ -22,7 +22,7 @@
   - name: 'Check that PGOPTIONS environment variable is effective (2/2)'
     assert:
       that:
-          - "{{ result|failed }}"
+          - "{{ result is failed }}"
 
   - name: 'Create a user (password encrypted: {{ encrypted }})'
     <<: *task_parameters
@@ -37,7 +37,7 @@
     - name: Check that ansible reports it was created
       assert:
         that:
-          - "{{ result|changed }}"
+          - "{{ result is changed }}"
 
   - name: Check that it was created
     <<: *task_parameters
@@ -61,7 +61,7 @@
     - name: Check that ansible reports no change
       assert:
         that:
-          - "{{ not result|changed }}"
+          - "{{ result is not changed }}"
 
   - name: 'Define an expiration time'
     <<: *task_parameters

--- a/test/integration/targets/prepare_nxos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_nxos_tests/tasks/main.yml
@@ -59,44 +59,44 @@
 
 # Check if platform is fretta
 - set_fact: fretta={% for row in nxos_inventory_output.stdout_lines[0]['TABLE_inv']['ROW_inv'] if 'FM-R' in row['productid'] %}"true"{% endfor %}
-  when: platform | match("N9K")
+  when: platform is match("N9K")
 
 # Set platform to N9K-F for fretta
 - set_fact: platform="N9K-F"
-  when: (platform | match("N9K")) and (fretta | search("true"))
+  when: ( platform is match("N9K")) and ( fretta is search("true"))
 
 # Check if platform is titanium
 - set_fact: titanium="false"
 - set_fact: titanium={% for row in nxos_inventory_output.stdout_lines[0]['TABLE_inv']['ROW_inv'] if 'NX-OSv' in row['desc']%}"true"{% endfor %}
-  when: platform | match("N7K")
+  when: platform is match("N7K")
 
 # Set platform to N35 for N3k-35xx
 - set_fact: platform="N35"
-  when: (chassis_type | search("C35"))
+  when: ( chassis_type is search("C35"))
 
 # Set platform to N35NG for N3k-35xx running image version
 # 7.0(3)I7 or later. NG(Next Gen)
 - set_fact: platform="N35NG"
-  when: (chassis_type | search("C35")) and image_version | search("7.0\(3\)I7")
+  when: ( chassis_type is search("C35")) and image_version is search("7.0\(3\)I7")
 
 # Create matrix of simple keys based on platform
 # and image version for use within test playbooks.
 - set_fact: imagetag=""
 - set_fact: imagetag="I2"
-  when: image_version | search("7.0\(3\)I2")
+  when: image_version is search("7.0\(3\)I2")
 - set_fact: imagetag="I3"
-  when: image_version | search("7.0\(3\)I3")
+  when: image_version is search("7.0\(3\)I3")
 - set_fact: imagetag="I4"
-  when: image_version | search("7.0\(3\)I4")
+  when: image_version is search("7.0\(3\)I4")
 - set_fact: imagetag="I5"
-  when: image_version | search("7.0\(3\)I5")
+  when: image_version is search("7.0\(3\)I5")
 - set_fact: imagetag="I6"
-  when: image_version | search("7.0\(3\)I6")
+  when: image_version is search("7.0\(3\)I6")
 - set_fact: imagetag="I7"
-  when: image_version | search("7.0\(3\)I7")
+  when: image_version is search("7.0\(3\)I7")
 - set_fact: imagetag="F1"
-  when: image_version | search("7.0\(3\)F1")
+  when: image_version is search("7.0\(3\)F1")
 - set_fact: imagetag="F2"
-  when: image_version | search("7.0\(3\)F2")
+  when: image_version is search("7.0\(3\)F2")
 - set_fact: imagetag="F3"
-  when: image_version | search("7.0\(3\)F3")
+  when: image_version is search("7.0\(3\)F3")

--- a/test/integration/targets/script/tasks/main.yml
+++ b/test/integration/targets/script/tasks/main.yml
@@ -100,9 +100,9 @@
 - name: Assert that script report a change, file was created, second run was skipped
   assert:
     that:
-      - _create_test1 | changed
+      - _create_test1 is changed
       - _create_stat1.stat.exists
-      - _create_test2 | skipped
+      - _create_test2 is skipped
 
 
 # removes
@@ -131,9 +131,9 @@
 - name: Assert that script report a change, file was removed, second run was skipped
   assert:
     that:
-      - _remove_test1 | changed
+      - _remove_test1 is changed
       - not _remove_stat1.stat.exists
-      - _remove_test2 | skipped
+      - _remove_test2 is skipped
 
 
 # async
@@ -151,7 +151,7 @@
 - name: assert task with async param failed
   assert:
     that:
-      - script_result3 | failed
+      - script_result3 is failed
       - script_result3.msg == "async is not supported for this task."
 
 
@@ -177,7 +177,7 @@
 - name: Assert that a change was reported but the script did not make changes
   assert:
     that:
-      - _check_mode_test | changed
+      - _check_mode_test is changed
       - not _afile_stat.stat.exists
 
 - name: Run script to create a file
@@ -197,7 +197,7 @@
 - name: Assert that task was skipped and mesage was returned
   assert:
     that:
-      - _check_mode_test2 | skipped
+      - _check_mode_test2 is skipped
       - '_check_mode_test2.msg == "skipped, since {{ output_dir_test | expanduser }}/afile2.txt exists"'
 
 - name: Remove afile2.txt
@@ -219,5 +219,5 @@
 - name: Assert that task was skipped and message was returned
   assert:
     that:
-      - _check_mode_test3 | skipped
+      - _check_mode_test3 is skipped
       - '_check_mode_test3.msg == "skipped, since {{ output_dir_test | expanduser }}/afile2.txt does not exist"'

--- a/test/integration/targets/seboolean/tasks/seboolean.yml
+++ b/test/integration/targets/seboolean/tasks/seboolean.yml
@@ -31,8 +31,8 @@
 - name: check output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - output.name == 'httpd_can_network_connect'
       - getsebool_output.stdout.startswith('httpd_can_network_connect      (on   ,  off)')
 ##########################################################################################
@@ -48,8 +48,8 @@
 - name: check output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - output.name == 'httpd_can_network_connect'
       - getsebool_output.stdout.startswith('httpd_can_network_connect      (off  ,  off)')
 ##########################################################################################
@@ -67,8 +67,8 @@
 - name: check output
   assert:
     that:
-      - output|changed
-      - not output|failed
+      - output is changed
+      - output is not failed
       - output.name == 'httpd_can_network_connect'
       - getsebool_output.stdout.startswith('httpd_can_network_connect      (on   ,   on)')
 ##########################################################################################

--- a/test/integration/targets/sefcontext/tasks/sefcontext.yml
+++ b/test/integration/targets/sefcontext/tasks/sefcontext.yml
@@ -31,7 +31,7 @@
 
 - assert:
     that:
-    - first|changed
+    - first is changed
     - first.setype == 'httpd_sys_content_t'
 
 - name: Set SELinux file context of foo/bar (again)
@@ -44,7 +44,7 @@
 
 - assert:
     that:
-    - not second|changed
+    - second is not changed
     - second.setype == 'httpd_sys_content_t'
 
 - name: Change SELinux file context of foo/bar
@@ -57,7 +57,7 @@
 
 - assert:
     that:
-    - third|changed
+    - third is changed
     - third.setype == 'unlabeled_t'
 
 - name: Change SELinux file context of foo/bar (again)
@@ -70,7 +70,7 @@
 
 - assert:
     that:
-    - not fourth|changed
+    - fourth is not changed
     - fourth.setype == 'unlabeled_t'
 
 - name: Delete SELinux file context of foo/bar
@@ -83,7 +83,7 @@
 
 - assert:
     that:
-    - fifth|changed
+    - fifth is changed
     - fifth.setype == 'httpd_sys_content_t'
 
 - name: Delete SELinux file context of foo/bar (again)
@@ -96,5 +96,5 @@
 
 - assert:
     that:
-    - not sixth|changed
+    - sixth is not changed
     - sixth.setype == 'unlabeled_t'

--- a/test/integration/targets/selinux/tasks/selinux.yml
+++ b/test/integration/targets/selinux/tasks/selinux.yml
@@ -54,7 +54,7 @@
 - name: TEST 1 | Assert that status was changed, reboot_required is True, a warning was displayed, and SELinux is configured properly
   assert:
     that:
-      - _disable_test1 | changed
+      - _disable_test1 is changed
       - _disable_test1.reboot_required
       - (_disable_test1.warnings | length ) >= 1
       - ansible_selinux.config_mode == 'disabled'
@@ -77,7 +77,7 @@
 - name: TEST 1 | Assert that no change is reported, a warnking was dispalyed, and reboot_required is True
   assert:
     that:
-      - not _disable_test2 | changed
+      - _disable_test2 is not changed
       - (_disable_test1.warnings | length ) >= 1
       - _disable_test2.reboot_required
 
@@ -93,8 +93,8 @@
   assert:
     that:
       - selinux_config_original | length == selinux_config_after | length
-      - selinux_config_after[selinux_config_after.index('SELINUX=disabled')] | search("^SELINUX=\w+$")
-      - selinux_config_after[selinux_config_after.index('SELINUXTYPE=targeted')] | search("^SELINUXTYPE=\w+$")
+      - selinux_config_after[selinux_config_after.index('SELINUX=disabled')]  is search("^SELINUX=\w+$")
+      - selinux_config_after[selinux_config_after.index('SELINUXTYPE=targeted')]  is search("^SELINUXTYPE=\w+$")
 
 - name: TEST 1 | Reset SELinux configuration for next test
   selinux:
@@ -126,7 +126,7 @@
 - name: TEST 2 | Assert that status was changed, reboot_required is False, no warnings were displayed, and SELinux is configured properly
   assert:
     that:
-      - _state_test1 | changed
+      - _state_test1 is changed
       - not _state_test1.reboot_required
       - _state_test1.warnings is not defined
       - ansible_selinux.config_mode == 'enforcing'
@@ -145,7 +145,7 @@
 - name: TEST 2 | Assert that no change was reported, no warnings were dispalyed, and reboot_required is False
   assert:
     that:
-      - not _state_test2 | changed
+      - _state_test2 is not changed
       - _state_test2.warnings is not defined
       - not _state_test2.reboot_required
 
@@ -161,8 +161,8 @@
   assert:
     that:
       - selinux_config_original | length == selinux_config_after | length
-      - selinux_config_after[selinux_config_after.index('SELINUX=enforcing')] | search("^SELINUX=\w+$")
-      - selinux_config_after[selinux_config_after.index('SELINUXTYPE=mls')] | search("^SELINUXTYPE=\w+$")
+      - selinux_config_after[selinux_config_after.index('SELINUX=enforcing')]  is search("^SELINUX=\w+$")
+      - selinux_config_after[selinux_config_after.index('SELINUXTYPE=mls')]  is search("^SELINUXTYPE=\w+$")
 
 - name: TEST 2 | Reset SELinux configuration for next test
   selinux:

--- a/test/integration/targets/sensu_client/tasks/main.yml
+++ b/test/integration/targets/sensu_client/tasks/main.yml
@@ -30,8 +30,8 @@
 - name: Assert that client data was set successfully and properly
   assert:
     that:
-      - "client | success"
-      - "client | changed"
+      - "client is successful"
+      - "client is changed"
       - "client_stat.stat.exists == true"
       - "client['config']['name'] == 'client'"
       - "'default' in client['config']['subscriptions']"
@@ -65,10 +65,10 @@
 - name: Assert that client deletion was successful
   assert:
     that:
-      - "client_delete | success"
-      - "client_delete | changed"
-      - "client_delete_twice | success"
-      - "not client_delete_twice | changed"
+      - "client_delete is successful"
+      - "client_delete is changed"
+      - "client_delete_twice is successful"
+      - "client_delete_twice is not changed"
       - "client_stat.stat.exists == false"
 
 - name: Configuring a client without subscriptions should fail
@@ -80,7 +80,7 @@
 - name: Assert failure to create client
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: subscriptions' in failure['msg']"
 
 - name: Configure a new client from scratch with custom parameters
@@ -137,10 +137,10 @@
 - name: Assert that client data was set successfully and properly
   assert:
     that:
-      - "client | success"
-      - "client | changed"
-      - "client_twice | success"
-      - "not client_twice | changed"
+      - "client is successful"
+      - "client is changed"
+      - "client_twice is successful"
+      - "client_twice is not changed"
       - "client_stat.stat.exists == true"
       - "client['config']['name'] == 'custom'"
       - "client['config']['address'] == 'host.fqdn'"

--- a/test/integration/targets/sensu_handler/tasks/main.yml
+++ b/test/integration/targets/sensu_handler/tasks/main.yml
@@ -36,10 +36,10 @@
 - name: Assert that handler data was set successfully and properly
   assert:
     that:
-      - "handler | success"
-      - "handler | changed"
-      - "handler_twice | success"
-      - "not handler_twice | changed"
+      - "handler is successful"
+      - "handler is changed"
+      - "handler_twice is successful"
+      - "handler_twice is not changed"
       - "handler_stat.stat.exists == true"
       - "handler['name'] == 'handler'"
       - "handler['file'] == '/etc/sensu/conf.d/handlers/handler.json'"
@@ -81,10 +81,10 @@
 - name: Assert that handler deletion was successful
   assert:
     that:
-      - "handler_delete | success"
-      - "handler_delete | changed"
-      - "handler_delete_twice | success"
-      - "not handler_delete_twice | changed"
+      - "handler_delete is successful"
+      - "handler_delete is changed"
+      - "handler_delete_twice is successful"
+      - "handler_delete_twice is not changed"
       - "handler_stat.stat.exists == false"
 
 - name: Configuring a handler without a name should fail
@@ -97,7 +97,7 @@
 - name: Assert that configuring a handler without a name fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'required arguments: name' in failure['msg']"
 
 - name: Configuring a handler without a type should fail
@@ -110,7 +110,7 @@
 - name: Assert that configuring a handler without a type fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: type' in failure['msg']"
 
 - include: pipe.yml

--- a/test/integration/targets/sensu_handler/tasks/pipe.yml
+++ b/test/integration/targets/sensu_handler/tasks/pipe.yml
@@ -9,7 +9,7 @@
 - name: Assert that configuring a handler with missing pipe parameters fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: command' in failure['msg']"
 
 - name: Configure a handler with pipe parameters

--- a/test/integration/targets/sensu_handler/tasks/set.yml
+++ b/test/integration/targets/sensu_handler/tasks/set.yml
@@ -8,7 +8,7 @@
 - name: Assert that configuring a handler with missing set parameters fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: handlers' in failure['msg']"
 
 - name: Configure a set handler
@@ -27,8 +27,8 @@
 - name: Validate set handler return data
   assert:
     that:
-      - "handler | success"
-      - "handler | changed"
+      - "handler is successful"
+      - "handler is changed"
       - "handler_stat.stat.exists == true"
       - "handler['name'] == 'set'"
       - "handler['file'] == '/etc/sensu/conf.d/handlers/set.json'"

--- a/test/integration/targets/sensu_handler/tasks/tcp.yml
+++ b/test/integration/targets/sensu_handler/tasks/tcp.yml
@@ -8,7 +8,7 @@
 - name: Assert that configuring a handler with missing tcp parameters fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: socket' in failure['msg']"
 
 - name: Configure a tcp handler
@@ -28,8 +28,8 @@
 - name: Validate tcp handler return data
   assert:
     that:
-      - "handler | success"
-      - "handler | changed"
+      - "handler is successful"
+      - "handler is changed"
       - "handler_stat.stat.exists == true"
       - "handler['name'] == 'tcp'"
       - "handler['file'] == '/etc/sensu/conf.d/handlers/tcp.json'"

--- a/test/integration/targets/sensu_handler/tasks/transport.yml
+++ b/test/integration/targets/sensu_handler/tasks/transport.yml
@@ -8,7 +8,7 @@
 - name: Assert that configuring a handler with missing transport parameters fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: pipe' in failure['msg']"
 
 - name: Configure a transport handler
@@ -28,8 +28,8 @@
 - name: Validate transport handler return data
   assert:
     that:
-      - "handler | success"
-      - "handler | changed"
+      - "handler is successful"
+      - "handler is changed"
       - "handler_stat.stat.exists == true"
       - "handler['name'] == 'transport'"
       - "handler['file'] == '/etc/sensu/conf.d/handlers/transport.json'"

--- a/test/integration/targets/sensu_handler/tasks/udp.yml
+++ b/test/integration/targets/sensu_handler/tasks/udp.yml
@@ -8,7 +8,7 @@
 - name: Assert that configuring a handler with missing udp parameters fails
   assert:
     that:
-      - failure | failed
+      - failure is failed
       - "'the following are missing: socket' in failure['msg']"
 
 - name: Configure a udp handler
@@ -28,8 +28,8 @@
 - name: Validate udp handler return data
   assert:
     that:
-      - "handler | success"
-      - "handler | changed"
+      - "handler is successful"
+      - "handler is changed"
       - "handler_stat.stat.exists == true"
       - "handler['name'] == 'udp'"
       - "handler['file'] == '/etc/sensu/conf.d/handlers/udp.json'"

--- a/test/integration/targets/service/tasks/main.yml
+++ b/test/integration/targets/service/tasks/main.yml
@@ -12,13 +12,13 @@
 # determine init system is in use
 - name: detect sysv init system
   set_fact: service_type=sysv
-  when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('6', '>=') and ansible_distribution_version|version_compare('7', '<'))
+  when: ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ( ansible_distribution_version is version('6', '>=') and ansible_distribution_version is version('7', '<'))
 - name: detect systemd init system
   set_fact: service_type=systemd
-  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and (ansible_distribution_version|version_compare('7', '>=') and ansible_distribution_version|version_compare('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version|version_compare('8', '>=')) or ansible_os_family == 'Suse'
+  when: (ansible_distribution in ['RedHat', 'CentOS', 'ScientificLinux'] and ( ansible_distribution_version is version('7', '>=') and ansible_distribution_version is version('8', '<'))) or ansible_distribution == 'Fedora' or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15.04', '>=')) or (ansible_distribution == 'Debian' and ansible_distribution_version is version('8', '>=')) or ansible_os_family == 'Suse'
 - name: detect upstart init system
   set_fact: service_type=upstart
-  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version|version_compare('15.04', '<')
+  when: ansible_distribution == 'Ubuntu' and ansible_distribution_version is version('15.04', '<')
 
 # setup test service script
 - include: 'sysv_setup.yml'
@@ -133,7 +133,7 @@
 - name: assert that the broken test failed
   assert:
     that:
-    - "broken_enable_result|failed"
+    - "broken_enable_result is failed"
 
 - name: remove the test daemon script
   file: path=/usr/sbin/ansible_test_service state=absent

--- a/test/integration/targets/setup_mysql_db/tasks/main.yml
+++ b/test/integration/targets/setup_mysql_db/tasks/main.yml
@@ -20,12 +20,12 @@
 - name: python 2
   set_fact:
     python_suffix: ""
-  when: ansible_python_version | version_compare('3', '<')
+  when: ansible_python_version is version('3', '<')
 
 - name: python 3
   set_fact:
     python_suffix: "-py3"
-  when: ansible_python_version | version_compare('3', '>=')
+  when: ansible_python_version is version('3', '>=')
 
 - include_vars: '{{ item }}'
   with_first_found:

--- a/test/integration/targets/setup_openssl/tasks/main.yml
+++ b/test/integration/targets/setup_openssl/tasks/main.yml
@@ -6,13 +6,13 @@
   become: True
   package:
     name: '{{ pyopenssl_package_name_python3 }}'
-  when: not ansible_os_family == 'Darwin' and  ansible_python_version|version_compare('3.0', '>=')
+  when: not ansible_os_family == 'Darwin' and  ansible_python_version is version('3.0', '>=')
 
 - name: Install pyOpenSSL
   become: True
   package:
     name: '{{ pyopenssl_package_name }}'
-  when: not ansible_os_family == 'Darwin' and ansible_python_version|version_compare('3.0', '<')
+  when: not ansible_os_family == 'Darwin' and ansible_python_version is version('3.0', '<')
 
 - name: Install pyOpenSSL
   become: True

--- a/test/integration/targets/setup_postgresql_db/tasks/main.yml
+++ b/test/integration/targets/setup_postgresql_db/tasks/main.yml
@@ -1,12 +1,12 @@
 - name: python 2
   set_fact:
     python_suffix: ""
-  when: ansible_python_version | version_compare('3', '<')
+  when: ansible_python_version is version('3', '<')
 
 - name: python 3
   set_fact:
     python_suffix: "-py3"
-  when: ansible_python_version | version_compare('3', '>=')
+  when: ansible_python_version is version('3', '>=')
 
 - include_vars: '{{ item }}'
   with_first_found:
@@ -108,7 +108,7 @@
 
   - name: Generate locale (RedHat)
     command: 'localedef -f ISO-8859-1 -i {{ item.locale }} {{ item.locale }}'
-    when: item|failed
+    when: item is failed
     with_items: '{{ locale_present.results }}'
   when: ansible_os_family == 'RedHat' and ansible_distribution != 'Fedora'
 

--- a/test/integration/targets/slurp/tasks/main.yml
+++ b/test/integration/targets/slurp/tasks/main.yml
@@ -31,8 +31,8 @@
     that:
       - 'slurp_existing.content'
       - 'slurp_existing.encoding == "base64"'
-      - 'not slurp_existing|changed'
-      - 'not slurp_existing|failed'
+      - 'slurp_existing is not changed'
+      - 'slurp_existing is not failed'
       - '"{{ slurp_existing.content | b64decode }}" == "We are at the café"'
 
 - name: Create a binary file to test with
@@ -51,8 +51,8 @@
     that:
       - "slurp_binary.content"
       - "slurp_binary.encoding == 'base64'"
-      - "not slurp_binary|changed"
-      - "not slurp_binary|failed"
+      - "slurp_binary is not changed"
+      - "slurp_binary is not failed"
 
 - name: test slurping a non-existent file
   slurp:
@@ -63,9 +63,9 @@
 - name: check slurp missing result
   assert:
     that:
-      - "slurp_missing|failed"
+      - "slurp_missing is failed"
       - "slurp_missing.msg"
-      - "not slurp_missing|changed"
+      - "slurp_missing is not changed"
 
 - name: Create a directory to test with
   file:
@@ -81,9 +81,9 @@
 - name: check slurp directory result
   assert:
     that:
-      - "slurp_dir|failed"
+      - "slurp_dir is failed"
       - "slurp_dir.msg"
-      - "not slurp_dir|changed"
+      - "slurp_dir is not changed"
 
 - name: test slurp with missing argument
   action: slurp
@@ -93,6 +93,6 @@
 - name: check slurp with missing argument result
   assert:
     that:
-      - "slurp_no_args|failed"
+      - "slurp_no_args is failed"
       - "slurp_no_args.msg"
-      - "not slurp_no_args|changed"
+      - "slurp_no_args is not changed"

--- a/test/integration/targets/sysctl/tasks/main.yml
+++ b/test/integration/targets/sysctl/tasks/main.yml
@@ -71,8 +71,8 @@
 - name: validate results
   assert:
       that:
-        - sysctl_test0 | changed
-        - not sysctl_test1 | changed
+        - sysctl_test0 is changed
+        - sysctl_test1 is not changed
         - 'sysctl_content0.stdout_lines[sysctl_content0.stdout_lines.index("vm.swappiness=5")] == "vm.swappiness=5"'
 
 - name: Remove kernel.panic
@@ -98,7 +98,7 @@
 - name: Validate results for key removal
   assert:
     that:
-      - sysctl_test2 | changed
+      - sysctl_test2 is changed
       - "'kernel.panic' not in sysctl_content2.stdout_lines"
 
 - name: Test remove kernel.panic again
@@ -113,7 +113,7 @@
 - name: Assert that no change was made
   assert:
     that:
-      - not sysctl_test2_change_test | changed
+      - sysctl_test2_change_test is not changed
 
 ##
 ## sysctl - sysctl_set
@@ -141,7 +141,7 @@
 - name: validate results for test 3
   assert:
     that:
-      - sysctl_test3 | changed
+      - sysctl_test3 is changed
       - 'sysctl_check3.stdout_lines == ["net.ipv4.ip_forward = 1"]'
 
 - name: Try sysctl with no name
@@ -155,7 +155,7 @@
 - name: validate nameless results
   assert:
     that:
-      - sysctl_no_name | failed
+      - sysctl_no_name is failed
       - "sysctl_no_name.msg == 'name cannot be None'"
 
 - name: Try sysctl with no value
@@ -169,5 +169,5 @@
 - name: validate nameless results
   assert:
     that:
-      - sysctl_no_value | failed
+      - sysctl_no_value is failed
       - "sysctl_no_value.msg == 'value cannot be None'"

--- a/test/integration/targets/template/tasks/main.yml
+++ b/test/integration/targets/template/tasks/main.yml
@@ -261,7 +261,7 @@
   assert: 
     that: 
       - "not templated.stat.exists"
-      - "template_result|changed"
+      - "template_result is changed"
 
 - name: fill in a basic template
   template: src=short.j2 dest={{output_dir}}/short.templated
@@ -274,7 +274,7 @@
 - name: verify that the file was marked as not changes in check mode
   assert: 
     that: 
-      - "not template_result|changed"
+      - "template_result is not changed"
       - "'templated_var_loaded' in lookup('file', '{{output_dir | expanduser}}/short.templated')"
 
 - name: change var for the template
@@ -290,7 +290,7 @@
   assert: 
     that: 
       - "'templated_var_loaded' in lookup('file', '{{output_dir | expanduser }}/short.templated')"
-      - "template_result|changed"
+      - "template_result is changed"
 
 # Create a template using a child template, to ensure that variables
 # are passed properly from the parent to subtemplate context (issue #20063)
@@ -304,7 +304,7 @@
 - name: verify that the parent and subtemplate creation worked
   assert:
     that:
-    - "template_result|changed"
+    - "template_result is changed"
 
 #
 # template module can overwrite a file that's been hard linked
@@ -368,7 +368,7 @@
 - name: verify that the file was marked as changed (Unix)
   assert:
     that:
-      - 'template_result|changed'
+      - 'template_result is changed'
 
 - name: fill in a basic template again (Unix)
   template:
@@ -379,7 +379,7 @@
 - name: verify that the template was not changed (Unix)
   assert:
     that:
-      - 'not template_result2|changed'
+      - 'template_result2 is not changed'
 
 # VERIFY UNIX CONTENTS
 - name: copy known good into place (Unix)
@@ -414,7 +414,7 @@
 - name: verify that the file was marked as changed (DOS)
   assert:
     that:
-      - 'template_result|changed'
+      - 'template_result is changed'
 
 - name: fill in a basic template again (DOS)
   template:
@@ -426,7 +426,7 @@
 - name: verify that the template was not changed (DOS)
   assert:
     that:
-      - 'not template_result2|changed'
+      - 'template_result2 is not changed'
 
 # VERIFY DOS CONTENTS
 - name: copy known good into place (DOS)

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -103,7 +103,7 @@
   assert:
     that:
       - "result.failed == true"
-      - "'Failed to validate the SSL certificate' in result.msg or (result.msg | match('hostname .* doesn.t match .*'))"
+      - "'Failed to validate the SSL certificate' in result.msg or ( result.msg is match('hostname .* doesn.t match .*'))"
       - "stat_result.stat.exists == false"
 
 - name: Clean up any cruft from the results directory
@@ -159,7 +159,7 @@
 - name: Ensure bad SSL site reidrect fails
   assert:
     that:
-      - result|failed
+      - result is failed
       - 'badssl_host in result.msg'
 
 - name: test basic auth
@@ -216,7 +216,7 @@
 - name: Assert SNI verification succeeds on new python
   assert:
     that:
-      - result|success
+      - result is successful
       - 'sni_host in result.content'
   when: ansible_python.has_sslcontext
 
@@ -230,8 +230,8 @@
 - name: Assert SNI verification fails on old python
   assert:
     that:
-      - result|failed
-  when: not result|skipped
+      - result is failed
+  when: result is not skipped
 
 - name: install OS packages that are needed for SNI on old python
   package:
@@ -256,7 +256,7 @@
 - name: Assert SNI verification succeeds on old python
   assert:
     that:
-      - result|success
+      - result is successful
       - 'sni_host in result.content'
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
@@ -300,7 +300,7 @@
 - name: Assert SNI verification succeeds on old python with pip urllib3 contrib
   assert:
     that:
-      - result|success
+      - result is successful
       - 'sni_host in result.content'
   when: not ansible_python.has_sslcontext and not is_ubuntu_precise|bool
 
@@ -371,5 +371,5 @@
     return_content: true
     validate_certs: yes
   register: result
-  failed_when: not result|failed
+  failed_when: result is not failed
   when: has_httptester

--- a/test/integration/targets/user/tasks/main.yml
+++ b/test/integration/targets/user/tasks/main.yml
@@ -74,7 +74,7 @@
       that:
           - "user_test1.results|map(attribute='changed')|unique|list == [False]"
           - "user_test1.results|map(attribute='state')|unique|list == ['present']"
-  when: "jinja2_version.stdout|version_compare('2.6', '>=')"
+  when: "jinja2_version.stdout is version('2.6', '>=')"
 
 - name: validate changed results for testcase 1 (jinja >= 2.6)
   assert:
@@ -89,7 +89,7 @@
           - "user_test1.results[2]['state'] == 'present'"
           - "user_test1.results[3]['state'] == 'present'"
           - "user_test1.results[4]['state'] == 'present'"
-  when: "jinja2_version.stdout|version_compare('2.6', '<')"
+  when: "jinja2_version.stdout is version('2.6', '<')"
 
 ##
 ## user remove

--- a/test/integration/targets/wait_for/tasks/main.yml
+++ b/test/integration/targets/wait_for/tasks/main.yml
@@ -28,7 +28,7 @@
 - name: verify test for absent path
   assert:
     that:
-      - waitfor|success
+      - waitfor is successful
       - "waitfor.path == '/tmp/wait_for_file'"
       - waitfor.elapsed >= 5
       - waitfor.elapsed <= 15
@@ -46,7 +46,7 @@
 - name: verify test for absent path
   assert:
     that:
-      - waitfor|success
+      - waitfor is successful
       - "waitfor.path == '/tmp/wait_for_file'"
       - waitfor.elapsed >= 5
       - waitfor.elapsed <= 15
@@ -65,7 +65,7 @@
 - name: verify test wait for port timeout
   assert:
     that:
-      - waitfor|success
+      - waitfor is successful
       - "waitfor.search_regex == 'completed'"
       - waitfor.elapsed >= 5
       - waitfor.elapsed <= 15
@@ -79,7 +79,7 @@
 - name: verify test wait for port timeout
   assert:
     that:
-      - waitfor|failed
+      - waitfor is failed
       - waitfor.elapsed == 3
       - "waitfor.msg == 'Timeout when waiting for 127.0.0.1:12121'"
 
@@ -93,7 +93,7 @@
 - name: verify test fail with custom msg
   assert:
     that:
-      - waitfor|failed
+      - waitfor is failed
       - waitfor.elapsed == 3
       - "waitfor.msg == 'fail with custom message'"
 
@@ -110,8 +110,8 @@
 - name: verify test wait for port sleep
   assert:
     that:
-      - waitfor|success
-      - not waitfor|changed
+      - waitfor is successful
+      - waitfor is not changed
       - "waitfor.port == {{ http_port }}"
 
 - name: install psutil using pip (non-Linux only)
@@ -128,6 +128,6 @@
 - name: verify test wait for port
   assert:
     that:
-      - waitfor|success
-      - not waitfor|changed
+      - waitfor is successful
+      - waitfor is not changed
       - "waitfor.port == {{ http_port }}"

--- a/test/integration/targets/wakeonlan/tasks/main.yml
+++ b/test/integration/targets/wakeonlan/tasks/main.yml
@@ -18,7 +18,7 @@
 - name: Check error message
   assert:
     that:
-    - incorrect_mac_length|failed
+    - incorrect_mac_length is failed
     - incorrect_mac_length.msg is search('Incorrect MAC address length')
 
 - name: Provide an incorrect MAC format
@@ -31,7 +31,7 @@
 - name: Check error message
   assert:
     that:
-    - incorrect_mac_format|failed
+    - incorrect_mac_format is failed
     - incorrect_mac_format.msg is search('Incorrect MAC address format')
 
 - name: Cause a socket error
@@ -44,5 +44,5 @@
 - name: Check error message
   assert:
     that:
-    - incorrect_broadcast_address|failed
+    - incorrect_broadcast_address is failed
     - incorrect_broadcast_address.msg is search('not known')

--- a/test/integration/targets/win_acl_inheritance/tasks/main.yml
+++ b/test/integration/targets/win_acl_inheritance/tasks/main.yml
@@ -32,7 +32,7 @@
 - name: assert remove inheritance check
   assert:
     that:
-    - remove_check|changed
+    - remove_check is changed
     - actual_remove_check.inherited == True
 
 - name: remove inheritance
@@ -50,7 +50,7 @@
 - name: assert remove inheritance
   assert:
     that:
-    - remove|changed
+    - remove is changed
     - actual_remove.inherited == False
     - actual_remove.user_details['BUILTIN/Administrators'].isinherited == False
     - actual_remove.user_details['BUILTIN/Administrators'].isnotinherited == True
@@ -76,7 +76,7 @@
 - name: assert remove inheritance again
   assert:
     that:
-    - not remove_again|changed
+    - remove_again is not changed
     - actual_remove_again.inherited == False
     - actual_remove.user_details['BUILTIN/Administrators'].isinherited == False
     - actual_remove.user_details['BUILTIN/Administrators'].isnotinherited == True
@@ -103,7 +103,7 @@
 - name: assert add inheritance check
   assert:
     that:
-    - add_check|changed
+    - add_check is changed
     - actual_add_check.inherited == False
     - actual_add_check.user_details['BUILTIN/Administrators'].isinherited == False
     - actual_add_check.user_details['BUILTIN/Administrators'].isnotinherited == True
@@ -129,7 +129,7 @@
 - name: assert add inheritance
   assert:
     that:
-    - add|changed
+    - add is changed
     - actual_add.inherited == True
     - actual_add.user_details['BUILTIN/Administrators'].isinherited == True
     - actual_add.user_details['BUILTIN/Administrators'].isnotinherited == False
@@ -155,7 +155,7 @@
 - name: assert add inheritance again
   assert:
     that:
-    - not add_again|changed
+    - add_again is not changed
     - actual_add_again.inherited == True
     - actual_add_again.user_details['BUILTIN/Administrators'].isinherited == True
     - actual_add_again.user_details['BUILTIN/Administrators'].isnotinherited == False

--- a/test/integration/targets/win_async_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_async_wrapper/tasks/main.yml
@@ -54,7 +54,7 @@
 #- name: validate tempdir response
 #  assert:
 #    that:
-#    - tempdircheck.stdout | search('False')
+#    - tempdircheck.stdout is search('False')
 
 - name: async poll retry
   async_test:
@@ -90,7 +90,7 @@
 #- name: validate tempdir response
 #  assert:
 #    that:
-#    - tempdircheck.stdout | search('False')
+#    - tempdircheck.stdout is search('False')
 
 - name: async poll timeout
   async_test:
@@ -106,7 +106,7 @@
     - asyncresult.ansible_job_id is match('\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult.changed == false
-    - asyncresult | failed == true
+    - asyncresult is failed == true
     - asyncresult.msg is search('timed out')
 
 - name: async poll graceful module failure
@@ -123,7 +123,7 @@
     - asyncresult.ansible_job_id is match('\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult.changed == true
-    - asyncresult | failed == true
+    - asyncresult is failed == true
     - asyncresult.msg == 'failed gracefully'
 
 - name: async poll exception module failure
@@ -140,7 +140,7 @@
     - asyncresult.ansible_job_id is match('\d+\.\d+')
     - asyncresult.finished == 1
     - asyncresult.changed == false
-    - asyncresult | failed == true
+    - asyncresult is failed == true
 # TODO: re-enable after catastrophic failure behavior is cleaned up
 #    - asyncresult.msg is search('failing via exception')
 

--- a/test/integration/targets/win_audit_rule/tasks/add.yml
+++ b/test/integration/targets/win_audit_rule/tasks/add.yml
@@ -60,9 +60,9 @@
 - name: check mode ADD assert that a change is needed, but no change occurred to the audit rules
   assert:
     that:
-    - directory | changed
-    - file | changed
-    - registry | changed
+    - directory is changed
+    - file is changed
+    - registry is changed
     - not directory_results.matching_rule_found and directory_results.path_type == 'directory'
     - not file_results.matching_rule_found and file_results.path_type == 'file'
     - not registry_results.matching_rule_found and registry_results.path_type == 'registry'
@@ -126,9 +126,9 @@
 - name: ADD assert that the rules were added and a change is detected
   assert:
     that:
-    - directory | changed
-    - file | changed
-    - registry | changed
+    - directory is changed
+    - file is changed
+    - registry is changed
     - directory_results.matching_rule_found and directory_results.path_type == 'directory'
     - file_results.matching_rule_found and file_results.path_type == 'file'
     - registry_results.matching_rule_found and registry_results.path_type == 'registry'
@@ -167,6 +167,6 @@
 - name: idempotent ADD assert that a change did not occur
   assert:
     that:
-    - not directory | changed and directory.path_type == 'directory'
-    - not file | changed and file.path_type == 'file'
-    - not registry | changed and registry.path_type == 'registry'
+    - directory is not changed and directory.path_type == 'directory'
+    - file is not changed and file.path_type == 'file'
+    - registry is not changed and registry.path_type == 'registry'

--- a/test/integration/targets/win_audit_rule/tasks/modify.yml
+++ b/test/integration/targets/win_audit_rule/tasks/modify.yml
@@ -60,9 +60,9 @@
 - name: check mode modify assert that change is needed but rights still equal the original rights and not test_audit_rule_new_rights
   assert:
     that:
-    - directory | changed
-    - file | changed
-    - registry | changed
+    - directory is changed
+    - file is changed
+    - registry is changed
     - not directory_results.matching_rule_found and directory_results.path_type == 'directory'
     - not file_results.matching_rule_found and file_results.path_type == 'file'
     - not registry_results.matching_rule_found and registry_results.path_type == 'registry'
@@ -126,9 +126,9 @@
 - name: modify assert that the rules were modified and a change is detected
   assert:
     that:
-    - directory | changed
-    - file | changed
-    - registry | changed
+    - directory is changed
+    - file is changed
+    - registry is changed
     - directory_results.matching_rule_found and directory_results.path_type == 'directory'
     - file_results.matching_rule_found and file_results.path_type == 'file'
     - registry_results.matching_rule_found and registry_results.path_type == 'registry'
@@ -167,6 +167,6 @@
 - name: idempotent modify assert that and a change is not detected
   assert:
     that:
-    - not directory | changed and directory.path_type == 'directory'
-    - not file | changed and file.path_type == 'file'
-    - not registry | changed and registry.path_type == 'registry'
+    - directory is not changed and directory.path_type == 'directory'
+    - file is not changed and file.path_type == 'file'
+    - registry is not changed and registry.path_type == 'registry'

--- a/test/integration/targets/win_audit_rule/tasks/remove.yml
+++ b/test/integration/targets/win_audit_rule/tasks/remove.yml
@@ -53,9 +53,9 @@
 - name: check mode remove assert that change detected, but rule is still present
   assert:
     that:
-    - directory | changed
-    - file | changed
-    - registry | changed
+    - directory is changed
+    - file is changed
+    - registry is changed
     - directory_results.matching_rule_found and directory_results.path_type == 'directory'
     - file_results.matching_rule_found and file_results.path_type == 'file'
     - registry_results.matching_rule_found and registry_results.path_type == 'registry'
@@ -112,9 +112,9 @@
 - name: remove assert that change detected and rule is gone
   assert:
     that:
-    - directory | changed
-    - file | changed
-    - registry | changed
+    - directory is changed
+    - file is changed
+    - registry is changed
     - not directory_results.matching_rule_found and directory_results.path_type == 'directory'
     - not file_results.matching_rule_found and file_results.path_type == 'file'
     - not registry_results.matching_rule_found and registry_results.path_type == 'registry'
@@ -146,6 +146,6 @@
 - name: idempotent remove assert that no change detected
   assert:
     that:
-    - not directory | changed and directory.path_type == 'directory'
-    - not file | changed and file.path_type == 'file'
-    - not registry | changed and registry.path_type == 'registry'
+    - directory is not changed and directory.path_type == 'directory'
+    - file is not changed and file.path_type == 'file'
+    - registry is not changed and registry.path_type == 'registry'

--- a/test/integration/targets/win_become/tasks/main.yml
+++ b/test/integration/targets/win_become/tasks/main.yml
@@ -173,13 +173,13 @@
   - name: verify older hosts failed with become + async
     assert:
       that:
-      - whoami_out|failed
+      - whoami_out is failed
     when: os_version.stdout_lines[0] == "False"
 
   - name: verify newer hosts worked with become + async
     assert:
       that:
-      - whoami_out|success
+      - whoami_out is successful
     when: os_version.stdout_lines[0] == "True"
 
 # FUTURE: test raw + script become behavior once they're running under the exec wrapper again

--- a/test/integration/targets/win_command/tasks/main.yml
+++ b/test/integration/targets/win_command/tasks/main.yml
@@ -86,7 +86,7 @@
 - name: validate result
   assert:
     that:
-    - cmdout|skipped
+    - cmdout is skipped
     - cmdout.msg is search('exists')
 
 - name: ensure testfile is still present

--- a/test/integration/targets/win_command/tasks/main.yml
+++ b/test/integration/targets/win_command/tasks/main.yml
@@ -5,8 +5,8 @@
 - name: validate result
   assert:
     that:
-    - cmdout|success
-    - cmdout|changed
+    - cmdout is successful
+    - cmdout is changed
     - cmdout.cmd == 'whoami /groups'
     - cmdout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
     - cmdout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
@@ -24,8 +24,8 @@
 - name: validate result
   assert:
     that:
-    - cmdout|failed
-    - not cmdout|changed
+    - cmdout is failed
+    - cmdout is not changed
     - cmdout.cmd == 'bogus_command1234'
     - cmdout.rc == 2
     - "'Could not locate the following executable bogus_command1234' in cmdout.msg"
@@ -37,8 +37,8 @@
 - name: validate result
   assert:
     that:
-    - cmdout|success
-    - cmdout|changed
+    - cmdout is successful
+    - cmdout is changed
     - cmdout.cmd == 'cmd /c "echo some output & echo some error 1>&2"'
     - cmdout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
     - cmdout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
@@ -62,8 +62,8 @@
 - name: validate result
   assert:
     that:
-    - cmdout|success
-    - cmdout|changed
+    - cmdout is successful
+    - cmdout is changed
 
 - name: run again with creates, should skip
   win_command: cmd /c "echo $null >> c:\testfile.txt"
@@ -74,7 +74,7 @@
 - name: validate result
   assert:
     that:
-    - cmdout|skipped
+    - cmdout is skipped
     - cmdout.msg is search('exists')
 
 - name: test creates with hidden system file, should skip
@@ -108,8 +108,8 @@
 - name: validate result
   assert:
     that:
-    - cmdout|success
-    - cmdout|changed
+    - cmdout is successful
+    - cmdout is changed
 
 - name: run again with removes, should skip
   win_command: cmd /c "del c:\testfile.txt"
@@ -120,7 +120,7 @@
 - name: validate result
   assert:
     that:
-    - cmdout|skipped
+    - cmdout is skipped
     - cmdout.msg is search('does not exist')
 
 - name: run something with known nonzero exit code
@@ -131,7 +131,7 @@
 - name: validate result
   assert:
     that:
-    - cmdout|failed
+    - cmdout is failed
     - cmdout.failed == True # check the failure key explicitly, since failed does magic with RC
     - cmdout.rc == 254
 
@@ -164,7 +164,7 @@
 - name: assert call to argv binary with absolute path
   assert:
     that:
-    - cmdout|changed
+    - cmdout is changed
     - cmdout.rc == 0
     - cmdout.stdout_lines[0] == 'arg1'
     - cmdout.stdout_lines[1] == 'arg 2'
@@ -180,7 +180,7 @@
 - name: assert call to argv binary with relative path
   assert:
     that:
-    - cmdout|changed
+    - cmdout is changed
     - cmdout.rc == 0
     - cmdout.stdout_lines[0] == 'C:\\path\\end\\slash\\'
     - cmdout.stdout_lines[1] == 'ADDLOCAL=msi,example'
@@ -200,7 +200,7 @@
 - name: assert run stdin test
   assert:
     that:
-    - cmdout|changed
+    - cmdout is changed
     - cmdout.rc == 0
     - cmdout.stdout_lines|count == 1
     - cmdout.stdout_lines[0] == "some input"

--- a/test/integration/targets/win_copy/tasks/remote_tests.yml
+++ b/test/integration/targets/win_copy/tasks/remote_tests.yml
@@ -87,7 +87,7 @@
 - name: assert copy single file remote (check mode)
   assert:
     that:
-    - remote_copy_file_check|changed
+    - remote_copy_file_check is changed
     - remote_copy_file_actual_check.stat.exists == False
 
 - name: copy single file remote
@@ -105,7 +105,7 @@
 - name: assert copy single file remote
   assert:
     that:
-    - remote_copy_file|changed
+    - remote_copy_file is changed
     - remote_copy_file.operation == 'file_copy'
     - remote_copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - remote_copy_file.size == 8
@@ -123,7 +123,7 @@
 - name: assert copy single file remote (idempotent)
   assert:
     that:
-    - not remote_copy_file_again|changed
+    - remote_copy_file_again is not changed
 
 - name: copy single file into folder remote (check mode)
   win_copy:
@@ -141,7 +141,7 @@
 - name: assert copy single file into folder remote (check mode)
   assert:
     that:
-    - remote_copy_file_to_folder_check|changed
+    - remote_copy_file_to_folder_check is changed
     - remote_copy_file_to_folder_actual_check.stat.exists == False
 
 - name: copy single file into folder remote
@@ -159,7 +159,7 @@
 - name: assert copy single file into folder remote
   assert:
     that:
-    - remote_copy_file_to_folder|changed
+    - remote_copy_file_to_folder is changed
     - remote_copy_file_to_folder.operation == 'file_copy'
     - remote_copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - remote_copy_file_to_folder.size == 8
@@ -177,7 +177,7 @@
 - name: assert copy single file into folder remote
   assert:
     that:
-    - not remote_copy_file_to_folder_again|changed
+    - remote_copy_file_to_folder_again is not changed
 
 - name: copy single file to missing folder (check mode)
   win_copy:
@@ -195,7 +195,7 @@
 - name: assert copy single file to missing folder remote (check mode)
   assert:
     that:
-    - remote_copy_file_to_missing_folder_check|changed
+    - remote_copy_file_to_missing_folder_check is changed
     - remote_copy_file_to_missing_folder_check.operation == 'file_copy'
     - remote_copy_file_to_missing_folder_actual_check.stat.exists == False
 
@@ -214,7 +214,7 @@
 - name: assert copy single file to missing folder remote
   assert:
     that:
-    - remote_copy_file_to_missing_folder|changed
+    - remote_copy_file_to_missing_folder is changed
     - remote_copy_file_to_missing_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - remote_copy_file_to_missing_folder.operation == 'file_copy'
     - remote_copy_file_to_missing_folder.size == 8
@@ -242,7 +242,7 @@
 - name: assert copy folder to folder remote (check mode)
   assert:
     that:
-    - remote_copy_folder_to_folder_check|changed
+    - remote_copy_folder_to_folder_check is changed
     - remote_copy_folder_to_folder_check.operation == 'folder_copy'
     - remote_copy_folder_to_folder_actual_check.stat.exists == False
 
@@ -263,7 +263,7 @@
 - name: assert copy folder to folder remote
   assert:
     that:
-    - remote_copy_folder_to_folder|changed
+    - remote_copy_folder_to_folder is changed
     - remote_copy_folder_to_folder.operation == 'folder_copy'
     - remote_copy_folder_to_folder_actual.examined == 11
     - remote_copy_folder_to_folder_actual.matched == 6
@@ -284,7 +284,7 @@
 - name: assert copy folder to folder remote (idempotent)
   assert:
     that:
-    - not remote_copy_folder_to_folder_again|changed
+    - remote_copy_folder_to_folder_again is not changed
 
 - name: change remote file after folder to folder test
   win_copy:
@@ -313,7 +313,7 @@
 - name: assert copy folder after changes
   assert:
     that:
-    - remote_copy_folder_to_folder_after_change|changed
+    - remote_copy_folder_to_folder_after_change is changed
     - remote_copy_folder_to_folder_after_change_actual.matched == 2
     - remote_copy_folder_to_folder_after_change_actual.files[0].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
     - remote_copy_folder_to_folder_after_change_actual.files[1].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
@@ -339,7 +339,7 @@
 - name: assert copy folder content to folder remote with backslash (check mode)
   assert:
     that:
-    - remote_copy_folder_content_backslash_check|changed
+    - remote_copy_folder_content_backslash_check is changed
     - remote_copy_folder_content_backslash_actual_check.stat.exists == False
 
 - name: copy folder contents to folder remote with backslash
@@ -359,7 +359,7 @@
 - name: assert copy folder content to folder remote with backslash
   assert:
     that:
-    - remote_copy_folder_content_backslash|changed
+    - remote_copy_folder_content_backslash is changed
     - remote_copy_folder_content_backslash.operation == 'folder_copy'
     - remote_copy_folder_content_backslash_actual.examined == 10
     - remote_copy_folder_content_backslash_actual.matched == 5
@@ -379,7 +379,7 @@
 - name: assert copy folder content to folder remote with backslash (idempotent)
   assert:
     that:
-    - not remote_copy_folder_content_backslash_again|changed
+    - remote_copy_folder_content_backslash_again is not changed
 
 - name: change remote file after folder content to folder test
   win_copy:
@@ -408,7 +408,7 @@
 - name: assert copy folder content to folder after changes
   assert:
     that:
-    - remote_copy_folder_content_to_folder_after_change|changed
+    - remote_copy_folder_content_to_folder_after_change is changed
     - remote_copy_folder_content_to_folder_after_change_actual.matched == 2
     - remote_copy_folder_content_to_folder_after_change_actual.files[0].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
     - remote_copy_folder_content_to_folder_after_change_actual.files[1].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'

--- a/test/integration/targets/win_copy/tasks/tests.yml
+++ b/test/integration/targets/win_copy/tasks/tests.yml
@@ -36,7 +36,7 @@
 - name: assert failure message when copying an encrypted file without the password set
   assert:
     that:
-    - fail_copy_encrypted_file|failed
+    - fail_copy_encrypted_file is failed
     - fail_copy_encrypted_file.msg == 'A vault password or secret must be specified to decrypt {{role_path}}/files-different/vault/vault-file'
 
 - name: fail to copy a directory with an encrypted file without the password
@@ -49,7 +49,7 @@
 - name: assert failure message when copying a directory that contains an encrypted file without the password set
   assert:
     that:
-    - fail_copy_directory_with_enc_file|failed
+    - fail_copy_directory_with_enc_file is failed
     - fail_copy_directory_with_enc_file.msg == 'A vault password or secret must be specified to decrypt {{role_path}}/files-different/vault/vault-file'
 
 - name: copy with content (check mode)
@@ -67,7 +67,7 @@
 - name: assert copy with content (check mode)
   assert:
     that:
-    - copy_content_check|changed
+    - copy_content_check is changed
     - copy_content_check.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
     - copy_content_check.operation == 'file_copy'
     - copy_content_check.size == 1
@@ -87,7 +87,7 @@
 - name: assert copy with content
   assert:
     that:
-    - copy_content|changed
+    - copy_content is changed
     - copy_content.checksum == '86f7e437faa5a7fce15d1ddcb9eaeaea377667b8'
     - copy_content.operation == 'file_copy'
     - copy_content.size == 1
@@ -103,7 +103,7 @@
 - name: assert copy with content (idempotent)
   assert:
     that:
-    - not copy_content_again|changed
+    - copy_content_again is not changed
 
 - name: copy with content change when missing
   win_copy:
@@ -115,7 +115,7 @@
 - name: assert copy with content change when missing
   assert:
     that:
-    - not copy_content_when_missing|changed
+    - copy_content_when_missing is not changed
 
 - name: copy single file (check mode)
   win_copy:
@@ -132,7 +132,7 @@
 - name: assert copy single file (check mode)
   assert:
     that:
-    - copy_file_check|changed
+    - copy_file_check is changed
     - copy_file_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - copy_file_check.operation == 'file_copy'
     - copy_file_check.size == 8
@@ -152,7 +152,7 @@
 - name: assert copy single file
   assert:
     that:
-    - copy_file|changed
+    - copy_file is changed
     - copy_file.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - copy_file.operation == 'file_copy'
     - copy_file.size == 8
@@ -168,7 +168,7 @@
 - name: assert copy single file (idempotent)
   assert:
     that:
-    - not copy_file_again|changed
+    - copy_file_again is not changed
 
 - name: copy single file to folder (check mode)
   win_copy:
@@ -185,7 +185,7 @@
 - name: assert copy single file to folder (check mode)
   assert:
     that:
-    - copy_file_to_folder_check|changed
+    - copy_file_to_folder_check is changed
     - copy_file_to_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - copy_file_to_folder_check.operation == 'file_copy'
     - copy_file_to_folder_check.size == 8
@@ -205,7 +205,7 @@
 - name: assert copy single file to folder
   assert:
     that:
-    - copy_file_to_folder|changed
+    - copy_file_to_folder is changed
     - copy_file_to_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - copy_file_to_folder.operation == 'file_copy'
     - copy_file_to_folder.size == 8
@@ -221,7 +221,7 @@
 - name: assert copy single file to folder (idempotent)
   assert:
     that:
-    - not copy_file_to_folder_again|changed
+    - copy_file_to_folder_again is not changed
 
 - name: copy single file to missing folder (check mode)
   win_copy:
@@ -238,7 +238,7 @@
 - name: assert copy single file to missing folder (check mode)
   assert:
     that:
-    - copy_file_to_missing_folder_check|changed
+    - copy_file_to_missing_folder_check is changed
     - copy_file_to_missing_folder_check.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - copy_file_to_missing_folder_check.operation == 'file_copy'
     - copy_file_to_missing_folder_check.size == 8
@@ -258,7 +258,7 @@
 - name: assert copy single file to missing folder
   assert:
     that:
-    - copy_file_to_missing_folder|changed
+    - copy_file_to_missing_folder is changed
     - copy_file_to_missing_folder.checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
     - copy_file_to_missing_folder.operation == 'file_copy'
     - copy_file_to_missing_folder.size == 8
@@ -280,7 +280,7 @@
 - name: assert copy folder (check mode)
   assert:
     that:
-    - copy_folder_check|changed
+    - copy_folder_check is changed
     - copy_folder_check.operation == 'folder_copy'
     - copy_folder_actual_check.stat.exists == False
 
@@ -300,7 +300,7 @@
 - name: assert copy folder
   assert:
     that:
-    - copy_folder|changed
+    - copy_folder is changed
     - copy_folder.operation == 'folder_copy'
     - copy_folder_actual.examined == 11 # includes files and folders, the below is the nested order
     - copy_folder_actual.matched == 6
@@ -320,7 +320,7 @@
 - name: assert copy folder (idempotent)
   assert:
     that:
-    - not copy_folder_again|changed
+    - copy_folder_again is not changed
 
 - name: change the text of a file in the remote source
   win_copy:
@@ -348,7 +348,7 @@
 - name: assert copy folder after changes
   assert:
     that:
-    - copy_folder_after_change|changed
+    - copy_folder_after_change is changed
     - copy_folder_after_changes_actual.matched == 2
     - copy_folder_after_changes_actual.files[0].checksum == 'b54ba7f5621240d403f06815f7246006ef8c7d43'
     - copy_folder_after_changes_actual.files[1].checksum == 'c79a6506c1c948be0d456ab5104d5e753ab2f3e6'
@@ -368,7 +368,7 @@
 - name: assert copy folder's contents (check mode)
   assert:
     that:
-    - copy_folder_contents_check|changed
+    - copy_folder_contents_check is changed
     - copy_folder_contents_check.operation == 'folder_copy'
     - copy_folder_contents_actual_check.stat.exists == False
 
@@ -388,7 +388,7 @@
 - name: assert copy folder
   assert:
     that:
-    - copy_folder_contents|changed
+    - copy_folder_contents is changed
     - copy_folder_contents.operation == 'folder_copy'
     - copy_folder_contents_actual.examined == 10 # includes files and folders, the below is the nested order
     - copy_folder_contents_actual.matched == 5
@@ -433,7 +433,7 @@
 - name: assert results of copy a file with colon as a source
   assert:
     that:
-    - copy_file_with_colon|changed
+    - copy_file_with_colon is changed
     - copy_file_with_colon_result.stat.exists == True
     - copy_file_with_colon_result.stat.checksum == "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3" 
 
@@ -458,7 +458,7 @@
 - name: assert result of copy an encrypted file without decrypting
   assert:
     that:
-    - copy_encrypted_file|changed
+    - copy_encrypted_file is changed
     - copy_encrypted_file_result.stat.checksum == "74a89620002d253f38834ee5b06cddd28956a43d"
 
 - name: copy an encrypted file without decrypting (idempotent)
@@ -471,7 +471,7 @@
 - name: assert result of copy an encrypted file without decrypting (idempotent)
   assert:
     that:
-    - not copy_encrypted_file_again|changed
+    - copy_encrypted_file_again is not changed
 
 - name: copy folder with encrypted files without decrypting
   win_copy:
@@ -490,7 +490,7 @@
 - name: assert result of copy folder with encrypted files without decrypting
   assert:
     that:
-    - copy_encrypted_file|changed
+    - copy_encrypted_file is changed
     - copy_encrypted_file_result.files|count == 2
     - copy_encrypted_file_result.files[0].checksum == "834563c94127730ecfa42dfc1e1821bbda2e51da"
     - copy_encrypted_file_result.files[1].checksum == "74a89620002d253f38834ee5b06cddd28956a43d"
@@ -505,7 +505,7 @@
 - name: assert result of copy folder with encrypted files without decrypting (idempotent)
   assert:
     that:
-    - not copy_encrypted_file_again|changed
+    - copy_encrypted_file_again is not changed
 
 - name: remove test folder after local to remote tests
   win_file:

--- a/test/integration/targets/win_domain_group/tasks/main.yml
+++ b/test/integration/targets/win_domain_group/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: assert create group with defaults checl
   assert:
     that:
-    - create_default_check|changed
+    - create_default_check is changed
     - create_default_actual_check.rc == 1
 
 - name: create group with defaults
@@ -52,7 +52,7 @@
 - name: assert create group with defaults
   assert:
     that:
-    - create_default|changed
+    - create_default is changed
     - create_default.category == 'Security'
     - create_default.description == None
     - create_default.display_name == None
@@ -75,7 +75,7 @@
 - name: assert create group with defaults again
   assert:
     that:
-    - not create_default_again|changed
+    - create_default_again is not changed
 
 - name: remove group check
   win_domain_group:
@@ -91,7 +91,7 @@
 - name: assert remove group check
   assert:
     that:
-    - remove_group_check|changed
+    - remove_group_check is changed
     - remove_group_actual_check.rc == 0
 
 - name: remove group
@@ -108,7 +108,7 @@
 - name: assert remove group
   assert:
     that:
-    - remove_group|changed
+    - remove_group is changed
     - remove_group_actual.rc == 1
 
 - name: remove group again
@@ -120,7 +120,7 @@
 - name: assert remove group again
   assert:
     that:
-    - not remove_group_again|changed
+    - remove_group_again is not changed
 
 - name: create non default group check
   win_domain_group:
@@ -147,7 +147,7 @@
 - name: assert create non default group check
   assert:
     that:
-    - create_non_default_check|changed
+    - create_non_default_check is changed
     - create_non_default_actual_check.rc == 1
 
 - name: create non default group
@@ -174,7 +174,7 @@
 - name: assert create non default group
   assert:
     that:
-    - create_non_default|changed
+    - create_non_default is changed
     - create_non_default.category == 'Distribution'
     - create_non_default.description == 'Group Description'
     - create_non_default.display_name == 'Group Display Name'
@@ -207,7 +207,7 @@
 - name: assert create non default group again
   assert:
     that:
-    - not create_non_default_again|changed
+    - create_non_default_again is not changed
 
 - name: try and move group with protection mode on
   win_domain_group:
@@ -240,7 +240,7 @@
 - name: assert modify existing group check
   assert:
     that:
-    - modify_existing_check|changed
+    - modify_existing_check is changed
     - modify_existing_actual_check.stdout == 'CN=' + test_win_domain_group_name + ',' + test_win_domain_group_ou_path + '\r\n'
 
 - name: modify existing group
@@ -266,7 +266,7 @@
 - name: assert modify existing group
   assert:
     that:
-    - modify_existing|changed
+    - modify_existing is changed
     - modify_existing.category == 'Security'
     - modify_existing.description == 'New Description'
     - modify_existing.display_name == 'New Display Name'
@@ -299,7 +299,7 @@
 - name: assert modify existing group again
   assert:
     that:
-    - not modify_existing_again|changed
+    - modify_existing_again is not changed
 
 - name: fail change managed_by to invalid user
   win_domain_group:
@@ -332,7 +332,7 @@
 - name: assert delete group with protection mode on
   assert:
     that:
-    - delete_with_force|changed
+    - delete_with_force is changed
     - delete_with_force_actual.rc == 1
 
 - name: ensure the test group is deleted after the test

--- a/test/integration/targets/win_domain_membership/tasks/tests.yml
+++ b/test/integration/targets/win_domain_membership/tasks/tests.yml
@@ -15,7 +15,7 @@
 - name: assert result of change workgroup (check mode)
   assert:
     that:
-    - change_workgroup_check|changed
+    - change_workgroup_check is changed
     - change_workgroup_result_check.stdout == workgroup.stdout
 
 - name: change workgroup
@@ -33,7 +33,7 @@
 - name: assert result of change workgroup
   assert:
     that:
-    - change_workgroup|changed
+    - change_workgroup is changed
     - change_workgroup_result.stdout_lines[0] == "ANSIBLETEST"
 
 - name: change workgroup (idempotent)
@@ -47,7 +47,7 @@
 - name: assert result of change workgroup (idempotent)
   assert:
     that:
-    - not change_workgroup_again|changed
+    - change_workgroup_again is not changed
 
 - name: change workgroup fail invalid name
   win_domain_membership:

--- a/test/integration/targets/win_dotnet_ngen/tasks/main.yml
+++ b/test/integration/targets/win_dotnet_ngen/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: assert run in check mode
   assert:
     that:
-    - result_check|changed
+    - result_check is changed
     - result_check.dotnet_ngen_update_exit_code == 0
     - result_check.dotnet_ngen_update_output == "check mode output for C:\\Windows\\Microsoft.NET\\Framework\\v4.0.30319\\ngen.exe update /force"
     - result_check.dotnet_ngen_eqi_exit_code == 0

--- a/test/integration/targets/win_dsc/tasks/destructive.yml
+++ b/test/integration/targets/win_dsc/tasks/destructive.yml
@@ -56,7 +56,7 @@
 - name: assert results of create an IIS website (check mode)
   assert:
     that:
-    - win_dsc_iis_check|changed
+    - win_dsc_iis_check is changed
     - win_dsc_iis_check_result.exists == False
 
 - name: create an IIS website with auth and binding info
@@ -92,7 +92,7 @@
 - name: assert results of create an IIS website
   assert:
     that:
-    - win_dsc_iis|changed
+    - win_dsc_iis is changed
     - win_dsc_iis_result.exists == True
     - win_dsc_iis_result.auth.anonymous == True
     - win_dsc_iis_result.auth.basic == False
@@ -132,4 +132,4 @@
 - name: assert results of create an IIS website (idempotent)
   assert:
     that:
-    - not win_dsc_iis_again|changed
+    - win_dsc_iis_again is not changed

--- a/test/integration/targets/win_dsc/tasks/tests.yml
+++ b/test/integration/targets/win_dsc/tasks/tests.yml
@@ -42,7 +42,7 @@
 - name: assert result of add Windows feature (check mode)
   assert:
     that:
-    - win_dsc_add_feature_check|changed
+    - win_dsc_add_feature_check is changed
     - win_dsc_add_feature_result_check.stdout == "False\r\n"
 
 - name: add Windows feature
@@ -59,7 +59,7 @@
 - name: assert result of add Windows feature
   assert:
     that:
-    - win_dsc_add_feature|changed
+    - win_dsc_add_feature is changed
     - win_dsc_add_feature_result.stdout == "True\r\n"
 
 - name: add Windows feature (idempotent)
@@ -72,7 +72,7 @@
 - name: assert result of add Windows feature (idempotent)
   assert:
     that:
-    - not win_dsc_add_feature_again|changed
+    - win_dsc_add_feature_again is not changed
 
 - name: remove Windows feature (check mode)
   win_dsc:
@@ -89,7 +89,7 @@
 - name: assert result of remove Windows feature (check mode)
   assert:
     that:
-    - win_dsc_remove_feature_check|changed
+    - win_dsc_remove_feature_check is changed
     - win_dsc_remove_feature_result_check.stdout == "True\r\n"
 
 - name: remove Windows feature
@@ -106,7 +106,7 @@
 - name: assert result of remove Windows feature
   assert:
     that:
-    - win_dsc_remove_feature|changed
+    - win_dsc_remove_feature is changed
     - win_dsc_remove_feature_result.stdout == "False\r\n"
 
 - name: remove Windows feature (idempotent)
@@ -119,7 +119,7 @@
 - name: assert result of remove Windows feature (idempotent)
   assert:
     that:
-    - not win_dsc_remove_feature_again|changed
+    - win_dsc_remove_feature_again is not changed
 
 - name: ensure test folder doesn't exist before test
   win_file:
@@ -147,7 +147,7 @@
 - name: assert results of create test file (check mode)
   assert:
     that:
-    - win_dsc_create_file_check|changed
+    - win_dsc_create_file_check is changed
     - win_dsc_create_file_result_check.stat.exists == False
 
 - name: create test file
@@ -170,7 +170,7 @@
 - name: assert results of create test file
   assert:
     that:
-    - win_dsc_create_file|changed
+    - win_dsc_create_file is changed
     - win_dsc_create_file_result.stat.exists == True
     - win_dsc_create_file_result.stat.isdir == False
     - win_dsc_create_file_result.stat.ishidden == True
@@ -189,7 +189,7 @@
 - name: assert results of create test file (idempotent)
   assert:
     that:
-    - not win_dsc_create_file_again|changed
+    - win_dsc_create_file_again is not changed
 
 - name: get SID of current ansible user
   win_shell: (New-Object System.Security.Principal.NTAccount("{{ansible_user}}")).Translate([System.Security.Principal.SecurityIdentifier]).ToString()
@@ -216,7 +216,7 @@
 - name: assert results of run DSC process as another user
   assert:
     that:
-    - win_dsc_runas|changed
+    - win_dsc_runas is changed
     - win_dsc_runas_result.content|b64decode == win_dsc_actual_sid.stdout
 
 - name: create custom DSC resource folder
@@ -305,7 +305,7 @@
 - name: assert result of custom DSC resource
   assert:
     that:
-    - test_dsc_custom|changed
+    - test_dsc_custom is changed
     - test_dsc_custom_output.content|b64decode|strip_newline == test_dsc_custom_expected|strip_newline
 
 - name: run custom DSC resource with version
@@ -326,5 +326,5 @@
 - name: assert result of custom DSC resource with version
   assert:
     that:
-    - test_dsc_custom|changed
+    - test_dsc_custom is changed
     - test_dsc_custom_output_version.content|b64decode|strip_newline == test_dsc_custom_expected_version|strip_newline

--- a/test/integration/targets/win_environment/tasks/main.yml
+++ b/test/integration/targets/win_environment/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: assert change test environment value for machine check
   assert:
     that:
-    - create_machine_check|changed
+    - create_machine_check is changed
     - create_machine_check_actual.stdout == ""
 
 - name: create test environment value for machine
@@ -43,7 +43,7 @@
 - name: assert test environment value for machine
   assert:
     that:
-    - create_machine|changed
+    - create_machine is changed
     - create_machine.before_value == None
     - create_machine_actual.stdout == "{{test_machine_environment_value}}\r\n"
 
@@ -62,7 +62,7 @@
 - name: assert create test environment value for machine again
   assert:
     that:
-    - not create_machine_again|changed
+    - create_machine_again is not changed
     - create_machine_again.before_value == test_machine_environment_value
     - create_machine_actual_again.stdout == "{{test_machine_environment_value}}\r\n"
 
@@ -82,7 +82,7 @@
 - name: assert change test environment value for machine check
   assert:
     that:
-    - change_machine_check|changed
+    - change_machine_check is changed
     - change_machine_check.before_value == test_machine_environment_value
     - change_machine_actual_check.stdout == "{{test_machine_environment_value}}\r\n"
 
@@ -101,7 +101,7 @@
 - name: assert change test environment value for machine
   assert:
     that:
-    - change_machine|changed
+    - change_machine is changed
     - change_machine.before_value == test_machine_environment_value
     - change_machine_actual.stdout == "{{test_new_machine_environment_value}}\r\n"
 
@@ -120,7 +120,7 @@
 - name: assert change test environment value for machine again
   assert:
     that:
-    - not change_machine_again|changed
+    - change_machine_again is not changed
     - change_machine_again.before_value == test_new_machine_environment_value
     - change_machine_actual_again.stdout == "{{test_new_machine_environment_value}}\r\n"
 
@@ -140,7 +140,7 @@
 - name: assert change test environment value for user check
   assert:
     that:
-    - create_user_check|changed
+    - create_user_check is changed
     - create_user_check_actual.stdout == ""
 
 - name: create test environment value for user
@@ -158,7 +158,7 @@
 - name: assert test environment value for user
   assert:
     that:
-    - create_user|changed
+    - create_user is changed
     - create_user.before_value == None
     - create_user_actual.stdout == "{{test_user_environment_value}}\r\n"
 
@@ -177,7 +177,7 @@
 - name: assert create test environment value for user again
   assert:
     that:
-    - not create_user_again|changed
+    - create_user_again is not changed
     - create_user_again.before_value == test_user_environment_value
     - create_user_actual_again.stdout == "{{test_user_environment_value}}\r\n"
 
@@ -197,7 +197,7 @@
 - name: assert change test environment value for user check
   assert:
     that:
-    - change_user_check|changed
+    - change_user_check is changed
     - change_user_check.before_value == test_user_environment_value
     - change_user_actual_check.stdout == "{{test_user_environment_value}}\r\n"
 
@@ -216,7 +216,7 @@
 - name: assert change test environment value for user
   assert:
     that:
-    - change_user|changed
+    - change_user is changed
     - change_user.before_value == test_user_environment_value
     - change_user_actual.stdout == "{{test_new_user_environment_value}}\r\n"
 
@@ -235,7 +235,7 @@
 - name: assert change test environment value for user again
   assert:
     that:
-    - not change_user_again|changed
+    - change_user_again is not changed
     - change_user_again.before_value == test_new_user_environment_value
     - change_user_actual_again.stdout == "{{test_new_user_environment_value}}\r\n"
 

--- a/test/integration/targets/win_exec_wrapper/tasks/main.yml
+++ b/test/integration/targets/win_exec_wrapper/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: assert test out invalid options
   assert:
     that:
-    - invalid_options|success
+    - invalid_options is successful
     - invalid_options.output == "output"
 
 - name: test out invalid os version
@@ -17,7 +17,7 @@
 - name: assert test out invalid os version
   assert:
     that:
-    - invalid_os_version|failed
+    - invalid_os_version is failed
     - '"This module cannot run on this OS as it requires a minimum version of 20.0, actual was " in invalid_os_version.msg'
 
 - name: test out invalid powershell version
@@ -28,7 +28,7 @@
 - name: assert test out invalid powershell version
   assert:
     that:
-    - invalid_ps_version|failed
+    - invalid_ps_version is failed
     - '"This module cannot run as it requires a minimum PowerShell version of 20.0.0.0, actual was " in invalid_ps_version.msg'
 
 - name: test out become requires without become_user set
@@ -38,7 +38,7 @@
 - name: assert become requires without become_user set
   assert:
     that:
-    - become_system|success
+    - become_system is successful
     - become_system.output == "S-1-5-18"
 
 - set_fact:
@@ -86,7 +86,7 @@
   - name: assert become requires when become_user set
     assert:
       that:
-      - become_system|success
+      - become_system is successful
       - become_system.output == become_test_user_result.sid
 
   always:

--- a/test/integration/targets/win_feature/tasks/main.yml
+++ b/test/integration/targets/win_feature/tasks/main.yml
@@ -26,7 +26,7 @@
   win_feature:
     name: "{{ test_win_feature_name }}"
     state: absent
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: install feature
   win_feature:
@@ -36,12 +36,12 @@
     include_sub_features: yes
     include_management_tools: yes
   register: win_feature_install_result
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: check result of installing feature
   assert:
     that:
-      - "win_feature_install_result|changed"
+      - "win_feature_install_result is changed"
       - "win_feature_install_result.success"
       - "win_feature_install_result.exitcode == 'Success'"
       - "not win_feature_install_result.restart_needed"
@@ -52,7 +52,7 @@
       - "win_feature_install_result.feature_result[0].restart_needed is defined"
       - "win_feature_install_result.feature_result[0].skip_reason"
       - "win_feature_install_result.feature_result[0].success is defined"
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: install feature again
   win_feature:
@@ -62,29 +62,29 @@
     include_sub_features: yes
     include_management_tools: yes
   register: win_feature_install_again_result
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: check result of installing feature again
   assert:
     that:
-      - "not win_feature_install_again_result|changed"
+      - "win_feature_install_again_result is not changed"
       - "win_feature_install_again_result.success"
       - "win_feature_install_again_result.exitcode == 'NoChangeNeeded'"
       - "not win_feature_install_again_result.restart_needed"
       - "win_feature_install_again_result.feature_result == []"
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: remove feature
   win_feature:
     name: "{{ test_win_feature_name }}"
     state: absent
   register: win_feature_remove_result
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: check result of removing feature
   assert:
     that:
-      - "win_feature_remove_result|changed"
+      - "win_feature_remove_result is changed"
       - "win_feature_remove_result.success"
       - "win_feature_remove_result.exitcode == 'Success'"
       - "not win_feature_remove_result.restart_needed"
@@ -95,24 +95,24 @@
       - "win_feature_remove_result.feature_result[0].restart_needed is defined"
       - "win_feature_remove_result.feature_result[0].skip_reason"
       - "win_feature_remove_result.feature_result[0].success is defined"
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: remove feature again
   win_feature:
     name: "{{ test_win_feature_name }}"
     state: absent
   register: win_feature_remove_again_result
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: check result of removing feature again
   assert:
     that:
-      - "not win_feature_remove_again_result|changed"
+      - "win_feature_remove_again_result is not changed"
       - "win_feature_remove_again_result.success"
       - "win_feature_remove_again_result.exitcode == 'NoChangeNeeded'"
       - "not win_feature_remove_again_result.restart_needed"
       - "win_feature_remove_again_result.feature_result == []"
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: try to install an invalid feature name
   win_feature:
@@ -120,16 +120,16 @@
     state: present
   register: win_feature_install_invalid_result
   ignore_errors: true
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: check result of installing invalid feature name
   assert:
     that:
-      - "win_feature_install_invalid_result|failed"
-      - "not win_feature_install_invalid_result|changed"
+      - "win_feature_install_invalid_result is failed"
+      - "win_feature_install_invalid_result is not changed"
       - "win_feature_install_invalid_result.msg"
       - "win_feature_install_invalid_result.exitcode == 'InvalidArgs'"
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: try to remove an invalid feature name
   win_feature:
@@ -137,13 +137,13 @@
     state: absent
   register: win_feature_remove_invalid_result
   ignore_errors: true
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful
 
 - name: check result of removing invalid feature name
   assert:
     that:
-      - "win_feature_remove_invalid_result|failed"
-      - "not win_feature_remove_invalid_result|changed"
+      - "win_feature_remove_invalid_result is failed"
+      - "win_feature_remove_invalid_result is not changed"
       - "win_feature_remove_invalid_result.msg"
       - "win_feature_remove_invalid_result.exitcode == 'InvalidArgs'"
-  when: win_feature_has_servermanager|success
+  when: win_feature_has_servermanager is successful

--- a/test/integration/targets/win_fetch/tasks/main.yml
+++ b/test/integration/targets/win_fetch/tasks/main.yml
@@ -84,7 +84,7 @@
 #- name: check fetch flat to directory result
 #  assert:
 #    that:
-#      - "not fetch_flat_dir|changed"
+#      - "fetch_flat_dir is not changed"
 
 - name: fetch a large binary file
   fetch: src="C:/Windows/explorer.exe" dest={{ host_output_dir }}
@@ -142,9 +142,9 @@
 - name: check fetch missing no fail result
   assert:
     that:
-      - "not fetch_missing_nofail|failed"
+      - "fetch_missing_nofail is not failed"
       - "fetch_missing_nofail.msg"
-      - "not fetch_missing_nofail|changed"
+      - "fetch_missing_nofail is not changed"
 
 - name: attempt to fetch a non-existent file - fail on missing
   fetch: src="~/this_file_should_not_exist.txt" dest={{ host_output_dir }} fail_on_missing=yes
@@ -154,9 +154,9 @@
 - name: check fetch missing with failure
   assert:
     that:
-      - "fetch_missing|failed"
+      - "fetch_missing is failed"
       - "fetch_missing.msg"
-      - "not fetch_missing|changed"
+      - "fetch_missing is not changed"
 
 - name: attempt to fetch a directory
   fetch: src="C:\\Windows" dest={{ host_output_dir }}
@@ -167,5 +167,5 @@
   assert:
     that:
       # Doesn't fail anymore, only returns a message.
-      - "not fetch_dir|changed"
+      - "fetch_dir is not changed"
       - "fetch_dir.msg"

--- a/test/integration/targets/win_firewall/tasks/main.yml
+++ b/test/integration/targets/win_firewall/tasks/main.yml
@@ -46,7 +46,7 @@
   - name: Test firewall_on
     assert:
       that:
-      - firewall_on|changed
+      - firewall_on is changed
       - firewall_on.Domain.enabled
       - firewall_on.Private.enabled
       - firewall_on.Public.enabled

--- a/test/integration/targets/win_firewall/tasks/tests.yml
+++ b/test/integration/targets/win_firewall/tasks/tests.yml
@@ -9,7 +9,7 @@
 - name: Test firewall_off_again
   assert:
     that:
-    - not firewall_off_again|changed
+    - firewall_off_again is not changed
     - not firewall_off_again.Domain.enabled
     - not firewall_off_again.Private.enabled
     - not firewall_off_again.Public.enabled
@@ -23,7 +23,7 @@
 - name: Test firewall_public_on
   assert:
     that:
-    - firewall_public_on|changed
+    - firewall_public_on is changed
     - not firewall_public_on.Domain.enabled
     - not firewall_public_on.Private.enabled
     - firewall_public_on.Public.enabled
@@ -38,7 +38,7 @@
 - name: Test firewall_public_on_again (normal mode)
   assert:
     that:
-    - not firewall_public_on_again|changed
+    - firewall_public_on_again is not changed
     - not firewall_public_on_again.Domain.enabled
     - not firewall_public_on_again.Private.enabled
     - firewall_public_on_again.Public.enabled
@@ -47,7 +47,7 @@
 - name: Test firewall_public_on_again (check-mode)
   assert:
     that:
-    - firewall_public_on_again|changed
+    - firewall_public_on_again is changed
     - not firewall_public_on_again.Domain.enabled
     - not firewall_public_on_again.Private.enabled
     - firewall_public_on_again.Public.enabled
@@ -64,7 +64,7 @@
 - name: Test firewall_domain_on (normal mode)
   assert:
     that:
-    - firewall_domain_on|changed
+    - firewall_domain_on is changed
     - firewall_domain_on.Domain.enabled
     - not firewall_domain_on.Private.enabled
     - firewall_domain_on.Public.enabled
@@ -73,7 +73,7 @@
 - name: Test firewall_domain_on (check-mode)
   assert:
     that:
-    - firewall_domain_on|changed
+    - firewall_domain_on is changed
     - firewall_domain_on.Domain.enabled
     - not firewall_domain_on.Private.enabled
     - not firewall_domain_on.Public.enabled
@@ -89,7 +89,7 @@
 - name: Test firewall_domain_on_again (normal mode)
   assert:
     that:
-    - not firewall_domain_on_again|changed
+    - firewall_domain_on_again is not changed
     - firewall_domain_on.Domain.enabled
     - not firewall_domain_on.Private.enabled
     - firewall_domain_on.Public.enabled
@@ -98,7 +98,7 @@
 - name: Test firewall_domain_on_again (check-mode)
   assert:
     that:
-    - firewall_domain_on_again|changed
+    - firewall_domain_on_again is changed
     - firewall_domain_on.Domain.enabled
     - not firewall_domain_on.Private.enabled
     - not firewall_domain_on.Public.enabled
@@ -114,7 +114,7 @@
 - name: Test firewall_on
   assert:
     that:
-    - firewall_on|changed
+    - firewall_on is changed
     - firewall_on.Domain.enabled
     - firewall_on.Private.enabled
     - firewall_on.Public.enabled
@@ -129,7 +129,7 @@
 - name: Test firewall_on_again (normal mode)
   assert:
     that:
-    - not firewall_on_again|changed
+    - firewall_on_again is not changed
     - firewall_on_again.Domain.enabled
     - firewall_on_again.Private.enabled
     - firewall_on_again.Public.enabled
@@ -138,7 +138,7 @@
 - name: Test firewall_on_again (check-mode)
   assert:
     that:
-    - firewall_on_again|changed
+    - firewall_on_again is changed
     - firewall_on_again.Domain.enabled
     - firewall_on_again.Private.enabled
     - firewall_on_again.Public.enabled
@@ -154,7 +154,7 @@
 - name: Test firewall_off2 (normal mode)
   assert:
     that:
-    - firewall_off2|changed
+    - firewall_off2 is changed
     - not firewall_off2.Domain.enabled
     - not firewall_off2.Private.enabled
     - not firewall_off2.Public.enabled
@@ -163,7 +163,7 @@
 - name: Test firewall_off2 (check-mode)
   assert:
     that:
-    - not firewall_off2|changed
+    - firewall_off2 is not changed
     - not firewall_off2.Domain.enabled
     - not firewall_off2.Private.enabled
     - not firewall_off2.Public.enabled
@@ -179,7 +179,7 @@
 - name: Test firewall_off2_again (normal mode)
   assert:
     that:
-    - not firewall_off2_again|changed
+    - firewall_off2_again is not changed
     - not firewall_off2_again.Domain.enabled
     - not firewall_off2_again.Private.enabled
     - not firewall_off2_again.Public.enabled

--- a/test/integration/targets/win_firewall_rule/tasks/main.yml
+++ b/test/integration/targets/win_firewall_rule/tasks/main.yml
@@ -322,7 +322,7 @@
     that:
     - add_firewall_rule_with_edge_traversal.changed == true
   # Works on windows >= Windows 7/Windows Server 2008 R2
-  when: ansible_distribution_version | version_compare('6.1', '>=')
+  when: ansible_distribution_version is version('6.1', '>=')
 
 - name: Add firewall rule with 'authenticate' secure flag
   win_firewall_rule:
@@ -341,7 +341,7 @@
     that:
     - add_firewall_rule_with_secure_flags.changed == true
   # Works on windows >= Windows 8/Windows Server 2012
-  when: ansible_distribution_version | version_compare('6.2', '>=')
+  when: ansible_distribution_version is version('6.2', '>=')
 
 - name: Add firewall rule with profiles in string format
   win_firewall_rule:

--- a/test/integration/targets/win_get_url/tasks/main.yml
+++ b/test/integration/targets/win_get_url/tasks/main.yml
@@ -32,8 +32,8 @@
 - name: Check that url was downloaded
   assert:
     that:
-      - not win_get_url_result|failed
-      - win_get_url_result|changed
+      - win_get_url_result is not failed
+      - win_get_url_result is changed
       - win_get_url_result.url
       - win_get_url_result.dest
 
@@ -46,8 +46,8 @@
 - name: Check that url was downloaded again
   assert:
     that:
-      - not win_get_url_result_again|failed
-      - win_get_url_result_again|changed
+      - win_get_url_result_again is not failed
+      - win_get_url_result_again is changed
 
 - name: Test win_get_url module again with force=no
   win_get_url:
@@ -59,8 +59,8 @@
 - name: Check that url was not downloaded again
   assert:
     that:
-      - not win_get_url_result_noforce|failed
-      - not win_get_url_result_noforce|changed
+      - win_get_url_result_noforce is not failed
+      - win_get_url_result_noforce is not changed
 
 - name: Test win_get_url module with url that returns a 404
   win_get_url:
@@ -72,7 +72,7 @@
 - name: Check that the download failed for an invalid url
   assert:
     that:
-      - win_get_url_result_invalid_link|failed
+      - win_get_url_result_invalid_link is failed
       - win_get_url_result_invalid_link.status_code == 404
 
 - name: Test win_get_url module with an invalid path
@@ -85,7 +85,7 @@
 - name: Check that the download failed for an invalid path
   assert:
     that:
-      - win_get_url_result_invalid_path|failed
+      - win_get_url_result_invalid_path is failed
 
 - name: Test win_get_url module with a valid path that is a directory
   win_get_url:
@@ -97,7 +97,7 @@
 - name: Check that the download did NOT fail, even though dest was directory
   assert:
     that:
-      - win_get_url_result_dir_path|changed
+      - win_get_url_result_dir_path is changed
 
 - name: Test win_get_url with a valid url path and a dest that is a directory (from 2.4 should use url path as filename)
   win_get_url:
@@ -113,7 +113,7 @@
 - name: Check that the download succeeded (changed) and dest is as expected
   assert:
     that:
-      - win_get_url_result_dir_path_urlpath|changed
+      - win_get_url_result_dir_path_urlpath is changed
       - win_get_url_result_dir_path_urlpath.dest == expected_dest_path
 
 - name: Check you get a helpful message if the parent folder of the dest doesn't exist
@@ -126,7 +126,7 @@
 - name: Check if dest parent dir does not exist, module fails and you get a specific error message
   assert:
     that:
-      - win_get_url_result_invalid_dest|failed
+      - win_get_url_result_invalid_dest is failed
       - win_get_url_result_invalid_dest.msg is search('does not exist, or is not visible to the current user')
 
 - name: Check you get a helpful message if the parent folder of the dest doesn't exist
@@ -139,5 +139,5 @@
 - name: Check if dest parent dir does not exist, module fails and you get a specific error message
   assert:
     that:
-      - win_get_url_result_invalid_dest2|failed
+      - win_get_url_result_invalid_dest2 is failed
       - win_get_url_result_invalid_dest2.msg is search('does not exist')

--- a/test/integration/targets/win_group/tasks/main.yml
+++ b/test/integration/targets/win_group/tasks/main.yml
@@ -30,7 +30,7 @@
 - name: check create result without name parameter
   assert:
     that:
-      - "win_group_create_noname|failed"
+      - "win_group_create_noname is failed"
 
 - name: create test group with invalid state parameter
   win_group:
@@ -42,7 +42,7 @@
 - name: check create result with invalid state parameter
   assert:
     that:
-      - "win_group_create_invalid_state|failed"
+      - "win_group_create_invalid_state is failed"
 
 - name: create test group
   win_group:
@@ -53,7 +53,7 @@
 - name: check create group results
   assert:
     that:
-      - "win_group_create|changed"
+      - "win_group_create is changed"
 
 - name: create test group again with same options
   win_group:
@@ -65,7 +65,7 @@
 - name: check create group again results
   assert:
     that:
-      - "not win_group_create_again|changed"
+      - "win_group_create_again is not changed"
 
 - name: create test group again but change description
   win_group:
@@ -76,7 +76,7 @@
 - name: check create group results after updating description
   assert:
     that:
-      - "win_group_create_new_description|changed"
+      - "win_group_create_new_description is changed"
 
 - name: remove test group
   win_group:
@@ -87,7 +87,7 @@
 - name: check remove group result
   assert:
     that:
-      - "win_group_remove|changed"
+      - "win_group_remove is changed"
 
 - name: remove test group again
   win_group:
@@ -98,4 +98,4 @@
 - name: check remove group again result
   assert:
     that:
-      - "not win_group_remove_again|changed"
+      - "win_group_remove_again is not changed"

--- a/test/integration/targets/win_hotfix/tasks/tests.yml
+++ b/test/integration/targets/win_hotfix/tasks/tests.yml
@@ -21,7 +21,7 @@
 - name: assert remove an identifier that isn't installed
   assert:
     that:
-    - not remove_missing_hotfix_identifier|changed
+    - remove_missing_hotfix_identifier is not changed
 
 - name: remove a kb that isn't installed
   win_hotfix:
@@ -32,4 +32,4 @@
 - name: assert remove a kb that isn't installed
   assert:
     that:
-    - not remove_missing_hotfix_kb|changed
+    - remove_missing_hotfix_kb is not changed

--- a/test/integration/targets/win_hotfix/tasks/tests_2012R2.yml
+++ b/test/integration/targets/win_hotfix/tasks/tests_2012R2.yml
@@ -57,7 +57,7 @@
 - name: assert install hotfix check
   assert:
     that:
-    - install_hotfix_check|changed
+    - install_hotfix_check is changed
     - install_hotfix_check.kb == test_win_hotfix_kb
     - install_hotfix_check.identifier == test_win_hotfix_identifier
     - install_hotfix_actual_check.rc != 0
@@ -75,7 +75,7 @@
 - name: assert install hotfix
   assert:
     that:
-    - install_hotfix|changed
+    - install_hotfix is changed
     - install_hotfix.kb == test_win_hotfix_kb
     - install_hotfix.identifier == test_win_hotfix_identifier
     - install_hotfix.reboot_required == False
@@ -90,7 +90,7 @@
 - name: assert install hotfix again
   assert:
     that:
-    - not install_hotfix_again|changed
+    - install_hotfix_again is not changed
     - install_hotfix_again.kb == test_win_hotfix_kb
     - install_hotfix_again.identifier == test_win_hotfix_identifier
     - install_hotfix_again.reboot_required == False
@@ -109,7 +109,7 @@
 - name: assert uninstall hotfix check
   assert:
     that:
-    - uninstall_hotfix_check|changed
+    - uninstall_hotfix_check is changed
     - uninstall_hotfix_check.kb == test_win_hotfix_kb
     - uninstall_hotfix_check.identifier == test_win_hotfix_identifier
     - uninstall_hotfix_actual_check.rc == 0
@@ -128,7 +128,7 @@
 - name: assert uninstall hotfix
   assert:
     that:
-    - uninstall_hotfix|changed
+    - uninstall_hotfix is changed
     - uninstall_hotfix.kb == test_win_hotfix_kb
     - uninstall_hotfix.identifier == test_win_hotfix_identifier
     - uninstall_hotfix.reboot_required == False
@@ -143,7 +143,7 @@
 - name: assert uninstall hotfix again
   assert:
     that:
-    - not uninstall_hotfix_again|changed
+    - uninstall_hotfix_again is not changed
     - uninstall_hotfix_again.reboot_required == False
 
 - name: install reboot hotfix
@@ -160,7 +160,7 @@
 - name: assert install reboot hotfix
   assert:
     that:
-    - install_reboot_hotfix|changed
+    - install_reboot_hotfix is changed
     - install_reboot_hotfix.kb == test_win_hotfix_reboot_kb
     - install_reboot_hotfix.identifier == test_win_hotfix_reboot_identifier
     - install_reboot_hotfix.reboot_required == True
@@ -175,7 +175,7 @@
 - name: assert install reboot again before rebooting
   assert:
     that:
-    - not install_before_rebooting|changed
+    - install_before_rebooting is not changed
     - install_before_rebooting.reboot_required == True
 
 - win_reboot:
@@ -190,7 +190,7 @@
 - name: assert install reboot hotfix again
   assert:
     that:
-    - not install_reboot_hotfix_again|changed
+    - install_reboot_hotfix_again is not changed
     - install_reboot_hotfix_again.reboot_required == False
 
 - name: uninstall hotfix with kb check
@@ -207,7 +207,7 @@
 - name: assert uninstall hotfix with kb check
   assert:
     that:
-    - uninstall_hotfix_kb_check|changed
+    - uninstall_hotfix_kb_check is changed
     - uninstall_hotfix_kb_check.kb == test_win_hotfix_reboot_kb
     - uninstall_hotfix_kb_check.identifier == test_win_hotfix_reboot_identifier
     - uninstall_hotfix_kb_check.reboot_required == False
@@ -227,7 +227,7 @@
 - name: assert uninstall hotfix with kb
   assert:
     that:
-    - uninstall_hotfix_kb|changed
+    - uninstall_hotfix_kb is changed
     - uninstall_hotfix_kb.kb == test_win_hotfix_reboot_kb
     - uninstall_hotfix_kb.identifier == test_win_hotfix_reboot_identifier
     - uninstall_hotfix_kb.reboot_required == True
@@ -244,7 +244,7 @@
 - name: assert uninstall hotfix with kb again
   assert:
     that:
-    - not uninstall_hotfix_kb_again|changed
+    - uninstall_hotfix_kb_again is not changed
     - uninstall_hotfix_kb_again.reboot_required == False
 
 - name: remove test staging folder

--- a/test/integration/targets/win_iis_webapppool/tasks/tests.yml
+++ b/test/integration/targets/win_iis_webapppool/tasks/tests.yml
@@ -14,7 +14,7 @@
 - name: assert create default pool check
   assert:
     that:
-    - create_default_check|changed
+    - create_default_check is changed
     - create_default_actual_check.rc == 1
 
 - name: create default pool
@@ -31,7 +31,7 @@
 - name: assert create default pool
   assert:
     that:
-    - create_default|changed
+    - create_default is changed
     - create_default.info.attributes.name == test_iis_webapppool_name
     - create_default.info.attributes.startMode == 'OnDemand'
     - create_default.info.attributes.state == 'Started'
@@ -52,7 +52,7 @@
 - name: assert change attributes of pool check
   assert:
     that:
-    - change_pool_attributes_check|changed
+    - change_pool_attributes_check is changed
     - change_pool_attributes_check.info == create_default.info
 
 - name: change attributes of pool
@@ -70,7 +70,7 @@
 - name: assert change attributes of pool
   assert:
     that:
-    - change_pool_attributes|changed
+    - change_pool_attributes is changed
     - change_pool_attributes.info.attributes.managedPipelineMode == 'Classic'
     - change_pool_attributes.info.cpu.limit == 95
     - change_pool_attributes.info.processModel.identityType == 'LocalSystem'
@@ -90,7 +90,7 @@
 - name: assert change attributes of pool again
   assert:
     that:
-    - not change_pool_attributes_again|changed
+    - change_pool_attributes_again is not changed
     - change_pool_attributes_again.info == change_pool_attributes.info
 
 - name: change attributes of pool (old style) check
@@ -104,7 +104,7 @@
 - name: assert change attributes of pool (old style) check
   assert:
     that:
-    - change_pool_attributes_deprecated_check|changed
+    - change_pool_attributes_deprecated_check is changed
     - change_pool_attributes_deprecated_check.info == change_pool_attributes_again.info
 
 - name: change attributes of pool (old style)
@@ -117,7 +117,7 @@
 - name: assert change attributes of pool (old style)
   assert:
     that:
-    - change_pool_attributes_deprecated|changed
+    - change_pool_attributes_deprecated is changed
     - change_pool_attributes_deprecated.info.attributes.managedPipelineMode == 'Integrated'
     - change_pool_attributes_deprecated.info.attributes.startMode == 'OnDemand'
     - change_pool_attributes_deprecated.info.cpu.limit == 10
@@ -133,7 +133,7 @@
 - name: assert change attributes of pool (old style) again
   assert:
     that:
-    - not change_pool_attributes_deprecated_again|changed
+    - change_pool_attributes_deprecated_again is not changed
     - change_pool_attributes_deprecated_again.info == change_pool_attributes_deprecated.info
 
 - name: change more complex variables check
@@ -151,7 +151,7 @@
 - name: assert change more complex variables check
   assert:
     that:
-    - change_complex_attributes_check|changed
+    - change_complex_attributes_check is changed
     - change_complex_attributes_check.info == change_pool_attributes_deprecated_again.info
 
 - name: change more complex variables
@@ -168,7 +168,7 @@
 - name: assert change more complex variables
   assert:
     that:
-    - change_complex_attributes|changed
+    - change_complex_attributes is changed
     - change_complex_attributes.info.attributes.queueLength == 500
     - change_complex_attributes.info.recycling.periodicRestart.requests == 10
     - change_complex_attributes.info.recycling.periodicRestart.time.TotalSeconds == 300
@@ -188,7 +188,7 @@
 - name: assert change more complex variables again
   assert:
     that:
-    - not change_complex_attributes_again|changed
+    - change_complex_attributes_again is not changed
     - change_complex_attributes_again.info == change_complex_attributes.info
 
 - name: stop web pool check
@@ -205,7 +205,7 @@
 - name: assert stop web pool check
   assert:
     that:
-    - stop_pool_check|changed
+    - stop_pool_check is changed
     - stop_pool_actual_check.stdout == 'Started\r\n'
 
 - name: stop web pool
@@ -221,7 +221,7 @@
 - name: assert stop web pool
   assert:
     that:
-    - stop_pool|changed
+    - stop_pool is changed
     - stop_pool_actual.stdout == 'Stopped\r\n'
 
 - name: stop web pool again
@@ -237,7 +237,7 @@
 - name: assert stop web pool again
   assert:
     that:
-    - not stop_pool_again|changed
+    - stop_pool_again is not changed
     - stop_pool_actual_again.stdout == 'Stopped\r\n'
 
 - name: start web pool check
@@ -254,7 +254,7 @@
 - name: assert start web pool check
   assert:
     that:
-    - start_pool_check|changed
+    - start_pool_check is changed
     - start_pool_actual_check.stdout == 'Stopped\r\n'
 
 - name: start web pool
@@ -270,7 +270,7 @@
 - name: assert start web pool
   assert:
     that:
-    - start_pool|changed
+    - start_pool is changed
     - start_pool_actual.stdout == 'Started\r\n'
 
 - name: start web pool again
@@ -286,7 +286,7 @@
 - name: assert start web pool again
   assert:
     that:
-    - not start_pool_again|changed
+    - start_pool_again is not changed
     - start_pool_actual_again.stdout == 'Started\r\n'
 
 - name: restart web pool
@@ -302,7 +302,7 @@
 - name: assert restart web pool
   assert:
     that:
-    - restart_pool|changed
+    - restart_pool is changed
     - restart_pool_actual.stdout == 'Started\r\n'
 
 - name: stop pool before restart on stop test
@@ -324,7 +324,7 @@
 - name: assert restart from stopped web pool check
   assert:
     that:
-    - restart_from_stop_pool_check|changed
+    - restart_from_stop_pool_check is changed
     - restart_from_stop_pool_actual_check.stdout == 'Stopped\r\n'
 
 - name: restart from stopped web pool
@@ -340,7 +340,7 @@
 - name: assert restart from stopped web pool
   assert:
     that:
-    - restart_from_stop_pool|changed
+    - restart_from_stop_pool is changed
     - restart_from_stop_pool_actual.stdout == 'Started\r\n'
 
 - name: set web pool attribute that is a collection (check mode)
@@ -361,7 +361,7 @@
 - name: assert results of set web pool attribute that is a collection (check mode)
   assert:
     that:
-    - collection_change_check|changed
+    - collection_change_check is changed
     - collection_change_result_check.stdout == ""
 
 - name: set web pool attribute that is a collection
@@ -381,7 +381,7 @@
 - name: assert results of set web pool attribute that is a collection
   assert:
     that:
-    - collection_change|changed
+    - collection_change is changed
     - collection_change_result.stdout_lines == [ "00:10:00", "10:10:00" ]
 
 - name: set web pool attribute that is a collection (idempotent)
@@ -395,7 +395,7 @@
 - name: assert results of set web pool attribute that is a collection (idempotent)
   assert:
     that:
-    - not collection_change_again|changed
+    - collection_change_again is not changed
 
 # The following tests are only for IIS versions 8.0 or newer
 - block:
@@ -425,7 +425,7 @@
   - name: assert change attributes for newer IIS version check
     assert:
       that:
-      - iis_attributes_new_check|changed
+      - iis_attributes_new_check is changed
       - iis_attributes_new_check.info == iis_attributes_blank.info
 
   - name: change attributes for newer IIS version
@@ -442,7 +442,7 @@
   - name: assert change attributes for newer IIS version
     assert:
       that:
-      - iis_attributes_new|changed
+      - iis_attributes_new is changed
       - iis_attributes_new.info.attributes.startMode == 'AlwaysRunning'
       - iis_attributes_new.info.processModel.identityType == 'SpecificUser'
       - iis_attributes_new.info.processModel.userName == ansible_user
@@ -462,7 +462,7 @@
   - name: assert change attributes for newer IIS version again
     assert:
       that:
-      - not iis_attributes_new_again|changed
+      - iis_attributes_new_again is not changed
       - iis_attributes_new_again.info == iis_attributes_new.info
 
   when: iis_version.win_file_version.file_major_part|int > 7

--- a/test/integration/targets/win_lineinfile/tasks/main.yml
+++ b/test/integration/targets/win_lineinfile/tasks/main.yml
@@ -35,8 +35,8 @@
       - "result.stat.exists"
       - "not result.stat.isdir"
       - "result.stat.checksum == '5feac65e442c91f557fc90069ce6efc4d346ab51'"
-      - "not result|failed"
-      - "not result|changed"
+      - "result is not failed"
+      - "result is not changed"
 
 
 - name: insert a line at the beginning of the file, and back it up

--- a/test/integration/targets/win_mapped_drive/tasks/tests.yml
+++ b/test/integration/targets/win_mapped_drive/tasks/tests.yml
@@ -36,7 +36,7 @@
 - name: assert create mapped drive check
   assert:
     that:
-    - create_drive_check|changed
+    - create_drive_check is changed
     - create_drive_actual_check.rc == 2 # should fail with this error code when it isn't found
 
 - name: create mapped drive
@@ -53,7 +53,7 @@
 - name: assert create mapped drive
   assert:
     that:
-    - create_drive|changed
+    - create_drive is changed
     - create_drive_actual.rc == 0
     - create_drive_actual.stdout_lines[1] == "Remote name       \\\\{{ansible_hostname}}\\{{test_win_mapped_drive_path}}"
 
@@ -67,7 +67,7 @@
 - name: assert create mapped drive again
   assert:
     that:
-    - not create_drive_again|changed
+    - create_drive_again is not changed
 
 - name: change mapped drive target check
   win_mapped_drive:
@@ -84,7 +84,7 @@
 - name: assert change mapped drive target check
   assert:
     that:
-    - change_drive_target_check|changed
+    - change_drive_target_check is changed
     - change_drive_target_actual_check.rc == 0
     - change_drive_target_actual_check.stdout_lines[1] == "Remote name       \\\\{{ansible_hostname}}\\{{test_win_mapped_drive_path}}"
 
@@ -102,7 +102,7 @@
 - name: assert change mapped drive target
   assert:
     that:
-    - change_drive_target|changed
+    - change_drive_target is changed
     - change_drive_target_actual.rc == 0
     - change_drive_target_actual.stdout_lines[1] == "Remote name       \\\\{{ansible_hostname}}\\{{test_win_mapped_drive_path2}}"
 
@@ -129,7 +129,7 @@
 - name: assert delete mapped drive check
   assert:
     that:
-    - delete_drive_check|changed
+    - delete_drive_check is changed
     - delete_drive_actual_check.rc == 0
     - delete_drive_actual_check.stdout_lines[1] == "Remote name       \\\\{{ansible_hostname}}\\{{test_win_mapped_drive_path2}}"
 
@@ -148,7 +148,7 @@
 - name: assert delete mapped drive
   assert:
     that:
-    - delete_drive|changed
+    - delete_drive is changed
     - delete_drive_actual.rc == 2
 
 - name: delete mapped drive again
@@ -161,7 +161,7 @@
 - name: assert delete mapped drive again
   assert:
     that:
-    - not delete_drive_again|changed
+    - delete_drive_again is not changed
 
 # not much we can do to test out the credentials except that it sets it, winrm
 # makes it hard to actually test out we can still access the mapped drive
@@ -183,7 +183,7 @@
 - name: assert map drive with current credentials check
   assert:
     that:
-    - map_with_credentials_check|changed
+    - map_with_credentials_check is changed
     - map_with_credentials_actual_check.rc == 2
 
 - name: map drive with current credentials
@@ -208,7 +208,7 @@
 - name: assert map drive with current credentials
   assert:
     that:
-    - map_with_credentials|changed
+    - map_with_credentials is changed
     - map_with_credentials_actual.rc == 0
     - map_with_credential_actual_username.value == '{{ansible_hostname}}\\{{test_win_mapped_drive_temp_user}}'
 
@@ -224,7 +224,7 @@
 - name: assert map drive with current credentials again
   assert:
     that:
-    - map_with_credentials_again|changed # we expect a change as it will just delete and recreate if credentials are passed
+    - map_with_credentials_again is changed # we expect a change as it will just delete and recreate if credentials are passed
 
 - name: delete mapped drive without path check
   win_mapped_drive:
@@ -240,7 +240,7 @@
 - name: assert delete mapped drive without path check
   assert:
     that:
-    - delete_without_path_check|changed
+    - delete_without_path_check is changed
     - delete_without_path_actual_check.rc == 0
 
 - name: delete mapped drive without path
@@ -257,7 +257,7 @@
 - name: assert delete mapped drive without path check
   assert:
     that:
-    - delete_without_path|changed
+    - delete_without_path is changed
     - delete_without_path_actual.rc == 2
 
 - name: delete mapped drive without path again
@@ -269,4 +269,4 @@
 - name: assert delete mapped drive without path check again
   assert:
     that:
-    - not delete_without_path_again|changed
+    - delete_without_path_again is not changed

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -29,8 +29,8 @@
 
 - assert:
     that:
-    - bogus_utils | failed
-    - bogus_utils.msg | search("Could not find")
+    - bogus_utils is failed
+    - bogus_utils.msg is search("Could not find")
 
 - name: call module with camel conversion tests
   camel_conversion_test:

--- a/test/integration/targets/win_module_utils_legacy/tasks/main.yml
+++ b/test/integration/targets/win_module_utils_legacy/tasks/main.yml
@@ -13,7 +13,7 @@
 - name: test path shape validation
   testpath:
     path: "{{ item.path }}"
-  failed_when: path_shapes | failed != (item.should_fail | default(false))
+  failed_when: path_shapes is failed != (item.should_fail | default(false))
   register: path_shapes
   with_items:
   - path: C:\Windows
@@ -26,7 +26,7 @@
   testlist:
     value: '{{item.value}}'
   register: list_tests
-  failed_when: list_tests|failed or list_tests.count != item.count
+  failed_when: list_tests is failed or list_tests.count != item.count
   with_items:
   - value: []
     count: 0

--- a/test/integration/targets/win_msg/tasks/main.yml
+++ b/test/integration/targets/win_msg/tasks/main.yml
@@ -7,8 +7,8 @@
 - name: Test msg_result
   assert:
     that:
-    - not msg_result|failed
-    - msg_result|changed
+    - msg_result is not failed
+    - msg_result is changed
     - msg_result.runtime_seconds < 10
 
 - name: Warn user and wait for it
@@ -22,8 +22,8 @@
 - name: Test msg_wait_result
   assert:
     that:
-    - not msg_wait_result|failed
-    - msg_wait_result|changed
+    - msg_wait_result is not failed
+    - msg_wait_result is changed
     - msg_wait_result.runtime_seconds > 5
 
 - name: fail to send a message > 255 characters

--- a/test/integration/targets/win_msi/tasks/main.yml
+++ b/test/integration/targets/win_msi/tasks/main.yml
@@ -38,8 +38,8 @@
 - name: check win_msi install result
   assert:
     that:
-      - "not win_msi_install_result|failed"
-      - "win_msi_install_result|changed"
+      - "win_msi_install_result is not failed"
+      - "win_msi_install_result is changed"
 
 - name: install msi again with creates argument
   win_msi:
@@ -53,8 +53,8 @@
   ignore_errors: true
   assert: 
     that:
-      - "not win_msi_install_again_result|failed"
-      - "not win_msi_install_again_result|changed"
+      - "win_msi_install_again_result is not failed"
+      - "win_msi_install_again_result is not changed"
 
 - name: uninstall msi
   win_msi:
@@ -66,5 +66,5 @@
 - name: check win_msi uninstall result
   assert: 
     that:
-      - "not win_msi_uninstall_result|failed"
-      - "win_msi_uninstall_result|changed"
+      - "win_msi_uninstall_result is not failed"
+      - "win_msi_uninstall_result is changed"

--- a/test/integration/targets/win_owner/tasks/main.yml
+++ b/test/integration/targets/win_owner/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: assert set owner defaults check
   assert:
     that:
-    - defaults_check|changed
+    - defaults_check is changed
     - actual_defaults_check.stdout_lines[0] == 'BUILTIN\Administrators'
 
 - name: set owner defaults
@@ -77,7 +77,7 @@
 - name: assert set owner defaults
   assert:
     that:
-    - defaults|changed
+    - defaults is changed
     - actual_defaults.stdout_lines[0] == 'NT AUTHORITY\SYSTEM'
 
 - name: set owner defaults again
@@ -93,7 +93,7 @@
 - name: assert set owner defaults again
   assert:
     that:
-    - not defaults_again|changed
+    - defaults_again is not changed
     - actual_defaults_again.stdout_lines[0] == 'NT AUTHORITY\SYSTEM'
 
 - name: set owner recurse check
@@ -119,7 +119,7 @@
 - name: assert set owner recurse check
   assert:
     that:
-    - recurse_check|changed
+    - recurse_check is changed
 
 - name: set owner recurse
   win_owner:
@@ -143,7 +143,7 @@
 - name: assert set owner recurse
   assert:
     that:
-    - recurse|changed
+    - recurse is changed
 
 - name: set owner recurse again
   win_owner:
@@ -167,7 +167,7 @@
 - name: assert set owner recurse again
   assert:
     that:
-    - not recurse_again|changed
+    - recurse_again is not changed
 
 - name: create test user
   win_user:
@@ -196,7 +196,7 @@
 - name: assert set owner with space recurse
   assert:
     that:
-    - recurse_space|changed
+    - recurse_space is changed
 
 - name: set owner with space recurse again
   win_owner:
@@ -220,7 +220,7 @@
 - name: assert set owner with space recurse again
   assert:
     that:
-    - not recurse_space_again|changed
+    - recurse_space_again is not changed
 
 # Run cleanup after tests
 - name: delete test path

--- a/test/integration/targets/win_package/tasks/exe_tests.yml
+++ b/test/integration/targets/win_package/tasks/exe_tests.yml
@@ -16,7 +16,7 @@
 - name: assert install local exe (check mode)
   assert:
     that:
-    - install_local_exe_check|changed
+    - install_local_exe_check is changed
     - install_local_exe_check.reboot_required == False
     - install_local_exe_actual_check.exists == False
 
@@ -36,7 +36,7 @@
 - name: assert install local exe
   assert:
     that:
-    - install_local_exe|changed
+    - install_local_exe is changed
     - install_local_exe.reboot_required == False
     - install_local_exe.rc == 0
     - install_local_exe_actual.exists == True
@@ -52,7 +52,7 @@
 - name: assert install local exe (idempotent)
   assert:
     that:
-    - not install_local_exe_idempotent|changed
+    - install_local_exe_idempotent is not changed
 
 - name: uninstall local exe with path (check mode)
   win_package:
@@ -71,7 +71,7 @@
 - name: assert uninstall local exe with path (check mode)
   assert:
     that:
-    - uninstall_path_local_exe_check|changed
+    - uninstall_path_local_exe_check is changed
     - uninstall_path_local_exe_check.reboot_required == False
     - uninstall_path_local_exe_actual_check.exists == True
 
@@ -91,7 +91,7 @@
 - name: assert uninstall local exe with path
   assert:
     that:
-    - uninstall_path_local_exe|changed
+    - uninstall_path_local_exe is changed
     - uninstall_path_local_exe.reboot_required == False
     - uninstall_path_local_exe.rc == 0
     - uninstall_path_local_exe_actual.exists == False
@@ -107,7 +107,7 @@
 - name: assert uninstall local exe with path (idempotent)
   assert:
     that:
-    - not uninstall_path_local_exe_idempotent|changed
+    - uninstall_path_local_exe_idempotent is not changed
 
 - name: install url exe (check mode)
   win_package:
@@ -126,7 +126,7 @@
 - name: assert install url exe (check mode)
   assert:
     that:
-    - install_url_exe_check|changed
+    - install_url_exe_check is changed
     - install_url_exe_check.reboot_required == False
     - install_url_exe_actual_check.exists == False
 
@@ -146,7 +146,7 @@
 - name: assert install url exe
   assert:
     that:
-    - install_url_exe|changed
+    - install_url_exe is changed
     - install_url_exe.reboot_required == False
     - install_url_exe.rc == 0
     - install_url_exe_actual.exists == True
@@ -162,7 +162,7 @@
 - name: assert install url exe (idempotent)
   assert:
     that:
-    - not install_url_exe_again|changed
+    - install_url_exe_again is not changed
 
 - name: uninstall local exe with product_id (check mode)
   win_package:
@@ -180,7 +180,7 @@
 - name: assert uninstall local exe with product_id (check mode)
   assert:
     that:
-    - uninstall_id_local_exe_check|changed
+    - uninstall_id_local_exe_check is changed
     - uninstall_id_local_exe_check.reboot_required == False
     - uninstall_id_local_exe_actual_check.exists == True
 
@@ -199,7 +199,7 @@
 - name: assert uninstall local exe with product_id
   assert:
     that:
-    - uninstall_id_local_exe|changed
+    - uninstall_id_local_exe is changed
     - uninstall_id_local_exe.reboot_required == False
     - uninstall_id_local_exe.rc == 0
     - uninstall_id_local_exe_actual.exists == False
@@ -214,7 +214,7 @@
 - name: assert uninstall local exe with product_id (idempotent)
   assert:
     that:
-    - not uninstall_id_local_exe_idempotent|changed
+    - uninstall_id_local_exe_idempotent is not changed
 
 - name: install exe checking path
   win_package:
@@ -257,7 +257,7 @@
 - name: assert install exe checking path and version
   assert:
     that:
-    - not install_exe_create_version_match|changed
+    - install_exe_create_version_match is not changed
 
 - name: install exe checking path and version mismatch
   win_package:
@@ -270,7 +270,7 @@
 - name: assert install exe checking path and version mistmatch
   assert:
     that:
-    - install_exe_create_version_mismatch|changed
+    - install_exe_create_version_mismatch is changed
 
 - name: install exe checking service
   win_package:
@@ -282,7 +282,7 @@
 - name: assert install exe checking service
   assert:
     that:
-    - not install_exe_create_service_match|changed
+    - install_exe_create_service_match is not changed
 
 - name: install exe checking service mismatch
   win_package:
@@ -294,7 +294,7 @@
 - name: assert install exe checking service mismatch
   assert:
     that:
-    - install_exe_create_service_mismatch|changed
+    - install_exe_create_service_mismatch is changed
  
 - name: uninstall exe post tests
   win_package:

--- a/test/integration/targets/win_package/tasks/msi_tests.yml
+++ b/test/integration/targets/win_package/tasks/msi_tests.yml
@@ -21,7 +21,7 @@
 - name: assert install local msi (check mode)
   assert:
     that:
-    - install_local_msi_check|changed
+    - install_local_msi_check is changed
     - install_local_msi_check.reboot_required == False
     - install_local_msi_actual_check.exists == False
 
@@ -40,7 +40,7 @@
 - name: assert install local msi
   assert:
     that:
-    - install_local_msi|changed
+    - install_local_msi is changed
     - install_local_msi.reboot_required == False
     - install_local_msi.rc == 0
     - install_local_msi_actual.exists == True
@@ -54,7 +54,7 @@
 - name: assert install local msi (idempotent)
   assert:
     that:
-    - not install_local_msi_idempotent|changed
+    - install_local_msi_idempotent is not changed
 
 - name: uninstall local msi with path (check mode)
   win_package:
@@ -71,7 +71,7 @@
 - name: assert uninstall local msi with path (check mode)
   assert:
     that:
-    - uninstall_path_local_msi_check|changed
+    - uninstall_path_local_msi_check is changed
     - uninstall_path_local_msi_check.reboot_required == False
     - uninstall_path_local_msi_actual_check.exists == True
 
@@ -89,7 +89,7 @@
 - name: assert uninstall local msi with path
   assert:
     that:
-    - uninstall_path_local_msi|changed
+    - uninstall_path_local_msi is changed
     - uninstall_path_local_msi.reboot_required == False
     - uninstall_path_local_msi.rc == 0
     - uninstall_path_local_msi_actual.exists == False
@@ -103,7 +103,7 @@
 - name: assert uninstall local msi with path (idempotent)
   assert:
     that:
-    - not uninstall_path_local_msi_idempotent|changed
+    - uninstall_path_local_msi_idempotent is not changed
 
 - name: install url msi (check mode)
   win_package:
@@ -121,7 +121,7 @@
 - name: assert install url msi (check mode)
   assert:
     that:
-    - install_url_msi_check|changed
+    - install_url_msi_check is changed
     - install_url_msi_check.reboot_required == False
     - install_url_msi_actual_check.exists == False
 
@@ -140,7 +140,7 @@
 - name: assert install url msi
   assert:
     that:
-    - install_url_msi|changed
+    - install_url_msi is changed
     - install_url_msi.reboot_required == False
     - install_url_msi.rc == 0
     - install_url_msi_actual.exists == True
@@ -155,7 +155,7 @@
 - name: assert install url msi (idempotent)
   assert:
     that:
-    - not install_url_msi_again|changed
+    - install_url_msi_again is not changed
 
 - name: uninstall local msi with product_id (check mode)
   win_package:
@@ -172,7 +172,7 @@
 - name: assert uninstall local msi with product_id (check mode)
   assert:
     that:
-    - uninstall_id_local_msi_check|changed
+    - uninstall_id_local_msi_check is changed
     - uninstall_id_local_msi_check.reboot_required == False
     - uninstall_id_local_msi_actual_check.exists == True
 
@@ -190,7 +190,7 @@
 - name: assert uninstall local msi with product_id
   assert:
     that:
-    - uninstall_id_local_msi|changed
+    - uninstall_id_local_msi is changed
     - uninstall_id_local_msi.reboot_required == False
     - uninstall_id_local_msi.rc == 0
     - uninstall_id_local_msi_actual.exists == False
@@ -204,7 +204,7 @@
 - name: assert uninstall local msi with product_id (idempotent)
   assert:
     that:
-    - not uninstall_id_local_msi_idempotent|changed
+    - uninstall_id_local_msi_idempotent is not changed
 
 - name: install local reboot msi (check mode)
   win_package:
@@ -221,7 +221,7 @@
 - name: assert install local reboot msi (check mode)
   assert:
     that:
-    - install_local_reboot_msi_check|changed
+    - install_local_reboot_msi_check is changed
     - install_local_reboot_msi_check.reboot_required == False
     - install_local_reboot_msi_actual_check.exists == False
 
@@ -239,7 +239,7 @@
 - name: assert install local reboot msi
   assert:
     that:
-    - install_local_reboot_msi|changed
+    - install_local_reboot_msi is changed
     - install_local_reboot_msi.reboot_required == True
     - install_local_reboot_msi.rc == 3010
     - install_local_reboot_msi_actual.exists == True
@@ -253,7 +253,7 @@
 - name: assert install local reboot msi (idempotent)
   assert:
     that:
-    - not install_local_reboot_msi_idempotent|changed
+    - install_local_reboot_msi_idempotent is not changed
 
 - name: uninstall reboot msi after test
   win_package:
@@ -286,7 +286,7 @@
 - name: assert install local msi with arguments (check mode)
   assert:
     that:
-    - install_msi_argument_check|changed
+    - install_msi_argument_check is changed
     - install_msi_argument_check.reboot_required == False
     - install_msi_argument_moo_check.stat.exists == False
     - install_msi_argument_cow_check.stat.exists == False
@@ -311,7 +311,7 @@
 - name: assert install local msi with arguments
   assert:
     that:
-    - install_msi_argument|changed
+    - install_msi_argument is changed
     - install_msi_argument.reboot_required == False
     - install_msi_argument.rc == 0
     - install_msi_argument_moo.stat.exists == False
@@ -327,7 +327,7 @@
 - name: assert install local msi with arguments (idempotent)
   assert:
     that:
-    - not install_msi_argument_again|changed
+    - install_msi_argument_again is not changed
 
 - name: uninstall good msi after test
   win_package:
@@ -359,7 +359,7 @@
 - name: assert results of install msi to custom path using string arguments
   assert:
     that:
-    - install_msi_string_arguments|changed
+    - install_msi_string_arguments is changed
     - install_msi_string_arguments.reboot_required == False
     - install_msi_string_arguments.rc == 0
     - install_msi_string_arguments_moo.stat.exists == False
@@ -392,7 +392,7 @@
 - name: assert results of install msi to custom path using list arguments
   assert:
     that:
-    - install_msi_list_arguments|changed
+    - install_msi_list_arguments is changed
     - install_msi_list_arguments.reboot_required == False
     - install_msi_list_arguments.rc == 0
     - install_msi_list_arguments_moo.stat.exists == True

--- a/test/integration/targets/win_package/tasks/network_tests.yml
+++ b/test/integration/targets/win_package/tasks/network_tests.yml
@@ -17,7 +17,7 @@
 - name: assert install network msi (check mode)
   assert:
     that:
-    - install_network_msi_check|changed
+    - install_network_msi_check is changed
     - install_network_msi_check.reboot_required == False
     - install_network_msi_actual_check.exists == False
 
@@ -38,7 +38,7 @@
 - name: assert install network msi
   assert:
     that:
-    - install_network_msi|changed
+    - install_network_msi is changed
     - install_network_msi.reboot_required == False
     - install_network_msi.rc == 0
     - install_network_msi_actual.exists == True
@@ -55,7 +55,7 @@
 - name: assert install network msi (idempotent)
   assert:
     that:
-    - not install_network_msi_idempotent|changed
+    - install_network_msi_idempotent is not changed
 
 - name: uninstall network msi with path (check mode)
   win_package:
@@ -75,7 +75,7 @@
 - name: assert uninstall network msi with path (check mode)
   assert:
     that:
-    - uninstall_path_network_msi_check|changed
+    - uninstall_path_network_msi_check is changed
     - uninstall_path_network_msi_check.reboot_required == False
     - uninstall_path_network_msi_actual_check.exists == True
 
@@ -96,7 +96,7 @@
 - name: assert uninstall network msi with path
   assert:
     that:
-    - uninstall_path_network_msi|changed
+    - uninstall_path_network_msi is changed
     - uninstall_path_network_msi.reboot_required == False
     - uninstall_path_network_msi.rc == 0
     - uninstall_path_network_msi_actual.exists == False
@@ -113,7 +113,7 @@
 - name: assert uninstall network msi with path (idempotent)
   assert:
     that:
-    - not uninstall_path_network_msi_idempotent|changed
+    - uninstall_path_network_msi_idempotent is not changed
 
 - name: install network reboot msi (check mode)
   win_package:
@@ -133,7 +133,7 @@
 - name: assert install network reboot msi (check mode)
   assert:
     that:
-    - install_network_reboot_msi_check|changed
+    - install_network_reboot_msi_check is changed
     - install_network_reboot_msi_check.reboot_required == False
     - install_network_reboot_msi_actual_check.exists == False
 
@@ -154,7 +154,7 @@
 - name: assert install network reboot msi
   assert:
     that:
-    - install_network_reboot_msi|changed
+    - install_network_reboot_msi is changed
     - install_network_reboot_msi.reboot_required == True
     - install_network_reboot_msi.rc == 3010
     - install_network_reboot_msi_actual.exists == True
@@ -171,7 +171,7 @@
 - name: assert install network reboot msi (idempotent)
   assert:
     that:
-    - not install_network_reboot_msi_idempotent|changed
+    - install_network_reboot_msi_idempotent is not changed
 
 - name: uninstall network msi with product_id (check mode)
   win_package:
@@ -190,7 +190,7 @@
 - name: assert uninstall network msi with product_id (check mode)
   assert:
     that:
-    - uninstall_id_network_msi_check|changed
+    - uninstall_id_network_msi_check is changed
     - uninstall_id_network_msi_check.reboot_required == False
     - uninstall_id_network_msi_actual_check.exists == True
 
@@ -208,7 +208,7 @@
 - name: assert uninstall network msi with product_id
   assert:
     that:
-    - uninstall_id_network_msi|changed
+    - uninstall_id_network_msi is changed
     - uninstall_id_network_msi.reboot_required == True
     - uninstall_id_network_msi.rc == 3010
     - uninstall_id_network_msi_actual.exists == False
@@ -222,7 +222,7 @@
 - name: assert uninstall network msi with product_id (idempotent)
   assert:
     that:
-    - not uninstall_id_network_msi_idempotent|changed
+    - uninstall_id_network_msi_idempotent is not changed
 
 - name: ensure the install folder is cleaned in case uninstall didn't work
   win_file:
@@ -253,7 +253,7 @@
 - name: assert install network msi with arguments (check mode)
   assert:
     that:
-    - install_network_msi_argument_check|changed
+    - install_network_msi_argument_check is changed
     - install_network_msi_argument_check.reboot_required == False
     - install_network_msi_argument_moo_check.stat.exists == False
     - install_network_msi_argument_cow_check.stat.exists == False
@@ -281,7 +281,7 @@
 - name: assert install network msi with arguments
   assert:
     that:
-    - install_network_msi_argument|changed
+    - install_network_msi_argument is changed
     - install_network_msi_argument.reboot_required == False
     - install_network_msi_argument.rc == 0
     - install_network_msi_argument_moo.stat.exists == False
@@ -300,7 +300,7 @@
 - name: assert install network msi with arguments (idempotent)
   assert:
     that:
-    - not install_network_msi_argument_again|changed
+    - install_network_msi_argument_again is not changed
 
 - name: uninstall msi after test
   win_package:
@@ -326,7 +326,7 @@
 - name: assert install network exe (check mode)
   assert:
     that:
-    - install_network_exe_check|changed
+    - install_network_exe_check is changed
     - install_network_exe_check.reboot_required == False
     - install_network_exe_actual_check.exists == False
 
@@ -348,7 +348,7 @@
 - name: assert install network exe
   assert:
     that:
-    - install_network_exe|changed
+    - install_network_exe is changed
     - install_network_exe.reboot_required == False
     - install_network_exe.rc == 0
     - install_network_exe_actual.exists == True
@@ -366,7 +366,7 @@
 - name: assert install network exe (idempotent)
   assert:
     that:
-    - not install_network_exe_idempotent|changed
+    - install_network_exe_idempotent is not changed
 
 - name: uninstall network exe (check mode)
   win_package:
@@ -386,7 +386,7 @@
 - name: assert uninstall network exe (check mode)
   assert:
     that:
-    - uninstall_network_exe_check|changed
+    - uninstall_network_exe_check is changed
     - uninstall_network_exe_check.reboot_required == False
     - uninstall_network_exe_actual_check.exists == True
 
@@ -407,7 +407,7 @@
 - name: assert uninstall network exe
   assert:
     that:
-    - uninstall_network_exe|changed
+    - uninstall_network_exe is changed
     - uninstall_network_exe.reboot_required == False
     - uninstall_network_exe.rc == 0
     - uninstall_network_exe_actual.exists == False
@@ -424,4 +424,4 @@
 - name: assert uninstall network exe (idempotent)
   assert:
     that:
-    - not uninstall_network_exe_idempotent|changed
+    - uninstall_network_exe_idempotent is not changed

--- a/test/integration/targets/win_path/tasks/main.yml
+++ b/test/integration/targets/win_path/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: Ensure output
   assert:
     that:
-    - item.0 | changed
+    - item.0 is changed
     - item.0.path_value == "C:\\" + item.0.item + "Path"
     - item.1.stdout_lines[0] == 'C:\\' + item.0.item + 'Path'
   with_together:
@@ -47,7 +47,7 @@
 - name: Ensure output
   assert:
     that:
-    - multiout | changed
+    - multiout is changed
     - multiout.path_value == "C:\\PathZ;C:\\PathA"
     - varout.stdout_lines[0] == "C:\\PathZ;C:\\PathA"
 
@@ -84,10 +84,10 @@
 - name: Ensure output
   assert:
     that:
-    - addout | changed
+    - addout is changed
     - addout.path_value == 'C:\\PathZ;C:\\NewPath;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";%SystemRoot%\stuff'
     - varout.stdout_lines[0] == ('C:\\PathZ;C:\\NewPath;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";C:\Windows\stuff')
-    - not idemout | changed
+    - idemout is not changed
     - idemout.path_value == 'C:\\PathZ;C:\\NewPath;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";%SystemRoot%\stuff'
     - idemvarout.stdout_lines[0] == ('C:\\PathZ;C:\\NewPath;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";C:\Windows\stuff')
 
@@ -116,10 +116,10 @@
 - name: Ensure output
   assert:
     that:
-    - removeout | changed
+    - removeout is changed
     - removeout.path_value == 'C:\\PathZ;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";%SystemRoot%\stuff'
     - varout.stdout_lines[0] == 'C:\\PathZ;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";C:\Windows\stuff'
-    - not idemremoveout | changed
+    - idemremoveout is not changed
     - idemremoveout.path_value == 'C:\\PathZ;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";%SystemRoot%\stuff'
     - idemvarout.stdout_lines[0] == 'C:\\PathZ;C:\\PathA;C:\\PathWithTrailingBackslash\\;"C:\Quoted;With;Semicolons";C:\Windows\stuff'
 
@@ -141,7 +141,7 @@
 - name: Ensure output
   assert:
     that:
-    - removeout | changed
+    - removeout is changed
     - removeout.path_value == "C:\\PathA"
     - varout.stdout_lines[0] == "C:\\PathA"
 
@@ -172,10 +172,10 @@
 - name: Ensure output
   assert:
     that:
-    - checkadd | changed
+    - checkadd is changed
     - checkadd.path_value == "C:\\PathA;C:\\MissingPath"
     - checkaddvarout.stdout_lines[0] == "C:\\PathA" # shouldn't have actually changed the value
-    - checkremove | changed
+    - checkremove is changed
     - checkremove.path_value == ""
     - checkremovevarout.stdout_lines[0] == "C:\\PathA" # shouldn't have actually changed the value
 

--- a/test/integration/targets/win_ping/tasks/main.yml
+++ b/test/integration/targets/win_ping/tasks/main.yml
@@ -23,8 +23,8 @@
 - name: check win_ping result
   assert:
     that:
-      - not win_ping_result|failed
-      - not win_ping_result|changed
+      - win_ping_result is not failed
+      - win_ping_result is not changed
       - win_ping_result.ping == 'pong'
 
 - name: test win_ping with data
@@ -35,8 +35,8 @@
 - name: check win_ping result with data
   assert:
     that:
-      - not win_ping_with_data_result|failed
-      - not win_ping_with_data_result|changed
+      - win_ping_with_data_result is not failed
+      - win_ping_with_data_result is not changed
       - win_ping_with_data_result.ping == '☠'
 
 - name: test win_ping.ps1 with data as complex args
@@ -47,8 +47,8 @@
 - name: check win_ping.ps1 result with data
   assert:
     that:
-      - not win_ping_ps1_result|failed
-      - not win_ping_ps1_result|changed
+      - win_ping_ps1_result is not failed
+      - win_ping_ps1_result is not changed
       - win_ping_ps1_result.ping == 'bleep'
 
 - name: test win_ping with extra args to verify that v2 module replacer escaping works as expected
@@ -77,8 +77,8 @@
 - name: check that win_ping with extra args succeeds and ignores everything except data
   assert:
     that:
-      - not win_ping_extra_args_result|failed
-      - not win_ping_extra_args_result|changed
+      - win_ping_extra_args_result is not failed
+      - win_ping_extra_args_result is not changed
       - win_ping_extra_args_result.ping == 'bloop'
 
 - name: test win_ping using data=crash so that it throws an exception
@@ -90,8 +90,8 @@
 - name: check win_ping_crash result
   assert:
     that:
-      - win_ping_crash_result|failed
-      - not win_ping_crash_result|changed
+      - win_ping_crash_result is failed
+      - win_ping_crash_result is not changed
       - "'FullyQualifiedErrorId : boom' in win_ping_crash_result.module_stderr"
 
 # TODO: fix code or tests? discrete error returns from PS are strange...
@@ -104,8 +104,8 @@
 #- name: check win_ping_throw result
 #  assert:
 #    that:
-#      - win_ping_throw_result|failed
-#      - not win_ping_throw_result|changed
+#      - win_ping_throw_result is failed
+#      - win_ping_throw_result is not changed
 #      - win_ping_throw_result.msg == 'MODULE FAILURE'
 #      - win_ping_throw_result.exception
 #      - win_ping_throw_result.error_record
@@ -118,8 +118,8 @@
 #- name: check win_ping_throw_string result
 #  assert:
 #    that:
-#      - win_ping_throw_string_result|failed
-#      - not win_ping_throw_string_result|changed
+#      - win_ping_throw_string_result is failed
+#      - win_ping_throw_string_result is not changed
 #      - win_ping_throw_string_result.msg == 'no ping for you'
 #      - win_ping_throw_string_result.exception
 #      - win_ping_throw_string_result.error_record
@@ -132,8 +132,8 @@
 #- name: check win_ping_syntax_error result
 #  assert:
 #    that:
-#      - win_ping_syntax_error_result|failed
-#      - not win_ping_syntax_error_result|changed
+#      - win_ping_syntax_error_result is failed
+#      - win_ping_syntax_error_result is not changed
 #      - win_ping_syntax_error_result.msg
 #      - win_ping_syntax_error_result.exception
 #
@@ -145,8 +145,8 @@
 #- name: check win_ping_strict_mode_error result
 #  assert:
 #    that:
-#      - win_ping_strict_mode_error_result|failed
-#      - not win_ping_strict_mode_error_result|changed
+#      - win_ping_strict_mode_error_result is failed
+#      - win_ping_strict_mode_error_result is not changed
 #      - win_ping_strict_mode_error_result.msg
 #      - win_ping_strict_mode_error_result.exception
 #
@@ -157,6 +157,6 @@
 #- name: check win_ping_set_attr_result result
 #  assert:
 #    that:
-#      - not win_ping_set_attr_result|failed
-#      - not win_ping_set_attr_result|changed
+#      - win_ping_set_attr_result is not failed
+#      - win_ping_set_attr_result is not changed
 #      - win_ping_set_attr_result.ping == 'fixed'

--- a/test/integration/targets/win_power_plan/tasks/main.yml
+++ b/test/integration/targets/win_power_plan/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: check if module fails gracefully when older than 2008r2
   win_power_plan:
     name: "high performance"
-  when: os_version.stdout_lines[0] | version_compare('6.1','lt')
+  when: os_version.stdout_lines[0]  is version('6.1','lt')
   check_mode: yes
   register: old_os_check
   failed_when: old_os_check.msg != 'The win_power_plan Ansible module is only available on Server 2008r2 (6.1) and newer'
@@ -40,7 +40,7 @@
   - name: assert setting plan (check mode)
     assert:
       that:
-      - set_plan_check|changed
+      - set_plan_check is changed
       - set_plan_check_result.stdout == 'False\r\n'
 
   #Test that setting plan and that change is applied
@@ -57,7 +57,7 @@
   - name: assert setting plan
     assert:
       that:
-      - set_plan|changed
+      - set_plan is changed
       - set_plan_result.stdout == 'True\r\n'
 
   #Test that plan doesn't apply change if it is already set
@@ -69,9 +69,9 @@
   - name: assert setting plan (idempotent)
     assert:
       that:
-      - not set_plan_idempotent|changed
+      - set_plan_idempotent is not changed
 
-  when: os_version.stdout_lines[0] | version_compare('6.1','ge')
+  when: os_version.stdout_lines[0]  is version('6.1','ge')
   always:
   - name: always change back plan to high performance when done testing
     win_power_plan:

--- a/test/integration/targets/win_psmodule/tasks/test.yml
+++ b/test/integration/targets/win_psmodule/tasks/test.yml
@@ -9,7 +9,7 @@
 - name: test Powershell Gallery module setup
   assert:
     that:
-      - "module_setup|changed"
+      - "module_setup is changed"
       - "module_setup.output == 'Module {{ powershell_module }} installed'"
 
 - name: check idempotency reinstalling module
@@ -21,7 +21,7 @@
 - name: test win_psmodule idempotency
   assert:
     that:
-      - "not module_reinstall|changed"
+      - "module_reinstall is not changed"
 
 - name: check module install with allow_clobber not active
   win_psmodule:
@@ -32,7 +32,7 @@
 - name: test allow_clobber has failed
   assert:
     that:
-      - "fail_allow_clobber|failed"
+      - "fail_allow_clobber is failed"
 
 - name: check module install with allow_clobber active
   win_psmodule:
@@ -43,7 +43,7 @@
 - name: test module install with allow_clobber active
   assert:
     that:
-      - "ok_allow_clobber|changed"
+      - "ok_allow_clobber is changed"
 
 - name: check wrong module install attempt
   win_psmodule: 
@@ -55,7 +55,7 @@
 - name: test module setup fails
   assert:
     that:
-      - "module_fail|failed"
+      - "module_fail is failed"
 
 - name: check fake custom ps repository registration attempt
   win_psmodule:
@@ -68,7 +68,7 @@
 - name: test fake custom ps repository registration attempt
   assert:
     that:
-      - "repo_fail|failed"
+      - "repo_fail is failed"
 
 - name: check module is installed
   win_shell: (Get-Module -Name {{ powershell_module }} -ListAvailable).Name
@@ -97,7 +97,7 @@
 - name: test powershell module removal
   assert:
     that:
-      - "module_uninstall|changed"
+      - "module_uninstall is changed"
       - "module_uninstall.output == 'Module {{ powershell_module }} removed'"
 
 - name: check module is uninstalled
@@ -118,7 +118,7 @@
 - name: test idempotency
   assert:
     that:
-      - "not module_uninstall_2|changed"
+      - "module_uninstall_2 is not changed"
 
 - name: check removing allow_clobber module
   win_psmodule:
@@ -129,8 +129,8 @@
 - name: test removing allow_clobber module
   assert:
     that:
-      - "not module_uninstall_2|changed"
-      - "module_uninstall_3|changed"
+      - "module_uninstall_2 is not changed"
+      - "module_uninstall_3 is changed"
 
       
       

--- a/test/integration/targets/win_rabbitmq_plugin/tasks/main.yml
+++ b/test/integration/targets/win_rabbitmq_plugin/tasks/main.yml
@@ -4,4 +4,4 @@
 - include_tasks: tasks/tests.yml
   # Works on windows >= Windows 7/Windows Server 2008 R2
   # See https://github.com/ansible/ansible/pull/28118#issuecomment-323684042 for additional info.
-  when: ansible_distribution_version | version_compare('6.1', '>=')
+  when: ansible_distribution_version is version('6.1', '>=')

--- a/test/integration/targets/win_raw/tasks/main.yml
+++ b/test/integration/targets/win_raw/tasks/main.yml
@@ -26,8 +26,8 @@
       - "getmac_result.rc == 0"
       - "getmac_result.stdout"
       - "not getmac_result.stderr"
-      - "not getmac_result|failed"
-      - "getmac_result|changed"
+      - "getmac_result is not failed"
+      - "getmac_result is changed"
 
 - name: run ipconfig with /all argument
   raw: ipconfig /all
@@ -40,8 +40,8 @@
       - "ipconfig_result.stdout"
       - "'Physical Address' in ipconfig_result.stdout"
       - "not ipconfig_result.stderr"
-      - "not ipconfig_result|failed"
-      - "ipconfig_result|changed"
+      - "ipconfig_result is not failed"
+      - "ipconfig_result is changed"
 
 - name: run ipconfig with invalid argument
   raw: ipconfig /badswitch
@@ -54,8 +54,8 @@
       - "ipconfig_invalid_result.rc != 0"
       - "ipconfig_invalid_result.stdout" # ipconfig displays errors on stdout.
 #      - "not ipconfig_invalid_result.stderr"
-      - "ipconfig_invalid_result|failed"
-      - "ipconfig_invalid_result|changed"
+      - "ipconfig_invalid_result is failed"
+      - "ipconfig_invalid_result is changed"
 
 - name: run an unknown command
   raw: uname -a
@@ -68,8 +68,8 @@
       - "unknown_result.rc != 0"
       - "not unknown_result.stdout"
       - "unknown_result.stderr" # An unknown command displays error on stderr.
-      - "unknown_result|failed"
-      - "unknown_result|changed"
+      - "unknown_result is failed"
+      - "unknown_result is changed"
 
 - name: run a command that takes longer than 60 seconds
   raw: Start-Sleep -s 75
@@ -81,8 +81,8 @@
       - "sleep_command.rc == 0"
       - "not sleep_command.stdout"
       - "not sleep_command.stderr"
-      - "not sleep_command|failed"
-      - "sleep_command|changed"
+      - "sleep_command is not failed"
+      - "sleep_command is changed"
 
 - name: run a raw command with key=value arguments
   raw: echo wwe=raw
@@ -113,7 +113,7 @@
 - name: check raw + with_items result
   assert:
     that:
-      - "not raw_with_items_result|failed"
+      - "raw_with_items_result is not failed"
       - "raw_with_items_result.results|length == 32"
 
 # TODO: this test fails, since we're back to passing raw commands without modification
@@ -124,5 +124,5 @@
 #- name: check raw with job result
 #  assert:
 #    that:
-#    - raw_job_result | succeeded
+#    - raw_job_result is successful
 #    - raw_job_result.stdout_lines[0] == 'yo'

--- a/test/integration/targets/win_regedit/tasks/create_tests.yml
+++ b/test/integration/targets/win_regedit/tasks/create_tests.yml
@@ -26,7 +26,7 @@
 - name: assert create a null {{test_win_regedit_key_type}} check
   assert:
     that:
-    - null_check|changed
+    - null_check is changed
     - null_check.data_changed == False
     - null_check.data_type_changed == False
     - null_actual_check.exists == False
@@ -48,7 +48,7 @@
 - name: assert create a null {{test_win_regedit_key_type}}
   assert:
     that:
-    - null_create|changed
+    - null_create is changed
     - null_create.data_changed == False
     - null_create.data_type_changed == False
     - null_create_actual.exists == True
@@ -60,7 +60,7 @@
 - name: assert create a null {{test_win_regedit_key_type}} for dword and qword
   assert:
     that:
-    - null_create|changed
+    - null_create is changed
     - null_create.data_changed == False
     - null_create.data_type_changed == False
     - null_create_actual.exists == True
@@ -79,7 +79,7 @@
 - name: assert create a null {{test_win_regedit_key_type}} again
   assert:
     that:
-    - not null_create_again|changed
+    - null_create_again is not changed
 
 - name: create a {{test_win_regedit_key_type}} check
   win_regedit:
@@ -100,7 +100,7 @@
 - name: assert create a {{test_win_regedit_key_type}} check
   assert:
     that:
-    - data_create_check|changed
+    - data_create_check is changed
     - data_create_check.data_changed == False
     - data_create_check.data_type_changed == False
     - data_create_actual_check.exists == False
@@ -123,7 +123,7 @@
 - name: assert create a {{test_win_regedit_key_type}}
   assert:
     that:
-    - data_create|changed
+    - data_create is changed
     - data_create.data_changed == False
     - data_create.data_type_changed == False
     - data_create_actual.exists == True
@@ -142,7 +142,7 @@
 - name: assert create a {{test_win_regedit_key_type}} for dword or qword
   assert:
     that:
-    - data_create|changed
+    - data_create is changed
     - data_create.data_changed == False
     - data_create.data_type_changed == False
     - data_create_actual.exists == True
@@ -162,7 +162,7 @@
 - name: assert create a {{test_win_regedit_key_type}} again
   assert:
     that:
-    - not data_create_again|changed
+    - data_create_again is not changed
 
 - name: change existing {{test_win_regedit_key_type}} data check
   win_regedit:
@@ -183,7 +183,7 @@
 - name: assert change existing {{test_win_regedit_key_type}} data check
   assert:
     that:
-    - change_data_check|changed
+    - change_data_check is changed
     - change_data_check.data_changed == True
     - change_data_check.data_type_changed == False
     - change_data_actual_check == data_create_actual
@@ -206,7 +206,7 @@
 - name: assert change existing {{test_win_regedit_key_type}} data
   assert:
     that:
-    - change_data|changed
+    - change_data is changed
     - change_data.data_changed == True
     - change_data.data_type_changed == False
     - change_data_actual.raw_value == test_win_regedit_key_expected_value2
@@ -215,7 +215,7 @@
 - name: assert change existing {{test_win_regedit_key_type}} data for dword or qword
   assert:
     that:
-    - change_data|changed
+    - change_data is changed
     - change_data.data_changed == True
     - change_data.data_type_changed == False
     - change_data_actual.raw_value == test_win_regedit_key_expected_value2|int
@@ -233,4 +233,4 @@
 - name: assert change existing {{test_win_regedit_key_type}} data again
   assert:
     that:
-    - not change_data_again|changed
+    - change_data_again is not changed

--- a/test/integration/targets/win_regedit/tasks/tests.yml
+++ b/test/integration/targets/win_regedit/tasks/tests.yml
@@ -44,7 +44,7 @@
 - name: assert change string to binary check
   assert:
     that:
-    - change_string_binary_check|changed
+    - change_string_binary_check is changed
     - change_string_binary_check.data_changed == True
     - change_string_binary_check.data_type_changed == True
     - change_string_binary_actual_check.type == 'REG_SZ'
@@ -68,7 +68,7 @@
 - name: assert change string to binary check
   assert:
     that:
-    - change_string_binary|changed
+    - change_string_binary is changed
     - change_string_binary.data_changed == True
     - change_string_binary.data_type_changed == True
     - change_string_binary_actual.type == 'REG_BINARY'
@@ -90,7 +90,7 @@
 - name: assert modify the (Default) key property check
   assert:
     that:
-    - modify_default_check|changed
+    - modify_default_check is changed
     - modify_default_actual_check.stdout == ""
 
 - name: modify the (Default) key property
@@ -107,7 +107,7 @@
 - name: assert modify the (Default) key property
   assert:
     that:
-    - modify_default|changed
+    - modify_default is changed
     - modify_default_actual.stdout == "default value\r\n"
 
 - name: create an actual property called (Default)
@@ -131,7 +131,7 @@
 - name: assert create specific property called (Default) check
   assert:
     that:
-    - create_specific_default_check|changed
+    - create_specific_default_check is changed
     - create_specific_default_actual_default_check.stdout == "default value\r\n"
     - create_specific_default_actual_check.stdout == ""
 
@@ -155,7 +155,7 @@
 - name: assert create specific property called (Default)
   assert:
     that:
-    - create_specific_default|changed
+    - create_specific_default is changed
     - create_specific_default_actual_default.stdout == "default value\r\n"
     - create_specific_default_actual.stdout == "custom default value\r\n"
 
@@ -176,7 +176,7 @@
 - name: assert delete property check
   assert:
     that:
-    - delete_property_check|changed
+    - delete_property_check is changed
     - delete_property_actual_check.exists == True
 
 - name: delete property
@@ -195,7 +195,7 @@
 - name: assert delete property
   assert:
     that:
-    - delete_property|changed
+    - delete_property is changed
     - delete_property_actual.exists == False
 
 - name: delete property again
@@ -208,7 +208,7 @@
 - name: assert delete property again
   assert:
     that:
-    - not delete_property_again|changed
+    - delete_property_again is not changed
 
 - name: delete the key's (Default) property check
   win_regedit:
@@ -229,7 +229,7 @@
 - name: assert delete the key's (Default) property check
   assert:
     that:
-    - delete_default_check|changed
+    - delete_default_check is changed
     - delete_default_actual_check.stdout == "default value\r\n"
     - delete_default_custom_actual_check.stdout == "custom default value\r\n"
 
@@ -251,7 +251,7 @@
 - name: assert delete the key's (Default) property
   assert:
     that:
-    - delete_default|changed
+    - delete_default is changed
     - delete_default_actual.stdout == ""
     - delete_default_custom_actual.stdout == "custom default value\r\n"
 
@@ -280,7 +280,7 @@
 - name: assert delete the custom (Default) property check
   assert:
     that:
-    - delete_custom_default_check|changed
+    - delete_custom_default_check is changed
     - delete_custom_default_actual_check.stdout == "default value\r\n"
     - delete_custom_default_custom_actual_check.stdout == "custom default value\r\n"
 
@@ -303,7 +303,7 @@
 - name: assert delete the custom (Default) property
   assert:
     that:
-    - delete_custom_default|changed
+    - delete_custom_default is changed
     - delete_custom_default_actual.stdout == "default value\r\n"
     - delete_custom_default_custom_actual.stdout == ""
 
@@ -332,7 +332,7 @@
 - name: assert delete key and it's sub keys check
   assert:
     that:
-    - delete_key_check|changed
+    - delete_key_check is changed
     - delete_key_actual_check.exists
     - delete_key_actual_check.sub_keys == ["nest1", "nest2"]
 
@@ -351,7 +351,7 @@
 - name: assert delete key and it's sub keys
   assert:
     that:
-    - delete_key|changed
+    - delete_key is changed
     - delete_key_actual.exists == False
 
 - name: delete key and it's sub keys again
@@ -364,7 +364,7 @@
 - name: assert delete key and it's sub keys again
   assert:
     that:
-    - not delete_key_again|changed
+    - delete_key_again is not changed
 
 - name: create key in HKEY_CLASSES_ROOT check
   win_regedit:
@@ -384,7 +384,7 @@
 - name: assert create key in HKEY_CLASSES_ROOT check
   assert:
     that:
-    - create_hkcr_key_check|changed
+    - create_hkcr_key_check is changed
     - create_hkcr_key_actual_check.exists == False
 
 - name: create key in HKEY_CLASSES_ROOT
@@ -404,7 +404,7 @@
 - name: assert create key in HKEY_CLASSES_ROOT
   assert:
     that:
-    - create_hkcr_key|changed
+    - create_hkcr_key is changed
     - create_hkcr_key_actual.exists == True
     - create_hkcr_key_actual.properties.test is defined
 
@@ -420,7 +420,7 @@
 - name: assert create key in HKEY_CLASSES_ROOT again
   assert:
     that:
-    - not create_hkcr_key_again|changed
+    - create_hkcr_key_again is not changed
 
 # https://github.com/ansible/ansible/issues/31782
 - name: create property like a json string
@@ -441,7 +441,7 @@
 - name: assert results of create property like a json string
   assert:
     that:
-    - create_prop_with_json|changed
+    - create_prop_with_json is changed
     - create_prop_with_json_result.exists == True
     - create_prop_with_json_result.value == 'test data'
 
@@ -457,7 +457,7 @@
 - name: assert results of create property like a json string (idempotent)
   assert:
     that:
-    - not create_prop_with_json_again|changed
+    - create_prop_with_json_again is not changed
 
 - name: create new key in loaded hive (check mode)
   win_regedit:
@@ -479,7 +479,7 @@
 - name: assert result of create new key in loaded hive (check mode)
   assert:
     that:
-    - new_key_in_hive_check|changed
+    - new_key_in_hive_check is changed
     - new_key_in_hive_result_check.stdout == "False\r\n"
 
 - name: create new key in loaded hive
@@ -501,7 +501,7 @@
 - name: assert result of create new key in loaded hive
   assert:
     that:
-    - new_key_in_hive|changed
+    - new_key_in_hive is changed
     - new_key_in_hive_result.stdout == "True\r\n"
 
 - name: create new key in loaded hive (idempotent)
@@ -514,7 +514,7 @@
 - name: assert result of create new key in loaded hive (idempotent)
   assert:
     that:
-    - not new_key_in_hive_again|changed
+    - new_key_in_hive_again is not changed
 
 - name: set hive key property (check mode)
   win_regedit:
@@ -542,7 +542,7 @@
 - name: assert result of set hive key property (check mode)
   assert:
     that:
-    - new_prop_in_hive_check|changed
+    - new_prop_in_hive_check is changed
     - new_prop_in_hive_result_check.stdout == ""
 
 - name: set hive key property
@@ -570,7 +570,7 @@
 - name: assert result of set hive key property
   assert:
     that:
-    - new_prop_in_hive|changed
+    - new_prop_in_hive is changed
     - new_prop_in_hive_result.stdout == "string\r\n"
 
 - name: set hive key property (idempotent)
@@ -586,7 +586,7 @@
 - name: assert result of set hive key property (idempotent)
   assert:
     that:
-    - not new_prop_in_hive_again|changed
+    - new_prop_in_hive_again is not changed
 
 - name: remove hive key property (check mode)
   win_regedit:
@@ -612,7 +612,7 @@
 - name: assert result of remove hive key property (check mode)
   assert:
     that:
-    - remove_prop_in_hive_check|changed
+    - remove_prop_in_hive_check is changed
     - remove_prop_in_hive_result_check.stdout == "string\r\n"
 
 - name: remove hive key property
@@ -638,7 +638,7 @@
 - name: assert result of remove hive key property
   assert:
     that:
-    - remove_prop_in_hive|changed
+    - remove_prop_in_hive is changed
     - remove_prop_in_hive_result.stdout == ""
 
 - name: remove hive key property (idempotent)
@@ -652,7 +652,7 @@
 - name: assert result of set hive key property (idempotent)
   assert:
     that:
-    - not remove_prop_in_hive_again|changed
+    - remove_prop_in_hive_again is not changed
 
 - name: remove key in loaded hive (check mode)
   win_regedit:
@@ -675,7 +675,7 @@
 - name: assert result of removekey in loaded hive (check mode)
   assert:
     that:
-    - remove_key_in_hive_check|changed
+    - remove_key_in_hive_check is changed
     - remove_key_in_hive_result_check.stdout == "True\r\n"
 
 - name: remove key in loaded hive
@@ -698,7 +698,7 @@
 - name: assert result of remove key in loaded hive
   assert:
     that:
-    - remove_key_in_hive|changed
+    - remove_key_in_hive is changed
     - remove_key_in_hive_result.stdout == "False\r\n"
 
 - name: remove key in loaded hive (idempotent)
@@ -712,4 +712,4 @@
 - name: assert result of remove key in loaded hive (idempotent)
   assert:
     that:
-    - not remove_key_in_hive_again|changed
+    - remove_key_in_hive_again is not changed

--- a/test/integration/targets/win_region/tasks/main.yml
+++ b/test/integration/targets/win_region/tasks/main.yml
@@ -61,7 +61,7 @@
   assert:
     that:
     - "actual_location.stdout_lines[0] == '12'" # Corresponds to en-AU
-    - "check_location|changed"
+    - "check_location is changed"
     - "check_location.restart_required == False"
 
 - name: set location to United States
@@ -77,7 +77,7 @@
   assert:
     that:
     - "actual_location.stdout_lines[0] == '244'" # Corresponds to en-US
-    - "location|changed"
+    - "location is changed"
     - "location.restart_required == False"
 
 - name: set location to United States again
@@ -88,7 +88,7 @@
 - name: check that the result did not change
   assert:
     that:
-    - "not location_again|changed"
+    - "location_again is not changed"
     - "location_again.restart_required == False"
 
 - name: set format to English United States in check mode
@@ -105,7 +105,7 @@
   assert:
     that:
     - "actual_format.stdout_lines[0] == 'en-AU'"
-    - "check_format|changed"
+    - "check_format is changed"
     - "check_format.restart_required == False"
 
 - name: set format to English United States
@@ -121,7 +121,7 @@
   assert:
     that:
     - "actual_format.stdout_lines[0] == 'en-US'"
-    - "format|changed"
+    - "format is changed"
     - "format.restart_required == False"
 
 - name: set format to English United States again
@@ -132,7 +132,7 @@
 - name: check that the result did not change
   assert:
     that:
-    - "not format_again|changed"
+    - "format_again is not changed"
     - "format_again.restart_required == False"
 
 - name: set unicode_language to English United States in check mode
@@ -149,7 +149,7 @@
   assert:
     that:
     - "actual_unicode.stdout_lines[0] == '0c09'"
-    - "check_unicode|changed"
+    - "check_unicode is changed"
     - "check_unicode.restart_required == True"
 
 - name: set unicode_language to English United States
@@ -169,7 +169,7 @@
   assert:
     that:
     - "actual_unicode.stdout_lines[0] == '0409'" # corresponds to en-US
-    - "unicode|changed"
+    - "unicode is changed"
     - "unicode.restart_required == True"
 
 - name: set unicode_language to English United States again
@@ -180,7 +180,7 @@
 - name: check that the result did not change
   assert:
     that:
-    - "not unicode_again|changed"
+    - "unicode_again is not changed"
     - "unicode_again.restart_required == False"
 
 - name: copy settings when setting to the same format check mode
@@ -193,7 +193,7 @@
 - name: check that the result did not change in check mode
   assert:
     that:
-    - "not check_copy_same|changed"
+    - "check_copy_same is not changed"
     - "check_copy_same.restart_required == False"
 
 - name: copy settings when setting to the same format
@@ -205,7 +205,7 @@
 - name: check that the result did not change
   assert:
     that:
-    - "not copy_same|changed"
+    - "copy_same is not changed"
     - "copy_same.restart_required == False"
 
 - name: copy setting when setting to a different format
@@ -248,5 +248,5 @@
     - "actual_network.stdout_lines[0] == 'en-GB'"
     - "actual_temp.stdout_lines[0] == 'en-GB'"
     - "actual_default.stdout_lines[0] == 'en-GB'"
-    - "copy|changed"
+    - "copy is changed"
     - "copy.restart_required == False"

--- a/test/integration/targets/win_route/tasks/tests.yml
+++ b/test/integration/targets/win_route/tasks/tests.yml
@@ -14,7 +14,7 @@
 - name: test if route successfully addedd
   assert:
     that:
-      - route|changed
+      - route is changed
       - route_added.stdout_lines[0] == "{{ destination_ip_address }}"
 
 - name: add a static route to test idempotency
@@ -28,7 +28,7 @@
 - name: test idempotency
   assert:
     that:
-      - not idempotent_route|changed
+      - idempotent_route is not changed
       - idempotent_route.output == "Static route already exists"
 
 - name: remove route
@@ -44,7 +44,7 @@
 - name: test route is removed
   assert:
     that:
-      - route_removed|changed
+      - route_removed is changed
       - check_route_removed.stdout == ''
 
 - name: remove static route to test idempotency
@@ -56,7 +56,7 @@
 - name: test idempotency
   assert:
     that:
-      - not idempotent_route_removed|changed
+      - idempotent_route_removed is not changed
       - idempotent_route_removed.output == "No route to remove"
 
 - name: add route to wrong ip address
@@ -71,4 +71,4 @@
 - name: test route to wrong ip address
   assert:
     that:
-      - wrong_ip|failed
+      - wrong_ip is failed

--- a/test/integration/targets/win_scheduled_task/tasks/new_tests.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/new_tests.yml
@@ -19,7 +19,7 @@
 - name: assert results of create task (check mode)
   assert:
     that:
-    - create_task_check|changed
+    - create_task_check is changed
     - create_task_result_check.task_exists == False
 
 - name: create task
@@ -41,7 +41,7 @@
 - name: assert results of create task
   assert:
     that:
-    - create_task|changed
+    - create_task is changed
     - create_task_result.task_exists == True
     - create_task_result.actions|count == 1
     - create_task_result.actions[0].path == "cmd.exe"
@@ -63,7 +63,7 @@
 - name: assert results of create task (idempotent)
   assert:
     that:
-    - not create_task_again|changed
+    - create_task_again is not changed
 
 - name: change task (check mode)
   win_scheduled_task:
@@ -86,7 +86,7 @@
 - name: assert results of change task (check mode)
   assert:
     that:
-    - change_task_check|changed
+    - change_task_check is changed
     - change_task_result_check.actions|count == 1
     - change_task_result_check.registration_info.author == None
     - change_task_result_check.registration_info.description == "Original Description"
@@ -114,7 +114,7 @@
 - name: assert results of change task
   assert:
     that:
-    - change_task|changed
+    - change_task is changed
     - change_task_result.actions|count == 1
     - change_task_result.registration_info.author == "Cow Inc."
     - change_task_result.registration_info.description == "Test for Ansible"
@@ -136,7 +136,7 @@
 - name: assert results of change task (idempotent)
   assert:
     that:
-    - not change_task_again|changed
+    - change_task_again is not changed
 
 - name: add task action (check mode)
   win_scheduled_task:
@@ -160,7 +160,7 @@
 - name: assert results of add task action (check mode)
   assert:
     that:
-    - add_task_action_check|changed
+    - add_task_action_check is changed
     - add_task_action_result_check.actions|count == 1
     - add_task_action_result_check.actions[0].path == "cmd.exe"
     - add_task_action_result_check.actions[0].arguments == "/c echo hi"
@@ -187,7 +187,7 @@
 - name: assert results of add task action
   assert:
     that:
-    - add_task_action|changed
+    - add_task_action is changed
     - add_task_action_result.actions|count == 2
     - add_task_action_result.actions[0].path == "cmd.exe"
     - add_task_action_result.actions[0].arguments == "/c echo hi"
@@ -211,7 +211,7 @@
 - name: assert results of add task action (idempotent)
   assert:
     that:
-    - not add_task_action_again|changed
+    - add_task_action_again is not changed
 
 - name: remove task action (check mode)
   win_scheduled_task:
@@ -233,7 +233,7 @@
 - name: assert results of remove task action (check mode)
   assert:
     that:
-    - remove_task_action_check|changed
+    - remove_task_action_check is changed
     - remove_task_action_result_check.actions|count == 2
     - remove_task_action_result_check.actions[0].path == "cmd.exe"
     - remove_task_action_result_check.actions[0].arguments == "/c echo hi"
@@ -261,7 +261,7 @@
 - name: assert results of remove task action
   assert:
     that:
-    - remove_task_action|changed
+    - remove_task_action is changed
     - remove_task_action_result.actions|count == 1
     - remove_task_action_result.actions[0].path == "powershell.exe"
     - remove_task_action_result.actions[0].arguments == "-File C:\\ansible\\script.ps1"
@@ -280,7 +280,7 @@
 - name: assert results of remove task action (idempotent)
   assert:
     that:
-    - not remove_task_action_again|changed
+    - remove_task_action_again is not changed
 
 - name: remove task (check mode)
   win_scheduled_task:
@@ -298,7 +298,7 @@
 - name: assert results of remove task (check mode)
   assert:
     that:
-    - remove_task_check|changed
+    - remove_task_check is changed
     - remove_task_result_check.task_exists == True
 
 - name: remove task
@@ -316,7 +316,7 @@
 - name: assert results of remove task
   assert:
     that:
-    - remove_task|changed
+    - remove_task is changed
     - remove_task_result.task_exists == False
 
 - name: remove task (idempotent)
@@ -328,7 +328,7 @@
 - name: assert results of remove task (idempotent)
   assert:
     that:
-    - not remove_task_again|changed
+    - remove_task_again is not changed
 
 - name: create sole task in folder (check mode)
   win_scheduled_task:
@@ -348,7 +348,7 @@
 - name: assert results of create sole task in folder (check mode)
   assert:
     that:
-    - create_sole_task_check|changed
+    - create_sole_task_check is changed
     - create_sole_task_result_check.folder_exists == False
     - create_sole_task_result_check.task_exists == False
 
@@ -369,7 +369,7 @@
 - name: assert results of create sole task in folder
   assert:
     that:
-    - create_sole_task|changed
+    - create_sole_task is changed
     - create_sole_task_result.folder_exists == True
     - create_sole_task_result.task_exists == True
 
@@ -384,7 +384,7 @@
 - name: assert results of create sole task in folder (idempotent)
   assert:
     that:
-    - not create_sole_task_again|changed
+    - create_sole_task_again is not changed
 
 - name: remove sole task in folder (check mode)
   win_scheduled_task:
@@ -403,7 +403,7 @@
 - name: assert results of remove sole task in folder (check mode)
   assert:
     that:
-    - remove_sole_task_check|changed
+    - remove_sole_task_check is changed
     - remove_sole_task_result_check.folder_exists == True
     - remove_sole_task_result_check.task_exists == True
 
@@ -423,7 +423,7 @@
 - name: assert results of remove sole task in folder
   assert:
     that:
-    - remove_sole_task|changed
+    - remove_sole_task is changed
     - remove_sole_task_result.folder_exists == False
     - remove_sole_task_result.task_exists == False
 
@@ -437,4 +437,4 @@
 - name: assert results of remove sole task in folder (idempotent)
   assert:
     that:
-    - not remove_sole_task_again|changed
+    - remove_sole_task_again is not changed

--- a/test/integration/targets/win_scheduled_task/tasks/principals.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/principals.yml
@@ -29,7 +29,7 @@
 - name: assert results of task with password principal (check mode)
   assert:
     that:
-    - task_with_password_check|changed
+    - task_with_password_check is changed
     - task_with_password_result_check.task_exists == False
 
 - name: task with password principal
@@ -53,7 +53,7 @@
 - name: assert results of task with password principal
   assert:
     that:
-    - task_with_password|changed
+    - task_with_password is changed
     - task_with_password_result.task_exists == True
     - task_with_password_result.principal.group_id == None
     - task_with_password_result.principal.logon_type == "TASK_LOGON_PASSWORD"
@@ -75,7 +75,7 @@
 - name: assert results of task with password principal (idempotent)
   assert:
     that:
-    - not task_with_password_again|changed
+    - task_with_password_again is not changed
 
 - name: task with password principal force pass change
   win_scheduled_task:
@@ -92,7 +92,7 @@
 - name: assert results of task with password principal force pass change
   assert:
     that:
-    - task_with_password_force_update|changed
+    - task_with_password_force_update is changed
 
 - name: task with s4u principal (check mode)
   win_scheduled_task:
@@ -116,7 +116,7 @@
 - name: assert results of task with s4u principal (check mode)
   assert:
     that:
-    - task_with_s4u_check|changed
+    - task_with_s4u_check is changed
     - task_with_s4u_result_check.task_exists == True
     - task_with_s4u_result_check.principal.group_id == None
     - task_with_s4u_result_check.principal.logon_type == "TASK_LOGON_PASSWORD"
@@ -144,7 +144,7 @@
 - name: assert results of task with s4u principal
   assert:
     that:
-    - task_with_s4u|changed
+    - task_with_s4u is changed
     - task_with_s4u_result.task_exists == True
     - task_with_s4u_result.principal.group_id == None
     - task_with_s4u_result.principal.logon_type == "TASK_LOGON_S4U"
@@ -166,7 +166,7 @@
 - name: assert results of task with s4u principal (idempotent)
   assert:
     that:
-    - not task_with_s4u_again|changed
+    - task_with_s4u_again is not changed
 
 - name: task with interactive principal (check mode)
   win_scheduled_task:
@@ -188,7 +188,7 @@
 - name: assert results of task with interactive principal (check mode)
   assert:
     that:
-    - task_with_interactive_check|changed
+    - task_with_interactive_check is changed
     - task_with_interactive_result_check.task_exists == True
     - task_with_interactive_result_check.principal.group_id == None
     - task_with_interactive_result_check.principal.logon_type == "TASK_LOGON_S4U"
@@ -214,7 +214,7 @@
 - name: assert results of task with interactive principal
   assert:
     that:
-    - task_with_interactive|changed
+    - task_with_interactive is changed
     - task_with_interactive_result.task_exists == True
     - task_with_interactive_result.principal.group_id == None
     - task_with_interactive_result.principal.logon_type == "TASK_LOGON_INTERACTIVE_TOKEN"
@@ -234,7 +234,7 @@
 - name: assert results of task with interactive principal (idempotent)
   assert:
     that:
-    - not task_with_interactive_again|changed
+    - task_with_interactive_again is not changed
 
 - name: task with group principal (check mode)
   win_scheduled_task:
@@ -256,7 +256,7 @@
 - name: assert results of task with group principal (check mode)
   assert:
     that:
-    - task_with_group_check|changed
+    - task_with_group_check is changed
     - task_with_group_result_check.task_exists == True
     - task_with_group_result_check.principal.group_id == None
     - task_with_group_result_check.principal.logon_type == "TASK_LOGON_INTERACTIVE_TOKEN"
@@ -282,7 +282,7 @@
 - name: assert results of task with group principal
   assert:
     that:
-    - task_with_group|changed
+    - task_with_group is changed
     - task_with_group_result.task_exists == True
     - task_with_group_result.principal.group_id == "BUILTIN\\Administrators"
     - task_with_group_result.principal.logon_type == "TASK_LOGON_GROUP"
@@ -302,7 +302,7 @@
 - name: assert results of task with group principal (idempotent)
   assert:
     that:
-    - not task_with_group_again|changed
+    - task_with_group_again is not changed
 
 - name: task with service account principal (check mode)
   win_scheduled_task:
@@ -324,7 +324,7 @@
 - name: assert results of task with service account principal (check mode)
   assert:
     that:
-    - task_with_service_check|changed
+    - task_with_service_check is changed
     - task_with_service_result_check.task_exists == True
     - task_with_service_result_check.principal.group_id == "BUILTIN\\Administrators"
     - task_with_service_result_check.principal.logon_type == "TASK_LOGON_GROUP"
@@ -350,7 +350,7 @@
 - name: assert results of task with service account principal
   assert:
     that:
-    - task_with_service|changed
+    - task_with_service is changed
     - task_with_service_result.task_exists == True
     - task_with_service_result.principal.group_id == None
     - task_with_service_result.principal.logon_type == "TASK_LOGON_SERVICE_ACCOUNT"
@@ -370,7 +370,7 @@
 - name: assert results of task with service account principal (idempotent)
   assert:
     that:
-    - not task_with_service_again|changed
+    - task_with_service_again is not changed
 
 - name: task with highest privilege (check mode)
   win_scheduled_task:
@@ -393,7 +393,7 @@
 - name: assert results of task with highest privilege (check mode)
   assert:
     that:
-    - task_with_highest_privilege_check|changed
+    - task_with_highest_privilege_check is changed
     - task_with_highest_privilege_result_check.principal.run_level == "TASK_RUNLEVEL_LUA"
 
 - name: task with highest privilege
@@ -416,7 +416,7 @@
 - name: assert results of task with highest privilege
   assert:
     that:
-    - task_with_highest_privilege|changed
+    - task_with_highest_privilege is changed
     - task_with_highest_privilege_result.principal.run_level == "TASK_RUNLEVEL_HIGHEST"
 
 - name: task with highest privilege (idempotent)
@@ -433,4 +433,4 @@
 - name: assert results of task with highest privilege (idempotent)
   assert:
     that:
-    - not task_with_highest_privilege_again|changed
+    - task_with_highest_privilege_again is not changed

--- a/test/integration/targets/win_scheduled_task/tasks/tests.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/tests.yml
@@ -150,7 +150,7 @@
 - name: Test add_scheduled_task_new_path_1
   assert:
     that:
-    - add_scheduled_task_new_path_1|changed
+    - add_scheduled_task_new_path_1 is changed
 
 
 - name: Add scheduled task new path 2
@@ -162,13 +162,13 @@
 - name: Test add_scheduled_task_new_path_2 (normal mode)
   assert:
     that:
-    - add_scheduled_task_new_path_2|changed
+    - add_scheduled_task_new_path_2 is changed
   when: not in_check_mode
 
 - name: Test add_scheduled_task_new_path_2 (check-mode)
   assert:
     that:
-    - add_scheduled_task_new_path_2|changed
+    - add_scheduled_task_new_path_2 is changed
   when: in_check_mode
 
 
@@ -179,13 +179,13 @@
 - name: Test remove_scheduled_task_new_path_2 (normal mode)
   assert:
     that:
-    - remove_scheduled_task_new_path_2|changed
+    - remove_scheduled_task_new_path_2 is changed
   when: not in_check_mode
 
 - name: Test remove_scheduled_task_new_path_2 (check-mode)
   assert:
     that:
-    - not remove_scheduled_task_new_path_2|changed
+    - remove_scheduled_task_new_path_2 is not changed
   when: in_check_mode
 
 
@@ -196,13 +196,13 @@
 - name: Test remove_scheduled_task_new_path_1 (normal mode)
   assert:
     that:
-    - remove_scheduled_task_new_path_1|changed
+    - remove_scheduled_task_new_path_1 is changed
   when: not in_check_mode
 
 - name: Test remove_scheduled_task_new_path_1 (check-mode)
   assert:
     that:
-    - not remove_scheduled_task_new_path_1|changed
+    - remove_scheduled_task_new_path_1 is not changed
   when: in_check_mode
 
 

--- a/test/integration/targets/win_scheduled_task/tasks/triggers.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/triggers.yml
@@ -19,7 +19,7 @@
 - name: assert results of create boot trigger (check mode)
   assert:
     that:
-    - trigger_boot_check|changed
+    - trigger_boot_check is changed
     - trigger_boot_result_check.task_exists == False
 
 - name: create boot trigger
@@ -41,7 +41,7 @@
 - name: assert results of create boot trigger
   assert:
     that:
-    - trigger_boot|changed
+    - trigger_boot is changed
     - trigger_boot_result.task_exists == True
     - trigger_boot_result.triggers|count == 1
     - trigger_boot_result.triggers[0].type == "TASK_TRIGGER_BOOT"
@@ -62,7 +62,7 @@
 - name: assert results of create boot trigger (idempotent)
   assert:
     that:
-    - not trigger_boot_again|changed
+    - trigger_boot_again is not changed
 
 - name: create daily trigger (check mode)
   win_scheduled_task:
@@ -85,7 +85,7 @@
 - name: assert results of create daily trigger (check mode)
   assert:
     that:
-    - trigger_daily_check|changed
+    - trigger_daily_check is changed
     - trigger_daily_result_check.task_exists == True
     - trigger_daily_result_check.triggers|count == 1
     - trigger_daily_result_check.triggers[0].type == "TASK_TRIGGER_BOOT"
@@ -113,7 +113,7 @@
 - name: assert results of create daily trigger
   assert:
     that:
-    - trigger_daily|changed
+    - trigger_daily is changed
     - trigger_daily_result.task_exists == True
     - trigger_daily_result.triggers|count == 1
     - trigger_daily_result.triggers[0].type == "TASK_TRIGGER_DAILY"
@@ -135,7 +135,7 @@
 - name: assert results of create daily trigger (idempotent)
   assert:
     that:
-    - not trigger_daily_again|changed
+    - trigger_daily_again is not changed
 
 - name: create logon trigger (check mode)
   win_scheduled_task:
@@ -157,7 +157,7 @@
 - name: assert results of create logon trigger
   assert:
     that:
-    - trigger_logon_check|changed
+    - trigger_logon_check is changed
     - trigger_logon_result_check.task_exists == True
     - trigger_logon_result_check.triggers|count == 1
     - trigger_logon_result_check.triggers[0].type == "TASK_TRIGGER_DAILY"
@@ -184,7 +184,7 @@
 - name: assert results of create logon trigger
   assert:
     that:
-    - trigger_logon|changed
+    - trigger_logon is changed
     - trigger_logon_result.task_exists == True
     - trigger_logon_result.triggers|count == 1
     - trigger_logon_result.triggers[0].type == "TASK_TRIGGER_LOGON"
@@ -205,7 +205,7 @@
 - name: assert results of create logon trigger (idempotent)
   assert:
     that:
-    - not trigger_logon_again|changed
+    - trigger_logon_again is not changed
 
 - name: create monthly dow trigger (check mode)
   win_scheduled_task:
@@ -230,7 +230,7 @@
 - name: assert results of create monthly dow trigger (check mode)
   assert:
     that:
-    - trigger_monthlydow_check|changed
+    - trigger_monthlydow_check is changed
     - trigger_monthlydow_result_check.task_exists == True
     - trigger_monthlydow_result_check.triggers|count == 1
     - trigger_monthlydow_result_check.triggers[0].type == "TASK_TRIGGER_LOGON"
@@ -260,7 +260,7 @@
 - name: assert results of create monthly dow trigger
   assert:
     that:
-    - trigger_monthlydow|changed
+    - trigger_monthlydow is changed
     - trigger_monthlydow_result.task_exists == True
     - trigger_monthlydow_result.triggers|count == 1
     - trigger_monthlydow_result.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
@@ -286,7 +286,7 @@
 - name: assert results of create monthly dow trigger (idempotent)
   assert:
     that:
-    - not trigger_monthlydow_again|changed
+    - trigger_monthlydow_again is not changed
 
 - name: create task with multiple triggers (check mode)
   win_scheduled_task:
@@ -318,7 +318,7 @@
 - name: assert results of create task with multiple triggers (check mode)
   assert:
     that:
-    - create_multiple_triggers_check|changed
+    - create_multiple_triggers_check is changed
     - create_multiple_triggers_result_check.task_exists == True
     - create_multiple_triggers_result_check.triggers|count == 1
     - create_multiple_triggers_result_check.triggers[0].type == "TASK_TRIGGER_MONTHLYDOW"
@@ -357,7 +357,7 @@
 - name: assert results of create task with multiple triggers
   assert:
     that:
-    - create_multiple_triggers|changed
+    - create_multiple_triggers is changed
     - create_multiple_triggers_result.task_exists == True
     - create_multiple_triggers_result.triggers|count == 2
     - create_multiple_triggers_result.triggers[0].type == "TASK_TRIGGER_MONTHLY"
@@ -396,7 +396,7 @@
 - name: assert results of create task with multiple triggers (idempotent)
   assert:
     that:
-    - not create_multiple_triggers_again|changed
+    - create_multiple_triggers_again is not changed
 
 - name: change task with multiple triggers (check mode)
   win_scheduled_task:
@@ -422,7 +422,7 @@
 - name: assert results of change task with multiple triggers (check mode)
   assert:
     that:
-    - change_multiple_triggers_check|changed
+    - change_multiple_triggers_check is changed
     - change_multiple_triggers_result_check.task_exists == True
     - change_multiple_triggers_result_check.triggers|count == 2
     - change_multiple_triggers_result_check.triggers[0].type == "TASK_TRIGGER_MONTHLY"
@@ -461,7 +461,7 @@
 - name: assert results of change task with multiple triggers
   assert:
     that:
-    - change_multiple_triggers|changed
+    - change_multiple_triggers is changed
     - change_multiple_triggers_result.task_exists == True
     - change_multiple_triggers_result.triggers|count == 2
     - change_multiple_triggers_result.triggers[0].type == "TASK_TRIGGER_WEEKLY"
@@ -491,7 +491,7 @@
 - name: assert results of change task with multiple triggers (idempotent)
   assert:
     that:
-    - not change_multiple_triggers_again|changed
+    - change_multiple_triggers_again is not changed
 
 - name: remove trigger from multiple triggers (check mode)
   win_scheduled_task:
@@ -514,7 +514,7 @@
 - name: assert results of remove trigger from multiple triggers (check mode)
   assert:
     that:
-    - remove_single_trigger_check|changed
+    - remove_single_trigger_check is changed
     - remove_single_trigger_result_check.task_exists == True
     - remove_single_trigger_result_check.triggers|count == 2
     - remove_single_trigger_result_check.triggers[0].type == "TASK_TRIGGER_WEEKLY"
@@ -547,7 +547,7 @@
 - name: assert results of remove trigger from multiple triggers
   assert:
     that:
-    - remove_single_trigger|changed
+    - remove_single_trigger is changed
     - remove_single_trigger_result.task_exists == True
     - remove_single_trigger_result.triggers|count == 1
     - remove_single_trigger_result.triggers[0].type == "TASK_TRIGGER_REGISTRATION"
@@ -569,7 +569,7 @@
 - name: assert results of remove trigger from multiple triggers (idempotent)
   assert:
     that:
-    - not remove_single_trigger_again|changed
+    - remove_single_trigger_again is not changed
 
 - name: remove all triggers (check mode)
   win_scheduled_task:
@@ -590,7 +590,7 @@
 - name: assert results of remove all triggers (check mode)
   assert:
     that:
-    - remove_triggers_check|changed
+    - remove_triggers_check is changed
     - remove_triggers_result_check.task_exists == True
     - remove_triggers_result_check.triggers|count == 1
     - remove_triggers_result_check.triggers[0].type == "TASK_TRIGGER_REGISTRATION"
@@ -616,7 +616,7 @@
 - name: assert results of remove all triggers
   assert:
     that:
-    - remove_triggers|changed
+    - remove_triggers is changed
     - remove_triggers_result.task_exists == True
     - remove_triggers_result.triggers|count == 0
 
@@ -632,4 +632,4 @@
 - name: assert results of remove all triggers (idempotent)
   assert:
     that:
-    - not remove_triggers_again|changed
+    - remove_triggers_again is not changed

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -35,8 +35,8 @@
       - "test_script_result.stdout"
       - "'Woohoo' in test_script_result.stdout"
       - "not test_script_result.stderr"
-      - "not test_script_result | failed"
-      - "test_script_result | changed"
+      - "test_script_result is not failed"
+      - "test_script_result is changed"
 
 - name: run test script that takes arguments including a unicode char
   script: test_script_with_args.ps1 /this /that /Ӧther
@@ -51,8 +51,8 @@
       - "test_script_with_args_result.stdout_lines[1] == '/that'"
       - "test_script_with_args_result.stdout_lines[2] == '/Ӧther'"
       - "not test_script_with_args_result.stderr"
-      - "not test_script_with_args_result | failed"
-      - "test_script_with_args_result | changed"
+      - "test_script_with_args_result is not failed"
+      - "test_script_with_args_result is changed"
 
 - name: run test script that takes parameters passed via splatting
   script: test_script_with_splatting.ps1 @{ This = 'this'; That = '{{ test_win_script_value }}'; Other = 'other'}
@@ -67,8 +67,8 @@
       - "test_script_with_splatting_result.stdout_lines[1] == test_win_script_value"
       - "test_script_with_splatting_result.stdout_lines[2] == 'other'"
       - "not test_script_with_splatting_result.stderr"
-      - "not test_script_with_splatting_result | failed"
-      - "test_script_with_splatting_result | changed"
+      - "test_script_with_splatting_result is not failed"
+      - "test_script_with_splatting_result is changed"
 
 - name: run test script that takes splatted parameters from a variable
   script: test_script_with_splatting.ps1 {{ test_win_script_splat }}
@@ -83,8 +83,8 @@
       - "test_script_with_splatting2_result.stdout_lines[1] == 'THAT'"
       - "test_script_with_splatting2_result.stdout_lines[2] == 'OTHER'"
       - "not test_script_with_splatting2_result.stderr"
-      - "not test_script_with_splatting2_result | failed"
-      - "test_script_with_splatting2_result | changed"
+      - "test_script_with_splatting2_result is not failed"
+      - "test_script_with_splatting2_result is changed"
 
 - name: run test script that has errors
   script: test_script_with_errors.ps1
@@ -97,8 +97,8 @@
       - "test_script_with_errors_result.rc != 0"
       - "not test_script_with_errors_result.stdout"
       - "test_script_with_errors_result.stderr"
-      - "test_script_with_errors_result | failed"
-      - "test_script_with_errors_result | changed"
+      - "test_script_with_errors_result is failed"
+      - "test_script_with_errors_result is changed"
 
 - name: cleanup test file if it exists
   raw: Remove-Item "{{ test_win_script_filename }}" -Force
@@ -116,8 +116,8 @@
       - "test_script_creates_file_result.rc == 0"
       - "not test_script_creates_file_result.stdout"
       - "not test_script_creates_file_result.stderr"
-      - "not test_script_creates_file_result | failed"
-      - "test_script_creates_file_result | changed"
+      - "test_script_creates_file_result is not failed"
+      - "test_script_creates_file_result is changed"
 
 - name: run test script that creates a file again
   script: test_script_creates_file.ps1 {{ test_win_script_filename }}
@@ -128,9 +128,9 @@
 - name: check that the script did not run since the remote file exists
   assert:
     that:
-      - "not test_script_creates_file_again_result | failed"
-      - "not test_script_creates_file_again_result | changed"
-      - "test_script_creates_file_again_result | skipped"
+      - "test_script_creates_file_again_result is not failed"
+      - "test_script_creates_file_again_result is not changed"
+      - "test_script_creates_file_again_result is skipped"
 
 - name: run test script that removes a file
   script: test_script_removes_file.ps1 {{ test_win_script_filename }}
@@ -144,8 +144,8 @@
       - "test_script_removes_file_result.rc == 0"
       - "not test_script_removes_file_result.stdout"
       - "not test_script_removes_file_result.stderr"
-      - "not test_script_removes_file_result | failed"
-      - "test_script_removes_file_result | changed"
+      - "test_script_removes_file_result is not failed"
+      - "test_script_removes_file_result is changed"
 
 - name: run test script that removes a file again
   script: test_script_removes_file.ps1 {{ test_win_script_filename }}
@@ -156,9 +156,9 @@
 - name: check that the script did not run since the remote file does not exist
   assert:
     that:
-      - "not test_script_removes_file_again_result | failed"
-      - "not test_script_removes_file_again_result | changed"
-      - "test_script_removes_file_again_result | skipped"
+      - "test_script_removes_file_again_result is not failed"
+      - "test_script_removes_file_again_result is not changed"
+      - "test_script_removes_file_again_result is skipped"
 
 # TODO: these tests fail on 2008 (not even R2) with no output. It's related to the default codepage being UTF8- if we force it back to 437, it works fine.
 # Need to figure out a sane place to do that under the new exec wrapper.
@@ -173,8 +173,8 @@
 #      - "test_batch_result.stdout"
 #      - "'batch' in test_batch_result.stdout"
 #      - "not test_batch_result.stderr"
-#      - "not test_batch_result | failed"
-#      - "test_batch_result | changed"
+#      - "test_batch_result is not failed"
+#      - "test_batch_result is changed"
 
 
 #- name: run simple batch file with .cmd extension
@@ -188,8 +188,8 @@
 #      - "test_cmd_result.stdout"
 #      - "'cmd extension' in test_cmd_result.stdout"
 #      - "not test_cmd_result.stderr"
-#      - "not test_cmd_result | failed"
-#      - "test_cmd_result | changed"
+#      - "test_cmd_result is not failed"
+#      - "test_cmd_result is changed"
 
 - name: run test script that takes a boolean parameter
   script: test_script_bool.ps1 $true
@@ -211,7 +211,7 @@
 #- name: ensure that script ran and that environment var was passed
 #  assert:
 #    that:
-#    - test_script_env_result | succeeded
+#    - test_script_env_result is successful
 #    - test_script_env_result.stdout_lines[0] == 'task'
 #
 
@@ -232,7 +232,7 @@
 - name: Assert that a change was reported but the script did not make changes
   assert:
     that:
-      - test_script_creates_file_check_mode | changed
+      - test_script_creates_file_check_mode is changed
       - not create_file_stat.stat.exists
 
 - name: Run test script that creates a file
@@ -255,5 +255,5 @@
 - name: Assert that a change was reported but the script did not make changes
   assert:
     that:
-      - test_script_removes_file_check_mode | changed
+      - test_script_removes_file_check_mode is changed
       - remove_file_stat.stat.exists

--- a/test/integration/targets/win_security_policy/tasks/tests.yml
+++ b/test/integration/targets/win_security_policy/tasks/tests.yml
@@ -32,7 +32,7 @@
 - name: assert change existing key check
   assert:
     that:
-    - change_existing_check|changed
+    - change_existing_check is changed
     - change_existing_actual_check.value == 0
 
 - name: change existing key
@@ -51,7 +51,7 @@
 - name: assert change existing key
   assert:
     that:
-    - change_existing|changed
+    - change_existing is changed
     - change_existing_actual.value == 1
 
 - name: change existing key again
@@ -64,7 +64,7 @@
 - name: assert change existing key again
   assert:
     that:
-    - not change_existing_again|changed
+    - change_existing_again is not changed
     - change_existing_again.value == 1
 
 - name: change existing key with string type
@@ -77,7 +77,7 @@
 - name: assert change existing key with string type
   assert:
     that:
-    - not change_existing_key_with_type|changed
+    - change_existing_key_with_type is not changed
     - change_existing_key_with_type.value == "1"
 
 - name: change existing string key check
@@ -97,7 +97,7 @@
 - name: assert change existing string key check
   assert:
     that:
-    - change_existing_string_check|changed
+    - change_existing_string_check is changed
     - change_existing_string_actual_check.value == "Guest"
 
 - name: change existing string key
@@ -116,7 +116,7 @@
 - name: assert change existing string key
   assert:
     that:
-    - change_existing_string|changed
+    - change_existing_string is changed
     - change_existing_string_actual.value == "New Guest"
 
 - name: change existing string key again
@@ -129,5 +129,5 @@
 - name: assert change existing string key again
   assert:
     that:
-    - not change_existing_string_again|changed
+    - change_existing_string_again is not changed
     - change_existing_string_again.value == "New Guest"

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -10,7 +10,7 @@
 - name: check that creating a new service succeeds with a change
   assert:
     that:
-    - win_service_added|changed
+    - win_service_added is changed
     - win_service_added.name == test_win_service_name
     - win_service_added.can_pause_and_continue == False
     - win_service_added.display_name == test_win_service_display_name
@@ -32,7 +32,7 @@
 - name: check win_service result with short name
   assert:
     that:
-    - not win_service_name|changed
+    - win_service_name is not changed
     - win_service_name.name == test_win_service_name
     - win_service_name.can_pause_and_continue == False
     - win_service_name.display_name == test_win_service_display_name
@@ -54,7 +54,7 @@
 - name: check win_service result with display name
   assert:
     that:
-    - not win_service_display_name|changed
+    - win_service_display_name is not changed
     - win_service_display_name.name == test_win_service_name
     - win_service_display_name.can_pause_and_continue == False
     - win_service_display_name.display_name == test_win_service_display_name
@@ -76,7 +76,7 @@
 - name: check win_service result with invalid name
   assert:
     that:
-    - not win_service_invalid|changed
+    - win_service_invalid is not changed
     - win_service_invalid.exists == False
 
 - name: test win_service module with invalid name and absent state
@@ -88,7 +88,7 @@
 - name: check win_service result with invalid name and absent state
   assert:
     that:
-    - not win_service_invalid_with_absent|changed
+    - win_service_invalid_with_absent is not changed
     - win_service_invalid_with_absent.exists == False
 
 - name: test win_service module with invalid name and startup
@@ -121,7 +121,7 @@
 - name: check that enabling the service for manual startup succeeded
   assert:
     that:
-    - win_service_manual_start_mode|changed
+    - win_service_manual_start_mode is changed
     - win_service_manual_start_mode.start_mode == 'manual'
     - win_service_manual_start_mode.state == 'stopped'
 
@@ -134,7 +134,7 @@
 - name: check that enabling service for manual startup again didn't change anything
   assert:
     that:
-    - not win_service_manual_start_mode_again|changed
+    - win_service_manual_start_mode_again is not changed
     - win_service_manual_start_mode_again.start_mode == 'manual'
     - win_service_manual_start_mode_again.state == 'stopped'
 
@@ -147,7 +147,7 @@
 - name: check that that enabling the service for delayed startup succeeded
   assert:
     that:
-    - win_service_delayed_start_mode|changed
+    - win_service_delayed_start_mode is changed
     - win_service_delayed_start_mode.start_mode == 'delayed'
     - win_service_delayed_start_mode.state == 'stopped'
 
@@ -160,7 +160,7 @@
 - name: check that enabling the service for delayed startup again no changes
   assert:
     that:
-    - not win_service_delayed_start_mode_again|changed
+    - win_service_delayed_start_mode_again is not changed
     - win_service_delayed_start_mode_again.start_mode == 'delayed'
     - win_service_delayed_start_mode_again.state == 'stopped'
 
@@ -173,7 +173,7 @@
 - name: check that enabling the service for auto startup succeeded
   assert:
     that:
-    - win_service_auto_start_mode|changed
+    - win_service_auto_start_mode is changed
     - win_service_auto_start_mode.start_mode == 'auto'
     - win_service_auto_start_mode.state == 'stopped'
 
@@ -186,7 +186,7 @@
 - name: check that enabling the service for auto startup again no changes
   assert:
     that:
-    - not win_service_auto_start_mode_again|changed
+    - win_service_auto_start_mode_again is not changed
     - win_service_auto_start_mode_again.start_mode == 'auto'
     - win_service_auto_start_mode_again.state == 'stopped'
 
@@ -199,7 +199,7 @@
 - name: check that enabling the service for delayed startup from auto succeeded
   assert:
     that:
-    - win_service_delayed_start_mode_from_auto|changed
+    - win_service_delayed_start_mode_from_auto is changed
     - win_service_delayed_start_mode_from_auto.start_mode == 'delayed'
     - win_service_delayed_start_mode_from_auto.state == 'stopped'
 
@@ -212,7 +212,7 @@
 - name: check that enabling the service for delayed startup from auto succeeded again no change
   assert:
     that:
-    - not win_service_delayed_start_mode_from_auto_again|changed
+    - win_service_delayed_start_mode_from_auto_again is not changed
     - win_service_delayed_start_mode_from_auto_again.start_mode == 'delayed'
     - win_service_delayed_start_mode_from_auto_again.state == 'stopped'
 
@@ -225,7 +225,7 @@
 - name: check that starting the service succeeds with changes
   assert:
     that:
-    - win_service_start|changed
+    - win_service_start is changed
     - win_service_start.state == 'running'
 
 - name: start the service again
@@ -237,7 +237,7 @@
 - name: check that starting the service succeeds again with no changes
   assert:
     that:
-    - not win_service_start_again|changed
+    - win_service_start_again is not changed
     - win_service_start_again.state == 'running'
 
 - name: restart the service
@@ -249,7 +249,7 @@
 - name: check that restarting the service succeeds with changes
   assert:
     that:
-    - win_service_restart|changed
+    - win_service_restart is changed
     - win_service_restart.state =='running'
 
 - name: restart the service again
@@ -261,7 +261,7 @@
 - name: check that restarting the service again succeeds with changes
   assert:
     that:
-    - win_service_restart_again|changed
+    - win_service_restart_again is changed
     - win_service_restart_again.state =='running'
 
 - name: disable the service while running
@@ -273,7 +273,7 @@
 - name: check that disabling the service succeeds, service is still running
   assert:
     that:
-    - win_service_disabled_while_running|changed
+    - win_service_disabled_while_running is changed
     - win_service_disabled_while_running.start_mode == 'disabled'
     - win_service_disabled_while_running.state == 'running'
 
@@ -286,7 +286,7 @@
 - name: check that disabling the service again succeeds, service is still running but with no changes
   assert:
     that:
-    - not win_service_disabled_while_running_again|changed
+    - win_service_disabled_while_running_again is not changed
     - win_service_disabled_while_running_again.start_mode == 'disabled'
     - win_service_disabled_while_running_again.state == 'running'
 
@@ -299,7 +299,7 @@
 - name: check that stopping the service succeeds with changes
   assert:
     that:
-    - win_service_stopped|changed
+    - win_service_stopped is changed
     - win_service_stopped.state == 'stopped'
 
 - name: stop the service again
@@ -311,7 +311,7 @@
 - name: check that stopping the service again succeeds with no changes
   assert:
     that:
-    - not win_service_stopped_again|changed
+    - win_service_stopped_again is not changed
     - win_service_stopped_again.state == 'stopped'
 
 - name: set username without password
@@ -347,7 +347,7 @@
 - name: check that the service user has been set to Network Service
   assert:
     that:
-    - win_service_change_password_network_service|changed
+    - win_service_change_password_network_service is changed
     - win_service_change_password_network_service.username == 'NT AUTHORITY\\NetworkService'
     - win_service_change_password_network_service.desktop_interact == False
 
@@ -361,7 +361,7 @@
 - name: check that the service user has been set to Network Service and nothing changed
   assert:
     that:
-    - not win_service_change_password_network_service_again|changed
+    - win_service_change_password_network_service_again is not changed
     - win_service_change_password_network_service_again.username == 'NT AUTHORITY\\NetworkService'
     - win_service_change_password_network_service_again.desktop_interact == False
 
@@ -382,7 +382,7 @@
 - name: check that the service user has been set to Local Service
   assert:
     that:
-    - win_service_change_password_local_service|changed
+    - win_service_change_password_local_service is changed
     - win_service_change_password_local_service.username == 'NT AUTHORITY\\LocalService'
     - win_service_change_password_local_service.desktop_interact == False
 
@@ -396,7 +396,7 @@
 - name: check that the service user has been set to Local Service and nothing changed
   assert:
     that:
-    - not win_service_change_password_local_service_again|changed
+    - win_service_change_password_local_service_again is not changed
     - win_service_change_password_local_service_again.username == 'NT AUTHORITY\\LocalService'
     - win_service_change_password_local_service_again.desktop_interact == False
 
@@ -410,7 +410,7 @@
 - name: check that the service user has been set to Local System
   assert:
     that:
-    - win_service_change_password_local_system|changed
+    - win_service_change_password_local_system is changed
     - win_service_change_password_local_system.username == 'LocalSystem'
     - win_service_change_password_local_system.desktop_interact == False
 
@@ -424,7 +424,7 @@
 - name: check that the service user has been set to Local System and nothing changed
   assert:
     that:
-    - not win_service_change_password_local_system_again|changed
+    - win_service_change_password_local_system_again is not changed
     - win_service_change_password_local_system_again.username == 'LocalSystem'
     - win_service_change_password_local_system_again.desktop_interact == False
 
@@ -439,7 +439,7 @@
 - name: check that the service has been set to Local System with desktop interaction
   assert:
     that:
-    - win_service_local_system_desktop|changed
+    - win_service_local_system_desktop is changed
     - win_service_local_system_desktop.username == 'LocalSystem'
     - win_service_local_system_desktop.desktop_interact == True
     
@@ -454,7 +454,7 @@
 - name: check that the service has been set to Local System with desktop interaction again
   assert:
     that:
-    - not win_service_local_system_desktop_again|changed
+    - win_service_local_system_desktop_again is not changed
     - win_service_local_system_desktop_again.username == 'LocalSystem'
     - win_service_local_system_desktop_again.desktop_interact == True
 
@@ -467,7 +467,7 @@
 - name: check that desktop interaction has been disabled
   assert:
     that:
-    - win_service_desktop_disable|changed
+    - win_service_desktop_disable is changed
     - win_service_desktop_disable.username == 'LocalSystem'
     - win_service_desktop_disable.desktop_interact == False
 
@@ -480,7 +480,7 @@
 - name: check that desktop interaction has been disabled again
   assert:
     that:
-    - not win_service_desktop_disable_again|changed
+    - win_service_desktop_disable_again is not changed
     - win_service_desktop_disable_again.username == 'LocalSystem'
     - win_service_desktop_disable_again.desktop_interact == False
 
@@ -493,7 +493,7 @@
 - name: check that desktop iteraction has been enabled
   assert:
     that:
-    - win_service_desktop_enable|changed
+    - win_service_desktop_enable is changed
     - win_service_desktop_enable.username == 'LocalSystem'
     - win_service_desktop_enable.desktop_interact == True
 
@@ -506,7 +506,7 @@
 - name: check that desktop iteraction has been enabled again
   assert:
     that:
-    - not win_service_desktop_enable_again|changed
+    - win_service_desktop_enable_again is not changed
     - win_service_desktop_enable_again.username == 'LocalSystem'
     - win_service_desktop_enable_again.desktop_interact == True
 
@@ -520,7 +520,7 @@
 - name: check that the service user has been set to current user
   assert:
     that:
-    - win_service_change_password_current_user|changed
+    - win_service_change_password_current_user is changed
     - win_service_change_password_current_user.username == '.\\{{ansible_user}}'
     - win_service_change_password_current_user.desktop_interact == False
 
@@ -534,7 +534,7 @@
 - name: check that the service user has been set to current user and nothing changed
   assert:
     that:
-    - not win_service_change_password_current_user_again|changed
+    - win_service_change_password_current_user_again is not changed
     - win_service_change_password_current_user_again.username == '.\\{{ansible_user}}'
     - win_service_change_password_current_user_again.desktop_interact == False
 
@@ -547,7 +547,7 @@
 - name: check that the service display name has been changed
   assert:
     that:
-    - win_service_display_name|changed
+    - win_service_display_name is changed
     - win_service_display_name.display_name == 'Test Service New'
 
 - name: set service display name again
@@ -559,7 +559,7 @@
 - name: check that the service display name has been changed again
   assert:
     that:
-    - not win_service_display_name_again|changed
+    - win_service_display_name_again is not changed
     - win_service_display_name_again.display_name == 'Test Service New'
 
 - name: set service description
@@ -571,7 +571,7 @@
 - name: check that the service description has been changed
   assert:
     that:
-    - win_service_description|changed
+    - win_service_description is changed
     - win_service_description.description == 'New Description'
 
 - name: set service description again
@@ -583,7 +583,7 @@
 - name: check that the service description has been changed again
   assert:
     that:
-    - not win_service_description_again|changed
+    - win_service_description_again is not changed
     - win_service_description_again.description == 'New Description'
 
 - name: set service path
@@ -595,7 +595,7 @@
 - name: check that the service path has been changed
   assert:
     that:
-    - win_service_path|changed
+    - win_service_path is changed
     - win_service_path.path == 'C:\\temp\\test.exe'
 
 - name: set service path again
@@ -607,7 +607,7 @@
 - name: check that the service path has been changed again
   assert:
     that:
-    - not win_service_path_again|changed
+    - win_service_path_again is not changed
     - win_service_path_again.path == 'C:\\temp\\test.exe'
 
 - name: create test environment variable
@@ -626,7 +626,7 @@
 - name: check that the quoted service path has been changed
   assert:
     that:
-    - win_service_env_quote_path|changed
+    - win_service_env_quote_path is changed
     - win_service_env_quote_path.path == '"C:\\temp\\test.exe"'
 
 - name: set service path with quotes and env var again
@@ -638,7 +638,7 @@
 - name: check that the quoted service path has been changed again
   assert:
     that:
-    - not win_service_env_quote_path_again|changed
+    - win_service_env_quote_path_again is not changed
     - win_service_env_quote_path_again.path == '"C:\\temp\\test.exe"'
 
 - name: revert original service path back to normal
@@ -663,7 +663,7 @@
 - name: check that the service with a dependency has been created
   assert:
     that:
-    - win_service_dependency_string|changed
+    - win_service_dependency_string is changed
     - win_service_dependency_string.dependencies == ['{{test_win_service_name}}']
 
 - name: create new dependencys service again
@@ -675,7 +675,7 @@
 - name: check that the service with a dependency has been created again
   assert:
     that:
-    - not win_service_dependency_string_again|changed
+    - win_service_dependency_string_again is not changed
     - win_service_dependency_string_again.dependencies == ['{{test_win_service_name}}']
 
 - name: add another dependency to service
@@ -688,7 +688,7 @@
 - name: check that the service with a dependency has been added
   assert:
     that:
-    - win_service_dependency_add|changed
+    - win_service_dependency_add is changed
     - win_service_dependency_add.dependencies == ['{{test_win_service_name}}', 'TestServiceParent2']
 
 - name: add another dependency to service again
@@ -701,7 +701,7 @@
 - name: check that the service with a dependency has been added again
   assert:
     that:
-    - not win_service_dependency_add_again|changed
+    - win_service_dependency_add_again is not changed
     - win_service_dependency_add_again.dependencies == ['{{test_win_service_name}}', 'TestServiceParent2']
 
 - name: remove another dependency to service
@@ -714,7 +714,7 @@
 - name: check that the service with a dependency has been remove
   assert:
     that:
-    - win_service_dependency_add|changed
+    - win_service_dependency_add is changed
     - win_service_dependency_add.dependencies == ['{{test_win_service_name}}']
 
 - name: remove another dependency to service again
@@ -727,7 +727,7 @@
 - name: check that the service with a dependency has been removed again
   assert:
     that:
-    - not win_service_dependency_add_again|changed
+    - win_service_dependency_add_again is not changed
     - win_service_dependency_add_again.dependencies == ['{{test_win_service_name}}']
 
 - name: set dependency with a list
@@ -740,7 +740,7 @@
 - name: check that the service with dependencies has been set
   assert:
     that:
-    - win_service_dependency_set_list|changed
+    - win_service_dependency_set_list is changed
     - win_service_dependency_set_list.dependencies == ['{{test_win_service_name}}', 'TestServiceParent2']
 
 - name: make sure all services are stopped, set to LocalSystem and set to auto start before next test
@@ -806,7 +806,7 @@
 - name: check that removing the service while ignoring dependencies succeeds with changes
   assert:
     that:
-    - win_service_removed|changed
+    - win_service_removed is changed
     - win_service_removed.exists == False
     - win_service_removed.description is not defined
     - win_service_removed.display_name is not defined
@@ -839,7 +839,7 @@
   - name: assert pause a service check
     assert:
       that:
-      - win_service_paused_check|changed
+      - win_service_paused_check is changed
       - win_service_paused_check.state == 'running'
 
   - name: pause a service
@@ -851,7 +851,7 @@
   - name: assert pause a service
     assert:
       that:
-      - win_service_paused|changed
+      - win_service_paused is changed
       - win_service_paused.state == 'paused'
 
   - name: pause a service again
@@ -863,7 +863,7 @@
   - name: assert pause a service again
     assert:
       that:
-      - not win_service_paused_again|changed
+      - win_service_paused_again is not changed
 
   - name: start a paused service check
     win_service:
@@ -875,7 +875,7 @@
   - name: assert start a paused service check
     assert:
       that:
-      - start_paused_service_check|changed
+      - start_paused_service_check is changed
       - start_paused_service_check.state == 'paused'
 
   - name: start a paused service
@@ -887,7 +887,7 @@
   - name: assert start a paused service
     assert:
       that:
-      - start_paused_service|changed
+      - start_paused_service is changed
       - start_paused_service.state == 'running'
 
   - name: pause service for next test
@@ -906,7 +906,7 @@
   - name: assert stop a paused service check
     assert:
       that:
-      - stop_paused_service_check|changed
+      - stop_paused_service_check is changed
       - stop_paused_service_check.state == 'paused'
 
   - name: stop a paused service
@@ -919,7 +919,7 @@
   - name: assert stop a paused service
     assert:
       that:
-      - stop_paused_service|changed
+      - stop_paused_service is changed
       - stop_paused_service.state == 'stopped'
 
   - name: fail to pause a stopped service check

--- a/test/integration/targets/win_setup/tasks/main.yml
+++ b/test/integration/targets/win_setup/tasks/main.yml
@@ -23,8 +23,8 @@
 - name: check windows setup result
   assert:
     that:
-      - "not setup_result|failed"
-      - "not setup_result|changed"
+      - "setup_result is not failed"
+      - "setup_result is not changed"
       - "setup_result.ansible_facts"
       - "setup_result.ansible_facts.ansible_os_family == 'Windows'"
       - "setup_result.ansible_facts.ansible_date_time"

--- a/test/integration/targets/win_share/tasks/tests.yml
+++ b/test/integration/targets/win_share/tasks/tests.yml
@@ -14,7 +14,7 @@
 - name: assert create share check
   assert:
     that:
-    - create_share_check|changed
+    - create_share_check is changed
     - create_share_actual_check.stdout_lines == []
 
 - name: create share
@@ -31,7 +31,7 @@
 - name: assert create share
   assert:
     that:
-    - create_share|changed
+    - create_share is changed
     - create_share_actual.stdout_lines != []
 
 - name: create share again
@@ -48,7 +48,7 @@
 - name: assert create share again
   assert:
     that:
-    - not create_share_again|changed
+    - create_share_again is not changed
     - create_share_actual_again.stdout_lines == create_share_actual.stdout_lines
 
 - name: set caching mode to Programs check
@@ -67,7 +67,7 @@
 - name: assert caching mode to Programs check
   assert:
     that:
-    - caching_mode_programs_check|changed
+    - caching_mode_programs_check is changed
     - caching_mode_programs_actual_check.stdout == "Manual\r\n"
 
 - name: set caching mode to Programs
@@ -85,7 +85,7 @@
 - name: assert caching mode to Programs
   assert:
     that:
-    - caching_mode_programs|changed
+    - caching_mode_programs is changed
     - caching_mode_programs_actual.stdout == "Programs\r\n"
 
 - name: set caching mode to Programs again
@@ -103,7 +103,7 @@
 - name: assert caching mode to Programs again
   assert:
     that:
-    - not caching_mode_programs_again|changed
+    - caching_mode_programs_again is not changed
     - caching_mode_programs_actual_again.stdout == "Programs\r\n"
 
 - name: set encryption on share check
@@ -122,7 +122,7 @@
 - name: assert set encryption on check
   assert:
     that:
-    - encrypt_on_check|changed
+    - encrypt_on_check is changed
     - encrypt_on_actual_check.stdout == "False\r\n"
 
 - name: set encryption on share
@@ -140,7 +140,7 @@
 - name: assert set encryption on
   assert:
     that:
-    - encrypt_on|changed
+    - encrypt_on is changed
     - encrypt_on_actual.stdout == "True\r\n"
 
 - name: set encryption on share again
@@ -158,7 +158,7 @@
 - name: assert set encryption on again
   assert:
     that:
-    - not encrypt_on_again|changed
+    - encrypt_on_again is not changed
     - encrypt_on_actual.stdout == "True\r\n"
 
 - name: set description check
@@ -177,7 +177,7 @@
 - name: assert change description check
   assert:
     that:
-    - change_decription_check|changed
+    - change_decription_check is changed
     - change_description_actual_check.stdout == "\r\n"
 
 - name: set description
@@ -195,7 +195,7 @@
 - name: assert change description
   assert:
     that:
-    - change_decription|changed
+    - change_decription is changed
     - change_description_actual.stdout == "description\r\n"
 
 - name: set description again
@@ -213,7 +213,7 @@
 - name: assert change description again
   assert:
     that:
-    - not change_decription_again|changed
+    - change_decription_again is not changed
     - change_description_actual_again.stdout == "description\r\n"
 
 - name: set allow list check
@@ -232,7 +232,7 @@
 - name: assert allow list check
   assert:
     that:
-    - allow_list_check|changed
+    - allow_list_check is changed
     - allow_list_actual_check.stdout == "AccessBased\r\n"
 
 - name: set allow list
@@ -250,7 +250,7 @@
 - name: assert allow list
   assert:
     that:
-    - allow_list|changed
+    - allow_list is changed
     - allow_list_actual.stdout == "Unrestricted\r\n"
 
 - name: set allow list again
@@ -268,7 +268,7 @@
 - name: assert allow list check again
   assert:
     that:
-    - not allow_list_again|changed
+    - allow_list_again is not changed
     - allow_list_actual_again.stdout == "Unrestricted\r\n"
 
 - name: set deny list check
@@ -287,7 +287,7 @@
 - name: assert deny list check
   assert:
     that:
-    - deny_list_check|changed
+    - deny_list_check is changed
     - deny_list_actual_check.stdout == "Unrestricted\r\n"
 
 - name: set deny list
@@ -305,7 +305,7 @@
 - name: assert deny list
   assert:
     that:
-    - deny_list|changed
+    - deny_list is changed
     - deny_list_actual.stdout == "AccessBased\r\n"
 
 - name: set deny list again
@@ -323,7 +323,7 @@
 - name: assert deny list again
   assert:
     that:
-    - not deny_list_again|changed
+    - deny_list_again is not changed
     - deny_list_actual_again.stdout == "AccessBased\r\n"
 
 - name: set ACLs on share check
@@ -345,7 +345,7 @@
 - name: assert set ACLs on share check
   assert:
     that:
-    - set_acl_check|changed
+    - set_acl_check is changed
     - set_acl_actual_check.stdout == "Full|Deny|Everyone\n"
 
 - name: set ACLs on share
@@ -366,7 +366,7 @@
 - name: assert set ACLs on share
   assert:
     that:
-    - set_acl|changed
+    - set_acl is changed
     - set_acl_actual.stdout_lines|length == 4
     - set_acl_actual.stdout_lines[0] == 'Full|Deny|BUILTIN\\Remote Desktop Users'
     - set_acl_actual.stdout_lines[1] == 'Read|Allow|BUILTIN\\Guests'
@@ -391,7 +391,7 @@
 - name: assert set ACLs on share again
   assert:
     that:
-    - not set_acl_again|changed
+    - set_acl_again is not changed
     - set_acl_actual_again.stdout_lines|length == 4
     - set_acl_actual_again.stdout_lines[0] == 'Full|Deny|BUILTIN\\Remote Desktop Users'
     - set_acl_actual_again.stdout_lines[1] == 'Read|Allow|BUILTIN\\Guests'
@@ -412,7 +412,7 @@
 - name: assert remove share check
   assert:
     that:
-    - remove_share_check|changed
+    - remove_share_check is changed
     - remove_share_actual_check.stdout_lines != []
 
 - name: remove share
@@ -428,7 +428,7 @@
 - name: assert remove share
   assert:
     that:
-    - remove_share|changed
+    - remove_share is changed
     - remove_share_actual.stdout_lines == []
 
 - name: remove share again
@@ -444,5 +444,5 @@
 - name: assert remove share again
   assert:
     that:
-    - not remove_share_again|changed
+    - remove_share_again is not changed
     - remove_share_actual_again.stdout_lines == []

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -5,8 +5,8 @@
 - name: validate result
   assert:
     that:
-    - shellout|success
-    - shellout|changed
+    - shellout is successful
+    - shellout is changed
     - shellout.cmd == 'Write-Output "hello from Ansible"'
     - shellout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
     - shellout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
@@ -26,8 +26,8 @@
 - name: validate result
   assert:
     that:
-    - shellout|success
-    - shellout|changed
+    - shellout is successful
+    - shellout is changed
     - shellout.cmd == 'Write-Output "hello from Ansible"; Write-Output "another line"; Write-Output "yet another line"; Write-Output "envvar was $env:taskvar"'
     - shellout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
     - shellout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
@@ -46,9 +46,9 @@
 - name: validate result
   assert:
     that:
-    - shellout|failed
+    - shellout is failed
     - shellout.failed == true # check the failure key explicitly, since failed does magic with RC
-    - shellout|changed
+    - shellout is changed
     - shellout.cmd == 'bogus_command1234'
     - shellout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
     - shellout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
@@ -65,8 +65,8 @@
 - name: validate result
   assert:
     that:
-    - shellout|success
-    - shellout|changed
+    - shellout is successful
+    - shellout is changed
     - shellout.cmd == 'Write-Error "it broke"; Write-Output "some output"'
     - shellout.delta is match('^\d:(\d){2}:(\d){2}.(\d){6}$')
     - shellout.end is match('^(\d){4}\-(\d){2}\-(\d){2} (\d){2}:(\d){2}:(\d){2}.(\d){6}$')
@@ -90,8 +90,8 @@
 - name: validate result
   assert:
     that:
-    - shellout|success
-    - shellout|changed
+    - shellout is successful
+    - shellout is changed
 
 - name: run again with creates, should skip
   win_shell: echo $null >> c:\testfile.txt
@@ -102,7 +102,7 @@
 - name: validate result
   assert:
     that:
-    - shellout|skipped
+    - shellout is skipped
     - shellout.msg is search('exists')
 
 - name: test creates with hidden system file, should skip
@@ -136,8 +136,8 @@
 - name: validate result
   assert:
     that:
-    - shellout|success
-    - shellout|changed
+    - shellout is successful
+    - shellout is changed
 
 - name: run again with removes, should skip
   win_shell: echo $null >> c:\testfile.txt
@@ -148,7 +148,7 @@
 - name: validate result
   assert:
     that:
-    - shellout|skipped
+    - shellout is skipped
     - shellout.msg is search('does not exist')
 
 - name: run something with known nonzero exit code
@@ -159,7 +159,7 @@
 - name: validate result
   assert:
     that:
-    - shellout|failed
+    - shellout is failed
     - shellout.failed == True # check the failure key explicitly, since failed does magic with RC
     - shellout.rc == 254
 
@@ -172,8 +172,8 @@
 - name: validate result
   assert:
     that:
-    - shellout|success
-    - shellout|changed
+    - shellout is successful
+    - shellout is changed
     - shellout.rc == 0
     - shellout.stdout == "line1 \r\nline2\r\n"
     - shellout.stdout_lines == ["line1 ", "line2"]
@@ -186,7 +186,7 @@
 - name: check job result
   assert:
     that:
-    - shellout | succeeded
+    - shellout is successful
     - shellout.stdout_lines[0] == 'yo'
 
 - name: interleave large writes between stdout/stderr (check for buffer consumption deadlock)
@@ -210,7 +210,7 @@
 - name: assert run stdin test
   assert:
     that:
-    - shellout|changed
+    - shellout is changed
     - shellout.rc == 0
     - shellout.stderr == ""
     - shellout.stdout == "some input\r\n"

--- a/test/integration/targets/win_shell/tasks/main.yml
+++ b/test/integration/targets/win_shell/tasks/main.yml
@@ -114,7 +114,7 @@
 - name: validate result
   assert:
     that:
-    - shellout|skipped
+    - shellout is skipped
     - shellout.msg is search('exists')
 
 - name: ensure testfile is still present

--- a/test/integration/targets/win_slurp/tasks/main.yml
+++ b/test/integration/targets/win_slurp/tasks/main.yml
@@ -25,8 +25,8 @@
     that:
       - "slurp_existing.content"
       - "slurp_existing.encoding == 'base64'"
-      - "not slurp_existing|changed"
-      - "not slurp_existing|failed"
+      - "slurp_existing is not changed"
+      - "slurp_existing is not failed"
 
 - name: test slurping a large binary file with path param and backslashes
   slurp: path="C:\Windows\explorer.exe"
@@ -38,8 +38,8 @@
     that:
       - "slurp_path_backslashes.content"
       - "slurp_path_backslashes.encoding == 'base64'"
-      - "not slurp_path_backslashes|changed"
-      - "not slurp_path_backslashes|failed"
+      - "slurp_path_backslashes is not changed"
+      - "slurp_path_backslashes is not failed"
 
 - name: test slurping a non-existent file
   slurp: src="C:/this_file_should_not_exist.txt"
@@ -49,9 +49,9 @@
 - name: check slurp missing result
   assert:
     that:
-      - "slurp_missing|failed"
+      - "slurp_missing is failed"
       - "slurp_missing.msg"
-      - "not slurp_missing|changed"
+      - "slurp_missing is not changed"
 
 - name: test slurping a directory
   slurp: src="C:/Windows"
@@ -61,9 +61,9 @@
 - name: check slurp directory result
   assert:
     that:
-      - "slurp_dir|failed"
+      - "slurp_dir is failed"
       - "slurp_dir.msg"
-      - "not slurp_dir|changed"
+      - "slurp_dir is not changed"
 
 - name: test slurp with missing argument
   action: slurp
@@ -73,6 +73,6 @@
 - name: check slurp with missing argument result
   assert:
     that:
-      - "slurp_no_args|failed"
+      - "slurp_no_args is failed"
       - "slurp_no_args.msg"
-      - "not slurp_no_args|changed"
+      - "slurp_no_args is not changed"

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -419,8 +419,8 @@
   assert: 
     that:
       - not win_stat_missing.stat.exists
-      - not win_stat_missing|failed
-      - not win_stat_missing|changed
+      - win_stat_missing is not failed
+      - win_stat_missing is not changed
 
 - name: test win_stat module without path argument
   win_stat:

--- a/test/integration/targets/win_tempfile/tasks/main.yml
+++ b/test/integration/targets/win_tempfile/tasks/main.yml
@@ -21,9 +21,9 @@
 - name: assert create temp file defaults check
   assert:
     that:
-    - create_tmp_file_defaults_check|changed
+    - create_tmp_file_defaults_check is changed
     - create_tmp_file_defaults_check.state == 'file'
-    - create_tmp_file_defaults_check.path | regex_replace('\\\\', '/') | match(temp_value + '/ansible.*')
+    - create_tmp_file_defaults_check.path | regex_replace('\\\\', '/')  is match(temp_value + '/ansible.*')
     - actual_create_tmp_file_defaults_check.stat.exists == False
 
 - name: create temp file defaults
@@ -38,9 +38,9 @@
 - name: assert create temp file defaults
   assert:
     that:
-    - create_tmp_file_defaults|changed
+    - create_tmp_file_defaults is changed
     - create_tmp_file_defaults.state == 'file'
-    - create_tmp_file_defaults.path | regex_replace('\\\\', '/') | match(temp_value + '/ansible.*')
+    - create_tmp_file_defaults.path | regex_replace('\\\\', '/')  is match(temp_value + '/ansible.*')
     - actual_create_tmp_file_defaults.stat.exists == True
     - actual_create_tmp_file_defaults.stat.isdir == False
 
@@ -56,9 +56,9 @@
 - name: assert create temp file defaults
   assert:
     that:
-    - create_tmp_file_defaults_again|changed
+    - create_tmp_file_defaults_again is changed
     - create_tmp_file_defaults_again.state == 'file'
-    - create_tmp_file_defaults_again.path | regex_replace('\\\\', '/') | match(temp_value + '/ansible.*')
+    - create_tmp_file_defaults_again.path | regex_replace('\\\\', '/')  is match(temp_value + '/ansible.*')
     - create_tmp_file_defaults_again.path != create_tmp_file_defaults.path
     - actual_create_tmp_file_defaults_again.stat.exists == True
     - actual_create_tmp_file_defaults_again.stat.isdir == False
@@ -77,9 +77,9 @@
 - name: assert create temp folder check
   assert:
     that:
-    - create_tmp_folder_check|changed
+    - create_tmp_folder_check is changed
     - create_tmp_folder_check.state == 'directory'
-    - create_tmp_folder_check.path | regex_replace('\\\\', '/') | match(temp_value + '/ansible.*')
+    - create_tmp_folder_check.path | regex_replace('\\\\', '/')  is match(temp_value + '/ansible.*')
     - actual_create_tmp_folder_check.stat.exists == False
 
 - name: create temp folder
@@ -95,9 +95,9 @@
 - name: assert create temp folder
   assert:
     that:
-    - create_tmp_folder|changed
+    - create_tmp_folder is changed
     - create_tmp_folder.state == 'directory'
-    - create_tmp_folder.path | regex_replace('\\\\', '/') | match(temp_value + '/ansible.*')
+    - create_tmp_folder.path | regex_replace('\\\\', '/')  is match(temp_value + '/ansible.*')
     - actual_create_tmp_folder.stat.exists == True
     - actual_create_tmp_folder.stat.isdir == True
 
@@ -114,9 +114,9 @@
 - name: assert create temp file with suffix
   assert:
     that:
-    - create_tmp_file_suffix|changed
+    - create_tmp_file_suffix is changed
     - create_tmp_file_suffix.state == 'file'
-    - create_tmp_file_suffix.path | regex_replace('\\\\', '/') | match(temp_value + '/ansible.*.test-suffix')
+    - create_tmp_file_suffix.path | regex_replace('\\\\', '/')  is match(temp_value + '/ansible.*.test-suffix')
     - actual_creat_tmp_file_suffix.stat.exists == True
     - actual_creat_tmp_file_suffix.stat.isdir == False
 
@@ -133,9 +133,9 @@
 - name: assert create temp file with prefix
   assert:
     that:
-    - create_tmp_file_prefix|changed
+    - create_tmp_file_prefix is changed
     - create_tmp_file_prefix.state == 'file'
-    - create_tmp_file_prefix.path | regex_replace('\\\\', '/') | match(temp_value + '/test-prefix.*')
+    - create_tmp_file_prefix.path | regex_replace('\\\\', '/')  is match(temp_value + '/test-prefix.*')
     - actual_creat_tmp_file_prefix.stat.exists == True
     - actual_creat_tmp_file_prefix.stat.isdir == False
 
@@ -161,9 +161,9 @@
 - name: assert create temp file with different path
   assert:
     that:
-    - create_tmp_file_difference_path|changed
+    - create_tmp_file_difference_path is changed
     - create_tmp_file_difference_path.state == 'file'
-    - create_tmp_file_difference_path.path | regex_replace('\\\\', '/') | match(test_tempfile_path_regex + '/ansible.*')
+    - create_tmp_file_difference_path.path | regex_replace('\\\\', '/')  is match(test_tempfile_path_regex + '/ansible.*')
     - actual_creat_tmp_file_different_path.stat.exists == True
     - actual_creat_tmp_file_different_path.stat.isdir == False
 

--- a/test/integration/targets/win_template/tasks/main.yml
+++ b/test/integration/targets/win_template/tasks/main.yml
@@ -26,7 +26,7 @@
 - name: verify that the file was marked as changed (DOS)
   assert:
     that:
-      - 'template_result|changed'
+      - 'template_result is changed'
 
 - name: fill in a basic template again (DOS)
   win_template:
@@ -37,7 +37,7 @@
 - name: verify that the template was not changed (DOS)
   assert:
     that:
-      - 'not template_result2|changed'
+      - 'template_result2 is not changed'
 
 # VERIFY DOS CONTENTS
 - name: copy known good into place (DOS)
@@ -69,7 +69,7 @@
 - name: verify that the file was marked as changed (Unix)
   assert:
     that:
-      - 'template_result|changed'
+      - 'template_result is changed'
 
 - name: fill in a basic template again (Unix)
   win_template:
@@ -81,7 +81,7 @@
 - name: verify that the template was not changed (Unix)
   assert:
     that:
-      - 'not template_result2|changed'
+      - 'template_result2 is not changed'
 
 # VERIFY UNIX CONTENTS
 - name: copy known good into place (Unix)

--- a/test/integration/targets/win_timezone/tasks/tests.yml
+++ b/test/integration/targets/win_timezone/tasks/tests.yml
@@ -18,7 +18,7 @@
 - name: Test GMT+1 timezone
   assert:
     that:
-    - romance|changed
+    - romance is changed
     - romance.previous_timezone == 'GMT Standard Time'
     - romance.timezone == 'Romance Standard Time'
   when: not in_check_mode
@@ -26,7 +26,7 @@
 - name: Test GMT+1 timezone
   assert:
     that:
-    - romance|changed
+    - romance is changed
     - romance.previous_timezone == original.timezone
     - romance.timezone == 'Romance Standard Time'
   when: in_check_mode
@@ -39,7 +39,7 @@
 - name: Test GMT+1 timezone
   assert:
     that:
-    - not romance|changed
+    - romance is not changed
     - romance.previous_timezone == 'Romance Standard Time'
     - romance.timezone == 'Romance Standard Time'
   when: not in_check_mode
@@ -47,7 +47,7 @@
 - name: Test GMT+1 timezone
   assert:
     that:
-    - romance|changed
+    - romance is changed
     - romance.previous_timezone == original.timezone
     - romance.timezone == 'Romance Standard Time'
   when: in_check_mode
@@ -60,7 +60,7 @@
 - name: Test GMT-6 timezone
   assert:
     that:
-    - central|changed
+    - central is changed
     - central.previous_timezone == 'Romance Standard Time'
     - central.timezone == 'Central Standard Time'
   when: not in_check_mode
@@ -68,7 +68,7 @@
 - name: Test GMT+1 timezone
   assert:
     that:
-    - central|changed
+    - central is changed
     - central.previous_timezone == original.timezone
     - central.timezone == 'Central Standard Time'
   when: in_check_mode
@@ -82,7 +82,7 @@
 - name: Test GMT+666 timezone
   assert:
     that:
-    - dag|failed
+    - dag is failed
 
 - name: Restore original timezone
   win_timezone:

--- a/test/integration/targets/win_toast/tasks/tests.yml
+++ b/test/integration/targets/win_toast/tasks/tests.yml
@@ -8,7 +8,7 @@
 - name: Test msg_result when can_toast is true (normal mode, users)
   assert:
     that:
-    - not msg_result|failed
+    - msg_result is not failed
     - msg_result.time_taken > 10
   when: 
     - can_toast == True
@@ -18,7 +18,7 @@
 - name: Test msg_result when can_toast is true (normal mode, no users)
   assert:
     that:
-    - not msg_result|failed
+    - msg_result is not failed
     - msg_result.time_taken > 0.1
     - msg_result.toast_sent == False
   when: 
@@ -29,7 +29,7 @@
 - name: Test msg_result when can_toast is true (check mode, users)
   assert:
     that:
-    - not msg_result|failed
+    - msg_result is not failed
     - msg_result.time_taken > 0.1
   when: 
     - can_toast == True
@@ -38,7 +38,7 @@
 - name: Test msg_result when can_toast is true (check mode, no users)
   assert:
     that:
-    - not msg_result|failed
+    - msg_result is not failed
     - msg_result.time_taken > 0.1
     - msg_result.toast_sent == False
   when: 
@@ -49,7 +49,7 @@
 - name: Test msg_result when can_toast is false
   assert:
     that:
-    - msg_result|failed
+    - msg_result is failed
   when: can_toast == False
 
 - name: Warn user again
@@ -62,7 +62,7 @@
 - name: Test msg_result2 when can_toast is true (normal mode, users)
   assert:
     that:
-    - not msg_result2|failed
+    - msg_result2 is not failed
     - msg_result2.time_taken > 10
   when: 
     - can_toast == True
@@ -72,7 +72,7 @@
 - name: Test msg_result2 when can_toast is true (normal mode, no users)
   assert:
     that:
-    - not msg_result2|failed
+    - msg_result2 is not failed
     - msg_result2.time_taken > 0.1
   when: 
     - can_toast == True
@@ -82,7 +82,7 @@
 - name: Test msg_result2 when can_toast is true (check mode, users)
   assert:
     that:
-    - not msg_result2|failed
+    - msg_result2 is not failed
     - msg_result2.time_taken > 0.1
   when: 
     - can_toast == True
@@ -92,7 +92,7 @@
 - name: Test msg_result2 when can_toast is true (check mode, no users)
   assert:
     that:
-    - not msg_result2|failed
+    - msg_result2 is not failed
     - msg_result2.time_taken > 0.1
   when: 
     - can_toast == True
@@ -102,5 +102,5 @@
 - name: Test msg_result2 when can_toast is false
   assert:
     that:
-    - msg_result2|failed
+    - msg_result2 is failed
   when: can_toast == False

--- a/test/integration/targets/win_unzip/tasks/tests.yml
+++ b/test/integration/targets/win_unzip/tasks/tests.yml
@@ -12,7 +12,7 @@
 - name: Test unzip_archive (check-mode)
   assert:
     that:
-    - unzip_archive|changed == true
+    - unzip_archive is changed == true
     - unzip_archive.removed == false
     - unzip_archive_file.stat.exists == false
   when: in_check_mode
@@ -20,7 +20,7 @@
 - name: Test unzip_archive (normal mode)
   assert:
     that:
-    - unzip_archive|changed == true
+    - unzip_archive is changed == true
     - unzip_archive.removed == false
     - unzip_archive_file.stat.exists == true
   when: not in_check_mode
@@ -36,14 +36,14 @@
 - name: Test unzip_archive_again_creates (normal mode)
   assert:
     that:
-    - unzip_archive_again_creates|changed == false
+    - unzip_archive_again_creates is changed == false
     - unzip_archive_again_creates.removed == false
   when: not in_check_mode
 
 - name: Test unzip_archive_again_creates (check-mode)
   assert:
     that:
-    - unzip_archive_again_creates|changed == true
+    - unzip_archive_again_creates is changed == true
     - unzip_archive_again_creates.removed == false
   when: in_check_mode
 
@@ -59,7 +59,7 @@
 - name: Test unzip_archive_again
   assert:
     that:
-    - unzip_archive_again|changed == true
+    - unzip_archive_again is changed == true
     - unzip_archive_again.removed == true
 
 

--- a/test/integration/targets/win_user/tasks/main.yml
+++ b/test/integration/targets/win_user/tasks/main.yml
@@ -33,7 +33,7 @@
 - name: check user removal result again
   assert:
     that:
-      - "not win_user_remove_result_again|changed"
+      - "win_user_remove_result_again is not changed"
       - "win_user_remove_result_again.name"
       - "win_user_remove_result_again.msg"
       - "win_user_remove_result.state == 'absent'"
@@ -45,7 +45,7 @@
 - name: check missing query result
   assert:
     that:
-      - "not win_user_missing_query_result|changed"
+      - "win_user_missing_query_result is not changed"
       - "win_user_missing_query_result.name"
       - "win_user_missing_query_result.msg"
       - "win_user_missing_query_result.state == 'absent'"
@@ -57,7 +57,7 @@
 - name: check user creation result
   assert:
     that:
-      - "win_user_create_result|changed"
+      - "win_user_create_result is changed"
       - "win_user_create_result.name == '{{ test_win_user_name }}'"
       - "win_user_create_result.fullname == 'Test User'"
       - "win_user_create_result.description == 'Test user account'"
@@ -71,7 +71,7 @@
 - name: check full name and description update result
   assert:
     that:
-      - "win_user_update_result|changed"
+      - "win_user_update_result is changed"
       - "win_user_update_result.fullname == 'Test Ansible User'"
       - "win_user_update_result.description == 'Test user account created by Ansible'"
 
@@ -82,7 +82,7 @@
 - name: check full name and description result again
   assert:
     that:
-      - "not win_user_update_result_again|changed"
+      - "win_user_update_result_again is not changed"
       - "win_user_update_result_again.fullname == 'Test Ansible User'"
       - "win_user_update_result_again.description == 'Test user account created by Ansible'"
 
@@ -93,7 +93,7 @@
 - name: check no changes result
   assert:
     that:
-      - "not win_user_nochange_result|changed"
+      - "win_user_nochange_result is not changed"
 
 - name: test again with query state
   win_user: name="{{ test_win_user_name }}" state="query"
@@ -102,7 +102,7 @@
 - name: check query result
   assert:
     that:
-      - "not win_user_query_result|changed"
+      - "win_user_query_result is not changed"
       - "win_user_query_result.state == 'present'"
       - "win_user_query_result.name == '{{ test_win_user_name }}'"
       - "win_user_query_result.fullname == 'Test Ansible User'"
@@ -118,7 +118,7 @@
 - name: check password change result
   assert:
     that:
-      - "win_user_password_result|changed"
+      - "win_user_password_result is changed"
 
 - name: change user password again to same value
   win_user: name="{{ test_win_user_name }}" password="{{ test_win_user_password2 }}"
@@ -127,7 +127,7 @@
 - name: check password change result again
   assert:
     that:
-      - "not win_user_password_result_again|changed"
+      - "win_user_password_result_again is not changed"
 
 - name: check update_password=on_create for existing user
   win_user: name="{{ test_win_user_name }}" password="ThisP@ssW0rdShouldNotBeUsed" update_password=on_create
@@ -136,7 +136,7 @@
 - name: check password change with on_create flag result
   assert:
     that:
-      - "not win_user_nopasschange_result|changed"
+      - "win_user_nopasschange_result is not changed"
 
 - name: set password expired flag
   win_user: name="{{ test_win_user_name }}" password_expired=yes
@@ -145,7 +145,7 @@
 - name: check password expired result
   assert:
     that:
-      - "win_user_password_expired_result|changed"
+      - "win_user_password_expired_result is changed"
       - "win_user_password_expired_result.password_expired"
 
 - name: set password when expired
@@ -155,7 +155,7 @@
 - name: check set password on expired result
   assert:
     that:
-      - win_user_can_set_password_on_expired|changed
+      - win_user_can_set_password_on_expired is changed
 
 - name: set password expired flag again
   win_user: name="{{ test_win_user_name }}" password_expired=yes
@@ -164,7 +164,7 @@
 - name: check password expired result
   assert:
     that:
-      - "win_user_password_expired_result|changed"
+      - "win_user_password_expired_result is changed"
       - "win_user_password_expired_result.password_expired"
 
 - name: clear password expired flag
@@ -174,7 +174,7 @@
 - name: check clear password expired result
   assert:
     that:
-      - "win_user_clear_password_expired_result|changed"
+      - "win_user_clear_password_expired_result is changed"
       - "not win_user_clear_password_expired_result.password_expired"
 
 - name: set password never expires flag
@@ -184,7 +184,7 @@
 - name: check password never expires result
   assert:
     that:
-      - "win_user_password_never_expires_result|changed"
+      - "win_user_password_never_expires_result is changed"
       - "win_user_password_never_expires_result.password_never_expires"
 
 - name: clear password never expires flag
@@ -194,7 +194,7 @@
 - name: check clear password never expires result
   assert:
     that:
-      - "win_user_clear_password_never_expires_result|changed"
+      - "win_user_clear_password_never_expires_result is changed"
       - "not win_user_clear_password_never_expires_result.password_never_expires"
 
 - name: set user cannot change password flag
@@ -204,7 +204,7 @@
 - name: check user cannot change password result
   assert:
     that:
-      - "win_user_cannot_change_password_result|changed"
+      - "win_user_cannot_change_password_result is changed"
       - "win_user_cannot_change_password_result.user_cannot_change_password"
 
 - name: clear user cannot change password flag
@@ -214,7 +214,7 @@
 - name: check clear user cannot change password result
   assert:
     that:
-      - "win_user_can_change_password_result|changed"
+      - "win_user_can_change_password_result is changed"
       - "not win_user_can_change_password_result.user_cannot_change_password"
 
 - name: set account disabled flag
@@ -224,7 +224,7 @@
 - name: check account disabled result
   assert:
     that:
-      - "win_user_account_disabled_result|changed"
+      - "win_user_account_disabled_result is changed"
       - "win_user_account_disabled_result.account_disabled"
 
 - name: set password on disabled account
@@ -234,7 +234,7 @@
 - name: check set password on disabled result
   assert:
     that:
-      - win_user_can_set_password_on_disabled|changed
+      - win_user_can_set_password_on_disabled is changed
       - win_user_can_set_password_on_disabled.account_disabled
 
 - name: clear account disabled flag
@@ -244,7 +244,7 @@
 - name: check clear account disabled result
   assert:
     that:
-      - "win_user_clear_account_disabled_result|changed"
+      - "win_user_clear_account_disabled_result is changed"
       - "not win_user_clear_account_disabled_result.account_disabled"
 
 - name: attempt to set account locked flag
@@ -255,8 +255,8 @@
 - name: verify that attempting to set account locked flag fails
   assert:
     that:
-      - "win_user_set_account_locked_result|failed"
-      - "not win_user_set_account_locked_result|changed"
+      - "win_user_set_account_locked_result is failed"
+      - "win_user_set_account_locked_result is not changed"
 
 - name: attempt to lockout test account
   script: lockout_user.ps1 "{{ test_win_user_name }}"
@@ -273,7 +273,7 @@
 - name: check clear account lockout result if account was locked
   assert:
     that:
-      - "win_user_clear_account_locked_result|changed"
+      - "win_user_clear_account_locked_result is changed"
       - "not win_user_clear_account_locked_result.account_locked"
   when: "win_user_account_locked_result.account_locked"
 
@@ -284,7 +284,7 @@
 - name: check assign user to group result
   assert:
     that:
-      - "win_user_replace_groups_result|changed"
+      - "win_user_replace_groups_result is changed"
       - "win_user_replace_groups_result.groups|length == 1"
       - "win_user_replace_groups_result.groups[0]['name'] == 'Users'"
 
@@ -297,7 +297,7 @@
 - name: check assign user to group again result
   assert:
     that:
-      - "not win_user_replace_groups_again_result|changed"
+      - "win_user_replace_groups_again_result is not changed"
 
 - name: add user to another group
   win_user: name="{{ test_win_user_name }}" groups="Power Users" groups_action="add"
@@ -306,7 +306,7 @@
 - name: check add user to another group result
   assert:
     that:
-      - "win_user_add_groups_result|changed"
+      - "win_user_add_groups_result is changed"
       - "win_user_add_groups_result.groups|length == 2"
       - "win_user_add_groups_result.groups[0]['name'] in ('Users', 'Power Users')"
       - "win_user_add_groups_result.groups[1]['name'] in ('Users', 'Power Users')"
@@ -321,7 +321,7 @@
 - name: check add user to another group again result
   assert:
     that:
-      - "not win_user_add_groups_again_result|changed"
+      - "win_user_add_groups_again_result is not changed"
 
 - name: remove user from a group
   win_user: name="{{ test_win_user_name }}" groups="Users" groups_action="remove"
@@ -330,7 +330,7 @@
 - name: check remove user from group result
   assert:
     that:
-      - "win_user_remove_groups_result|changed"
+      - "win_user_remove_groups_result is changed"
       - "win_user_remove_groups_result.groups|length == 1"
       - "win_user_remove_groups_result.groups[0]['name'] == 'Power Users'"
 
@@ -345,7 +345,7 @@
 - name: check remove user from group again result
   assert:
     that:
-      - "not win_user_remove_groups_again_result|changed"
+      - "win_user_remove_groups_again_result is not changed"
 
 - name: reassign test user to multiple groups
   win_user: name="{{ test_win_user_name }}" groups="Users, Guests" groups_action="replace"
@@ -354,7 +354,7 @@
 - name: check reassign user groups result
   assert:
     that:
-      - "win_user_reassign_groups_result|changed"
+      - "win_user_reassign_groups_result is changed"
       - "win_user_reassign_groups_result.groups|length == 2"
       - "win_user_reassign_groups_result.groups[0]['name'] in ('Users', 'Guests')"
       - "win_user_reassign_groups_result.groups[1]['name'] in ('Users', 'Guests')"
@@ -371,7 +371,7 @@
 - name: check reassign user groups again result
   assert:
     that:
-      - "not win_user_reassign_groups_again_result|changed"
+      - "win_user_reassign_groups_again_result is not changed"
 
 - name: remove user from all groups
   win_user: name="{{ test_win_user_name }}" groups=""
@@ -380,7 +380,7 @@
 - name: check remove user from all groups result
   assert:
     that:
-      - "win_user_remove_all_groups_result|changed"
+      - "win_user_remove_all_groups_result is changed"
       - "win_user_remove_all_groups_result.groups|length == 0"
 
 - name: remove user from all groups again
@@ -392,7 +392,7 @@
 - name: check remove user from all groups again result
   assert:
     that:
-      - "not win_user_remove_all_groups_again_result|changed"
+      - "win_user_remove_all_groups_again_result is not changed"
 
 - name: assign user to invalid group
   win_user: name="{{ test_win_user_name }}" groups="Userz"
@@ -402,9 +402,9 @@
 - name: check invalid group result
   assert:
     that:
-      - "win_user_invalid_group_result|failed"
+      - "win_user_invalid_group_result is failed"
       - "win_user_invalid_group_result.msg"
-      - win_user_invalid_group_result.msg | match("group 'Userz' not found")
+      - win_user_invalid_group_result.msg is match("group 'Userz' not found")
 
 - name: remove test user when finished
   win_user: name="{{ test_win_user_name }}" state="absent"
@@ -413,7 +413,7 @@
 - name: check final user removal result
   assert:
     that:
-      - "win_user_final_remove_result|changed"
+      - "win_user_final_remove_result is changed"
       - "win_user_final_remove_result.name"
       - "win_user_final_remove_result.msg"
       - "win_user_final_remove_result.state == 'absent'"
@@ -425,7 +425,7 @@
 - name: check removed query result
   assert:
     that:
-      - "not win_user_removed_query_result|changed"
+      - "win_user_removed_query_result is not changed"
       - "win_user_removed_query_result.name"
       - "win_user_removed_query_result.msg"
       - "win_user_removed_query_result.state == 'absent'"

--- a/test/integration/targets/win_user_right/tasks/tests.yml
+++ b/test/integration/targets/win_user_right/tasks/tests.yml
@@ -24,7 +24,7 @@
 - name: assert remove from empty right check
   assert:
     that:
-    - not remove_empty_right_check|changed
+    - remove_empty_right_check is not changed
     - remove_empty_right_check.added == []
     - remove_empty_right_check.removed == []
 
@@ -39,7 +39,7 @@
 - name: assert remove from empty right
   assert:
     that:
-    - not remove_empty_right|changed
+    - remove_empty_right is not changed
     - remove_empty_right.added == []
     - remove_empty_right.removed == []
 
@@ -59,7 +59,7 @@
 - name: assert set administrator check
   assert:
     that:
-    - set_administrator_check|changed
+    - set_administrator_check is changed
     - set_administrator_check.added == ["{{ansible_hostname}}\\Administrator"]
     - set_administrator_check.removed == []
     - set_administrator_actual_check.users == []
@@ -79,7 +79,7 @@
 - name: assert set administrator check
   assert:
     that:
-    - set_administrator|changed
+    - set_administrator is changed
     - set_administrator.added == ["{{ansible_hostname}}\\Administrator"]
     - set_administrator.removed == []
     - set_administrator_actual.users == ['Administrator']
@@ -94,7 +94,7 @@
 - name: assert set administrator check
   assert:
     that:
-    - not set_administrator_again|changed
+    - set_administrator_again is not changed
     - set_administrator_again.added == []
     - set_administrator_again.removed == []
 
@@ -114,7 +114,7 @@
 - name: assert remove from right check
   assert:
     that:
-    - remove_right_check|changed
+    - remove_right_check is changed
     - remove_right_check.removed == ["{{ansible_hostname}}\\Administrator"]
     - remove_right_check.added == []
     - remove_right_actual_check.users == ['Administrator']
@@ -134,7 +134,7 @@
 - name: assert remove from right
   assert:
     that:
-    - remove_right|changed
+    - remove_right is changed
     - remove_right.removed == ["{{ansible_hostname}}\\Administrator"]
     - remove_right.added == []
     - remove_right_actual.users == []
@@ -149,7 +149,7 @@
 - name: assert remove from right
   assert:
     that:
-    - not remove_right_again|changed
+    - remove_right_again is not changed
     - remove_right_again.removed == []
     - remove_right_again.added == []
 
@@ -169,7 +169,7 @@
 - name: assert add to empty right check
   assert:
     that:
-    - add_right_on_empty_check|changed
+    - add_right_on_empty_check is changed
     - add_right_on_empty_check.removed == []
     - add_right_on_empty_check.added == ["{{ansible_hostname}}\\Administrator", "BUILTIN\\Administrators"]
     - add_right_on_empty_actual_check.users == []
@@ -189,7 +189,7 @@
 - name: assert add to empty right
   assert:
     that:
-    - add_right_on_empty|changed
+    - add_right_on_empty is changed
     - add_right_on_empty.removed == []
     - add_right_on_empty.added == ["{{ansible_hostname}}\\Administrator", "BUILTIN\\Administrators"]
     - add_right_on_empty_actual.users == ["Administrator", "BUILTIN\\Administrators"]
@@ -204,7 +204,7 @@
 - name: assert add to empty right
   assert:
     that:
-    - not add_right_on_empty_again|changed
+    - add_right_on_empty_again is not changed
     - add_right_on_empty_again.removed == []
     - add_right_on_empty_again.added == []
 
@@ -224,7 +224,7 @@
 - name: assert add to existing right check
   assert:
     that:
-    - add_right_on_existing_check|changed
+    - add_right_on_existing_check is changed
     - add_right_on_existing_check.removed == []
     - add_right_on_existing_check.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
     - add_right_on_existing_actual_check.users == ["Administrator", "BUILTIN\\Administrators"]
@@ -244,7 +244,7 @@
 - name: assert add to existing right
   assert:
     that:
-    - add_right_on_existing|changed
+    - add_right_on_existing is changed
     - add_right_on_existing.removed == []
     - add_right_on_existing.added == ["BUILTIN\\Guests", "BUILTIN\\Users"]
     - add_right_on_existing_actual.users == ["Administrator", "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
@@ -259,7 +259,7 @@
 - name: assert add to existing right
   assert:
     that:
-    - not add_right_on_existing_again|changed
+    - add_right_on_existing_again is not changed
     - add_right_on_existing_again.removed == []
     - add_right_on_existing_again.added == []
 
@@ -279,7 +279,7 @@
 - name: assert remove from existing check
   assert:
     that:
-    - remove_on_existing_check|changed
+    - remove_on_existing_check is changed
     - remove_on_existing_check.removed == ["BUILTIN\\Guests", "{{ansible_hostname}}\\Administrator"]
     - remove_on_existing_check.added == []
     - remove_on_existing_actual_check.users == ["Administrator", "BUILTIN\\Administrators", "BUILTIN\\Users", "BUILTIN\\Guests"]
@@ -299,7 +299,7 @@
 - name: assert remove from existing
   assert:
     that:
-    - remove_on_existing|changed
+    - remove_on_existing is changed
     - remove_on_existing.removed == ["BUILTIN\\Guests", "{{ansible_hostname}}\\Administrator"]
     - remove_on_existing.added == []
     - remove_on_existing_actual.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
@@ -314,7 +314,7 @@
 - name: assert remove from existing again
   assert:
     that:
-    - not remove_on_existing_again|changed
+    - remove_on_existing_again is not changed
     - remove_on_existing_again.removed == []
     - remove_on_existing_again.added == []
 
@@ -334,7 +334,7 @@
 - name: assert set to existing check
   assert:
     that:
-    - set_on_existing_check|changed
+    - set_on_existing_check is changed
     - set_on_existing_check.removed == ["BUILTIN\\Users"]
     - set_on_existing_check.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
     - set_on_existing_actual_check.users == ["BUILTIN\\Administrators", "BUILTIN\\Users"]
@@ -354,7 +354,7 @@
 - name: assert set to existing
   assert:
     that:
-    - set_on_existing|changed
+    - set_on_existing is changed
     - set_on_existing.removed == ["BUILTIN\\Users"]
     - set_on_existing.added == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Backup Operators"]
     - set_on_existing_actual.users == ["NT AUTHORITY\\SYSTEM", "BUILTIN\\Administrators", "BUILTIN\\Backup Operators"]
@@ -369,6 +369,6 @@
 - name: assert set to existing
   assert:
     that:
-    - not set_on_existing_again|changed
+    - set_on_existing_again is not changed
     - set_on_existing_again.removed == []
     - set_on_existing_again.added == []

--- a/test/integration/targets/windows-paths/tasks/main.yml
+++ b/test/integration/targets/windows-paths/tasks/main.yml
@@ -43,7 +43,7 @@
 
 - assert:
     that:
-    - good_result|success
+    - good_result is successful
     - good_result.stat.attributes == 'Directory'
     - good_result.stat.exists == true
     - good_result.stat.path == good
@@ -55,7 +55,7 @@
 
 - assert:
     that:
-    - works1_result|success
+    - works1_result is successful
     - works1_result.stat.attributes == 'Directory'
     - works1_result.stat.exists == true
     - works1_result.stat.path == good
@@ -67,7 +67,7 @@
 
 - assert:
     that:
-    - works2_result|success
+    - works2_result is successful
     - works2_result.stat.attributes == 'Directory'
     - works2_result.stat.exists == true
     - works2_result.stat.path == good
@@ -79,7 +79,7 @@
 
 - assert:
     that:
-    - trailing_result|success
+    - trailing_result is successful
     - trailing_result.stat.attributes == 'Directory'
     - trailing_result.stat.exists == true
     - trailing_result.stat.path == no_quotes_single  # path is without the trailing \
@@ -139,7 +139,7 @@
 
 - assert:
     that:
-    - good_result|success
+    - good_result is successful
     - good_result.stat.attributes == 'Directory'
     - good_result.stat.exists == true
     - good_result.stat.path == good
@@ -151,7 +151,7 @@
 
 - assert:
     that:
-    - works1_result|success
+    - works1_result is successful
     - works1_result.stat.attributes == 'Directory'
     - works1_result.stat.exists == true
     - works1_result.stat.path == good
@@ -163,7 +163,7 @@
 
 - assert:
     that:
-    - works2_result|success
+    - works2_result is successful
     - works2_result.stat.attributes == 'Directory'
     - works2_result.stat.exists == true
     - works2_result.stat.path == good
@@ -175,7 +175,7 @@
 
 - assert:
     that:
-    - trailing_result|success
+    - trailing_result is successful
     - trailing_result.stat.attributes == 'Directory'
     - trailing_result.stat.exists == true
     - trailing_result.stat.path == no_quotes_single  # path is without the trailing \
@@ -188,4 +188,4 @@
 
 - assert:
     that:
-    - tab_result|failed
+    - tab_result is failed

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -112,7 +112,7 @@
 - name: verify uninstall sos
   assert:
     that:
-        - "yum_result|success"
+        - "yum_result is successful"
 
 - name: install sos with state latest in check mode
   yum: name=sos state=latest
@@ -253,7 +253,7 @@
 - name: check non-existent rpm install failed
   assert:
     that:
-    - non_existent_rpm|failed
+    - non_existent_rpm is failed
 
 # Install in installroot='/'
 - name: install sos
@@ -380,7 +380,7 @@
     that:
         - "yum_result.rc == 1"
         - "not yum_result.changed"
-        - "yum_result|failed"
+        - "yum_result is failed"
 
 - name: verify yum module outputs
   assert:
@@ -400,7 +400,7 @@
 - name: verify installation failed
   assert:
     that:
-        - "yum_result|failed"
+        - "yum_result is failed"
         - "not yum_result.changed"
 
 - name: verify yum module outputs
@@ -419,7 +419,7 @@
 - name: verify installation failed
   assert:
     that:
-        - "yum_result|failed"
+        - "yum_result is failed"
         - "not yum_result.changed"
 
 - name: verify yum module outputs
@@ -469,7 +469,7 @@
     that:
         - "yum_result.rc == 1"
         - "not yum_result.changed"
-        - "yum_result|failed"
+        - "yum_result is failed"
 
 # setup for testing installing an RPM from url
 
@@ -501,7 +501,7 @@
     that:
         - "yum_result.rc == 0"
         - "yum_result.changed"
-        - "not yum_result|failed"
+        - "yum_result is not failed"
 
 - name: verify yum module outputs
   assert:
@@ -522,7 +522,7 @@
     that:
         - "yum_result.rc == 0"
         - "not yum_result.changed"
-        - "not yum_result|failed"
+        - "yum_result is not failed"
 
 - name: verify yum module outputs
   assert:
@@ -548,7 +548,7 @@
     that:
         - "yum_result.rc == 0"
         - "yum_result.changed"
-        - "not yum_result|failed"
+        - "yum_result is not failed"
 
 - name: verify yum module outputs
   assert:

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -254,12 +254,12 @@
 - name: verify simultaneous install/remove worked
   assert:
     that:
-      - zypper_res1|success
-      - zypper_res1|changed
-      - not zypper_res1a|changed
-      - zypper_res1b|changed
-      - not zypper_res2|changed
-      - not zypper_res3|changed
+      - zypper_res1 is successful
+      - zypper_res1 is changed
+      - zypper_res1a is not changed
+      - zypper_res1b is changed
+      - zypper_res2 is not changed
+      - zypper_res3 is not changed
 
 
 - name: install and remove with state=absent
@@ -273,7 +273,7 @@
 - name: verify simultaneous install/remove failed with absent
   assert:
     that:
-      - zypper_res|failed
+      - zypper_res is failed
       - zypper_res.results[0].msg == "Can not combine '+' prefix with state=remove/absent."
 
 - name: try rm patch
@@ -282,7 +282,7 @@
   register: zypper_patch
 - assert:
     that: 
-      - zypper_patch|failed
+      - zypper_patch is failed
       - zypper_patch.msg.startswith('Can not remove patches.')
 
 - name: try rm URL
@@ -291,7 +291,7 @@
   register: zypper_rm
 - assert:
     that: 
-      - zypper_rm|failed
+      - zypper_rm is failed
       - zypper_rm.msg.startswith('Can not remove via URL.')
 
 # check for https://github.com/ansible/ansible/issues/20139
@@ -313,6 +313,6 @@
 
 - assert:
     that:
-      - zypper_result_update_cache|success
-      - zypper_result_update_cache_check|success
-      - not zypper_result_update_cache_check|changed
+      - zypper_result_update_cache is successful
+      - zypper_result_update_cache_check is successful
+      - zypper_result_update_cache_check is not changed

--- a/test/legacy/roles/cloudscale_server/tasks/main.yml
+++ b/test/legacy/roles/cloudscale_server/tasks/main.yml
@@ -9,8 +9,8 @@
 - name: Verify create server
   assert:
     that:
-      - server|success
-      - server|changed
+      - server is successful
+      - server is changed
       - server.state == 'running'
 
 - name: Test create server indempotence
@@ -23,8 +23,8 @@
 - name: Verify create server
   assert:
     that:
-      - server|success
-      - not server|changed
+      - server is successful
+      - server is not changed
       - server.state == 'running'
 
 - name: Test create server stopped
@@ -38,8 +38,8 @@
 - name: Verify create server stopped
   assert:
     that:
-      - server_stopped|success
-      - server_stopped|changed
+      - server_stopped is successful
+      - server_stopped is changed
       - server_stopped.state == 'stopped'
 
 - name: Test create server failure without required parameters
@@ -50,7 +50,7 @@
 - name: Verify create server failure without required parameters
   assert:
     that:
-      - server_failed|failed
+      - server_failed is failed
       - "'Missing required parameter' in server_failed.msg"
 
 - name: Test server stopped
@@ -61,8 +61,8 @@
 - name: Verify server stopped
   assert:
     that:
-      - server|success
-      - server|changed
+      - server is successful
+      - server is changed
       - server.state == 'stopped'
 
 - name: Test server stopped indempotence
@@ -73,8 +73,8 @@
 - name: Verify server stopped indempotence
   assert:
     that:
-      - server|success
-      - not server|changed
+      - server is successful
+      - server is not changed
       - server.state == 'stopped'
 
 - name: Test server running
@@ -85,8 +85,8 @@
 - name: Verify server running
   assert:
     that:
-      - server|success
-      - server|changed
+      - server is successful
+      - server is changed
       - server.state == 'running'
 
 - name: Test server running indempotence
@@ -97,8 +97,8 @@
 - name: Verify server running indempotence
   assert:
     that:
-      - server|success
-      - not server|changed
+      - server is successful
+      - server is not changed
       - server.state == 'running'
 
 - name: Test server deletion by name
@@ -109,8 +109,8 @@
 - name: Verify server deletion
   assert:
     that:
-      - server|success
-      - server|changed
+      - server is successful
+      - server is changed
       - server.state == 'absent'
 
 - name: Test server deletion by uuid
@@ -121,8 +121,8 @@
 - name: Verify server deletion by uuid
   assert:
     that:
-      - server_stopped|success
-      - server_stopped|changed
+      - server_stopped is successful
+      - server_stopped is changed
       - server_stopped.state == 'absent'
 
 - name: Test server deletion indempotence
@@ -133,6 +133,6 @@
 - name: Verify server deletion
   assert:
     that:
-      - server|success
-      - not server|changed
+      - server is successful
+      - server is not changed
       - server.state == 'absent'

--- a/test/legacy/roles/netscaler_cs_action/tests/nitro/target_expression.yaml
+++ b/test/legacy/roles/netscaler_cs_action/tests/nitro/target_expression.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_expression/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_action/tests/nitro/target_lb_vserver.yaml
+++ b/test/legacy/roles/netscaler_cs_action/tests/nitro/target_lb_vserver.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/target_lb_vserver/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_policy/tests/nitro/policy_domain.yaml
+++ b/test/legacy/roles/netscaler_cs_policy/tests/nitro/policy_domain.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_domain/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_policy/tests/nitro/policy_rule.yaml
+++ b/test/legacy/roles/netscaler_cs_policy/tests/nitro/policy_rule.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_rule/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_policy/tests/nitro/policy_url.yaml
+++ b/test/legacy/roles/netscaler_cs_policy/tests/nitro/policy_url.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/policy_url/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_dns.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_dns.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_dns/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_http.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_http.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_ippattern.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_ippattern.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_ippattern/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_mssql.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_mssql.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mssql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_mysql.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_mysql.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_mysql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_oracle.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_oracle.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_oracle/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_policies.yaml
+++ b/test/legacy/roles/netscaler_cs_vserver/tests/nitro/cs_vserver_policies.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/cs_vserver_policies/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_gslb_service/tests/nitro/http.yaml
+++ b/test/legacy/roles/netscaler_gslb_service/tests/nitro/http.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_gslb_site/tests/nitro/gslb_site.yaml
+++ b/test/legacy/roles/netscaler_gslb_site/tests/nitro/gslb_site.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/gslb_site/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_gslb_vserver/tests/nitro/http.yaml
+++ b/test/legacy/roles/netscaler_gslb_vserver/tests/nitro/http.yaml
@@ -5,137 +5,137 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_domainbinding.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_domainbinding.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_domainbinding.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_domainbinding.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_gslbservice_binding.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_gslbservice_binding.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_gslbservice_binding.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/update_gslbservice_binding.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_gslb_vserver/tests/nitro/sourceiphash.yaml
+++ b/test/legacy/roles/netscaler_gslb_vserver/tests/nitro/sourceiphash.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/sourceiphash/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_aac.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_aac.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_aac/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_ag.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_ag.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_ag/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_web_interface.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_web_interface.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_web_interface/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_xd_doc.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_xd_doc.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xd_doc/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_xml_service.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_citrix_xml_service.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_citrix_xml_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_diameter.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_diameter.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_diameter/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_dns.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_dns.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_dns/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_ftp.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_ftp.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ftp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_http.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_http.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_http_ecv.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_http_ecv.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_ecv/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_http_inline.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_http_inline.yaml
@@ -5,21 +5,21 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/setup.yaml"
   vars:
@@ -30,53 +30,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_http_inline/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_ldap.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_ldap.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_ldap/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_load.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_load.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_load/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_nntp.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_nntp.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_nntp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_radius.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_radius.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_radius_accounting.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_radius_accounting.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_radius_accounting/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_rtsp.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_rtsp.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_rtsp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_sip.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_sip.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_sip/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_snmp.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_snmp.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_snmp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_storefront.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_storefront.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_storefront/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_tcp.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_tcp.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_tcp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_user.yaml
+++ b/test/legacy/roles/netscaler_lb_monitor/tests/nitro/lb_monitor_user.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_monitor_user/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_any.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_any.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_any/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_dns.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_dns.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_dns/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_http.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_http.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_http/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_iphash.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_iphash.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_iphash/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_ippattern.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_ippattern.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_ippattern/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_mssql.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_mssql.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mssql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_mysql.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_mysql.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_mysql/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_oracle.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_oracle.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_oracle/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_push.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_push.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_push/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_rtspnat.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_rtspnat.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_rtspnat/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_servicegroup.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_servicegroup.yaml
@@ -5,21 +5,21 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/setup.yaml"
   vars:
@@ -30,21 +30,21 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update.yaml"
   vars:
@@ -55,21 +55,21 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update_service.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update_service.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update_service.yaml"
   vars:
@@ -80,53 +80,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_servicegroup/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_tcp.yaml
+++ b/test/legacy/roles/netscaler_lb_vserver/tests/nitro/lb_vserver_tcp.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/lb_vserver_tcp/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_server/tests/nitro/server.yaml
+++ b/test/legacy/roles/netscaler_server/tests/nitro/server.yaml
@@ -5,35 +5,35 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server/update.yaml"
   vars:
@@ -44,39 +44,39 @@
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_server/tests/nitro/server_domain.yaml
+++ b/test/legacy/roles/netscaler_server/tests/nitro/server_domain.yaml
@@ -5,35 +5,35 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/update.yaml"
   vars:
@@ -44,39 +44,39 @@
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_domain/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_server/tests/nitro/server_ipv6.yaml
+++ b/test/legacy/roles/netscaler_server/tests/nitro/server_ipv6.yaml
@@ -5,35 +5,35 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/update.yaml"
   vars:
@@ -44,39 +44,39 @@
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/server_ipv6/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_service/tests/nitro/adns_service.yaml
+++ b/test/legacy/roles/netscaler_service/tests/nitro/adns_service.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/adns_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_service/tests/nitro/http_service.yaml
+++ b/test/legacy/roles/netscaler_service/tests/nitro/http_service.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/http_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_service/tests/nitro/ssl_service.yaml
+++ b/test/legacy/roles/netscaler_service/tests/nitro/ssl_service.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/ssl_service/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_servicegroup/tests/nitro/servicegroup.yaml
+++ b/test/legacy/roles/netscaler_servicegroup/tests/nitro/servicegroup.yaml
@@ -5,81 +5,81 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_servicegroup/tests/nitro/servicegroup_monitors.yaml
+++ b/test/legacy/roles/netscaler_servicegroup/tests/nitro/servicegroup_monitors.yaml
@@ -5,109 +5,109 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/update.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/update.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/default_only.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/default_only.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/default_only.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/default_only.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/servicegroup_monitors/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/netscaler_ssl_certkey/tests/nitro/certkey.yaml
+++ b/test/legacy/roles/netscaler_ssl_certkey/tests/nitro/certkey.yaml
@@ -5,53 +5,53 @@
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/setup.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/setup.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: result|changed
+    that: result is changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/remove.yaml"
   vars:
     check_mode: yes
 
 - assert:
-    that: not result|changed
+    that: result is not changed
 
 - include: "{{ role_path }}/tests/nitro/certkey/remove.yaml"
   vars:
     check_mode: no
 
 - assert:
-    that: not result|changed
+    that: result is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/a_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/a_record.yml
@@ -15,8 +15,8 @@
 - name: "Validate: A record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '127.0.0.1'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'A'
@@ -37,8 +37,8 @@
 - name: "Validate: A record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: A record update"
   cloudflare_dns:
@@ -54,8 +54,8 @@
 - name: "Validate: A record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
 
 - name: "Test: A record duplicate (create new record)"
@@ -72,8 +72,8 @@
 - name: "Validate: A record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '127.0.1.1'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'A'
@@ -94,8 +94,8 @@
 - name: "Validate: A record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == '127.0.0.1'
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.type == 'A'
@@ -117,8 +117,8 @@
 - name: "Validate: A record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '127.0.1.1'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'A'
@@ -140,8 +140,8 @@
 - name: "Validate: A record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: A record deletion"
   cloudflare_dns:
@@ -158,8 +158,8 @@
 - name: "Validate: A record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: A record deletion succeeded"
   cloudflare_dns:
@@ -176,5 +176,5 @@
 - name: "Validate: A record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/aaaa_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/aaaa_record.yml
@@ -15,8 +15,8 @@
 - name: "Validate: AAAA record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '::1'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'AAAA'
@@ -37,8 +37,8 @@
 - name: "Validate: AAAA record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: AAAA record update"
   cloudflare_dns:
@@ -54,8 +54,8 @@
 - name: "Validate: AAAA record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
 
 - name: "Test: AAAA record duplicate (create new record)"
@@ -72,8 +72,8 @@
 - name: "Validate: AAAA record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '::2'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'AAAA'
@@ -94,8 +94,8 @@
 - name: "Validate: AAAA record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == '::1'
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.type == 'AAAA'
@@ -117,8 +117,8 @@
 - name: "Validate: AAAA record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '::2'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'AAAA'
@@ -140,8 +140,8 @@
 - name: "Validate: AAAA record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: AAAA record deletion"
   cloudflare_dns:
@@ -158,8 +158,8 @@
 - name: "Validate: AAAA record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: AAAA record deletion succeeded"
   cloudflare_dns:
@@ -176,5 +176,5 @@
 - name: "Validate: AAAA record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/cname_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/cname_record.yml
@@ -17,8 +17,8 @@
 - name: "Validate: CNAME record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == "srv1.{{ cloudflare_zone }}"
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'CNAME'
@@ -39,8 +39,8 @@
 - name: "Validate: CNAME record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: CNAME record update"
   cloudflare_dns:
@@ -56,8 +56,8 @@
 - name: "Validate: CNAME record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == "srv2.{{ cloudflare_zone }}"
       - cloudflare_dns.result.record.ttl == 300
 
@@ -76,8 +76,8 @@
 - name: "Validate: CNAME record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == "srv3.{{ cloudflare_zone }}"
       - cloudflare_dns.result.record.ttl == 600
       - cloudflare_dns.result.record.type == 'CNAME'
@@ -99,8 +99,8 @@
 - name: "Validate: CNAME record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: CNAME record deletion"
   cloudflare_dns:
@@ -117,8 +117,8 @@
 - name: "Validate: CNAME record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: CNAME record deletion succeeded"
   cloudflare_dns:
@@ -135,5 +135,5 @@
 - name: "Validate: CNAME record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/main.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: "Validate: no args"
   assert:
     that:
-      - cloudflare_dns|failed
+      - cloudflare_dns is failed
       - "cloudflare_dns.msg.find('missing required arguments: ') != -1"
 
 - name: "Test: only credentials"
@@ -20,7 +20,7 @@
 - name: "Validate: only credentials"
   assert:
     that:
-      - cloudflare_dns|failed
+      - cloudflare_dns is failed
       - "cloudflare_dns.msg.find('missing required arguments: ') != -1"
 
 - name: "Test: credentials and zone"
@@ -34,7 +34,7 @@
 - name: "Validate: credentials and zone"
   assert:
     that:
-      - cloudflare_dns|failed
+      - cloudflare_dns is failed
       - "cloudflare_dns.msg.find('but the following are missing: ') != -1"
 
 - name: "Test: credentials, zone and type"
@@ -49,7 +49,7 @@
 - name: "Validate: credentials, zone and type"
   assert:
     that:
-      - cloudflare_dns|failed
+      - cloudflare_dns is failed
       - "cloudflare_dns.msg.find('but the following are missing: ') != -1"
 
 ######## record tests #################

--- a/test/legacy/roles/test_cloudflare_dns/tasks/mx_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/mx_record.yml
@@ -16,8 +16,8 @@
 - name: "Validate: MX record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'mx1-{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.priority == 20
@@ -40,8 +40,8 @@
 - name: "Validate: MX record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: MX record update"
   cloudflare_dns:
@@ -58,8 +58,8 @@
 - name: "Validate: MX record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.priority == 10
 
@@ -78,8 +78,8 @@
 - name: "Validate: MX record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'mx2-{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.priority == 30
@@ -102,8 +102,8 @@
 - name: "Validate: MX record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == 'mx1-{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.priority == 10
@@ -127,8 +127,8 @@
 - name: "Validate: MX record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'mx2-{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.priority == 30
@@ -152,8 +152,8 @@
 - name: "Validate: MX record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: MX record deletion"
   cloudflare_dns:
@@ -171,8 +171,8 @@
 - name: "Validate: MX record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: MX record deletion succeeded"
   cloudflare_dns:
@@ -190,5 +190,5 @@
 - name: "Validate: MX record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/ns_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/ns_record.yml
@@ -17,8 +17,8 @@
 - name: "Validate: NS record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'an.si.ble'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'NS'
@@ -39,8 +39,8 @@
 - name: "Validate: NS record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: NS record update"
   cloudflare_dns:
@@ -56,8 +56,8 @@
 - name: "Validate: NS record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
 
 - name: "Test: NS record duplicate (create new record)"
@@ -74,8 +74,8 @@
 - name: "Validate: NS record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'ble.si.an'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'NS'
@@ -96,8 +96,8 @@
 - name: "Validate: NS record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == 'an.si.ble'
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.type == 'NS'
@@ -119,8 +119,8 @@
 - name: "Validate: NS record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'ble.si.an'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'NS'
@@ -142,8 +142,8 @@
 - name: "Validate: NS record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: NS record deletion"
   cloudflare_dns:
@@ -160,8 +160,8 @@
 - name: "Validate: NS record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: NS record deletion succeeded"
   cloudflare_dns:
@@ -178,5 +178,5 @@
 - name: "Validate: NS record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/spf_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/spf_record.yml
@@ -19,8 +19,8 @@
 - name: "Validate: SPF record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == "{{ txt_teststring }}"
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'SPF'
@@ -41,8 +41,8 @@
 - name: "Validate: SPF record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: SPF record update"
   cloudflare_dns:
@@ -58,8 +58,8 @@
 - name: "Validate: SPF record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
 
 - name: "Test: SPF record duplicate (create new record)"
@@ -76,8 +76,8 @@
 - name: "Validate: SPF record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'v=spf1 teststring'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'SPF'
@@ -98,8 +98,8 @@
 - name: "Validate: SPF record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == "{{ txt_teststring }}"
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.type == 'SPF'
@@ -121,8 +121,8 @@
 - name: "Validate: SPF record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'v=spf1 teststring'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'SPF'
@@ -144,8 +144,8 @@
 - name: "Validate: SPF record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: SPF record deletion"
   cloudflare_dns:
@@ -162,8 +162,8 @@
 - name: "Validate: SPF record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: SPF record deletion succeeded"
   cloudflare_dns:
@@ -180,5 +180,5 @@
 - name: "Validate: SPF record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/srv_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/srv_record.yml
@@ -20,8 +20,8 @@
 - name: "Validate: SRV record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '5\t3500\tsrv1.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.data.target == 'srv1.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
@@ -54,8 +54,8 @@
 - name: "Validate: SRV record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 # changing the following attributes creates a new record:
 #  weight
@@ -82,8 +82,8 @@
 - name: "Validate: SRV record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.data.target == 'srv1.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.data.port == 3500
@@ -112,8 +112,8 @@
 - name: "Validate: SRV record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '19\t9999\tsrv2.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.data.target == 'srv2.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
@@ -146,8 +146,8 @@
 - name: "Validate: SRV record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == '5\t3500\tsrv1.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.data.target == 'srv1.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
@@ -181,8 +181,8 @@
 - name: "Validate: SRV record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == '19\t9999\tsrv2.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.data.target == 'srv2.{{ cloudflare_dns_record  }}.{{ cloudflare_zone }}'
@@ -216,8 +216,8 @@
 - name: "Validate: SRV record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: SRV record deletion"
   cloudflare_dns:
@@ -239,8 +239,8 @@
 - name: "Validate: SRV record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: SRV record deletion succeeded"
   cloudflare_dns:
@@ -262,5 +262,5 @@
 - name: "Validate: SRV record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_cloudflare_dns/tasks/txt_record.yml
+++ b/test/legacy/roles/test_cloudflare_dns/tasks/txt_record.yml
@@ -19,8 +19,8 @@
 - name: "Validate: TXT record creation"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == "{{ txt_teststring }}"
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'TXT'
@@ -41,8 +41,8 @@
 - name: "Validate: TXT record idempotency"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: TXT record update"
   cloudflare_dns:
@@ -58,8 +58,8 @@
 - name: "Validate: TXT record update"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.ttl == 300
 
 - name: "Test: TXT record duplicate (create new record)"
@@ -76,8 +76,8 @@
 - name: "Validate: TXT record duplicate (create new record)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'teststring'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'TXT'
@@ -98,8 +98,8 @@
 - name: "Validate: TXT record duplicate (old record present)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
       - cloudflare_dns.result.record.content == "{{ txt_teststring }}"
       - cloudflare_dns.result.record.ttl == 300
       - cloudflare_dns.result.record.type == 'TXT'
@@ -121,8 +121,8 @@
 - name: "Validate: TXT record duplicate (make new record solo)"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
       - cloudflare_dns.result.record.content == 'teststring'
       - cloudflare_dns.result.record.ttl == 150
       - cloudflare_dns.result.record.type == 'TXT'
@@ -144,8 +144,8 @@
 - name: "Validate: TXT record duplicate (old record absent)"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed
 
 - name: "Test: TXT record deletion"
   cloudflare_dns:
@@ -162,8 +162,8 @@
 - name: "Validate: TXT record deletion"
   assert:
     that:
-      - cloudflare_dns|success
-      - cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is changed
 
 - name: "Test: TXT record deletion succeeded"
   cloudflare_dns:
@@ -180,5 +180,5 @@
 - name: "Validate: TXT record deletion succeeded"
   assert:
     that:
-      - cloudflare_dns|success
-      - not cloudflare_dns|changed
+      - cloudflare_dns is successful
+      - cloudflare_dns is not changed

--- a/test/legacy/roles/test_consul_inventory/tasks/main.yml
+++ b/test/legacy/roles/test_consul_inventory/tasks/main.yml
@@ -23,7 +23,7 @@
 - name: metadata from the kv store gets added to the facts for a host
   assert:
     that:
-        - clearance | match('top_secret')
+        - clearance is match('top_secret')
   when: inventory_hostname == '11.0.0.2'
 
 - name: extra groups a host should be added to can be loaded from kv

--- a/test/legacy/roles/test_consul_kv/tasks/main.yml
+++ b/test/legacy/roles/test_consul_kv/tasks/main.yml
@@ -70,7 +70,7 @@
 - name: kv test
   assert:
     that:
-      - "{{item | match('somevalue_one')}}"
+      - "{{ item is match('somevalue_one')}}"
   with_consul_kv:
     - 'key/to/lookup_one token={{acl_token}}'
 
@@ -78,7 +78,7 @@
 - name: recursive kv lookup test
   assert:
     that:
-      - "{{item| match('somevalue_(one|two)')}}"
+      - "{{ item is match('somevalue_(one|two)')}}"
   with_consul_kv:
     - 'key/to recurse=true token={{acl_token}}'
 

--- a/test/legacy/roles/test_consul_service/tasks/main.yml
+++ b/test/legacy/roles/test_consul_service/tasks/main.yml
@@ -56,7 +56,7 @@
 - name: verify registering service without name fails
   assert:
     that:
-        - noname_result | failed
+        - noname_result is failed
 
 - name: register very basic service without service_port
   consul:

--- a/test/legacy/roles/test_exoscale_dns/tasks/main.yml
+++ b/test/legacy/roles/test_exoscale_dns/tasks/main.yml
@@ -8,7 +8,7 @@
 - name: verify setup
   assert:
     that:
-    - result|success
+    - result is successful
 
 - name: test fail if missing name
   local_action:
@@ -18,7 +18,7 @@
 - name: verify results of fail if missing params
   assert:
     that:
-    - result|failed
+    - result is failed
     - 'result.msg == "missing required arguments: name"'
 
 - name: test create a domain
@@ -29,7 +29,7 @@
 - name: verify results of test create a domain
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_domain.name == "{{ exo_dns_domain_name }}"'
 
 - name: test create a domain idempotence
@@ -40,7 +40,7 @@
 - name: verify results of test create a domain idempotence
   assert:
     that:
-    - not result|changed
+    - result is not changed
     - 'result.exo_dns_domain.name == "{{ exo_dns_domain_name }}"'
 
 - name: test fail if missing required params
@@ -51,7 +51,7 @@
 - name: verify results of test fail if missing required params
   assert:
     that:
-    - result|failed
+    - result is failed
     - 'result.msg == "missing required arguments: domain"'
 
 - name: test fail if missing required params
@@ -64,7 +64,7 @@
 - name: verify results of test fail if missing required params
   assert:
     that:
-    - result|failed
+    - result is failed
     - 'result.msg == "name is  but the following are missing: content"'
 
 - name: test fail if missing required params state=present
@@ -77,7 +77,7 @@
 - name: verify results of test fail if missing required params state=present
   assert:
     that:
-    - result|failed
+    - result is failed
     - 'result.msg == "state is present but the following are missing: content"'
 
 - name: test fail if missing required params state=absent
@@ -91,7 +91,7 @@
 - name: verify results of test fail if missing required params state=absent
   assert:
     that:
-    - result|failed
+    - result is failed
     - 'result.msg == "name is  but the following are missing: content"'
 
 - name: test create a record
@@ -104,7 +104,7 @@
 - name: verify results of test create a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.4"'
@@ -119,7 +119,7 @@
 - name: verify results of test create a record
   assert:
     that:
-    - not result|changed
+    - result is not changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.4"'
@@ -135,7 +135,7 @@
 - name: verify results of test update a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.5"'
@@ -152,7 +152,7 @@
 - name: verify results of test update a record idempotence
   assert:
     that:
-    - not result|changed
+    - result is not changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.5"'
@@ -168,7 +168,7 @@
 - name: verify results of test create a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.5"'
@@ -184,7 +184,7 @@
 - name: verify results of test create a record idempotence
   assert:
     that:
-    - not result|changed
+    - result is not changed
 
 - name: setup an existing MX record
   local_action:
@@ -198,7 +198,7 @@
 - name: verify results of test create a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == ""'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "mx2.{{ exo_dns_domain_name }}"'
@@ -216,7 +216,7 @@
 - name: verify results of test create a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == ""'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "mx1.{{ exo_dns_domain_name }}"'
@@ -235,7 +235,7 @@
 - name: verify results of test create a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == ""'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "mx1.{{ exo_dns_domain_name }}"'
@@ -254,7 +254,7 @@
 - name: verify results of test delete a MX record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == ""'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "mx1.{{ exo_dns_domain_name }}"'
@@ -272,7 +272,7 @@
 - name: verify results of test delete a MX record idempotence
   assert:
     that:
-    - not result|changed
+    - result is not changed
 
 - name: test create first multiple a record
   local_action:
@@ -285,7 +285,7 @@
 - name: verify results of test create first multiple a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.4"'
@@ -301,7 +301,7 @@
 - name: verify results of test create another similar a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.5"'
@@ -319,7 +319,7 @@
 - name: verify results of test create another similar a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.5"'
@@ -336,7 +336,7 @@
 - name: verify results of test create first multiple a record idempotence
   assert:
     that:
-    - not result|changed
+    - result is not changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.4"'
@@ -353,7 +353,7 @@
 - name: verify results of test delete similar a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.5"'
@@ -370,7 +370,7 @@
 - name: verify results of test delete first similar a record
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_record.name == "{{ exo_dns_record_name_web }}"'
     - 'result.exo_dns_record.domain == "{{ exo_dns_domain_name }}"'
     - 'result.exo_dns_record.content == "1.2.3.4"'
@@ -384,7 +384,7 @@
 - name: verify results of test delete a domain
   assert:
     that:
-    - result|changed
+    - result is changed
     - 'result.exo_dns_domain.name == "{{ exo_dns_domain_name }}"'
 
 - name: test delete a domain idempotence
@@ -396,4 +396,4 @@
 - name: verify results of test delete a domain idempotence
   assert:
     that:
-    - not result|changed
+    - result is not changed

--- a/test/legacy/roles/test_gce/tasks/main.yml
+++ b/test/legacy/roles/test_gce/tasks/main.yml
@@ -193,7 +193,7 @@
   assert:
     that:
        - 'result.failed'
-       - '{{ result.msg | match("Disk at index 0 does not match:.*") }}'
+       - '{{ result.msg is match("Disk at index 0 does not match:.*") }}'
 
 # ============================================================
 - name: test disks given with name and mode
@@ -230,7 +230,7 @@
   assert:
     that:
        - 'result.failed'
-       - '{{ result.msg | match("Disk at index 0 is in the wrong mode:.*") }}'
+       - '{{ result.msg is match("Disk at index 0 is in the wrong mode:.*") }}'
 
 # ============================================================
 - name: test disks given, state absent (expected changed=true)

--- a/test/legacy/roles/test_jenkins_job/tasks/main.yml
+++ b/test/legacy/roles/test_jenkins_job/tasks/main.yml
@@ -11,7 +11,7 @@
 - name: verify setup
   assert:
     that:
-    - result|success
+    - result is successful
 
 - name: test fail on missing params
   local_action:
@@ -25,7 +25,7 @@
 - name: verify test fail on missing params
   assert:
     that:
-    - result|failed
+    - result is failed
     - 'result.msg == "one of the following params is required on state=present: config,enabled"'
 
 - name: test create a job
@@ -40,8 +40,8 @@
 - name: verify test create a job
   assert:
     that:
-    - result|success
-    - result|changed
+    - result is successful
+    - result is changed
     - result.enabled
 
 - name: test create a job idempotence
@@ -56,8 +56,8 @@
 - name: verify test create a job idempotence
   assert:
     that:
-    - result|success
-    - not result|changed
+    - result is successful
+    - result is not changed
     - result.enabled
 
 - name: test create a enabled job idempotence
@@ -72,8 +72,8 @@
 - name: verify test create a enabled job idempotence
   assert:
     that:
-    - result|success
-    - not result|changed
+    - result is successful
+    - result is not changed
     - result.enabled
 
 - name: test update a job
@@ -90,8 +90,8 @@
 - name: verify test create a enabled job idempotence
   assert:
     that:
-    - result|success
-    - result|changed
+    - result is successful
+    - result is changed
     - result.enabled
 
 - name: test disable an existing job without config
@@ -106,8 +106,8 @@
 - name: verify test disable an existing job without config
   assert:
     that:
-    - result|success
-    - result|changed
+    - result is successful
+    - result is changed
     - not result.enabled
 
 - name: test disable an existing job without config idempotence
@@ -122,8 +122,8 @@
 - name: verify test disable an existing job without config idempotence
   assert:
     that:
-    - result|success
-    - not result|changed
+    - result is successful
+    - result is not changed
     - not result.enabled
 
 - name: test reset to config job
@@ -138,8 +138,8 @@
 - name: verify test reset to config job
   assert:
     that:
-    - result|success
-    - result|changed
+    - result is successful
+    - result is changed
 
 - name: test remove job
   local_action:
@@ -153,8 +153,8 @@
 - name: verify test remove job
   assert:
     that:
-    - result|success
-    - result|changed
+    - result is successful
+    - result is changed
 
 - name: test remove job idempotence
   local_action:
@@ -168,5 +168,5 @@
 - name: verify test remove job idempotence
   assert:
     that:
-    - result|success
-    - not result|changed
+    - result is successful
+    - result is not changed

--- a/test/legacy/roles/test_rax/tasks/main.yml
+++ b/test/legacy/roles/test_rax/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax with no args
   assert:
     that:
-      - rax|failed
+      - rax is failed
       - rax.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -24,7 +24,7 @@
 - name: Validate results of rax with only creds
   assert:
     that:
-      - rax|failed
+      - rax is failed
       - rax.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -42,7 +42,7 @@
 - name: Validate rax creds and region
   assert:
     that:
-      - rax|failed
+      - rax is failed
       - rax.msg == 'image is required for the "rax" module'
 # ============================================================
 
@@ -61,7 +61,7 @@
 - name: Validate rax with creds, region and image
   assert:
     that:
-      - rax|failed
+      - rax is failed
       - rax.msg == 'flavor is required for the "rax" module'
 # ============================================================
 
@@ -81,7 +81,7 @@
 - name: Validate rax with creds, region, image and flavor
   assert:
     that:
-      - rax|failed
+      - rax is failed
       - rax.msg == 'name is required for the "rax" module'
 # ============================================================
 
@@ -101,8 +101,8 @@
 - name: Validate rax with creds, region, image, flavor and name
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-1"
@@ -125,7 +125,7 @@
 - name: "Validate delete integration 1"
   assert:
     that:
-      - rax|changed
+      - rax is changed
       - rax.action == 'delete'
       - rax.success[0].name == "{{ resource_prefix }}-1"
 # ============================================================
@@ -148,8 +148,8 @@
 - name: Validate rax basic idepmpotency 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-2"
@@ -171,8 +171,8 @@
 - name: Validate rax basic idempotency 2
   assert:
     that:
-      - rax|success
-      - not rax|changed
+      - rax is successful
+      - rax is not changed
       - not rax.action
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-2"
@@ -194,8 +194,8 @@
 - name: "Validate delete integration 2"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success[0].name == "{{ resource_prefix }}-2"
       - rax.success[0].rax_status == "DELETED"
@@ -221,8 +221,8 @@
 - name: Validate rax basic idepmpotency with meta 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-3"
@@ -247,8 +247,8 @@
 - name: Validate rax basic idempotency with meta 2
   assert:
     that:
-      - rax|success
-      - not rax|changed
+      - rax is successful
+      - rax is not changed
       - not rax.action
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-3"
@@ -272,8 +272,8 @@
 - name: "Validate delete integration 3"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success[0].name == "{{ resource_prefix }}-3"
       - rax.success[0].rax_status == "DELETED"
@@ -298,8 +298,8 @@
 - name: Validate rax basic idepmpotency multi server 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -320,8 +320,8 @@
 - name: Validate rax basic idempotency multi server 2
   assert:
     that:
-      - rax|success
-      - not rax|changed
+      - rax is successful
+      - rax is not changed
       - not rax.action
       - rax.instances|length == 2
       - not rax.success
@@ -342,8 +342,8 @@
 - name: Validate rax basic idempotency multi server 3
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 3
       - rax.success|length == 1
@@ -365,8 +365,8 @@
 - name: "Validate delete integration 4"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 3
       - not rax.instances
@@ -392,8 +392,8 @@
 - name: Validate rax multi server group without exact_count 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -417,8 +417,8 @@
 - name: "Validate delete integration 5"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 2
       - not rax.instances
@@ -444,8 +444,8 @@
 - name: Validate rax multi server group without exact_count non-idempotency 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -468,8 +468,8 @@
 - name: Validate rax multi server group without exact_count non-idempotency 2
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 4
       - rax.instances|map(attribute='rax_name')|unique|length == 4
@@ -492,8 +492,8 @@
 - name: "Validate delete integration 6"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 4
       - not rax.instances
@@ -520,8 +520,8 @@
 - name: Validate rax multi server group with exact_count 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -545,8 +545,8 @@
 - name: Validate rax multi server group with exact_count 2
   assert:
     that:
-      - rax|success
-      - not rax|changed
+      - rax is successful
+      - rax is not changed
       - not rax.action
       - rax.instances|length == 2
       - rax.instances|map(attribute='rax_name')|unique|length == 2
@@ -569,8 +569,8 @@
 - name: Validate rax multi server group with exact_count 3
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 4
       - rax.success|length == 2
@@ -595,8 +595,8 @@
 - name: "Validate delete integration 7"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 4
       - not rax.instances
@@ -623,8 +623,8 @@
 - name: Validate rax multi server group without exact_count and disabled auto_increment 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -649,8 +649,8 @@
 - name: "Validate delete integration 8"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 2
       - not rax.instances
@@ -677,8 +677,8 @@
 - name: Validate rax multi server group with exact_count and no printf 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -702,8 +702,8 @@
 - name: "Validate delete integration 9"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 2
       - not rax.instances
@@ -731,8 +731,8 @@
 - name: Validate rax multi server group with exact_count and offset 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -757,8 +757,8 @@
 - name: "Validate delete integration 10"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 2
       - not rax.instances
@@ -786,8 +786,8 @@
 - name: Validate rax multi server group with exact_count and offset 1
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 2
       - rax.instances == rax.success
@@ -812,8 +812,8 @@
 - name: "Validate delete integration 11"
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'delete'
       - rax.success|length == 2
       - not rax.instances
@@ -837,8 +837,8 @@
 - name: Validate rax instance_ids absent 1 (create)
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-12"
@@ -862,8 +862,8 @@
 - name: Validate rax instance_ids absent 2 (delete)
   assert:
     that:
-      - rax2|success
-      - rax2|changed
+      - rax2 is successful
+      - rax2 is changed
       - rax2.action == 'delete'
       - rax2.success.0.rax_id == rax.success.0.rax_id
 # ============================================================

--- a/test/legacy/roles/test_rax_cbs/tasks/main.yml
+++ b/test/legacy/roles/test_rax_cbs/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_cbs with no args
   assert:
     that:
-      - rax_cbs|failed
+      - rax_cbs is failed
       - 'rax_cbs.msg == "missing required arguments: name"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_cbs with no args
   assert:
     that:
-      - rax_cbs|failed
+      - rax_cbs is failed
       - rax_cbs.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -41,7 +41,7 @@
 - name: Validate results of rax_cbs with name and credentials
   assert:
     that:
-      - rax_cbs|failed
+      - rax_cbs is failed
       - rax_cbs.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -61,8 +61,8 @@
 - name: Validate rax_cbs creds, region and name
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-1"
       - rax_cbs.volume.attachments == []
       - rax_cbs.volume.size == 100
@@ -81,8 +81,8 @@
 - name: Validate delete integration 1
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-1"
 # ============================================================
 
@@ -102,7 +102,7 @@
 - name: Validate rax_cbs creds, region, name and invalid size
   assert:
     that:
-      - rax_cbs|failed
+      - rax_cbs is failed
 # ============================================================
 
 
@@ -122,8 +122,8 @@
 - name: Validate rax_cbs creds, region and valid size
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-2"
       - rax_cbs.volume.attachments == []
       - rax_cbs.volume.size == 150
@@ -142,8 +142,8 @@
 - name: Validate delete integration 2
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-2"
 # ============================================================
 
@@ -163,7 +163,7 @@
 - name: Validate rax_cbs creds, region, name and invalid volume_type
   assert:
     that:
-      - rax_cbs|failed
+      - rax_cbs is failed
       - 'rax_cbs.msg == "value of volume_type must be one of: SSD,SATA, got: fail"'
 # ============================================================
 
@@ -184,8 +184,8 @@
 - name: Validate rax_cbs creds, region and valid volume_size
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-3"
       - rax_cbs.volume.attachments == []
       - rax_cbs.volume.size == 100
@@ -204,8 +204,8 @@
 - name: Validate delete integration 3
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-3"
 # ============================================================
 
@@ -226,8 +226,8 @@
 - name: Validate rax_cbs creds, region and description
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-4"
       - rax_cbs.volume.description == '{{ resource_prefix }}-4 description'
       - rax_cbs.volume.attachments == []
@@ -247,8 +247,8 @@
 - name: Validate delete integration 4
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-4"
 # ============================================================
 
@@ -270,8 +270,8 @@
 - name: Validate rax_cbs creds, region and meta
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-5"
       - rax_cbs.volume.attachments == []
       - rax_cbs.volume.size == 100
@@ -291,8 +291,8 @@
 - name: Validate delete integration 5
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-5"
 # ============================================================
 
@@ -312,8 +312,8 @@
 - name: Validate rax_cbs with idempotency 1
   assert:
     that:
-      - rax_cbs_1|success
-      - rax_cbs_1|changed
+      - rax_cbs_1 is successful
+      - rax_cbs_1 is changed
       - rax_cbs_1.volume.display_name == "{{ resource_prefix }}-6"
 
 - name: Test rax_cbs with idempotency 2
@@ -327,8 +327,8 @@
 - name: Validate rax_cbs with idempotency 2
   assert:
     that:
-      - rax_cbs_2|success
-      - not rax_cbs_2|changed
+      - rax_cbs_2 is successful
+      - rax_cbs_2 is not changed
       - rax_cbs_2.volume.display_name == "{{ resource_prefix }}-6"
       - rax_cbs_2.volume.id == rax_cbs_1.volume.id
 
@@ -344,7 +344,7 @@
 - name: Validate delete integration 6
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.name == "{{ resource_prefix }}-6"
 # ============================================================

--- a/test/legacy/roles/test_rax_cbs_attachments/tasks/main.yml
+++ b/test/legacy/roles/test_rax_cbs_attachments/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_cbs_attachments with no args
   assert:
     that:
-      - rax_cbs_attachments|failed
+      - rax_cbs_attachments is failed
       - 'rax_cbs_attachments.msg == "missing required arguments: server,volume,device"'
 # ============================================================
 
@@ -25,7 +25,7 @@
 - name: Validate results of rax_cbs_attachments with server, volume and device
   assert:
     that:
-      - rax_cbs_attachments|failed
+      - rax_cbs_attachments is failed
       - rax_cbs_attachments.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -45,7 +45,7 @@
 - name: Validate results of rax_cbs_attachments with credentials, server, volume and device
   assert:
     that:
-      - rax_cbs_attachments|failed
+      - rax_cbs_attachments is failed
       - rax_cbs_attachments.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -66,7 +66,7 @@
 - name: Validate rax_cbs_attachments creds, region, invalid server, invalid volume and device
   assert:
     that:
-      - rax_cbs_attachments|failed
+      - rax_cbs_attachments is failed
       - rax_cbs_attachments.msg == 'No matching storage volumes were found'
 # ============================================================
 
@@ -86,8 +86,8 @@
 - name: Validate volume build
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
       - rax_cbs.volume.display_name == "{{ resource_prefix }}-rax_cbs_attachments"
 # ============================================================
 
@@ -109,8 +109,8 @@
 - name: Validate CloudServer build
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-rax_cbs_attachments"
@@ -133,7 +133,7 @@
 - name: Validate rax_cbs_attachments creds, region, invalid server, volume and device
   assert:
     that:
-      - rax_cbs_attachments|failed
+      - rax_cbs_attachments is failed
       - rax_cbs_attachments.msg == 'No Server was matched by name, try using the Server ID instead'
 # ============================================================
 
@@ -155,8 +155,8 @@
 - name: Validate rax_cbs_attachments creds, region, server, volume and device (valid)
   assert:
     that:
-      - rax_cbs_attachments|success
-      - rax_cbs_attachments|changed
+      - rax_cbs_attachments is successful
+      - rax_cbs_attachments is changed
       - rax_cbs_attachments.volume.attachments.0.device == '/dev/xvde'
       - rax_cbs_attachments.volume.attachments.0.server_id == "{{ rax.instances[0].id }}"
 
@@ -175,8 +175,8 @@
 - name: Validate idempotent present test
   assert:
     that:
-      - rax_cbs_attachments|success
-      - not rax_cbs_attachments|changed
+      - rax_cbs_attachments is successful
+      - rax_cbs_attachments is not changed
 
 - name: Unattach volume
   rax_cbs_attachments:
@@ -194,8 +194,8 @@
 - name: Validate unattach volume
   assert:
     that:
-      - rax_cbs_attachments|success
-      - rax_cbs_attachments|changed
+      - rax_cbs_attachments is successful
+      - rax_cbs_attachments is changed
       - rax_cbs_attachments.volume.attachments == []
 
 - name: Idempotent absent test
@@ -214,8 +214,8 @@
 - name: Validate idempotent absent test
   assert:
     that:
-      - rax_cbs_attachments|success
-      - not rax_cbs_attachments|changed
+      - rax_cbs_attachments is successful
+      - rax_cbs_attachments is not changed
 # ============================================================
 
 
@@ -233,8 +233,8 @@
 - name: Validate delete integration 6
   assert:
     that:
-      - rax_cbs|success
-      - rax_cbs|changed
+      - rax_cbs is successful
+      - rax_cbs is changed
 # ============================================================
 
 
@@ -254,7 +254,7 @@
 - name: "Validate delete"
   assert:
     that:
-      - rax|changed
-      - rax|success
+      - rax is changed
+      - rax is successful
       - rax.action == 'delete'
 # ============================================================

--- a/test/legacy/roles/test_rax_cdb/tasks/main.yml
+++ b/test/legacy/roles/test_rax_cdb/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_cdb with no args
   assert:
     that:
-      - rax_cdb|failed
+      - rax_cdb is failed
       - 'rax_cdb.msg == "missing required arguments: name"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_cdb with only creds
   assert:
     that:
-      - rax_cdb|failed
+      - rax_cdb is failed
       - rax_cdb.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -41,7 +41,7 @@
 - name: Validate results of rax_cdb with only creds
   assert:
     that:
-      - rax_cdb|failed
+      - rax_cdb is failed
       - rax_cdb.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -59,7 +59,7 @@
 - name: Validate rax_cdb creds and region
   assert:
     that:
-      - rax_cdb|failed
+      - rax_cdb is failed
       - 'rax_cdb.msg == "missing required arguments: name"'
 # ============================================================
 
@@ -79,8 +79,8 @@
 - name: Validate rax_cdb with creds, region and name
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == '{{ resource_prefix }}-1'
       - rax_cdb.cdb.hostname
       - rax_cdb.cdb.status == 'ACTIVE'
@@ -99,8 +99,8 @@
 - name: "Validate delete integration 1"
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-1"
 
 # ============================================================
@@ -121,8 +121,8 @@
 - name: Validate rax_cdb idempotent test 1
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-2"
       - rax_cdb.cdb.status == 'ACTIVE'
 
@@ -139,8 +139,8 @@
 - name: Validate rax_cdb idempotent test 2
   assert:
     that:
-      - rax_cdb|success
-      - not rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is not changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-2"
       - rax_cdb.cdb.status == 'ACTIVE'
 
@@ -158,7 +158,7 @@
 - name: "Validate delete integration 2"
   assert:
     that:
-      - rax_cdb|changed
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-2"
 # ============================================================
 
@@ -178,8 +178,8 @@
 - name: Validate rax_cdb resize volume 1
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-3"
       - rax_cdb.cdb.status == 'ACTIVE'
 
@@ -197,8 +197,8 @@
 - name: Validate rax_cdb resize volume 2
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-3"
       - rax_cdb.cdb.status == 'ACTIVE'
 
@@ -216,7 +216,7 @@
 - name: "Validate delete integration 3"
   assert:
     that:
-      - rax_cdb|changed
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-3"
 # ============================================================
 
@@ -236,8 +236,8 @@
 - name: Validate rax_cdb resize flavor 1
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-4"
       - rax_cdb.cdb.status == 'ACTIVE'
 
@@ -255,8 +255,8 @@
 - name: Validate rax_cdb resize flavor 2
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-4"
       - rax_cdb.cdb.status == 'ACTIVE'
 
@@ -274,6 +274,6 @@
 - name: "Validate delete integration 4"
   assert:
     that:
-      - rax_cdb|changed
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-4"
 # ============================================================

--- a/test/legacy/roles/test_rax_cdb_database/tasks/main.yml
+++ b/test/legacy/roles/test_rax_cdb_database/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_cdb_database with no args
   assert:
     that:
-      - rax_cdb_database|failed
+      - rax_cdb_database is failed
       - 'rax_cdb_database.msg == "missing required arguments: name,cdb_id"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_cdb_database with name
   assert:
     that:
-      - rax_cdb_database|failed
+      - rax_cdb_database is failed
       - 'rax_cdb_database.msg == "missing required arguments: cdb_id"'
 # ============================================================
 
@@ -40,7 +40,7 @@
 - name: Validate results of rax_cdb_database with name and cdb_id
   assert:
     that:
-      - rax_cdb_database|failed
+      - rax_cdb_database is failed
       - rax_cdb_database.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -59,7 +59,7 @@
 - name: Validate results of rax_cdb_database with name, cdb_id and creds
   assert:
     that:
-      - rax_cdb_database|failed
+      - rax_cdb_database is failed
       - rax_cdb_database.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -79,7 +79,7 @@
 - name: Validate rax_cdb_database name, invalid cdb_id, creds and region
   assert:
     that:
-      - rax_cdb_database|failed
+      - rax_cdb_database is failed
 # ============================================================
 
 
@@ -98,8 +98,8 @@
 - name: Validate build
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == '{{ resource_prefix }}-rax_cdb_database'
       - rax_cdb.cdb.status == 'ACTIVE'
 # ============================================================
@@ -119,8 +119,8 @@
 - name: Validate rax_cdb_database name, cdb_id, creds and region
   assert:
     that:
-      - rax_cdb_database|success
-      - rax_cdb_database|changed
+      - rax_cdb_database is successful
+      - rax_cdb_database is changed
       - rax_cdb_database.database.name == "{{ resource_prefix }}-1"
 
 - name: Delete integration 1
@@ -136,8 +136,8 @@
 - name: Validate delete integration 1
   assert:
     that:
-      - rax_cdb_database|success
-      - rax_cdb_database|changed
+      - rax_cdb_database is successful
+      - rax_cdb_database is changed
       - rax_cdb_database.database.name == "{{ resource_prefix }}-1"
 # ============================================================
 
@@ -156,8 +156,8 @@
 - name: Validate rax_cdb_database idempotency 1
   assert:
     that:
-      - rax_cdb_database|success
-      - rax_cdb_database|changed
+      - rax_cdb_database is successful
+      - rax_cdb_database is changed
       - rax_cdb_database.database.name == "{{ resource_prefix }}-2"
 
 - name: Test rax_cdb_database idempotency 2
@@ -172,8 +172,8 @@
 - name: Validate rax_cdb_database idempotency 2
   assert:
     that:
-      - rax_cdb_database|success
-      - not rax_cdb_database|changed
+      - rax_cdb_database is successful
+      - rax_cdb_database is not changed
       - rax_cdb_database.database.name == "{{ resource_prefix }}-2"
 
 - name: Delete integration 2
@@ -189,8 +189,8 @@
 - name: Validate delete integration 2
   assert:
     that:
-      - rax_cdb_database|success
-      - rax_cdb_database|changed
+      - rax_cdb_database is successful
+      - rax_cdb_database is changed
       - rax_cdb_database.database.name == "{{ resource_prefix }}-2"
 # ============================================================
 
@@ -211,7 +211,7 @@
 - name: Validate Delete
   assert:
     that:
-      - rax_cdb|success
-      - rax_cdb|changed
+      - rax_cdb is successful
+      - rax_cdb is changed
       - rax_cdb.cdb.name == "{{ resource_prefix }}-rax_cdb_database"
 # ============================================================

--- a/test/legacy/roles/test_rax_clb/tasks/main.yml
+++ b/test/legacy/roles/test_rax_clb/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_clb with no args
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - 'rax_clb.msg == "missing required arguments: name"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_clb with only creds
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - rax_clb.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -41,7 +41,7 @@
 - name: Validate results of rax_clb with only creds
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - rax_clb.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -59,7 +59,7 @@
 - name: Validate rax_clb creds and region
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - 'rax_clb.msg == "missing required arguments: name"'
 # ============================================================
 
@@ -79,7 +79,7 @@
 - name: Validate rax_clb with creds, region and name
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 80
       - rax_clb.balancer.protocol == 'HTTP'
       - rax_clb.balancer.timeout == 30
@@ -102,7 +102,7 @@
 - name: "Validate delete integration 1"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-1"
 
 # ============================================================
@@ -124,7 +124,7 @@
 - name: Validate rax_clb with creds, region, name and protocol
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 80
       - rax_clb.balancer.protocol == 'TCP'
       - rax_clb.balancer.timeout == 30
@@ -146,7 +146,7 @@
 - name: "Validate delete integration 2"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-2"
 # ============================================================
 
@@ -168,7 +168,7 @@
 - name: Validate rax_clb with creds, region, name, protocol and port
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 8080
       - rax_clb.balancer.protocol == 'TCP'
       - rax_clb.balancer.timeout == 30
@@ -190,7 +190,7 @@
 - name: "Validate delete integration 3"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-3"
 # ============================================================
 
@@ -213,7 +213,7 @@
 - name: Validate rax_clb with creds, region, name, protocol and type
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 8080
       - rax_clb.balancer.protocol == 'TCP'
       - rax_clb.balancer.timeout == 30
@@ -235,7 +235,7 @@
 - name: "Validate delete integration 4"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-4"
 # ============================================================
 
@@ -260,7 +260,7 @@
 - name: Validate rax_clb with invalid timeout
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - rax_clb.msg == '"timeout" must be greater than or equal to 30'
 # ============================================================
 
@@ -284,7 +284,7 @@
 - name: Validate rax_clb with creds, region, name, protocol, type and timeout
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 8080
       - rax_clb.balancer.protocol == 'TCP'
       - rax_clb.balancer.timeout == 60
@@ -306,7 +306,7 @@
 - name: "Validate delete integration 5"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-5"
 # ============================================================
 
@@ -331,7 +331,7 @@
 - name: Validate rax_clb with creds, region, name, protocol, type, timeout and algorithm
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 8080
       - rax_clb.balancer.protocol == 'TCP'
       - rax_clb.balancer.timeout == 60
@@ -354,7 +354,7 @@
 - name: "Validate delete integration 6"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-6"
 # ============================================================
 
@@ -377,7 +377,7 @@
 - name: Validate rax_clb with invalid timeout
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - 'rax_clb.msg == "value of type must be one of: PUBLIC,SERVICENET, got: BAD"'
 # ============================================================
 
@@ -400,7 +400,7 @@
 - name: Validate rax_clb with invalid timeout
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - 'rax_clb.msg == "value of protocol must be one of: DNS_TCP,DNS_UDP,FTP,HTTP,HTTPS,IMAPS,IMAPv4,LDAP,LDAPS,MYSQL,POP3,POP3S,SMTP,TCP,TCP_CLIENT_FIRST,UDP,UDP_STREAM,SFTP, got: BAD"'
 # ============================================================
 
@@ -423,7 +423,7 @@
 - name: Validate rax_clb with invalid timeout
   assert:
     that:
-      - rax_clb|failed
+      - rax_clb is failed
       - 'rax_clb.msg == "value of algorithm must be one of: RANDOM,LEAST_CONNECTIONS,ROUND_ROBIN,WEIGHTED_LEAST_CONNECTIONS,WEIGHTED_ROUND_ROBIN, got: BAD"'
 # ============================================================
 
@@ -450,7 +450,7 @@
 - name: Validate rax_clb with creds, region, name, protocol, type, timeout, algorithm and metadata
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
       - rax_clb.balancer.port == 8080
       - rax_clb.balancer.protocol == 'TCP'
       - rax_clb.balancer.timeout == 60
@@ -474,7 +474,7 @@
 - name: "Validate delete integration 7"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.name == "{{ resource_prefix }}-7"
 # ============================================================
 
@@ -494,7 +494,7 @@
 - name: Validate rax_clb with shared VIP HTTP
   assert:
     that:
-      - rax_clb_http|success
+      - rax_clb_http is successful
       - rax_clb_http.balancer.protocol == 'HTTP'
       - rax_clb_http.balancer.virtual_ips.0.type == 'PUBLIC'
       - rax_clb_http.balancer.status == 'ACTIVE'
@@ -515,7 +515,7 @@
 - name: Validate Test rax_clb with shared VIP
   assert:
     that:
-      - rax_clb_https|success
+      - rax_clb_https is successful
       - rax_clb_https.balancer.protocol == 'HTTPS'
       - rax_clb_https.balancer.status == 'ACTIVE'
       - rax_clb_http.balancer.virtual_ips == rax_clb_https.balancer.virtual_ips
@@ -545,8 +545,8 @@
 - name: "Validate delete integration 8"
   assert:
     that:
-      - rax_clb_http|changed
-      - rax_clb_https|changed
+      - rax_clb_http is changed
+      - rax_clb_https is changed
 # ============================================================
 
 
@@ -565,7 +565,7 @@
 - name: Validate rax_clb with updated protocol 1
   assert:
     that:
-      - rax_clb_p1|success
+      - rax_clb_p1 is successful
       - rax_clb_p1.balancer.protocol == 'HTTP'
       - rax_clb_p1.balancer.virtual_ips.0.type == 'PUBLIC'
       - rax_clb_p1.balancer.status == 'ACTIVE'
@@ -585,8 +585,8 @@
   assert:
     that:
       - rax_clb_p1.balancer.id == rax_clb_p2.balancer.id
-      - rax_clb_p2|success
-      - rax_clb_p2|changed
+      - rax_clb_p2 is successful
+      - rax_clb_p2 is changed
       - rax_clb_p2.balancer.protocol == 'TCP'
       - rax_clb_p2.balancer.status == 'ACTIVE'
 
@@ -604,7 +604,7 @@
 - name: "Validate delete integration 9"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
 # ============================================================
 
 
@@ -623,7 +623,7 @@
 - name: Validate rax_clb with updated algorithm 1
   assert:
     that:
-      - rax_clb_a1|success
+      - rax_clb_a1 is successful
       - rax_clb_a1.balancer.algorithm == 'LEAST_CONNECTIONS'
       - rax_clb_a1.balancer.status == 'ACTIVE'
 
@@ -642,8 +642,8 @@
   assert:
     that:
       - rax_clb_a1.balancer.id == rax_clb_a2.balancer.id
-      - rax_clb_a2|success
-      - rax_clb_a2|changed
+      - rax_clb_a2 is successful
+      - rax_clb_a2 is changed
       - rax_clb_a2.balancer.algorithm == 'RANDOM'
       - rax_clb_a2.balancer.status == 'ACTIVE'
 
@@ -661,7 +661,7 @@
 - name: "Validate delete integration 10"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb_a1.balancer.id == rax_clb.balancer.id
 # ============================================================
 
@@ -681,7 +681,7 @@
 - name: Validate rax_clb with updated port 1
   assert:
     that:
-      - rax_clb_1|success
+      - rax_clb_1 is successful
       - rax_clb_1.balancer.port == 80
       - rax_clb_1.balancer.status == 'ACTIVE'
 
@@ -700,8 +700,8 @@
   assert:
     that:
       - rax_clb_1.balancer.id == rax_clb_2.balancer.id
-      - rax_clb_2|success
-      - rax_clb_2|changed
+      - rax_clb_2 is successful
+      - rax_clb_2 is changed
       - rax_clb_2.balancer.port == 8080
       - rax_clb_2.balancer.status == 'ACTIVE'
 
@@ -719,7 +719,7 @@
 - name: "Validate delete integration 11"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb_1.balancer.id == rax_clb.balancer.id
 # ============================================================
 
@@ -739,7 +739,7 @@
 - name: Validate rax_clb with updated timeout 1
   assert:
     that:
-      - rax_clb_1|success
+      - rax_clb_1 is successful
       - rax_clb_1.balancer.timeout == 30
       - rax_clb_1.balancer.status == 'ACTIVE'
 
@@ -758,8 +758,8 @@
   assert:
     that:
       - rax_clb_1.balancer.id == rax_clb_2.balancer.id
-      - rax_clb_2|success
-      - rax_clb_2|changed
+      - rax_clb_2 is successful
+      - rax_clb_2 is changed
       - rax_clb_2.balancer.timeout == 60
       - rax_clb_2.balancer.status == 'ACTIVE'
 
@@ -777,7 +777,7 @@
 - name: "Validate delete integration 12"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb_1.balancer.id == rax_clb.balancer.id
 # ============================================================
 
@@ -797,7 +797,7 @@
 - name: Validate rax_clb with invalid updated type 1
   assert:
     that:
-      - rax_clb_1|success
+      - rax_clb_1 is successful
       - rax_clb_1.balancer.status == 'ACTIVE'
 
 - name: Test rax_clb with invalid updated type 2
@@ -815,7 +815,7 @@
 - name: Validate rax_clb with updated timeout 2
   assert:
     that:
-      - rax_clb_2|failed
+      - rax_clb_2 is failed
       - rax_clb_2.msg == 'Load balancer Virtual IP type cannot be changed'
 
 - name: Delete integration 13
@@ -832,7 +832,7 @@
 - name: "Validate delete integration 13"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb_1.balancer.id == rax_clb.balancer.id
 # ============================================================
 
@@ -852,7 +852,7 @@
 - name: Validate rax_clb with updated meta 1
   assert:
     that:
-      - rax_clb_1|success
+      - rax_clb_1 is successful
       - rax_clb_1.balancer.status == 'ACTIVE'
       - rax_clb_1.balancer.metadata is not defined
 
@@ -872,8 +872,8 @@
   assert:
     that:
       - rax_clb_1.balancer.id == rax_clb_2.balancer.id
-      - rax_clb_2|success
-      - rax_clb_2|changed
+      - rax_clb_2 is successful
+      - rax_clb_2 is changed
       - rax_clb_2.balancer.metadata.0.key == 'foo'
       - rax_clb_2.balancer.metadata.0.value == 'bar'
       - rax_clb_2.balancer.status == 'ACTIVE'
@@ -892,6 +892,6 @@
 - name: "Validate delete integration 14"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb_1.balancer.id == rax_clb.balancer.id
 # ============================================================

--- a/test/legacy/roles/test_rax_clb_nodes/tasks/main.yml
+++ b/test/legacy/roles/test_rax_clb_nodes/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_clb_nodes with no args
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - 'rax_clb_nodes.msg == "missing required arguments: load_balancer_id"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_clb_nodes with load_balancer_id
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -41,7 +41,7 @@
 - name: Validate results of rax_clb_nodes with credentials and load_balancer_id
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -60,7 +60,7 @@
 - name: Validate rax_clb_nodes creds, region and load_balancer_id
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg == 'Load balancer not found'
 # ============================================================
 
@@ -80,7 +80,7 @@
 - name: Validate rax_clb creation
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
 
 - name: Set variable for CLB ID
   set_fact:
@@ -102,7 +102,7 @@
 - name: Validate rax_clb_nodes creds, region and valid load_balancer_id
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg == 'You must include an address and a port when creating a node.'
 # ============================================================
 
@@ -122,7 +122,7 @@
 - name: Validate rax_clb_nodes creds, region, load_balancer_id and address
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg == 'You must include an address and a port when creating a node.'
 # ============================================================
 
@@ -143,7 +143,7 @@
 - name: Validate rax_clb_nodes creds, region, load_balancer_id, invalid address and port
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg == "Invalid node address. The address '10.10.10.10' is currently not accepted for this request."
 # ============================================================
 
@@ -165,7 +165,7 @@
 - name: Validate rax_clb_nodes creds, region, load_balancer_id, address and port
   assert:
     that:
-      - rax_clb_nodes|success
+      - rax_clb_nodes is successful
       - rax_clb_nodes.node.address == '172.16.0.1'
       - rax_clb_nodes.node.condition == 'ENABLED'
       - rax_clb_nodes.node.port == 80
@@ -188,7 +188,7 @@
 - name: Validate delete integration 1
   assert:
     that:
-      - rax_clb_nodes|success
+      - rax_clb_nodes is successful
 # ============================================================
 
 
@@ -211,7 +211,7 @@
 - name: Validate rax_clb_nodes creds, region, load_balancer_id, address, port and type
   assert:
     that:
-      - rax_clb_nodes|failed
+      - rax_clb_nodes is failed
       - rax_clb_nodes.msg == 'you must enable health monitoring to use secondary nodes'
 # ============================================================
 
@@ -232,6 +232,6 @@
 - name: "Validate delete integration 3"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.id == rax_clb_id|int
 # ============================================================

--- a/test/legacy/roles/test_rax_facts/tasks/main.yml
+++ b/test/legacy/roles/test_rax_facts/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_facts with no args
   assert:
     that:
-      - rax_facts|failed
+      - rax_facts is failed
       - 'rax_facts.msg == "one of the following is required: address,id,name"'
 # ============================================================
 
@@ -25,7 +25,7 @@
 - name: Validate results of rax_facts with only creds
   assert:
     that:
-      - rax_facts|failed
+      - rax_facts is failed
       - rax_facts.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -44,9 +44,9 @@
 - name: Validate rax_facts creds, region and address
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts == {}
-      - not rax_facts|changed
+      - rax_facts is not changed
 # ============================================================
 
 
@@ -64,9 +64,9 @@
 - name: Validate rax_facts creds, region and id
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts == {}
-      - not rax_facts|changed
+      - rax_facts is not changed
 # ============================================================
 
 
@@ -84,9 +84,9 @@
 - name: Validate rax_facts creds, region and name
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts == {}
-      - not rax_facts|changed
+      - rax_facts is not changed
 # ============================================================
 
 
@@ -106,7 +106,7 @@
 - name: Validate rax_facts creds, region, address, id and name
   assert:
     that:
-      - rax_facts|failed
+      - rax_facts is failed
       - "rax_facts.msg == 'parameters are mutually exclusive: [\\'address\\', \\'id\\', \\'name\\']'"
 # ============================================================
 
@@ -128,8 +128,8 @@
 - name: Validate build
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-rax_facts"
@@ -150,7 +150,7 @@
 - name: Validate rax_facts creds, region, and valid public IPv4 address
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts.rax_flavor == rax.success.0.rax_flavor
       - rax_facts.ansible_facts.rax_image == rax.success.0.rax_image
       - rax_facts.ansible_facts.rax_addresses == rax.success.0.rax_addresses
@@ -174,7 +174,7 @@
 - name: Validate rax_facts creds, region, and valid public IPv6 address
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts.rax_flavor == rax.success.0.rax_flavor
       - rax_facts.ansible_facts.rax_image == rax.success.0.rax_image
       - rax_facts.ansible_facts.rax_addresses == rax.success.0.rax_addresses
@@ -198,7 +198,7 @@
 - name: Validate rax_facts creds, region, and valid private IPv4 address
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts.rax_flavor == rax.success.0.rax_flavor
       - rax_facts.ansible_facts.rax_image == rax.success.0.rax_image
       - rax_facts.ansible_facts.rax_addresses == rax.success.0.rax_addresses
@@ -222,7 +222,7 @@
 - name: Validate rax_facts creds, region, and valid ID
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts.rax_flavor == rax.success.0.rax_flavor
       - rax_facts.ansible_facts.rax_image == rax.success.0.rax_image
       - rax_facts.ansible_facts.rax_addresses == rax.success.0.rax_addresses
@@ -246,7 +246,7 @@
 - name: Validate rax_facts creds, region, and valid name
   assert:
     that:
-      - rax_facts|success
+      - rax_facts is successful
       - rax_facts.ansible_facts.rax_flavor == rax.success.0.rax_flavor
       - rax_facts.ansible_facts.rax_image == rax.success.0.rax_image
       - rax_facts.ansible_facts.rax_addresses == rax.success.0.rax_addresses
@@ -274,8 +274,8 @@
 - name: "Validate delete"
   assert:
     that:
-      - rax|changed
-      - rax|success
+      - rax is changed
+      - rax is successful
       - rax.action == 'delete'
       - rax.success[0].name == "{{ resource_prefix }}-rax_facts"
 # ============================================================

--- a/test/legacy/roles/test_rax_identity/tasks/main.yml
+++ b/test/legacy/roles/test_rax_identity/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_identity with no args
   assert:
     that:
-      - rax_identity|failed
+      - rax_identity is failed
       - rax_identity.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -24,7 +24,7 @@
 - name: Validate results of rax_identity with name and credentials
   assert:
     that:
-      - rax_identity|failed
+      - rax_identity is failed
       - rax_identity.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -41,8 +41,8 @@
 - name: Validate results of rax_identity with name and credentials
   assert:
     that:
-      - rax_identity|success
-      - not rax_identity|changed
+      - rax_identity is successful
+      - rax_identity is not changed
       - rax_identity.identity.region == "{{ rackspace_region }}"
       - rax_identity.identity.username == "{{ rackspace_username }}"
       - rax_identity.identity.authenticated

--- a/test/legacy/roles/test_rax_keypair/tasks/main.yml
+++ b/test/legacy/roles/test_rax_keypair/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_keypair with no args
   assert:
     that:
-      - rax_keypair|failed
+      - rax_keypair is failed
       - 'rax_keypair.msg == "missing required arguments: name"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_keypair with no args
   assert:
     that:
-      - rax_keypair|failed
+      - rax_keypair is failed
       - rax_keypair.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -41,7 +41,7 @@
 - name: Validate results of rax_keypair with name and credentials
   assert:
     that:
-      - rax_keypair|failed
+      - rax_keypair is failed
       - rax_keypair.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -73,8 +73,8 @@
 - name: Validate rax_keypair creds, region, name and public_key string
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-1"
       - rax_keypair.keypair.public_key == "{{ rackspace_keypair_pub }}"
 
@@ -91,8 +91,8 @@
 - name: Validate delete integration 1
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-1"
 # ============================================================
 
@@ -111,8 +111,8 @@
 - name: Validate rax_keypair creds, region, name and public_key path
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-2"
       - rax_keypair.keypair.public_key == "{{ rackspace_keypair_pub }}"
 
@@ -129,8 +129,8 @@
 - name: Validate delete integration 2
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-2"
 # ============================================================
 
@@ -149,8 +149,8 @@
 - name: Validate rax_keypair with idempotency 1
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-3"
       - rax_keypair.keypair.public_key == "{{ rackspace_keypair_pub }}"
 
@@ -166,8 +166,8 @@
 - name: Validate rax_keypair with idempotency 1
   assert:
     that:
-      - rax_keypair|success
-      - not rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is not changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-3"
       - rax_keypair.keypair.public_key == "{{ rackspace_keypair_pub }}"
 
@@ -184,8 +184,8 @@
 - name: Validate delete integration 3
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-3"
 # ============================================================
 
@@ -203,8 +203,8 @@
 - name: Validate rax_keypair creds, region and name
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-4"
       - rax_keypair.keypair.private_key is defined
       - rax_keypair.keypair.public_key is defined
@@ -220,8 +220,8 @@
 - name: Validate rax_keypair creds, region and name
   assert:
     that:
-      - rax_keypair|success
-      - not rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is not changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-4"
       - rax_keypair.keypair.private_key is not defined
       - rax_keypair.keypair.public_key is defined
@@ -239,7 +239,7 @@
 - name: Validate delete integration 4
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-4"
 # ============================================================

--- a/test/legacy/roles/test_rax_meta/tasks/main.yml
+++ b/test/legacy/roles/test_rax_meta/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_meta with no args
   assert:
     that:
-      - rax_meta|failed
+      - rax_meta is failed
       - 'rax_meta.msg == "one of the following is required: address,id,name"'
 # ============================================================
 
@@ -25,7 +25,7 @@
 - name: Validate results of rax_meta with only creds
   assert:
     that:
-      - rax_meta|failed
+      - rax_meta is failed
       - rax_meta.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -43,7 +43,7 @@
 - name: Validate rax_meta creds, region and address
   assert:
     that:
-      - rax_meta|failed
+      - rax_meta is failed
       - rax_meta.msg == 'Failed to find a server matching provided search parameters'
 # ============================================================
 
@@ -62,7 +62,7 @@
 - name: Validate rax_meta creds, region and id
   assert:
     that:
-      - rax_meta|failed
+      - rax_meta is failed
       - rax_meta.msg == 'Failed to find a server matching provided search parameters'
 # ============================================================
 
@@ -81,7 +81,7 @@
 - name: Validate rax_meta creds, region and name
   assert:
     that:
-      - rax_meta|failed
+      - rax_meta is failed
       - rax_meta.msg == 'Failed to find a server matching provided search parameters'
 # ============================================================
 
@@ -102,7 +102,7 @@
 - name: Validate rax_meta creds, region, address, id and name
   assert:
     that:
-      - rax_meta|failed
+      - rax_meta is failed
       - "rax_meta.msg == 'parameters are mutually exclusive: [\\'address\\', \\'id\\', \\'name\\']'"
 # ============================================================
 
@@ -125,8 +125,8 @@
 - name: Validate build
   assert:
     that:
-      - rax|success
-      - rax|changed
+      - rax is successful
+      - rax is changed
       - rax.action == 'create'
       - rax.instances|length == 1
       - rax.instances[0].name == "{{ resource_prefix }}-rax_meta"
@@ -147,7 +147,7 @@
 - name: Validate rax_meta creds, region, and valid public IPv4 address
   assert:
     that:
-      - rax_meta|success
+      - rax_meta is successful
       - rax_meta.meta == {}
 # ============================================================
 
@@ -165,7 +165,7 @@
 - name: Validate rax_meta creds, region, and valid public IPv6 address
   assert:
     that:
-      - rax_meta|success
+      - rax_meta is successful
       - rax_meta.meta == {}
 # ============================================================
 
@@ -184,7 +184,7 @@
 - name: Validate rax_meta creds, region, and valid private IPv4 address
   assert:
     that:
-      - rax_meta|success
+      - rax_meta is successful
       - rax_meta.meta == {}
 # ============================================================
 
@@ -203,7 +203,7 @@
 - name: Validate rax_meta creds, region, and valid ID
   assert:
     that:
-      - rax_meta|success
+      - rax_meta is successful
       - rax_meta.meta == {}
 # ============================================================
 
@@ -222,7 +222,7 @@
 - name: Validate rax_meta creds, region, and valid name
   assert:
     that:
-      - rax_meta|success
+      - rax_meta is successful
       - rax_meta.meta == {}
 # ============================================================
 
@@ -243,8 +243,8 @@
 - name: Validate rax_meta creds, region, and valid ID set foo=bar
   assert:
     that:
-      - rax_meta|success
-      - rax_meta|changed
+      - rax_meta is successful
+      - rax_meta is changed
       - "rax_meta.meta == {'foo': 'bar'}"
 # ============================================================
 
@@ -265,7 +265,7 @@
 - name: Validate rax_meta creds, region, and valid ID set bar=baz
   assert:
     that:
-      - rax_meta|success
+      - rax_meta is successful
       - "rax_meta.meta == {'bar': 'baz'}"
 # ============================================================
 
@@ -286,8 +286,8 @@
 - name: Validate rax_meta creds, region, and valid ID set bar=baz
   assert:
     that:
-      - rax_meta|success
-      - not rax_meta|changed
+      - rax_meta is successful
+      - rax_meta is not changed
       - "rax_meta.meta == {'bar': 'baz'}"
 # ============================================================
 
@@ -306,8 +306,8 @@
 - name: Validate rax_meta creds, region, and valid ID delete meta
   assert:
     that:
-      - rax_meta|success
-      - rax_meta|changed
+      - rax_meta is successful
+      - rax_meta is changed
       - rax_meta.meta == {}
 # ============================================================
 
@@ -329,8 +329,8 @@
 - name: "Validate delete"
   assert:
     that:
-      - rax|changed
-      - rax|success
+      - rax is changed
+      - rax is successful
       - rax.action == 'delete'
       - rax.success[0].name == "{{ resource_prefix }}-rax_meta"
 # ============================================================

--- a/test/legacy/roles/test_rax_network/tasks/main.yml
+++ b/test/legacy/roles/test_rax_network/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_network with no args
   assert:
     that:
-      - rax_network|failed
+      - rax_network is failed
       - 'rax_network.msg == "missing required arguments: label"'
 # ============================================================
 
@@ -23,7 +23,7 @@
 - name: Validate results of rax_network with no args
   assert:
     that:
-      - rax_network|failed
+      - rax_network is failed
       - rax_network.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -41,7 +41,7 @@
 - name: Validate results of rax_network with creds
   assert:
     that:
-      - rax_network|failed
+      - rax_network is failed
       - rax_network.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -60,7 +60,7 @@
 - name: Validate results of rax_network with creds and region
   assert:
     that:
-      - rax_network|failed
+      - rax_network is failed
       - 'rax_network.msg == "missing required arguments: cidr"'
 # ============================================================
 
@@ -79,8 +79,8 @@
 - name: Validate results of rax_network with creds, region and cidr
   assert:
     that:
-      - rax_network|success
-      - rax_network|changed
+      - rax_network is successful
+      - rax_network is changed
       - rax_network.networks.0.cidr == "172.17.141.0/24"
       - rax_network.networks.0.label == "{{ resource_prefix }}-1"
 
@@ -96,8 +96,8 @@
 - name: Validate delete integration 1
   assert:
     that:
-      - rax_network|changed
-      - rax_network|success
+      - rax_network is changed
+      - rax_network is successful
       - rax_network.networks.0.label == "{{ resource_prefix }}-1"
       - rax_network.networks.0.cidr == "172.17.141.0/24"
 # ============================================================
@@ -117,8 +117,8 @@
 - name: Validate rax_network idempotency 1
   assert:
     that:
-      - rax_network|success
-      - rax_network|changed
+      - rax_network is successful
+      - rax_network is changed
       - rax_network.networks.0.cidr == "172.17.142.0/24"
       - rax_network.networks.0.label == "{{ resource_prefix }}-2"
 
@@ -134,8 +134,8 @@
 - name: Validate rax_network idempotency 2
   assert:
     that:
-      - rax_network|success
-      - not rax_network|changed
+      - rax_network is successful
+      - rax_network is not changed
       - rax_network.networks.0.cidr == "172.17.142.0/24"
       - rax_network.networks.0.label == "{{ resource_prefix }}-2"
 
@@ -151,8 +151,8 @@
 - name: Validate delete integration 2
   assert:
     that:
-      - rax_network|changed
-      - rax_network|success
+      - rax_network is changed
+      - rax_network is successful
       - rax_network.networks.0.label == "{{ resource_prefix }}-2"
       - rax_network.networks.0.cidr == "172.17.142.0/24"
 # ============================================================

--- a/test/legacy/roles/test_rax_scaling_group/tasks/main.yml
+++ b/test/legacy/roles/test_rax_scaling_group/tasks/main.yml
@@ -7,7 +7,7 @@
 - name: Validate results of rax_scaling_group with no args
   assert:
     that:
-      - rax_scaling_group|failed
+      - rax_scaling_group is failed
       - "rax_scaling_group.msg == 'missing required arguments: image,min_entities,flavor,max_entities,name,server_name'"
 # ============================================================
 
@@ -28,7 +28,7 @@
 - name: Validate results of rax_scaling_group with image,min_entities,flavor,max_entities,name,server_name
   assert:
     that:
-      - rax_scaling_group|failed
+      - rax_scaling_group is failed
       - rax_scaling_group.msg == 'No credentials supplied!'
 # ============================================================
 
@@ -51,7 +51,7 @@
 - name: Validate results of rax_scaling_group with creds and required args
   assert:
     that:
-      - rax_scaling_group|failed
+      - rax_scaling_group is failed
       - rax_scaling_group.msg.startswith('None is not a valid region')
 # ============================================================
 
@@ -74,7 +74,7 @@
 - name: Validate results of rax_scaling_group with creds, region and required args
   assert:
     that:
-      - rax_scaling_group|success
+      - rax_scaling_group is successful
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-1"
       - rax_scaling_group.autoscale_group.min_entities == 1
       - rax_scaling_group.autoscale_group.max_entities == 1
@@ -101,7 +101,7 @@
 - name: Validate idempotency 1
   assert:
     that:
-      - not rax_scaling_group|changed
+      - rax_scaling_group is not changed
 
 - name: Remove servers 1
   rax_scaling_group:
@@ -119,7 +119,7 @@
 - name: Validate remove servers 1
   assert:
     that:
-      - rax_scaling_group|changed
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.min_entities == 0
       - rax_scaling_group.autoscale_group.max_entities == 0
       - rax_scaling_group.autoscale_group.state.desiredCapacity == 0
@@ -141,7 +141,7 @@
 - name: Validate delete integration 1
   assert:
     that:
-      - rax_scaling_group|changed
+      - rax_scaling_group is changed
 # ============================================================
 
 
@@ -163,7 +163,7 @@
 - name: Validate results of rax_scaling_group server_name change
   assert:
     that:
-      - rax_scaling_group|success
+      - rax_scaling_group is successful
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-2"
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.name == "{{ resource_prefix }}-2"
 
@@ -183,7 +183,7 @@
 - name: Validate results of rax_scaling_group server_name change 2
   assert:
     that:
-      - rax_scaling_group|changed
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-2"
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.name == "{{ resource_prefix }}-2a"
 
@@ -203,7 +203,7 @@
 - name: Validate remove servers 2
   assert:
     that:
-      - rax_scaling_group|changed
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.min_entities == 0
       - rax_scaling_group.autoscale_group.max_entities == 0
       - rax_scaling_group.autoscale_group.state.desiredCapacity == 0
@@ -225,7 +225,7 @@
 - name: Validate delete integration 2
   assert:
     that:
-      - rax_scaling_group|changed
+      - rax_scaling_group is changed
 # ============================================================
 
 
@@ -251,7 +251,7 @@
 - name: Validate results of rax_scaling_group with load balancers
   assert:
     that:
-      - rax_scaling_group|failed
+      - rax_scaling_group is failed
       - rax_scaling_group.msg.startswith('Load balancer ID is not an integer')
 # ============================================================
 
@@ -271,7 +271,7 @@
 - name: Validate rax_clb creation
   assert:
     that:
-      - rax_clb|success
+      - rax_clb is successful
 
 - name: Set variable for CLB ID
   set_fact:
@@ -300,7 +300,7 @@
 - name: Validate results of rax_scaling_group with load balancers
   assert:
     that:
-      - rax_scaling_group|success
+      - rax_scaling_group is successful
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-3"
       - rax_scaling_group.autoscale_group.launchConfiguration.args.loadBalancers[0].loadBalancerId == rax_clb_id|int
 
@@ -353,7 +353,7 @@
 - name: Validate results of rax_scaling_group files change 1
   assert:
     that:
-      - rax_scaling_group|success
+      - rax_scaling_group is successful
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-4"
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.personality|length == 1
 
@@ -373,7 +373,7 @@
 - name: Validate results of rax_scaling_group files change 2
   assert:
     that:
-      - rax_scaling_group|changed
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-4"
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.personality is not defined
 
@@ -424,8 +424,8 @@
 - name: Validate default create
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.name == "{{ resource_prefix }}-5"
       - rax_scaling_group.autoscale_group.min_entities == 1
       - rax_scaling_group.autoscale_group.max_entities == 1
@@ -457,8 +457,8 @@
 - name: Validate cooldown change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.cooldown == 500
 # ============================================================
 
@@ -482,8 +482,8 @@
 - name: Validate max_entities change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.max_entities == 2
 # ============================================================
 
@@ -507,8 +507,8 @@
 - name: Validate min_entities change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.min_entities == 2
 # ============================================================
 
@@ -532,8 +532,8 @@
 - name: Validate server_name change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.name == "{{ resource_prefix }}-5-1"
 # ============================================================
 
@@ -557,8 +557,8 @@
 - name: Validate image change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.imageRef == "{{ rackspace_alt_image_id }}"
 # ============================================================
 
@@ -582,8 +582,8 @@
 - name: Validate flavor change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.flavorRef == "{{ rackspace_alt_flavor }}"
 # ============================================================
 
@@ -608,8 +608,8 @@
 - name: Validate flavor change
   assert:
     that:
-      - rax_scaling_group|success
-      - not rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is not changed
       - "rax_scaling_group.autoscale_group.launchConfiguration.args.server['OS-DCF:diskConfig'] == 'AUTO'"
 
 - name: Change disk_config 2
@@ -630,8 +630,8 @@
 - name: Validate flavor change 2
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - "rax_scaling_group.autoscale_group.launchConfiguration.args.server['OS-DCF:diskConfig'] == 'MANUAL'"
 # ============================================================
 
@@ -658,8 +658,8 @@
 - name: Validate networks change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.networks.0.uuid == "00000000-0000-0000-0000-000000000000"
 # ============================================================
 
@@ -690,8 +690,8 @@
 - name: Validate networks change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.loadBalancers.0.loadBalancerId == rax_clb_id|int
 # ============================================================
 
@@ -710,8 +710,8 @@
 - name: Validate rax_keypair creation
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
       - rax_keypair.keypair.name == "{{ resource_prefix }}-keypair"
       - rax_keypair.keypair.public_key == "{{ rackspace_keypair_pub }}"
 # ============================================================
@@ -744,8 +744,8 @@
 - name: Validate key_name change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.key_name == "{{ resource_prefix }}-keypair"
 # ============================================================
 
@@ -778,8 +778,8 @@
 - name: Validate config_drive change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.config_drive
 # ============================================================
 
@@ -813,8 +813,8 @@
 - name: Validate config_drive change
   assert:
     that:
-      - rax_scaling_group|success
-      - rax_scaling_group|changed
+      - rax_scaling_group is successful
+      - rax_scaling_group is changed
       - rax_scaling_group.autoscale_group.launchConfiguration.args.server.user_data == '{{ "foo"|b64encode }}'
 # ============================================================
 
@@ -834,8 +834,8 @@
 - name: Validate rax_keypair creation
   assert:
     that:
-      - rax_keypair|success
-      - rax_keypair|changed
+      - rax_keypair is successful
+      - rax_keypair is changed
 # ============================================================
 
 
@@ -855,6 +855,6 @@
 - name: "Validate delete integration 3"
   assert:
     that:
-      - rax_clb|changed
+      - rax_clb is changed
       - rax_clb.balancer.id == rax_clb_id|int
 # ============================================================

--- a/test/units/template/test_tests_as_filters_warning.py
+++ b/test/units/template/test_tests_as_filters_warning.py
@@ -1,0 +1,30 @@
+from ansible.template import Templar, display
+from units.mock.loader import DictDataLoader
+
+
+def test_tests_as_filters_warning(mocker):
+    fake_loader = DictDataLoader({
+        "/path/to/my_file.txt": "foo\n",
+    })
+    templar = Templar(loader=fake_loader, variables={})
+    filters = templar._get_filters()
+
+    mocker.patch.object(display, 'deprecated')
+
+    # Call successful test, ensure the message is correct
+    filters['successful']({})
+    display.deprecated.assert_called_once_with(
+        'Using tests as filters is deprecated. Instead of using `result|successful` instead use `result is successful`', version='2.9'
+    )
+
+    # Call success test, ensure the message is correct
+    display.deprecated.reset_mock()
+    filters['success']({})
+    display.deprecated.assert_called_once_with(
+        'Using tests as filters is deprecated. Instead of using `result|success` instead use `result is success`', version='2.9'
+    )
+
+    # Call bool filter, ensure no deprecation message was displayed
+    display.deprecated.reset_mock()
+    filters['bool'](True)
+    assert display.deprecated.call_count == 0


### PR DESCRIPTION
##### SUMMARY
This PR adds a deprecation warning for using jinja tests as filters for eventual removal.

See https://github.com/ansible/proposals/issues/83

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
tests/filters

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

Things to be done:

- ~~Update docs to use proper test syntax instead of filter syntax~~
- ~~Update tests to use proper test syntax instead of filter syntax~~