### PR TITLE
Add ec2_snapshot alias to ec2_ami integration target

### DIFF
--- a/test/integration/targets/ec2_ami/aliases
+++ b/test/integration/targets/ec2_ami/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 posix/ci/cloud/group1/aws
 ec2_ami_facts
+ec2_snapshot


### PR DESCRIPTION
##### SUMMARY

Run the ec2_ami integration tests when any changes are made to ec2_snapshot module


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_ami integration tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```