### PR TITLE
Boto3 and boto fixup

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -144,8 +144,7 @@ from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_con
 import traceback
 
 try:
-    import boto3
-    from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError, WaiterError
+    from botocore.exceptions import ClientError, NoCredentialsError, WaiterError
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
@@ -158,8 +157,6 @@ def copy_image(module, ec2):
     module : AnsibleModule object
     ec2: ec2 connection object
     """
-
-    tags = module.params.get('tags')
 
     params = {'SourceRegion': module.params.get('source_region'),
               'SourceImageId': module.params.get('source_image_id'),
@@ -206,18 +203,9 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec)
 
-    # TODO: Check botocore version
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if HAS_BOTO3:
-
-        try:
-            ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
-                             **aws_connect_params)
-        except NoRegionError:
-            module.fail_json(msg='AWS Region is required')
-    else:
-        module.fail_json(msg='boto3 required for this module')
+    ec2 = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url,
+                     **aws_connect_params)
 
     copy_image(module, ec2)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_ami_copy.py
@@ -144,13 +144,6 @@ from ansible.module_utils.ec2 import (boto3_conn, ec2_argument_spec, get_aws_con
 import traceback
 
 try:
-    import boto
-    import boto.ec2
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
-try:
     import boto3
     from botocore.exceptions import ClientError, NoCredentialsError, NoRegionError, WaiterError
     HAS_BOTO3 = True
@@ -213,8 +206,6 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec)
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
     # TODO: Check botocore version
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
@@ -26,6 +26,7 @@ description:
     - Gather facts about ec2 ENI interfaces in AWS
 version_added: "2.0"
 author: "Rob White (@wimnat)"
+requirements: [ boto3 ]
 options:
   filters:
     description:

--- a/lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
@@ -138,10 +138,7 @@ def main():
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
-    if region:
-        connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-    else:
-        module.fail_json(msg="region must be specified")
+    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
 
     list_eni(connection, module)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
@@ -53,27 +53,18 @@ EXAMPLES = '''
 '''
 
 try:
-    import boto.ec2
-    from boto.exception import BotoServerError
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
-try:
-    import boto3
     from botocore.exceptions import ClientError, NoCredentialsError
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import (AnsibleAWSError,
-                                      ansible_dict_to_boto3_filter_list, boto3_conn,
-                                      boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict,
-                                      connect_to_aws, ec2_argument_spec, get_aws_connection_info)
+from ansible.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
+from ansible.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
+from ansible.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
 
 
-def list_ec2_eni_boto3(connection, module):
+def list_eni(connection, module):
 
     if module.params.get("filters") is None:
         filters = []
@@ -132,22 +123,6 @@ def get_eni_info(interface):
     return interface_info
 
 
-def list_eni(connection, module):
-
-    filters = module.params.get("filters")
-    interface_dict_array = []
-
-    try:
-        all_eni = connection.get_all_network_interfaces(filters=filters)
-    except BotoServerError as e:
-        module.fail_json(msg=e.message)
-
-    for interface in all_eni:
-        interface_dict_array.append(get_eni_info(interface))
-
-    module.exit_json(interfaces=interface_dict_array)
-
-
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
@@ -158,30 +133,17 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec)
 
-    if not HAS_BOTO:
-        module.fail_json(msg='boto required for this module')
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
 
-    if HAS_BOTO3:
-        region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 
-        if region:
-            connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-        else:
-            module.fail_json(msg="region must be specified")
-
-        list_ec2_eni_boto3(connection, module)
+    if region:
+        connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
     else:
-        region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+        module.fail_json(msg="region must be specified")
 
-        if region:
-            try:
-                connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
-            except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-                module.fail_json(msg=str(e))
-        else:
-            module.fail_json(msg="region must be specified")
-
-        list_eni(connection, module)
+    list_eni(connection, module)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/cloud/amazon/ecs_cluster.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_cluster.py
@@ -22,7 +22,7 @@ description:
     - Creates or terminates ecs clusters.
 version_added: "2.0"
 author: Mark Chance(@Java1Guy)
-requirements: [ boto, boto3 ]
+requirements: [ boto3 ]
 options:
     state:
         description:
@@ -104,12 +104,6 @@ status:
 import time
 
 try:
-    import boto
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
-try:
     import boto3
     HAS_BOTO3 = True
 except ImportError:
@@ -125,14 +119,12 @@ class EcsClusterManager:
     def __init__(self, module):
         self.module = module
 
-        try:
-            # self.ecs = boto3.client('ecs')
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            if not region:
-                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
-            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto.exception.NoAuthHandlerFound as e:
-            self.module.fail_json(msg="Can't authorize connection - %s" % str(e))
+        # self.ecs = boto3.client('ecs')
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+        self.ecs = boto3_conn(module, conn_type='client', resource='ecs',
+                              region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def find_in_array(self, array_of_clusters, cluster_name, field_name='clusterArn'):
         for c in array_of_clusters:
@@ -175,9 +167,6 @@ def main():
     required_together = (['state', 'name'])
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True, required_together=required_together)
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required.')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/lib/ansible/modules/cloud/amazon/ecs_cluster.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_cluster.py
@@ -121,8 +121,6 @@ class EcsClusterManager:
 
         # self.ecs = boto3.client('ecs')
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        if not region:
-            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         self.ecs = boto3_conn(module, conn_type='client', resource='ecs',
                               region=region, endpoint=ec2_url, **aws_connect_kwargs)
 

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -36,7 +36,7 @@ author:
     - "Stephane Maarek (@simplesteph)"
     - "Zac Blazic (@zacblazic)"
 
-requirements: [ json, boto, botocore, boto3 ]
+requirements: [ json, botocore, boto3 ]
 options:
     state:
         description:
@@ -267,14 +267,7 @@ DEPLOYMENT_CONFIGURATION_TYPE_MAP = {
 
 
 try:
-    import boto
     import botocore
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
-try:
-    import boto3
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
@@ -289,13 +282,10 @@ class EcsServiceManager:
     def __init__(self, module):
         self.module = module
 
-        try:
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            if not region:
-                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
-            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto.exception.NoAuthHandlerFound as e:
-            self.module.fail_json(msg="Can't authorize connection - %s" % str(e))
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+        self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def find_in_array(self, array_of_services, service_name, field_name='serviceArn'):
         for c in array_of_services:
@@ -402,9 +392,6 @@ def main():
                            ],
                            required_together=[['load_balancers', 'role']]
                            )
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required.')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -283,8 +283,6 @@ class EcsServiceManager:
         self.module = module
 
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        if not region:
-            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def find_in_array(self, array_of_services, service_name, field_name='serviceArn'):

--- a/lib/ansible/modules/cloud/amazon/ecs_service_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service_facts.py
@@ -22,7 +22,7 @@ version_added: "2.1"
 author:
     - "Mark Chance (@java1guy)"
     - "Darek Kaczynski (@kaczynskid)"
-requirements: [ json, boto, botocore, boto3 ]
+requirements: [ json, botocore, boto3 ]
 options:
     details:
         description:
@@ -124,14 +124,7 @@ services:
 '''  # NOQA
 
 try:
-    import boto
     import botocore
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
-try:
-    import boto3
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
@@ -146,14 +139,11 @@ class EcsServiceManager:
     def __init__(self, module):
         self.module = module
 
-        try:
-            # self.ecs = boto3.client('ecs')
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            if not region:
-                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
-            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto.exception.NoAuthHandlerFound as e:
-            self.module.fail_json(msg="Can't authorize connection - %s" % str(e))
+        # self.ecs = boto3.client('ecs')
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+        self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     # def list_clusters(self):
     #   return self.client.list_clusters()
@@ -210,9 +200,6 @@ def main():
     ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required.')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/lib/ansible/modules/cloud/amazon/ecs_service_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service_facts.py
@@ -141,8 +141,6 @@ class EcsServiceManager:
 
         # self.ecs = boto3.client('ecs')
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        if not region:
-            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     # def list_clusters(self):

--- a/lib/ansible/modules/cloud/amazon/ecs_task.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_task.py
@@ -19,7 +19,7 @@ description:
     - Creates or deletes instances of task definitions.
 version_added: "2.0"
 author: Mark Chance(@Java1Guy)
-requirements: [ json, boto, botocore, boto3 ]
+requirements: [ json, botocore, boto3 ]
 options:
     operation:
         description:
@@ -149,15 +149,9 @@ task:
             returned: only when details is true
             type: string
 '''
-try:
-    import boto
-    import botocore
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
 
 try:
-    import boto3
+    import botocore
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
@@ -172,13 +166,10 @@ class EcsExecManager:
     def __init__(self, module):
         self.module = module
 
-        try:
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            if not region:
-                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
-            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto.exception.NoAuthHandlerFound as e:
-            module.fail_json(msg="Can't authorize connection - %s " % str(e))
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+        self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def list_tasks(self, cluster_name, service_name, status):
         response = self.ecs.list_tasks(

--- a/lib/ansible/modules/cloud/amazon/ecs_task.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_task.py
@@ -167,8 +167,6 @@ class EcsExecManager:
         self.module = module
 
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        if not region:
-            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def list_tasks(self, cluster_name, service_name, status):
@@ -232,9 +230,6 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     # Validate Requirements
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required.')
-
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')
 

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -133,8 +133,6 @@ class EcsTaskManager:
         self.module = module
 
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        if not region:
-            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
         self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def describe_task(self, task_name):

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -27,7 +27,7 @@ description:
     - Registers or deregisters task definitions in the Amazon Web Services (AWS) EC2 Container Service (ECS)
 version_added: "2.0"
 author: Mark Chance(@Java1Guy)
-requirements: [ json, boto, botocore, boto3 ]
+requirements: [ json, botocore, boto3 ]
 options:
     state:
         description:
@@ -114,15 +114,9 @@ taskdefinition:
     type: dict
     returned: always
 '''
-try:
-    import boto
-    import botocore
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
 
 try:
-    import boto3
+    import botocore
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
@@ -138,13 +132,10 @@ class EcsTaskManager:
     def __init__(self, module):
         self.module = module
 
-        try:
-            region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-            if not region:
-                module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
-            self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-        except boto.exception.NoAuthHandlerFound as e:
-            module.fail_json(msg="Can't authorize connection - " % str(e))
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        if not region:
+            module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")
+        self.ecs = boto3_conn(module, conn_type='client', resource='ecs', region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
     def describe_task(self, task_name):
         try:
@@ -232,9 +223,6 @@ def main():
         volumes=dict(required=False, type='list')))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_BOTO:
-        module.fail_json(msg='boto is required.')
 
     if not HAS_BOTO3:
         module.fail_json(msg='boto3 is required.')

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -218,13 +218,9 @@ class EFSConnection(object):
     STATE_DELETED = 'deleted'
 
     def __init__(self, module, region, **aws_connect_params):
-        try:
-            self.connection = boto3_conn(module, conn_type='client',
-                                         resource='efs', region=region,
-                                         **aws_connect_params)
-        except Exception as e:
-            module.fail_json(msg="Failed to connect to AWS: %s" % str(e))
-
+        self.connection = boto3_conn(module, conn_type='client',
+                                     resource='efs', region=region,
+                                     **aws_connect_params)
         self.region = region
         self.wait = module.params.get('wait')
         self.wait_timeout = module.params.get('wait_timeout')

--- a/lib/ansible/modules/cloud/amazon/efs.py
+++ b/lib/ansible/modules/cloud/amazon/efs.py
@@ -490,7 +490,7 @@ class EFSConnection(object):
 
 def iterate_all(attr, map_method, **kwargs):
     """
-     Method creates iterator from boto result set
+     Method creates iterator from result set
     """
     args = dict((key, value) for (key, value) in kwargs.items() if value is not None)
     wait = 1


### PR DESCRIPTION
##### SUMMARY
Change all modules that import both boto and boto3

Update to use latest connection handling (so no need to check for region any more, boto3_conn does this)

Some pep8 tidy up

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Various AWS modules

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 5ff36c3423) last updated 2017/11/10 12:20:32 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]
```


##### ADDITIONAL INFORMATION

These modules are marked as preview so no tests are required. I'll add some information about what testing I've performed.