### PR TITLE
Add details about snapshot in result

### DIFF
--- a/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_snapshot/tasks/main.yml
@@ -176,3 +176,23 @@
 #     name: "{{ vm1 | basename }}"
 #     state: revert
 #     snapshot_name: snap_a
+
+# # Test0009: Create snap_a and check in result
+# - name: 0009 - create snapshot a
+#   vmware_guest_snapshot:
+#     validate_certs: False
+#     hostname: "{{ vcsim }}"
+#     username: "{{ vcsim_instance['json']['username'] }}"
+#     password: "{{ vcsim_instance['json']['password'] }}"
+#     datacenter: "{{ dc1 | basename }}"
+#     folder: "{{ vm1 | dirname }}"
+#     name: "{{ vm1 | basename }}"
+#     state: present
+#     snapshot_name: snap_a
+#     description: "snap named a"
+#   register: snapshot_details
+
+# - name: Check if snapshot details available or not
+#   assert:
+#     that:
+#         - "snapshot_details.results['current_snapshot']['name'] == 'snap_a'


### PR DESCRIPTION
##### SUMMARY
This fix adds details about snapshots in result of
vmware_guest_snapshot, when operation is successful.

Fixes: #32154

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest_snapshot.py
test/integration/targets/vmware_guest_snapshot/tasks/main.yml

##### ANSIBLE VERSION
```
2.5devel
```