### PR TITLE
Add ISSU capability and fix workflow bug for nxos_install_os module

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -115,16 +115,16 @@ install_state:
     type: dictionary
     sample: {
     "install_state": [
-        "Compatibility check is done:", 
-        "Module  bootable          Impact  Install-type  Reason", 
-        "------  --------  --------------  ------------  ------", 
-        "     1       yes  non-disruptive         reset  ", 
-        "Images will be upgraded according to following table:", 
-        "Module       Image                  Running-Version(pri:alt)           New-Version  Upg-Required", 
-        "------  ----------  ----------------------------------------  --------------------  ------------", 
-        "     1        nxos                               7.0(3)I6(1)           7.0(3)I7(1)           yes", 
+        "Compatibility check is done:",
+        "Module  bootable          Impact  Install-type  Reason",
+        "------  --------  --------------  ------------  ------",
+        "     1       yes  non-disruptive         reset  ",
+        "Images will be upgraded according to following table:",
+        "Module       Image                  Running-Version(pri:alt)           New-Version  Upg-Required",
+        "------  ----------  ----------------------------------------  --------------------  ------------",
+        "     1        nxos                               7.0(3)I6(1)           7.0(3)I7(1)           yes",
         "     1        bios                        v4.4.0(07/12/2017)    v4.4.0(07/12/2017)            no"
-    ], 
+    ],
     }
 '''
 
@@ -506,7 +506,9 @@ def do_install_all(module, issu, image, kick=None):
         upgrade = check_install_in_progress(module, commands, opts)
 
         # Special case:  If we encounter a backend processing error at this
-        # stage, then we consider the switch upgraded.
+        # stage it means the command was sent and the upgrade was started but
+        # we will need to use the impact data instead of the current install
+        # data.
         if upgrade['backend_processing_error']:
             upgrade['upgrade_succeeded'] = True
             upgrade['use_impact_data'] = True
@@ -530,8 +532,6 @@ def main():
         kickstart_image_file=dict(required=False),
         issu=dict(choices=['required', 'desired', 'no', 'yes'], default='no'),
     )
-    # ISSU choices, 'required', 'desired', 'no', 'yes'
-    # parse intsall all commands for everything.
 
     argument_spec.update(nxos_argument_spec)
 
@@ -569,10 +569,9 @@ def main():
         else:
             msg = msg + "file: system: %s" % sif
         module.fail_json(msg=msg, raw_data=install_result['list_data'])
-    else:
-        state = install_result['processed']
-        changed = install_result['upgrade_needed']
 
+    state = install_result['processed']
+    changed = install_result['upgrade_needed']
     module.exit_json(changed=changed, install_state=state, warnings=warnings)
 
 

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -31,17 +31,17 @@ description:
       image and kickstart image and optionally select to install using
       ISSU (In Server Software Upgrade).
 notes:
-    - Tested against the following platforms and images:
-        - N9k: 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1)
-        - N3k: 6.0(2)A8(6), 6.0(2)A8(8)
-        - N7k: 7.3(0)D1(1), 8.0(1), 8.2(1)
+    - Tested against the following platforms and images
+      - N9k 7.0(3)I4(6), 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1)
+      - N3k 6.0(2)A8(6), 6.0(2)A8(8)
+      - N7k 7.3(0)D1(1), 8.0(1), 8.2(1)
     - This module executes longer then the default ansible timeout value and
       will generate errors unless the module timeout parameter is set to a
       value of 500 seconds or higher.
-      NOTE: The example time is sufficent for most upgrades but this can be
-            tuned higher based on specific upgrade time requirements.
-            The module will exit with a failure message if the timer is
-            not set to 500 seconds or higher.
+      The example time is sufficent for most upgrades but this can be
+      tuned higher based on specific upgrade time requirements.
+      The module will exit with a failure message if the timer is
+      not set to 500 seconds or higher.
     - Do not include full file paths, just the name of the file(s) stored on
       the top level flash directory.
     - This module attempts to install the software immediately,
@@ -72,13 +72,13 @@ options:
         description:
             - Upgrade using In Service Software Upgrade (ISSU).
               (Only supported on N9k platforms)
-        required: false
-        choices: ['required','desired', 'yes', 'no']
             - Selecting 'required' or 'yes' means that upgrades will only
               proceed if the switch is capable of ISSU.
             - Selecting 'desired' means that upgrades will use ISSU if possible
               but will fall back to disruptive upgrade if needed.
             - Selecting 'no' means do not use ISSU. Forced disruptive.
+        required: false
+        choices: ['required','desired', 'yes', 'no']
         default: 'no'
 '''
 
