### PR TITLE
Select default resource_pool from the given cluster if not specified

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1132,7 +1132,7 @@ class PyVmomiHelper(PyVmomi):
             self.module.fail_json(msg='Could not find resource_pool "%s"' % resource_pool_name)
         return resource_pool
       
-    def select_default_resource_pool_by_cluster(self,cluster_name)
+    def select_default_resource_pool_by_cluster(self, cluster_name):
         cluster = self.cache.get_cluster(cluster_name)
         resource_pool = cluster.resourcePool
         if resource_pool is None:
@@ -1213,7 +1213,7 @@ class PyVmomiHelper(PyVmomi):
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
         elif self.params['cluster'] and not self.params['resource_pool']:
-            resource_pool = self.select_default_resource_pool_by_cluster(self.params['cluster'])  
+            resource_pool = self.select_default_resource_pool_by_cluster(self.params['cluster'])
         else:
             resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1131,15 +1131,14 @@ class PyVmomiHelper(PyVmomi):
         if resource_pool is None:
             self.module.fail_json(msg='Could not find resource_pool "%s"' % resource_pool_name)
         return resource_pool
-      
+
     def select_default_resource_pool_by_cluster(self, cluster_name):
         cluster = self.cache.get_cluster(cluster_name)
         resource_pool = cluster.resourcePool
         if resource_pool is None:
             self.module.fail_json(msg='Could not find resource_pool for cluster "%s"' % cluster_name)
         return resource_pool
-  
-      
+
     def select_resource_pool_by_host(self, host):
         resource_pools = self.cache.get_all_objs(self.content, [vim.ResourcePool])
         for rp in resource_pools.items():

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1131,7 +1131,15 @@ class PyVmomiHelper(PyVmomi):
         if resource_pool is None:
             self.module.fail_json(msg='Could not find resource_pool "%s"' % resource_pool_name)
         return resource_pool
-
+      
+    def select_default_resource_pool_by_cluster(self,cluster_name)
+        cluster = self.cache.get_cluster(cluster_name)
+        resource_pool = cluster.resourcePool
+        if resource_pool is None:
+            self.module.fail_json(msg='Could not find resource_pool for cluster "%s"' % cluster_name)
+        return resource_pool
+  
+      
     def select_resource_pool_by_host(self, host):
         resource_pools = self.cache.get_all_objs(self.content, [vim.ResourcePool])
         for rp in resource_pools.items():
@@ -1204,6 +1212,8 @@ class PyVmomiHelper(PyVmomi):
         if self.params['esxi_hostname']:
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
+        elif self.params['cluster'] and not self.params['resource_pool']:
+            resource_pool = self.select_default_resource_pool_by_cluster(self.params['cluster'])  
         else:
             resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
 


### PR DESCRIPTION
##### SUMMARY
If not specified, module selects a resource pool called 'Resources'. If you have multiple clusters in your datacenter, there are several 'Resources' resource pools. With this fix if no resource_pool is specified, module selects the default one of the specified cluster.

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]

```


##### ADDITIONAL INFORMATION
While deploying with this playbook systematically cloned the template to a wrong host. That host didn't had the required networks and then failed reconfiguration of nics.

```
---
- hosts: localhost
  tasks:
    - name: configure VM
      vmware_guest:
        hostname: "{{ vcenter }}"
        username: "{{ username }}"
        password: "{{ password }}"
        validate_certs: false
        datacenter: "DC 1"
        folder: "{{ folder }}"
        name: "{{ name }}"
        annotation: "{{ note }}"
        state: poweredon
        guest_id: "{{ guest_id }}"
        cluster: "{{ cluster }}"
        hardware:
          memory_mb: "{{ memoria }}"
          num_cpus: "{{ processori }}"
          scsi: paravirtual
        networks:
        - name: "{{ network_name }}"
          ip: "{{ ip }}"
          netmask:  "{{ netmask }}"
          gateway: "{{ gateway }}"
          domain: "{{ domain }}"
          dns_servers:
          - 8.8.8.8
          - 8.8.4.4
        - name: "{{ network_name2|default(omit) }}"
          ip: "{{ ip2|default(omit) }}"
          netmask: "{{ netmask2|default(omit) }}"
        customization:
          domain: intranet.local
          dns_suffix: intranet.local
          hostname: "{{ hostname }}"
          dns_servers:
          - 8.8.8.8
          - 8.8.4.4
        template: "{{ template }}"
        wait_for_ip_address: no
```

Error was on ansible side:
```
"A specified parameter was not correct: spec.deviceChange.device.port.switchUuid"
```

On vmware additional infos are reported:
```
Host vmmanagement01.intranet.local is not member of VDS vds-production
```

After some debugging i found out that module was selecting the Default RP of Management Cluster instead of the one i specified in the one i specified in the playbook.
