### PR TITLE
[WIP] see if switching to [void] instead of | Out-Null has any effect …

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -71,19 +71,19 @@ Function Copy-File($source, $dest) {
             Fail-Json -obj $result -message "cannot copy file from $source to $($dest): object at dest parent dir is not a folder"
         } elseif (-not (Test-Path -Path $file_dir)) {
             # directory doesn't exist, need to create
-            New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode | Out-Null
+            [void] New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode 
             $diff += "+$file_dir\`n"
         }
 
         if (Test-Path -Path $dest -PathType Leaf) {
-            Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode | Out-Null
+            [void] Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode
             $diff += "-$dest`n"
         }
 
         if (-not $check_mode) {
             # cannot run with -WhatIf:$check_mode as if the parent dir didn't
             # exist and was created above would still not exist in check mode
-            Copy-Item -Path $source -Destination $dest -Force | Out-Null
+            [void] Copy-Item -Path $source -Destination $dest -Force
         }
         $diff += "+$dest`n"
 
@@ -116,7 +116,7 @@ Function Copy-Folder($source, $dest) {
             Fail-Json -obj $result -message "cannot copy folder from $source to $($dest): dest is already a file"
         }
 
-        New-Item -Path $dest -ItemType Container -WhatIf:$check_mode | Out-Null
+        [void] New-Item -Path $dest -ItemType Container -WhatIf:$check_mode
         $diff += "+$dest\`n"
         $result.changed = $true
 
