### PR TITLE
Fix include_role variable exposure

### DIFF
--- a/lib/ansible/executor/play_iterator.py
+++ b/lib/ansible/executor/play_iterator.py
@@ -423,7 +423,16 @@ class PlayIterator:
 
                             # we're advancing blocks, so if this was an end-of-role block we
                             # mark the current role complete
-                            if block._eor and host.name in block._role._had_task_run and not in_child and not peek:
+                            # unless we are the role or it allows_duplicates
+                            if (
+                                block._eor and
+                                host.name in block._role._had_task_run and (
+                                    (not in_child) or
+                                    (not (block._role._metadata and
+                                          block._role._metadata.allow_duplicates))
+                                ) and
+                                not peek
+                            ):
                                 block._role._completed[host.name] = True
                     else:
                         task = block.always[state.cur_always_task]

--- a/lib/ansible/playbook/block.py
+++ b/lib/ansible/playbook/block.py
@@ -236,6 +236,7 @@ class Block(Base, Become, Conditional, Taggable):
         # import is here to avoid import loops
         from ansible.playbook.task_include import TaskInclude
         from ansible.playbook.handler_task_include import HandlerTaskInclude
+        from ansible.playbook.role_include import IncludeRole
 
         # we don't want the full set of attributes (the task lists), as that
         # would lead to a serialize/deserialize loop
@@ -262,6 +263,9 @@ class Block(Base, Become, Conditional, Taggable):
                 p = TaskInclude()
             elif parent_type == 'HandlerTaskInclude':
                 p = HandlerTaskInclude()
+            elif parent_type == 'IncludeRole':
+                p = IncludeRole()
+
             p.deserialize(parent_data)
             self._parent = p
             self._dep_chain = self._parent.get_dep_chain()

--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -326,7 +326,8 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
                         ir._role_name = templar.template(ir._role_name)
 
                     # uses compiled list from object
-                    blocks, _ = ir.get_block_list(variable_manager=variable_manager, loader=loader)
+                    blocks, _ = ir.get_block_list(
+                        play, variable_manager=variable_manager, loader=loader)
                     t = task_list.extend(blocks)
                 else:
                     # passes task object itself for latter generation of list

--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -109,7 +109,16 @@ class IncludedFile:
                                     include_target = templar.template(include_result['include'])
                                     if original_task._role:
                                         new_basedir = os.path.join(original_task._role._role_path, 'tasks', cumulative_path)
-                                        include_file = loader.path_dwim_relative(new_basedir, 'tasks', include_target)
+                                        candidates = [loader.path_dwim_relative(original_task._role._role_path, 'tasks', include_target),
+                                                      loader.path_dwim_relative(new_basedir, 'tasks', include_target)]
+                                        for include_file in candidates:
+                                            try:
+                                                # may throw OSError
+                                                os.stat(include_file)
+                                                # or select the task file if it exists
+                                                break
+                                            except OSError:
+                                                pass
                                     else:
                                         include_file = loader.path_dwim_relative(loader.get_basedir(), cumulative_path, include_target)
 

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -291,6 +291,12 @@ class Play(Base, Taggable, Become):
     def get_dynamic_roles(self):
         return self._dynamic_roles[:]
 
+    def unregister_dynamic_role(self, drole):
+        try:
+            self._dynamic_roles.pop(self._dynamic_roles.index(drole))
+        except ValueError:
+            pass
+
     def register_dynamic_role(self, drole):
         if not getattr(drole, 'private', None):
             try:

--- a/lib/ansible/playbook/play.py
+++ b/lib/ansible/playbook/play.py
@@ -91,6 +91,7 @@ class Play(Base, Taggable, Become):
         self._included_conditional = None
         self._included_path = None
         self._removed_hosts = []
+        self._dynamic_roles = []
         self.ROLE_CACHE = {}
 
     def __repr__(self):
@@ -287,6 +288,16 @@ class Play(Base, Taggable, Become):
     def get_roles(self):
         return self.roles[:]
 
