### PR TITLE
add_evaluation_delay of datadog monitor

### DIFF
--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -121,7 +121,7 @@ options:
         description: ["Time to delay evaluation (in seconds). It is effective for sparse values."]
         required: false
         default: null
-        version_added: "2.5"
+        version_added: "2.7"
     id:
         description: ["The id of the alert. If set, will be used instead of the name to locate the alert."]
         required: false

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -117,6 +117,11 @@ options:
         required: false
         default: null
         version_added: "2.4"
+    evaluation_delay:
+        description: ["Time to delay evaluation (in seconds). It is effective for sparse values."]
+        required: false
+        default: null
+        version_added: "2.n"
     id:
         description: ["The id of the alert. If set, will be used instead of the name to locate the alert."]
         required: false
@@ -192,6 +197,7 @@ def main():
             locked=dict(required=False, default=False, type='bool'),
             require_full_window=dict(required=False, default=None, type='bool'),
             new_host_delay=dict(required=False, default=None),
+            evaluation_delay=dict(required=False, default=None),
             id=dict(required=False)
         )
     )
@@ -297,7 +303,8 @@ def install_monitor(module):
         "notify_audit": module.boolean(module.params['notify_audit']),
         "locked": module.boolean(module.params['locked']),
         "require_full_window": module.params['require_full_window'],
-        "new_host_delay": module.params['new_host_delay']
+        "new_host_delay": module.params['new_host_delay'],
+        "evaluation_delay": module.params['evaluation_delay']
     }
 
     if module.params['type'] == "service check":

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -121,7 +121,7 @@ options:
         description: ["Time to delay evaluation (in seconds). It is effective for sparse values."]
         required: false
         default: null
-        version_added: "2.4"
+        version_added: "2.5"
     id:
         description: ["The id of the alert. If set, will be used instead of the name to locate the alert."]
         required: false

--- a/lib/ansible/modules/monitoring/datadog_monitor.py
+++ b/lib/ansible/modules/monitoring/datadog_monitor.py
@@ -121,7 +121,7 @@ options:
         description: ["Time to delay evaluation (in seconds). It is effective for sparse values."]
         required: false
         default: null
-        version_added: "2.n"
+        version_added: "2.4"
     id:
         description: ["The id of the alert. If set, will be used instead of the name to locate the alert."]
         required: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Supported new_host_delay of DataDog Monitor

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- datadog_monitor

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
```

##### ADDITIONAL INFORMATION
<!---
https://docs.datadoghq.com/api/#monitor-create
  -->

