### PR TITLE
Handle ip name-server lines containing multiple nameservers (#32235)

### DIFF
--- a/lib/ansible/modules/network/ios/ios_system.py
+++ b/lib/ansible/modules/network/ios/ios_system.py
@@ -266,12 +266,13 @@ def parse_domain_search(config):
     return matches
 
 def parse_name_servers(config):
-    match = re.findall('^ip name-server (?:vrf (\S+) )*(\S+)', config, re.M)
+    match = re.findall('^ip name-server (?:vrf (\S+) )*(.*)', config, re.M)
     matches = list()
-    for vrf, server in match:
+    for vrf, servers in match:
         if not vrf:
             vrf = None
-        matches.append({'server': server, 'vrf': vrf})
+        for server in servers.split():
+            matches.append({'server': server, 'vrf': vrf})
     return matches
 
 def parse_lookup_source(config):


### PR DESCRIPTION
In CSR, multiple nameservers are defined in one line, whereas on IOS
it's on multiple ones.
This change handles both.
(cherry picked from commit 80c8b99a62e521ee7c5cd576ac43b3d462f4a432)