### PR TITLE
ansible module package also supports a list of packages as name

### DIFF
--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -52,6 +52,14 @@ EXAMPLES = '''
     name: ntpdate
     state: present
 
+# Install multiple packages
+- name: install ntp and ntpdate
+  package:
+    name:
+      - ntp
+      - ntpdate
+    state: present
+
 # This uses a variable as this changes per distribution.
 - name: remove the apache package
   package:


### PR DESCRIPTION
##### SUMMARY
This PR will add an example of using the Ansible package module. It adds a task how to install multiple packages.

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
module package

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'~/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```