### PR TITLE
Synchronize: Document the private_key option

### DIFF
--- a/lib/ansible/modules/files/synchronize.py
+++ b/lib/ansible/modules/files/synchronize.py
@@ -146,6 +146,10 @@ options:
     type: bool
     default: 'no'
     version_added: "2.0"
+  private_key:
+    description:
+      - Specify the private key to use for SSH-based rsync connections (e.g. C(~/.ssh/id_rsa))
+    version_added: "1.6"
 notes:
    - rsync must be installed on both the local and remote host.
    - For the C(synchronize) module, the "local host" is the host `the synchronize task originates on`, and the "destination host" is the host


### PR DESCRIPTION
`synchronize` has supported the `private_key` option for a long time,
apparently. But for some reason it was never documented.

Today I managed to workaround the synchronize quoting bug by just using

```
private_key: /path/to/id_rsa
```

instead of

```
rsync_opts:
  - "--rsh 'ssh -i /path/to/id_rsa'"
```

So, I'll just go ahead and document this useful option ...

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
synchronize

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (synchronize_document_private_key_option 71e93039c8) last updated 2017/11/09 18:13:49 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/towolf/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/towolf/src/local/github/ansible/lib/ansible
  executable location = /home/towolf/src/local/github/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]

```

