### PR TITLE
#30142:Enable attach data disk to existing VM or detach it from VM

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -103,7 +103,7 @@ EXAMPLES = '''
         resource_group: Testing
         disk_size_gb: 4
         managed_by: testvm001
-    
+
     - name: Unmount the managed disk to VM
       azure_rm_managed_disk:
         name: mymanageddisk
@@ -350,7 +350,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
                 self.name,
                 parameter)
             aux = self.get_poller_result(poller)
-            return  managed_disk_to_dict(aux)
+            return managed_disk_to_dict(aux)
         except CloudError as e:
             self.fail("Error creating the managed disk: {0}".format(str(e)))
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -85,6 +85,7 @@ options:
         description:
             - Name of an existing virtual machine with which the disk is or will be associated, this VM should be in the same resource group.
         required: false
+        version_added: 2.5
     tags:
         description:
             - Tags to assign to the managed disk.

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -144,8 +144,7 @@ from ansible.module_utils.azure_rm_common import AzureRMModuleBase
 try:
     from msrestazure.tools import parse_resource_id
     from msrestazure.azure_exceptions import CloudError
-    from azure.mgmt.compute.models import DiskCreateOption, DiskCreateOptionTypes, ManagedDiskParameters, \
-                                          DiskSku, DataDisk
+    from azure.mgmt.compute.models import DiskCreateOption, DiskCreateOptionTypes, ManagedDiskParameters, DiskSku, DataDisk
 except ImportError:
     # This is handled in azure_rm_common
     pass
@@ -274,8 +273,8 @@ class AzureRMManagedDisk(AzureRMModuleBase):
 
         if self.state == 'absent':
             changed = self.delete_managed_disk() or changed
-        
-        self.results['changed'] =  changed
+
+        self.results['changed'] = changed
         self.results['state'] = result
         return self.results
 
@@ -287,7 +286,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
         lun = max(luns) + 1 if luns else 0
 
         # prepare the data disk
-        params = ManagedDiskParameters(id = disk.get('id'), storage_account_type = disk.get('storage_account_type'))
+        params = ManagedDiskParameters(id=disk.get('id'), storage_account_type=disk.get('storage_account_type'))
         data_disk = DataDisk(lun, DiskCreateOptionTypes.attach, managed_disk=params)
         vm.storage_profile.data_disks.append(data_disk)
         self._update_vm(vm_name, vm)
@@ -306,7 +305,7 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             self.get_poller_result(poller)
         except Exception as exc:
             self.fail("Error updating virtual machine {0} - {1}".format(name, str(exc)))
-    
+
     def _get_vm(self, name):
         try:
             return self.compute_client.virtual_machines.get(self.resource_group, name, expand='instanceview')

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -75,7 +75,7 @@ options:
     managed_by:
         description:
             - Name of an existing virtual machine with which the disk is or will be associated, this VM should be in the same resource group.
-            - C(None) for detaching the disk from a vm.
+            - To detach a disk from a vm, keep undefined.
         version_added: 2.5
     tags:
         description:

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -31,12 +31,11 @@ options:
         required: true
     name:
         description:
-            - Name of the managed disk
+            - Name of the managed disk.
         required: true
     state:
         description:
-            - Assert the state of the managed disk. Use C(present) to create or update a managed disk and
-              'absent' to delete a managed disk.
+            - Assert the state of the managed disk. Use C(present) to create or update a managed disk and 'absent' to delete a managed disk.
         default: present
         choices:
             - absent
@@ -47,13 +46,13 @@ options:
         default: resource_group location
     storage_account_type:
         description:
-            - Type of storage for the managed disk: C(Standard_LRS)  or C(Premium_LRS). If not specified the disk is created C(Standard_LRS)
+            - "Type of storage for the managed disk: C(Standard_LRS)  or C(Premium_LRS). If not specified the disk is created C(Standard_LRS)."
         choices:
             - Standard_LRS
             - Premium_LRS
     create_option:
         description:
-            - Allowed values: empty, import, copy. C(import) from a VHD file in I(source_uri) and C(copy) from previous managed disk I(source_resource_uri).
+            - "Allowed values: empty, import, copy. C(import) from a VHD file in I(source_uri) and C(copy) from previous managed disk I(source_resource_uri)".
         choices:
             - empty
             - import

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -52,7 +52,7 @@ options:
             - Premium_LRS
     create_option:
         description:
-            - "Allowed values: empty, import, copy. C(import) from a VHD file in I(source_uri) and C(copy) from previous managed disk I(source_resource_uri)".
+            - "Allowed values: empty, import, copy. C(import) from a VHD file in I(source_uri) and C(copy) from previous managed disk I(source_resource_uri)."
         choices:
             - empty
             - import

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -27,7 +27,7 @@ description:
 options:
     resource_group:
         description:
-            - "Name of a resource group where the managed disk exists or will be created."
+            - Name of a resource group where the managed disk exists or will be created.
         required: true
     name:
         description:
@@ -35,7 +35,7 @@ options:
         required: true
     state:
         description:
-            - Assert the state of the managed disk. Use 'present' to create or update a managed disk and
+            - Assert the state of the managed disk. Use C(present) to create or update a managed disk and
               'absent' to delete a managed disk.
         default: present
         choices:
@@ -47,35 +47,36 @@ options:
         default: resource_group location
     storage_account_type:
         description:
-            - "Type of storage for the managed disk: 'Standard_LRS'  or 'Premium_LRS'. If not specified the disk is created 'Standard_LRS'"
+            - Type of storage for the managed disk: C(Standard_LRS)  or C(Premium_LRS). If not specified the disk is created C(Standard_LRS)
         choices:
             - Standard_LRS
             - Premium_LRS
     create_option:
         description:
-            - "Allowed values: empty, import, copy. 'import' from a VHD file in 'source_uri' and 'copy' from previous managed disk 'source_resource_uri'."
+            - Allowed values: empty, import, copy. C(import) from a VHD file in I(source_uri) and C(copy) from previous managed disk I(source_resource_uri).
         choices:
             - empty
             - import
             - copy
     source_uri:
         description:
-            - URI to a valid VHD file to be used when 'create_option' is 'import'.
+            - URI to a valid VHD file to be used when I(create_option) is C(import).
     source_resource_uri:
         description:
-            - The resource ID of the managed disk to copy when 'create_option' is 'copy'.
+            - The resource ID of the managed disk to copy when I(create_option) is C(copy).
     os_type:
         description:
-            - "Type of Operating System: 'linux' or 'windows'. Used when 'create_option' is either 'copy' or 'import' and the source is an OS disk."
+            - Type of Operating System: C(linux) or C(windows). Used when I(create_option) is either C(copy) or C(import) and the source is an OS disk.
         choices:
             - linux
             - windows
     disk_size_gb:
         description:
-            - Size in GB of the managed disk to be created. If 'create_option' is 'copy' then the value must be greater than or equal to the source's size.
+            - Size in GB of the managed disk to be created. If I(create_option) is C(copy) then the value must be greater than or equal to the source's size.
     managed_by:
         description:
             - Name of an existing virtual machine with which the disk is or will be associated, this VM should be in the same resource group.
+            - C(None) for detaching the disk from a vm.
         version_added: 2.5
     tags:
         description:
@@ -177,44 +178,35 @@ class AzureRMManagedDisk(AzureRMModuleBase):
             ),
             state=dict(
                 type='str',
-                required=False,
                 default='present',
                 choices=['present', 'absent']
             ),
             location=dict(
-                type='str',
-                required=False
+                type='str'
             ),
             storage_account_type=dict(
                 type='str',
-                required=False,
                 choices=['Standard_LRS', 'Premium_LRS']
             ),
             create_option=dict(
                 type='str',
-                required=False,
                 choices=['empty', 'import', 'copy']
             ),
             source_uri=dict(
-                type='str',
-                required=False
+                type='str'
             ),
             source_resource_uri=dict(
-                type='str',
-                required=False
+                type='str'
             ),
             os_type=dict(
                 type='str',
-                required=False,
                 choices=['linux', 'windows']
             ),
             disk_size_gb=dict(
-                type='int',
-                required=False
+                type='int'
             ),
             managed_by=dict(
-                type='str',
-                required=False
+                type='str'
             )
         )
         required_if = [

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk.py
@@ -65,7 +65,7 @@ options:
             - The resource ID of the managed disk to copy when I(create_option) is C(copy).
     os_type:
         description:
-            - Type of Operating System: C(linux) or C(windows). Used when I(create_option) is either C(copy) or C(import) and the source is an OS disk.
+            - "Type of Operating System: C(linux) or C(windows). Used when I(create_option) is either C(copy) or C(import) and the source is an OS disk."
         choices:
             - linux
             - windows

--- a/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_managed_disk_facts.py
@@ -100,7 +100,8 @@ def managed_disk_to_dict(managed_disk):
         tags=managed_disk.tags,
         disk_size_gb=managed_disk.disk_size_gb,
         os_type=os_type,
-        storage_account_type='Premium_LRS' if managed_disk.sku.tier == 'Premium' else 'Standard_LRS'
+        storage_account_type=managed_disk.sku.name.value,
+        managed_by=managed_disk.managed_by
     )
 
 
@@ -139,6 +140,10 @@ class AzureRMManagedDiskFacts(AzureRMModuleBase):
             ),
             disk_size_gb=dict(
                 type='int',
+                required=False
+            ),
+            managed_by=dict(
+                type='str',
                 required=False
             ),
             tags=dict(

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -23,14 +23,7 @@
        tags:
            testing: testing
            delete: never
-   register: output
    check_mode: yes
-
- - name: Assert status succeeded (Check Mode)
-   assert:
-     that:
-       - output.changed
-       - output.state
 
  - name: Test invalid account name (should give error)
    azure_rm_managed_disk:
@@ -130,7 +123,7 @@
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}" 
        name: "{{ managed_disk1 }}"
-       storage_account_type: "Premium_LRS"
+       storage_account_type: Premium_LRS
        disk_size_gb: 2
    register: output
 
@@ -190,6 +183,70 @@
        that:
            - "azure_managed_disk | length > 0"
 
+ - name: Create virtual network
+   azure_rm_virtualnetwork:
+       resource_group: "{{ resource_group }}"
+       name: testvm001
+       address_prefixes: "10.10.0.0/16"
+
+ - name: Add subnet
+   azure_rm_subnet:
+       resource_group: "{{ resource_group }}"
+       name: testvm001
+       address_prefix: "10.10.0.0/24"
+       virtual_network: testvm001
+
+ - name: Create public ip
+   azure_rm_publicipaddress:
+       resource_group: "{{ resource_group }}"
+       allocation_method: Static
+       name: testvm001
+
+ - name: Create security group
+   azure_rm_securitygroup:
+       resource_group: "{{ resource_group }}"
+       name: testvm001
+
+ - name: Create NIC
+   azure_rm_networkinterface:
+       resource_group: "{{ resource_group }}"
+       name: testvm001
+       virtual_network: testvm001
+       subnet: testvm001
+       public_ip_name: testvm001
+       security_group: testvm001
+
+ - name: Create virtual machine
+   azure_rm_virtualmachine:
+       resource_group: "{{ resource_group }}"
+       name: testvm001
+       admin_username: adminuser
+       admin_password: Password123!
+       os_type: Linux
+       managed_disk_type: Premium_LRS
+       vm_size: Standard_DS1_v2
+       network_interfaces: testvm001
+       image:
+         offer: UbuntuServer
+         publisher: Canonical
+         sku: 16.04-LTS
+         version: latest
+ 
+ - name: Mount the disk to virtual machine
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 2
+       managed_by: testvm001
+       tags:
+           testing: testing
+           delete: never
+   register: mounted
+  
+ - assert:
+     that:
+       - "'testvm001' in mounted.state.managed_by"
+
  - name: Delete managed disk (Check Mode)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}" 
@@ -198,12 +255,6 @@
        disk_size_gb: 2
    check_mode: yes
 
- - name: Assert status succeeded 
-   assert:
-     that:
-       - output.changed
-       - output.state
-
  - name: Delete managed disk 
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}" 
@@ -211,6 +262,10 @@
        disk_size_gb: 1
        state: absent
    check_mode: no
+ - name: Assert status succeeded 
+   assert:
+     that:
+       - output.changed
 
  - name: Delete copied managed disk 
    azure_rm_managed_disk:
@@ -219,3 +274,10 @@
        disk_size_gb: 2
        state: absent
    check_mode: no
+
+ - name: Delete virtual machine
+   azure_rm_virtualmachine:
+       resource_group: "{{ resource_group }}"
+       name: testvm001
+       state: absent
+       vm_size: Standard_DS1_v2

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -5,19 +5,19 @@
 
  - name: Clearing (if) previous disks were created (1/2)
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk2 }}"
        state: absent
 
  - name: Clearing (if) previous disks were created (2/2)
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
-       state: absent  
-       
+       state: absent
+
  - name: Create managed disk (Check Mode)
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 1
        tags:
@@ -34,20 +34,20 @@
 
  - name: Test invalid account name (should give error)
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "invalid_char$"
        disk_size_gb: 1
        state: present
-   register: output     
-   ignore_errors: yes  
+   register: output
+   ignore_errors: yes
    check_mode: no
 
  - name: Assert task failed
    assert: { that: "output['failed'] == True" }
 
- - name: Create new managed disk succesfully 
+ - name: Create new managed disk succesfully
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        storage_account_type: "Standard_LRS"
        disk_size_gb: 1
@@ -56,7 +56,7 @@
            delete: never
    register: output
 
- - name: Assert status succeeded and results include an Id value 
+ - name: Assert status succeeded and results include an Id value
    assert:
      that:
        - output.changed
@@ -64,14 +64,14 @@
 
  - name: Copy disk to a new managed disk
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk2 }}"
        create_option: "copy"
        source_resource_uri: "{{ output.state.id }}"
        disk_size_gb: 1
    register: copy
 
- - name: Assert status succeeded and results include an Id value 
+ - name: Assert status succeeded and results include an Id value
    assert:
      that:
        - copy.changed
@@ -79,13 +79,13 @@
 
  - name: Update a new disk without changes
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        storage_account_type: "Standard_LRS"
        disk_size_gb: 1
    register: output
 
- - name: Assert status succeeded and results include an Id value 
+ - name: Assert status succeeded and results include an Id value
    assert:
      that:
        - not output.changed
@@ -93,17 +93,17 @@
 
  - name: Change storage account type to an invalid type
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        storage_account_type: "PremiumL"
        disk_size_gb: 1
    register: output
-   ignore_errors: yes 
+   ignore_errors: yes
 
- - name: Assert storage account type change failed 
+ - name: Assert storage account type change failed
    assert: { that: "output['failed'] == True" }
 
- - name: Change disk size to incompatible size 
+ - name: Change disk size to incompatible size
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
@@ -116,7 +116,7 @@
 
  - name: Change disk to bigger size
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2
    register: output
@@ -128,7 +128,7 @@
 
  - name: Change disk to Premium
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        storage_account_type: "Premium_LRS"
        disk_size_gb: 2
@@ -249,7 +249,7 @@
            testing: testing
            delete: never
    register: mounted
-  
+
  - assert:
      that:
        - "'testvm001' in mounted.state.managed_by"
@@ -264,7 +264,7 @@
            delete: never
    check_mode: yes
    register: mounted
-  
+
  - assert:
      that:
        - mounted.changed
@@ -314,9 +314,9 @@
        - mounted.changed
        - "'testvm001' in mounted.state.managed_by"
 
- - name: Change disk size to incompatible size 
+ - name: Change disk size to incompatible size
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        state: absent
        managed_by: testvm001
@@ -328,28 +328,28 @@
 
  - name: Delete managed disk (Check Mode)
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        state: absent
    register: output
    check_mode: yes
 
- - name: Assert status succeeded 
+ - name: Assert status succeeded
    assert:
      that:
        - output.changed
        - output.state
 
- - name: Delete managed disk 
+ - name: Delete managed disk
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk2 }}"
        state: absent
    check_mode: no
 
- - name: Delete copied managed disk 
+ - name: Delete copied managed disk
    azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}" 
+       resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2
        state: absent

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -23,7 +23,14 @@
        tags:
            testing: testing
            delete: never
+   register: output
    check_mode: yes
+
+ - name: Assert status succeeded (Check Mode)
+   assert:
+     that:
+       - output.changed
+       - output.state
 
  - name: Test invalid account name (should give error)
    azure_rm_managed_disk:
@@ -123,7 +130,7 @@
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}" 
        name: "{{ managed_disk1 }}"
-       storage_account_type: Premium_LRS
+       storage_account_type: "Premium_LRS"
        disk_size_gb: 2
    register: output
 
@@ -246,26 +253,99 @@
  - assert:
      that:
        - "'testvm001' in mounted.state.managed_by"
+ 
+ - name: Unmount the disk to virtual machine (check mode)
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 2
+       tags:
+           testing: testing
+           delete: never
+   check_mode: yes
+   register: mounted
+  
+ - assert:
+     that:
+       - mounted.changed
+
+ - name: Unmount the disk to virtual machine
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 2
+       tags:
+           testing: testing
+           delete: never
+   register: mounted
+
+ - assert:
+     that:
+       - mounted.changed
+       - not mounted.state.managed_by
+
+ - name: Update disk size
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 4
+       tags:
+           testing: testing
+           delete: never
+   register: output
+
+ - assert:
+    that:
+      - output.state.disk_size_gb == 4
+
+ - name: Attach the disk to virtual machine again
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 4
+       managed_by: testvm001
+       tags:
+           testing: testing
+           delete: never
+   register: mounted
+
+ - assert:
+     that:
+       - mounted.changed
+       - "'testvm001' in mounted.state.managed_by"
+
+ - name: Change disk size to incompatible size 
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}" 
+       name: "{{ managed_disk1 }}"
+       state: absent
+       managed_by: testvm001
+   register: output
+   ignore_errors: yes
+
+ - name: Assert delete failed since disk is attached to VM
+   assert: { that: "output['failed'] == True" }
 
  - name: Delete managed disk (Check Mode)
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}" 
        name: "{{ managed_disk1 }}"
        state: absent
-       disk_size_gb: 2
+   register: output
    check_mode: yes
+
+ - name: Assert status succeeded 
+   assert:
+     that:
+       - output.changed
+       - output.state
 
  - name: Delete managed disk 
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}" 
        name: "{{ managed_disk2 }}"
-       disk_size_gb: 1
        state: absent
    check_mode: no
- - name: Assert status succeeded 
-   assert:
-     that:
-       - output.changed
 
  - name: Delete copied managed disk 
    azure_rm_managed_disk:

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -314,7 +314,7 @@
        - not mounted.state.managed_by
  
   - name: Unmount the disk to virtual machine (idempotent)
-   azure_rm_managed_disk:
+    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -312,9 +312,9 @@
      that:
        - mounted.changed
        - not mounted.state.managed_by
- 
-  - name: Unmount the disk to virtual machine (idempotent)
-    azure_rm_managed_disk:
+
+ - name: Unmount the disk to virtual machine (idempotent)
+   azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
        name: "{{ managed_disk1 }}"
        disk_size_gb: 2

--- a/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
+++ b/test/integration/targets/azure_rm_managed_disk/tasks/main.yml
@@ -3,17 +3,14 @@
        managed_disk1: "{{ resource_group | hash('md5') | truncate(24, True, '') }}"
        managed_disk2: "{{ resource_group | hash('md5') | truncate(18, True, '') }}"
 
- - name: Clearing (if) previous disks were created (1/2)
+ - name: Clearing (if) previous disks were created
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk2 }}"
+       name: "{{item }}"
        state: absent
-
- - name: Clearing (if) previous disks were created (2/2)
-   azure_rm_managed_disk:
-       resource_group: "{{ resource_group }}"
-       name: "{{ managed_disk1 }}"
-       state: absent
+   with_items:
+     - "{{ managed_disk2 }}"
+     - "{{ managed_disk1 }}"
 
  - name: Create managed disk (Check Mode)
    azure_rm_managed_disk:
@@ -239,6 +236,22 @@
          sku: 16.04-LTS
          version: latest
  
+ - name: Mount the disk to virtual machine (check mode)
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 2
+       managed_by: testvm001
+       tags:
+           testing: testing
+           delete: never
+   register: mounted
+   check_mode: yes
+
+ - assert:
+     that:
+       - not mounted.state.managed_by
+
  - name: Mount the disk to virtual machine
    azure_rm_managed_disk:
        resource_group: "{{ resource_group }}"
@@ -252,6 +265,22 @@
 
  - assert:
      that:
+       - "'testvm001' in mounted.state.managed_by"
+
+ - name: Mount the disk to virtual machine (idempotent)
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 2
+       managed_by: testvm001
+       tags:
+           testing: testing
+           delete: never
+   register: mounted
+
+ - assert:
+     that:
+       - not mounted.changed
        - "'testvm001' in mounted.state.managed_by"
  
  - name: Unmount the disk to virtual machine (check mode)
@@ -282,6 +311,21 @@
  - assert:
      that:
        - mounted.changed
+       - not mounted.state.managed_by
+ 
+  - name: Unmount the disk to virtual machine (idempotent)
+   azure_rm_managed_disk:
+       resource_group: "{{ resource_group }}"
+       name: "{{ managed_disk1 }}"
+       disk_size_gb: 2
+       tags:
+           testing: testing
+           delete: never
+   register: mounted
+
+ - assert:
+     that:
+       - not mounted.changed
        - not mounted.state.managed_by
 
  - name: Update disk size


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
A managed disk can be attach to an existing virtual machine or detach from it.
Feature issue #30142 

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
azure_rm_managed_disk.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
