### PR TITLE
Add 'signalled' state to supervisorctl module with associated 'signal…

### DIFF
--- a/lib/ansible/modules/web_infrastructure/supervisorctl.py
+++ b/lib/ansible/modules/web_infrastructure/supervisorctl.py
@@ -47,7 +47,11 @@ options:
     description:
       - The desired state of program/group.
     required: true
-    choices: [ "present", "started", "stopped", "restarted", "absent" ]
+    choices: [ "present", "started", "stopped", "restarted", "absent", "signalled" ]
+  signal:
+    description:
+      - The signal to send to the program/group, when combined with the 'signalled' state. Required when l(state=signalled).
+    version_added: "2.8"
   supervisorctl_path:
     description:
       - path to supervisorctl executable
@@ -86,6 +90,12 @@ EXAMPLES = '''
     username: test
     password: testpass
     server_url: http://localhost:9001
+
+# Send a signal to my_app via supervisorctl
+- supervisorctl:
+    name: my_app
+    state: signalled
+    signal: USR1
 '''
 
 import os
@@ -100,7 +110,8 @@ def main():
         username=dict(required=False),
         password=dict(required=False, no_log=True),
         supervisorctl_path=dict(required=False, type='path'),
-        state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped', 'absent'])
+        state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped', 'absent', 'signalled']),
+        signal=dict(required=False)
     )
 
     module = AnsibleModule(argument_spec=arg_spec, supports_check_mode=True)
@@ -116,6 +127,7 @@ def main():
     username = module.params.get('username')
     password = module.params.get('password')
     supervisorctl_path = module.params.get('supervisorctl_path')
+    signal = module.params.get('signal')
 
     # we check error message for a pattern, so we need to make sure that's in C locale
     module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C', LC_CTYPE='C')
@@ -137,6 +149,9 @@ def main():
         supervisorctl_args.extend(['-u', username])
     if password:
         supervisorctl_args.extend(['-p', password])
+
+    if state == 'signalled' and not signal:
+        module.fail_json(msg="State 'signalled' requires a 'signal' value")
 
     def run_supervisorctl(cmd, name=None, **kwargs):
         args = list(supervisorctl_args)  # copy the master args
@@ -235,6 +250,11 @@ def main():
         if len(processes) == 0:
             module.fail_json(name=name, msg="ERROR (no such process)")
         take_action_on_processes(processes, lambda s: s in ('RUNNING', 'STARTING'), 'stop', 'stopped')
+
+    if state == 'signalled':
+        if len(processes) == 0:
+            module.fail_json(name=name, msg="ERROR (no such process)")
+        take_action_on_processes(processes, lambda s: s in ('RUNNING'), "signal %s" % signal, 'signalled')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a 'signalled' state to the supervisorctl module, and an associated 'signal' parameter. Supervisorctl now supports sending signals to running processes, which is useful for signalling changes without a restart.

https://github.com/ansible/ansible/issues/29847
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
supervisorctl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (supervisorctl-signal b97b39ecf0) last updated 2017/11/08 10:24:32 (GMT -400)
  config file = /Users/adam.harvie/.ansible.cfg
  configured module search path = ['/Users/adam.harvie/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/adam.harvie/Code/ansible/lib/ansible
  executable location = /Users/adam.harvie/Code/ansible/bin/ansible
  python version = 3.6.0 (default, Dec 24 2016, 08:01:42) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
A couple of notes on the change:
- The `signal` parameter is conditionally required for `state: signalled`. I'm not sure if this is a best practice, but: `supervisorctl signal <signal_name>` will fail without a provided `signal_name`, and it didn't seem to make much sense to assume a default.
- The `signal <signal_name>` is constructed in the call to `take_action_on_processes` as the `cmd` parameter like so: `"signal %s" % signal`. The reason being that the `supervisorctl_args` have the `cmd` appended at the end, so extending args with the signal name wouldn't work with the `signal` command coming at the end.
- I didn't see any tests that needed changing, but let me know if I missed something.

Test playbook setup:
```
- name: test supervisorctl signal
  hosts: my_hosts
  tasks:
    - name: run supervisorctl signal
      supervisorctl:
        name: my_app
        state: signalled
        signal: USR1
```
Test inventory contained a single host - `a900` in my case - with a supervisor process `my_app` running that would log output on receiving a `USR1` signal.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ansible-playbook -i test_inventory testsupervisorctl.yml 

PLAY [test supervisorctl signal] ***************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************
ok: [a900]

TASK [run supervisorctl signal] ****************************************************************************************************************************************************************************
changed: [a900]

PLAY RECAP *************************************************************************************************************************************************************************************************
a900                       : ok=2    changed=1    unreachable=0    failed=0   

```
