### PR TITLE
removed psobject to hashtables that were missed

### DIFF
--- a/lib/ansible/modules/windows/win_iis_virtualdirectory.ps1
+++ b/lib/ansible/modules/windows/win_iis_virtualdirectory.ps1
@@ -26,13 +26,13 @@ $params = Parse-Args $args;
 # Name parameter
 $name = Get-Attr $params "name" $FALSE;
 If ($name -eq $FALSE) {
-    Fail-Json (New-Object psobject) "missing required argument: name";
+    Fail-Json @{} "missing required argument: name";
 }
 
 # Site
 $site = Get-Attr $params "site" $FALSE;
 If ($site -eq $FALSE) {
-    Fail-Json (New-Object psobject) "missing required argument: site";
+    Fail-Json @{} "missing required argument: site";
 }
 
 # Application
@@ -53,8 +53,8 @@ if ((Get-Module "WebAdministration" -ErrorAction SilentlyContinue) -eq $null) {
 }
 
 # Result
-$result = New-Object psobject @{
-  directory = New-Object psobject
+$result = @{
+  directory = @{}
   changed = $false
 };
 
@@ -76,13 +76,13 @@ try {
   # Add directory
   If(($state -eq 'present') -and (-not $directory)) {
     If ($physical_path -eq $FALSE) {
-      Fail-Json (New-Object psobject) "missing required arguments: physical_path"
+      Fail-Json @{} "missing required arguments: physical_path"
     }
     If (-not (Test-Path $physical_path)) {
-      Fail-Json (New-Object psobject) "specified folder must already exist: physical_path"
+      Fail-Json @{} "specified folder must already exist: physical_path"
     }
 
-    $directory_parameters = New-Object psobject @{
+    $directory_parameters = @{
       Site = $site
       Name = $name
       PhysicalPath = $physical_path
@@ -108,7 +108,7 @@ try {
     # Change Physical Path if needed
     if($physical_path) {
       If (-not (Test-Path $physical_path)) {
-        Fail-Json (New-Object psobject) "specified folder must already exist: physical_path"
+        Fail-Json @{} "specified folder must already exist: physical_path"
       }
 
       $vdir_folder = Get-Item $directory.PhysicalPath
@@ -125,7 +125,7 @@ try {
 
 # Result
 $directory = Get-WebVirtualDirectory -Site $site -Name $name
-$result.directory = New-Object psobject @{
+$result.directory = @{
   PhysicalPath = $directory.PhysicalPath
 }
 

--- a/lib/ansible/modules/windows/win_iis_webbinding.ps1
+++ b/lib/ansible/modules/windows/win_iis_webbinding.ps1
@@ -32,7 +32,7 @@ $ip = Get-AnsibleParam $params -name "ip"
 $certificatehash = Get-AnsibleParam $params -name "certificate_hash" -default $false
 $certificateStoreName = Get-AnsibleParam $params -name "certificate_store_name" -default "MY"
 
-$binding_parameters = New-Object psobject @{
+$binding_parameters = @{
   Name = $name
 };
 
@@ -58,7 +58,7 @@ if ((Get-Module "WebAdministration" -ErrorAction SilentlyContinue) -eq $null){
 }
 
 function Create-Binding-Info {
-  return New-Object psobject @{
+  return @{
     "bindingInformation" = $args[0].bindingInformation
     "certificateHash" = $args[0].certificateHash
     "certificateStoreName" = $args[0].certificateStoreName
@@ -69,7 +69,7 @@ function Create-Binding-Info {
 }
 
 # Result
-$result = New-Object psobject @{
+$result = @{
   changed = $false
   parameters = $binding_parameters
   matched = @()

--- a/lib/ansible/modules/windows/win_iis_website.ps1
+++ b/lib/ansible/modules/windows/win_iis_website.ps1
@@ -25,14 +25,14 @@ $params = Parse-Args $args;
 # Name parameter
 $name = Get-Attr $params "name" $FALSE;
 If ($name -eq $FALSE) {
-    Fail-Json (New-Object psobject) "missing required argument: name";
+    Fail-Json @{} "missing required argument: name";
 }
 
 # State parameter
 $state = Get-Attr $params "state" $FALSE;
 $state.ToString().ToLower();
 If (($state -ne $FALSE) -and ($state -ne 'started') -and ($state -ne 'stopped') -and ($state -ne 'restarted') -and ($state -ne 'absent')) {
-  Fail-Json (New-Object psobject) "state is '$state'; must be 'started', 'restarted', 'stopped' or 'absent'"
+  Fail-Json @{} "state is '$state'; must be 'started', 'restarted', 'stopped' or 'absent'"
 }
 
 # Path parameter
@@ -65,8 +65,8 @@ if ((Get-Module "WebAdministration" -ErrorAction SilentlyContinue) -eq $null) {
 }
 
 # Result
-$result = New-Object psobject @{
-  site = New-Object psobject
+$result = @{
+  site = @{}
   changed = $false
 };
 
@@ -77,13 +77,13 @@ Try {
   # Add site
   If(($state -ne 'absent') -and (-not $site)) {
     If ($physical_path -eq $FALSE) {
-      Fail-Json (New-Object psobject) "missing required arguments: physical_path"
+      Fail-Json @{} "missing required arguments: physical_path"
     }
     ElseIf (-not (Test-Path $physical_path)) {
-      Fail-Json (New-Object psobject) "specified folder must already exist: physical_path"
+      Fail-Json @{} "specified folder must already exist: physical_path"
     }
 
-    $site_parameters = New-Object psobject @{
+    $site_parameters = @{
       Name = $name
       PhysicalPath = $physical_path
     };
@@ -129,7 +129,7 @@ Try {
     # Change Physical Path if needed
     if($physical_path) {
       If (-not (Test-Path $physical_path)) {
-        Fail-Json (New-Object psobject) "specified folder must already exist: physical_path"
+        Fail-Json @{} "specified folder must already exist: physical_path"
       }
 
       $folder = Get-Item $physical_path
@@ -173,7 +173,7 @@ Try {
 }
 Catch
 {
-  Fail-Json (New-Object psobject) $_.Exception.Message
+  Fail-Json @{} $_.Exception.Message
 }
 
 if ($state -ne 'absent')
@@ -183,7 +183,7 @@ if ($state -ne 'absent')
 
 if ($site)
 {
-  $result.site = New-Object psobject @{
+  $result.site = @{
     Name = $site.Name
     ID = $site.ID
     State = $site.State

--- a/lib/ansible/modules/windows/win_reg_stat.ps1
+++ b/lib/ansible/modules/windows/win_reg_stat.ps1
@@ -69,7 +69,7 @@ Function Get-PropertyObject($hive, $net_hive, $path, $property) {
         $raw_value = $value
     }
 
-    $object = New-Object PSObject @{
+    $object = @{
         raw_value = $raw_value
         value = $value
         type = $type

--- a/lib/ansible/modules/windows/win_region.ps1
+++ b/lib/ansible/modules/windows/win_region.ps1
@@ -102,7 +102,7 @@ Function Set-CultureLegacy($culture) {
 
     $lookup = New-Object Ansible.LocaleHelper($culture)
     # hex values are from http://www.pinvoke.net/default.aspx/kernel32/GetLocaleInfoEx.html
-    $wanted_values = New-Object PSObject @{
+    $wanted_values = @{
         Locale = '{0:x8}' -f ([System.Globalization.CultureInfo]$culture).LCID
         LocaleName = $culture
         s1159 = $lookup.GetValueFromType(0x00000028)
@@ -151,7 +151,7 @@ Function Set-CultureLegacy($culture) {
     }
 
     $properties = Get-ItemProperty $reg_key
-    foreach($property in $properties.PSObject.Properties) {
+    foreach($property in $properties.GetEnumerator()) {
         if (Test-RegistryProperty -reg_key $reg_key -property $property.Name) {
             $name = $property.Name
             $old_value = $property.Value

--- a/lib/ansible/modules/windows/win_region.ps1
+++ b/lib/ansible/modules/windows/win_region.ps1
@@ -151,7 +151,7 @@ Function Set-CultureLegacy($culture) {
     }
 
     $properties = Get-ItemProperty $reg_key
-    foreach($property in $properties.GetEnumerator()) {
+    foreach($property in $properties.PSObject.Properties) {
         if (Test-RegistryProperty -reg_key $reg_key -property $property.Name) {
             $name = $property.Name
             $old_value = $property.Value

--- a/test/integration/targets/win_ping/library/win_ping_set_attr.ps1
+++ b/test/integration/targets/win_ping/library/win_ping_set_attr.ps1
@@ -20,7 +20,7 @@ $params = Parse-Args $args $true;
 
 $data = Get-Attr $params "data" "pong";
 
-$result = New-Object psobject @{
+$result = @{
     changed = $false
     ping = "pong"
 };

--- a/test/integration/targets/win_ping/library/win_ping_strict_mode_error.ps1
+++ b/test/integration/targets/win_ping/library/win_ping_strict_mode_error.ps1
@@ -22,7 +22,7 @@ $x = $params.thisPropertyDoesNotExist
 
 $data = Get-Attr $params "data" "pong";
 
-$result = New-Object psobject @{
+$result = @{
     changed = $false
     ping = $data
 };

--- a/test/integration/targets/win_ping/library/win_ping_syntax_error.ps1
+++ b/test/integration/targets/win_ping/library/win_ping_syntax_error.ps1
@@ -22,7 +22,7 @@ $params = Parse-Args $args $true;
 
 $data = Get-Attr $params "data" "pong";
 
-$result = New-Object psobject @{
+$result = @{
     changed = $false
     ping = $data
 };

--- a/test/integration/targets/win_ping/library/win_ping_throw.ps1
+++ b/test/integration/targets/win_ping/library/win_ping_throw.ps1
@@ -22,7 +22,7 @@ $params = Parse-Args $args $true;
 
 $data = Get-Attr $params "data" "pong";
 
-$result = New-Object psobject @{
+$result = @{
     changed = $false
     ping = $data
 };

--- a/test/integration/targets/win_ping/library/win_ping_throw_string.ps1
+++ b/test/integration/targets/win_ping/library/win_ping_throw_string.ps1
@@ -22,7 +22,7 @@ $params = Parse-Args $args $true;
 
 $data = Get-Attr $params "data" "pong";
 
-$result = New-Object psobject @{
+$result = @{
     changed = $false
     ping = $data
 };


### PR DESCRIPTION
##### SUMMARY
A change in 2.4 meant that we can no longer pass PSObjects to `Fail-Json` or `Exit-Json` or else it fails. Unfortunately some modules were missed and this change fixes up those modules as well as remove some other references to `PSObjects` where they are not needed.

While having tests would have picked this up, I don't have the bandwidth right now to continue writing them for now.

Fixes: https://github.com/ansible/ansible/issues/32696

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
windows

##### ANSIBLE VERSION
```
2.5
```