### PR TITLE
ec2_key: add a test for the force option

### DIFF
--- a/test/integration/targets/ec2_key/tasks/main.yml
+++ b/test/integration/targets/ec2_key/tasks/main.yml
@@ -147,7 +147,7 @@
            - '"EC2ResponseError: 401 Unauthorized" in result.module_stderr'
 
     # ============================================================
-    - name: test state=absent with key_material
+    - name: test removing a non-existant keypair
       ec2_key:
         name='{{ec2_key_name}}'
         ec2_region={{ec2_region}}
@@ -295,6 +295,26 @@
            - '"fingerprint" in result.results[0].key'
            - '"private_key" not in result.results[0].key'
            - 'result.results[0].key.fingerprint == "{{fingerprint}}"'
+
+    # ============================================================
+
+    - name: test force=no with another_key_material (expect changed=false)
+      ec2_key:
+        name='{{ec2_key_name}}'
+        ec2_region='{{ec2_region}}'
+        ec2_access_key='{{ec2_access_key}}'
+        ec2_secret_key='{{ec2_secret_key}}'
+        security_token='{{security_token}}'
+        key_material='{{another_key_material}}'
+        force=no
+      register: result
+
+    - name: assert force=no with another_key_material (expect changed=false)
+      assert:
+        that:
+          - 'not result.changed'
+          # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
+          # - 'result.key.fingerprint == "{{fingerprint}}"'
 
     # ============================================================
     - name: test state=absent with key_material (expect changed=true)

--- a/test/integration/targets/ec2_key/tasks/main.yml
+++ b/test/integration/targets/ec2_key/tasks/main.yml
@@ -5,9 +5,6 @@
 #  - EC2_SECRET_KEY -> AWS_SECRET_ACCESS_KEY -> AWX_SECRET_KEY
 #  - EC2_REGION -> AWS_REGION
 #
-# TODO - name: test 'region' parameter
-# TODO - name: test 'state=absent' parameter for existing key
-# TODO - name: test 'state=absent' parameter for missing key
 # TODO - name: test 'validate_certs' parameter
 
 # ============================================================
@@ -147,7 +144,7 @@
            - '"EC2ResponseError: 401 Unauthorized" in result.module_stderr'
 
     # ============================================================
-    - name: test removing a non-existant keypair
+    - name: test removing a non-existent keypair
       ec2_key:
         name='{{ec2_key_name}}'
         ec2_region={{ec2_region}}
@@ -300,21 +297,20 @@
 
     - name: test force=no with another_key_material (expect changed=false)
       ec2_key:
-        name='{{ec2_key_name}}'
-        ec2_region='{{ec2_region}}'
-        ec2_access_key='{{ec2_access_key}}'
-        ec2_secret_key='{{ec2_secret_key}}'
-        security_token='{{security_token}}'
-        key_material='{{another_key_material}}'
-        force=no
+        name: '{{ ec2_key_name }}'
+        ec2_region: '{{ ec2_region }}'
+        ec2_access_key: '{{ ec2_access_key }}'
+        ec2_secret_key: '{{ ec2_secret_key }}'
+        security_token: '{{ security_token }}'
+        key_material: '{{ another_key_material }}'
+        force: no
       register: result
 
     - name: assert force=no with another_key_material (expect changed=false)
       assert:
         that:
           - 'not result.changed'
-          # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
-          # - 'result.key.fingerprint == "{{fingerprint}}"'
+          - 'result.key.fingerprint == "{{ fingerprint }}"'
 
     # ============================================================
     - name: test state=absent with key_material (expect changed=true)

--- a/test/integration/targets/setup_sshkey/tasks/main.yml
+++ b/test/integration/targets/setup_sshkey/tasks/main.yml
@@ -15,51 +15,41 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: create random file
-  shell: mktemp /tmp/id_rsa.XXXXXX
-  register: sshkey
+- name: create a temp file
+  tempfile:
+    state: file
+  register: sshkey_file
   tags:
     - prepare
 
 - name: generate sshkey
-  shell: echo 'y' | ssh-keygen -P '' -f {{sshkey.stdout}}
+  shell: echo 'y' | ssh-keygen -P '' -f {{ sshkey_file.path }}
   tags:
     - prepare
 
-- name: record key_material
-  command: cat {{sshkey.stdout}}.pub
-  register: key_material
-  tags:
-    - prepare
-
-- name: create another random file
-  shell: mktemp /tmp/id_rsa.XXXXXX
-  register: another_sshkey
+- name: create another temp file
+  tempfile:
+    state: file
+  register: another_sshkey_file
   tags:
     - prepare
 
 - name: generate another_sshkey
-  shell: echo 'y' | ssh-keygen -P '' -f {{another_sshkey.stdout}}
-  tags:
-    - prepare
-
-- name: record another key_material
-  command: cat {{another_sshkey.stdout}}.pub
-  register: another_key_material
+  shell: echo 'y' | ssh-keygen -P '' -f {{ another_sshkey_file.path }}
   tags:
     - prepare
 
 - name: record fingerprint
-  shell: openssl rsa -in {{sshkey.stdout}} -pubout -outform DER 2>/dev/null | openssl md5 -c
+  shell: openssl rsa -in {{ sshkey_file.path }} -pubout -outform DER 2>/dev/null | openssl md5 -c
   register: fingerprint
   tags:
     - prepare
 
 - name: set facts for future roles
   set_fact:
-    sshkey: '{{sshkey.stdout}}'
-    key_material: '{{key_material.stdout}}'
-    another_key_material: '{{another_key_material.stdout}}'
-    fingerprint: '{{fingerprint.stdout.split()[1]}}'
+    sshkey: '{{ sshkey_file.path }}'
+    key_material: "{{ lookup('file', sshkey_file.path ~ '.pub') }}"
+    another_key_material: "{{ lookup('file', another_sshkey_file.path ~ '.pub') }}"
+    fingerprint: '{{ fingerprint.stdout.split()[1] }}'
   tags:
     - prepare

--- a/test/integration/targets/setup_sshkey/tasks/main.yml
+++ b/test/integration/targets/setup_sshkey/tasks/main.yml
@@ -32,6 +32,23 @@
   tags:
     - prepare
 
+- name: create another random file
+  shell: mktemp /tmp/id_rsa.XXXXXX
+  register: another_sshkey
+  tags:
+    - prepare
+
+- name: generate another_sshkey
+  shell: echo 'y' | ssh-keygen -P '' -f {{another_sshkey.stdout}}
+  tags:
+    - prepare
+
+- name: record another key_material
+  command: cat {{another_sshkey.stdout}}.pub
+  register: another_key_material
+  tags:
+    - prepare
+
 - name: record fingerprint
   shell: openssl rsa -in {{sshkey.stdout}} -pubout -outform DER 2>/dev/null | openssl md5 -c
   register: fingerprint
@@ -42,6 +59,7 @@
   set_fact:
     sshkey: '{{sshkey.stdout}}'
     key_material: '{{key_material.stdout}}'
+    another_key_material: '{{another_key_material.stdout}}'
     fingerprint: '{{fingerprint.stdout.split()[1]}}'
   tags:
     - prepare


### PR DESCRIPTION
##### SUMMARY
ec2_key has an option called 'force'. If you try to create a keypair with the name of an already existing different keypair, the force option lets you control what should happen. When `force=no`, the key should not be overwritten.

This PR adds a test for this case.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
`ec2_key`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