+    def get_dynamic_roles(self):
+        return self._dynamic_roles[:]
+
+    def register_dynamic_role(self, drole):
+        if not getattr(drole, 'private', None):
+            try:
+                self._dynamic_roles.index(drole)
+            except ValueError:
+                self._dynamic_roles.append(drole)
+
     def get_tasks(self):
         tasklist = []
         for task in self.pre_tasks + self.tasks + self.post_tasks:
@@ -296,13 +307,26 @@ class Play(Base, Taggable, Become):
                 tasklist.append(task)
         return tasklist
 
-    def serialize(self):
+    def serialize(self, skip_dynamic_roles=False):
         data = super(Play, self).serialize()
 
+        if skip_dynamic_roles is None:
+            skip_dynamic_roles = []
+
         roles = []
+        dynamic_roles = []
         for role in self.get_roles():
             roles.append(role.serialize())
+
         data['roles'] = roles
+
+        if not skip_dynamic_roles:
+            for role in self.get_dynamic_roles():
+                rdata = role.serialize(no_play=True)
+                dynamic_roles.append(rdata)
+
+        data['dynamic_roles'] = dynamic_roles
+
         data['included_path'] = self._included_path
 
         return data
@@ -322,9 +346,22 @@ class Play(Base, Taggable, Become):
             setattr(self, 'roles', roles)
             del data['roles']
 
+        if 'dynamic_roles' in data:
+            role_data = data.get('dynamic_roles', [])
+            droles = []
+            for role in role_data:
+                r = Role()
+                role['_irole_play'] = self
+                r.deserialize(role)
+                droles.append(r)
+
+            setattr(self, 'dynamic_roles', droles)
+            del data['dynamic_roles']
+
     def copy(self):
         new_me = super(Play, self).copy()
         new_me.ROLE_CACHE = self.ROLE_CACHE.copy()
         new_me._included_conditional = self._included_conditional
         new_me._included_path = self._included_path
+        new_me._dynamic_roles = self._dynamic_roles[:]
         return new_me

--- a/lib/ansible/playbook/role/__init__.py
+++ b/lib/ansible/playbook/role/__init__.py
@@ -139,8 +139,11 @@ class Role(Base, Become, Conditional, Taggable):
             params = role_include.get_role_params()
             if role_include.when is not None:
                 params['when'] = role_include.when
-            if role_include.tags is not None:
-                params['tags'] = role_include.tags
+            # If a role is defined, either via include_role/Static, no matter
+            # what tags are not a criterion for the cache, as that's not them
+            # that would change upcoming result
+            # if role_include.tags is not None:
+            #     params['tags'] = role_include.tags
             if from_files is not None:
                 params['from_files'] = from_files
             if role_include.vars:

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -54,7 +54,7 @@ class IncludeRole(TaskInclude):
     # ATTRIBUTES
 
     # private as this is a 'module options' vs a task property
-    _allow_duplicates = FieldAttribute(isa='bool', default=False, private=True)
+    _allow_duplicates = FieldAttribute(isa='bool', default=None, private=True)
     _private = FieldAttribute(isa='bool', default=None, private=True)
 
     def __init__(self, block=None, role=None, task_include=None):
@@ -191,7 +191,14 @@ class IncludeRole(TaskInclude):
         role = Role.load(
             ri, play, parent_role=self._parent_role,
             from_files=self._from_files)
-        role._metadata.allow_duplicates = self.allow_duplicates
+        # proxy allow_duplicates attribute to role if explicitly set
+        if self.allow_duplicates is not None:
+            role._metadata.allow_duplicates = self.allow_duplicates
+        # in any case sync allow_duplicates between the role and this include statement
+        # This is the side effect if we didnt explicitly setted the allow_duplicates attribute
+        # to fallback on the included role setting
+        if self.allow_duplicates is None and role._metadata:
+            self.allow_duplicates = role._metadata.allow_duplicates
         self._role_path = role._role_path
         self.set_dynamic_role(role)
         play.register_dynamic_role(self)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -54,7 +54,7 @@ class IncludeRole(TaskInclude):
     # ATTRIBUTES
 
     # private as this is a 'module options' vs a task property
