### PR TITLE
Fix issue #28250 - vmware_guest - server already exists

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -198,9 +198,21 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
             folder = datacenter.hostFolder
         vm = find_vm_by_name(content, vm_id, folder)
     elif vm_id_type == 'inventory_path':
-        searchpath = folder
+
+        dcpath = compile_folder_path_for_object(datacenter)
+
+        # Check for full path first in case it was already supplied
+        if (folder.startswith(dcpath + datacenter + '/vm')):
+           fullpath = folder
+        elif (folder.startswith('/vm/') or folder == '/vm'):
+           fullpath = "%s%s%s" % (dcpath, datacenter, folder)
+        elif (folder.startswith('/')):
+           fullpath = "%s%s/vm%s" % (dcpath, datacenter, folder)
+        else:
+           fullpath = "%s%s/vm/%s" % (dcpath, datacenter, folder)
+
         # get all objects for this path
-        f_obj = si.FindByInventoryPath(searchpath)
+        f_obj = si.FindByInventoryPath(fullpath)
         if f_obj:
             if isinstance(f_obj, vim.Datacenter):
                 f_obj = f_obj.vmFolder

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -203,13 +203,13 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
 
         # Check for full path first in case it was already supplied
         if (folder.startswith(dcpath + datacenter + '/vm')):
-           fullpath = folder
+            fullpath = folder
         elif (folder.startswith('/vm/') or folder == '/vm'):
-           fullpath = "%s%s%s" % (dcpath, datacenter, folder)
+            fullpath = "%s%s%s" % (dcpath, datacenter, folder)
         elif (folder.startswith('/')):
-           fullpath = "%s%s/vm%s" % (dcpath, datacenter, folder)
+            fullpath = "%s%s/vm%s" % (dcpath, datacenter, folder)
         else:
-           fullpath = "%s%s/vm/%s" % (dcpath, datacenter, folder)
+            fullpath = "%s%s/vm/%s" % (dcpath, datacenter, folder)
 
         # get all objects for this path
         f_obj = si.FindByInventoryPath(fullpath)

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -182,6 +182,7 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
     """ UUID is unique to a VM, every other id returns the first match. """
     si = content.searchIndex
     vm = None
+    f_obj = None
 
     if vm_id_type == 'dns_name':
         vm = si.FindByDnsName(datacenter=datacenter, dnsName=vm_id, vmSearch=True)
@@ -214,6 +215,7 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
 
             # get all objects for this path
             f_obj = si.FindByInventoryPath(fullpath)
+
         if f_obj:
             if isinstance(f_obj, vim.Datacenter):
                 f_obj = f_obj.vmFolder

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -199,20 +199,21 @@ def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None, cluster
         vm = find_vm_by_name(content, vm_id, folder)
     elif vm_id_type == 'inventory_path':
 
-        dcpath = compile_folder_path_for_object(datacenter)
+        if datacenter:
+            dcpath = compile_folder_path_for_object(datacenter)
 
-        # Check for full path first in case it was already supplied
-        if (folder.startswith(dcpath + datacenter + '/vm')):
-            fullpath = folder
-        elif (folder.startswith('/vm/') or folder == '/vm'):
-            fullpath = "%s%s%s" % (dcpath, datacenter, folder)
-        elif (folder.startswith('/')):
-            fullpath = "%s%s/vm%s" % (dcpath, datacenter, folder)
-        else:
-            fullpath = "%s%s/vm/%s" % (dcpath, datacenter, folder)
+            # Check for full path first in case it was already supplied
+            if (folder.startswith(dcpath + datacenter + '/vm')):
+                fullpath = folder
+            elif (folder.startswith('/vm/') or folder == '/vm'):
+                fullpath = "%s%s%s" % (dcpath, datacenter, folder)
+            elif (folder.startswith('/')):
+                fullpath = "%s%s/vm%s" % (dcpath, datacenter, folder)
+            else:
+                fullpath = "%s%s/vm/%s" % (dcpath, datacenter, folder)
 
-        # get all objects for this path
-        f_obj = si.FindByInventoryPath(fullpath)
+            # get all objects for this path
+            f_obj = si.FindByInventoryPath(fullpath)
         if f_obj:
             if isinstance(f_obj, vim.Datacenter):
                 f_obj = f_obj.vmFolder

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -117,7 +117,7 @@ class PyVmomiHelper(object):
         elif folder and name:
             if self.params['name_match'] == 'first':
                 match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", folder=folder, match_first=match_first)
