### PR TITLE
sanity tests - avoid integration test tox directories …

### DIFF
--- a/test/sanity/code-smell/no-get-exception.sh
+++ b/test/sanity/code-smell/no-get-exception.sh
@@ -4,7 +4,7 @@
 # get_exception is no longer needed as we no longer support python-2.4 on the controller.
 
 # We eventually want pycompat24 and basic.py to be the only things on this list
-get_exception=$(find . -path ./test/runner/.tox -prune \
+get_exception=$(find . \( -type d -name .tox -prune \) \
         -o -path ./lib/ansible/module_utils/pycompat24.py -prune \
         -o -path ./lib/ansible/module_utils/basic.py -prune \
         -o -path ./lib/ansible/modules/storage/netapp -prune \

--- a/test/sanity/code-smell/no-wildcard-import.sh
+++ b/test/sanity/code-smell/no-wildcard-import.sh
@@ -11,7 +11,7 @@
 # unittest.py is importing code for an installed library for compat (pylint disabled added)
 #
 # Everything else needs to be fixed
-wildcard_imports=$(find . -path ./test/runner/.tox -prune \
+wildcard_imports=$(find . \( -type d -name .tox -prune \) \
         -o -path ./lib/ansible/vars/unsafe_proxy.py -prune \
         -o -path ./lib/ansible/executor/module_common.py -prune \
         -o -path ./test/units/plugins/action/test_action.py \


### PR DESCRIPTION


##### SUMMARY

If you run integration tests with a --tox flag then you get a tox directory which confuses the sanity tests.  This patch avoids traversing such directories.  

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME

sanity tests 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
  config file = None
  configured module search path = [u'/home/mikedlr/dev/ansible/ansible-dev/library']
  ansible python module location = /home/mikedlr/dev/ansible/ansible-dev/lib/ansible
  executable location = /home/mikedlr/dev/ansible/ansible-dev/bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```

##### ADDITIONAL INFORMATION

N/A