-    _allow_duplicates = FieldAttribute(isa='bool', default=True, private=True)
+    _allow_duplicates = FieldAttribute(isa='bool', default=False, private=True)
     _private = FieldAttribute(isa='bool', default=None, private=True)
 
     def __init__(self, block=None, role=None, task_include=None):
@@ -65,25 +65,50 @@ class IncludeRole(TaskInclude):
         self._parent_role = role
         self._role_name = None
         self._role_path = None
+        self._play = None
+        self._role = None
 
-    def get_block_list(self, play=None, variable_manager=None, loader=None):
+    def serialize(self, no_play=False):
+        data = super(IncludeRole, self).serialize()
+        if not self._squashed and not self._finalized:
+            data['_irole_name'] = self._role_name
+            if self._parent_role:
+                data['_irole_prole'] = self._parent_role.serialize()
+            data['_irole_path'] = self._role_path
+            if self._role:
+                data['_irole_drole'] = self._role.serialize()
+            if self._play and not no_play:
+                data['_irole_play'] = self._play.serialize(
+                    skip_dynamic_roles=True)
+        return data
 
-        # only need play passed in when dynamic
-        if play is None:
-            myplay = self._parent._play
-        else:
-            myplay = play
+    def deserialize(self, data, play=None, include_deps=True):
+        from ansible.playbook.play import Play
+        from ansible.playbook.role import Role
+        self._role_name = data.get('_irole_name', '')
+        self._role_path = data.get('_irole_path', '')
+        if play is None and '_irole_play' in data:
+            play = Play()
+            play.deserialize(data['_irole_play'])
+        if play is not None:
+            setattr(self, '_play', play)
+        if '_irole_drole' in data:
+            r = Role()
+            r.deserialize(data['_irole_drole'])
+            setattr(self, '_role', r)
+        if '_irole_prole' in data:
+            r = Role()
+            r.deserialize(data['_irole_prole'])
+            setattr(self, '_parent_role', r)
+        if play is not None:
+            play.register_dynamic_role(self)
+        super(IncludeRole, self).deserialize(data)
 
-        ri = RoleInclude.load(self._role_name, play=myplay, variable_manager=variable_manager, loader=loader)
-        ri.vars.update(self.vars)
-
-        # build role
-        actual_role = Role.load(ri, myplay, parent_role=self._parent_role, from_files=self._from_files)
-        actual_role._metadata.allow_duplicates = self.allow_duplicates
-
-        # save this for later use
-        self._role_path = actual_role._role_path
-
+    def get_block_list(self, play, variable_manager=None, loader=None):
+        self.set_play(play)
+        play = self.get_play()  # may throw error if play is None
+        # Get role
+        ir = self.load_dynamic_role()
         # compile role with parent roles as dependencies to ensure they inherit
         # variables
         if not self._parent_role:
@@ -92,13 +117,14 @@ class IncludeRole(TaskInclude):
             dep_chain = list(self._parent_role._parents)
             dep_chain.append(self._parent_role)
 
-        blocks = actual_role.compile(play=myplay, dep_chain=dep_chain)
+        blocks = ir.compile(play=self._play, dep_chain=dep_chain)
         for b in blocks:
             b._parent = self
 
         # updated available handlers in play
-        handlers = actual_role.get_handler_blocks(play=myplay)
-        myplay.handlers = myplay.handlers + handlers
+        handlers = ir.get_handler_blocks(play=self._play)
+
+        play.handlers = self._play.handlers + handlers
         return blocks, handlers
 
     @staticmethod
@@ -131,15 +157,80 @@ class IncludeRole(TaskInclude):
         return ir
 
     def copy(self, exclude_parent=False, exclude_tasks=False):
-
         new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
         new_me.statically_loaded = self.statically_loaded
         new_me._from_files = self._from_files.copy()
         new_me._parent_role = self._parent_role
         new_me._role_name = self._role_name
         new_me._role_path = self._role_path
