### PR TITLE
Fixing nxos_vlan to match platform agnostic net_vlan

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -289,10 +289,7 @@ def main():
         state=dict(choices=['present', 'absent', 'active', 'suspend'], default='present', required=False),
         admin_state=dict(choices=['up', 'down'], required=False),
         mode=dict(choices=['ce', 'fabricpath'], required=False),
-<<<<<<< HEAD
 
-=======
->>>>>>> upstream/devel
     )
 
     argument_spec.update(nxos_argument_spec)

--- a/lib/ansible/modules/network/nxos/nxos_vlan.py
+++ b/lib/ansible/modules/network/nxos/nxos_vlan.py
@@ -48,7 +48,7 @@ options:
   vlan_state:
     description:
       - Manage the vlan operational state of the VLAN
-        (equivalent to state {active | suspend} command.
+        This is being deprecated in favor of state:
     required: false
     default: active
     choices: ['active','suspend']
@@ -71,7 +71,7 @@ options:
       - Manage the state of the resource.
     required: false
     default: present
-    choices: ['present','absent']
+    choices: ['present','absent', 'active', 'suspend']
   mode:
     description:
       - Set VLAN mode to classical ethernet or fabricpath.
@@ -286,9 +286,13 @@ def main():
         name=dict(required=False),
         vlan_state=dict(choices=['active', 'suspend'], required=False),
         mapped_vni=dict(required=False, type='str'),
-        state=dict(choices=['present', 'absent'], default='present', required=False),
+        state=dict(choices=['present', 'absent', 'active', 'suspend'], default='present', required=False),
         admin_state=dict(choices=['up', 'down'], required=False),
         mode=dict(choices=['ce', 'fabricpath'], required=False),
+<<<<<<< HEAD
+
+=======
+>>>>>>> upstream/devel
     )
 
     argument_spec.update(nxos_argument_spec)
@@ -309,6 +313,13 @@ def main():
     admin_state = module.params['admin_state']
     mapped_vni = module.params['mapped_vni']
     state = module.params['state']
+
+    # this allows vlan_state to remain backwards compatible as we move towards
+    # pushing all 4 options into state to match net_vlan
+    if state == 'active' or state == 'suspend':
+        vlan_state = module.params['state']
+        state = 'present'
+
     mode = module.params['mode']
 
     if vlan_id:


### PR DESCRIPTION
##### SUMMARY
There is no issue on this, but the platform agnostic module does not match the nxos_vlan module.  I tested this minor configuration change with net_vlan and it works in my limited testing.  With this change the net_vlan module will now work for active and suspend for state, however it is still backwards compatible.  This will need to be changed again when/if we deprecate vlan_state

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
http://docs.ansible.com/ansible/latest/nxos_vlan_module.html

##### ANSIBLE VERSION
```
[root@centos ~]# ansible --version
ansible 2.4.0.0
  config file = /root/ansible.cfg
  configured module search path = [u'/usr/lib/python2.7/site-packages/napalm_ansible']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Check out https://docs.ansible.com/ansible/2.4/net_vlan_module.html and look at the state options

This playbook will work, before it would fail on the `suspend` b/c it was not a valid choice
```
value of state must be one of: present,absent, got: suspend
```

Here is the playbook that now works->
```
[root@centos ~]# cat net/net_vlan.yml
---
- hosts: cisco
  connection: local
  vars:
    ansible_network_os: nxos
  tasks:
    - name: configure vlans neighbor
      net_vlan:
        vlan_id: '{{ item.vlan_id }}'
        name: '{{ item.name }}'
        state: '{{ item.state | default("present") }}'
        provider: "{{login_info}}"
      with_items:
        - { vlan_id: '1', name: 'default' }
        - { vlan_id: '2', name: 'Vl2' }
        - { vlan_id: '3', name: 'Vl3', state: 'suspend' }
```
