### PR TITLE
Fixes default format of network_group_modules to ini list…

### DIFF
--- a/examples/ansible.cfg
+++ b/examples/ansible.cfg
@@ -51,7 +51,7 @@
 # with a maximum timeout of 10 seconds. This
 # option lets you increase or decrease that
 # timeout to something more suitable for the
-# environment. 
+# environment.
 # gather_timeout = 10
 
 # additional paths to search for roles in, colon separated
@@ -295,7 +295,7 @@
 
 # This family of modules use an alternative execution path optimized for network appliances
 # only update this setting if you know how this works, otherwise it can break module execution
-#network_group_modules=['eos', 'nxos', 'ios', 'iosxr', 'junos', 'vyos']
+#network_group_modules=eos, nxos, ios, iosxr, junos, vyos
 
 # When enabled, this option allows lookups (via variables like {{lookup('foo')}} or when used as
 # a loop with `with_foo`) to return data that is not marked "unsafe". This means the data may contain
@@ -356,16 +356,16 @@
 # paramiko on older platforms rather than removing it, -C controls compression use
 #ssh_args = -C -o ControlMaster=auto -o ControlPersist=60s
 
-# The base directory for the ControlPath sockets. 
+# The base directory for the ControlPath sockets.
 # This is the "%(directory)s" in the control_path option
-# 
-# Example: 
+#
+# Example:
 # control_path_dir = /tmp/.ansible/cp
 #control_path_dir = ~/.ansible/cp
 
-# The path to use for the ControlPath sockets. This defaults to a hashed string of the hostname, 
-# port and username (empty string in the config). The hash mitigates a common problem users 
-# found with long hostames and the conventional %(directory)s/ansible-ssh-%%h-%%p-%%r format. 
+# The path to use for the ControlPath sockets. This defaults to a hashed string of the hostname,
+# port and username (empty string in the config). The hash mitigates a common problem users
+# found with long hostames and the conventional %(directory)s/ansible-ssh-%%h-%%p-%%r format.
 # In those cases, a "too long for Unix domain socket" ssh error would occur.
 #
 # Example:
@@ -404,8 +404,8 @@
 [persistent_connection]
 
 # Configures the persistent connection timeout value in seconds.  This value is
-# how long the persistent connection will remain idle before it is destroyed.  
-# If the connection doesn't receive a request before the timeout value 
+# how long the persistent connection will remain idle before it is destroyed.
+# If the connection doesn't receive a request before the timeout value
 # expires, the connection is shutdown. The default value is 30 seconds.
 #connect_timeout = 30
 


### PR DESCRIPTION
… Removing trailing whitespaces from comments for style consistency. Fixes #26154

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
network_group_modules was formatted for python, but needed to be formatted for ini since it is in ansible.cfg.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible.cfg
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0
  config file = /home/v-jamigh/git/Ansible-Networking/ansible.cfg
  configured module search path = [u'/home/v-jamigh/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/v-jamigh/tmp/ansible/lib/ansible
  executable location = /home/v-jamigh/tmp/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```