### PR TITLE
Add aci_bd_dhcp_label.py

### DIFF
--- a/lib/ansible/module_utils/aci.py
+++ b/lib/ansible/module_utils/aci.py
@@ -66,6 +66,7 @@ URL_MAPPING = dict(
     aep=dict(aci_class='infraAttEntityP', mo='infra/attentp-', key='name'),
     ap=dict(aci_class='fvAp', mo='ap-', key='name'),
     bd=dict(aci_class='fvBD', mo='BD-', key='name'),
+    bd_dhcp_label=dict(aci_class='dhcpLbl', mo='dhcplbl-', key='name'),
     bd_l3out=dict(aci_class='fvRsBDToOut', mo='rsBDToOut-', key='tnL3extOutName'),
     contract=dict(aci_class='vzBrCP', mo='brc-', key='name'),
     entry=dict(aci_class='vzEntry', mo='e-', key='name'),
@@ -765,3 +766,4 @@ class ACIModule(object):
         else:
             self.result['changed'] = True
             self.result['method'] = 'POST'
+

--- a/lib/ansible/module_utils/aci.py
+++ b/lib/ansible/module_utils/aci.py
@@ -766,4 +766,3 @@ class ACIModule(object):
         else:
             self.result['changed'] = True
             self.result['method'] = 'POST'
-

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -20,7 +20,7 @@ description:
   I(dhcp:Lbl) at U(https://pubhub-prod.s3.amazonaws.com/media/apic-mim-ref/docs/MO-dhcpLbl.html).
 author:
 - sig9 (sig9@sig9.org)
-version_added: '2.4'
+version_added: '2.5'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -20,7 +20,7 @@ description:
   I(dhcp:Lbl) at U(https://pubhub-prod.s3.amazonaws.com/media/apic-mim-ref/docs/MO-dhcpLbl.html).
 author:
 - sig9 (sig9@sig9.org)
-version_added: '3.0'
+version_added: '2.4'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -121,8 +121,8 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ['state', 'absent', ['bd', 'tenant']],
-            ['state', 'present', ['bd', 'tenant']],
+            ['state', 'absent', ['bd', 'tenant', 'dhcp_label']],
+            ['state', 'present', ['bd', 'tenant', 'dhcp_label']],
         ],
     )
 

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -24,7 +24,9 @@ version_added: '3.0'
 requirements:
 - ACI Fabric 1.0(3f)+
 notes:
-- A DHCP relay label contains a name for the label, the scope, and a DHCP option policy. The scope is the owner of the relay server and the DHCP option policy supplies DHCP clients with configuration parameters such as domain, nameserver, and subnet router addresses. 
+- A DHCP relay label contains a name for the label, the scope, and a DHCP option policy.
+  The scope is the owner of the relay server and the DHCP option policy supplies DHCP clients
+  with configuration parameters such as domain, nameserver, and subnet router addresses.
 options:
   bd:
     description:
@@ -37,10 +39,11 @@ options:
     - The name of the DHCP Relay Label.
   dhcp_option:
     description:
-    - The DHCP option is used to supply DHCP clients with configuration parameters such as a domain, name server, subnet, and network address.
+    - The DHCP option is used to supply DHCP clients with configuration parameters
+    such as a domain, name server, subnet, and network address.
   owner:
     description:
-    - Represents the target relay servers ownership. 
+    - Represents the target relay servers ownership.
   tenant:
     description:
     - The name of the Tenant.
@@ -67,7 +70,7 @@ def main():
         tenant=dict(type='str', aliases=['tenant_name']),
         method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
     )
-    
+
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
@@ -76,22 +79,22 @@ def main():
             ['state', 'present', ['bd', 'tenant']],
         ],
     )
-    
+
     description = module.params['description']
     dhcp_label = module.params['dhcp_label']
     dhcp_option = module.params['dhcp_option']
     owner = module.params['owner']
     state = module.params['state']
-    
+
     module.params['bd_dhcp_label'] = dhcp_label
-    
+
     aci = ACIModule(module)
     aci.construct_url(
         root_class='tenant', subclass_1='bd', subclass_2='bd_dhcp_label',
         child_classes=['dhcpRsDhcpOptionPol'],
     )
     aci.get_existing()
-    
+
     if state == 'present':
         # Filter out module params with null values
         aci.payload(
@@ -105,19 +108,18 @@ def main():
                 {'dhcpRsDhcpOptionPol': {'attributes': {'tnDhcpOptionPolName': dhcp_option}}},
             ],
         )
-        
+
         # Generate config diff which will be used as POST request body
         aci.get_diff(aci_class='dhcpLbl')
-        
+
         # Submit changes if module not in check_mode and the proposed is different than existing
         aci.post_config()
-    
+
     elif state == 'absent':
         aci.delete_config()
-    
+
     module.exit_json(**aci.result)
 
 
 if __name__ == "__main__":
     main()
-

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -31,28 +31,74 @@ options:
   bd:
     description:
     - The name of the Bridge Domain.
+    required: yes
   description:
     description:
     - Specifies a description of the policy definition.
+    required: no
   dhcp_label:
     description:
     - The name of the DHCP Relay Label.
+    required: yes
   dhcp_option:
     description:
     - The DHCP option is used to supply DHCP clients with configuration parameters
       such as a domain, name server, subnet, and network address.
+    required: no
   owner:
     description:
     - Represents the target relay servers ownership.
+    required: yes
+    choices: [ infra, tenant ]
+    default: infra
   tenant:
     description:
     - The name of the Tenant.
     aliases: [ tenant_name ]
