### PR TITLE
Added docs fragment for proxysql

### DIFF
--- a/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_backend_servers.py
@@ -85,36 +85,9 @@ options:
       - When C(present) - adds the host, when C(absent) - removes the host.
     choices: [ "present", "absent" ]
     default: present
-  save_to_disk:
-    description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
-    default: True
-  load_to_runtime:
-    description:
-      - Dynamically load mysql host config to runtime memory.
-    default: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.managing_config
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_global_variables.py
@@ -25,36 +25,9 @@ options:
     description:
       - Defines a value the variable specified using I(variable) should be set
         to.
-  save_to_disk:
-    description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
-    default: True
-  load_to_runtime:
-    description:
-      - Dynamically load mysql host config to runtime memory.
-    default: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.managing_config
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_manage_config.py
@@ -52,27 +52,8 @@ options:
                  config file.
     choices: [ "MEMORY", "DISK", "RUNTIME", "CONFIG" ]
     required: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_mysql_users.py
@@ -47,8 +47,8 @@ options:
          to ProxySQL (thus a "frontend" user), transactions started within a
          hostgroup will remain within that hostgroup regardless of any other
          rules.
-         If omitted the proxysql database default for I(transaction_persistent) is
-         C(False).
+         If omitted the proxysql database default for I(transaction_persistent)
+         is C(False).
   fast_forward:
     description:
       - If I(fast_forward) is set to C(True), I(fast_forward) will bypass the
@@ -75,36 +75,9 @@ options:
       - When C(present) - adds the user, when C(absent) - removes the user.
     choices: [ "present", "absent" ]
     default: present
-  save_to_disk:
-    description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
-    default: True
-  load_to_runtime:
-    description:
-      - Dynamically load mysql host config to runtime memory.
-    default: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.managing_config
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_query_rules.py
@@ -134,36 +134,9 @@ options:
         however if you need this behaviour and you're not concerned about the
         schedules deleted, you can set I(force_delete) to C(True).
     default: False
-  save_to_disk:
-    description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
-    default: True
-  load_to_runtime:
-    description:
-      - Dynamically load mysql host config to runtime memory.
-    default: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.managing_config
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_replication_hostgroups.py
@@ -37,36 +37,9 @@ options:
         removes the replication hostgroup.
     choices: [ "present", "absent" ]
     default: present
-  save_to_disk:
-    description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
-    default: True
-  load_to_runtime:
-    description:
-      - Dynamically load mysql host config to runtime memory.
-    default: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.managing_config
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
+++ b/lib/ansible/modules/database/proxysql/proxysql_scheduler.py
@@ -60,36 +60,9 @@ options:
         however if you need this behaviour and you're not concerned about the
         schedules deleted, you can set I(force_delete) to C(True).
     default: False
-  save_to_disk:
-    description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
-    default: True
-  load_to_runtime:
-    description:
-      - Dynamically load mysql host config to runtime memory.
-    default: True
-  login_user:
-    description:
-      - The username used to authenticate to ProxySQL admin interface.
-    default: None
-  login_password:
-    description:
-      - The password used to authenticate to ProxySQL admin interface.
-    default: None
-  login_host:
-    description:
-      - The host used to connect to ProxySQL admin interface.
-    default: '127.0.0.1'
-  login_port:
-    description:
-      - The port used to connect to ProxySQL admin interface.
-    default: 6032
-  config_file:
-    description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
-    default: ''
+extends_documentation_fragment:
+  - proxysql.managing_config
+  - proxysql.connectivity
 '''
 
 EXAMPLES = '''

--- a/lib/ansible/utils/module_docs_fragments/proxysql.py
+++ b/lib/ansible/utils/module_docs_fragments/proxysql.py
@@ -1,0 +1,47 @@
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt
+
+
+class ModuleDocFragment(object):
+
+    # Documentation fragment for ProxySQL connectivity
+    CONNECTIVITY = '''
+options:
+  login_user:
+    description:
+      - The username used to authenticate to ProxySQL admin interface.
+    default: None
+  login_password:
+    description:
+      - The password used to authenticate to ProxySQL admin interface.
+    default: None
+  login_host:
+    description:
+      - The host used to connect to ProxySQL admin interface.
+    default: '127.0.0.1'
+  login_port:
+    description:
+      - The port used to connect to ProxySQL admin interface.
+    default: 6032
+  config_file:
+    description:
+      - Specify a config file from which login_user and login_password are to
+        be read.
+    default: ''
+requirements:
+   - MySQLdb
+'''
+
+    # Documentation fragment for managing ProxySQL configuration
+    MANAGING_CONFIG = '''
+options:
+  save_to_disk:
+    description:
+      - Save mysql host config to sqlite db on disk to persist the
+        configuration.
+    default: True
+  load_to_runtime:
+    description:
+      - Dynamically load mysql host config to runtime memory.
+    default: True
+'''

--- a/lib/ansible/utils/module_docs_fragments/proxysql.py
+++ b/lib/ansible/utils/module_docs_fragments/proxysql.py
@@ -25,8 +25,8 @@ options:
     default: 6032
   config_file:
     description:
-      - Specify a config file from which login_user and login_password are to
-        be read.
+      - Specify a config file from which I(login_user) and I(login_password)
+        are to be read.
     default: ''
 requirements:
    - MySQLdb
@@ -37,11 +37,12 @@ requirements:
 options:
   save_to_disk:
     description:
-      - Save mysql host config to sqlite db on disk to persist the
-        configuration.
+      - Save config to sqlite db on disk to persist the configuration.
+    type: bool
     default: True
   load_to_runtime:
     description:
-      - Dynamically load mysql host config to runtime memory.
+      - Dynamically load config to runtime memory.
+    type: bool
     default: True
 '''


### PR DESCRIPTION
##### SUMMARY
Adding a documentation fragment for the proxysql modules.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
http://docs.ansible.com/ansible/latest/list_of_database_modules.html#proxysql

##### ANSIBLE VERSION
```
ansible 2.5.0 (add_docs_fragment 6f9ed4cc28) last updated 2017/11/02 15:30:54 (GMT +100)
  config file = None
  configured module search path = [u'/Users/ben/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ben/Work/bmildren/ansible/lib/ansible
  executable location = /Users/ben/Work/bmildren/ansible/bin/ansible
  python version = 2.7.12 (default, Oct 11 2016, 05:20:59) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```


##### ADDITIONAL INFORMATION
I've verified the change locally using ansible-docs, adding docs fragment here is a precursary step, I'll create a separate PR for each individual module to update and extend the existing docs.
