### PR TITLE
module_utils: vmware.py. Incorrect chain of attributes to obtain snapshots from virtual machine

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -370,7 +370,7 @@ def get_current_snap_obj(snapshots, snapob):
 
 def list_snapshots(vm):
     result = {}
-    snapshot = _get_vm_prop(vm, ('vm', 'snapshot'))
+    snapshot = _get_vm_prop(vm, ('snapshot',))
     if not snapshot:
         return result
     if vm.snapshot is None:

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -112,6 +112,7 @@
 # Testcase 0004: Get details about virtual machines with two snapshots using UUID
 - name: Create first snapshot
   vmware_guest_snapshot:
+    validate_certs: False
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"
@@ -123,6 +124,7 @@
 
 - name: Create second snapshot
   vmware_guest_snapshot:
+    validate_certs: False
     hostname: "{{ vcsim }}"
     username: "{{ vcsim_instance['json']['username'] }}"
     password: "{{ vcsim_instance['json']['password'] }}"

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -90,3 +90,63 @@
       - "guest_facts_0002['instance']['hw_name'] == vm1 | basename"
       - "guest_facts_0002['instance']['hw_product_uuid'] is defined"
       - "guest_facts_0002['instance']['hw_product_uuid'] == vm1_uuid"
+
+# Testcase 0003: Get details about virtual machines without snapshots using UUID
+- name: get empty list of snapshots from virtual machine using UUID
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    uuid: "{{ vm1_uuid }}"
+  register: guest_facts_0003
+
+- debug: msg="{{ guest_facts_0003 }}"
+
+- assert:
+    that:
+      - "guest_facts_0003['instance']['snapshots']|length == 0"
+      - "guest_facts_0003['instance']['current_snapshot'] is none"
+
+# Testcase 0004: Get details about virtual machines with two snapshots using UUID
+- name: Create first snapshot
+  vmware_guest_snapshot:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    name: "{{ vm1 | basename }}"
+    folder: "{{ vm1 | dirname }}"
+    state: present
+    snapshot_name: snap1
+
+- name: Create second snapshot
+  vmware_guest_snapshot:
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    name: "{{ vm1 | basename }}"
+    folder: "{{ vm1 | dirname }}"
+    state: present
+    snapshot_name: snap2
+
+- name: get list of snapshots from virtual machine using UUID
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    uuid: "{{ vm1_uuid }}"
+  register: guest_facts_0004
+
+- debug: msg="{{ guest_facts_0004 }}"
+
+- assert:
+    that:
+      - "guest_facts_0004['instance']['snapshots'] is defined"
+      - "guest_facts_0004['instance']['snapshots'][0]['name'] == 'snap1'"
+      - "guest_facts_0004['instance']['snapshots'][1]['name'] == 'snap2'"
+      - "guest_facts_0004['instance']['current_snapshot']['name'] == 'snap2'"


### PR DESCRIPTION
##### SUMMARY
Incorrect chain of attributes to obtain snapshots from virtual machine. Module 'vmware_guest_facts' uses method 'gather_vm_facts' of vmware.py and always gets empty list of snapshots. 
Changed tuple ('vm', 'snapshot') on ('snapshot',) in module_utils: vmware.py

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils: vmware.py
module: vmware_guest_facts

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

```


##### ADDITIONAL INFORMATION
Virtual machine in VmWare VSphere with one snapshot 'Temp'

playbook getVmFacts.yml
---
- hosts: localhost
  gather_facts: True
  tasks:  
  - name: Get VM Properties
    vmware_guest_facts:
       hostname: #hided
       password: #hided
       username: #hided
       uuid: "{{ uuid }}"
       validate_certs: no
       datacenter: #hided
    register: vm_facts
  
  - name: Debug
    debug: msg="{{ vm_facts.instance.snapshots }}"

command: ansible-playbook getVmFacts.yml -e uuid=#hided


Output before fix:
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Get VM Properties] *******************************************************
ok: [localhost]

TASK [Debug] *******************************************************************
ok: [localhost] => {
    "msg": []
}

Output after fix:
PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Get VM Properties] *******************************************************
ok: [localhost]

TASK [Debug] *******************************************************************
ok: [localhost] => {
    "msg": [
        {
            "creation_time": "2017-10-18T12:13:32.572000+00:00",
            "description": "",
            "id": 2,
            "name": "Temp",
            "state": "poweredOn"
        }
    ]
}
