### PR TITLE
Add ec2_vpc_route_table example, fix typo

### DIFF
--- a/lib/ansible/modules/cloud/amazon/GUIDELINES.md
+++ b/lib/ansible/modules/cloud/amazon/GUIDELINES.md
@@ -198,7 +198,7 @@ _fail_json_aws() is a new method and may be subject to change.  You can use it i
 being contributed back to Ansible, however if you are publishing your module separately please
 don't use it before the start of 2018 / Ansible 2.4_
 
-In the AnsibleAWSModule there is a special method, `module.fail_json.aws()` for nice reporting of
+In the AnsibleAWSModule there is a special method, `module.fail_json_aws()` for nice reporting of
 exceptions.  Call this on your exception and it will report the error together with a traceback for
 use in Ansible verbose mode.
 

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_route_table.py
@@ -128,6 +128,13 @@ EXAMPLES = '''
         instance_id: "{{ nat.instance_id }}"
   register: nat_route_table
 
+- name: delete route table
+  ec2_vpc_route_table:
+    vpc_id: vpc-1245678
+    region: us-west-1
+    route_table_id: "{{ route_table.id }}"
+    lookup: id
+    state: absent
 '''
 
 import re


### PR DESCRIPTION
##### SUMMARY
* Add an example of deleting a VPC route table in the `ec2_vpc_route_table` module. This requires an extra parameter, `lookup`, that is not required when creating a route table. This is already stated in the options documentation.

* Also fix the name of the `fail_json_aws()` method in the AWS development guidelines, from  `fail_json.aws()`.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2_vpc_route_table

##### ANSIBLE VERSION
N/A
