### PR TITLE
  python3 support for letsencrypt module (fixes #30690)

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -370,7 +370,7 @@ class ACMEAccount(object):
 
         pub_hex, pub_exp = re.search(
             r"modulus:\n\s+00:([a-f0-9\:\s]+?)\npublicExponent: ([0-9]+)",
-            to_text(out), re.MULTILINE | re.DOTALL).groups()
+            to_text(out, errors='surrogate_or_strict'), re.MULTILINE | re.DOTALL).groups()
         pub_exp = "{0:x}".format(int(pub_exp))
         if len(pub_exp) % 2:
             pub_exp = "0{0}".format(pub_exp)
@@ -554,10 +554,10 @@ class ACMEClient(object):
         _, out, _ = self.module.run_command(openssl_csr_cmd, check_rc=True)
 
         domains = set([])
-        common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", to_text(out))
+        common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", to_text(out, errors='surrogate_or_strict'))
         if common_name is not None:
             domains.add(common_name.group(1))
-        subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", to_text(out), re.MULTILINE | re.DOTALL)
+        subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", to_text(out, errors='surrogate_or_strict'), re.MULTILINE | re.DOTALL)
         if subject_alt_names is not None:
             for san in subject_alt_names.group(1).split(", "):
                 if san.startswith("DNS:"):

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -182,7 +182,7 @@ def _upsert_lowercase_headers(func):
     @wraps(func)
     def func_wrapper(name, *args, **kwargs):
         response, info = func(name, *args, **kwargs)
-        info.update({header.lower(): value for header, value in info.items()})
+        info.update(dict((header.lower(), value) for (header, value) in info.items()))
         return response, info
     return func_wrapper
 

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -168,9 +168,25 @@ import time
 import traceback
 from datetime import datetime
 
+from functools import wraps
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_native, to_text, to_bytes
 from ansible.module_utils.urls import fetch_url
+
+
+def _upsert_lowercase_headers(func):
+    '''
+     Decorator to append the lowercase representation of the header names (dict keys) returned in the info dict
+
+    '''
+    @wraps(func)
+    def func_wrapper(name, *args, **kwargs):
+        response, info = func(name, *args, **kwargs)
+        info.update({header.lower(): value for header, value in info.items()})
+        return response, info
+    return func_wrapper
+
+fetch_url = _upsert_lowercase_headers(fetch_url)
 
 
 def nopad_b64(data):
@@ -180,12 +196,11 @@ def nopad_b64(data):
 def simple_get(module, url):
     resp, info = fetch_url(module, url, method='GET')
 
-    result = None
+    result = {}
     try:
         content = resp.read()
     except AttributeError:
-        if info['body']:
-            content = info['body']
+        content = info.get('body')
 
     if content:
         if info['content-type'].startswith('application/json'):
@@ -355,7 +370,7 @@ class ACMEAccount(object):
 
         pub_hex, pub_exp = re.search(
             r"modulus:\n\s+00:([a-f0-9\:\s]+?)\npublicExponent: ([0-9]+)",
-            out.decode('utf8'), re.MULTILINE | re.DOTALL).groups()
+            to_text(out), re.MULTILINE | re.DOTALL).groups()
         pub_exp = "{0:x}".format(int(pub_exp))
         if len(pub_exp) % 2:
             pub_exp = "0{0}".format(pub_exp)
@@ -385,16 +400,15 @@ class ACMEAccount(object):
             "header": self.jws_header,
             "protected": protected64,
             "payload": payload64,
-            "signature": nopad_b64(out),
+            "signature": nopad_b64(to_bytes(out)),
         })
 
         resp, info = fetch_url(self.module, url, data=data, method='POST')
-        result = None
+        result = {}
         try:
             content = resp.read()
         except AttributeError:
-            if info['body']:
-                content = info['body']
+            content = info.get('body')
 
         if content:
             if info['content-type'].startswith('application/json'):
@@ -540,10 +554,10 @@ class ACMEClient(object):
         _, out, _ = self.module.run_command(openssl_csr_cmd, check_rc=True)
 
         domains = set([])
-        common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", out.decode('utf8'))
+        common_name = re.search(r"Subject:.*? CN\s?=\s?([^\s,;/]+)", to_text(out))
         if common_name is not None:
             domains.add(common_name.group(1))
-        subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE | re.DOTALL)
+        subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", to_text(out), re.MULTILINE | re.DOTALL)
         if subject_alt_names is not None:
             for san in subject_alt_names.group(1).split(", "):
                 if san.startswith("DNS:"):
@@ -640,7 +654,7 @@ class ACMEClient(object):
             elif type == 'dns-01':
                 # https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-7.4
                 resource = '_acme-challenge'
-                value = nopad_b64(hashlib.sha256(keyauthorization).digest()).encode('utf8')
+                value = nopad_b64(hashlib.sha256(to_bytes(keyauthorization)).digest())
             else:
                 continue
 

--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -168,25 +168,23 @@ import time
 import traceback
 from datetime import datetime
 
-from functools import wraps
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native, to_text, to_bytes
-from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.urls import fetch_url as _fetch_url
 
 
-def _upsert_lowercase_headers(func):
+def _lowercase_fetch_url(*args, **kwargs):
     '''
-     Decorator to append the lowercase representation of the header names (dict keys) returned in the info dict
+     Add lowercase representations of the header names as dict keys
 
     '''
-    @wraps(func)
-    def func_wrapper(name, *args, **kwargs):
-        response, info = func(name, *args, **kwargs)
-        info.update(dict((header.lower(), value) for (header, value) in info.items()))
-        return response, info
-    return func_wrapper
+    response, info = _fetch_url(*args, **kwargs)
 
-fetch_url = _upsert_lowercase_headers(fetch_url)
+    info.update(dict((header.lower(), value) for (header, value) in info.items()))
+    return response, info
+
+
+fetch_url = _lowercase_fetch_url
 
 
 def nopad_b64(data):


### PR DESCRIPTION
  * decorate fetch_url to upsert lowercase representation of the header names returned in info-dict

  * initialize result to a dict in some methods to prevent 'NoneType is not iterable' TypeError

  * use dict.get() to retrieve values from info dict to prevent KeyError

  * convert to/from text/bytes using _text methods for PY3 support

##### SUMMARY
fixes  #30690

##### ISSUE TYPE

 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/web_infrastructure/letsencrypt.py

##### ANSIBLE VERSION
```
ansible 2.5.0
```