-
+        new_me.private = self.private
+        new_me._play = self._play
+        new_me._role = self._role
         return new_me
+
+    def load_dynamic_role(self, allow_duplicates=None):
+        if allow_duplicates is None:
+            allow_duplicates = self.allow_duplicates
+        play = self.get_play()
+        variable_manager = self.get_variable_manager()
+        loader = variable_manager._loader
+        # build role
+        ri = RoleInclude.load(self._role_name,
+                              play=play,
+                              variable_manager=variable_manager,
+                              loader=loader)
+        if self.vars:
+            v = self.vars.copy()
+            # bypass vars from include_role itself
+            for k in [
+                'name', 'private', 'allow_duplicates',
+                'defaults_from', 'tasks_from', 'vars_from'
+            ]:
+                v.pop(k, None)
+            ri.vars.update(v)
+        role = Role.load(
+            ri, play, parent_role=self._parent_role,
+            from_files=self._from_files)
+        role._metadata.allow_duplicates = self.allow_duplicates
+        self._role_path = role._role_path
+        self.set_dynamic_role(role)
+        play.register_dynamic_role(self)
+        return role
+
+    def set_play(self, play):
+        self._play = play
+
+    def get_play(self):
+        if self._play is None:
+            raise ValueError('Play is not initialised')
+        return self._play
+
+    def set_dynamic_role(self, value):
+        self._role = value
+
+    def get_dynamic_role(self):
+        if self._role is None:
+            raise ValueError('Role is not initialised, call load !')
+        return self._role
+
+    @property
+    def is_loaded(self):
+        return self._role is not None
+
+    def get_default_vars(self, dep_chain=None):
+        if not self.is_loaded:
+            return dict()
+        if dep_chain is None:
+            dep_chain = self.get_dep_chain()
+        return self.get_dynamic_role().get_default_vars(dep_chain=dep_chain)
+
+    def get_vars(self, include_params=True):
+        ret = TaskInclude.get_vars(self, include_params=include_params)
+        if self.is_loaded:  # not yet loaded skip
+            ret.update(
+                self.get_dynamic_role().get_vars(include_params=include_params)
+            )
+        return ret
 
     def get_include_params(self):
         v = super(IncludeRole, self).get_include_params()

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -21,6 +21,9 @@ __metaclass__ = type
 
 from os.path import basename
 
+import cProfile
+import tempfile
+
 from ansible.errors import AnsibleParserError
 from ansible.playbook.attribute import FieldAttribute
 from ansible.playbook.task_include import TaskInclude
@@ -45,7 +48,7 @@ class IncludeRole(TaskInclude):
 
     BASE = ('name', 'role')  # directly assigned
     FROM_ARGS = ('tasks_from', 'vars_from', 'defaults_from')  # used to populate from dict in role
-    OTHER_ARGS = ('private', 'allow_duplicates')  # assigned to matching property
+    OTHER_ARGS = ('private', 'allow_duplicates', 'profiling')  # assigned to matching property
     VALID_ARGS = tuple(frozenset(BASE + FROM_ARGS + OTHER_ARGS))  # all valid args
 
     _inheritable = False
@@ -56,6 +59,7 @@ class IncludeRole(TaskInclude):
     # private as this is a 'module options' vs a task property
     _allow_duplicates = FieldAttribute(isa='bool', default=None, private=True)
     _private = FieldAttribute(isa='bool', default=None, private=True)
+    _profiling = FieldAttribute(isa='bool', default=None, private=True)
 
     def __init__(self, block=None, role=None, task_include=None):
 
@@ -170,6 +174,10 @@ class IncludeRole(TaskInclude):
         return new_me
 
     def load_dynamic_role(self, allow_duplicates=None):
+        pr = None
+        if self.profiling:
+            pr = cProfile.Profile()
+            pr.enable()
         if allow_duplicates is None:
             allow_duplicates = self.allow_duplicates
         play = self.get_play()
