### PR TITLE
Add new AWS modules to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,12 @@ Ansible Changes By Release
 
 #### Cloud
 
-  * aws_ssm_parameter_store
-  * digital_ocean_sshkey_facts
-  * ec2_ami_facts
+* aws_acm_facts
+* aws_kms_facts
+* aws_ssm_parameter_store
+* digital_ocean_sshkey_facts
+* ec2_ami_facts
+* ecs_taskdefinition_facts
 
 #### Windows
 


### PR DESCRIPTION
##### SUMMARY
Ensure CHANGELOG is up to date for AWS modules

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
CHANGELOG

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 5ff36c3423) last updated 2017/11/10 12:20:32 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.13 (default, Sep  5 2017, 08:53:59) [GCC 7.1.1 20170622 (Red Hat 7.1.1-3)]

```
