### PR TITLE
azure_rm_virtualmachine: add custom image support

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -96,6 +96,10 @@ options:
               offer, sku and version. NOTE: set image.version to 'latest' to get the most recent version of a given
               image."
         required: true
+    custom_image:
+        description:
+            - The name of a custom image used to build the VM.
+            - Can be used instead of I(image).        
     storage_account_name:
         description:
             - Name of an existing storage account that supports creation of VHD blobs. If not specified for a new VM,
@@ -344,10 +348,10 @@ EXAMPLES = '''
     storage_container: osdisk
     storage_blob: osdisk.vhd
     image:
-    offer: CoreOS
-    publisher: CoreOS
-    sku: Stable
-    version: latest
+      offer: CoreOS
+      publisher: CoreOS
+      sku: Stable
+      version: latest
     data_disks:
     - lun: 0
       disk_size_gb: 64
@@ -357,6 +361,15 @@ EXAMPLES = '''
       disk_size_gb: 128
       storage_container_name: datadisk2
       storage_blob_name: datadisk2.vhd
+
+- name: Create a VM with a custom image
+  azure_rm_virtualmachine:
+    resource_group: Testing
+    name: testvm001
+    vm_size: Standard_DS1_v2
+    admin_username: adminUser
+    admin_password: password01
+    custom_image: customimage001
 
 - name: Power Off
   azure_rm_virtualmachine:
@@ -606,7 +619,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             admin_password=dict(type='str', no_log=True),
             ssh_password_enabled=dict(type='bool', default=True),
             ssh_public_keys=dict(type='list'),
-            image=dict(),
+            image=dict(type='dict'),
+            custom_image=dict(type='str'),
             storage_account_name=dict(type='str', aliases=['storage_account']),
             storage_container_name=dict(type='str', aliases=['storage_container'], default='vhds'),
             storage_blob_name=dict(type='str', aliases=['storage_blob']),
@@ -640,6 +654,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         self.ssh_password_enabled = None
         self.ssh_public_keys = None
         self.image = None
+        self.custom_image = None
         self.storage_account_name = None
         self.storage_container_name = None
         self.storage_blob_name = None
@@ -690,7 +705,6 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
         disable_ssh_password = None
         vm_dict = None
         image_reference = None
-        custom_image = False
 
         resource_group = self.get_resource_group(self.resource_group)
         if not self.location:
@@ -719,33 +733,32 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if not key.get('path') or not key.get('key_data'):
                         self.fail(msg)
 
+            if self.image and self.custom_image:
+                self.fail("parameter error: expecting image or custom_image and not both")
+
             if self.image:
-                if isinstance(self.image, str):
-                    custom_image = True
-                    vm_image = self.get_vm_image()
-                    image_reference = ImageReference(
-                        id=vm_image.id
-                    )
-                    self.log("Using custom image id {0}".format(vm_image.id))
-                elif isinstance(self.image, dict):
-                    if not self.image.get('publisher') or not self.image.get('offer') or not self.image.get('sku') \
-                       or not self.image.get('version'):
-                        self.error("parameter error: expecting image to contain publisher, offer, sku and version keys.")
+                if not self.image.get('publisher') or not self.image.get('offer') or not self.image.get('sku') \
+                        or not self.image.get('version'):
+                    self.fail("parameter error: expecting image to contain publisher, offer, sku and version keys.")
 
-                    marketplace_image = self.get_marketplace_image_version()
-                    if self.image['version'] == 'latest':
-                        self.image['version'] = marketplace_image.name
-                        self.log("Using image version {0}".format(self.image['version']))
+                marketplace_image = self.get_marketplace_image_version()
+                if self.image['version'] == 'latest':
+                    self.image['version'] = marketplace_image.name
+                    self.log("Using image version {0}".format(self.image['version']))
 
-                    image_reference = ImageReference(
-                        publisher=self.image['publisher'],
-                        offer=self.image['offer'],
-                        sku=self.image['sku'],
-                        version=self.image['version']
-                    )
-                else:
-                    self.error("parameter error: expecting image to be either a string with an image name or dict with "
-                               "a markplace image details")
+                image_reference = ImageReference(
+                    publisher=self.image['publisher'],
+                    offer=self.image['offer'],
+                    sku=self.image['sku'],
+                    version=self.image['version']
+                )
+
+            if self.custom_image:
+                vm_image = self.get_vm_image()
+                image_reference = ImageReference(
+                    id=vm_image.id
+                )
+                self.log("Using custom image id {0}".format(vm_image.id))
 
             if self.plan:
                 if not self.plan.get('name') or not self.plan.get('product') or not self.plan.get('publisher'):
