### PR TITLE
DatacenterFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/module_utils/oneview.py
+++ b/lib/ansible/module_utils/oneview.py
@@ -207,7 +207,7 @@ class OneViewModuleBase(object):
         config=dict(type='path'),
         hostname=dict(type='str'),
         username=dict(type='str'),
-        password=dict(type='str'),
+        password=dict(type='str', no_log=True),
         api_version=dict(type='int'),
         image_streamer_hostname=dict(type='str')
     )

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
@@ -43,7 +43,6 @@ EXAMPLES = '''
     username: administrator
     password: my_password
     api_version: 500
-  no_log: true
   delegate_to: localhost
 - debug: var=datacenters
 
@@ -58,7 +57,6 @@ EXAMPLES = '''
       count: 3
       sort: 'name:descending'
       filter: 'state=Unmanaged'
-  no_log: true
 - debug: var=datacenters
 
 - name: Gather facts about a Data Center by name
@@ -68,7 +66,6 @@ EXAMPLES = '''
     password: my_password
     api_version: 500
     name: "My Data Center"
-  no_log: true
   delegate_to: localhost
 - debug: var=datacenters
 
@@ -81,7 +78,6 @@ EXAMPLES = '''
     name: "My Data Center"
     options:
       - visualContent
-  no_log: true
   delegate_to: localhost
 - debug: var=datacenters
 - debug: var=datacenter_visual_content

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_datacenter_facts
+short_description: Retrieve facts about the OneView Data Centers.
+description:
+    - Retrieve facts about the OneView Data Centers.
+version_added: "2.5"
+requirements:
+    - "hpOneView >= 2.0.1"
+author:
+    - Alex Monteiro (@aalexmonteiro)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Priyanka Sood (@soodpr)
+    - Ricardo Galeno (@ricardogpsf)
+options:
+    name:
+      description:
+        - Data Center name.
+    options:
+      description:
+        - "Retrieve additional facts. Options available: 'visualContent'."
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Data Centers
+  oneview_datacenter_facts:
+    config: "/etc/oneview/oneview_config.json"
+  delegate_to: localhost
+- debug: var=datacenters
+
+- name: Gather paginated, filtered and sorted facts about Data Centers
+  oneview_datacenter_facts:
+    config: "/etc/oneview/oneview_config.json"
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: 'state=Unmanaged'
+- debug: var=datacenters
+
+- name: Gather facts about a Data Center by name
+  oneview_datacenter_facts:
+    config: "/etc/oneview/oneview_config.json"
+    name: "My Data Center"
+  delegate_to: localhost
+- debug: var=datacenters
+
+- name: Gather facts about the Data Center Visual Content
+  oneview_datacenter_facts:
+    config: "/etc/oneview/oneview_config.json"
+    name: "My Data Center"
+    options:
+      - visualContent
+  delegate_to: localhost
+- debug: var=datacenters
+- debug: var=datacenter_visual_content
+'''
+
+RETURN = '''
+datacenters:
+    description: Has all the OneView facts about the Data Centers.
+    returned: Always, but can be null.
+    type: dict
+
+datacenter_visual_content:
+    description: Has facts about the Data Center Visual Content.
+    returned: When requested, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class DatacenterFactsModule(OneViewModuleBase):
+    argument_spec = dict(
+        name=dict(type='str'),
+        options=dict(type='list'),
+        params=dict(type='dict')
+    )
+
+    def __init__(self):
+        super(DatacenterFactsModule, self).__init__(additional_arg_spec=self.argument_spec)
+
+    def execute_module(self):
+
+        client = self.oneview_client.datacenters
+        ansible_facts = {}
+
+        if self.module.params.get('name'):
+            datacenters = client.get_by('name', self.module.params['name'])
+
+            if self.options and 'visualContent' in self.options:
+                if datacenters:
+                    ansible_facts['datacenter_visual_content'] = client.get_visual_content(datacenters[0]['uri'])
+                else:
+                    ansible_facts['datacenter_visual_content'] = None
+
+            ansible_facts['datacenters'] = datacenters
+        else:
+            ansible_facts['datacenters'] = client.get_all(**self.facts_params)
+
+        return dict(changed=False,
+                    ansible_facts=ansible_facts)
+
+
+def main():
+    DatacenterFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
@@ -12,7 +12,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: oneview_datacenter_facts
-short_description: Retrieve facts about the OneView Data Centers.
+short_description: Retrieve facts about the OneView Data Centers
 description:
     - Retrieve facts about the OneView Data Centers.
 version_added: "2.5"
@@ -39,13 +39,19 @@ extends_documentation_fragment:
 EXAMPLES = '''
 - name: Gather facts about all Data Centers
   oneview_datacenter_facts:
-    config: "/etc/oneview/oneview_config.json"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
   delegate_to: localhost
 - debug: var=datacenters
 
 - name: Gather paginated, filtered and sorted facts about Data Centers
   oneview_datacenter_facts:
-    config: "/etc/oneview/oneview_config.json"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     params:
       start: 0
       count: 3

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter_facts.py
@@ -43,6 +43,7 @@ EXAMPLES = '''
     username: administrator
     password: my_password
     api_version: 500
