### PR TITLE
PEP8 set the line length limit

### DIFF
--- a/CODING_GUIDELINES.md
+++ b/CODING_GUIDELINES.md
@@ -15,11 +15,11 @@ Language
   * If you want to write non-Python ansible modules or inventory scripts, that's fine, but they are not going to get merged in most likely.  Sorry!!  
 
 PEP 8 and basic style checks
-===========================
+============================
 
   * [PEP 8](https://www.python.org/dev/peps/pep-0008/) is a great Python style guide, which you should read.
   * PEP 8 must not be strictly followed in all aspects, but most of it is good advice
-  * In particular, we don't really care about line lengths.  Buy a bigger monitor!
+  * The line is limited to 160 characters.
   * To run checks for things we care about, use [ansible-test](http://docs.ansible.com/ansible/dev_guide/testing_pep8.html#running-locally).
   * Similarly, additional checks can be made with "make pyflakes"
   * There is no need to submit code changes for PEP 8 and pyflakes fixes, as these break attribution history.  Project leadership will make these periodically.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Indicate that the line length is limited to 160 characters now, since the test will fail if the line is longer than 160 chars.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
