### PR TITLE
Update win_copy for #32677

### DIFF
--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -233,7 +233,7 @@ class ActionModule(ActionBase):
     def _create_zip_tempfile(self, files, directories):
         tmpdir = tempfile.mkdtemp()
         zip_file_path = os.path.join(tmpdir, "win_copy.zip")
-        zip_file = zipfile.ZipFile(zip_file_path, "w")
+        zip_file = zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED, True)
 
         # encoding the file/dir name with base64 so Windows can unzip a unicode
         # filename and get the right name, Windows doesn't handle unicode names

--- a/lib/ansible/plugins/action/win_copy.py
+++ b/lib/ansible/plugins/action/win_copy.py
@@ -233,7 +233,7 @@ class ActionModule(ActionBase):
     def _create_zip_tempfile(self, files, directories):
         tmpdir = tempfile.mkdtemp()
         zip_file_path = os.path.join(tmpdir, "win_copy.zip")
-        zip_file = zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_DEFLATED, True)
+        zip_file = zipfile.ZipFile(zip_file_path, "w", zipfile.ZIP_STORED, True)
 
         # encoding the file/dir name with base64 so Windows can unzip a unicode
         # filename and get the right name, Windows doesn't handle unicode names


### PR DESCRIPTION
SUMMARY

Fixes missing large file support in win_copy

Fixes: #32677 

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

lib/ansible/plugins/action/win_copy.py

ANSIBLE VERSION

Stable-2.4