### PR TITLE
Get the moid in a more failsafe manner

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -234,7 +234,11 @@ def compile_folder_path_for_object(vobj):
     thisobj = vobj
     while hasattr(thisobj, 'parent'):
         thisobj = thisobj.parent
-        if thisobj.name == 'Datacenters':
+        try:
+            moid = thisobj._moId
+        except AttributeError:
+            moid = None
+        if moid in ['group-d1', 'ha-folder-root']:
             break
         if isinstance(thisobj, vim.Folder):
             paths.append(thisobj.name)


### PR DESCRIPTION
##### SUMMARY
Backport #31133

(cherry picked from commit eca4897a088f70475799c1d90803f9f3568f619b)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
```
stable-2.4
```