### PR TITLE
vApp properties support

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -225,7 +225,7 @@ options:
     - ' - C(value) (string): Property value'
     - ' - C(type) (string): Value type, string type by default.'
     - ' - C(operation) (string): add, edit, remove. Required only when removing properties. If property present the parameter will be defaulted to "edit".'
-    version_added: '2.5'
+    version_added: '2.6'
 extends_documentation_fragment: vmware.documentation
 '''
 

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -25,3 +25,4 @@
 - include: disk_type_d1_c1_f0.yml
 - include: create_nw_d1_c1_f0.yml
 #- include: template_d1_c1_f0.yml
+- include: vapp_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -1,0 +1,113 @@
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/killall' }}"
+- name: start vcsim with no folders
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/spawn?datacenter=1&cluster=1&folder=0' }}"
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- name: get a list of Clusters from vcsim
+  uri:
+    url: "{{ 'http://' + vcsim + ':5000/govc_find?filter=CCR' }}"
+  register: clusterlist
+
+- debug: var=vcsim_instance
+- debug: var=clusterlist
+
+- name: Create test VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: vApp-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    cluster: "{{ clusterlist['json'][0] }}"
+    resource_pool: Resources
+    guest_id: centos64Guest
+    hardware:
+      memory_mb: 512
+      num_cpus: 1
+      scsi: paravirtual
+    disk:
+    - size_mb: 128
+      type: thin
+      datastore: LocalDS_0
+  register: vapp_vm
+
+- debug: var=vapp_vm
+
+- name: assert the vApp prepeties were created
+  assert:
+    that:
+      - "vapp_vm.failed == false"
+      - "vapp_vm.changed == true"
+
+- name:  Define vApp properties for the new VM
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: vApp-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    vapp_properties:
+    - id: prop_id1
+      category: category
+      label: prop_label1
+      type: string
+      value: prop_value1
+    - id: prop_id2
+      category: category
+      label: prop_label2
+      type: string
+      value: prop_value2
+    state: present
+  register: vapp_vm
+
+- debug: var=vapp_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "vapp_vm.failed == false"
+      - "vapp_vm.changed == true"
+
+- name:  Edit one vApp property and removing another 
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    folder: "/{{ (clusterlist['json'][0]|basename).split('_')[0] }}/vm"
+    name: vApp-Test
+    datacenter: "{{ (clusterlist['json'][0]|basename).split('_')[0] }}"
+    vapp_properties:
+    - id: prop_id1
+      operation: remove
+    - id: prop_id2
+      value: prop_value3
+    state: present
+  register: vapp_vm
+
+- debug: var=vapp_vm
+
+- name: assert the VM was changed
+  assert:
+    that:
+      - "vapp_vm.failed == false"
+      - "vapp_vm.changed == true"

--- a/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/vapp_d1_c1_f0.yml
@@ -50,12 +50,6 @@
 
 - debug: var=vapp_vm
 
-- name: assert the vApp prepeties were created
-  assert:
-    that:
-      - "vapp_vm.failed == false"
-      - "vapp_vm.changed == true"
-
 - name:  Define vApp properties for the new VM
   vmware_guest:
     validate_certs: False
@@ -81,7 +75,7 @@
 
 - debug: var=vapp_vm
 
-- name: assert the VM was changed
+- name: assert the vApp propeties were created
   assert:
     that:
       - "vapp_vm.failed == false"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The change adds support for vApp properties manipulation.
Defined properties are available to guest via OVF environment.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/cloud/vmware/vmware_guest.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel f96d1ee759) last updated 2017/11/05 12:36:33 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/ansible/lib/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```
