### PR TITLE
Fix IndexError raised on galaxy-install

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -22,6 +22,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import errno
 import datetime
 import os
 import tarfile
@@ -325,11 +326,10 @@ class GalaxyRole(object):
                         installed = True
                     except OSError as e:
                         error = True
-                        if e[0] == 13 and len(self.paths) > 1:
+                        if e.errno == errno.EACCES and len(self.paths) > 1:
                             current = self.paths.index(self.path)
-                            nextidx = current + 1
-                            if len(self.paths) >= current:
-                                self.path = self.paths[nextidx]
+                            if len(self.paths) > current:
+                                self.path = self.paths[current + 1]
                                 error = False
                         if error:
                             raise AnsibleError("Could not update files in %s: %s" % (self.path, str(e)))


### PR DESCRIPTION
##### SUMMARY
This patch fixes IndexError, that may be raised When trying
to install a role with `ansible-galaxy` in case of
access error to roles directory.

Fixes: ansible/galaxy#149

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/galaxy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix/galaxy-install-index-error df8a7d7150) last updated 2017/11/07 14:14:42 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/cutwater/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cutwater/work/rh/ansible/lib/ansible
  executable location = /home/cutwater/.pyenv/versions/ansible/bin/ansible
  python version = 2.7.13 (default, Jun  2 2017, 13:44:55) [GCC 7.1.1 20170516]
```
