### PR TITLE
Deprecate ec2_ami_find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Ansible Changes By Release
 * The ``with_<lookup>`` loops are deprecated in favor of the new ``loop`` keyword
 
 #### Deprecated Modules (to be removed in 2.9):
+* ec2_ami_find
 
 #### Removed Modules (previously deprecated):
 * accelerate
@@ -42,6 +43,7 @@ Ansible Changes By Release
 
   * aws_ssm_parameter_store
   * digital_ocean_sshkey_facts
+  * ec2_ami_facts
 
 #### Windows
 

--- a/lib/ansible/modules/cloud/amazon/_ec2_ami_find.py
+++ b/lib/ansible/modules/cloud/amazon/_ec2_ami_find.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 
@@ -16,6 +16,7 @@ DOCUMENTATION = '''
 module: ec2_ami_find
 version_added: '2.0'
 short_description: Searches for AMIs to obtain the AMI ID and other information
+deprecated: Deprecated in 2.5. Use M(ec2_ami_facts) instead.
 description:
   - Returns list of matching AMIs with AMI ID, along with other useful information
   - Can search AMIs with different owners
@@ -347,6 +348,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
+
+    module.deprecate("The 'ec2_ami_find' module has been deprecated. Use 'ec2_ami_facts' instead.", version=2.9)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module, install via pip or your package manager')

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -1,3 +1,4 @@
+lib/ansible/modules/cloud/amazon/_ec2_ami_find.py
 lib/ansible/modules/cloud/amazon/_ec2_ami_search.py
 lib/ansible/modules/cloud/amazon/_ec2_remote_facts.py
 lib/ansible/modules/cloud/amazon/_ec2_vpc.py
@@ -7,7 +8,6 @@ lib/ansible/modules/cloud/amazon/cloudformation.py
 lib/ansible/modules/cloud/amazon/cloudfront_facts.py
 lib/ansible/modules/cloud/amazon/dynamodb_table.py
 lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
-lib/ansible/modules/cloud/amazon/ec2_ami_find.py
 lib/ansible/modules/cloud/amazon/ec2_elb.py
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
 lib/ansible/modules/cloud/amazon/ec2_eni_facts.py


### PR DESCRIPTION
##### SUMMARY
Deprecate `ec2_ami_find` module. The new module `ec2_ami_facts` should be used instead.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`ec2_ami_find`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```
