### PR TITLE
Removes bigip_snmp_trap from skip file

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_snmp_trap.py
+++ b/lib/ansible/modules/network/f5/bigip_snmp_trap.py
@@ -4,13 +4,17 @@
 # Copyright (c) 2017 F5 Networks Inc.
 # GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: bigip_snmp_trap
-short_description: Manipulate SNMP trap information on a BIG-IP.
+short_description: Manipulate SNMP trap information on a BIG-IP
 description:
   - Manipulate SNMP trap information on a BIG-IP.
 version_added: 2.4
@@ -67,70 +71,73 @@ author:
   - Tim Rupp (@caphrim007)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create snmp v1 trap
   bigip_snmp_trap:
-      community: "general"
-      destination: "1.2.3.4"
-      name: "my-trap1"
-      network: "management"
-      port: "9000"
-      snmp_version: "1"
-      server: "lb.mydomain.com"
-      user: "admin"
-      password: "secret"
+    community: general
+    destination: 1.2.3.4
+    name: my-trap1
+    network: management
+    port: 9000
+    snmp_version: 1
+    server: lb.mydomain.com
+    user: admin
+    password: secret
   delegate_to: localhost
 
 - name: Create snmp v2 trap
   bigip_snmp_trap:
-      community: "general"
-      destination: "5.6.7.8"
-      name: "my-trap2"
-      network: "default"
-      port: "7000"
-      snmp_version: "2c"
-      server: "lb.mydomain.com"
-      user: "admin"
-      password: "secret"
+    community: general
+    destination: 5.6.7.8
+    name: my-trap2
+    network: default
+    port: 7000
+    snmp_version: 2c
+    server: lb.mydomain.com
+    user: admin
+    password: secret
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 snmp_version:
-    description: The new C(snmp_version) configured on the remote device.
-    returned: changed and success
-    type: string
-    sample: "2c"
+  description: The new C(snmp_version) configured on the remote device.
+  returned: changed and success
+  type: string
+  sample: 2c
 community:
-    description: The new C(community) name for the trap destination.
-    returned: changed and success
-    type: list
-    sample: "secret"
+  description: The new C(community) name for the trap destination.
+  returned: changed and success
+  type: list
+  sample: secret
 destination:
-    description: The new address for the trap destination in either IP or hostname form.
-    returned: changed and success
-    type: string
-    sample: "1.2.3.4"
+  description: The new address for the trap destination in either IP or hostname form.
+  returned: changed and success
+  type: string
+  sample: 1.2.3.4
 port:
-    description: The new C(port) of the trap destination.
-    returned: changed and success
-    type: string
-    sample: "900"
+  description: The new C(port) of the trap destination.
+  returned: changed and success
+  type: string
+  sample: 900
 network:
-    description: The new name of the network the SNMP trap is on.
-    returned: changed and success
-    type: string
-    sample: "management"
+  description: The new name of the network the SNMP trap is on.
+  returned: changed and success
+  type: string
+  sample: management
 '''
 
+
+from ansible.module_utils.f5_utils import AnsibleF5Client
+from ansible.module_utils.f5_utils import AnsibleF5Parameters
+from ansible.module_utils.f5_utils import HAS_F5SDK
+from ansible.module_utils.f5_utils import F5ModuleError
 from distutils.version import LooseVersion
-from ansible.module_utils.f5_utils import (
-    AnsibleF5Client,
-    AnsibleF5Parameters,
-    HAS_F5SDK,
-    F5ModuleError,
-    iControlUnexpectedHTTPError
-)
+
+try:
+    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+except ImportError:
+    HAS_F5SDK = False
 
 
 class Parameters(AnsibleF5Parameters):

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -22,7 +22,6 @@ lib/ansible/modules/network/f5/bigip_pool.py
 lib/ansible/modules/network/f5/bigip_provision.py
 lib/ansible/modules/network/f5/bigip_qkview.py
 lib/ansible/modules/network/f5/bigip_snmp.py
-lib/ansible/modules/network/f5/bigip_snmp_trap.py
 lib/ansible/modules/network/ios/ios_static_route.py
 lib/ansible/modules/network/lenovo/cnos_backup.py
 lib/ansible/modules/network/lenovo/cnos_bgp.py

--- a/test/units/modules/network/f5/test_bigip_snmp_trap.py
+++ b/test/units/modules/network/f5/test_bigip_snmp_trap.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2017 F5 Networks Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2017 F5 Networks Inc.
+# GNU General Public License v3.0 (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
@@ -41,6 +27,7 @@ try:
     from library.bigip_snmp_trap import NetworkedManager
     from library.bigip_snmp_trap import NonNetworkedManager
     from library.bigip_snmp_trap import ArgumentSpec
+    from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_snmp_trap import NetworkedParameters
@@ -49,6 +36,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_snmp_trap import NetworkedManager
         from ansible.modules.network.f5.bigip_snmp_trap import NonNetworkedManager
         from ansible.modules.network.f5.bigip_snmp_trap import ArgumentSpec
+        from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Removes bigip_snmp_trap from skip file

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_snmp_trap

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = [u'/here/library']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
