### PR TITLE
Facts distribution clear linux 31501

### DIFF
--- a/hacking/tests/gen_distribution_version_testcase.py
+++ b/hacking/tests/gen_distribution_version_testcase.py
@@ -32,6 +32,7 @@ filelist = [
     '/etc/altlinux-release',
     '/etc/os-release',
     '/etc/coreos/update.conf',
+    '/usr/lib/os-release',
 ]
 
 fcont = {}

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -82,7 +82,7 @@ class DistributionFiles:
         'OracleLinux': 'Oracle Linux',
         'RedHat': 'Red Hat',
         'Altlinux': 'ALT Linux',
-        'ClearLinux': 'Clear Linux Software for Intel Architecture',
+        'ClearLinux': 'Clear Linux',
         'SMGL': 'Source Mage GNU/Linux',
     }
 
@@ -115,6 +115,7 @@ class DistributionFiles:
             if self.SEARCH_STRING[name] in dist_file_content:
                 # this sets distribution=RedHat if 'Red Hat' shows up in data
                 dist_file_dict['distribution'] = name
+                dist_file_dict['distribution_file_search_string'] = self.SEARCH_STRING[name]
             else:
                 # this sets distribution to what's in the data, e.g. CentOS, Scientific, ...
                 dist_file_dict['distribution'] = dist_file_content.split()[0]

--- a/test/units/module_utils/test_distribution_version.py
+++ b/test/units/module_utils/test_distribution_version.py
@@ -839,6 +839,37 @@ DISTRIB_DESCRIPTION="CoreOS 976.0.0 (Coeur Rouge)"
         }
     },
 
+    # ClearLinux https://github.com/ansible/ansible/issues/31501#issuecomment-340861535
+    {
+        "platform.dist": [
+            "Clear Linux OS for Intel Architecture",
+            "18450",
+            "clear-linux-os"
+        ],
+        "input": {
+            "/usr/lib/os-release": '''
+NAME="Clear Linux OS for Intel Architecture"
+VERSION=1
+ID=clear-linux-os
+VERSION_ID=18450
+PRETTY_NAME="Clear Linux OS for Intel Architecture"
+ANSI_COLOR="1;35"
+HOME_URL="https://clearlinux.org"
+SUPPORT_URL="https://clearlinux.org"
+BUG_REPORT_URL="mailto:dev@lists.clearlinux.org"
+PRIVACY_POLICY_URL="http://www.intel.com/privacy"
+'''
+        },
+        "name": "Clear Linux OS for Intel Architecture 1",
+        "result": {
+            "distribution_release": "clear-linux-os",
+            "distribution": "ClearLinux",
+            "distribution_major_version": "18450",
+            "os_family": "ClearLinux",
+            "distribution_version": "18450"
+        }
+    },
+
     # ArchLinux with no /etc/arch-release but with a /etc/os-release with NAME=Arch Linux
     # The fact needs to map 'Arch Linux' to 'Archlinux' for compat with 2.3 and earlier facts
     {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix distribution fact for ClearLinux
    
    The search string used to look for Clear Linux
    was changed in 45a9f967749ec68e2077fe1d1d32dd37660ab376 to
    be more specific, but was too specific. Now finding
    a substring match for 'Clear Linux' in /usr/lib/os-release
    is enough to consider a match.
    
    Since the details of the full name in os-release varies
    ('Clear Linux Software for Intel Architecture',
     'Clear Linux OS for Intel Architecture', etc) the
    search string match was failing and would fall back to the
    'first word in the release file' method resulting in
    ansible_distribution='NAME="Clear'
    
    Also add a meta fact indicating which search string
    was matched.
    
Fixes #31501


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/module_utils/facts/system/distribution.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (facts_distribution_clear_linux_31501 c0fce2d48c) last updated 2017/11/01 13:07:04 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, May 10 2017, 20:04:28) [GCC 6.3.1 20161221 (Red Hat 6.3.1-1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
