### PR TITLE
Add support for imaging VMs in Azure

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -29,9 +29,10 @@ options:
 
 extends_documentation_fragment:
   - azure
-
-short_description: "Capture Azure Virtual Machine Images"
-version_added: "2.5"
+  - azure_tags
+  
+short_description: "Show information about available Azure Virtual Machine Images"
+version_added: "2.6"
 
 '''
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -30,7 +30,7 @@ options:
 extends_documentation_fragment:
   - azure
   - azure_tags
-  
+
 short_description: "Show information about available Azure Virtual Machine Images"
 version_added: "2.6"
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+author: "Emma Laurijssens van Engelenhoven"
+description:
+  - "Capture an Azure Virtual Machine image for the deployment of other VMs in Azure 
+     The VM should be generalized usimg sysprep. After this command runs, the Virtual Machine will be unusable.
+     Depends on pip azure module 2.0.0 or above and azure-mgmt-compute 2.1.0 and above."
+module: azure_rm_image_facts
+options:
+  name:
+    description:
+      - "The name of the image being queried."
+    required: false
+
+short_description: "Capture Azure Virtual Machine Images"
+version_added: "2.9"
+
+'''
+
+EXAMPLES = '''
+- name: Capture image
+  hosts: 127.0.0.1
+  connection: local
+
+  tasks:
+    - name: List all images in subscription
+      azure_rm_image_facts:
+        subscription_id: "{{ subscription_id }}"
+        resource_group_name: "{{ resource_group_name }}"
+        client_id: "{{ secrets.client_id }}"
+        tenant_id: "{{ tenant_id }}"
+        client_secret: "{{ secrets.client_secret }}"
+
+    - name: List facts about given image name
+      azure_rm_image_facts:
+        subscription_id: "{{ subscription_id }}"
+        resource_group_name: "{{ resource_group_name }}"
+        client_id: "{{ secrets.client_id }}"
+        tenant_id: "{{ tenant_id }}"
+        client_secret: "{{ secrets.client_secret }}"
+        name: win2016-1
+
+'''
+
+from ansible.module_utils.azure_rm_common import AzureRMModuleBase
+
+try:
+    from msrestazure.azure_exceptions import CloudError
+except:
+    pass
+
+
+class AzureRMImageFacts(AzureRMModuleBase):
+    def __init__(self):
+
+        self.module_arg_spec = dict(
+            name=dict(
+                type='str',
+                required=False
+            )
+        )
+
+        self.resource_group = None
+        self.name = None
+        self.location = None
+        self.tags = None
+
+        self.results = dict(
+            changed=False,
+            status="None",
+            ansible_facts=dict(azure_images=None)
+        )
+
+        super(AzureRMImageFacts, self).__init__(
+            derived_arg_spec=self.module_arg_spec,
+            supports_check_mode=True,
+            supports_tags=True)
+
+    def exec_module(self, **kwargs):
+
+        for key in list(self.module_arg_spec.keys()) + ['tags']:
+            setattr(self, key, kwargs[key])
+
+        self.results['ansible_facts'] = (
+            self.get_item() if self.name
+            else self.list_items())
+
+        return self.results
+
+    def _list_images(self):
+        try:
+            images = self.compute_client.images
+            image_list = images.list()  # (resource_group_name=self.resource_group, name=self.name)
+        except CloudError:
+            self.fail("No images found!")
+        except Exception as e:
+            self.fail("An exception occurred: {}".format(str(e)))
+
+        named_images = []
+
+        for image in image_list:
+            image_info = dict(name=image.name,
+                              location=image.location,
+                              resource_group=image.id.split("/")[4],
+                              managed=(not (image.storage_profile.os_disk.managed_disk is None))
+                              )
+            named_images.append(image_info)
+
+        return named_images
+
+    def list_items(self):
+
+        image_names = self._list_images()
+
+        return dict(azure_images=image_names,
+                    status="Found",
+                    changed=False)
+
+    def get_item(self):
+
+        status = "Not found"
+        image_names = self._list_images()
+        image_item = []
+
+        found = any(elem['name'] == self.name for elem in image_names)
+
+        if found:
+            for image in image_names:
+                if image['name'] == self.name:
+                    status = "Found"
+                    image_item.append(image)
+
+        return dict(azure_images=image_item,
+                    status=status,
+                    changed=False)
+
+
+def main():
+    AzureRMImageFacts()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -1,20 +1,11 @@
 #!/usr/bin/python
