### PR TITLE
Fix a typo in openssl_csr examples

### DIFF
--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -183,7 +183,7 @@ EXAMPLES = '''
     privatekey_path: /etc/ssl/private/ansible.com.pem
     common_name: www.ansible.com
     key_usage:
-      - digitlaSignature
+      - digitalSignature
       - keyAgreement
     extended_key_usage:
       - clientAuth


### PR DESCRIPTION
##### SUMMARY
Fix a typo in the examples for the OpenSSL CSR module

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openssl_csr
