### PR TITLE
Fix: modifying existing application lb using certificates now properly sets certificates

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_application_lb.py
+++ b/lib/ansible/modules/cloud/amazon/elb_application_lb.py
@@ -538,9 +538,13 @@ def compare_listener(current_listener, new_listener):
         if current_listener['SslPolicy'] != new_listener['SslPolicy']:
             modified_listener['SslPolicy'] = new_listener['SslPolicy']
         if current_listener['Certificates'][0]['CertificateArn'] != new_listener['Certificates'][0]['CertificateArn']:
+            modified_listener['Certificates'] = []
+            modified_listener['Certificates'].append({})
             modified_listener['Certificates'][0]['CertificateArn'] = new_listener['Certificates'][0]['CertificateArn']
     elif current_listener['Protocol'] != 'HTTPS' and new_listener['Protocol'] == 'HTTPS':
         modified_listener['SslPolicy'] = new_listener['SslPolicy']
+        modified_listener['Certificates'] = []
+        modified_listener['Certificates'].append({})
         modified_listener['Certificates'][0]['CertificateArn'] = new_listener['Certificates'][0]['CertificateArn']
 
     # Default action


### PR DESCRIPTION
##### SUMMARY
Backport of #28217

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /home/will/src/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```
