### PR TITLE
win_get_url: Added force_basic_auth option

### DIFF
--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -106,7 +106,7 @@ Function Download-File($result, $url, $dest, $headers, $credentials, $timeout, $
     }
 
     if ($credentials) {
-        $extWebClient.Credentials = $credentials
+        $extWebClient.Headers.Add("Authorization","Basic $credentials")
     }
 
     if (-not $whatif) {
@@ -170,7 +170,7 @@ if ($proxy_url) {
 
 $credentials = $null
 if ($url_username -and $url_password) {
-    $credentials = New-Object System.Net.NetworkCredential($url_username, $url_password)
+    $credentials = [convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($url_username+":"+$url_password))
 }
 
 # If skip_certificate_validation was specified, use validate_certs

--- a/lib/ansible/modules/windows/win_get_url.ps1
+++ b/lib/ansible/modules/windows/win_get_url.ps1
@@ -106,7 +106,11 @@ Function Download-File($result, $url, $dest, $headers, $credentials, $timeout, $
     }
 
     if ($credentials) {
-        $extWebClient.Headers.Add("Authorization","Basic $credentials")
+        if ($force_basic_auth) {
+            $extWebClient.Headers.Add("Authorization","Basic $credentials")
+        } else {
+            $extWebClient.Credentials = $credentials
+        }
     }
 
     if (-not $whatif) {
@@ -138,6 +142,7 @@ $skip_certificate_validation = Get-AnsibleParam -obj $params -name "skip_certifi
 $validate_certs = Get-AnsibleParam -obj $params -name "validate_certs" -type "bool" -default $true
 $url_username = Get-AnsibleParam -obj $params -name "url_username" -type "str" -aliases "username"
 $url_password = Get-AnsibleParam -obj $params -name "url_password" -type "str" -aliases "password"
+$force_basic_auth = Get-AnsibleParam -obj $params -name "force_basic_auth" -type "bool" -default $false
 $use_proxy = Get-AnsibleParam -obj $params -name "use_proxy" -type "bool" -default $true
 $proxy_url = Get-AnsibleParam -obj $params -name "proxy_url" -type "str"
 $proxy_username = Get-AnsibleParam -obj $params -name "proxy_username" -type "str"
@@ -170,7 +175,12 @@ if ($proxy_url) {
 
 $credentials = $null
 if ($url_username -and $url_password) {
-    $credentials = [convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($url_username+":"+$url_password))
+    if ($force_basic_auth) {
+        $credentials = [convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($url_username+":"+$url_password))
+    } else {
+        $credentials = New-Object System.Net.NetworkCredential($url_username, $url_password) 
+    }
+    
 }
 
 # If skip_certificate_validation was specified, use validate_certs

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -69,6 +69,11 @@ options:
     description:
     - Basic authentication password.
     aliases: [ password ]
+  force_basic_auth:
+    description:
+    - If enabled, win_get_url uses "Authorization" header to provide Basic Authentication authorization mechanism instead of Microsoft's WebClient.
+    type: bool
+    default: false
   skip_certificate_validation:
     description:
     - This option is deprecated since v2.4, please use C(validate_certs) instead.

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -74,6 +74,7 @@ options:
     - If enabled, win_get_url uses "Authorization" header to provide Basic Authentication authorization mechanism instead of Microsoft's WebClient.
     type: bool
     default: false
+    version_added: "2.5"
   skip_certificate_validation:
     description:
     - This option is deprecated since v2.4, please use C(validate_certs) instead.

--- a/lib/ansible/modules/windows/win_get_url.py
+++ b/lib/ansible/modules/windows/win_get_url.py
@@ -71,9 +71,10 @@ options:
     aliases: [ password ]
   force_basic_auth:
     description:
-    - If enabled, win_get_url uses "Authorization" header to provide Basic Authentication authorization mechanism instead of Microsoft's WebClient.
+    - If C(yes), will add a Basic authentication header on the initial request.
+    - If C(no), will use Microsoft's WebClient to handle authentication.
     type: bool
-    default: false
+    default: 'no'
     version_added: "2.5"
   skip_certificate_validation:
     description:


### PR DESCRIPTION
##### SUMMARY
Changed way of authenticating using Basic auth to Headers per https://www.ietf.org/rfc/rfc2617.txt (Basic Authentication Scheme). I have found that current method was not working on Powershell 5.0. After some search it turned out that previous method was generating problems for number of users.


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
win_get_url

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /home/zew_2_12412/.ansible.cfg
  configured module search path = [u'/home/zew_2_12412/ansible/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```