### PR TITLE
modules: zypper_repository: Do not ignore the 'name' parameter

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper_repository.py
+++ b/lib/ansible/modules/packaging/os/zypper_repository.py
@@ -375,7 +375,7 @@ def main():
 
     exists, mod, old_repos = repo_exists(module, repodata, overwrite_multiple)
 
-    if repo:
+    if repo.endswith('.repo'):
         shortname = repo
     else:
         shortname = alias


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request

##### SUMMARY
Every zypper repository has the 'repo' parameter set. As such, the
shortname variable was always set to 'repo' even if we had set a
different name for our repository using the 'name' parameter. This
causes problems when trying to determine what to do once the repository
is instelled (for example running 'refresh' to import GPG keys). We
should only set 'shortname' to 'repo' if 'repo' ends up with '.repo'
which means it is a proper repofile.

Fixes #32375 