### PR TITLE
Get StackEvents when ClientRequestToken is not used Fixes #32396

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -292,7 +292,7 @@ def create_stack(module, stack_params, cfn):
 
     try:
         cfn.create_stack(**stack_params)
-        result = stack_operation(cfn, stack_params['StackName'], 'CREATE', stack_params['ClientRequestToken'])
+        result = stack_operation(cfn, stack_params['StackName'], 'CREATE', stack_params.get('ClientRequestToken', None))
     except Exception as err:
         error_msg = boto_exception(err)
         module.fail_json(msg="Failed to create stack {0}: {1}.".format(stack_params.get('StackName'), error_msg), exception=traceback.format_exc())
@@ -351,7 +351,7 @@ def update_stack(module, stack_params, cfn):
     # don't need to be updated.
     try:
         cfn.update_stack(**stack_params)
-        result = stack_operation(cfn, stack_params['StackName'], 'UPDATE', stack_params['ClientRequestToken'])
+        result = stack_operation(cfn, stack_params['StackName'], 'UPDATE', stack_params.get('ClientRequestToken', None))
     except Exception as err:
         error_msg = boto_exception(err)
         if 'No updates are to be performed.' in error_msg:
@@ -630,7 +630,7 @@ def main():
                 result = {'changed': False, 'output': 'Stack not found.'}
             else:
                 cfn.delete_stack(StackName=stack_params['StackName'])
-                result = stack_operation(cfn, stack_params['StackName'], 'DELETE', stack_params['ClientRequestToken'])
+                result = stack_operation(cfn, stack_params['StackName'], 'DELETE', stack_params.get('ClientRequestToken', None))
         except Exception as err:
             module.fail_json(msg=boto_exception(err), exception=traceback.format_exc())
 

--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -256,7 +256,7 @@ def get_stack_events(cfn, stack_name, token_filter=None):
                 "StackEvents[?ClientRequestToken == '{0}']".format(token_filter)
             ))
         else:
-            events = list(pg)
+            events = list(pg.search("StackEvents[*]"))
     except (botocore.exceptions.ValidationError, botocore.exceptions.ClientError) as err:
         error_msg = boto_exception(err)
         if 'does not exist' in error_msg:

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_2.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_2.json
@@ -21,7 +21,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -42,7 +41,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -63,7 +61,6 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_3.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_3.json
@@ -21,7 +21,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -42,7 +41,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -63,7 +61,6 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_4.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_4.json
@@ -21,7 +21,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -42,7 +41,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -63,7 +61,6 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_5.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_5.json
@@ -21,7 +21,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -42,7 +41,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -63,7 +61,6 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_7.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/basic_s3_stack/cloudformation.DescribeStackEvents_7.json
@@ -19,7 +19,6 @@
                 },
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             },
             {
@@ -40,7 +39,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -62,7 +60,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -83,7 +80,6 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -104,7 +100,6 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.CreateStack_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.CreateStack_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "03fbfc36-b5d0-11e7-ae09-550cfe4b2358",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "03fbfc36-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:07 GMT",
+                "content-length": "393",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.CreateStack_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.CreateStack_1.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200,
     "data": {
-        "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+        "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DeleteStack_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DeleteStack_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "170d1e02-b5d0-11e7-ae09-550cfe4b2358",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "170d1e02-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:39 GMT",
+                "content-length": "212",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_1.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -18,10 +18,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_1.json
@@ -20,6 +20,7 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_2.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_2.json
@@ -4,26 +4,6 @@
         "StackEvents": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
-                "ResourceStatus": "CREATE_COMPLETE",
-                "ResourceType": "AWS::S3::Bucket",
-                "Timestamp": {
-                    "hour": 19,
-                    "__class__": "datetime",
-                    "month": 10,
-                    "second": 33,
-                    "microsecond": 200000,
-                    "year": 2017,
-                    "day": 20,
-                    "minute": 51
-                },
-                "StackName": "ansible-test-basic-yaml",
-                "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "LogicalResourceId": "MyBucket"
-            },
-            {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -41,6 +21,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -61,6 +42,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -81,19 +63,20 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "075d9d71-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+                "x-amzn-requestid": "075d9d71-b5d0-11e7-ae09-550cfe4b2358",
                 "vary": "Accept-Encoding",
-                "content-length": "3490",
+                "content-length": "2730",
                 "content-type": "text/xml",
-                "date": "Fri, 20 Oct 2017 19:51:34 GMT"
+                "date": "Fri, 20 Oct 2017 19:51:13 GMT"
             }
         }
     }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_2.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_2.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -18,14 +18,14 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "Resource creation Initiated",
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:11.159Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -39,14 +39,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -61,10 +61,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_3.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_3.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -18,14 +18,14 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "Resource creation Initiated",
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:11.159Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -39,14 +39,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -61,10 +61,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_3.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_3.json
@@ -4,26 +4,6 @@
         "StackEvents": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
