### PR TITLE
Fix example on comparing master config

### DIFF
--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -248,7 +248,7 @@ EXAMPLES = """
 
 - name: check the running-config against master config
   ios_config:
-    diff_config: intended
+    diff_against: intended
     intended_config: "{{ lookup('file', 'master.cfg') }}"
 
 - name: check the startup-config against the running-config


### PR DESCRIPTION
Current example produces error message: 

"msg": "Unsupported parameters for (ios_config) module: diff_config Supported parameters include: after,auth_pass,authorize,backup,before,defaults,diff_against,diff_ignore_lines,force,host,intended_config,lines,match,multiline_delimiter,parents,password,port,provider,replace,running_config,save,save_when,src,ssh_keyfile,timeout,username"

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