@@ -90,22 +90,22 @@ EXAMPLES = '''
     issu: desired
     provider: "{{ connection | combine({'timeout': 500}) }}"
 
- - name: Wait for device to come back up with new image
-   wait_for:
+- name: Wait for device to come back up with new image
+  wait_for:
     port: 22
     state: started
     timeout: 500
     delay: 60
     host: "{{ inventory_hostname }}"
 
-  - name: "Check installed OS for newly installed version"
-    nxos_command:
-      commands: ['show version | json']
-      provider: "{{ connection }}"
-    register: output
-  - assert:
-      that:
-      - output['stdout'][0]['kickstart_ver_str'] == '7.0(3)I6(1)'
+- name: Check installed OS for newly installed version
+  nxos_command:
+    commands: ['show version | json']
+    provider: "{{ connection }}"
+  register: output
+- assert:
+    that:
+    - output['stdout'][0]['kickstart_ver_str'] == '7.0(3)I6(1)'
 '''
 
 RETURN = '''
@@ -356,7 +356,7 @@ def massage_install_data(data):
         result_data = default_error_msg
 
     # Further processing may be needed for result_data
-    if len(data) == 2 and type(data[1]) is dict:
+    if len(data) == 2 and isinstance(data[1], dict):
         if 'clierror' in data[1].keys():
             result_data = data[1]['clierror']
         elif 'code' in data[1].keys() and data[1]['code'] == '500':

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -69,6 +69,7 @@ options:
         required: false
         default: null
     issu:
+        version_added: "2.5"
         description:
             - Upgrade using In Service Software Upgrade (ISSU).
               (Only supported on N9k platforms)

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -25,27 +25,30 @@ DOCUMENTATION = '''
 ---
 module: nxos_install_os
 extends_documentation_fragment: nxos
-short_description: Set boot options like boot image and kickstart image.
+short_description: Set boot options like boot, kickstart image and issu.
 description:
     - Install an operating system by setting the boot options like boot
-      image and kickstart image.
+      image and kickstart image and optionally select to install using ISSU.
 notes:
-    - Tested against NXOSv 7.3.(0)D1(1) on VIRL
-    - The module will fail due to timeout issues, but the install will go on
-      anyway. Ansible's block and rescue can be leveraged to handle this kind
-      of failure and check actual module results. See EXAMPLE for more about
-      this. The first task on the rescue block is needed to make sure the
-      device has completed all checks and it started to reboot. The second
-      task is needed to wait for the device to come back up. The last two tasks
-      are used to verify the installation process was successful.
+    - Tested against the following platforms and images:
+        - N9k: 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1)
+        - N3k: 6.0(2)A8(6), 6.0(2)A8(8)
+        - N7k: 7.3(0)D1(1), 8.0(1), 8.2(1)
+    - This module executes longer then the default ansible timeout values and
+      will generate errors unless the following ansible timers are configured.
+        - export ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=600
+        - export ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=600
+      NOTE: The example time is sufficent for most upgrades but this can be
+            tuned up or down based on specific upgrade time requirements.
+            If these timers are not utilized, then an ansible block/rescue
+            must be used but the module will generate a failure even on
+            successfull upgrades.
     - Do not include full file paths, just the name of the file(s) stored on
       the top level flash directory.
-    - You must know if your platform supports taking a kickstart image as a
-      parameter. If supplied but not supported, errors may occur.
     - This module attempts to install the software immediately,
       which may trigger a reboot.
-    - In check mode, the module tells you if the current boot images are set
-      to the desired images.
+    - In check mode, the module will indicate if an upgrade is needed and
+      weather or not the upgrade is disruptive or non-disruptive(ISSU).
 author:
     - Jason Edelman (@jedelman8)
     - Gabriele Gerbibo (@GGabriele)
@@ -62,17 +65,58 @@ options:
         default: null
     issu:
         description:
-            - Enable In Service Software Upgrade (ISSU).
+            - Upgrade using In Service Software Upgrade (ISSU).
+              (Only supported on N9k platforms)
         required: false
-        choices: ['true','false']
-        default: 'false'
+        choices: ['required','desired', 'yes', 'no']
+            - Selecting 'required' or 'yes' means that upgrades will only
+              proceed if the switch is capable of ISSU.
+            - Selecting 'desired' means that upgrades will use ISSU if possible
+              but will fall back to disruptive upgrade if needed.
+            - Selecting 'no' means do not use ISSU. Forced disruptive.
+        default: 'no'
 '''
 
 EXAMPLES = '''
