### PR TITLE
Adding RPC attribute parameters to junos_rpc network module

### DIFF
--- a/lib/ansible/modules/network/junos/junos_rpc.py
+++ b/lib/ansible/modules/network/junos/junos_rpc.py
@@ -39,6 +39,10 @@ options:
         accepts a set of key=value arguments.
     required: false
     default: null
+  attrs:
+    description:
+      - The C(attrs) arguments defines a list of attributes and their values
+        to set for the RPC call. This accepts a dictionary of key-values.
   output:
     description:
       - The C(output) argument specifies the desired output of the
@@ -66,6 +70,13 @@ EXAMPLES = """
 - name: get system information
   junos_rpc:
     rpc: get-system-information
+
+- name: load configuration
+  junos_rpc:
+    rpc: load-configuration
+    attrs:
+      action: override
+      url: /tmp/config.conf
 """
 
 RETURN = """
@@ -101,6 +112,7 @@ def main():
     argument_spec = dict(
         rpc=dict(required=True),
         args=dict(type='dict'),
+        attrs=dict(type='dict'),
         output=dict(default='xml', choices=['xml', 'json', 'text']),
     )
 
@@ -120,8 +132,12 @@ def main():
         module.fail_json(msg='invalid rpc for running in check_mode')
 
     args = module.params['args'] or {}
+    attrs = module.params['attrs'] or {}
 
     xattrs = {'format': module.params['output']}
+
+    for key, value in iteritems(attrs):
+        xattrs.update({key: value})
 
     element = Element(module.params['rpc'], xattrs)
 

--- a/lib/ansible/modules/network/junos/junos_rpc.py
+++ b/lib/ansible/modules/network/junos/junos_rpc.py
@@ -112,7 +112,7 @@ def main():
     argument_spec = dict(
         rpc=dict(required=True),
         args=dict(type='dict'),
-        attrs=dict(type='dict'),
+        attrs=dict(type='dict', version_added="2.5"),
         output=dict(default='xml', choices=['xml', 'json', 'text']),
     )
 

--- a/lib/ansible/modules/network/junos/junos_rpc.py
+++ b/lib/ansible/modules/network/junos/junos_rpc.py
@@ -43,6 +43,7 @@ options:
     description:
       - The C(attrs) arguments defines a list of attributes and their values
         to set for the RPC call. This accepts a dictionary of key-values.
+    version_added: "2.5"
   output:
     description:
       - The C(output) argument specifies the desired output of the
@@ -112,7 +113,7 @@ def main():
     argument_spec = dict(
         rpc=dict(required=True),
         args=dict(type='dict'),
-        attrs=dict(type='dict', version_added="2.5"),
+        attrs=dict(type='dict'),
         output=dict(default='xml', choices=['xml', 'json', 'text']),
     )
 

--- a/test/units/modules/network/junos/fixtures/load_configuration_xml.txt
+++ b/test/units/modules/network/junos/fixtures/load_configuration_xml.txt
@@ -1,0 +1,6 @@
+<rpc-reply>
+    <load-configuration-results>
+        <load-success/>
+        <load-error-count>0</load-error-count>
+    </load-configuration-results>
+</rpc-reply>

--- a/test/units/modules/network/junos/test_junos_rpc.py
+++ b/test/units/modules/network/junos/test_junos_rpc.py
@@ -34,7 +34,8 @@ RPC_CLI_MAP = {
     'get-interface-information': 'show interfaces details',
     'get-system-memory-information': 'show system memory',
     'get-chassis-inventory': 'show chassis hardware',
-    'get-system-storage': 'show system storage'
+    'get-system-storage': 'show system storage',
+    'load-configuration': 'load configuration'
 }
 
 

--- a/test/units/modules/network/junos/test_junos_rpc.py
+++ b/test/units/modules/network/junos/test_junos_rpc.py
@@ -93,4 +93,4 @@ class TestJunosCommandModule(TestJunosModule):
     def test_junos_rpc_attrs(self):
         set_module_args(dict(rpc='load-configuration', output='xml', attrs={'url': '/var/tmp/config.conf'}))
         result = self.execute_module(format='xml')
-        self.assertTrue(reply.find('<load-success/>'))
+        self.assertTrue(result['xml'].find('<load-success/>'))

--- a/test/units/modules/network/junos/test_junos_rpc.py
+++ b/test/units/modules/network/junos/test_junos_rpc.py
@@ -88,3 +88,8 @@ class TestJunosCommandModule(TestJunosModule):
         args, kwargs = self.send_request.call_args
         reply = tostring(args[1]).decode()
         self.assertTrue(reply.find('<interface>em0</interface><media /></get-software-information>'))
+
+    def test_junos_rpc_attrs(self):
+        set_module_args(dict(rpc='load-configuration', output='xml', attrs={'url': '/var/tmp/config.conf'}))
+        result = self.execute_module(format='xml')
+        self.assertTrue(reply.find('<load-success/>'))


### PR DESCRIPTION
##### SUMMARY
The junos_rpc module does not allow for specifying any RPC attributes other than `format`. Because many useful JunOS NETCONF functions require sending tag attributes in order to work, this module is restricted by the RPCs it can actually call.

This change adds an optional `attrs` module parameter that can be used to specify RPC attributes.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Network module `junos_rpc`.

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/corban.johnson/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
As an example, the `load-configuration` RPC uses tag attributes to set most of its parameters: https://www.juniper.net/documentation/en_US/junos/topics/reference/tag-summary/junos-xml-protocol-load-configuration.html