### PR TITLE
Fix loops with environment and add tests - fixes 32685

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -177,10 +177,9 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             if not isinstance(environments, list):
                 environments = [environments]
 
-            # the environments as inherited need to be reversed, to make
-            # sure we merge in the parent's values first so those in the
-            # block then task 'win' in precedence
-            environments.reverse()
+            # The order of environments matters to make sure we merge
+            # in the parent's values first so those in the block then
+            # task 'win' in precedence
             for environment in environments:
                 if environment is None or len(environment) == 0:
                     continue

--- a/test/integration/targets/environment/test_environment.yml
+++ b/test/integration/targets/environment/test_environment.yml
@@ -74,3 +74,93 @@
                 - '"not1" in test_env5.stdout_lines'
                 - '"val2" in test_env5.stdout_lines'
       environment: "{{test2}}"
+
+- name: test setting environment while using loops
+  hosts: testhost
+  environment:
+    foo: outer
+  tasks:
+    - name: verify foo==outer
+      command: /bin/echo $foo
+      loop:
+        - 1
+      register: test_foo
+
+    - name: assert foo==outer
+      assert:
+        that:
+          - "{{ test_foo.results[0].stdout == 'outer' }}"
+
+    - name: set environment on a task
+      environment:
+        foo: in_task
+      command: /bin/echo $foo
+      loop:
+        - 1
+      register: test_foo
+
+    - name: assert foo==in_task
+      assert:
+        that:
+          - "test_foo.results[0].stdout == 'in_task'"
+
+    - name: test that the outer env var is set appropriately still
+      command: /bin/echo $foo
+      loop:
+        - 1
+      register: test_foo
+
+    - name: assert foo==outer
+      assert:
+        that:
+          - "{{ test_foo.results[0].stdout == 'outer' }}"
+
+    - name: set environment on a block
+      environment:
+        foo: in_block
+      block:
+        - name: test the environment is set in the block
+          command: /bin/echo $foo
+          loop:
+            - 1
+          register: test_foo
+
+        - name: assert foo==in_block
+          assert:
+            that:
+              - "test_foo.results[0].stdout == 'in_block'"
+
+        - name: test setting environment in a task inside a block
+          environment:
+            foo: in_block_in_task
+          command: /bin/echo $foo
+          loop:
+            - 1
+          register: test_foo
+
+        - name: assert foo==in_block_in_task
+          assert:
+            that:
+              - "test_foo.results[0].stdout == 'in_block_in_task'"
+
+        - name: test the environment var is set to the parent value
+          command: /bin/echo $foo
+          loop:
+            - 1
+          register: test_foo
+
+        - name: assert foo==in_block
+          assert:
+            that:
+              - "test_foo.results[0].stdout == 'in_block'"
+
+    - name: test the env var foo has the initial value
+      command: /bin/echo $foo
+      loop:
+        - 1
+      register: test_foo
+
+    - name: assert foo==outer
+      assert:
+        that:
+          - "{{ test_foo.results[0].stdout == 'outer' }}"


### PR DESCRIPTION
##### SUMMARY
Fixes #32685
Loops break setting environment because the order is reversed.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/action/__init__.py

##### ANSIBLE VERSION
```
2.5.0
```