### PR TITLE
For jenkins_job, bring parity for the support of some parameters with other modules.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -184,6 +184,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+from ansible.module_utils.urls import url_argument_spec
 
 
 class JenkinsJob:

--- a/lib/ansible/modules/web_infrastructure/jenkins_job.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_job.py
@@ -70,7 +70,7 @@ options:
     description:
       - Option used to allow the user to overwrite any of the other options. To
         remove an option, set the value of the option to C(null).
-    version_added: 2.4
+    version_added: 2.5
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
- Add support for url params that most other modules support (includinging jenkins-plugin).
- Bring functionality around `params` and `force_basic_auth` from jenkins-plugin over to get some uniformity.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- jenkins_script

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Aug 16 2017, 20:02:23) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
This change provides a means to use some parameters consistently across all plugins and should in general help simplify the usage.

The `params` parameter is a generic pattern for passing in arbitrary parameters to modules, and is already supported by `jenkins_plugin`. Also, some common parameters to the Ansible framework can be passed in via `params` without any extra effort from the plugin. Right now, I can't even pass `validate_certs` to `jenkins_job` module because it doesn't accept `params`.