+  no_log: true
   delegate_to: localhost
 - debug: var=datacenters
 
@@ -57,21 +58,30 @@ EXAMPLES = '''
       count: 3
       sort: 'name:descending'
       filter: 'state=Unmanaged'
+  no_log: true
 - debug: var=datacenters
 
 - name: Gather facts about a Data Center by name
   oneview_datacenter_facts:
-    config: "/etc/oneview/oneview_config.json"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     name: "My Data Center"
+  no_log: true
   delegate_to: localhost
 - debug: var=datacenters
 
 - name: Gather facts about the Data Center Visual Content
   oneview_datacenter_facts:
-    config: "/etc/oneview/oneview_config.json"
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
     name: "My Data Center"
     options:
       - visualContent
+  no_log: true
   delegate_to: localhost
 - debug: var=datacenters
 - debug: var=datacenter_visual_content

--- a/test/units/modules/remote_management/oneview/conftest.py
+++ b/test/units/modules/remote_management/oneview/conftest.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+import pytest
+
+from mock import Mock, patch
+from oneview_module_loader import ONEVIEW_MODULE_UTILS_PATH
+from hpOneView.oneview_client import OneViewClient
+
+
+@pytest.fixture
+def mock_ov_client():
+    patcher_json_file = patch.object(OneViewClient, 'from_json_file')
+    client = patcher_json_file.start()
+    return client.return_value
+
+
+@pytest.fixture
+def mock_ansible_module():
+    patcher_ansible = patch(ONEVIEW_MODULE_UTILS_PATH + '.AnsibleModule')
+    patcher_ansible = patcher_ansible.start()
+    ansible_module = Mock()
+    patcher_ansible.return_value = ansible_module
+    return ansible_module

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import OneViewModuleBase
+from ansible.modules.remote_management.oneview.oneview_datacenter_facts import DatacenterFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_MANDATORY_MISSING = dict(
+    config='config.json',
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="MyDatacenter"
+)
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+)
+
+PARAMS_GET_CONNECTED = dict(
+    config='config.json',
+    name="MyDatacenter",
+    options=['visualContent']
+)
+
+
+class DatacentersFactsSpec(unittest.TestCase,
+                           FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, DatacenterFactsModule)
+        self.datacenters = self.mock_ov_client.datacenters
+
+        FactsParamsTestCase.configure_client_mock(self, self.datacenters)
+
+    def test_should_get_all_datacenters(self):
+        self.datacenters.get_all.return_value = {"name": "Data Center Name"}
+
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        DatacenterFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(datacenters=({"name": "Data Center Name"}))
+        )
+
+    def test_should_get_datacenter_by_name(self):
+        self.datacenters.get_by.return_value = [{"name": "Data Center Name"}]
+
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        DatacenterFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(datacenters=([{"name": "Data Center Name"}]))
+        )
+
+    def test_should_get_datacenter_visual_content(self):
+        self.datacenters.get_by.return_value = [{"name": "Data Center Name", "uri": "/rest/datacenter/id"}]
+
+        self.datacenters.get_visual_content.return_value = {
+            "name": "Visual Content"}
+
+        self.mock_ansible_module.params = PARAMS_GET_CONNECTED
+
+        DatacenterFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts={'datacenter_visual_content': {'name': 'Visual Content'},
+                           'datacenters': [{'name': 'Data Center Name', 'uri': '/rest/datacenter/id'}]}
+        )
+
+    def test_should_get_none_datacenter_visual_content(self):
+        self.datacenters.get_by.return_value = []
+
+        self.mock_ansible_module.params = PARAMS_GET_CONNECTED
+
+        DatacenterFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts={'datacenter_visual_content': None,
+                           'datacenters': []}
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
##### SUMMARY
Added new oneview_datacenter_facts module for retrieving [HPE OneView Datacenters](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/datacenters) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_datacenter_facts`

##### ANSIBLE VERSION
```
ansible 2.5.0 (hpe-oneview/datacenter-facts b56a3e9276) last updated 2017/11/08 18:51:59 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/ansible/lib/ansible
  executable location = /ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Example of usage:
```yaml
- name: Gather facts about all Data Centers
  oneview_datacenter_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost
- debug: var=datacenters

- name: Gather paginated, filtered and sorted facts about Data Centers
  oneview_datacenter_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    params:
      start: 0
      count: 3
      sort: 'name:descending'
      filter: 'state=Unmanaged'
  no_log: true
- debug: var=datacenters

- name: Gather facts about a Data Center by name
  oneview_datacenter_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    name: "My Data Center"
  no_log: true
  delegate_to: localhost
- debug: var=datacenters

- name: Gather facts about the Data Center Visual Content
  oneview_datacenter_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    name: "My Data Center"
    options:
      - visualContent
  no_log: true
  delegate_to: localhost
- debug: var=datacenters
- debug: var=datacenter_visual_content
```
