### PR TITLE
Add -f/--list_files option to the ansible-doc command for faster list

### DIFF
--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -52,7 +52,7 @@ class DocCLI(CLI):
     def parse(self):
 
         self.parser = CLI.base_parser(
-            usage='usage: %prog [-l|-f|-s] [options] [-t <plugin type] [plugin]',
+            usage='usage: %prog [-l|-F|-s] [options] [-t <plugin type] [plugin]',
             module_opts=True,
             desc="plugin documentation tool",
             epilog="See man pages for Ansible CLI options or website for tutorials https://docs.ansible.com"
@@ -73,7 +73,7 @@ class DocCLI(CLI):
         super(DocCLI, self).parse()
 
         if [self.options.all_plugins, self.options.list_dir, self.options.list_files, self.options.show_snippet].count(True) > 1:
-            raise AnsibleOptionsError("Only one of -l, -f, -s or -a can be used at the same time.")
+            raise AnsibleOptionsError("Only one of -l, -F, -s or -a can be used at the same time.")
 
         display.verbosity = self.options.verbosity
 

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -111,7 +111,6 @@ class DocCLI(CLI):
         search_paths = DocCLI.print_paths(loader)
         loader._paths = None  # reset so we can use subdirs below
 
-
         # list plugins names and filepath for type
         if self.options.list_files:
             paths = loader._get_paths()

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -239,7 +239,6 @@ class DocCLI(CLI):
         deprecated = []
         for plugin in sorted(self.plugin_list):
 
-            import q; q(plugin)
             try:
                 # if the module lives in a non-python file (eg, win_X.ps1), require the corresponding python file for docs
                 filename = loader.find_plugin(plugin, mod_type='.py', ignore_deprecated=True, check_aliases=True)

--- a/lib/ansible/cli/doc.py
+++ b/lib/ansible/cli/doc.py
@@ -58,7 +58,7 @@ class DocCLI(CLI):
             epilog="See man pages for Ansible CLI options or website for tutorials https://docs.ansible.com"
         )
 
-        self.parser.add_option("-f", "--list_files", action="store_true", default=False, dest="list_files",
+        self.parser.add_option("-F", "--list_files", action="store_true", default=False, dest="list_files",
                                help='Show plugin names and their source files without summaries (implies --list)')
         self.parser.add_option("-l", "--list", action="store_true", default=False, dest='list_dir',
                                help='List available plugins')


### PR DESCRIPTION

##### SUMMARY

ansibot is shifting to use ansible-doc to obtain a list of plugin names, however ansible-doc -l is painfully slow. This new cli opt skips all the doc parsing for the plugins and simply shows their name and filepath.

##### ISSUE TYPE

 - Feature Pull Request


##### COMPONENT NAME
ansible-doc

##### ANSIBLE VERSION

```
2.5
```



