### PR TITLE
Get (potentially) new composite host vars from inventory

### DIFF
--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -115,6 +115,11 @@ class InventoryModule(BaseInventoryPlugin):
 
                 # create composite vars
                 self._set_composite_vars(data.get('compose'), hostvars, host, strict=strict)
+                
+                # refetch host vars in case new ones have been created above
+                hostvars = inventory.hosts[host].get_vars()
+                if host in self._cache:  # adds facts if cache is active
+                    hostvars = combine_vars(hostvars, self._cache[host])
 
                 # constructed groups based on conditionals
                 self._add_host_to_composed_groups(data.get('groups'), hostvars, host, strict=strict)

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -115,7 +115,7 @@ class InventoryModule(BaseInventoryPlugin):
 
                 # create composite vars
                 self._set_composite_vars(data.get('compose'), hostvars, host, strict=strict)
-                
+
                 # refetch host vars in case new ones have been created above
                 hostvars = inventory.hosts[host].get_vars()
                 if host in self._cache:  # adds facts if cache is active


### PR DESCRIPTION
##### SUMMARY
I would like to create groups using variables that I have created in the 'compose' section however currently those variables are not available because they are fetched before the composite variables are calculated. 

I'm proposing simply retrieving the vars again after calculating the composite variables. I'm not sure of the 'cost' of this and whether it is necessary to track whether any composite variables are used or created to decide whether to fetch the host vars again? 

Example use case below.

```yaml
plugin: constructed
strict: False
compose:
    var_sum: var1 + var2
groups:
    var_sum_equals4: var_sum == 4
```

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
constructed

##### ANSIBLE VERSION
```
ansible 2.4.1.0
```
