### PR TITLE
Add prompt check in action plugin for network platform

### DIFF
--- a/lib/ansible/plugins/action/aireos.py
+++ b/lib/ansible/plugins/action/aireos.py
@@ -23,6 +23,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.aireos import aireos_provider_spec
 from ansible.module_utils.network_common import load_provider
@@ -69,10 +71,11 @@ class ActionModule(_ActionModule):
 
         # make sure we are in the right cli context which should be
         # enable mode and not config module
-        rc, out, err = connection.exec_command('prompt()')
-        if str(out).strip().endswith(')#'):
+        conn = Connection(socket_path)
+        out = conn.get_prompt()
+        if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            connection.exec_command('exit')
+            conn.send_command('exit')
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/aruba.py
+++ b/lib/ansible/plugins/action/aruba.py
@@ -23,6 +23,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.aruba import aruba_provider_spec
 from ansible.module_utils.network_common import load_provider
@@ -69,10 +71,11 @@ class ActionModule(_ActionModule):
 
         # make sure we are in the right cli context which should be
         # enable mode and not config module
-        rc, out, err = connection.exec_command('prompt()')
-        if str(out).strip().endswith(')#'):
+        conn = Connection(socket_path)
+        out = conn.get_prompt()
+        if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            connection.exec_command('exit')
+            conn.send_command('exit')
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/bigip.py
+++ b/lib/ansible/plugins/action/bigip.py
@@ -23,6 +23,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.module_utils.f5_utils import F5_COMMON_ARGS
 from ansible.module_utils.network_common import load_provider
 from ansible.plugins.action.normal import ActionModule as _ActionModule
@@ -64,12 +66,13 @@ class ActionModule(_ActionModule):
                                'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
 
             # make sure we are in the right cli context which should be
-            # enable mode and not config mode
-            rc, out, err = connection.exec_command('prompt()')
-            while '(config' in str(out):
+            # enable mode and not config module
+            conn = Connection(socket_path)
+            out = conn.get_prompt()
+            while '(config' in to_text(out, errors='surrogate_then_replace').strip():
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                connection.exec_command('exit')
-                rc, out, err = connection.exec_command('prompt()')
+                conn.send_command('exit')
+                out = conn.get_prompt()
 
             task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/ce.py
+++ b/lib/ansible/plugins/action/ce.py
@@ -23,6 +23,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.ce import ce_provider_spec
 from ansible.module_utils.network_common import load_provider
@@ -78,11 +80,12 @@ class ActionModule(_ActionModule):
 
             # make sure we are in the right cli context which should be
             # enable mode and not config module
-            rc, out, err = connection.exec_command('prompt()')
-            while str(out).strip().endswith(']'):
+            conn = Connection(socket_path)
+            out = conn.get_prompt()
+            while to_text(out, errors='surrogate_then_replace').strip().endswith(']'):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                connection.exec_command('return')
-                rc, out, err = connection.exec_command('prompt()')
+                conn.send_command('exit')
+                out = conn.get_prompt()
 
             task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/dellos10.py
+++ b/lib/ansible/plugins/action/dellos10.py
@@ -25,6 +25,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.dellos10 import dellos10_provider_spec
 from ansible.module_utils.network_common import load_provider
@@ -73,11 +75,12 @@ class ActionModule(_ActionModule):
 
         # make sure we are in the right cli context which should be
         # enable mode and not config module
-        rc, out, err = connection.exec_command('prompt()')
-        while str(out).strip().endswith(')#'):
+        conn = Connection(socket_path)
+        out = conn.get_prompt()
+        while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            connection.exec_command('exit')
-            rc, out, err = connection.exec_command('prompt()')
+            conn.send_command('exit')
+            out = conn.get_prompt()
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/dellos6.py
+++ b/lib/ansible/plugins/action/dellos6.py
@@ -22,6 +22,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.dellos6 import dellos6_provider_spec
 from ansible.module_utils.network_common import load_provider
@@ -69,11 +71,12 @@ class ActionModule(_ActionModule):
 
         # make sure we are in the right cli context which should be
         # enable mode and not config module
-        rc, out, err = connection.exec_command('prompt()')
-        while str(out).strip().endswith(')#'):
+        conn = Connection(socket_path)
+        out = conn.get_prompt()
+        while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            connection.exec_command('exit')
-            rc, out, err = connection.exec_command('prompt()')
+            conn.send_command('exit')
+            out = conn.get_prompt()
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -23,6 +23,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.module_utils.iosxr import iosxr_provider_spec
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network_common import load_provider
@@ -38,6 +40,7 @@ class ActionModule(_ActionModule):
 
     def run(self, tmp=None, task_vars=None):
 
