### PR TITLE
Added datacenter parameter to examples

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_find.py
@@ -47,6 +47,7 @@ EXAMPLES = '''
 - name: Find Guest's Folder using name
   vmware_guest_find:
     hostname: 192.168.1.209
+    datacenter: datacenter-name
     username: administrator@vsphere.local
     password: vmware
     validate_certs: no
@@ -56,6 +57,7 @@ EXAMPLES = '''
 - name: Find Guest's Folder using UUID
   vmware_guest_find:
     hostname: 192.168.1.209
+    datacenter: datacenter-name
     username: administrator@vsphere.local
     password: vmware
     validate_certs: no


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

In module vmware_guest_find I've added the datacenter parameter to the examples. IMHO a mandatory parameter should be used in any example.

I create this pull request against the devel branch. But I think this change should be backported to the released versions which are already using this module. Because it's a documentation change it should not bread any api. What's your opinion on this?

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest_find

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/jkastning/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```
