### PR TITLE
Fix byte-compiled module loading failure for six compatible libraries

### DIFF
--- a/lib/ansible/compat/six/__init__.py
+++ b/lib/ansible/compat/six/__init__.py
@@ -51,4 +51,12 @@ if _system_six:
 else:
     from . import _six as six
 six_py_file = '{0}.py'.format(os.path.splitext(six.__file__)[0])
-exec(open(six_py_file, 'rb').read())
+if os.path.exists(six_py_file):
+    exec(open(six_py_file, 'rb').read())
+else:
+    # If there is only exist byte compiled six module (pyc or.pyo) file,
+    # We need to load byte compiled file as same as .py file.
+    import marshal
+    six_compiled_file = open(six.__file__, 'rb')
+    six_compiled_file.seek(8)
+    exec(marshal.load(six_compiled_file))


### PR DESCRIPTION
##### SUMMARY
When ansible.compat.six.__init__.py is only support to load six.py file. If an environment only has byte-compiled file(.pyc or .pyo) in PYTHONPATH, it will not work.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- Ansible

##### ANSIBLE VERSION

- Ansible <= v2.3.x
```
ansible 2.3.3.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Nov  3 2017, 20:18:15) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
(py2.7-develop)
```

##### ADDITIONAL INFORMATION

1. I have `/usr/bin/six.pyc` and there is no `six.py` file (it is created by VMware-vSphere-Perl-SDK-6.5.0-4566394.x86_64.tar.gz):
```
# ls -l /usr/bin/six.*
-r--r--r--. 1 root root 31988 Nov  4 06:56 /usr/bin/six.pyc
```
2. Launch ansible command but it does not work with IOError:
```
# ansible --version
Traceback (most recent call last):
  File "/bin/ansible", line 43, in <module>
    import ansible.constants as C
  File "/usr/lib/python2.7/site-packages/ansible/constants.py", line 26, in <module>
    from ansible.compat.six import string_types
  File "/usr/lib/python2.7/site-packages/ansible/compat/six/__init__.py", line 54, in <module>
    exec(open(six_py_file, 'rb').read())
IOError: [Errno 2] No such file or directory: '/usr/bin/six.py'
```