### PR TITLE
Exception handling in vmware_inventory for vcsim

### DIFF
--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -418,7 +418,9 @@ class VMWareInventory(object):
                         self.custom_fields[f.key] = f.name
                 self.debugl('%d custom fields collected' % len(self.custom_fields))
         except vmodl.RuntimeFault as exc:
-            self.debugl("Unable to gather custom fields due to %s" % exc.msg)
+            self.debugl("Unable to gather custom fields due to %s" % exc)
+        except IndexError as exc:
+            self.debugl("Unable to gather custom fields due to %s" % exc)
 
         return instance_tuples
 

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -418,7 +418,7 @@ class VMWareInventory(object):
                         self.custom_fields[f.key] = f.name
                 self.debugl('%d custom fields collected' % len(self.custom_fields))
         except vmodl.RuntimeFault as exc:
-            self.debugl("Unable to gather custom fields due to %s" % exc)
+            self.debugl("Unable to gather custom fields due to %s" % exc.msg)
         except IndexError as exc:
             self.debugl("Unable to gather custom fields due to %s" % exc)
 

--- a/lib/ansible/modules/system/filament.py
+++ b/lib/ansible/modules/system/filament.py
@@ -1,0 +1,1 @@
+"hello world"

--- a/lib/ansible/modules/system/filament.py
+++ b/lib/ansible/modules/system/filament.py
@@ -1,1 +1,0 @@
-"hello world"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Made some changes to the vmware_inventory.py to support vcsim.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_inventory.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0 (vmware_changes fd5d0e1e5c) last updated 2017/11/09 01:54:33 (GMT +900)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gmuniz/pull-requests/ansible/lib/ansible
  executable location = /home/gmuniz/pull-requests/ansible/bin/ansible
  python version = 2.7.5 (default, Nov 20 2015, 02:00:19) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Had to make a change to the inventory script to mitigate this error:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
./vmware_inventory.py 
Traceback (most recent call last):
  File "./vmware_inventory.py", line 781, in <module>
    print(VMWareInventory().show())
  File "./vmware_inventory.py", line 166, in __init__
    self.do_api_calls_update_cache()
  File "./vmware_inventory.py", line 208, in do_api_calls_update_cache
    self.inventory = self.instances_to_inventory(self.get_instances())
  File "./vmware_inventory.py", line 361, in get_instances
    return self._get_instances(kwargs)
  File "./vmware_inventory.py", line 415, in _get_instances
    if cfm is not None and cfm.field:
  File "/root/.local/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py", line 574, in __call__
    return self.f(*args, **kwargs)
  File "/root/.local/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py", line 394, in _InvokeAccessor
    return self._stub.InvokeAccessor(self, info)
  File "/root/.local/lib/python2.7/site-packages/pyVmomi/StubAdapterAccessorImpl.py", line 43, in InvokeAccessor
    objectContent = result.objects[0]
```
