### PR TITLE
Fix pathing to epel package

### DIFF
--- a/test/integration/targets/rpm_key/tasks/rpm_key.yaml
+++ b/test/integration/targets/rpm_key/tasks/rpm_key.yaml
@@ -26,7 +26,7 @@
 
 - name: download sl rpm
   get_url:
-    url: https://download.fedoraproject.org/pub/epel/7/x86_64/s/sl-5.02-1.el7.x86_64.rpm
+    url: https://download.fedoraproject.org/pub/epel/7/x86_64/Packages/s/sl-5.02-1.el7.x86_64.rpm
     dest: /tmp/sl.rpm
 
 - name: download Mono key


### PR DESCRIPTION
##### SUMMARY
This PR fixes a path to a epel package that we are using for tests

Pathing in EPEL was recently updated to more closely mirror Fedora package pathing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
N/A