### PR TITLE
Correct typo on required keyword

### DIFF
--- a/lib/ansible/modules/notification/snow_record.py
+++ b/lib/ansible/modules/notification/snow_record.py
@@ -171,7 +171,7 @@ def run_module():
         state=dict(choices=['present', 'absent'],
                    type='str', required=True),
         number=dict(default=None, required=False, type='str'),
-        data=dict(default=None, requried=False, type='dict'),
+        data=dict(default=None, required=False, type='dict'),
         lookup_field=dict(default='number', required=False, type='str'),
         attachment=dict(default=None, required=False, type='str')
     )


### PR DESCRIPTION
##### SUMMARY
Just corrected a typo on required keyword on snow_record module

##### ISSUE TYPE

##### COMPONENT NAME
snow_record

##### ANSIBLE VERSION

```
ansible 2.5.0 (snow_record 9819b29c8b) last updated 2017/11/10 14:27:42 (GMT +100)
  config file = /home/pintoj/Desktop/ansible_work/GIT/ansible/ansible.cfg
  configured module search path = [u'/home/pintoj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pintoj/Desktop/ansible_work/GIT/ansible/lib/ansible
  executable location = /home/pintoj/Desktop/ansible_work/GIT/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