-                "ResourceStatus": "CREATE_COMPLETE",
-                "ResourceType": "AWS::S3::Bucket",
-                "Timestamp": {
-                    "hour": 19,
-                    "__class__": "datetime",
-                    "month": 10,
-                    "second": 33,
-                    "microsecond": 200000,
-                    "year": 2017,
-                    "day": 20,
-                    "minute": 51
-                },
-                "StackName": "ansible-test-basic-yaml",
-                "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "LogicalResourceId": "MyBucket"
-            },
-            {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -41,6 +21,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -61,6 +42,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -81,19 +63,20 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "0a7eb31b-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+                "x-amzn-requestid": "0a7eb31b-b5d0-11e7-ae09-550cfe4b2358",
                 "vary": "Accept-Encoding",
-                "content-length": "3490",
+                "content-length": "2730",
                 "content-type": "text/xml",
-                "date": "Fri, 20 Oct 2017 19:51:34 GMT"
+                "date": "Fri, 20 Oct 2017 19:51:19 GMT"
             }
         }
     }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_4.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_4.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -18,14 +18,14 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "Resource creation Initiated",
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:11.159Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -39,14 +39,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -61,10 +61,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_4.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_4.json
@@ -4,26 +4,6 @@
         "StackEvents": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
-                "ResourceStatus": "CREATE_COMPLETE",
-                "ResourceType": "AWS::S3::Bucket",
-                "Timestamp": {
-                    "hour": 19,
-                    "__class__": "datetime",
-                    "month": 10,
-                    "second": 33,
-                    "microsecond": 200000,
-                    "year": 2017,
-                    "day": 20,
-                    "minute": 51
-                },
-                "StackName": "ansible-test-basic-yaml",
-                "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "LogicalResourceId": "MyBucket"
-            },
-            {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -41,6 +21,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -61,6 +42,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -81,19 +63,20 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "0d9e1c06-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+                "x-amzn-requestid": "0d9e1c06-b5d0-11e7-ae09-550cfe4b2358",
                 "vary": "Accept-Encoding",
-                "content-length": "3490",
+                "content-length": "2730",
                 "content-type": "text/xml",
-                "date": "Fri, 20 Oct 2017 19:51:34 GMT"
+                "date": "Fri, 20 Oct 2017 19:51:24 GMT"
             }
         }
     }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_5.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_5.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -18,14 +18,14 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "Resource creation Initiated",
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:11.159Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -39,14 +39,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -61,10 +61,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_5.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_5.json
@@ -4,26 +4,6 @@
         "StackEvents": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
-                "ResourceStatus": "CREATE_COMPLETE",
-                "ResourceType": "AWS::S3::Bucket",
-                "Timestamp": {
-                    "hour": 19,
-                    "__class__": "datetime",
-                    "month": 10,
-                    "second": 33,
-                    "microsecond": 200000,
-                    "year": 2017,
-                    "day": 20,
-                    "minute": 51
-                },
-                "StackName": "ansible-test-basic-yaml",
-                "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
-                "LogicalResourceId": "MyBucket"
-            },
-            {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -41,6 +21,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -61,6 +42,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -81,19 +63,20 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "10bd84ca-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+                "x-amzn-requestid": "10bd84ca-b5d0-11e7-ae09-550cfe4b2358",
                 "vary": "Accept-Encoding",
-                "content-length": "3490",
+                "content-length": "2730",
                 "content-type": "text/xml",
-                "date": "Fri, 20 Oct 2017 19:51:34 GMT"
+                "date": "Fri, 20 Oct 2017 19:51:29 GMT"
             }
         }
     }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_6.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_6.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
                 "ResourceStatus": "CREATE_COMPLETE",
                 "ResourceType": "AWS::S3::Bucket",