@@ -203,6 +211,10 @@ class IncludeRole(TaskInclude):
         self._role_path = role._role_path
         self.set_dynamic_role(role)
         play.register_dynamic_role(self)
+        if self.profiling:
+            pr.disable()
+            fich, fic = tempfile.mkstemp()
+            pr.dump_stats(fic + '_role_astat')
         return role
 
     def set_play(self, play):

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -67,6 +67,7 @@ class IncludeRole(TaskInclude):
         self._role_path = None
         self._play = None
         self._role = None
+        self._cached_vars = {}
 
     def serialize(self, no_play=False):
         data = super(IncludeRole, self).serialize()
@@ -224,23 +225,47 @@ class IncludeRole(TaskInclude):
     def is_loaded(self):
         return self._role is not None
 
-    def get_default_vars(self, dep_chain=None):
-        if not self.is_loaded:
-            return dict()
-        if dep_chain is None:
-            dep_chain = self.get_dep_chain()
-        return self.get_dynamic_role().get_default_vars(dep_chain=dep_chain)
-
-    def get_vars(self, include_params=True):
-        ret = TaskInclude.get_vars(self, include_params=include_params)
-        if self.is_loaded:  # not yet loaded skip
-            ret.update(
-                self.get_dynamic_role().get_vars(include_params=include_params)
-            )
+    def cache_get(self, key, kval, func, *a, **kw):
+        try:
+            cache = self._cached_vars[key]
+        except KeyError:
+            cache = self._cached_vars[key] = {}
+        try:
+            ret = cache[kval]
+        except KeyError:
+            cache[kval] = ret = func(*a, **kw)
         return ret
 
+    def get_default_vars(self, dep_chain=None):
+        cache_key = (self.is_loaded, dep_chain and tuple(dep_chain) or None)
+
+        def func(dep_chain, *a, **kw):
+            if not self.is_loaded:
+                return dict()
+            if dep_chain is None:
+                dep_chain = self.get_dep_chain()
+            ret = self.get_dynamic_role().get_default_vars(dep_chain=dep_chain)
+            return ret
+        return self.cache_get('default', cache_key, func, dep_chain)
+
+    def get_vars(self, include_params=True):
+        cache_key = (include_params, self.is_loaded)
+
+        def func(include_params, *a, **kw):
+            ret = TaskInclude.get_vars(self, include_params=include_params)
+            if self.is_loaded:  # not yet loaded skip
+                ret.update(
+                    self.get_dynamic_role().get_vars(include_params=include_params)
+                )
+            return ret
+        return self.cache_get('vars', cache_key, func, include_params)
+
     def get_include_params(self):
-        v = super(IncludeRole, self).get_include_params()
-        if self._parent_role:
-            v.update(self._parent_role.get_role_params())
-        return v
+        cache_key = bool(self._parent_role)
+
+        def func(*a, **kw):
+            v = super(IncludeRole, self).get_include_params()
+            if self._parent_role:
+                v.update(self._parent_role.get_role_params())
+            return v
+        return self.cache_get('include_params', cache_key, func)

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -83,9 +83,20 @@ class IncludeRole(TaskInclude):
             if self._role:
                 data['_irole_drole'] = self._role.serialize()
             if self._play and not no_play:
+                # avoid deepcopy recurse errors
+                self._play.unregister_dynamic_role(self)
                 data['_irole_play'] = self._play.serialize(
                     skip_dynamic_roles=True)
+                self._play.register_dynamic_role(self)
         return data
+
+    def __setstate__(self, sr):
+        self.__init__()
+        self.deserialize(sr)
+
+    def __getstate__(self):
+        sr = self.serialize()
+        return sr
 
     def deserialize(self, data, play=None, include_deps=True):
         from ansible.playbook.play import Play
@@ -95,16 +106,19 @@ class IncludeRole(TaskInclude):
         if play is None and '_irole_play' in data:
             play = Play()
             play.deserialize(data['_irole_play'])