+1) Example using the environment variables to set addequate timeout values:
+export ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=600
+export ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=600
+
+- name: Install OS on N9k
+  check_mode: no
+  nxos_install_os:
+    system_image_file: n7000-s2-dk9.8.2.1.bin
+    kickstart_image_file: n7000-s2-kickstart.8.2.1.bin
+    issu: desired
+    provider: "{{ connection }}"
+
+ - name: Wait for device to come back up
+   wait_for:
+    port: 22
+    state: started
+    timeout: 500
+    delay: 60
+    host: "{{ inventory_hostname }}"
+
+- name: Check installed OS
+  nxos_command:
+    commands:
+      - show version
+  register: output
+- assert:
+    that:
+      - output['stdout'][0]['kickstart_ver_str'] == '8.2(1)'
+
+2) Example using block/rescue (NOT RECOMMENDED).  Module will still reported
+     a failure even when upgrade succeedes.
 - block:
-    - name: Install OS
+    - name: Install OS on N7k
+      check_mode: no
       nxos_install_os:
-        system_image_file: nxos.7.0.3.I2.2d.bin
+        system_image_file: n7000-s2-dk9.8.2.1.bin
+        kickstart_image_file: n7000-s2-kickstart.8.2.1.bin
+        issu: desired
+        provider: "{{ connection }}"
   rescue:
     - name: Wait for device to perform checks
       wait_for:
@@ -93,7 +137,7 @@ EXAMPLES = '''
       register: output
     - assert:
         that:
-          - output['stdout'][0]['kickstart_ver_str'] == '7.0(3)I4(1)'
+          - output['stdout'][0]['kickstart_ver_str'] == '8.2(1)'
 '''
 
 RETURN = '''
@@ -102,28 +146,60 @@ install_state:
     returned: always
     type: dictionary
     sample: {
-        "kick": "n5000-uk9-kickstart.7.2.1.N1.1.bin",
-        "sys": "n5000-uk9.7.2.1.N1.1.bin",
-        "status": "This is the log of last installation.\n
-            Continuing with installation process, please wait.\n
-            The login will be disabled until the installation is completed.\n
-            Performing supervisor state verification. \n
-            SUCCESS\n
-            Supervisor non-disruptive upgrade successful.\n
-            Install has been successful.\n",
+    "install_state": [
+        "Compatibility check is done:",
+        "Module  bootable          Impact  Install-type  Reason",
+        "------  --------  --------------  ------------  ------",
+        "     1       yes      disruptive         reset  default upgrade is not hitless",
+        "Images will be upgraded according to following table:",
+        "Module       Image                  Running-Version(pri:alt)           New-Version  Upg-Required",
+        "------  ----------  ----------------------------------------  --------------------  ------------",
+        "     1        nxos                               7.0(3)I7(1)           7.0(3)I6(1)           yes",
+        "     1        bios     v07.59(08/26/2016):v07.06(03/02/2014)    v07.59(08/26/2016)            no"
+    ],
     }
 '''
 
 
 import re
-
+from time import sleep
 from ansible.module_utils.nxos import load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
 
+from pprint import pprint
+
+
+def logit(data):
+    logFile = open('ilog', 'w')
+    pprint('\n^^^^^^^\n')
+    pprint(data, logFile)
+    pprint('\n^^^^^^^\n')
+
+
+def check_ansible_timers(module):
+    '''Check Ansible Timer Values'''
+    timers_set = True
+    import os
+    env_com = 'ANSIBLE_PERSISTENT_COMMAND_TIMEOUT'
+    env_con = 'ANSIBLE_PERSISTENT_CONNECT_TIMEOUT'
+    msg = ''
+    for tn in [env_com, env_con]:
+        tv = os.environ.get(tn)
+        if tv is None or (tv is not None and int(tv) < 600):
+            msg = msg + 'The ENV setting: %s\n' % tn
+            msg = msg + 'must be set to 600 seconds or higher for\n'
+            msg = msg + 'this module to function properly\n'
+            msg = msg + 'Example:\n'
+            msg = msg + 'export %s=600\n\n' % tn
+            timers_set = False
+
+    if not timers_set:
+        module.fail_json(msg=msg.split('\n'))
+
 
 # Output options are 'text' or 'json'
