### PR TITLE
Issue #32416. Fix exit from configuration mode in case of command failure

### DIFF
--- a/lib/ansible/module_utils/ios.py
+++ b/lib/ansible/module_utils/ios.py
@@ -133,6 +133,7 @@ def load_config(module, commands):
             continue
         rc, out, err = exec_command(module, command)
         if rc != 0:
+            exec_command(module, 'end')
             module.fail_json(msg=to_text(err, errors='surrogate_then_replace'), command=command, rc=rc)
 
     exec_command(module, 'end')


### PR DESCRIPTION
##### SUMMARY
Add exit from device configuration mode in case of device command failure
Fixes issue #32416

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/ios.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0 (devel 7db28d5e4d) last updated 2017/11/01 11:44:01 (GMT +1100)
  config file = None
  configured module search path = [u'/home/d653903/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/d653903/dev/ansible/lib/ansible
  executable location = /home/d653903/dev/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