-# This file is part of Ansible
 #
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
+# Copyright (c) 2017 Emma Laurijssens van Engelenhoven, <emma@talwyn-esp.nl>
 #
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#  GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
@@ -23,16 +14,21 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 ---
-author: Emma Laurijssens van Engelenhoven
+author: Emma Laurijssens van Engelenhoven (@elaurijssens)
 description:
   - Show information about VM images in a given subscription in Azure.
-    Depends on pip azure module 2.0.0 or above and azure-mgmt-compute 2.1.0 and above.
+  - Depends on pip azure module 2.0.0 or above and azure-mgmt-compute 2.1.0 and above.
 module: azure_rm_image_facts
 options:
   name:
     description:
       - The name of the image being queried.
-    required: false
+  resource_group:
+    description:
+      - The name of the resource group to search in
+
+extends_documentation_fragment:
+  - azure
 
 short_description: "Capture Azure Virtual Machine Images"
 version_added: "2.5"
@@ -40,26 +36,16 @@ version_added: "2.5"
 '''
 
 EXAMPLES = '''
-- name: Capture image
-  hosts: 127.0.0.1
-  connection: local
+  - name: List all images in subscription
+    azure_rm_image_facts:
+      subscription_id: dee31f9f-1b6d-408b-aadf-720486bd766c
+      client_id: 46a522a7-ff6d-4e04-a89f-2c6882c8b483
+      tenant_id: b497b8d9-2bab-4acb-bbc3-fec05692409d
+      client_secret: R0gwWU93MGp5TVowR2FvOGhc4NDYwMUpRQzVZWT0=
 
-  tasks:
-    - name: List all images in subscription
-      azure_rm_image_facts:
-        subscription_id: "{{ subscription_id }}"
-        client_id: "{{ secrets.client_id }}"
-        tenant_id: "{{ tenant_id }}"
-        client_secret: "{{ secrets.client_secret }}"
-
-    - name: List facts about given image name
-      azure_rm_image_facts:
-        subscription_id: "{{ subscription_id }}"
-        resource_group_name: "{{ resource_group_name }}"
-        client_id: "{{ secrets.client_id }}"
-        tenant_id: "{{ tenant_id }}"
-        client_secret: "{{ secrets.client_secret }}"
-        name: win2016-1
+  - name: List facts about given image name
+    azure_rm_image_facts:
+      name: win2016-1
 
 '''
 
@@ -68,12 +54,11 @@ azure_images:
     description: A list of matching image dicts
     returned: always
     type: list
-found:
+exists:
     description: Whether or not the requested image was found
     returned: always
     type: bool
 '''
-
 
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 
@@ -90,6 +75,10 @@ class AzureRMImageFacts(AzureRMModuleBase):
             name=dict(
                 type='str',
                 required=False
+            ),
+            resource_group=dict(
+                type='str',
+                required=False
             )
         )
 
@@ -100,7 +89,6 @@ class AzureRMImageFacts(AzureRMModuleBase):
 
         self.results = dict(
             changed=False,
-            status="None",
             ansible_facts=dict(azure_images=None)
         )
 
@@ -115,7 +103,7 @@ class AzureRMImageFacts(AzureRMModuleBase):
             setattr(self, key, kwargs[key])
 
         self.results['ansible_facts'] = (
-            self.get_item() if self.name
+            self.get_item() if (self.name or self.resource_group)
             else self.list_items())
 
         return self.results
@@ -123,20 +111,34 @@ class AzureRMImageFacts(AzureRMModuleBase):
     def _list_images(self):
         try:
             images = self.compute_client.images
-            image_list = images.list()  # (resource_group_name=self.resource_group, name=self.name)
+            image_list = images.list()
         except CloudError:
             self.fail("No images found!")
         except Exception as e:
-            self.fail("An exception occurred: {}".format(str(e)))
+            self.fail("An exception occurred: {0}".format(str(e)))
 
         named_images = []
 
+
         for image in image_list:
+
+            data_disks = []
+
+            for disks in image.storage_profile.data_disks:
+                data_disks.append(dict(lun=disks.lun,
+                                       disk_size_gb=disks.disk_size_gb,
+                                       managed_disk=(not (disks.managed_disk is None))))
+
+            os_disk = dict(disk_size_gb=image.storage_profile.os_disk.disk_size_gb,
+                           managed_disk=(not (image.storage_profile.os_disk.managed_disk is None)))
+
             image_info = dict(name=image.name,
                               location=image.location,
                               resource_group=image.id.split("/")[4],
-                              managed=(not (image.storage_profile.os_disk.managed_disk is None))
-                              )
+                              managed=(not (image.storage_profile.os_disk.managed_disk is None)),
+                              id=image.id,
+                              storage_profile=dict(os_disk=os_disk,
+                                                   data_disks=data_disks))
             named_images.append(image_info)
 
         return named_images
