### PR TITLE
eos_eapi: adding the desired state config to the new vrf fixes #32111…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,7 @@ Ansible Changes By Release
 * Fix ios_logging module issue where facility is being deleted along with host:
   (https://github.com/ansible/ansible/pull/32234)
 * Fix wrong prompt issue for network modules (https://github.com/ansible/ansible/pull/32426)
-
+* Fix eos_eapi to enable non-default vrfs if the default vrf is already configured (https://github.com/ansible/ansible/pull/32112)
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/modules/network/eos/eos_eapi.py
+++ b/lib/ansible/modules/network/eos/eos_eapi.py
@@ -260,11 +260,17 @@ def map_obj_to_commands(updates, module, warnings):
         else:
             add('protocol unix-socket')
 
+    if needs_update('state') and not needs_update('vrf'):
+        if want['state'] == 'stopped':
+            add('shutdown')
+        elif want['state'] == 'started':
+            add('no shutdown')
+
 
     if needs_update('vrf'):
         add('vrf %s' % want['vrf'])
-
-    if needs_update('state'):
+        # switching operational vrfs here
+        # need to add the desired state as well
         if want['state'] == 'stopped':
             add('shutdown')
         elif want['state'] == 'started':

--- a/test/units/modules/network/eos/test_eos_eapi.py
+++ b/test/units/modules/network/eos/test_eos_eapi.py
@@ -134,6 +134,11 @@ class TestEosEapiModule(TestEosModule):
         commands = ['management api http-commands', 'vrf test', 'no shutdown']
         self.start_unconfigured(changed=True, commands=commands)
 
+    def test_eos_eapi_change_from_default_vrf(self):
+        set_module_args(dict(vrf='test'))
+        commands = ['management api http-commands', 'vrf test', 'no shutdown']
+        self.start_configured(changed=True, commands=commands)
+
     def test_eos_eapi_vrf_missing(self):
         set_module_args(dict(vrf='missing'))
         self.start_unconfigured(failed=True)


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
… (#32112)

* adding the desired state config to the new vrf fixes #32111

* fix default vrf initial configured

* add unit test

* Update CHANGELOG

(cherry picked from commit 2c99cbc8746735381eec6e4ee3f5ae8b9e7d7971)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_eapi

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
