### PR TITLE
Fixes clear_facts, clear_host_errors and end_play #27973

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -869,28 +869,28 @@ class StrategyBase:
             self._inventory.refresh_inventory()
             msg = "inventory successfully refreshed"
         elif meta_action == 'clear_facts':
-            if _evaluate_conditional(target_host):
-                for host in self._inventory.get_hosts(iterator._play.hosts):
+            for host in self._inventory.get_hosts(iterator._play.hosts):
+                if _evaluate_conditional(host):
                     hostname = host.get_name()
                     self._variable_manager.clear_facts(hostname)
-                msg = "facts cleared"
-            else:
-                skipped = True
+                    msg = "facts cleared"
+                else:
+                    skipped = True
         elif meta_action == 'clear_host_errors':
-            if _evaluate_conditional(target_host):
-                for host in self._inventory.get_hosts(iterator._play.hosts):
+            for host in self._inventory.get_hosts(iterator._play.hosts):
+                if _evaluate_conditional(host):
                     self._tqm._failed_hosts.pop(host.name, False)
                     self._tqm._unreachable_hosts.pop(host.name, False)
                     iterator._host_states[host.name].fail_state = iterator.FAILED_NONE
-                msg = "cleared host errors"
-            else:
-                skipped = True
+                    msg="cleared host errors"
+                else:
+                    skipped = True
         elif meta_action == 'end_play':
-            if _evaluate_conditional(target_host):
-                for host in self._inventory.get_hosts(iterator._play.hosts):
-                    if host.name not in self._tqm._unreachable_hosts:
+            for host in self._inventory.get_hosts(iterator._play.hosts):
+                if host.name not in self._tqm._unreachable_hosts:
+                    if _evaluate_conditional(host):
                         iterator._host_states[host.name].run_state = iterator.ITERATING_COMPLETE
-                msg = "ending play"
+                        msg = "ending play"
         elif meta_action == 'reset_connection':
             connection = connection_loader.get(play_context.connection, play_context, os.devnull)
             play_context.set_options_from_plugin(connection)

--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -882,7 +882,7 @@ class StrategyBase:
                     self._tqm._failed_hosts.pop(host.name, False)
                     self._tqm._unreachable_hosts.pop(host.name, False)
                     iterator._host_states[host.name].fail_state = iterator.FAILED_NONE
-                    msg="cleared host errors"
+                    msg = "cleared host errors"
                 else:
                     skipped = True
         elif meta_action == 'end_play':


### PR DESCRIPTION
##### SUMMARY
This used to work in Ansible 2.2 After this code got refactored in Ansible 2.3 it failed.
For the linear strategy, meta tasks are just run once and for all hosts currently being iterated over. This causes an issue for 'end_play', 'clear_facts' and 'clear_host_errors' because of ' _evaluate_conditional(target_host)' being called in the wrong location. 

- meta_action 'clear_facts' fixed by putting calling _evaluate_conditional(target_host) before the loop
- meta_action 'clear_host_errors' fixed by calling _evaluate_conditional(target_host) before the loop
- meta_action 'end_play' fixed by calling _evaluate_conditional(target_host) before the loop

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible/lib/ansible/plugins/strategy/__init__.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
```