@@ -145,8 +147,10 @@ class AzureRMImageFacts(AzureRMModuleBase):
 
         image_names = self._list_images()
 
+        exists = not (not image_names)
+
         return dict(azure_images=image_names,
-                    found=True,
+                    exists=exists,
                     changed=False)
 
     def get_item(self):
@@ -154,15 +158,24 @@ class AzureRMImageFacts(AzureRMModuleBase):
         image_names = self._list_images()
         image_item = []
 
-        found = any(elem['name'] == self.name for elem in image_names)
+        found = False
 
-        if found:
-            for image in image_names:
+        for image in image_names:
+            if self.name and self.resource_group:
+                if (image['name'] == self.name) and (image['resource_group'].lower() == self.resource_group.lower()):
+                    image_item.append(image)
+                    found = True
+            elif self.name:
                 if image['name'] == self.name:
                     image_item.append(image)
+                    found = True
+            elif self.resource_group:
+                if image['resource_group'].lower() == self.resource_group.lower():
+                    image_item.append(image)
+                    found = True
 
         return dict(azure_images=image_item,
-                    found=found,
+                    exists=found,
                     changed=False)
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -15,25 +15,27 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import absolute_import, division, print_function
-
 __metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
-author: "Emma Laurijssens van Engelenhoven"
+author: Emma Laurijssens van Engelenhoven
 description:
-  - "Capture an Azure Virtual Machine image for the deployment of other VMs in Azure 
-     The VM should be generalized usimg sysprep. After this command runs, the Virtual Machine will be unusable.
-     Depends on pip azure module 2.0.0 or above and azure-mgmt-compute 2.1.0 and above."
+  - Show information about VM images in a given subscription in Azure.
+    Depends on pip azure module 2.0.0 or above and azure-mgmt-compute 2.1.0 and above.
 module: azure_rm_image_facts
 options:
   name:
     description:
-      - "The name of the image being queried."
+      - The name of the image being queried.
     required: false
 
 short_description: "Capture Azure Virtual Machine Images"
-version_added: "2.9"
+version_added: "2.5"
 
 '''
 
@@ -46,7 +48,6 @@ EXAMPLES = '''
     - name: List all images in subscription
       azure_rm_image_facts:
         subscription_id: "{{ subscription_id }}"
-        resource_group_name: "{{ resource_group_name }}"
         client_id: "{{ secrets.client_id }}"
         tenant_id: "{{ tenant_id }}"
         client_secret: "{{ secrets.client_secret }}"
@@ -61,6 +62,18 @@ EXAMPLES = '''
         name: win2016-1
 
 '''
+
+RETURN = '''
+azure_images:
+    description: A list of matching image dicts
+    returned: always
+    type: list
+found:
+    description: Whether or not the requested image was found
+    returned: always
+    type: bool
+'''
+
 
 from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 
@@ -133,12 +146,11 @@ class AzureRMImageFacts(AzureRMModuleBase):
         image_names = self._list_images()
 
         return dict(azure_images=image_names,
-                    status="Found",
+                    found=True,
                     changed=False)
 
     def get_item(self):
 
-        status = "Not found"
         image_names = self._list_images()
         image_item = []
 
@@ -147,11 +159,10 @@ class AzureRMImageFacts(AzureRMModuleBase):
         if found:
             for image in image_names:
                 if image['name'] == self.name:
-                    status = "Found"
                     image_item.append(image)
 
         return dict(azure_images=image_item,
-                    status=status,
+                    found=found,
                     changed=False)
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_image_facts.py
@@ -120,7 +120,6 @@ class AzureRMImageFacts(AzureRMModuleBase):
 
         named_images = []
 
-
         for image in image_list:
 
             data_disks = []


### PR DESCRIPTION
##### SUMMARY
Adding support for Azure VM images

##### ISSUE TYPE
 - New Module Pull Request


##### COMPONENT NAME
azure_rm_image
azure_rm_image_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /Users/elaurijssens/raet/voyager-image-factory/ansible.cfg
  configured module search path = [u'/Users/elaurijssens/raet/voyager-image-factory/library', u'/Users/elaurijssens/.ansible/library', u'/usr/share/ansible/library']
  ansible python module location = /Users/elaurijssens/Library/Python/2.7/lib/python/site-packages/ansible
  executable location = /Users/elaurijssens/Library/Python/2.7/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
This set of modules handles images in Azure. It's my first attempt at creating a missing link here. I'm certain I missed a couple of things and programming style might not be up to par but hey, it's a start.
