### PR TITLE
fix typo/ URI error

### DIFF
--- a/docs/docsite/rst/windows_setup.rst
+++ b/docs/docsite/rst/windows_setup.rst
@@ -139,7 +139,7 @@ listener created and configured.
 To view the current listeners that are running on the WinRM service, run the
 following command::
 
-    winrm enumerate winrm/config/Listeners
+    winrm enumerate winrm/config/Listener
 
 This will output something like the following::
 


### PR DESCRIPTION
##### SUMMARY
URI uses singular: "Listener"

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
N/A
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Using current command Listener(s) - plural generates the following error:
PS C:\windows\system32>   winrm enumerate winrm/config/Listeners
WSManFault
    Message
        ProviderFault
            WSManFault
                Message = The WS-Management service cannot process the request. The resource URI does not support the Enumerate operation.

Error number:  -2144108495 0x80338031
The WS-Management service cannot process the request because the WS-Addressing Action URI in the request is not compatible with the resource.

