### PR TITLE
**Temporary**

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -177,7 +177,7 @@ def main():
             original_basename=dict(required=False),  # Internal use only, for recursive ops
             recurse=dict(default=False, type='bool'),
             force=dict(required=False, default=False, type='bool'),
-            follow=dict(required=False, default=True, type='bool'),
+            follow=dict(required=False, default=False, type='bool'),
             diff_peek=dict(default=None),  # Internal use only, for internal checks in the action plugins
             validate=dict(required=False, default=None),  # Internal use only, for template and copy
             src=dict(required=False, default=None, type='path'),


### PR DESCRIPTION
The copy module has been failing since we changed the default of the
file module's follow parameter.  Make this change to try to get tests
working and then we'll diagnose and fix this afterwards.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/file.py
lib/ansible/plugins/action/copy.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
This will be reverted once we have a chance to diagnose how the copy module needs to change for this change to file's default follow value.