### PR TITLE
Detect list type in params for yum_repository (fixes #32691)

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -472,6 +472,7 @@ state:
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import configparser
 
 
@@ -701,7 +702,16 @@ def main():
 
     # Update module parameters by user's parameters if defined
     if 'params' in module.params and isinstance(module.params['params'], dict):
-        module.params.update(module.params['params'])
+        for pk, pv in module.params['params'].items():
+            if pk != 'params':
+                if (
+                        'type' in module.argument_spec[pk] and
+                        module.argument_spec[pk]['type'] == 'list' and
+                        isinstance(pv, string_types)):
+                    module.params[pk] = [pv]
+                else:
+                    module.params[pk] = pv
+
         # Remove the params
         module.params.pop('params', None)
 

--- a/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
+++ b/test/integration/targets/yum_repository/tasks/yum_repository_centos.yml
@@ -159,18 +159,44 @@
       - gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG2-KEY-EPEL-{{ ansible_distribution_major_version }}
 
 - set_fact:
-    repofile: "{{ lookup('file', '/etc/yum.repos.d/listtest.repo') }}"
+    repolistfile: "{{ lookup('file', '/etc/yum.repos.d/listtest.repo') }}"
 
 - name: Assert that lists were properly inserted
   assert:
     that:
-      - "'download.fedoraproject.org' in repofile"
-      - "'download2.fedoraproject.org' in repofile"
-      - "'RPM-GPG-KEY-EPEL' in repofile"
-      - "'RPM-GPG2-KEY-EPEL' in repofile"
+      - "'download.fedoraproject.org' in repolistfile"
+      - "'download2.fedoraproject.org' in repolistfile"
+      - "'RPM-GPG-KEY-EPEL' in repolistfile"
+      - "'RPM-GPG2-KEY-EPEL' in repolistfile"
     value:
 
 - name: Cleanup list test repo
   yum_repository:
     name: listtest
+    state: absent
+
+- name: Test string for baseurl and gpgkey
+  yum_repository:
+    name: strtest
+    description: Testing string feature
+    params:
+      baseurl:
+        - https://download.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+        - https://download2.fedoraproject.org/pub/epel/{{ ansible_distribution_major_version }}/{{ ansible_architecture }}/
+      gpgkey: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}
+
+- set_fact:
+    repostrfile: "{{ lookup('file', '/etc/yum.repos.d/strtest.repo') }}"
+
+- name: Assert that strings were properly inserted
+  assert:
+    that:
+      - "'download.fedoraproject.org' in repostrfile"
+      - "'download2.fedoraproject.org' in repolistfile"
+      - "'RPM-GPG-KEY-EPEL' in repostrfile"
+    value:
+
+- name: Cleanup list test repo
+  yum_repository:
+    name: strtest
     state: absent


### PR DESCRIPTION
##### SUMMARY
Fixes issue reported in #32691.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
`yum_repository`

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION
None.