### PR TITLE
fixes to events/callbacks

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -310,9 +310,7 @@ class CallbackBase(AnsiblePlugin):
         host = result._host.get_name()
         self.runner_on_unreachable(host, result._result)
 
-    def v2_runner_on_no_hosts(self, task):
-        self.runner_on_no_hosts()
-
+    # FIXME: not called
     def v2_runner_on_async_poll(self, result):
         host = result._host.get_name()
         jid = result._result.get('ansible_job_id')
@@ -320,18 +318,17 @@ class CallbackBase(AnsiblePlugin):
         clock = 0
         self.runner_on_async_poll(host, result._result, jid, clock)
 
+    # FIXME: not called
     def v2_runner_on_async_ok(self, result):
         host = result._host.get_name()
         jid = result._result.get('ansible_job_id')
         self.runner_on_async_ok(host, result._result, jid)
 
+    # FIXME: not called
     def v2_runner_on_async_failed(self, result):
         host = result._host.get_name()
         jid = result._result.get('ansible_job_id')
         self.runner_on_async_failed(host, result._result, jid)
-
-    def v2_runner_on_file_diff(self, result, diff):
-        pass  # no v1 correspondence
 
     def v2_playbook_on_start(self, playbook):
         self.playbook_on_start()
@@ -349,6 +346,7 @@ class CallbackBase(AnsiblePlugin):
     def v2_playbook_on_task_start(self, task, is_conditional):
         self.playbook_on_task_start(task.name, is_conditional)
 
+    # FIXME: not called
     def v2_playbook_on_cleanup_task_start(self, task):
         pass  # no v1 correspondence
 
@@ -358,13 +356,12 @@ class CallbackBase(AnsiblePlugin):
     def v2_playbook_on_vars_prompt(self, varname, private=True, prompt=None, encrypt=None, confirm=False, salt_size=None, salt=None, default=None):
         self.playbook_on_vars_prompt(varname, private, prompt, encrypt, confirm, salt_size, salt, default)
 
-    def v2_playbook_on_setup(self):
-        self.playbook_on_setup()
-
+    # FIXME: not called
     def v2_playbook_on_import_for_host(self, result, imported_file):
         host = result._host.get_name()
         self.playbook_on_import_for_host(host, imported_file)
 
+    # FIXME: not called
     def v2_playbook_on_not_import_for_host(self, result, missing_file):
         host = result._host.get_name()
         self.playbook_on_not_import_for_host(host, missing_file)

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -304,3 +304,6 @@ class CallbackModule(CallbackBase):
         if (self._display.verbosity > 2 or '_ansible_verbose_always' in result._result) and '_ansible_verbose_override' not in result._result:
             msg += "Result was: %s" % self._dump_results(result._result)
         self._display.display(msg, color=C.COLOR_DEBUG)
+
+    def v2_playbook_on_notify(self, handler, host):
+        display.vv("NOTIFIED HANDLER %s for %s" % (handler.get_name(), host))

--- a/lib/ansible/plugins/callback/default.py
+++ b/lib/ansible/plugins/callback/default.py
@@ -306,4 +306,4 @@ class CallbackModule(CallbackBase):
         self._display.display(msg, color=C.COLOR_DEBUG)
 
     def v2_playbook_on_notify(self, handler, host):
-        display.vv("NOTIFIED HANDLER %s for %s" % (handler.get_name(), host))
+        self._display.vv("NOTIFIED HANDLER %s for %s" % (handler.get_name(), host))

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -454,8 +454,7 @@ class StrategyBase:
                                         self._notified_handlers[target_handler._uuid] = []
                                     if original_host not in self._notified_handlers[target_handler._uuid]:
                                         self._notified_handlers[target_handler._uuid].append(original_host)
-                                        # FIXME: should this be a callback?
-                                        display.vv("NOTIFIED HANDLER %s" % (handler_name,))
+                                        self._tqm.send_callback('v2_playbook_on_notify', target_handler, original_host)
                                 else:
                                     # As there may be more than one handler with the notified name as the
                                     # parent, so we just keep track of whether or not we found one at all
@@ -465,7 +464,7 @@ class StrategyBase:
                                             found = True
                                             if original_host not in self._notified_handlers[target_handler._uuid]:
                                                 self._notified_handlers[target_handler._uuid].append(original_host)
-                                                display.vv("NOTIFIED HANDLER %s" % (target_handler.get_name(),))
+                                                self._tqm.send_callback('v2_playbook_on_notify', target_handler, original_host)
 
                                 if handler_name in self._listening_handlers:
                                     for listening_handler_uuid in self._listening_handlers[handler_name]:
@@ -476,7 +475,7 @@ class StrategyBase:
                                             continue
                                         if original_host not in self._notified_handlers[listening_handler._uuid]:
                                             self._notified_handlers[listening_handler._uuid].append(original_host)
-                                            display.vv("NOTIFIED HANDLER %s" % (listening_handler.get_name(),))
+                                            self._tqm.send_callback('v2_playbook_on_notify', listening_handler, original_host)
 
                                 # and if none were found, then we raise an error
                                 if not found:


### PR DESCRIPTION
##### SUMMARY
  - made note of 'not called' methods for future fixes
  - removed uncalled v2_runner_on_file_diff because dupe of v2_on_file_diff, which is called
  - removed v2_runner_on_no_hosts due to existing pb level ones, which are called
  - removed v2_on_setup, it is just a task, triggers normal task events
  - v2_on_notify is now called when a handler is notified
  - TODO: async, cleanup? and import events
    these currently occur in code that has no access to sending events


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
events
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```