### PR TITLE
apk: Override system repositories

### DIFF
--- a/lib/ansible/modules/packaging/os/apk.py
+++ b/lib/ansible/modules/packaging/os/apk.py
@@ -40,7 +40,8 @@ options:
     default: null
   repository:
     description:
-      - A package repository or multiple repositories
+      - A package repository or multiple repositories.
+        Unlike with the underlying apk command, this list will override the system repositories rather than supplement them.
     required: false
     default: null
     version_added: "2.4"
@@ -299,7 +300,7 @@ def main():
     # add repositories to the APK_PATH
     if p['repository']:
         for r in p['repository']:
-            APK_PATH = "%s --repository %s" % (APK_PATH, r)
+            APK_PATH = "%s --repository %s --repositories-file /dev/null" % (APK_PATH, r)
 
     # normalize the state parameter
     if p['state'] in ['present', 'installed']:


### PR DESCRIPTION
Override system repositories when repository option is specified. This fixes inconsistencies when using check mode.

##### SUMMARY
The 'apk upgrade --repository X' command will use a combination of the system repositories and the repository specified on the commandline. When updating the system repository and doing an apk upgrade in the same playbook, this makes check mode return inaccurate results because the system repository is not actually updated in check mode. The solution is to run 'apk upgrade --repository X --repositories-file /dev/null' to force apk to ignore the system repositories.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
apk.py

##### ANSIBLE VERSION
```
ansible 2.2.1.0
  config file = 
  configured module search path = Default w/o overrides
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
