### PR TITLE
cloud: ovirt: ovirt_cluster.py Fix issue with 'external_network_providers'

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -507,6 +507,8 @@ class ClustersModule(BaseModule):
         return equal(item.get('id'), entity.id) and equal(item.get('name'), entity.name)
 
     def _update_check_external_network_providers(self, entity):
+        if self.param('external_network_providers') is None:
+            return True
         if entity.external_network_providers is None:
             return not self.param('external_network_providers')
         entity_providers = self._connection.follow_link(entity.external_network_providers)


### PR DESCRIPTION
##### SUMMARY
Commit 2b08fd3f added external_network_providers parameter for ovirt_cluster module.
This parameter is not marked as required and should not be such, however calling the
module without this parameter will result in failure.

Copying failure message from our Jenkins run: 

```
15:15:47   File "/tmp/ansible_7TN29f/ansible_module_ovirt_clusters.py", line 510, in _update_check_external_network_providers
15:15:47     if entity.external_network_providers is None:
15:15:47 AttributeError: 'Cluster' object has no attribute 'external_network_providers'
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/ovirt/ovirt_cluster.py

##### ANSIBLE VERSION
devel branch
