### PR TITLE
Allow ec2_lc module to use volume_type for block devices

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -833,6 +833,9 @@ def create_block_device(module, ec2, volume):
     # we add handling for either/or but not both
     if all(key in volume for key in ['device_type', 'volume_type']):
         module.fail_json(msg='device_type is a deprecated name for volume_type. Do not use both device_type and volume_type')
+    if 'device_type' in volume:
+        module.deprecate('device_type is deprecated for block devices - use volume_type instead',
+                         version=2.9)
 
     # get whichever one is set, or NoneType if neither are set
     volume_type = volume.get('device_type') or volume.get('volume_type')

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -192,9 +192,13 @@ def create_block_device_meta(module, volume):
     # device_type has been used historically to represent volume_type,
     # however ec2_vol uses volume_type, as does the BlockDeviceType, so
     # we add handling for either/or but not both
-    if 'device_type' in volume and 'volume_type' in volume:
-        module.fail_json(msg='device_type is a deprecated name for volume_type. '
-                         'Do not use both device_type and volume_type')
+    if 'device_type' in volume:
+        if 'volume_type' in volume:
+            module.fail_json(msg='device_type is a deprecated name for volume_type. '
+                             'Do not use both device_type and volume_type')
+        else:
+            module.deprecate('device_type is deprecated for block devices - use volume_type instead',
+                             version=2.9)
 
     # rewrite device_type key to volume_type
     if 'device_type' in volume:

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -151,7 +151,7 @@ EXAMPLES = '''
     volumes:
     - device_name: /dev/sda1
       volume_size: 100
-      device_type: io1
+      volume_type: io1
       iops: 3000
       delete_on_termination: true
       encrypted: true
@@ -168,7 +168,7 @@ EXAMPLES = '''
     volumes:
     - device_name: /dev/sda1
       volume_size: 120
-      device_type: io1
+      volume_type: io1
       iops: 3000
       delete_on_termination: true
 
@@ -188,11 +188,23 @@ except ImportError:
 
 def create_block_device_meta(module, volume):
     MAX_IOPS_TO_SIZE_RATIO = 30
+
+    # device_type has been used historically to represent volume_type,
+    # however ec2_vol uses volume_type, as does the BlockDeviceType, so
+    # we add handling for either/or but not both
+    if 'device_type' in volume and 'volume_type' in volume:
+        module.fail_json(msg='device_type is a deprecated name for volume_type. '
+                         'Do not use both device_type and volume_type')
+
+    # rewrite device_type key to volume_type
+    if 'device_type' in volume:
+        volume['volume_type'] = volume.pop('device_type')
+
     if 'snapshot' not in volume and 'ephemeral' not in volume:
         if 'volume_size' not in volume:
             module.fail_json(msg='Size must be specified when creating a new volume or modifying the root volume')
     if 'snapshot' in volume:
-        if 'device_type' in volume and volume.get('device_type') == 'io1' and 'iops' not in volume:
+        if volume.get('volume_type') == 'io1' and 'iops' not in volume:
             module.fail_json(msg='io1 volumes must have an iops value set')
     if 'ephemeral' in volume:
         if 'snapshot' in volume:


### PR DESCRIPTION
##### SUMMARY
Makes ec2_lc consistent with ec2, ec2_ami, ec2_vol etc.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_lc

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 312155a641) last updated 2017/11/01 13:01:11 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```
