### PR TITLE
Do not set a default value for description in the iam_role module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/iam_role.py
+++ b/lib/ansible/modules/cloud/amazon/iam_role.py
@@ -214,7 +214,8 @@ def create_or_update_role(connection, module):
     params['Path'] = module.params.get('path')
     params['RoleName'] = module.params.get('name')
     params['AssumeRolePolicyDocument'] = module.params.get('assume_role_policy_document')
-    params['Description'] = module.params.get('description')
+    if module.params.get('description') is not None:
+        params['Description'] = module.params.get('description')
     managed_policies = module.params.get('managed_policy')
     if managed_policies:
         managed_policies = convert_friendly_names_to_arns(connection, module, managed_policies)
@@ -368,7 +369,7 @@ def main():
             assume_role_policy_document=dict(type='json'),
             managed_policy=dict(type='list', aliases=['managed_policies']),
             state=dict(choices=['present', 'absent'], required=True),
-            description=dict(required=False, type='str', default='')
+            description=dict(required=False, type='str')
         )
     )
 


### PR DESCRIPTION
##### SUMMARY
Bug noticed in https://github.com/ansible/ansible/pull/32582#issuecomment-342380235. This allows the description to be left unset. Now to remove a description an empty string must be provided.

cc @wimnat @InTheCloudDan 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/iam_role.py

##### ANSIBLE VERSION
```
2.5.0
```