@@ -893,7 +906,7 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                     if self.managed_disk_type:
                         vhd = None
                         managed_disk = ManagedDiskParameters(storage_account_type=self.managed_disk_type)
-                    elif custom_image:
+                    elif self.custom_image:
                         vhd = None
                         managed_disk = None
                     else:
@@ -1398,10 +1411,10 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
             self.fail("Error fetching custom images from subscription - {0}".format(str(exc)))
 
         for vm_image in vm_images:
-            if vm_image.name == self.image:
+            if vm_image.name == self.custom_image:
                 return vm_image
 
-        self.fail("Error could not find image with name {0}".format(self.image))
+        self.fail("Error could not find image with name {0}".format(self.custom_image))
 
     def get_storage_account(self, name):
         try:

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -100,7 +100,7 @@ options:
         description:
             - The name of a custom image used to build the VM.
             - Can be used instead of I(image).
-        version_added: "2.5"       
+        version_added: "2.5"
     storage_account_name:
         description:
             - Name of an existing storage account that supports creation of VHD blobs. If not specified for a new VM,

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -99,7 +99,8 @@ options:
     custom_image:
         description:
             - The name of a custom image used to build the VM.
-            - Can be used instead of I(image).        
+            - Can be used instead of I(image).
+        version_added: "2.5"       
     storage_account_name:
         description:
             - Name of an existing storage account that supports creation of VHD blobs. If not specified for a new VM,

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -186,3 +186,13 @@
       image: invalid-image
   register: fail_missing_custom_image
   failed_when: fail_missing_custom_image.msg != "Error could not find image with name invalid-image"
+
+- name: assert error finding missing custom image (dict style)
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm002
+      state: present
+      image:
+        name: invalid-image
+  register: fail_missing_custom_image_dict
+  failed_when: fail_missing_custom_image_dict.msg != "Error could not find image with name invalid-image"

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -156,16 +156,33 @@
 - assert:
       that: azure_publicipaddresses | length == 0
 
-- name: Check error message when supplying both image and custom_image
+# TODO: Until we have a module to create/delete images this is the best tests
+# I can do
+- name: assert error thrown with invalid image dict
   azure_rm_virtualmachine:
       resource_group: "{{ resource_group }}"
       name: testvm002
       state: present
-      custom_image: customimage
       image:
         offer: UbuntuServer
-        publisher: Canonical
-        sku: 16.04-LTS
-        version: latest
-  register: fail_image_and_custom
-  failed_when: 'fail_image_and_custom.msg != "parameter error: expecting image or custom_image and not both"'
+  register: fail_invalid_image_dict
+  failed_when: 'fail_invalid_image_dict.msg != "parameter error: expecting image to contain [publisher, offer, sku, version] or [name, resource_group]"'
+
+- name: assert error thrown with invalid image type
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm002
+      state: present
+      image:
+      - testing
+  register: fail_invalid_image_type
+  failed_when: 'fail_invalid_image_type.msg != "parameter error: expecting image to be a string or dict not list"'
+
+- name: assert error finding missing custom image
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm002
+      state: present
+      image: invalid-image
+  register: fail_missing_custom_image
+  failed_when: fail_missing_custom_image.msg != "Error could not find image with name invalid-image"

--- a/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
+++ b/test/integration/targets/azure_rm_virtualmachine/tasks/virtualmachine.yml
@@ -155,3 +155,17 @@
 
 - assert:
       that: azure_publicipaddresses | length == 0
+
+- name: Check error message when supplying both image and custom_image
+  azure_rm_virtualmachine:
+      resource_group: "{{ resource_group }}"
+      name: testvm002
+      state: present
+      custom_image: customimage
+      image:
+        offer: UbuntuServer
+        publisher: Canonical
+        sku: 16.04-LTS
+        version: latest
+  register: fail_image_and_custom
+  failed_when: 'fail_image_and_custom.msg != "parameter error: expecting image or custom_image and not both"'


### PR DESCRIPTION
##### SUMMARY
Allows someone to create a VM from a custom image using the new `custom_image` option.

Fixes https://github.com/ansible/ansible/issues/24328

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
azure_rm_virtualmachine

##### ANSIBLE VERSION
```
2.5
```