### PR TITLE
[WIP] Add option to `ipa_user` for setting expiration date

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -23,6 +23,11 @@ options:
     description: Display name
   givenname:
     description: First name
+  krbpasswordexpiration:
+    description:
+    - Date at which the user password will expire
+    - In the format YYYYMMddHHmmss
+    - e.g. 20180121182022 will expire on 21 January 2018 at 18:20:22
   loginshell:
     description: Login shell
   mail:
@@ -75,6 +80,7 @@ EXAMPLES = '''
 - ipa_user:
     name: pinky
     state: present
+    krbpasswordexpiration: 20200119235959
     givenname: Pinky
     sn: Acme
     mail:
@@ -138,11 +144,14 @@ class UserIPAClient(IPAClient):
         return self._post_json(method='user_enable', name=name)
 
 
-def get_user_dict(displayname=None, givenname=None, loginshell=None, mail=None, nsaccountlock=False, sn=None,
-                  sshpubkey=None, telephonenumber=None, title=None, userpassword=None, gidnumber=None, uidnumber=None):
+def get_user_dict(displayname=None, givenname=None, krbpasswordexpiration=None, loginshell=None,
+                  mail=None, nsaccountlock=False, sn=None, sshpubkey=None, telephonenumber=None,
+                  title=None, userpassword=None, gidnumber=None, uidnumber=None):
     user = {}
     if displayname is not None:
         user['displayname'] = displayname
+    if krbpasswordexpiration is not None:
+        user['krbpasswordexpiration'] = krbpasswordexpiration + "Z"
     if givenname is not None:
         user['givenname'] = givenname
     if loginshell is not None:
@@ -226,6 +235,7 @@ def ensure(module, client):
     nsaccountlock = state == 'disabled'
 
     module_user = get_user_dict(displayname=module.params.get('displayname'),
+                                krbpasswordexpiration=module.params.get('krbpasswordexpiration'),
                                 givenname=module.params.get('givenname'),
                                 loginshell=module.params['loginshell'],
                                 mail=module.params['mail'], sn=module.params['sn'],
@@ -261,6 +271,7 @@ def main():
     argument_spec = ipa_argument_spec()
     argument_spec.update(displayname=dict(type='str'),
                          givenname=dict(type='str'),
+                         krbpasswordexpiration=dict(type='str'),
                          loginshell=dict(type='str'),
                          mail=dict(type='list'),
                          sn=dict(type='str'),

--- a/lib/ansible/modules/identity/ipa/ipa_user.py
+++ b/lib/ansible/modules/identity/ipa/ipa_user.py
@@ -28,6 +28,7 @@ options:
     - Date at which the user password will expire
     - In the format YYYYMMddHHmmss
     - e.g. 20180121182022 will expire on 21 January 2018 at 18:20:22
+    version_added: 2.5
   loginshell:
     description: Login shell
   mail:


### PR DESCRIPTION
##### SUMMARY
Accept `krbpasswordexpiration` parameter, allowing the user to set an expiration date on the specified user.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ipa_user module

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ally/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
