### PR TITLE
[WIP] Add ability to remove tags by key only

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_tag.py
@@ -196,10 +196,11 @@ def main():
             if (key, value) in set(tagdict.items()):
                 dictremove[key] = value
         if purge_tags:
-            dictremove = {x:None for x in tagdict if x not in tags}
+            dictremove = dict.fromkeys(set(tagdict) - set(tags), None)
         if not module.check_mode:
             ec2.delete_tags(resource, dictremove)
         module.exit_json(msg="Tags %s removed for resource %s." % (dictremove,resource), changed=True)
+
 
     if state == 'list':
         module.exit_json(changed=False, tags=tagdict)

--- a/lib/ansible/modules/cloud/amazon/ec2_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_tag.py
@@ -41,7 +41,7 @@ options:
     aliases: []
   purge_tags:
     description:
-      - Purge tags by providing key only, no value. '{"key":""}' and '{"key":"","key":""}'
+      - Whether or not to delete tags by providing which tags to keep only, no value. '{"keepkey":""}' and '{"keepkey":"","keepotherkey":""}'
     required: false
     default: false
     aliases: []
@@ -125,7 +125,7 @@ EXAMPLES = '''
     state: absent
     purge_tags: yes
     tags:
-      TestKey: ""
+      KeepThisKey: ""
 '''
 
 
@@ -195,8 +195,8 @@ def main():
         for (key, value) in set(tags.items()):
             if (key, value) in set(tagdict.items()):
                 dictremove[key] = value
-            if purge_tags:
-                dictremove[key] = None
+        if purge_tags:
+            dictremove = {x:None for x in tagdict if x not in tags}
         if not module.check_mode:
             ec2.delete_tags(resource, dictremove)
         module.exit_json(msg="Tags %s removed for resource %s." % (dictremove,resource), changed=True)

--- a/lib/ansible/modules/cloud/amazon/ec2_tag.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_tag.py
@@ -122,7 +122,7 @@ EXAMPLES = '''
   ec2_tag:
     region: eu-west-1
     resource: vol-XXXXXX
-    state: absent
+    state: present
     purge_tags: yes
     tags:
       KeepThisKey: ""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding the ability to remove EC2 Tags by key only. It was requested in:
https://github.com/ansible/ansible/issues/30145

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_tags

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (ec2_tags_remove ef28e3d47f) last updated 2017/10/31 22:41:48 (GMT -400)
  config file = None
  configured module search path = [u'/Users/danielobrien/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/danielobrien/Projects/ansible/lib/ansible
  executable location = /Users/danielobrien/Projects/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
