### PR TITLE
module_utils/manageiq: add find_collection_resource_or_fail

### DIFF
--- a/lib/ansible/module_utils/manageiq.py
+++ b/lib/ansible/module_utils/manageiq.py
@@ -149,3 +149,17 @@ class ManageIQ(object):
         except Exception as e:
             self.module.fail_json(msg="failed to find resource {error}".format(error=e))
         return vars(entity)
+
+    def find_collection_resource_or_fail(self, collection_name, **params):
+        """ Searches the collection resource by the collection name and the param passed.
+
+        Returns:
+            the resource as an object if it exists in manageiq, Fail otherwise.
+        """
+        resource = self.find_collection_resource_by(collection_name, **params)
+        if resource:
+            return resource
+        else:
+            msg = "{collection_name} where {params} does not exist in manageiq".format(
+                collection_name=collection_name, params=str(params))
+            self.module.fail_json(msg=msg)


### PR DESCRIPTION
##### SUMMARY
This pull request adds a small method `find_collection_resource_or_fail` to the manageiq module utils.
the method tries to find a collection resource in ManageIQ, and calls module.fail_json if the resource was not found.

It is needed for the following pull requests:
https://github.com/ansible/ansible/pull/31233
https://github.com/ansible/ansible/pull/32354

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/manageiq.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```