### PR TITLE
ec2_lc: fix backwards compatibility - fixes #32575

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -219,7 +219,7 @@ def create_block_device_meta(module, volume):
         return_object['Ebs']['VolumeSize'] = int(volume.get('volume_size', 0))
 
     if 'volume_type' in volume:
-        return_object['Ebs']['VolumeType'] = volume.get('volume_type')
+        return_object['Ebs']['VolumeType'] = volume.get('device_type')
 
     if 'delete_on_termination' in volume:
         return_object['Ebs']['DeleteOnTermination'] = volume.get('delete_on_termination', False)


### PR DESCRIPTION
##### SUMMARY
In 2.3 volume_type was set with: https://github.com/ansible/ansible/blob/stable-2.3/lib/ansible/modules/cloud/amazon/ec2_lc.py#L174. Now https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/cloud/amazon/ec2_lc.py#L222. Broken when ported to boto3.

Fixes #32575.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_lc.py

##### ANSIBLE VERSION
```
2.5.0
```