### PR TITLE
Fix junos netconf port issue in integration test

### DIFF
--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -12,7 +12,7 @@
 - name: Change port
   junos_netconf:
     state: present
-    netconf_port: 22
+    netconf_port: 8080
   register: result
 
 - assert:
@@ -22,23 +22,19 @@
 - name: idempotent tests
   junos_netconf:
     state: present
-    netconf_port: 22
+    netconf_port: 8080
   register: result
 
 - assert:
     that:
       - "result.changed == false"
 
-- name: wait for persistent socket to timeout, this ensures new socket creation with connection type netconf
-  pause:
-    seconds: 120
-
-- name: Ensure we can communicate over 22
+- name: Ensure we can communicate over 8080
   junos_command:
     rpcs:
     - get-software-information
     provider: "{{ netconf }}"
-    port: 22
+    port: 8080
 
 # This protects against the port override above not being honoured and a bug setting the port
 - name: Ensure we can NOT communicate over default port
@@ -52,10 +48,6 @@
     that:
       - "result.failed == true"
       - "'unable to open shell' in result.msg"
-
-- name: wait for persistent socket to timeout, this ensures new socket creation with connection type netconf
-  pause:
-    seconds: 120
 
 - name: Set back netconf to default port
   junos_netconf:

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -45,7 +45,7 @@
 
 - name: wait for persistent socket to timeout
   pause:
-    seconds: 120
+    seconds: 150
 
 - name: Ensure we can NOT talk via netconf
   junos_command:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
tests/cli/changeport.yaml
tests/cli/netconf.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