+            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=self.params['datacenter'], folder=folder, match_first=match_first)
         return vm
 
     def gather_facts(self, vm):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
@@ -110,6 +110,7 @@ class PyVmomiHelper(object):
         self.content = connect_to_api(self.module)
 
     def getvm(self, name=None, uuid=None, folder=None):
+        dc = self.params['datacenter']
         vm = None
         match_first = False
         if uuid:
@@ -117,7 +118,7 @@ class PyVmomiHelper(object):
         elif folder and name:
             if self.params['name_match'] == 'first':
                 match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=self.params['datacenter'], folder=folder, match_first=match_first)
+            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=dc, folder=folder, match_first=match_first)
         return vm
 
     def gather_facts(self, vm):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -231,6 +231,7 @@ class PyVmomiHelper(object):
         self.content = connect_to_api(self.module)
 
     def getvm(self, name=None, uuid=None, folder=None):
+        dc = self.params['datacenter']
         vm = None
         match_first = False
         if uuid:
@@ -238,7 +239,7 @@ class PyVmomiHelper(object):
         elif folder and name:
             if self.params['name_match'] == 'first':
                 match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=self.params['datacenter'], folder=folder, match_first=match_first)
+            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=dc, folder=folder, match_first=match_first)
         return vm
 
     @staticmethod

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
@@ -238,7 +238,7 @@ class PyVmomiHelper(object):
         elif folder and name:
             if self.params['name_match'] == 'first':
                 match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", folder=folder, match_first=match_first)
+            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=self.params['datacenter'], folder=folder, match_first=match_first)
         return vm
 
     @staticmethod

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -116,6 +116,7 @@ class PyVmomiHelper(object):
         self.content = connect_to_api(self.module)
 
     def getvm(self, name=None, uuid=None, folder=None):
+        dc = self.params['datacenter']
         vm = None
         match_first = False
         if uuid:
@@ -123,7 +124,7 @@ class PyVmomiHelper(object):
         elif folder and name:
             if self.params['name_match'] == 'first':
                 match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=self.params['datacenter'], folder=folder, match_first=match_first)
+            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=dc, folder=folder, match_first=match_first)
         return vm
 
     def gather_facts(self, vm):

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
@@ -123,7 +123,7 @@ class PyVmomiHelper(object):
         elif folder and name:
             if self.params['name_match'] == 'first':
                 match_first = True
-            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", folder=folder, match_first=match_first)
+            vm = find_vm_by_id(self.content, vm_id=name, vm_id_type="inventory_path", datacenter=self.params['datacenter'], folder=folder, match_first=match_first)
         return vm
 
     def gather_facts(self, vm):

--- a/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_vm_shell.py
@@ -181,7 +181,7 @@ def main():
             module.fail_json(changed=False, msg="Unable to find %(cluster)s cluster" % module.params)
 
     if module.params['vm_id_type'] == 'inventory_path':
-        vm = find_vm_by_id(content, vm_id=module.params['vm_id'], vm_id_type="inventory_path", folder=folder)
+        vm = find_vm_by_id(content, vm_id=module.params['vm_id'], vm_id_type="inventory_path", datacenter=datacenter, folder=folder)
     else:
         vm = find_vm_by_id(content, vm_id=module.params['vm_id'], vm_id_type=module.params['vm_id_type'], datacenter=datacenter, cluster=cluster)
 


### PR DESCRIPTION
##### SUMMARY
I changed the way of the function `find_vm_by_id()` in `module_utils/vmware.py` get the vm folder path. It's not take the datacenter name on the folder path. I changed all reference to that function find_vm_by_id(), because I need the datacenter object on that function.

#28250 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/vmware.py
lib/ansible/modules/cloud/vmware/vmware_guest_facts.py
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
lib/ansible/modules/cloud/vmware/vmware_guest_tools_wait.py
lib/ansible/modules/cloud/vmware/vmware_vm_shell.py

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```

##### ADDITIONAL INFORMATION
This fix is to resolve this bug report #28250 