+    required: yes
 '''
 
-EXAMPLES = r''' # '''
+EXAMPLES = r'''
+- name: Create a new DHCP Relay Label to a Bridge Domain
+  aci_bd_dhcp_label:
+    host: "{{ apic }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    tenant: "{{ tenant }}"
+    bd: "{{ inventory_hostname }}"
+    dhcp_label: "{{ dhcp_label }}"
+    owner: "{{ owner }}"
+    state: "present"
 
-RETURN = r''' # '''
+- name: Remove a DHCP Relay Label for a Bridge Domain
+  aci_bd_dhcp_label:
+    host: "{{ apic }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    tenant: "{{ tenant }}"
+    bd: "{{ inventory_hostname }}"
+    dhcp_label: "{{ dhcp_label }}"
+    owner: "{{ owner }}"
+    state: "absent"
+
+- name: Query a DHCP Relay Label of a Bridge Domain
+  aci_bd_dhcp_label:
+    host: "{{ apic }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    tenant: "{{ tenant }}"
+    bd: "{{ inventory_hostname }}"
+    dhcp_label: "{{ dhcp_label }}"
+    owner: "{{ owner }}"
+    state: "query"
+'''
+
+RETURN = r'''
+#
+'''
 
 from ansible.module_utils.aci import ACIModule, aci_argument_spec
 from ansible.module_utils.basic import AnsibleModule

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -40,7 +40,7 @@ options:
   dhcp_option:
     description:
     - The DHCP option is used to supply DHCP clients with configuration parameters
-    such as a domain, name server, subnet, and network address.
+      such as a domain, name server, subnet, and network address.
   owner:
     description:
     - Represents the target relay servers ownership.

--- a/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
+++ b/lib/ansible/modules/network/aci/aci_bd_dhcp_label.py
@@ -1,0 +1,123 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: aci_bd_dhcp_label
+short_description: Manage DHCP Label on Cisco ACI fabrics (dhcp:Lbl)
+description:
+- Manage DHCP Label on Cisco ACI fabrics (dhcp:Lbl)
+- More information from the internal APIC class
+  I(dhcp:Lbl) at U(https://pubhub-prod.s3.amazonaws.com/media/apic-mim-ref/docs/MO-dhcpLbl.html).
+author:
+- sig9 (sig9@sig9.org)
+version_added: '3.0'
+requirements:
+- ACI Fabric 1.0(3f)+
+notes:
+- A DHCP relay label contains a name for the label, the scope, and a DHCP option policy. The scope is the owner of the relay server and the DHCP option policy supplies DHCP clients with configuration parameters such as domain, nameserver, and subnet router addresses. 
+options:
+  bd:
+    description:
+    - The name of the Bridge Domain.
+  description:
+    description:
+    - Specifies a description of the policy definition.
+  dhcp_label:
+    description:
+    - The name of the DHCP Relay Label.
+  dhcp_option:
+    description:
+    - The DHCP option is used to supply DHCP clients with configuration parameters such as a domain, name server, subnet, and network address.
+  owner:
+    description:
+    - Represents the target relay servers ownership. 
+  tenant:
+    description:
+    - The name of the Tenant.
+    aliases: [ tenant_name ]
+'''
+
+EXAMPLES = r''' # '''
+
+RETURN = r''' # '''
+
+from ansible.module_utils.aci import ACIModule, aci_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+def main():
+    argument_spec = aci_argument_spec
+    argument_spec.update(
+        bd=dict(type='str', aliases=['bd_name']),
+        description=dict(type='str', aliases=['descr']),
+        dhcp_label=dict(type='str'),
+        dhcp_option=dict(type='str'),
+        owner=dict(type='str'),
+        state=dict(type='str', default='present', choices=['absent', 'present', 'query']),
+        tenant=dict(type='str', aliases=['tenant_name']),
+        method=dict(type='str', choices=['delete', 'get', 'post'], aliases=['action'], removed_in_version='2.6'),  # Deprecated starting from v2.6
+    )
+    
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'absent', ['bd', 'tenant']],
+            ['state', 'present', ['bd', 'tenant']],
+        ],
+    )
+    
+    description = module.params['description']
+    dhcp_label = module.params['dhcp_label']
+    dhcp_option = module.params['dhcp_option']
+    owner = module.params['owner']
+    state = module.params['state']
+    
+    module.params['bd_dhcp_label'] = dhcp_label
+    
+    aci = ACIModule(module)
+    aci.construct_url(
+        root_class='tenant', subclass_1='bd', subclass_2='bd_dhcp_label',
+        child_classes=['dhcpRsDhcpOptionPol'],
+    )
+    aci.get_existing()
+    
+    if state == 'present':
+        # Filter out module params with null values
+        aci.payload(
+            aci_class='dhcpLbl',
+            class_config=dict(
+                descr=description,
+                name=dhcp_label,
+                owner=owner,
+            ),
+            child_configs=[
+                {'dhcpRsDhcpOptionPol': {'attributes': {'tnDhcpOptionPolName': dhcp_option}}},
+            ],
+        )
+        
+        # Generate config diff which will be used as POST request body
+        aci.get_diff(aci_class='dhcpLbl')
+        
+        # Submit changes if module not in check_mode and the proposed is different than existing
+        aci.post_config()
+    
+    elif state == 'absent':
+        aci.delete_config()
+    
+    module.exit_json(**aci.result)
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This module is supposed to manage a DHCP Relay Label with Cisco ACI.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

aci_bd_dhcp_label

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

N/A.