### PR TITLE
Fix wrong prompt issue for network modules (#32426)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ Ansible Changes By Release
   (https://github.com/ansible/ansible/pull/32321)
 * Fix ios_logging module issue where facility is being deleted along with host:
   (https://github.com/ansible/ansible/pull/32234)
+* Fix wrong prompt issue for network modules (https://github.com/ansible/ansible/pull/32426)
+
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/plugins/action/ios.py
+++ b/lib/ansible/plugins/action/ios.py
@@ -73,9 +73,10 @@ class ActionModule(_ActionModule):
         # make sure we are in the right cli context which should be
         # enable mode and not config module
         rc, out, err = connection.exec_command('prompt()')
-        if str(out).strip().endswith(')#'):
+        while str(out).strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
             connection.exec_command('exit')
+            rc, out, err = connection.exec_command('prompt()')
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -248,6 +248,7 @@ class Connection(Rpc, _Connection):
                     match = regex.search(response)
                     if match:
                         errored_response = response
+                        self._matched_prompt = match.group()
                         break
 
         if not is_error_message:

--- a/test/integration/targets/ios_config/tests/cli/defaults.yaml
+++ b/test/integration/targets/ios_config/tests/cli/defaults.yaml
@@ -40,4 +40,23 @@
       - "result.changed == false"
       - "result.updates is not defined"
 
+- name: Check device is in proper prompt after error
+  ios_config:
+    lines:
+        - mac-address-table notification mac-move
+    authorize: yes
+  ignore_errors: yes
+
+- name: show interfaces brief to ensure deivce goes to valid prompt
+  ios_command:
+    commands:
+      - show interfaces
+    authorize: yes
+  register: result
+
+- assert:
+    that:
+      - "result.changed == false"
+      - "result.stdout is defined"
+
 - debug: msg="END cli/defaults.yaml"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* Fix wrong prompt issue for network modules

Fixes #31161
Fixes #32416

*  Store the device prompt in case of error
   from the remote device
*  Check for prompt value in ios action plugin

*  Add integration test
*  Update Changelog

(cherry picked from commit 26583adb582fa3baae4497be4094d920c4771681)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
action/ios.py
connection/network_cli.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
