### PR TITLE
Fixed minor typo in the Docs

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -169,7 +169,7 @@ Content of the *webserver.yml* file:
 Dependencies
 ============
 
-Roles can also be dependent on other roles, and when you install a role that has dependencies, those dependenices will automatically be installed.
+Roles can also be dependent on other roles, and when you install a role that has dependencies, those dependencies will automatically be installed.
 
 You specify role dependencies in the ``meta/main.yml`` file by providing a list of roles. If the source of a role is Galaxy, you can simply specify the role in
 the format ``username.role_name``. The more complex format used in ``requirements.yml`` is also supported, allowing you to provide ``src``, ``scm``, ``version``, and ``name``.


### PR DESCRIPTION
##### SUMMARY
There is a minor typo in the document. 
`dependenices` rather than `dependencies`

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
NA

##### ANSIBLE VERSION
NA


##### ADDITIONAL INFORMATION
NA

