### PR TITLE
Fix non-ascii errors in config manager

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -28,7 +28,7 @@ from ansible import constants as C
 from ansible.errors import AnsibleError, AnsibleOptionsError, AnsibleParserError
 from ansible.inventory.data import InventoryData
 from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.parsing.utils.addresses import parse_address
 from ansible.plugins.loader import PluginLoader
 from ansible.utils.path import unfrackpath
@@ -260,16 +260,16 @@ class InventoryManager(object):
                         # in case plugin fails 1/2 way we dont want partial inventory
                         plugin.parse(self._inventory, self._loader, source, cache=cache)
                         parsed = True
-                        display.vvv('Parsed %s inventory source with %s plugin' % (to_native(source), plugin_name))
+                        display.vvv('Parsed %s inventory source with %s plugin' % (to_text(source), plugin_name))
                         break
                     except AnsibleParserError as e:
-                        display.debug('%s was not parsable by %s' % (to_native(source), plugin_name))
+                        display.debug('%s was not parsable by %s' % (to_text(source), plugin_name))
                         failures.append({'src': source, 'plugin': plugin_name, 'exc': e})
                     except Exception as e:
-                        display.debug('%s failed to parse %s' % (plugin_name, to_native(source)))
+                        display.debug('%s failed to parse %s' % (plugin_name, to_text(source)))
                         failures.append({'src': source, 'plugin': plugin_name, 'exc': e})
                 else:
-                    display.debug('%s did not meet %s requirements' % (to_native(source), plugin_name))
+                    display.debug('%s did not meet %s requirements' % (to_text(source), plugin_name))
             else:
                 if not parsed and failures:
                     # only if no plugin processed files should we show errors.
@@ -282,10 +282,10 @@ class InventoryManager(object):
                         raise AnsibleParserError(msg)
                     else:
                         for fail in failures:
-                            display.warning('\n* Failed to parse %s with %s plugin: %s' % (to_native(fail['src']), fail['plugin'], to_native(fail['exc'])))
-                            display.vvv(fail['exc'].tb)
+                            display.warning(u'\n* Failed to parse %s with %s plugin: %s' % (to_text(fail['src']), fail['plugin'], to_text(fail['exc'])))
+                            display.vvv(to_text(fail['exc'].tb))
         if not parsed:
-            display.warning("Unable to parse %s as an inventory source" % to_native(source))
+            display.warning("Unable to parse %s as an inventory source" % to_text(source))
 
         # clear up, jic
         self._inventory.current_source = None


### PR DESCRIPTION
##### SUMMARY
When using display methods, we want to use text strings.

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```