### PR TITLE
Removes gtm wide ip from skip file

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
+++ b/lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
@@ -4,14 +4,18 @@
 # Copyright (c) 2017 F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: bigip_gtm_wide_ip
-short_description: Manages F5 BIG-IP GTM wide ip.
+short_description: Manages F5 BIG-IP GTM wide ip
 description:
   - Manages F5 BIG-IP GTM wide ip.
 version_added: "2.0"
@@ -62,6 +66,11 @@ options:
       - disabled
       - enabled
     version_added: 2.4
+  partition:
+    description:
+      - Device partition to manage resources on.
+    default: Common
+    version_added: 2.5
 notes:
   - Requires the f5-sdk Python package on the host. This is as easy as pip
     install f5-sdk.
@@ -72,40 +81,42 @@ author:
   - Tim Rupp (@caphrim007)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Set lb method
   bigip_gtm_wide_ip:
-      server: "lb.mydomain.com"
-      user: "admin"
-      password: "secret"
-      lb_method: "round-robin"
-      name: "my-wide-ip.example.com"
+    server: lb.mydomain.com
+    user: admin
+    password: secret
+    lb_method: round-robin
+    name: my-wide-ip.example.com
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 lb_method:
-    description: The new load balancing method used by the wide IP.
-    returned: changed
-    type: string
-    sample: "topology"
+  description: The new load balancing method used by the wide IP.
+  returned: changed
+  type: string
+  sample: topology
 state:
-    description: The new state of the wide IP.
-    returned: changed
-    type: string
-    sample: "disabled"
+  description: The new state of the wide IP.
+  returned: changed
+  type: string
+  sample: disabled
 '''
 
 import re
 
-from ansible.module_utils.f5_utils import (
-    AnsibleF5Client,
-    AnsibleF5Parameters,
-    HAS_F5SDK,
-    F5ModuleError,
-    iControlUnexpectedHTTPError
-)
+from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.f5_utils import AnsibleF5Parameters
+from ansible.module_utils.f5_utils import HAS_F5SDK
+from ansible.module_utils.f5_utils import F5ModuleError
 from distutils.version import LooseVersion
+
+try:
+    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+except ImportError:
+    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):
@@ -494,23 +505,18 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         self.argument_spec = dict(
             lb_method=dict(
-                required=False,
-                choices=lb_method_choices,
-                default=None
+                choices=lb_method_choices
             ),
             name=dict(
                 required=True,
                 aliases=['wide_ip']
             ),
             type=dict(
-                required=False,
-                default=None,
                 choices=[
                     'a', 'aaaa', 'cname', 'mx', 'naptr', 'srv'
                 ]
             ),
             state=dict(
-                required=False,
                 default='present',
                 choices=['absent', 'present', 'enabled', 'disabled']
             )

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -14,7 +14,6 @@ lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
 lib/ansible/modules/clustering/consul_acl.py
 lib/ansible/modules/network/cloudengine/ce_file_copy.py
-lib/ansible/modules/network/f5/bigip_gtm_wide_ip.py
 lib/ansible/modules/network/f5/bigip_hostname.py
 lib/ansible/modules/network/f5/bigip_iapp_service.py
 lib/ansible/modules/network/f5/bigip_iapp_template.py

--- a/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
+++ b/test/units/modules/network/f5/test_bigip_gtm_wide_ip.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017 F5 Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -42,6 +28,7 @@ try:
     from library.bigip_gtm_wide_ip import ArgumentSpec
     from library.bigip_gtm_wide_ip import UntypedManager
     from library.bigip_gtm_wide_ip import TypedManager
+    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_gtm_wide_ip import Parameters
@@ -49,6 +36,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_gtm_wide_ip import ArgumentSpec
         from ansible.modules.network.f5.bigip_gtm_wide_ip import UntypedManager
         from ansible.modules.network.f5.bigip_gtm_wide_ip import TypedManager
+        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Removes gtm wide ip from skip file

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_gtm_wide_ip

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
