### PR TITLE
nxos_bgp_neighbor_af feature idea disable-peer-as-check

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp_neighbor_af.py
@@ -136,6 +136,12 @@ options:
         or 'default'.
     required: false
     default: null
+  disable_peer_as_check:
+    description:
+      - Disable checking of peer AS-number while advertising
+    required: false
+    choices: ['true', 'false']
+    version_added: 2.5
   filter_list_in:
     description:
       - Valid values are a string defining a filter-list name,
@@ -294,6 +300,7 @@ BOOL_PARAMS = [
     'allowas_in',
     'as_override',
     'default_originate',
+    'disable_peer_as_check',
     'next_hop_self',
     'next_hop_third_party',
     'route_reflector_client',
@@ -312,6 +319,7 @@ PARAM_TO_COMMAND_KEYMAP = {
     'as_override': 'as-override',
     'default_originate': 'default-originate',
     'default_originate_route_map': 'default-originate route-map',
+    'disable_peer_as_check': 'disable-peer-as-check',
     'filter_list_in': 'filter-list in',
     'filter_list_out': 'filter-list out',
     'max_prefix_limit': 'maximum-prefix',
@@ -637,6 +645,7 @@ def main():
         as_override=dict(required=False, type='bool'),
         default_originate=dict(required=False, type='bool'),
         default_originate_route_map=dict(required=False, type='str'),
+        disable_peer_as_check=dict(required=False, type='bool'),
         filter_list_in=dict(required=False, type='str'),
         filter_list_out=dict(required=False, type='str'),
         max_prefix_limit=dict(required=False, type='str'),

--- a/test/units/modules/network/nxos/test_nxos_bgp_neighbor_af.py
+++ b/test/units/modules/network/nxos/test_nxos_bgp_neighbor_af.py
@@ -97,3 +97,11 @@ class TestNxosBgpNeighborAfModule(TestNxosModule):
             changed=True, sort=False,
             commands=['router bgp 65535', 'neighbor 3.3.3.5', 'address-family ipv4 unicast', 'maximum-prefix 20 20']
         )
+
+    def test_nxos_bgp_neighbor_af_disable_peer_as_check(self):
+        set_module_args(dict(asn=65535, neighbor='3.3.3.5', afi='ipv4',
+                             safi='unicast', disable_peer_as_check=True))
+        self.execute_module(
+            changed=True,
+            commands=['router bgp 65535', 'neighbor 3.3.3.5', 'address-family ipv4 unicast', 'disable-peer-as-check']
+        )


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/30658
Add option `disable_peer_as_check` to module `nxos_bgp_neighbor_af`
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_bgp_neighbor_af
test/units/modules/network/nxos/test_nxos_bgp_neighbor_af
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```