### PR TITLE
luseradd defaults to creating w/o need for -m

### DIFF
--- a/lib/ansible/modules/system/user.py
+++ b/lib/ansible/modules/system/user.py
@@ -396,9 +396,7 @@ class User(object):
             cmd.append(self.password)
 
         if self.create_home:
-            if self.local:
-                cmd.append('-M')
-            else:
+            if not self.local:
                 cmd.append('-m')
 
             if self.skeleton is not None:


### PR DESCRIPTION
##### SUMMARY
and -M is incorrect in this case

E
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
user
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```