+        socket_path = None
         if self._play_context.connection == 'local':
             provider = load_provider(iosxr_provider_spec, self._task.args)
 
@@ -62,5 +65,18 @@ class ActionModule(_ActionModule):
 
             task_vars['ansible_socket'] = socket_path
 
+        # make sure we are in the right cli context which should be
+        # enable mode and not config module
+        if socket_path is None:
+            socket_path = self._connection.socket_path
+
+        conn = Connection(socket_path)
+        out = conn.get_prompt()
+        while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
+            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
+            conn.send_command('exit')
+            rc, out, err = conn.get_prompt()
+
         result = super(ActionModule, self).run(tmp, task_vars)
+
         return result

--- a/lib/ansible/plugins/action/iosxr.py
+++ b/lib/ansible/plugins/action/iosxr.py
@@ -74,7 +74,7 @@ class ActionModule(_ActionModule):
         out = conn.get_prompt()
         while to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
+            conn.send_command('abort')
             rc, out, err = conn.get_prompt()
 
         result = super(ActionModule, self).run(tmp, task_vars)

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -24,6 +24,8 @@ import copy
 import json
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.plugins.action.normal import ActionModule as _ActionModule
 from ansible.module_utils.network_common import load_provider
 from ansible.module_utils.ironware import ironware_provider_spec
@@ -73,10 +75,11 @@ class ActionModule(_ActionModule):
 
         # make sure we are in the right cli context which should be
         # enable mode and not config module
-        rc, out, err = connection.exec_command('prompt()')
-        if str(out).strip().endswith(')#'):
+        conn = Connection(socket_path)
+        out = conn.get_prompt()
+        if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
             display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            connection.exec_command('exit')
+            conn.send_command('exit')
 
         task_vars['ansible_socket'] = socket_path
 

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -21,6 +21,8 @@ import sys
 import copy
 
 from ansible import constants as C
+from ansible.module_utils._text import to_text
+from ansible.module_utils.connection import Connection
 from ansible.errors import AnsibleError
 from ansible.plugins.action import ActionBase
 from ansible.module_utils.network_common import load_provider
@@ -67,9 +69,22 @@ class ActionModule(ActionBase):
             play_context.become = self.provider['authorize'] or False
             play_context.become_pass = self.provider['auth_pass']
 
+        socket_path = None
         if self._play_context.connection == 'local':
             socket_path = self._start_connection(play_context)
             task_vars['ansible_socket'] = socket_path
+
+        if play_context.connection == 'network_cli':
+            # make sure we are in the right cli context which should be
+            # enable mode and not config module
+            if socket_path is None:
+                socket_path = self._connection.socket_path
+
+            conn = Connection(socket_path)
+            out = conn.get_prompt()
+            if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
+                display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
+                conn.send_command('exit')
 
         if 'fail_on_missing_module' not in self._task.args:
             self._task.args['fail_on_missing_module'] = False
@@ -118,13 +133,6 @@ class ActionModule(ActionBase):
             return {'failed': True,
                     'msg': 'unable to open shell. Please see: ' +
                            'https://docs.ansible.com/ansible/network_debug_troubleshooting.html#unable-to-open-shell'}
-
-        # make sure we are in the right cli context which should be
-        # enable mode and not config module
-        rc, out, err = connection.exec_command('prompt()')
-        if str(out).strip().endswith(')#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            connection.exec_command('exit')
 
         if self._play_context.become_method == 'enable':
             self._play_context.become = False

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -80,7 +80,6 @@ class ActionModule(_ActionModule):
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
                 conn.send_command('exit')
                 out = conn.get_prompt()
-
         else:
             provider['transport'] = 'nxapi'
             if provider.get('host') is None:

--- a/lib/ansible/plugins/action/nxos.py
+++ b/lib/ansible/plugins/action/nxos.py
@@ -81,8 +81,6 @@ class ActionModule(_ActionModule):
                 conn.send_command('exit')
                 out = conn.get_prompt()
 
-
-
         else:
             provider['transport'] = 'nxapi'
             if provider.get('host') is None:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  In case of ignore_errors for a wrong configuration
   the prompt is left in configuration mode and moved to
   next task, if the next tasks requires prompt to be
   in an operational state it results in failure.
*  Hence add a check to ensure right prompt at the start of
    each task run.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/action/aireos.py
plugins/action/aruba.py
plugins/action/bigip.py
plugins/action/ce.py
plugins/action/dellos10.py
plugins/action/dellos6.py
plugins/action/dellos9.py
plugins/action/eos.py
plugins/action/ios.py
plugins/action/iosxr.py
plugins/action/ironware.py
plugins/action/junos.py
plugins/action/net_base.py
plugins/action/nxos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
