### PR TITLE
ipa_dnsrecord: Allow for TXT Records

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnsrecord.py
@@ -31,7 +31,7 @@ options:
   record_type:
     description:
     - The type of DNS record name
-    - Currently, 'A', 'AAAA', 'PTR' and 'TXT' are supported
+    - Currently, 'A', 'AAAA', 'PTR' and 'TXT' (added in 2.5) are supported
     required: false
     default: 'A'
     choices: ['A', 'AAAA', 'PTR', 'TXT']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This pull-request adds the possibility to add and remove TXT records.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ipa_dnsrecord 
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (TTL 6bc85744ef) last updated 2017/10/31 19:56:44 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = 
  ansible python module location = 
  executable location = 
  python version = 3.6.3 (default, Oct  3 2017, 21:45:48) [GCC 7.2.0]

```