### PR TITLE
fix AttributeError eos_static_route

### DIFF
--- a/lib/ansible/modules/network/eos/eos_static_route.py
+++ b/lib/ansible/modules/network/eos/eos_static_route.py
@@ -189,16 +189,17 @@ def main():
                            supports_check_mode=True)
 
     address = module.params['address']
-    prefix = address.split('/')[-1]
+    if address is not None:
+        prefix = address.split('/')[-1]
+
+    if address and prefix:
+        if '/' not in address or not validate_ip_address(address.split('/')[0]):
+            module.fail_json(msg='{} is not a valid IP address'.format(address))
+
+        if not validate_prefix(prefix):
+            module.fail_json(msg='Length of prefix should be between 0 and 32 bits')
+
     warnings = list()
-    check_args(module, warnings)
-
-    if '/' not in address or not validate_ip_address(address.split('/')[0]):
-        module.fail_json(msg='{} is not a valid IP address'.format(address))
-
-    if not validate_prefix(prefix):
-        module.fail_json(msg='Length of prefix should be between 0 and 32 bits')
-
     result = {'changed': False}
     if warnings:
         result['warnings'] = warnings


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix `AttributeError: 'NoneType' object has no attribute 'split'` 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/eos/eos_static_route
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```