### PR TITLE
Fixes #30863: support update source_address_prefix in azure_rm_securitygroup

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_securitygroup.py
@@ -426,6 +426,9 @@ def compare_rules(r, rule):
         if rule['direction'] != r['direction']:
             changed = True
             r['direction'] = rule['direction']
+        if rule['source_address_prefix'] != str(r['source_address_prefix']):
+            changed = True
+            r['source_address_prefix'] = rule['source_address_prefix']
     return matched, changed
 
 

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -14,9 +14,9 @@
             access: Deny
             priority: 100
             direction: Inbound
-          - name: 'AllowSSH'
+          - name: AllowSSH
             protocol: Tcp
-            source_address_prefix: '174.109.158.0/24'
+            source_address_prefix: 174.109.158.0/24
             destination_port_range: 22
             access: Allow
             priority: 101
@@ -41,15 +41,15 @@
       resource_group: "{{ resource_group }}"
       name: mysecgroup
       rules:
-          - name: 'AllowSSH'
+          - name: AllowSSH
             protocol: Tcp
-            source_address_prefix: '174.108.158.0/24'
+            source_address_prefix: 174.108.158.0/24
             destination_port_range: 22
             access: Allow
             priority: 101
           - name: AllowSSHFromHome
             protocol: Tcp
-            source_address_prefix: '174.109.158.0/24'
+            source_address_prefix: 174.109.158.0/24
             destination_port_range: 22-23
             priority: 102
   register: output
@@ -64,15 +64,15 @@
       resource_group: "{{ resource_group }}"
       name: mysecgroup
       rules:
-          - name: 'AllowSSH'
+          - name: AllowSSH
             protocol: Tcp
-            source_address_prefix: '174.108.158.0/24'
+            source_address_prefix: 174.108.158.0/24
             destination_port_range: 22
             access: Allow
             priority: 101
           - name: AllowSSHFromHome
             protocol: Tcp
-            source_address_prefix: '174.109.158.0/24'
+            source_address_prefix: 174.109.158.0/24
             destination_port_range: 22-23
             priority: 102
   register: output

--- a/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
+++ b/test/integration/targets/azure_rm_securitygroup/tasks/main.yml
@@ -41,11 +41,12 @@
       resource_group: "{{ resource_group }}"
       name: mysecgroup
       rules:
-          - name: DenySSH
+          - name: 'AllowSSH'
             protocol: Tcp
-            destination_port_range: 22-23
-            access: Deny
-            priority: 100
+            source_address_prefix: '174.108.158.0/24'
+            destination_port_range: 22
+            access: Allow
+            priority: 101
           - name: AllowSSHFromHome
             protocol: Tcp
             source_address_prefix: '174.109.158.0/24'
@@ -53,18 +54,22 @@
             priority: 102
   register: output
 
-- assert: { that: "{{ output.state.rules | length }} == 3" }
+- assert: 
+      that:
+          - "{{ output.state.rules | length }} == 3"
+          - output.state.rules[1].source_address_prefix == '174.108.158.0/24'
 
 - name: Test idempotence
   azure_rm_securitygroup:
       resource_group: "{{ resource_group }}"
       name: mysecgroup
       rules:
-          - name: DenySSH
+          - name: 'AllowSSH'
             protocol: Tcp
-            destination_port_range: 22-23
-            access: Deny
-            priority: 100
+            source_address_prefix: '174.108.158.0/24'
+            destination_port_range: 22
+            access: Allow
+            priority: 101
           - name: AllowSSHFromHome
             protocol: Tcp
             source_address_prefix: '174.109.158.0/24'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #30863
Fix the security group cannot update source data prefix problem

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
azure_rm_securitygroup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
