### PR TITLE
nxos_config and nxos_facts - fixes for N35 platform. 

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -390,13 +390,16 @@ def main():
     running_config = None
     startup_config = None
 
+    sh_run_config = {'command': 'show running-config', 'output': 'text'}
+    sh_startup_config = {'command': 'show startup-config', 'output': 'text'}
+
     diff_ignore_lines = module.params['diff_ignore_lines']
 
     if module.params['save']:
         module.params['save_when'] = 'always'
 
     if module.params['save_when'] != 'never':
-        output = run_commands(module, ['show running-config', 'show startup-config'])
+        output = run_commands(module, [sh_run_config, sh_startup_config])
 
         running_config = NetworkConfig(indent=1, contents=output[0], ignore_lines=diff_ignore_lines)
         startup_config = NetworkConfig(indent=1, contents=output[1], ignore_lines=diff_ignore_lines)
@@ -413,7 +416,7 @@ def main():
 
     if module._diff:
         if not running_config:
-            output = run_commands(module, 'show running-config')
+            output = run_commands(module, [sh_run_config])
             contents = output[0]
         else:
             contents = running_config.config_text
@@ -430,7 +433,7 @@ def main():
 
         elif module.params['diff_against'] == 'startup':
             if not startup_config:
-                output = run_commands(module, 'show startup-config')
+                output = run_commands(module, [sh_startup_config])
                 contents = output[0]
             else:
                 contents = output[0]

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -273,6 +273,7 @@ from ansible.module_utils.netcfg import NetworkConfig, dumps
 from ansible.module_utils.nxos import get_config, load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec
 from ansible.module_utils.nxos import check_args as nxos_check_args
+from ansible.module_utils.network_common import to_list
 
 
 def get_running_config(module, config=None):
@@ -294,6 +295,17 @@ def get_candidate(module):
         parents = module.params['parents'] or list()
         candidate.add(module.params['lines'], parents=parents)
     return candidate
+
+
+def execute_show_commands(module, commands, output='text'):
+    cmds = []
+    for command in to_list(commands):
+        cmd = { 'command': command,
+                'output': output,
+              }
+        cmds.append(cmd)
+    body = run_commands(module, cmds)
+    return body
 
 
 def main():
@@ -390,16 +402,13 @@ def main():
     running_config = None
     startup_config = None
 
-    sh_run_config = {'command': 'show running-config', 'output': 'text'}
-    sh_startup_config = {'command': 'show startup-config', 'output': 'text'}
-
     diff_ignore_lines = module.params['diff_ignore_lines']
 
     if module.params['save']:
         module.params['save_when'] = 'always'
 
     if module.params['save_when'] != 'never':
-        output = run_commands(module, [sh_run_config, sh_startup_config])
+        output = execute_show_commands(module, ['show running-config', 'show startup-config'])
 
         running_config = NetworkConfig(indent=1, contents=output[0], ignore_lines=diff_ignore_lines)
         startup_config = NetworkConfig(indent=1, contents=output[1], ignore_lines=diff_ignore_lines)
@@ -416,7 +425,7 @@ def main():
 
     if module._diff:
         if not running_config:
-            output = run_commands(module, [sh_run_config])
+            output = execute_show_commands(module, 'show running-config')
             contents = output[0]
         else:
             contents = running_config.config_text
@@ -433,7 +442,7 @@ def main():
 
         elif module.params['diff_against'] == 'startup':
             if not startup_config:
-                output = run_commands(module, [sh_startup_config])
+                output = execute_show_commands(module, 'show startup-config')
                 contents = output[0]
             else:
                 contents = output[0]

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -171,7 +171,7 @@ import re
 from ansible.module_utils.nxos import run_commands, get_config
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.six import string_types, iteritems
 
 
 class FactsBase(object):
@@ -290,7 +290,7 @@ class Interfaces(FactsBase):
             self.facts['interfaces'] = self.populate_interfaces(data)
 
         data = self.run('show ipv6 interface', 'json')
-        if data and not (type(data) == str or type(data) == unicode):
+        if data and not isinstance(data, string_types):
             self.parse_ipv6_interfaces(data)
 
         data = self.run('show lldp neighbors')

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -290,7 +290,7 @@ class Interfaces(FactsBase):
             self.facts['interfaces'] = self.populate_interfaces(data)
 
         data = self.run('show ipv6 interface', 'json')
-        if data and not isinstance(data, basestring):
+        if data and not (type(data) == str or type(data) == unicode):
             self.parse_ipv6_interfaces(data)
 
         data = self.run('show lldp neighbors')

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -290,7 +290,7 @@ class Interfaces(FactsBase):
             self.facts['interfaces'] = self.populate_interfaces(data)
 
         data = self.run('show ipv6 interface', 'json')
-        if data:
+        if data and not isinstance(data, basestring):
             self.parse_ipv6_interfaces(data)
 
         data = self.run('show lldp neighbors')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The N3548 doesn't support 'sh ipv6 interface' as well as structure output for 'sh running-config'. Modified nxos_facts to check for error string (which today get's treated as valid data for facts) and modified nxos_config to use unstructured output for all cli irrespective of transport.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_config
- nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (n35_fixes bf934bbbaf) last updated 2017/11/09 14:14:36 (GMT -400)
  config file = None
  configured module search path = [u'/Users/rahushen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rahushen/cisco/ansible/lib/ansible
  executable location = /Users/rahushen/cisco/ansible/bin/ansible
  python version = 2.7.12 (v2.7.12:d33e0cf91556, Jun 26 2016, 12:10:39) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```