### PR TITLE
Updating the options to allow decryption and new save_when.

### DIFF
--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -125,10 +125,12 @@ options:
         will only be copied to the startup-config if it has changed since
         the last save to startup-config.  If the argument is set to
         I(never), the running-config will never be copied to the
-        startup-config
+        startup-config.  If the argument is set to I(changed), then the running-config
+        will only be copied to the startup-config if the task has made a change.
     required: false
     default: never
-    choices: ['always', 'never', 'modified']
+    choices: ['always', 'never', 'modified', 'changed']
+    version_added: "2.5"
   diff_against:
     description:
       - When using the C(ansible-playbook --diff) command line argument
@@ -160,6 +162,15 @@ options:
         argument, the task should also modify the C(diff_against) value and
         set it to I(intended).
     required: false
+  encrypt:
+    description:
+      - This allows an Aruba controller's passwords and keys to be displayed in plain
+        text when set to I(false) or encrypted when set to I(true).
+        If set to I(false), the setting will re-encrypt at the end of the module run.
+        Backups are still encrypted even when set to I(false).
+    required: false
+    default: true
+    version_added: "2.5"
 """
 
 EXAMPLES = """
@@ -266,10 +277,12 @@ def main():
 
         backup=dict(type='bool', default=False),
 
-        save_when=dict(choices=['always', 'never', 'modified'], default='never'),
+        save_when=dict(choices=['always', 'never', 'modified', 'changed'], default='never'),
 
         diff_against=dict(choices=['running', 'startup', 'intended']),
         diff_ignore_lines=dict(type='list'),
+
+        encrypt=dict(type='bool', default=True),
     )
 
     argument_spec.update(aruba_argument_spec)
@@ -297,6 +310,9 @@ def main():
         config = NetworkConfig(indent=1, contents=contents)
         if module.params['backup']:
             result['__backup__'] = contents
+
+    if not module.params['encrypt']:
+        run_commands(module, 'encrypt disable')
 
     if any((module.params['src'], module.params['lines'])):
         match = module.params['match']
@@ -343,6 +359,9 @@ def main():
 
         if running_config.sha1 != startup_config.sha1:
             save_config(module, result)
+    elif module.params['save_when'] == 'changed':
+        if result['changed']:
+            save_config(module, result)
 
     if module._diff:
         if not running_config:
@@ -380,6 +399,9 @@ def main():
                     'diff': {'before': str(base_config), 'after': str(running_config)}
                 })
 
+    # make sure 'encrypt enable' is applied if it was ever disabled
+    if not module.params['encrypt']:
+        run_commands(module, 'encrypt enable')
     module.exit_json(**result)
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Updating the options to allow decryption and new save_when.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aruba_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0
  config file = /home/v-jamigh/git/Ansible-Networking/ansible.cfg
  configured module search path = [u'/home/v-jamigh/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/v-jamigh/tmp/ansible/lib/ansible
  executable location = /home/v-jamigh/tmp/ansible/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```
