### PR TITLE
Fix platform agnostic failure for eos modules

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -77,8 +77,8 @@ eos_top_spec = {
 eos_argument_spec.update(eos_top_spec)
 
 
-def get_argspec():
-    return eos_argument_spec
+def get_provider_argspec():
+    return eos_provider_spec
 
 
 def check_args(module, warnings):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Platform agnostic action plugin (net_base) calls
`get_provider_argspec()` to fetch the provider specific
details for each platform. This fix adds the function in
eos module_utils and returns a dict of provider spec.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_uitls/eos.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
