### PR TITLE
Add the template lookup escaping to the 2.4 porting guide

### DIFF
--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -131,6 +131,28 @@ Developers:
 * Any callbacks inheriting from other callbacks might need to also be updated to contain the same documented options
   as the parent or the options won't be available.  This is noted in the developer guide.
 
+Template lookup plugin
+----------------------
+
+Prior to Ansible 2.4, the strings passed to the template lookup plugin would have backslashes
+escaped.  This has changed so that users have to escape backslashes themselves in 2.4.  This change
+brings the template lookup plugin inline with the template module so that the same backslash
+escaping rules apply to both.
+
+If you have a template lookup like this::
+
+    - debug:
+        msg: '{{ lookup("template", "tpl.j2") }}'
+
+And the template in :file:`tpl.j2` is::
+
+    {{ "name surname" | regex_replace("^[^\s]+\s+(.*)", "\1") }}
+
+Change the template like this::
+
+    {{ "name surname" | regex_replace("^[^\\s]+\\s+(.*)", "\\1") }}
+
+
 Networking
 ==========
 

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -131,24 +131,30 @@ Developers:
 * Any callbacks inheriting from other callbacks might need to also be updated to contain the same documented options
   as the parent or the options won't be available.  This is noted in the developer guide.
 
-Template lookup plugin
-----------------------
+Template lookup plugin: Escaping Strings
+----------------------------------------
 
-Prior to Ansible 2.4, the strings passed to the template lookup plugin would have backslashes
-escaped.  This has changed so that users have to escape backslashes themselves in 2.4.  This change
+Prior to Ansible 2.4, backslashes in strings passed to the template lookup plugin would be escaped
+automatically. In 2.4, users are responsible for escaping backslashes themselves. This change
 brings the template lookup plugin inline with the template module so that the same backslash
 escaping rules apply to both.
 
-If you have a template lookup like this::
+If you have a template lookup like this
+
+.. code-block::
 
     - debug:
-        msg: '{{ lookup("template", "tpl.j2") }}'
+        msg: '{{ lookup("template", "template.j2") }}'
 
-And the template in :file:`tpl.j2` is::
+**OLD** In Ansible 2.3 (and earlier) :file:`template.j2` would look like this:
+
+.. code-block:: jinja
 
     {{ "name surname" | regex_replace("^[^\s]+\s+(.*)", "\1") }}
 
-Change the template like this::
+**NEW** In Ansible 2.4 it should be changed to look like this:
+
+.. code-block:: jinja
 
     {{ "name surname" | regex_replace("^[^\\s]+\\s+(.*)", "\\1") }}
 

--- a/docs/docsite/rst/porting_guide_2.4.rst
+++ b/docs/docsite/rst/porting_guide_2.4.rst
@@ -139,9 +139,7 @@ automatically. In 2.4, users are responsible for escaping backslashes themselves
 brings the template lookup plugin inline with the template module so that the same backslash
 escaping rules apply to both.
 
-If you have a template lookup like this
-
-.. code-block::
+If you have a template lookup like this::
 
     - debug:
         msg: '{{ lookup("template", "template.j2") }}'


### PR DESCRIPTION
##### SUMMARY

This change can break playbooks so make sure we include it in the porting guide.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel and 2.4
```