### PR TITLE
win_service: quoted path fix

### DIFF
--- a/lib/ansible/modules/windows/win_service.ps1
+++ b/lib/ansible/modules/windows/win_service.ps1
@@ -32,7 +32,7 @@ $display_name = Get-AnsibleParam -obj $params -name 'display_name' -type 'str'
 $force_dependent_services = Get-AnsibleParam -obj $params -name 'force_dependent_services' -type 'bool' -default $false
 $name = Get-AnsibleParam -obj $params -name 'name' -type 'str' -failifempty $true
 $password = Get-AnsibleParam -obj $params -name 'password' -type 'str'
-$path = Get-AnsibleParam -obj $params -name 'path' -type 'path'
+$path = Get-AnsibleParam -obj $params -name 'path'
 $start_mode = Get-AnsibleParam -obj $params -name 'start_mode' -type 'str' -validateset 'auto','manual','disabled','delayed'
 $state = Get-AnsibleParam -obj $params -name 'state' -type 'str' -validateset 'started','stopped','restarted','absent','paused'
 $username = Get-AnsibleParam -obj $params -name 'username' -type 'str'
@@ -50,6 +50,9 @@ if ($password -ne $null -and $username -eq $null) {
 }
 if ($desktop_interact -eq $true -and (-not ($username -eq "LocalSystem" -or $username -eq $null))) {
     Fail-Json $result "Can only set 'desktop_interact' to true when 'username' equals 'LocalSystem'"
+}
+if ($path -ne $null) {
+    $path = [System.Environment]::ExpandEnvironmentVariables($path)
 }
 
 Function Get-ServiceInfo($name) {

--- a/test/integration/targets/win_service/tasks/main.yml
+++ b/test/integration/targets/win_service/tasks/main.yml
@@ -51,3 +51,9 @@
     - '{{test_win_service_name}}'
     - TestServiceParent2
     - TestServiceDependency
+
+  - name: remove test environment variable
+    win_environment:
+      name: TEST_SERVICE_PATH
+      level: machine
+      state: absent

--- a/test/integration/targets/win_service/tasks/tests.yml
+++ b/test/integration/targets/win_service/tasks/tests.yml
@@ -610,6 +610,37 @@
     - not win_service_path_again|changed
     - win_service_path_again.path == 'C:\\temp\\test.exe'
 
+- name: create test environment variable
+  win_environment:
+    name: TEST_SERVICE_PATH
+    value: C:\temp
+    level: machine
+    state: present
+
+- name: set service path with quotes and env var
+  win_service:
+    name: "{{test_win_service_name}}"
+    path: '"%TEST_SERVICE_PATH%\test.exe"'
+  register: win_service_env_quote_path
+
+- name: check that the quoted service path has been changed
+  assert:
+    that:
+    - win_service_env_quote_path|changed
+    - win_service_env_quote_path.path == '"C:\\temp\\test.exe"'
+
+- name: set service path with quotes and env var again
+  win_service:
+    name: "{{test_win_service_name}}"
+    path: '"%TEST_SERVICE_PATH%\test.exe"'
+  register: win_service_env_quote_path_again
+
+- name: check that the quoted service path has been changed again
+  assert:
+    that:
+    - not win_service_env_quote_path_again|changed
+    - win_service_env_quote_path_again.path == '"C:\\temp\\test.exe"'
+
 - name: revert original service path back to normal
   win_service:
     name: "{{test_win_service_name}}"


### PR DESCRIPTION
##### SUMMARY
In 2.4, the powershell type of `path` has an explicit check as to whether it is a valid path or not. The `win_service` module used this for the `path` check but it is a valid scenario to quote this value which fails in 2.4. This change removes the `path` type for `path` but it will still expand the environment variables like before. Includes an integration test to ensure it doesn't regress again in the future.

Fixes https://github.com/ansible/ansible/issues/32368

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_service

##### ANSIBLE VERSION
```
2.4
```