@@ -189,7 +189,7 @@ Function Extract-Zip($src, $dest) {
         $entry_dir = [System.IO.Path]::GetDirectoryName($entry_target_path)
 
         if (-not (Test-Path -Path $entry_dir)) {
-            New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode | Out-Null
+            [void] New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode
         }
 
         if ($is_dir -eq $false) {
@@ -202,7 +202,7 @@ Function Extract-Zip($src, $dest) {
 
 Function Extract-ZipLegacy($src, $dest) {
     if (-not (Test-Path -Path $dest)) {
-        New-Item -Path $dest -ItemType Directory -WhatIf:$check_mode | Out-Null
+        [void] New-Item -Path $dest -ItemType Directory -WhatIf:$check_mode
     }
     $shell = New-Object -ComObject Shell.Application
     $zip = $shell.NameSpace($src)
@@ -221,7 +221,7 @@ Function Extract-ZipLegacy($src, $dest) {
         $entry_dir = [System.IO.Path]::GetDirectoryName($entry_target_path)
 
         if (-not (Test-Path -Path $entry_dir)) {
-            New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode | Out-Null
+            [void] New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode
         }
 
         if ($is_dir -eq $false -and (-not $check_mode)) {
@@ -234,7 +234,7 @@ Function Extract-ZipLegacy($src, $dest) {
 
             # once file is extraced, we need to rename it with non base64 name
             $combined_encoded_path = [System.IO.Path]::Combine($dest, $encoded_archive_entry)
-            Move-Item -Path $combined_encoded_path -Destination $entry_target_path -Force | Out-Null
+            [void] Move-Item -Path $combined_encoded_path -Destination $entry_target_path -Force
         }
     }
 }
@@ -297,8 +297,8 @@ if ($mode -eq "query") {
     # Detect if the PS zip assemblies are available or whether to use Shell
     $use_legacy = $false
     try {
-        Add-Type -AssemblyName System.IO.Compression.FileSystem | Out-Null
-        Add-Type -AssemblyName System.IO.Compression | Out-Null
+        [void] Add-Type -AssemblyName System.IO.Compression.FileSystem
+        [void] Add-Type -AssemblyName System.IO.Compression
     } catch {
         $use_legacy = $true
     }
@@ -391,7 +391,7 @@ if ($mode -eq "query") {
         if (Test-Path -Path $parent_dir -PathType Leaf) {
             Fail-Json -obj $result -message "object at destination parent dir $parent_dir is currently a file"
         } elseif (-not (Test-Path -Path $parent_dir -PathType Container)) {
-            New-Item -Path $parent_dir -ItemType Directory | Out-Null
+            [void] New-Item -Path $parent_dir -ItemType Directory 
         }
     } else {
         $remote_dest = $dest
@@ -405,7 +405,7 @@ if ($mode -eq "query") {
         }
     }
 
-    Copy-Item -Path $src -Destination $remote_dest -Force | Out-Null
+    [void] Copy-Item -Path $src -Destination $remote_dest -Force
     $result.changed = $true
 }
 

--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -1,8 +1,7 @@
 #!powershell
-# This file is part of Ansible
 
-# (c) 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
@@ -71,19 +70,19 @@ Function Copy-File($source, $dest) {
             Fail-Json -obj $result -message "cannot copy file from $source to $($dest): object at dest parent dir is not a folder"
         } elseif (-not (Test-Path -Path $file_dir)) {
             # directory doesn't exist, need to create
-            [void] (New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode)
+            New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode > $null
             $diff += "+$file_dir\`n"
         }
 
         if (Test-Path -Path $dest -PathType Leaf) {
-            [void] (Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode)
+            Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode > $null
             $diff += "-$dest`n"
         }
 
         if (-not $check_mode) {
             # cannot run with -WhatIf:$check_mode as if the parent dir didn't
             # exist and was created above would still not exist in check mode
-            [void] (Copy-Item -Path $source -Destination $dest -Force)
+            Copy-Item -Path $source -Destination $dest -Force > $null
         }
         $diff += "+$dest`n"
 
@@ -116,7 +115,7 @@ Function Copy-Folder($source, $dest) {
             Fail-Json -obj $result -message "cannot copy folder from $source to $($dest): dest is already a file"
         }
 
-        [void] (New-Item -Path $dest -ItemType Container -WhatIf:$check_mode)
+        New-Item -Path $dest -ItemType Container -WhatIf:$check_mode > $null
         $diff += "+$dest\`n"
         $result.changed = $true
 
@@ -189,7 +188,7 @@ Function Extract-Zip($src, $dest) {
         $entry_dir = [System.IO.Path]::GetDirectoryName($entry_target_path)
 
         if (-not (Test-Path -Path $entry_dir)) {
-            [void] (New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode)
+            New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode > $null
         }
 
         if ($is_dir -eq $false) {
@@ -202,7 +201,7 @@ Function Extract-Zip($src, $dest) {
 
 Function Extract-ZipLegacy($src, $dest) {
     if (-not (Test-Path -Path $dest)) {
-        [void] (New-Item -Path $dest -ItemType Directory -WhatIf:$check_mode)
+        New-Item -Path $dest -ItemType Directory -WhatIf:$check_mode > $null
     }
     $shell = New-Object -ComObject Shell.Application
     $zip = $shell.NameSpace($src)
@@ -221,7 +220,7 @@ Function Extract-ZipLegacy($src, $dest) {
         $entry_dir = [System.IO.Path]::GetDirectoryName($entry_target_path)
 
         if (-not (Test-Path -Path $entry_dir)) {
-            [void] (New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode)
+            New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode > $null
         }
 
         if ($is_dir -eq $false -and (-not $check_mode)) {
@@ -234,7 +233,7 @@ Function Extract-ZipLegacy($src, $dest) {
 
             # once file is extraced, we need to rename it with non base64 name
             $combined_encoded_path = [System.IO.Path]::Combine($dest, $encoded_archive_entry)
-            [void] (Move-Item -Path $combined_encoded_path -Destination $entry_target_path -Force)
+            Move-Item -Path $combined_encoded_path -Destination $entry_target_path -Force > $null
         }
     }
 }
@@ -297,8 +296,8 @@ if ($mode -eq "query") {
     # Detect if the PS zip assemblies are available or whether to use Shell
     $use_legacy = $false
     try {
-        [void] (Add-Type -AssemblyName System.IO.Compression.FileSystem)
-        [void] (Add-Type -AssemblyName System.IO.Compression)
+        Add-Type -AssemblyName System.IO.Compression.FileSystem > $null
+        Add-Type -AssemblyName System.IO.Compression > $null
     } catch {
         $use_legacy = $true
     }
@@ -391,7 +390,7 @@ if ($mode -eq "query") {
         if (Test-Path -Path $parent_dir -PathType Leaf) {
             Fail-Json -obj $result -message "object at destination parent dir $parent_dir is currently a file"
         } elseif (-not (Test-Path -Path $parent_dir -PathType Container)) {
-            [void] (New-Item -Path $parent_dir -ItemType Directory)
+            New-Item -Path $parent_dir -ItemType Directory > $null
         }
     } else {
         $remote_dest = $dest
@@ -405,7 +404,7 @@ if ($mode -eq "query") {
         }
     }
 
-    [void] (Copy-Item -Path $src -Destination $remote_dest -Force)
+    Copy-Item -Path $src -Destination $remote_dest -Force > $null
     $result.changed = $true
 }
 

--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -116,7 +116,7 @@ Function Copy-Folder($source, $dest) {
             Fail-Json -obj $result -message "cannot copy folder from $source to $($dest): dest is already a file"
         }
 
-        [void] New-Item -Path $dest -ItemType Container -WhatIf:$check_mode
+        [void] (New-Item -Path $dest -ItemType Container -WhatIf:$check_mode)
         $diff += "+$dest\`n"
         $result.changed = $true
 
@@ -189,7 +189,7 @@ Function Extract-Zip($src, $dest) {
         $entry_dir = [System.IO.Path]::GetDirectoryName($entry_target_path)
 
         if (-not (Test-Path -Path $entry_dir)) {
-            [void] New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode
+            [void] (New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode)
         }
 
         if ($is_dir -eq $false) {
@@ -202,7 +202,7 @@ Function Extract-Zip($src, $dest) {
 
 Function Extract-ZipLegacy($src, $dest) {
     if (-not (Test-Path -Path $dest)) {
-        [void] New-Item -Path $dest -ItemType Directory -WhatIf:$check_mode
+        [void] (New-Item -Path $dest -ItemType Directory -WhatIf:$check_mode)
     }
     $shell = New-Object -ComObject Shell.Application
     $zip = $shell.NameSpace($src)
@@ -221,7 +221,7 @@ Function Extract-ZipLegacy($src, $dest) {
         $entry_dir = [System.IO.Path]::GetDirectoryName($entry_target_path)
 
         if (-not (Test-Path -Path $entry_dir)) {
-            [void] New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode
+            [void] (New-Item -Path $entry_dir -ItemType Directory -WhatIf:$check_mode)
         }
 
         if ($is_dir -eq $false -and (-not $check_mode)) {
@@ -234,7 +234,7 @@ Function Extract-ZipLegacy($src, $dest) {
 
             # once file is extraced, we need to rename it with non base64 name
             $combined_encoded_path = [System.IO.Path]::Combine($dest, $encoded_archive_entry)
-            [void] Move-Item -Path $combined_encoded_path -Destination $entry_target_path -Force
+            [void] (Move-Item -Path $combined_encoded_path -Destination $entry_target_path -Force)
         }
     }
 }
@@ -297,8 +297,8 @@ if ($mode -eq "query") {
     # Detect if the PS zip assemblies are available or whether to use Shell
     $use_legacy = $false
     try {
-        [void] Add-Type -AssemblyName System.IO.Compression.FileSystem
-        [void] Add-Type -AssemblyName System.IO.Compression
+        [void] (Add-Type -AssemblyName System.IO.Compression.FileSystem)
+        [void] (Add-Type -AssemblyName System.IO.Compression)
     } catch {
         $use_legacy = $true
     }
@@ -391,7 +391,7 @@ if ($mode -eq "query") {
         if (Test-Path -Path $parent_dir -PathType Leaf) {
             Fail-Json -obj $result -message "object at destination parent dir $parent_dir is currently a file"
         } elseif (-not (Test-Path -Path $parent_dir -PathType Container)) {
-            [void] New-Item -Path $parent_dir -ItemType Directory 
+            [void] (New-Item -Path $parent_dir -ItemType Directory)
         }
     } else {
         $remote_dest = $dest
@@ -405,7 +405,7 @@ if ($mode -eq "query") {
         }
     }
 
-    [void] Copy-Item -Path $src -Destination $remote_dest -Force
+    [void] (Copy-Item -Path $src -Destination $remote_dest -Force)
     $result.changed = $true
 }
 

--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -71,19 +71,19 @@ Function Copy-File($source, $dest) {
             Fail-Json -obj $result -message "cannot copy file from $source to $($dest): object at dest parent dir is not a folder"
         } elseif (-not (Test-Path -Path $file_dir)) {
             # directory doesn't exist, need to create
-            [void] New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode 
+            [void] (New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode)
             $diff += "+$file_dir\`n"
         }
 
         if (Test-Path -Path $dest -PathType Leaf) {
-            [void] Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode
+            [void] (Remove-Item -Path $dest -Force -Recurse -WhatIf:$check_mode)
             $diff += "-$dest`n"
         }
 
         if (-not $check_mode) {
             # cannot run with -WhatIf:$check_mode as if the parent dir didn't
             # exist and was created above would still not exist in check mode
-            [void] Copy-Item -Path $source -Destination $dest -Force
+            [void] (Copy-Item -Path $source -Destination $dest -Force)
         }
         $diff += "+$dest`n"
 

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -461,11 +461,11 @@ class Connection(ConnectionBase):
             }}
             process {{
                $bytes = [System.Convert]::FromBase64String($input)
-               $sha1.TransformBlock($bytes, 0, $bytes.Length, $bytes, 0) | Out-Null
+               [void] ($sha1.TransformBlock($bytes, 0, $bytes.Length, $bytes, 0))
                $fd.Write($bytes, 0, $bytes.Length)
             }}
             end {{
-                $sha1.TransformFinalBlock($bytes, 0, 0) | Out-Null
+                [void] ($sha1.TransformFinalBlock($bytes, 0, 0))
 
                 $hash = [System.BitConverter]::ToString($sha1.Hash).Replace("-", "").ToLowerInvariant()
 
@@ -510,12 +510,12 @@ class Connection(ConnectionBase):
                         If (Test-Path -PathType Leaf "%(path)s")
                         {
                             $stream = New-Object IO.FileStream("%(path)s", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [IO.FileShare]::ReadWrite);
-                            $stream.Seek(%(offset)d, [System.IO.SeekOrigin]::Begin) | Out-Null;
+                            [void] ($stream.Seek(%(offset)d, [System.IO.SeekOrigin]::Begin));
                             $buffer = New-Object Byte[] %(buffer_size)d;
                             $bytesRead = $stream.Read($buffer, 0, %(buffer_size)d);
                             $bytes = $buffer[0..($bytesRead-1)];
                             [System.Convert]::ToBase64String($bytes);
-                            $stream.Close() | Out-Null;
+                            [void] ($stream.Close())
                         }
                         ElseIf (Test-Path -PathType Container "%(path)s")
                         {

--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -1,5 +1,5 @@
-# (c) 2014, Chris Church <chris@ninemoreminutes.com>
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2014, Chris Church <chris@ninemoreminutes.com>
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -30,13 +30,13 @@ DOCUMENTATION = """
 
 import base64
 import inspect
+import json
 import os
 import re
 import shlex
-import traceback
-import json
-import tempfile
 import subprocess
+import tempfile
+import traceback
 
 HAVE_KERBEROS = False
 try:
@@ -461,11 +461,11 @@ class Connection(ConnectionBase):
             }}
             process {{
                $bytes = [System.Convert]::FromBase64String($input)
-               [void] ($sha1.TransformBlock($bytes, 0, $bytes.Length, $bytes, 0))
+               $sha1.TransformBlock($bytes, 0, $bytes.Length, $bytes, 0) > $null
                $fd.Write($bytes, 0, $bytes.Length)
             }}
             end {{
-                [void] ($sha1.TransformFinalBlock($bytes, 0, 0))
+                $sha1.TransformFinalBlock($bytes, 0, 0) > $null
 
                 $hash = [System.BitConverter]::ToString($sha1.Hash).Replace("-", "").ToLowerInvariant()
 
@@ -510,12 +510,12 @@ class Connection(ConnectionBase):
                         If (Test-Path -PathType Leaf "%(path)s")
                         {
                             $stream = New-Object IO.FileStream("%(path)s", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [IO.FileShare]::ReadWrite);
-                            [void] ($stream.Seek(%(offset)d, [System.IO.SeekOrigin]::Begin));
+                            $stream.Seek(%(offset)d, [System.IO.SeekOrigin]::Begin) > $null;
                             $buffer = New-Object Byte[] %(buffer_size)d;
                             $bytesRead = $stream.Read($buffer, 0, %(buffer_size)d);
                             $bytes = $buffer[0..($bytesRead-1)];
                             [System.Convert]::ToBase64String($bytes);
-                            [void] ($stream.Close())
+                            $stream.Close() > $null;
                         }
                         ElseIf (Test-Path -PathType Container "%(path)s")
                         {

--- a/lib/ansible/plugins/shell/powershell.py
+++ b/lib/ansible/plugins/shell/powershell.py
@@ -1,5 +1,4 @@
 # Copyright: (c) 2014, Chris Church <chris@ninemoreminutes.com>
-#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
@@ -89,12 +88,12 @@ end {
     # load the current action entrypoint as a module custom object with a Run method
     $entrypoint = New-Module -ScriptBlock ([scriptblock]::Create($entrypoint)) -AsCustomObject
 
-    [void] (Set-Variable -Scope global -Name complex_args -Value $payload["module_args"])
+    Set-Variable -Scope global -Name complex_args -Value $payload["module_args"] > $null
 
     # dynamically create/load modules
     ForEach ($mod in $payload.powershell_modules.GetEnumerator()) {
         $decoded_module = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($mod.Value))
-        [void] (New-Module -ScriptBlock ([scriptblock]::Create($decoded_module)) -Name $mod.Key | Import-Module -WarningAction SilentlyContinue)
+        New-Module -ScriptBlock ([scriptblock]::Create($decoded_module)) -Name $mod.Key | Import-Module -WarningAction SilentlyContinue > $null
     }
 
     $output = $entrypoint.Run($payload)
@@ -112,29 +111,29 @@ Function Run($payload) {
 
     $ps = [powershell]::Create()
 
-    [void] ($ps.AddStatement().AddCommand("Set-Variable").AddParameters(@{Scope="global";Name="complex_args";Value=$payload.module_args}))
-    [void] ($ps.AddCommand("Out-Null"))
+    $ps.AddStatement().AddCommand("Set-Variable").AddParameters(@{Scope="global";Name="complex_args";Value=$payload.module_args}) > $null
+    $ps.AddCommand("Out-Null") > $null
 
     # redefine Write-Host to dump to output instead of failing- lots of scripts use it
-    [void] ($ps.AddStatement().AddScript("Function Write-Host(`$msg){ Write-Output `$msg }"))
+    $ps.AddStatement().AddScript("Function Write-Host(`$msg){ Write-Output `$msg }") > $null
 
     ForEach ($env_kv in $payload.environment.GetEnumerator()) {
         $escaped_env_set = "`$env:{0} = '{1}'" -f $env_kv.Key,$env_kv.Value.Replace("'","''")
-        [void] ($ps.AddStatement().AddScript($escaped_env_set))
+        $ps.AddStatement().AddScript($escaped_env_set) > $null
     }
 
     # dynamically create/load modules
     ForEach ($mod in $payload.powershell_modules.GetEnumerator()) {
         $decoded_module = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($mod.Value))
-        [void] ($ps.AddStatement().AddCommand("New-Module").AddParameters(@{ScriptBlock=([scriptblock]::Create($decoded_module));Name=$mod.Key}))
-        [void] ($ps.AddCommand("Import-Module").AddParameters(@{WarningAction="SilentlyContinue"}))
-        [void] ($ps.AddCommand("Out-Null"))
+        $ps.AddStatement().AddCommand("New-Module").AddParameters(@{ScriptBlock=([scriptblock]::Create($decoded_module));Name=$mod.Key}) > $null
+        $ps.AddCommand("Import-Module").AddParameters(@{WarningAction="SilentlyContinue"}) > $null
+        $ps.AddCommand("Out-Null") > $null
     }
 
     # force input encoding to preamble-free UTF8 so PS sub-processes (eg, Start-Job) don't blow up
-    [void] ($ps.AddStatement().AddScript("[Console]::InputEncoding = New-Object Text.UTF8Encoding `$false"))
+    $ps.AddStatement().AddScript("[Console]::InputEncoding = New-Object Text.UTF8Encoding `$false") > $null
 
-    [void] ($ps.AddStatement().AddScript($entrypoint))
+    $ps.AddStatement().AddScript($entrypoint) > $null
 
     $output = $ps.Invoke()
 
@@ -927,12 +926,12 @@ $exec_wrapper = {
     # load the current action entrypoint as a module custom object with a Run method
     $entrypoint = New-Module -ScriptBlock ([scriptblock]::Create($entrypoint)) -AsCustomObject
 
-    [void] (Set-Variable -Scope global -Name complex_args -Value $payload["module_args"])
+    Set-Variable -Scope global -Name complex_args -Value $payload["module_args"] > $null
 
     # dynamically create/load modules
     ForEach ($mod in $payload.powershell_modules.GetEnumerator()) {
         $decoded_module = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($mod.Value))
-        [void] (New-Module -ScriptBlock ([scriptblock]::Create($decoded_module)) -Name $mod.Key | Import-Module -WarningAction SilentlyContinue)
+        New-Module -ScriptBlock ([scriptblock]::Create($decoded_module)) -Name $mod.Key | Import-Module -WarningAction SilentlyContinue > $null
     }
 
     $output = $entrypoint.Run($payload)
@@ -975,7 +974,7 @@ Function Run($payload) {
             throw "become_user '$username' is not recognized on this host"
         }
 
-        [void] (Set-Acl $temp $acl)
+        Set-Acl $temp $acl > $null
 
         $payload_string = $payload | ConvertTo-Json -Depth 99 -Compress
 
@@ -1049,12 +1048,12 @@ $entrypoint = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase6
 # load the current action entrypoint as a module custom object with a Run method
 $entrypoint = New-Module -ScriptBlock ([scriptblock]::Create($entrypoint)) -AsCustomObject
 
-[void] (Set-Variable -Scope global -Name complex_args -Value $payload["module_args"])
+Set-Variable -Scope global -Name complex_args -Value $payload["module_args"] > $null
 
 # dynamically create/load modules
 ForEach ($mod in $payload.powershell_modules.GetEnumerator()) {
     $decoded_module = [System.Text.Encoding]::UTF8.GetString([System.Convert]::FromBase64String($mod.Value))
-    [void] (New-Module -ScriptBlock ([scriptblock]::Create($decoded_module)) -Name $mod.Key | Import-Module -WarningAction SilentlyContinue)
+    New-Module -ScriptBlock ([scriptblock]::Create($decoded_module)) -Name $mod.Key | Import-Module -WarningAction SilentlyContinue > $null
 }
 
 $output = $entrypoint.Run($payload)
@@ -1284,7 +1283,7 @@ Function Run($payload) {
 
     $payload.async_results_path = $results_path
 
-    [void] ([System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($results_path)))
+    [System.IO.Directory]::CreateDirectory([System.IO.Path]::GetDirectoryName($results_path)) > $null
 
     Add-Type -TypeDefinition $native_process_util -Debug:$false
 
@@ -1467,8 +1466,8 @@ Function Run($payload) {
     $job = [powershell]::Create()
     $job.Runspace = $rs
 
-    [void] ($job.AddScript($entrypoint))
-    [void] ($job.AddStatement().AddCommand("Run").AddArgument($payload))
+    $job.AddScript($entrypoint) > $null
+    $job.AddStatement().AddCommand("Run").AddArgument($payload) > $null
 
     Log "job BeginInvoke()"
 
@@ -1512,7 +1511,7 @@ Function Run($payload) {
         Log "wrote output to $resultfile_path"
     }
     Else {
-        [void] ($job.BeginStop($null, $null))  # best effort stop
+        $job.BeginStop($null, $null) > $null  # best effort stop
         # write timeout to result object
         $result.failed = $true
         $result.msg = "timed out waiting for module completion"
@@ -1522,7 +1521,7 @@ Function Run($payload) {
     }
 
     # in the case of a hung pipeline, this will cause the process to stay alive until it's un-hung...
-    #[void] ($rs.Close())
+    #$rs.Close() > $null
 }
 
 '''  # end async_watchdog


### PR DESCRIPTION
…on module speed.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
possibly a tiny speedup, 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Not a fix, might be an optimization

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_copy
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (win_less_piping_experiment 350da50df4) last updated 2017/11/01 17:42:32 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
WIP not for merge.

related to WWG discussion.  setup only has 1 | Out-Null that could be changed, so decided to try win_copy which has 12 occurrences.
TODO add measure-command to benchmark.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