+            del data['_irole_play']
         if play is not None:
             setattr(self, '_play', play)
         if '_irole_drole' in data:
             r = Role()
             r.deserialize(data['_irole_drole'])
             setattr(self, '_role', r)
+            del data['_irole_drole']
         if '_irole_prole' in data:
             r = Role()
             r.deserialize(data['_irole_prole'])
             setattr(self, '_parent_role', r)
+            del data['_irole_prole']
         if play is not None:
             play.register_dynamic_role(self)
         super(IncludeRole, self).deserialize(data)
@@ -162,7 +176,29 @@ class IncludeRole(TaskInclude):
         return ir
 
     def copy(self, exclude_parent=False, exclude_tasks=False):
+        # save our attrs
+        role = self._role
+        cachedvars = self._cached_vars
+        parentrole = self._parent_role
+        parent = self._parent
+        play = self._play
+
+        # be smaller for parent methods to shallow copy
+        self._role = None
+        self._cached_vars = {}
+        self._parent = None
+        self._parent_role = None
+        self._play = None
+
         new_me = super(IncludeRole, self).copy(exclude_parent=exclude_parent, exclude_tasks=exclude_tasks)
+
+        # restore our state
+        self._role = role
+        self._cached_vars = cachedvars
+        self._parent_role = parentrole
+        self._parent = parent
+        self._play = play
+
         new_me.statically_loaded = self.statically_loaded
         new_me._from_files = self._from_files.copy()
         new_me._parent_role = self._parent_role
@@ -172,6 +208,11 @@ class IncludeRole(TaskInclude):
         new_me._play = self._play
         new_me._role = self._role
         return new_me
+
+    def __deepcopy__(self, memo):
+        ret = self.deserialize(self.serialize())
+        memo[id(self)] = ret
+        return ret
 
     def load_dynamic_role(self, allow_duplicates=None):
         pr = None

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -59,7 +59,7 @@ class TaskInclude(Task):
         new_me.statically_loaded = self.statically_loaded
         return new_me
 
