### PR TITLE
fail module if unknown state passed to set_vm_power_state

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -720,6 +720,10 @@ def set_vm_power_state(content, vm, state, force):
                     result['failed'] = True
                     result['msg'] = "Virtual machine %s must be in poweredon state for guest shutdown/reboot" % vm.name
 
+            else:
+                result['failed'] = True
+                result['msg'] = "Unsupported expected state provided: %s" % expected_state
+
         except Exception as e:
             result['failed'] = True
             result['msg'] = to_text(e)


### PR DESCRIPTION
##### SUMMARY
If an unsupported power state is somehow provided to set_vm_power_state, fail the module.  Resolves issue #32552 in conjunction with pull request #32295.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
module_utils/vmware.py

##### ANSIBLE VERSION
```
ansible 2.5.0
commit 9d156c6cb1bb584ad7ded8c54462d8b90fc4ce58
```