### PR TITLE
Fixes #32092

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -72,7 +72,9 @@ options:
     choices: [ "yes", "no" ]
   force:
     description:
-      - If C(yes), force installs/removes.
+      - 'Corresponds to the C(--force-yes) to I(apt-get) and implies C(allow_unauthenticated: yes)'
+      - 'This option *is not* the equivalent of passing the C(-f) flag to I(apt-get) on the command line'
+      - '**This is a destructive operation with the potential to destroy your system, and it should almost never be used.** Please also see C(man apt-get) for more information.'
     required: false
     default: "no"
     choices: [ "yes", "no" ]

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -74,7 +74,8 @@ options:
     description:
       - 'Corresponds to the C(--force-yes) to I(apt-get) and implies C(allow_unauthenticated: yes)'
       - 'This option *is not* the equivalent of passing the C(-f) flag to I(apt-get) on the command line'
-      - '**This is a destructive operation with the potential to destroy your system, and it should almost never be used.** Please also see C(man apt-get) for more information.'
+      - '**This is a destructive operation with the potential to destroy your system, and it should almost never be used.**
+         Please also see C(man apt-get) for more information.'
     required: false
     default: "no"
     choices: [ "yes", "no" ]


### PR DESCRIPTION
##### SUMMARY
Adds the detail requested in #32092 to the `apt` module documentation, specifically cautioning users against the dangers of `force: yes`.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
apt module

##### ANSIBLE VERSION
```
ansible 2.5.0 (32092_warn_on_apt_force 57fbedbad3) last updated 2017/10/31 17:32:20 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ally/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ally/Projects/Personal/ansible/lib/ansible
  executable location = /home/ally/Projects/Personal/ansible/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]
```
