### PR TITLE
dynamodb_table: use region derived from get_aws_connection_info() to fix tagging bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -273,6 +273,7 @@ Ansible Changes By Release
 * Fix ansible-doc and ansible-console module-path option (https://github.com/ansible/ansible/pull/31744)
 * Fix for hostname module on RHEL 7.5 (https://github.com/ansible/ansible/issues/31811)
 * Fix provider password leak in logs for asa modules (https://github.com/ansible/ansible/issues/32343)
+* Fix tagging for dynamodb_table if region is not explicitly passed to the module (https://github.com/ansible/ansible/pull/32557)
 
 ### Known Bugs
 * Implicit localhost is getting ansible_connection from all:vars instead of

--- a/lib/ansible/modules/cloud/amazon/dynamodb_table.py
+++ b/lib/ansible/modules/cloud/amazon/dynamodb_table.py
@@ -184,7 +184,7 @@ INDEX_OPTIONS = INDEX_REQUIRED_OPTIONS + ['hash_key_type', 'range_key_name', 'ra
 INDEX_TYPE_OPTIONS = ['all', 'global_all', 'global_include', 'global_keys_only', 'include', 'keys_only']
 
 
-def create_or_update_dynamo_table(connection, module, boto3_dynamodb=None, boto3_sts=None):
+def create_or_update_dynamo_table(connection, module, boto3_dynamodb=None, boto3_sts=None, region=None):
     table_name = module.params.get('name')
     hash_key_name = module.params.get('hash_key_name')
     hash_key_type = module.params.get('hash_key_type')
@@ -193,7 +193,6 @@ def create_or_update_dynamo_table(connection, module, boto3_dynamodb=None, boto3
     read_capacity = module.params.get('read_capacity')
     write_capacity = module.params.get('write_capacity')
     all_indexes = module.params.get('indexes')
-    region = module.params.get('region')
     tags = module.params.get('tags')
     wait_for_active_timeout = module.params.get('wait_for_active_timeout')
 
@@ -481,7 +480,7 @@ def main():
 
     state = module.params.get('state')
     if state == 'present':
-        create_or_update_dynamo_table(connection, module, boto3_dynamodb, boto3_sts)
+        create_or_update_dynamo_table(connection, module, boto3_dynamodb, boto3_sts, region)
     elif state == 'absent':
         delete_dynamo_table(connection, module)
 


### PR DESCRIPTION
##### SUMMARY
Merged to devel in #32557.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/dynamodb_table.py

##### ANSIBLE VERSION
```
ansible 2.4.2.0 (2.4_dynamodb_table_tags 28c8893479) last updated 2017/11/03 16:20:59 (GMT -400)
  config file = /Users/shertel/Workspace/ansible/ansible.cfg
  configured module search path = ['/Users/shertel/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/shertel/Workspace/ansible/lib/ansible
  executable location = /Users/shertel/Workspace/ansible/bin/ansible
  python version = 3.5.2 (default, Oct 11 2016, 04:59:56) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.38)]
```