@@ -17,14 +17,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -39,14 +39,14 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "Resource creation Initiated",
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:11.159Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -60,14 +60,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -82,10 +82,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_6.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_6.json
@@ -20,6 +20,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -41,6 +42,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -61,6 +63,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -81,6 +84,7 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_7.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_7.json
@@ -4,6 +4,26 @@
         "StackEvents": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "EventId": "140d7220-b5d0-11e7-933f-50a686be7356",
+                "ResourceStatus": "CREATE_COMPLETE",
+                "ResourceType": "AWS::CloudFormation::Stack",
+                "Timestamp": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 10,
+                    "second": 35,
+                    "microsecond": 121000,
+                    "year": 2017,
+                    "day": 20,
+                    "minute": 51
+                },
+                "StackName": "ansible-test-basic-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
+                "LogicalResourceId": "ansible-test-basic-yaml"
+            },
+            {
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
                 "ResourceStatus": "CREATE_COMPLETE",
                 "ResourceType": "AWS::S3::Bucket",
@@ -20,6 +40,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -41,6 +62,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -61,6 +83,7 @@
                 "StackName": "ansible-test-basic-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
@@ -81,19 +104,20 @@
                 "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
                 "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "ansible-test-basic-yaml"
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "16faf590-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "13dbb3fd-b5d0-11e7-ae09-550cfe4b2358",
+                "x-amzn-requestid": "16faf590-b5d0-11e7-ae09-550cfe4b2358",
                 "vary": "Accept-Encoding",
-                "content-length": "3490",
+                "content-length": "4276",
                 "content-type": "text/xml",
-                "date": "Fri, 20 Oct 2017 19:51:34 GMT"
+                "date": "Fri, 20 Oct 2017 19:51:39 GMT"
             }
         }
     }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_7.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStackEvents_7.json
@@ -3,7 +3,7 @@
     "data": {
         "StackEvents": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "140d7220-b5d0-11e7-933f-50a686be7356",
                 "ResourceStatus": "CREATE_COMPLETE",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -17,13 +17,13 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_COMPLETE-2017-10-20T19:51:33.200Z",
                 "ResourceStatus": "CREATE_COMPLETE",
                 "ResourceType": "AWS::S3::Bucket",
@@ -37,14 +37,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:12.754Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -59,14 +59,14 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "Resource creation Initiated",
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
-                "PhysicalResourceId": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4",
+                "PhysicalResourceId": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "MyBucket-CREATE_IN_PROGRESS-2017-10-20T19:51:11.159Z",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::S3::Bucket",
@@ -80,14 +80,14 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "ResourceProperties": "{}\n",
                 "PhysicalResourceId": "",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
                 "LogicalResourceId": "MyBucket"
             },
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
                 "ResourceStatus": "CREATE_IN_PROGRESS",
                 "ResourceType": "AWS::CloudFormation::Stack",
@@ -102,10 +102,10 @@
                     "minute": 51
                 },
                 "ResourceStatusReason": "User Initiated",