-    def get_vars(self):
+    def get_vars(self, include_params=True):
         '''
         We override the parent Task() classes get_vars here because
         we need to include the args of the include into the vars as
@@ -72,8 +72,9 @@ class TaskInclude(Task):
             if self._parent:
                 all_vars.update(self._parent.get_vars())
 
-            all_vars.update(self.vars)
-            all_vars.update(self.args)
+            if include_params:
+                all_vars.update(self.vars)
+                all_vars.update(self.args)
 
             if 'tags' in all_vars:
                 del all_vars['tags']

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -332,6 +332,13 @@ class StrategyModule(StrategyBase):
                                     variable_manager=self._variable_manager,
                                     loader=self._loader,
                                 )
+                                # Prevent included tasks to run if already done
+                                if (
+                                    new_ir._role.has_run(host) and
+                                    (new_ir._role._metadata is None or (new_ir._role._metadata and not new_ir._role._metadata.allow_duplicates))
+                                ):
+                                    display.debug("'%s' skipped because role has already run" % new_ir)
+                                    new_blocks, handler_blocks = [], []
                                 self._tqm.update_handler_list([handler for handler_block in handler_blocks for handler in handler_block.block])
                             else:
                                 new_blocks = self._load_included_file(included_file, iterator=iterator)

--- a/lib/ansible/vars/manager.py
+++ b/lib/ansible/vars/manager.py
@@ -205,10 +205,13 @@ class VariableManager:
         # default for all cases
         basedirs = [self._loader.get_basedir()]
 
+        # First compile vars that are coming from roles (defaults/main.yml)
+        # from within the play (both static and loaded dynamically)
+        # Of course for dynamic, we are only the ones which are
+        # already parsed yet through playbooks/role_include.py
+        # and not marked as private on the include statement.
         if play:
-            # first we compile any vars specified in defaults/main.yml
-            # for all roles within the specified play
-            for role in play.get_roles():
+            for role in play.get_roles() + play.get_dynamic_roles():
                 all_vars = combine_vars(all_vars, role.get_default_vars())
 
         if task:
@@ -392,7 +395,7 @@ class VariableManager:
             # By default, we now merge in all vars from all roles in the play,
             # unless the user has disabled this via a config option
             if not C.DEFAULT_PRIVATE_ROLE_VARS:
-                for role in play.get_roles():
+                for role in play.get_roles() + play.get_dynamic_roles():
                     all_vars = combine_vars(all_vars, role.get_vars(include_params=False))
 
         # next, we merge in the vars from the role, which will specifically

--- a/test/integration/targets/include_role/aliases
+++ b/test/integration/targets/include_role/aliases
@@ -1,0 +1,2 @@
+posix/ci/group3
+include_role

--- a/test/integration/targets/include_role/include_role.yml
+++ b/test/integration/targets/include_role/include_role.yml
@@ -1,0 +1,41 @@
+- name: verify that play can access vars after include role
+  hosts: testhost
+  tasks:
+    - shell: echo {{testinc_defvar1|default('notdefined')}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'notdefined'
+    - include_role: {name: test_include_role}
+      register: testa
+    - shell: echo {{testinc_defvar1}}
+      register: test2
+    - shell: echo {{testinc_varvar1}}
+      register: test3
+    - assert:
+        that:
+          - testdep1.stdout == 'from deprole'
+          - test1.stdout == 'from role'
+          - test2.stdout == 'foobar'
+          - test3.stdout == 'muche'
+
+- name: verify that vars doesnt survive after play
+  hosts: testhost
+  tasks:
+    - shell: echo {{testinc_defvar1|default('notdefined')}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'notdefined'
+
+- name: verify that we can play with default vars
+  hosts: testhost
+  tasks:
+    - include_role: {name: test_include_role}
+      vars:
+        testinc_defvar1: overriden
+    - shell: echo {{testinc_defvar1}}
+      register: test2
+    - assert:
+        that:
+          - test2.stdout == 'overriden'

--- a/test/integration/targets/include_role/roles/test_include_role/defaults/main.yml
+++ b/test/integration/targets/include_role/roles/test_include_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testinc_defvar1: foobar
+testinc_varvar1: foobar

--- a/test/integration/targets/include_role/roles/test_include_role/meta/main.yml
+++ b/test/integration/targets/include_role/roles/test_include_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: [test_includedep_role]

--- a/test/integration/targets/include_role/roles/test_include_role/tasks/main.yml
+++ b/test/integration/targets/include_role/roles/test_include_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: noop task
+  shell: echo from role
+  register: test1

--- a/test/integration/targets/include_role/roles/test_include_role/vars/main.yml
+++ b/test/integration/targets/include_role/roles/test_include_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testinc_varvar1: muche

--- a/test/integration/targets/include_role/roles/test_includedep_role/defaults/main.yml
+++ b/test/integration/targets/include_role/roles/test_includedep_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testdepinc_defvar1: foobar
+testdepinc_varvar1: foobar

--- a/test/integration/targets/include_role/roles/test_includedep_role/meta/main.yml
+++ b/test/integration/targets/include_role/roles/test_includedep_role/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/test/integration/targets/include_role/roles/test_includedep_role/tasks/main.yml
+++ b/test/integration/targets/include_role/roles/test_includedep_role/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: noop task
+  shell: echo from deprole
+  register: testdep1

--- a/test/integration/targets/include_role/roles/test_includedep_role/vars/main.yml
+++ b/test/integration/targets/include_role/roles/test_includedep_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testdepinc_varvar1: muche

--- a/test/integration/targets/include_role/runme.sh
+++ b/test/integration/targets/include_role/runme.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -eux
+ansible-playbook -i../../inventory include_role.yml -v

--- a/test/integration/targets/include_role_nested/aliases
+++ b/test/integration/targets/include_role_nested/aliases
@@ -1,0 +1,2 @@
+posix/ci/group3
+include_role

--- a/test/integration/targets/include_role_nested/nested.yml
+++ b/test/integration/targets/include_role_nested/nested.yml
@@ -1,0 +1,6 @@
+- name: >-
+    verify that multiple level of nested statements and 
+    include+meta doesnt mess included files mecanisms
+  hosts: testhost
+  tasks:
+  - include_tasks: ./tasks/nested/nested.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep2_defvar1: foobar
+testnesteddep2_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: nested/nested/test_nested_dep_role2a

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./rund.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/rund.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/tasks/rund.yml
@@ -1,0 +1,2 @@
+---
+- shell: echo from deprole2a

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep2_varvar1: muche

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep2_defvar1: foobar
+testnesteddep2_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: nested/nested/test_nested_dep_role2b

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./rune.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/rune.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/tasks/rune.yml
@@ -1,0 +1,2 @@
+---
+- shell: echo from deprole2

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2a/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep2_varvar1: muche

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep2_defvar1: foobar
+testnesteddep2_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./runf.yml

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/runf.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/tasks/runf.yml
@@ -1,0 +1,2 @@
+---
+- shell: echo from deprole2b

--- a/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/nested/test_nested_dep_role2b/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep2_varvar1: muche

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/defaults/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+testnesteddep_defvar1: foobar
+testnesteddep_varvar1: foobar

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/meta/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./runc.yml

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/runc.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/tasks/runc.yml
@@ -1,0 +1,4 @@
+---
+- debug:
+    msg: from test_nested_dep_role
+- include_role: {name: nested/nested/test_nested_dep_role2}

--- a/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/vars/main.yml
+++ b/test/integration/targets/include_role_nested/nested/nested/test_nested_dep_role/vars/main.yml
@@ -1,0 +1,2 @@
+---
+testnesteddep_varvar1: muche

--- a/test/integration/targets/include_role_nested/nestedtasks/nested/nested.yml
+++ b/test/integration/targets/include_role_nested/nestedtasks/nested/nested.yml
@@ -1,0 +1,2 @@
+---
+- include_role: {name: test_nested_include_task}

--- a/test/integration/targets/include_role_nested/roles/test_nested_include_task/meta/main.yml
+++ b/test/integration/targets/include_role_nested/roles/test_nested_include_task/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+- role: nested/test_nested_dep_role

--- a/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/main.yml
+++ b/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/main.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ./runa.yml

--- a/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/runa.yml
+++ b/test/integration/targets/include_role_nested/roles/test_nested_include_task/tasks/runa.yml
@@ -1,0 +1,3 @@
+---
+- debug: 
+    msg: from test_nested_include_task

--- a/test/integration/targets/include_role_nested/runme.sh
+++ b/test/integration/targets/include_role_nested/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+W=$(cd "$(dirname "$0")" && pwd)
+export ANSIBLE_ROLES_PATH="$W/nested:$W/roles"
+set -eux
+ansible-playbook -i../../inventory nested.yml -v

--- a/test/integration/targets/include_role_nested/tasks/nested/nested.yml
+++ b/test/integration/targets/include_role_nested/tasks/nested/nested.yml
@@ -1,0 +1,2 @@
+---
+- include_tasks: ../../nestedtasks/nested/nested.yml


### PR DESCRIPTION
##### SUMMARY
This fixes #21890 where include_role doesnt bring for the play the variables from underlying roles
I m splitting this PR in multiple more scopped PRS before closing it.
SEE:
- #35167
- #32565
- #35164 
- #35166
- #35163


##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request


##### ANSIBLE VERSION
```
ansible-playbook 2.4.0 (devel fec360551b) last updated 2017/11/04 03:08:01 (GMT +200)
  config file = /home/kiorky/projects/mc/x/x/local/corpusops.bootstrap/hacking/vagrant/ansible.cfg
  configured module search path = [u'/home/kiorky/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/kiorky/projects/mc/corpusops/corpusops.bootstrap/venv/src/ansible/lib/ansible
  executable location = /home/kiorky/projects/mc/corpusops/corpusops.bootstrap/venv/bin/ansible-playbook
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