-def execute_show_command(command, module, output='text'):
+def execute_show_command(module, command, output='text'):
     cmds = [{
         'command': command,
         'output': output,
@@ -134,7 +210,7 @@ def execute_show_command(command, module, output='text'):
 
 def get_platform(module):
     """Determine platform type"""
-    data = execute_show_command('show inventory', module, 'json')
+    data = execute_show_command(module, 'show inventory', 'json')
     pid = data[0]['TABLE_inv']['ROW_inv'][0]['productid']
 
     if re.search(r'N3K', pid):
@@ -153,64 +229,310 @@ def get_platform(module):
     return type
 
 
-def get_boot_options(module):
-    """Get current boot variables
-    like system image and kickstart image.
-    Returns:
-        A dictionary, e.g. { 'kick': router_kick.img, 'sys': 'router_sys.img'}
+def kickstart_image_required(module):
+    '''Determine if platform requires a kickstart image'''
+    data = execute_show_command(module, 'show version')[0]
+    kickstart_required = False
+    for x in data.split('\n'):
+        if re.search(r'kickstart image file is:', x):
+            kickstart_required = True
+
+    return kickstart_required
+
+
+def parse_show_install(data):
+    """Helper method to parse the output of the 'show install all impact' or
+        'install all' commands.
+
+    Sample Output:
+
+    Installer will perform impact only check. Please wait.
+
+    Verifying image bootflash:/nxos.7.0.3.F2.2.bin for boot variable "nxos".
+    [####################] 100% -- SUCCESS
+
+    Verifying image type.
+    [####################] 100% -- SUCCESS
+
+    Preparing "bios" version info using image bootflash:/nxos.7.0.3.F2.2.bin.
+    [####################] 100% -- SUCCESS
+
+    Preparing "nxos" version info using image bootflash:/nxos.7.0.3.F2.2.bin.
+    [####################] 100% -- SUCCESS
+
+    Performing module support checks.
+    [####################] 100% -- SUCCESS
+
+    Notifying services about system upgrade.
+    [####################] 100% -- SUCCESS
+
+
+
+    Compatibility check is done:
+    Module  bootable          Impact  Install-type  Reason
+    ------  --------  --------------  ------------  ------
+         8       yes      disruptive         reset  Incompatible image for ISSU
+        21       yes      disruptive         reset  Incompatible image for ISSU
+
+
+    Images will be upgraded according to following table:
+    Module       Image  Running-Version(pri:alt)    New-Version   Upg-Required
+    ------  ----------  ----------------------------------------  ------------
+         8       lcn9k                7.0(3)F3(2)    7.0(3)F2(2)           yes
+         8        bios                     v01.17         v01.17            no
+        21       lcn9k                7.0(3)F3(2)    7.0(3)F2(2)           yes
+        21        bios                     v01.70         v01.70            no
     """
-    command = 'show boot'
-    body = execute_show_command(command, module)[0]
-    boot_options_raw_text = body.split('Boot Variables on next reload')[1]
+    data = data.split('\n')
+    ud = {'raw': data}
+    ud['processed'] = []
+    ud['disruptive'] = False
+    ud['upgrade'] = False
+    ud['error'] = False
+    for x in data:
+        # Check for errors and exit if found.
+        if re.search(r'Pre-upgrade check failed', x):
+            ud['error'] = True
+            break
+        if re.search(r'[I|i]nvalid command', x):
+            ud['error'] = True
+            break
+        if re.search(r'Another install procedure may be in progress', x):
+            ud['error'] = True
+            break
 
-    if 'kickstart' in boot_options_raw_text:
-        kick_regex = r'kickstart variable = bootflash:/(\S+)'
-        sys_regex = r'system variable = bootflash:/(\S+)'
+        # Begin normal parsing.
+        if re.search(r'----|Module|Images will|Compatibility', x):
+            ud['processed'].append(x)
+            continue
+        # Check to see if upgrade will be disruptive or non-disruptive and
+        # build dictionary of individual modules and their status.
+        # Sample Line:
+        #
+        # Module  bootable      Impact  Install-type  Reason
+        # ------  --------  ----------  ------------  ------
+        #     8        yes  disruptive         reset  Incompatible image
+        rd = r'(\d+)\s+(\S+)\s+(disruptive|non-disruptive)\s+(\S+)'
+        mo = re.search(rd, x)
+        if mo:
+            ud['processed'].append(x)
+            key = 'm%s' % mo.group(1)
+            field = 'disruptive'
+            if mo.group(3) == 'non-disruptive':
+                ud[key] = {field: False}
+            else:
+                ud[field] = True
+                ud[key] = {field: True}
+            field = 'bootable'
+            if mo.group(2) == 'yes':
+                ud[key].update({field: True})
+            else:
+                ud[key].update({field: False})
+            continue
 
-        kick = re.search(kick_regex, boot_options_raw_text).group(1)
-        sys = re.search(sys_regex, boot_options_raw_text).group(1)
-        retdict = dict(kick=kick, sys=sys)
+        # Check to see if switch needs an upgrade and build a dictionary
+        # of individual modules and their individual upgrade status.
+        # Sample Line:
+        #
+        # Module  Image  Running-Version(pri:alt)    New-Version  Upg-Required
+        # ------  -----  ----------------------------------------  ------------
+        # 8       lcn9k                7.0(3)F3(2)    7.0(3)F2(2)           yes
+        mo = re.search(r'(\d+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(yes|no)', x)
+        if mo:
+            ud['processed'].append(x)
+            key = 'm%s_%s' % (mo.group(1), mo.group(2))
+            field = 'upgrade'
+            if mo.group(5) == 'yes':
+                ud[field] = True
+                ud[key] = {field: True}
+            else:
+                ud[key] = {field: False}
+            continue
+
+    return ud
+
+
+def massage_install_data(data):
+    # Transport cli returns a list containing one result item.
+    # Transport nxapi returns a list containing two items.  The second item
+    # contains the data we are interested in.
+    default_error_msg = 'No install all data found'
+    if len(data) == 1:
+        result_data = data[0]
+    elif len(data) == 2:
+        result_data = data[1]
     else:
-        nxos_regex = r'NXOS variable = bootflash:/(\S+)'
-        nxos = re.search(nxos_regex, boot_options_raw_text).group(1)
-        retdict = dict(sys=nxos)
+        result_data = default_error_msg
 
-    command = 'show install all status'
-    retdict['status'] = execute_show_command(command, module)[0]
+    # Further processing may be needed for result_data
+    if len(data) == 2 and type(data[1]) is dict:
+        if 'clierror' in data[1].keys():
+            result_data = data[1]['clierror']
+        elif 'code' in data[1].keys() and data[1]['code'] == '500':
+            # We encountered a backend processing error for nxapi
+            result_data = data[1]['msg']
+        else:
+            result_data = default_error_msg
+    return result_data
 
-    return retdict
 
-
-def already_set(current_boot_options, system_image_file, kickstart_image_file):
-    return current_boot_options.get('sys') == system_image_file \
-        and current_boot_options.get('kick') == kickstart_image_file
-
-
-def do_install_all(module, issu, image_name, kickstart=None):
-    """Set boot variables
-    like system image and kickstart image and boot the os.
-    Args:
-        The main system image file name.
-    Keyword Args: many implementors may choose
-        to supply a kickstart parameter to specify a kickstart image.
-    """
+def build_install_cmd_set(issu, image, kick, type):
     commands = ['terminal dont-ask']
-    issu_cmd = 'non-disruptive' if issu else ''
-    if kickstart is None:
-        commands.append('install all nxos %s %s' % (image_name, issu_cmd))
+    if re.search(r'required|desired|yes', issu):
+        issu_cmd = 'non-disruptive'
+    else:
+        issu_cmd = ''
+    if type == 'impact':
+        rootcmd = 'show install all impact'
+    else:
+        rootcmd = 'install all'
+    if kick is None:
+        commands.append(
+            '%s nxos %s %s' % (rootcmd, image, issu_cmd))
     else:
         commands.append(
-            'install all system %s kickstart %s' % (image_name, kickstart))
-    install_result = load_config(module, commands)
-    return install_result
+            '%s system %s kickstart %s' % (rootcmd, image, kick))
+    return commands
+
+
+def do_install_all(module, issu, image, kick=None):
+    """Perform the switch upgrade using the 'install all' command"""
+    result_dict = {'pass': False}
+    datachkmode = check_mode(module, issu, image, kick)
+    if datachkmode['error']:
+        # Check mode discovered an error so return with this info.
+        result_dict['ud'] = datachkmode
+    elif not datachkmode['upgrade']:
+        # The switch is already upgraded.  Nothing more to do.
+        result_dict['pass'] = True
+        result_dict['ud'] = datachkmode
+    else:
+        # If we get here, check_mode returned no errors and the switch
+        # needs to be upgraded.
+        if datachkmode['disruptive']:
+            issu = 'no'
+        commands = build_install_cmd_set(issu, image, kick, 'install')
+        opts = {'ignore_timeout': True}
+        # The system may be busy from the call to check_mode so loop until
+        # it's done.
+        in_progress = r'Another install procedure may be in progress'
+        for attempt in range(20):
+            data = load_config(module, commands, True, opts)
+            data = massage_install_data(data)
+            if re.search(in_progress, data, re.M):
+                logit('Install in progress')
+                sleep(1)
+                continue
+            break
+
+        msg1 = 'Finishing the upgrade'
+        msg2 = 'Install has been successful'
+        # When the switch is ISSU capable, the call to load_config will time
+        # out but the upgrade still succeeds.
+        msg3 = 'Connection failure: timed out'
+        msg4 = 'timeout trying to send command: install'
+        msg5 = 'Backend processing error'
+        success_re = r'%s|%s|%s|%s|%s' % (msg1, msg2, msg3, msg4, msg5)
+        if re.search(success_re, data):
+            result_dict['pass'] = True
+
+        if result_dict['pass']:
+            msg = r'%s|%s|%s' % (msg3, msg4, msg5)
+            if re.search(msg, data):
+                result_dict['ud'] = datachkmode
+        result_dict['ud'] = parse_show_install(data)
+    return result_dict
+
+
+def parse_show_version(data):
+    version_data = {'raw': data[0].split('\n')}
+    version_data['version'] = ''
+    version_data['error'] = False
+    for x in version_data['raw']:
+        mo = re.search(r'(kickstart|system):\s+version\s+(\S+)', x)
+        if mo:
+            version_data['version'] = mo.group(2)
+            continue
+
+    if version_data['version'] == '':
+        version_data['error'] = True
+
+    return version_data
+
+
+def check_mode_legacy(module, issu, image, kick=None):
+    """Some platforms/images/transports don't support the 'install all impact'
+        command so we need to use a different method."""
+    current = execute_show_command(module, 'show version', 'json')[0]
+    # Call parse_show_data on empty string to create the default upgrade
+    # data stucture dictionary
+    data = parse_show_install('')
+    upgrade_msg = 'No upgrade required'
+
+    # Process System Image
+    tsver = 'show version image bootflash:%s' % image
+    target_image = parse_show_version(execute_show_command(module, tsver))
+    if target_image['error']:
+        data['error'] = True
+        data['raw'] = target_image['raw']
+        return data
+    if current['kickstart_ver_str'] != target_image:
+        data['upgrade'] = True
+        data['disruptive'] = True
+        upgrade_msg = 'Switch upgraded: system: %s' % tsver
+
+    # Process Kickstart Image
+    if kick is not None:
+        tkver = 'show version image bootflash:%s' % kick
+        target_kick = parse_show_version(execute_show_command(module, tkver))
+        if target_kick['error']:
+            data['error'] = True
+            data['raw'] = target_kick['raw']
+            return data
+        if current['kickstart_ver_str'] != target_kick:
+            data['upgrade'] = True
+            data['disruptive'] = True
+            upgrade_msg = upgrade_msg + ' kickstart: %s' % tkver
+
+    data['processed'] = upgrade_msg
+    return data
+
+
+def check_mode_nextgen(module, issu, image, kick=None):
+    """Use the 'install all impact' command for check_mode"""
+    commands = build_install_cmd_set(issu, image, kick, 'impact')
+    data = massage_install_data(load_config(module, commands, True))
+    data = parse_show_install(data)
+    # If an error is encountered when issu is 'desired' then try again
+    # but set issu to 'no'
+    if data['error'] and issu == 'desired':
+        issu = 'no'
+        commands = build_install_cmd_set(issu, image, kick, 'impact')
+        data = massage_install_data(load_config(module, commands, True))
+        data = parse_show_install(data)
+    if re.search(r'No install all data found', data['raw'][0]):
+        data['error'] = True
+    return data
+
+
+def check_mode(module, issu, image, kick=None):
+    """Check switch upgrade impact using 'show install all impact' command"""
+    global platform
+    if re.search(r'N5K|N6K|N7K', platform):
+        data = check_mode_legacy(module, issu, image, kick)
+    else:
+        data = check_mode_nextgen(module, issu, image, kick)
+    return data
 
 
 def main():
     argument_spec = dict(
         system_image_file=dict(required=True),
         kickstart_image_file=dict(required=False),
-        issu=dict(required=False, type='bool', default='false'),
+        issu=dict(choices=['required', 'desired', 'no', 'yes'], default='no'),
     )
+    # ISSU choices, 'required', 'desired', 'no', 'yes'
+    # parse intsall all commands for everything.
 
     argument_spec.update(nxos_argument_spec)
 
@@ -220,6 +542,13 @@ def main():
     warnings = list()
     check_args(module, warnings)
 
+    # This module will error out if the following Ansible timers are not
+    # set properly.
+    # 1) export ANSIBLE_PERSISTENT_COMMAND_TIMEOUT=600
+    # 2) export ANSIBLE_PERSISTENT_CONNECT_TIMEOUT=600
+    check_ansible_timers(module)
+
+    global platform
     platform = get_platform(module)
 
     # Get system_image_file(sif), kickstart_image_file(kif) and
@@ -228,28 +557,48 @@ def main():
     kif = module.params['kickstart_image_file']
     issu = module.params['issu']
 
-    if issu and not platform == 'N9K':
-        msg = "ISSU option is not supported on %s platforms" % platform
-        module.fail_json(msg=msg)
-
     if kif == 'null':
         kif = None
 
-    # Determine current boot options
-    cbo = get_boot_options(module)
-    changed = False
-    if not already_set(cbo, sif, kif):
-        changed = True
+    if kickstart_image_required(module) and kif is None:
+        msg = '%s platform requires a kickstart_image_file' % platform
+        module.fail_json(msg=msg)
 
-    if not module.check_mode and changed is True:
-        ir = do_install_all(module, issu, sif, kickstart=kif)[0]
-        if re.search(r'Finishing the upgrade, switch will reboot', ir):
-            cbo = ir
+    if re.search(r'N3K|N5K|N6K|N7K', platform):
+        if re.search(r'required|yes', issu):
+            msg1 = 'Module does not support ISSU for %s platforms' % platform
+            msg2 = "\nParameter 'issu' must be set to either 'no' or 'desired'"
+            module.fail_json(msg=msg1 + msg2)
+
+    if module.check_mode:
+        ud = check_mode(module, issu, sif, kick=kif)
+        changed = ud['upgrade']
+        if ud['error']:
+            chk_mode = ud['raw']
+            msg = 'Check mode error encountered'
+            module.fail_json(msg=msg, changed=changed, install_state=chk_mode)
         else:
-            module.fail_json(msg=ir)
+            chk_mode = ud['processed']
+        module.exit_json(changed=changed, install_state=chk_mode)
 
-    module.exit_json(changed=changed, install_state=cbo,
-                     warnings=warnings)
+    install_result = do_install_all(module, issu, sif, kick=kif)
+    logit('Install Passed: %s' % install_result['pass'])
+    logit('Device Needs Upgrade: %s' % install_result['ud']['upgrade'])
+    logit('Upgrade Errored?: %s' % install_result['ud']['error'])
+    logit('Processed:\n%s' % install_result['ud']['processed'])
+    logit('Raw Data:\n%s' % install_result['ud']['raw'])
+    if install_result['pass']:
+        state = install_result['ud']['processed']
+        changed = install_result['ud']['upgrade']
+    else:
+        msg = "Failed to upgrade device using image "
+        if kif:
+            msg = msg + "files: kickstart: %s, system: %s" % (kif, sif)
+        else:
+            msg = msg + "file: system: %s" % sif
+        module.fail_json(msg=msg, raw_data=install_result['ud']['raw'])
+
+    module.exit_json(changed=changed, install_state=state, warnings=warnings)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -540,9 +540,6 @@ def main():
     # tuned high enough.
     check_ansible_timer(module)
 
-    global platform
-    platform = get_platform(module)
-
     # Get system_image_file(sif), kickstart_image_file(kif) and
     # issu settings from module params.
     sif = module.params['system_image_file']

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -116,16 +116,16 @@ install_state:
     type: dictionary
     sample: {
     "install_state": [
-        "Compatibility check is done:",
-        "Module  bootable          Impact  Install-type  Reason",
-        "------  --------  --------------  ------------  ------",
-        "     1       yes      disruptive         reset  default upgrade is not hitless",
-        "Images will be upgraded according to following table:",
-        "Module       Image                  Running-Version(pri:alt)           New-Version  Upg-Required",
-        "------  ----------  ----------------------------------------  --------------------  ------------",
-        "     1        nxos                               7.0(3)I7(1)           7.0(3)I6(1)           yes",
-        "     1        bios     v07.59(08/26/2016):v07.06(03/02/2014)    v07.59(08/26/2016)            no"
-    ],
+        "Compatibility check is done:", 
+        "Module  bootable          Impact  Install-type  Reason", 
+        "------  --------  --------------  ------------  ------", 
+        "     1       yes  non-disruptive         reset  ", 
+        "Images will be upgraded according to following table:", 
+        "Module       Image                  Running-Version(pri:alt)           New-Version  Upg-Required", 
+        "------  ----------  ----------------------------------------  --------------------  ------------", 
+        "     1        nxos                               7.0(3)I6(1)           7.0(3)I7(1)           yes", 
+        "     1        bios                        v4.4.0(07/12/2017)    v4.4.0(07/12/2017)            no"
+    ], 
     }
 '''
 

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -32,8 +32,8 @@ description:
       ISSU (In Server Software Upgrade).
 notes:
     - Tested against the following platforms and images
-      - N9k 7.0(3)I4(6), 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1)
-      - N3k 6.0(2)A8(6), 6.0(2)A8(8)
+      - N9k 7.0(3)I4(6), 7.0(3)I5(3), 7.0(3)I6(1), 7.0(3)I7(1), 7.0(3)F2(2), 7.0(3)F3(2)
+      - N3k 6.0(2)A8(6), 6.0(2)A8(8), 7.0(3)I6(1), 7.0(3)I7(1)
       - N7k 7.3(0)D1(1), 8.0(1), 8.2(1)
     - This module executes longer then the default ansible timeout value and
       will generate errors unless the module timeout parameter is set to a
@@ -47,7 +47,7 @@ notes:
     - This module attempts to install the software immediately,
       which may trigger a reboot.
     - In check mode, the module will indicate if an upgrade is needed and
-      weather or not the upgrade is disruptive or non-disruptive(ISSU).
+      whether or not the upgrade is disruptive or non-disruptive(ISSU).
 author:
     - Jason Edelman (@jedelman8)
     - Gabriele Gerbibo (@GGabriele)
@@ -56,12 +56,6 @@ options:
     system_image_file:
         description:
             - Name of the system (or combined) image file on flash.
-        required: true
-    timeout:
-        description:
-            - The upgrade commands are long running so the timeout value must
-              be set to a value of 500 or greater or the module will exit
-              with a failure message.
         required: true
     kickstart_image_file:
         description:

--- a/lib/ansible/modules/network/nxos/nxos_install_os.py
+++ b/lib/ansible/modules/network/nxos/nxos_install_os.py
@@ -88,8 +88,7 @@ EXAMPLES = '''
   nxos_install_os:
     system_image_file: nxos.7.0.3.I6.1.bin
     issu: desired
-    timeout: 500
-    provider: "{{ connection }}"
+    provider: "{{ connection | combine({'timeout': 500}) }}"
 
  - name: Wait for device to come back up with new image
    wait_for:

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -226,7 +226,6 @@ lib/ansible/modules/network/nxos/nxos_gir_profile_management.py
 lib/ansible/modules/network/nxos/nxos_igmp.py
 lib/ansible/modules/network/nxos/nxos_igmp_interface.py
 lib/ansible/modules/network/nxos/nxos_igmp_snooping.py
-lib/ansible/modules/network/nxos/nxos_install_os.py
 lib/ansible/modules/network/nxos/nxos_ntp_auth.py
 lib/ansible/modules/network/nxos/nxos_ntp_options.py
 lib/ansible/modules/network/nxos/nxos_nxapi.py


### PR DESCRIPTION
##### SUMMARY
This update brings 3 major changes to the module.

1. Adds ISSU support for NXOS platforms that are ISSU capable.
    * The module uses the `show install all impact` command to make this determination.
2. Fixes the workflow such that the module no longer errors out each time forcing the use of a block/rescue.
    * Previously the module would always report a failure  due to connection timeout for the install itself and additional tasks were used to check success/failure of the upgrade.
3. Addition of an options `opts` dictionary argument to `load_config` so that we can pass an `ignore_timeout` flag from the `nxos_install_os` module.  This is needed to achieve number 2 above.
    * This argument defaults to `None` so there is no impact to modules that are not using this option.
    * In the future `return_error` could also be passed in using `opts` and any additional future requirements can use `opts` but this is beyond the scope of this PR.

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
nxos_install_os

##### ANSIBLE VERSION
```
ansible 2.5.0 (rel150/issu d541da73ac) last updated 2017/11/03 08:34:08 (GMT -400)
  config file = None
  configured module search path = [u'/Users/mwiebe/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/lib/ansible
  executable location = /Users/mwiebe/Projects/nxos_ansible/fix_ansible/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]
```


##### ADDITIONAL INFORMATION
The following describes the high level workflow for each upgrade.

1. Perform module parameter checks.
    * Make sure provider timeout value is 500 seconds or higher and exit if not.
    * Gather platform type information and make this available for use if needed in the module.
    * Determine if kickstart image is needed and exit if not.
2. Gather pre-upgrade information.
    * Gather information from the `show install all impact` command and use this information to determine if a `non-disruptive ISSU capable` upgrade is possible or drop back to disruptive if not.
        * The issu module option controls this workflow by indicating the expected result  for ISSU (required, desired, no)
    * If an unrecoverable error is encountered using the `show install all impact` command the module drops back to a legacy method of collecting similar information.
3. Start actual upgrade/downgrade.
    * Return data gathered in step 2 if any of the following are true.
       * Check mode is enabled
       * An error was encountered.
       * No upgrade is needed because the switch is already running the desired software.
    * Use the `install all` command to upgrade the device and return the data.


NOTE: Tests are not included in this PR because upgrades by nature are disruptive and increase the run times for integration tests significantly.  Tests are being added to our private test harness for regular validation.