-                "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackName": "ansible-test-client-request-token-yaml",
+                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "ClientRequestToken": "3faf3fb5-b289-41fc-b940-44151828f6cf",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "LogicalResourceId": "ansible-test-client-request-token-yaml"
             }
         ],
         "ResponseMetadata": {

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_1.json
@@ -1,13 +1,14 @@
 {
     "status_code": 200,
     "data": {
-        "StackEvents": [
+        "Stacks": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
-                "ResourceStatus": "CREATE_IN_PROGRESS",
-                "ResourceType": "AWS::CloudFormation::Stack",
-                "Timestamp": {
+                "EnableTerminationProtection": false,
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "StackStatusReason": "User Initiated",
+                "CreationTime": {
                     "hour": 19,
                     "__class__": "datetime",
                     "month": 10,
@@ -17,20 +18,21 @@
                     "day": 20,
                     "minute": 51
                 },
-                "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_IN_PROGRESS",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "042974db-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+                "x-amzn-requestid": "042974db-b5d0-11e7-ae09-550cfe4b2358",
                 "date": "Fri, 20 Oct 2017 19:51:08 GMT",
-                "content-length": "1183",
+                "content-length": "975",
                 "content-type": "text/xml"
             }
         }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_1.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_1.json
@@ -3,7 +3,7 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "EnableTerminationProtection": false,
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
@@ -18,7 +18,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_IN_PROGRESS",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_2.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_2.json
@@ -3,7 +3,7 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
                 "EnableTerminationProtection": false,
@@ -17,7 +17,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_IN_PROGRESS",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_2.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_2.json
@@ -1,13 +1,13 @@
 {
     "status_code": 200,
     "data": {
-        "StackEvents": [
+        "Stacks": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
-                "ResourceStatus": "CREATE_IN_PROGRESS",
-                "ResourceType": "AWS::CloudFormation::Stack",
-                "Timestamp": {
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "EnableTerminationProtection": false,
+                "CreationTime": {
                     "hour": 19,
                     "__class__": "datetime",
                     "month": 10,
@@ -17,20 +17,21 @@
                     "day": 20,
                     "minute": 51
                 },
-                "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_IN_PROGRESS",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "074b26dc-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
-                "date": "Fri, 20 Oct 2017 19:51:08 GMT",
-                "content-length": "1183",
+                "x-amzn-requestid": "074b26dc-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:13 GMT",
+                "content-length": "913",
                 "content-type": "text/xml"
             }
         }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_3.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_3.json
@@ -3,7 +3,7 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
                 "EnableTerminationProtection": false,
@@ -17,7 +17,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_IN_PROGRESS",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_3.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_3.json
@@ -1,13 +1,13 @@
 {
     "status_code": 200,
     "data": {
-        "StackEvents": [
+        "Stacks": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
-                "ResourceStatus": "CREATE_IN_PROGRESS",
-                "ResourceType": "AWS::CloudFormation::Stack",
-                "Timestamp": {
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "EnableTerminationProtection": false,
+                "CreationTime": {
                     "hour": 19,
                     "__class__": "datetime",
                     "month": 10,
@@ -17,20 +17,21 @@
                     "day": 20,
                     "minute": 51
                 },
-                "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_IN_PROGRESS",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "0a6cb1b3-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
-                "date": "Fri, 20 Oct 2017 19:51:08 GMT",
-                "content-length": "1183",
+                "x-amzn-requestid": "0a6cb1b3-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:18 GMT",
+                "content-length": "913",
                 "content-type": "text/xml"
             }
         }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_4.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_4.json
@@ -1,13 +1,13 @@
 {
     "status_code": 200,
     "data": {
-        "StackEvents": [
+        "Stacks": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
-                "ResourceStatus": "CREATE_IN_PROGRESS",
-                "ResourceType": "AWS::CloudFormation::Stack",
-                "Timestamp": {
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "EnableTerminationProtection": false,
+                "CreationTime": {
                     "hour": 19,
                     "__class__": "datetime",
                     "month": 10,
@@ -17,20 +17,21 @@
                     "day": 20,
                     "minute": 51
                 },
-                "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_IN_PROGRESS",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "0d8cddf1-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
-                "date": "Fri, 20 Oct 2017 19:51:08 GMT",
-                "content-length": "1183",
+                "x-amzn-requestid": "0d8cddf1-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:23 GMT",
+                "content-length": "913",
                 "content-type": "text/xml"
             }
         }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_4.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_4.json
@@ -3,7 +3,7 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
                 "EnableTerminationProtection": false,
@@ -17,7 +17,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_IN_PROGRESS",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_5.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_5.json
@@ -3,7 +3,7 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
                 "EnableTerminationProtection": false,
@@ -17,7 +17,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_IN_PROGRESS",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_5.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_5.json
@@ -1,13 +1,13 @@
 {
     "status_code": 200,
     "data": {
-        "StackEvents": [
+        "Stacks": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
-                "ResourceStatus": "CREATE_IN_PROGRESS",
-                "ResourceType": "AWS::CloudFormation::Stack",
-                "Timestamp": {
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "EnableTerminationProtection": false,
+                "CreationTime": {
                     "hour": 19,
                     "__class__": "datetime",
                     "month": 10,
@@ -17,20 +17,21 @@
                     "day": 20,
                     "minute": 51
                 },
-                "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_IN_PROGRESS",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "10ac94d5-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
-                "date": "Fri, 20 Oct 2017 19:51:08 GMT",
-                "content-length": "1183",
+                "x-amzn-requestid": "10ac94d5-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:28 GMT",
+                "content-length": "913",
                 "content-type": "text/xml"
             }
         }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_6.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_6.json
@@ -3,7 +3,7 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
                 "EnableTerminationProtection": false,
@@ -17,7 +17,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_IN_PROGRESS",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_6.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_6.json
@@ -1,13 +1,13 @@
 {
     "status_code": 200,
     "data": {
-        "StackEvents": [
+        "Stacks": [
             {
                 "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "EventId": "04032730-b5d0-11e7-86b8-503ac93168c5",
-                "ResourceStatus": "CREATE_IN_PROGRESS",
-                "ResourceType": "AWS::CloudFormation::Stack",
-                "Timestamp": {
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "EnableTerminationProtection": false,
+                "CreationTime": {
                     "hour": 19,
                     "__class__": "datetime",
                     "month": 10,
@@ -17,20 +17,21 @@
                     "day": 20,
                     "minute": 51
                 },
-                "ResourceStatusReason": "User Initiated",
                 "StackName": "ansible-test-basic-yaml",
-                "PhysicalResourceId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
-                "LogicalResourceId": "ansible-test-basic-yaml"
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_IN_PROGRESS",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
             }
         ],
         "ResponseMetadata": {
             "RetryAttempts": 0,
             "HTTPStatusCode": 200,
-            "RequestId": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
+            "RequestId": "13caeb1b-b5d0-11e7-ae09-550cfe4b2358",
             "HTTPHeaders": {
-                "x-amzn-requestid": "043d4a05-b5d0-11e7-ae09-550cfe4b2358",
-                "date": "Fri, 20 Oct 2017 19:51:08 GMT",
-                "content-length": "1183",
+                "x-amzn-requestid": "13caeb1b-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:33 GMT",
+                "content-length": "913",
                 "content-type": "text/xml"
             }
         }

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_7.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_7.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "Stacks": [
+            {
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "Description": "Basic template that creates an S3 bucket",
+                "Tags": [],
+                "Outputs": [
+                    {
+                        "OutputKey": "TheName",
+                        "OutputValue": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4"
+                    }
+                ],
+                "EnableTerminationProtection": false,
+                "CreationTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 10,
+                    "second": 8,
+                    "microsecond": 324000,
+                    "year": 2017,
+                    "day": 20,
+                    "minute": 51
+                },
+                "StackName": "ansible-test-basic-yaml",
+                "NotificationARNs": [],
+                "StackStatus": "CREATE_COMPLETE",
+                "DisableRollback": false,
+                "RollbackConfiguration": {}
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "16ea53bb-b5d0-11e7-ae09-550cfe4b2358",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "16ea53bb-b5d0-11e7-ae09-550cfe4b2358",
+                "date": "Fri, 20 Oct 2017 19:51:39 GMT",
+                "content-length": "1115",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_7.json
+++ b/test/units/modules/cloud/amazon/placebo_recordings/cloudformation/client_request_token_s3_stack/cloudformation.DescribeStacks_7.json
@@ -3,13 +3,13 @@
     "data": {
         "Stacks": [
             {
-                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-basic-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
+                "StackId": "arn:aws:cloudformation:us-west-2:123456789012:stack/ansible-test-client-request-token-yaml/04023cd0-b5d0-11e7-86b8-503ac93168c5",
                 "Description": "Basic template that creates an S3 bucket",
                 "Tags": [],
                 "Outputs": [
                     {
                         "OutputKey": "TheName",
-                        "OutputValue": "ansible-test-basic-yaml-mybucket-13m2y4v8bptj4"
+                        "OutputValue": "ansible-test-client-request-token-yaml-mybucket-13m2y4v8bptj4"
                     }
                 ],
                 "EnableTerminationProtection": false,
@@ -23,7 +23,7 @@
                     "day": 20,
                     "minute": 51
                 },
-                "StackName": "ansible-test-basic-yaml",
+                "StackName": "ansible-test-client-request-token-yaml",
                 "NotificationARNs": [],
                 "StackStatus": "CREATE_COMPLETE",
                 "DisableRollback": false,

--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -18,7 +18,7 @@
 import pytest
 from mock import patch
 
-from . placebo_fixtures import placeboify, maybe_sleep
+from .placebo_fixtures import placeboify, maybe_sleep
 from ansible.modules.cloud.amazon import cloudformation as cfn_module
 
 basic_yaml_tpl = """
@@ -73,12 +73,28 @@ def test_invalid_template_json(placeboify):
     assert "ValidationError" in m.exit_kwargs['msg']
 
 
-def test_basic_s3_stack(maybe_sleep, placeboify):
+def test_client_request_token_s3_stack(maybe_sleep, placeboify):
     connection = placeboify.client('cloudformation')
     params = {
         'StackName': 'ansible-test-basic-yaml',
         'TemplateBody': basic_yaml_tpl,
         'ClientRequestToken': '3faf3fb5-b289-41fc-b940-44151828f6cf',
+    }
+    m = FakeModule(disable_rollback=False)
+    result = cfn_module.create_stack(m, params, connection)
+    assert result['changed']
+    assert len(result['events']) > 1
+    # require that the final recorded stack state was CREATE_COMPLETE
+    # events are retrieved newest-first, so 0 is the latest
+    assert 'CREATE_COMPLETE' in result['events'][0]
+    connection.delete_stack(StackName='ansible-test-basic-yaml')
+
+
+def test_basic_s3_stack(maybe_sleep, placeboify):
+    connection = placeboify.client('cloudformation')
+    params = {
+        'StackName': 'ansible-test-basic-yaml',
+        'TemplateBody': basic_yaml_tpl
     }
     m = FakeModule(disable_rollback=False)
     result = cfn_module.create_stack(m, params, connection)

--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -76,7 +76,7 @@ def test_invalid_template_json(placeboify):
 def test_client_request_token_s3_stack(maybe_sleep, placeboify):
     connection = placeboify.client('cloudformation')
     params = {
-        'StackName': 'ansible-test-basic-yaml',
+        'StackName': 'ansible-test-client-request-token-yaml',
         'TemplateBody': basic_yaml_tpl,
         'ClientRequestToken': '3faf3fb5-b289-41fc-b940-44151828f6cf',
     }
@@ -87,7 +87,7 @@ def test_client_request_token_s3_stack(maybe_sleep, placeboify):
     # require that the final recorded stack state was CREATE_COMPLETE
     # events are retrieved newest-first, so 0 is the latest
     assert 'CREATE_COMPLETE' in result['events'][0]
-    connection.delete_stack(StackName='ansible-test-basic-yaml')
+    connection.delete_stack(StackName='ansible-test-client-request-token-yaml')
 
 
 def test_basic_s3_stack(maybe_sleep, placeboify):


### PR DESCRIPTION
##### SUMMARY
This PR fixes an issue related to the ClientRequestToken implementation.
When getting the stack events without a token_filter, we still need to retrieve the StackEvents element, otherwise the the creation of the event list would fail with a TypeError exception.

Fixes #32396.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudformation

##### ANSIBLE VERSION
```
ansible-playbook 2.5.0
  config file = /Users/e48687/.ansible.cfg
  configured module search path = [u'/Users/e48687/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible-playbook
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
Included test unit cases that cover the scenario where the ClientRequestToken is not being used in the create stack method.