### PR TITLE
Update example to show usage for a common https URL.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -168,7 +168,7 @@ EXAMPLES = '''
     state: absent
 
 #
-# Example of how to authenticate (Note that url can also be specfied a top level module parameter)
+# Example of how to authenticate
 #
 # my_jenkins_params:
 #   url_username: admin

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -168,17 +168,18 @@ EXAMPLES = '''
     state: absent
 
 #
-# Example of how to authenticate
+# Example of how to authenticate (Note that url can also be specfied a top level module parameter)
 #
 # my_jenkins_params:
 #   url_username: admin
+#   url: https://localhost:8433
+#   validate_certs: no
 #
 - name: Install plugin
   jenkins_plugin:
     name: build-pipeline-plugin
     params: "{{ my_jenkins_params }}"
     url_password: p4ssw0rd
-    url: http://localhost:8888
 # Note that url_password **can not** be placed in params as params could end up in a log file
 
 #


### PR DESCRIPTION
##### SUMMARY
Updated the example to show how to specify the URL in the most common case, which is the localhost running on an SSL port without a valid certificate.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
- jenkins_plugin

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Aug 16 2017, 20:02:23) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
