### PR TITLE
Fix ios_config file prompt issue (#32744)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,8 @@ Ansible Changes By Release
 * Add extra error handling for wmare connect to correctly detect scenarios where
   username does not have the required logon permissions
   (https://github.com/ansible/ansible/pull/32613)
+* Fix ios_config file prompt issue while using save_when
+  (https://github.com/ansible/ansible/pull/32744)
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -483,7 +483,7 @@ def main():
         if running_config.sha1 != startup_config.sha1 or module.params['save_when'] == 'always':
             result['changed'] = True
             if not module.check_mode:
-                run_commands(module, 'copy running-config startup-config')
+                run_commands(module, 'copy running-config startup-config\r')
             else:
                 module.warn('Skipping command `copy running-config startup-config` '
                             'due to check_mode.  Configuration not copied to '

--- a/test/integration/targets/ios_config/tests/cli/save.yaml
+++ b/test/integration/targets/ios_config/tests/cli/save.yaml
@@ -34,10 +34,33 @@
 # FIXME https://github.com/ansible/ansible-modules-core/issues/5008
   ignore_errors: true
 
+- name: delete config (setup)
+  ios_config:
+    replace: line
+    lines:
+      - "ip http server"
+    save_when: modified
+    authorize: yes
+  register: result
+
+- name: save should always run
+  ios_config:
+    replace: line
+    lines:
+      - "ip http server"
+    save_when: modified
+    authorize: yes
+  register: result
+
 - assert:
     that:
       - "result.changed == true"
-# FIXME https://github.com/ansible/ansible-modules-core/issues/5008
-  ignore_errors: true
+
+- name: teardown
+  ios_config:
+    lines:
+      - "no ip http server"
+    authorize: yes
+  register: result
 
 - debug: msg="END cli/save.yaml"

--- a/test/units/modules/network/ios/test_ios_config.py
+++ b/test/units/modules/network/ios/test_ios_config.py
@@ -76,7 +76,7 @@ class TestIosConfigModule(TestIosModule):
         self.assertEqual(self.get_config.call_count, 0)
         self.assertEqual(self.load_config.call_count, 0)
         args = self.run_commands.call_args[0][1]
-        self.assertIn('copy running-config startup-config', args)
+        self.assertIn('copy running-config startup-config\r', args)
 
     def test_ios_config_lines_wo_parents(self):
         set_module_args(dict(lines=['hostname foo']))


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #23263

Add a carriage return (\r) at end on copy config
command which results in prompt on cli terminal
(cherry picked from commit 37b053727971a8cf80d45c648667cc46f8e212bf)

Update CHANGELOG.md
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_config

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
