### PR TITLE
Call out fields for tower_credentials

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_credential.py
@@ -80,7 +80,7 @@ options:
         - Unlock password for ssh_key. Use ASK for prompting.
     authorize:
       description:
-        - Should use authroize for net type.
+        - Should use authorize for net type.
       required: False
       default: False
     authorize_password:
@@ -131,7 +131,7 @@ options:
       default: null
     vault_password:
       description:
-        - Valut password. Use ASK for prompting.
+        - Vault password. Use ASK for prompting.
     state:
       description:
         - Desired state of the resource.
@@ -231,6 +231,7 @@ def main():
                     params['ssh_key_data'] = f.read()
 
             if state == 'present':
+                params.pop('state')
                 result = credential.modify(**params)
                 json_output['id'] = result['id']
             elif state == 'absent':


### PR DESCRIPTION
##### SUMMARY
When passing **params directly to credential.modify(), you get a rejection
by the API due to fields that it doesn't accept (such as 'state'). Call
out the individual fields like in tower_project.py results in a successful
call to the v1 API.

Tested both state: present, and state: absent. Also fixed two
small documentation typos.

Fixes #32352

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`tower_credential`

##### ANSIBLE VERSION
```
ansible 2.5.0 (bug/issue_32352_tower_credentials 7c68bb0c1a) last updated 2017/10/31 09:56:20 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/lmadsen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lmadsen/src/github/leifmadsen/ansible/lib/ansible
  executable location = /home/lmadsen/src/github/leifmadsen/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```

##### ADDITIONAL INFORMATION
Working playbook
```
# vim: ft=yaml tabstop=2 shiftwidth=2 expandtab
---

- hosts: localhost
  pre_tasks:
    - name: Check for tower_cli configuration
      stat:
        path: "{{ ansible_env.HOME }}/.tower_cli.cfg"
      register: tower_cli_cfg

    - name: Fail if tower_cli configuration doesn't exist
      fail:
        msg: "You need to configure Tower CLI in ~/.tower_cli.cfg"
      when: not tower_cli_cfg.stat.exists

  tasks:
    - name: Configure SCM Credential
      tower_credential:
        name: Git
        description: Git default credential
        organization: Default
        kind: scm
        state: present
        tower_verify_ssl: False

    - name: Configure projects
      tower_project:
        name: "openstack-builder-testing"
        organization: Default
        state: present
        scm_type: git
        scm_url: "https://github.com/leifmadsen/openstack-inventory-builder.git"
        scm_branch: master
        scm_clean: yes
        scm_credential: Git
        scm_delete_on_update: yes
        scm_update_on_launch: yes
        tower_verify_ssl: False
```

`state: absent`
```
ansible-playbook -i ~/src/github/leifmadsen/awx-builder/inventory/localhost ~/src/github/leifmadsen/awx-builder/site.yml 

PLAY [localhost] ******************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************************************************************
ok: [127.0.0.1]

TASK [Check for tower_cli configuration] ******************************************************************************************************************************************************************************************************
ok: [127.0.0.1]

TASK [Fail if tower_cli configuration doesn't exist] ******************************************************************************************************************************************************************************************
skipping: [127.0.0.1]

TASK [Configure SCM Credential] ***************************************************************************************************************************************************************************************************************
changed: [127.0.0.1]

TASK [Configure projects] *********************************************************************************************************************************************************************************************************************
changed: [127.0.0.1]

PLAY RECAP ************************************************************************************************************************************************************************************************************************************
127.0.0.1                  : ok=4    changed=2    unreachable=0    failed=0   

```

`state: present`
```
ansible-playbook -i ~/src/github/leifmadsen/awx-builder/inventory/localhost ~/src/github/leifmadsen/awx-builder/site.yml 

PLAY [localhost] ******************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] ************************************************************************************************************************************************************************************************************************
ok: [127.0.0.1]

TASK [Check for tower_cli configuration] ******************************************************************************************************************************************************************************************************
ok: [127.0.0.1]

TASK [Fail if tower_cli configuration doesn't exist] ******************************************************************************************************************************************************************************************
skipping: [127.0.0.1]

TASK [Configure SCM Credential] ***************************************************************************************************************************************************************************************************************
changed: [127.0.0.1]

TASK [Configure projects] *********************************************************************************************************************************************************************************************************************
changed: [127.0.0.1]

PLAY RECAP ************************************************************************************************************************************************************************************************************************************
127.0.0.1                  : ok=4    changed=2    unreachable=0    failed=0 
```