### PR TITLE
DatacenterModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
@@ -29,8 +29,8 @@ options:
             - Indicates the desired state for the Datacenter resource.
               C(absent) will remove the resource from OneView, if it exists.
               C(present) will ensure the datacenter resource exists and its properties are compliant with HPE OneView.
-        default: present
         choices: ['present', 'absent']
+        default: present
     data:
         description:
             - List with Datacenter properties and its associated states.
@@ -130,8 +130,8 @@ class DatacenterModule(OneViewModuleBase):
     RESOURCE_FACT_NAME = 'datacenter'
 
     argument_spec = dict(
-        state=dict(type='str', default='present', choices=['present', 'absent']),
-        data=dict(required=True, type='dict')
+        state=dict(type='str', default='present', choices=['absent', 'present',]),
+        data=dict(type='dict', required=True)
     )
 
     def __init__(self):

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
@@ -130,7 +130,7 @@ class DatacenterModule(OneViewModuleBase):
     RESOURCE_FACT_NAME = 'datacenter'
 
     argument_spec = dict(
-        state=dict(type='str', default='present', choices=['absent', 'present',]),
+        state=dict(type='str', default='present', choices=['absent', 'present']),
         data=dict(type='dict', required=True)
     )
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
@@ -12,12 +12,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: oneview_datacenter
-short_description: Manage OneView Data Center resources
+short_description: Manage OneView Datacenter resources
 description:
-    - "Provides an interface to manage Data Center resources. Can add, update, and remove."
+    - "Provides an interface to manage Datacenter resources. Can add, update, and remove."
 version_added: "2.5"
 requirements:
-    - "python >= 2.7.9"
     - "hpOneView >= 3.1.0"
 author:
     - Alex Monteiro (@aalexmonteiro)
@@ -27,14 +26,14 @@ author:
 options:
     state:
         description:
-            - Indicates the desired state for the Data Center resource.
-              C(present) will ensure data properties are compliant with OneView.
+            - Indicates the desired state for the Datacenter resource.
               C(absent) will remove the resource from OneView, if it exists.
+              C(present) will ensure the datacenter resource exists and its properties are compliant with HPE OneView.
+        default: present
         choices: ['present', 'absent']
-        required: true
     data:
         description:
-            - List with Data Center properties and its associated states.
+            - List with Datacenter properties and its associated states.
         required: true
 
 extends_documentation_fragment:
@@ -43,7 +42,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = '''
-- name: Add a Data Center
+- name: Add a Datacenter
   oneview_datacenter:
     hostname: 172.16.101.48
     username: administrator
@@ -63,7 +62,7 @@ EXAMPLES = '''
   no_log: true
   delegate_to: localhost
 
-- name: Update the Data Center with specified properties (no racks)
+- name: Update the Datacenter with specified properties (no racks)
   oneview_datacenter:
     hostname: 172.16.101.48
     username: administrator
@@ -85,7 +84,7 @@ EXAMPLES = '''
   no_log: true
   delegate_to: localhost
 
-- name: Rename the Data Center
+- name: Rename the Datacenter
   oneview_datacenter:
     hostname: 172.16.101.48
     username: administrator
@@ -98,7 +97,7 @@ EXAMPLES = '''
   no_log: true
   delegate_to: localhost
 
-- name: Remove the Data Center
+- name: Remove the Datacenter
   oneview_datacenter:
     hostname: 172.16.101.48
     username: administrator
@@ -113,7 +112,7 @@ EXAMPLES = '''
 
 RETURN = '''
 datacenter:
-    description: Has the OneView facts about the Data Center.
+    description: Has the OneView facts about the Datacenter.
     returned: On state 'present'. Can be null.
     type: dict
 '''
@@ -122,19 +121,16 @@ from ansible.module_utils.oneview import OneViewModuleBase, OneViewModuleResourc
 
 
 class DatacenterModule(OneViewModuleBase):
-    MSG_CREATED = 'Data Center added successfully.'
-    MSG_UPDATED = 'Data Center updated successfully.'
-    MSG_ALREADY_PRESENT = 'Data Center is already present.'
-    MSG_DELETED = 'Data Center removed successfully.'
-    MSG_ALREADY_ABSENT = 'Data Center is already absent.'
+    MSG_CREATED = 'Datacenter added successfully.'
+    MSG_UPDATED = 'Datacenter updated successfully.'
+    MSG_ALREADY_PRESENT = 'Datacenter is already present.'
+    MSG_DELETED = 'Datacenter removed successfully.'
+    MSG_ALREADY_ABSENT = 'Datacenter is already absent.'
     MSG_RACK_NOT_FOUND = 'Rack was not found.'
     RESOURCE_FACT_NAME = 'datacenter'
 
     argument_spec = dict(
-        state=dict(
-            required=True,
-            choices=['present', 'absent']
-        ),
+        state=dict(type='str', default='present', choices=['present', 'absent']),
         data=dict(required=True, type='dict')
     )
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
@@ -59,7 +59,6 @@ EXAMPLES = '''
         depth: 6000
         name: "MyDatacenter"
         width: 5000
-  no_log: true
   delegate_to: localhost
 
 - name: Update the Datacenter with specified properties (no racks)
@@ -81,7 +80,6 @@ EXAMPLES = '''
         deratingType: NaJp
         name: "MyDatacenter"
         width: 4000
-  no_log: true
   delegate_to: localhost
 
 - name: Rename the Datacenter
@@ -94,7 +92,6 @@ EXAMPLES = '''
     data:
         name: "MyDatacenter"
         newName: "My Datacenter"
-  no_log: true
   delegate_to: localhost
 
 - name: Remove the Datacenter
@@ -106,7 +103,6 @@ EXAMPLES = '''
     state: absent
     data:
         name: 'My Datacenter'
-  no_log: true
   delegate_to: localhost
 '''
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
@@ -1,0 +1,178 @@
+#!/usr/bin/python
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_datacenter
+short_description: Manage OneView Data Center resources
+description:
+    - "Provides an interface to manage Data Center resources. Can add, update, and remove."
+version_added: "2.5"
+requirements:
+    - "python >= 2.7.9"
+    - "hpOneView >= 3.1.0"
+author:
+    - Alex Monteiro (@aalexmonteiro)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Priyanka Sood (@soodpr)
+    - Ricardo Galeno (@ricardogpsf)
+options:
+    state:
+        description:
+            - Indicates the desired state for the Data Center resource.
+              C(present) will ensure data properties are compliant with OneView.
+              C(absent) will remove the resource from OneView, if it exists.
+        choices: ['present', 'absent']
+        required: true
+    data:
+        description:
+            - List with Data Center properties and its associated states.
+        required: true
+
+extends_documentation_fragment:
+    - oneview
+    - oneview.validateetag
+'''
+
+EXAMPLES = '''
+- name: Add a Data Center
+  oneview_datacenter:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: present
+    data:
+        contents:
+            # You can choose either resourceName or resourceUri to inform the Rack
+            - resourceName: '{{ datacenter_content_rack_name }}' # option 1
+              resourceUri: ''                                    # option 2
+              x: 1000
+              y: 1000
+        depth: 6000
+        name: "MyDatacenter"
+        width: 5000
+  no_log: true
+  delegate_to: localhost
+
+- name: Update the Data Center with specified properties (no racks)
+  oneview_datacenter:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: present
+    data:
+        contents: ~
+        coolingCapacity: '5'
+        coolingMultiplier: '1.5'
+        costPerKilowattHour: '0.10'
+        currency: USD
+        defaultPowerLineVoltage: '220'
+        deratingPercentage: '20.0'
+        depth: 5000
+        deratingType: NaJp
+        name: "MyDatacenter"
+        width: 4000
+  no_log: true
+  delegate_to: localhost
+
+- name: Rename the Data Center
+  oneview_datacenter:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: present
+    data:
+        name: "MyDatacenter"
+        newName: "My Datacenter"
+  no_log: true
+  delegate_to: localhost
+
+- name: Remove the Data Center
+  oneview_datacenter:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: absent
+    data:
+        name: 'My Datacenter'
+  no_log: true
+  delegate_to: localhost
+'''
+
+RETURN = '''
+datacenter:
+    description: Has the OneView facts about the Data Center.
+    returned: On state 'present'. Can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase, OneViewModuleResourceNotFound
+
+
+class DatacenterModule(OneViewModuleBase):
+    MSG_CREATED = 'Data Center added successfully.'
+    MSG_UPDATED = 'Data Center updated successfully.'
+    MSG_ALREADY_PRESENT = 'Data Center is already present.'
+    MSG_DELETED = 'Data Center removed successfully.'
+    MSG_ALREADY_ABSENT = 'Data Center is already absent.'
+    MSG_RACK_NOT_FOUND = 'Rack was not found.'
+    RESOURCE_FACT_NAME = 'datacenter'
+
+    argument_spec = dict(
+        state=dict(
+            required=True,
+            choices=['present', 'absent']
+        ),
+        data=dict(required=True, type='dict')
+    )
+
+    def __init__(self):
+        super(DatacenterModule, self).__init__(additional_arg_spec=self.argument_spec,
+                                               validate_etag_support=True)
+        self.resource_client = self.oneview_client.datacenters
+
+    def execute_module(self):
+
+        resource = self.get_by_name(self.data['name'])
+
+        if self.state == 'present':
+            self.__replace_name_by_uris(self.data)
+            return self.resource_present(resource, self.RESOURCE_FACT_NAME, 'add')
+        elif self.state == 'absent':
+            return self.resource_absent(resource, 'remove')
+
+    def __replace_name_by_uris(self, resource):
+        contents = resource.get('contents')
+
+        if contents:
+            for content in contents:
+                resource_name = content.pop('resourceName', None)
+                if resource_name:
+                    content['resourceUri'] = self.__get_rack_by_name(resource_name)['uri']
+
+    def __get_rack_by_name(self, name):
+        racks = self.oneview_client.racks.get_by('name', name)
+        if racks:
+            return racks[0]
+        else:
+            raise OneViewModuleResourceNotFound(self.MSG_RACK_NOT_FOUND)
+
+
+def main():
+    DatacenterModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_datacenter.py
@@ -140,21 +140,21 @@ class DatacenterModule(OneViewModuleBase):
         resource = self.get_by_name(self.data['name'])
 
         if self.state == 'present':
-            self.__replace_name_by_uris(self.data)
+            self._replace_name_by_uris(self.data)
             return self.resource_present(resource, self.RESOURCE_FACT_NAME, 'add')
         elif self.state == 'absent':
             return self.resource_absent(resource, 'remove')
 
-    def __replace_name_by_uris(self, resource):
+    def _replace_name_by_uris(self, resource):
         contents = resource.get('contents')
 
         if contents:
             for content in contents:
                 resource_name = content.pop('resourceName', None)
                 if resource_name:
-                    content['resourceUri'] = self.__get_rack_by_name(resource_name)['uri']
+                    content['resourceUri'] = self._get_rack_by_name(resource_name)['uri']
 
-    def __get_rack_by_name(self, name):
+    def _get_rack_by_name(self, name):
         racks = self.oneview_client.racks.get_by('name', name)
         if racks:
             return racks[0]

--- a/test/units/modules/remote_management/oneview/hpe_test_utils.py
+++ b/test/units/modules/remote_management/oneview/hpe_test_utils.py
@@ -27,17 +27,16 @@ from hpOneView.oneview_client import OneViewClient
 class OneViewBaseTest(object):
     @pytest.fixture(autouse=True)
     def setUp(self, mock_ansible_module, mock_ov_client, request):
+        class_name = type(self).__name__
         marker = request.node.get_marker('resource')
-        self.resource = getattr(mock_ov_client, "%s" % (marker.args))
+        self.resource = getattr(mock_ov_client, "%s" % (marker.kwargs[class_name]))
         self.mock_ov_client = mock_ov_client
         self.mock_ansible_module = mock_ansible_module
 
     @pytest.fixture
     def testing_module(self):
         resource_name = type(self).__name__.replace('Test', '')
-        resource_module_path_name = resource_name.replace('Module', '')
-        resource_module_path_name = re.findall('[A-Z][^A-Z]*', resource_module_path_name)
-        resource_module_path_name = 'oneview_' + str.join('_', resource_module_path_name).lower()
+        resource_module_path_name = self.underscore(resource_name.replace('Module', ''))
 
         ansible = __import__('ansible')
         oneview_module = ansible.modules.remote_management.oneview
@@ -54,6 +53,11 @@ class OneViewBaseTest(object):
             raise Exception(message)
         return testing_module
 
+    def underscore(self, word):
+        word = re.findall('[A-Z][^A-Z]*', word)
+        word = 'oneview_' + str.join('_', word).lower()
+        return word
+
     def test_main_function_should_call_run_method(self, testing_module, mock_ansible_module):
         mock_ansible_module.params = {'config': 'config.json'}
 
@@ -64,7 +68,7 @@ class OneViewBaseTest(object):
             mock_run.assert_called_once()
 
 
-class FactsParamsTest(OneViewBaseTest):
+class OneViewBaseFactsTest(OneViewBaseTest):
     def test_should_get_all_using_filters(self, testing_module):
         self.resource.get_all.return_value = []
 

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import yaml
+
+from ansible.compat.tests import unittest, mock
+from oneview_module_loader import OneViewModuleBase
+from ansible.modules.remote_management.oneview.oneview_datacenter import DatacenterModule
+from hpe_test_utils import OneViewBaseTestCase
+
+FAKE_MSG_ERROR = 'Fake message error'
+
+RACK_URI = '/rest/racks/rackid'
+
+YAML_DATACENTER = """
+        config: "{{ config }}"
+        state: present
+        data:
+            name: "MyDatacenter"
+            width: 5000
+            depth: 6000
+            contents:
+                - resourceName: "Rack-221"
+                  resourceUri: '/rest/racks/rackid'
+                  x: 1000
+                  y: 1000
+          """
+
+YAML_DATACENTER_CHANGE = """
+        config: "{{ config }}"
+        state: present
+        data:
+            name: "MyDatacenter"
+            newName: "MyDatacenter1"
+            width: 5000
+            depth: 5000
+            contents:
+                - resourceUri: '/rest/racks/rackid'
+                  x: 1000
+                  y: 1000
+      """
+
+YAML_DATACENTER_ABSENT = """
+        config: "{{ config }}"
+        state: absent
+        data:
+            name: 'MyDatacenter'
+        """
+
+DICT_DEFAULT_DATACENTER = yaml.load(YAML_DATACENTER)["data"]
+DICT_DEFAULT_DATACENTER_CHANGED = yaml.load(YAML_DATACENTER_CHANGE)["data"]
+
+
+class DatacenterModuleSpec(unittest.TestCase,
+                           OneViewBaseTestCase):
+    """
+    OneViewBaseTestCase has tests for the main function and provides the mocks used in this test case.
+    """
+
+    def setUp(self):
+        self.configure_mocks(self, DatacenterModule)
+        self.resource = self.mock_ov_client.datacenters
+
+    def test_should_create_new_datacenter(self):
+        self.resource.get_by.return_value = []
+        self.resource.add.return_value = {"name": "name"}
+        self.mock_ov_client.racks.get_by.return_value = [{'uri': RACK_URI}]
+
+        self.mock_ansible_module.params = yaml.load(YAML_DATACENTER)
+
+        DatacenterModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=DatacenterModule.MSG_CREATED,
+            ansible_facts=dict(datacenter={"name": "name"})
+        )
+
+    def test_should_update_the_datacenter(self):
+        self.resource.get_by.side_effect = [[DICT_DEFAULT_DATACENTER], []]
+        self.resource.update.return_value = {"name": "name"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_DATACENTER_CHANGE)
+
+        DatacenterModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=DatacenterModule.MSG_UPDATED,
+            ansible_facts=dict(datacenter={"name": "name"})
+        )
+
+    def test_should_not_update_when_data_is_equals(self):
+        datacenter_replaced = DICT_DEFAULT_DATACENTER.copy()
+        del datacenter_replaced['contents'][0]['resourceName']
+
+        self.resource.get_by.return_value = [DICT_DEFAULT_DATACENTER]
+        self.mock_ov_client.racks.get_by.return_value = [{'uri': RACK_URI}]
+
+        self.mock_ansible_module.params = yaml.load(YAML_DATACENTER)
+
+        DatacenterModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=DatacenterModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(datacenter=DICT_DEFAULT_DATACENTER)
+        )
+
+    def test_should_remove_datacenter(self):
+        self.resource.get_by.return_value = [DICT_DEFAULT_DATACENTER]
+
+        self.mock_ansible_module.params = yaml.load(YAML_DATACENTER_ABSENT)
+
+        DatacenterModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=DatacenterModule.MSG_DELETED
+        )
+
+    def test_should_do_nothing_when_datacenter_not_exist(self):
+        self.resource.get_by.return_value = []
+
+        self.mock_ansible_module.params = yaml.load(YAML_DATACENTER_ABSENT)
+
+        DatacenterModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=DatacenterModule.MSG_ALREADY_ABSENT
+        )
+
+    def test_should_fail_when_switch_type_was_not_found(self):
+        self.resource.get_by.return_value = []
+        self.mock_ov_client.racks.get_by.return_value = []
+
+        self.mock_ansible_module.params = yaml.load(YAML_DATACENTER)
+
+        DatacenterModule().run()
+
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=DatacenterModule.MSG_RACK_NOT_FOUND)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter.py
@@ -1,14 +1,13 @@
 # Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import pytest
 import yaml
 
-from ansible.compat.tests import unittest, mock
+from ansible.compat.tests import mock
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_datacenter import DatacenterModule
-from hpe_test_utils import OneViewBaseTestCase
-
-FAKE_MSG_ERROR = 'Fake message error'
+from hpe_test_utils import OneViewBaseTest
 
 RACK_URI = '/rest/racks/rackid'
 
@@ -51,15 +50,11 @@ DICT_DEFAULT_DATACENTER = yaml.load(YAML_DATACENTER)["data"]
 DICT_DEFAULT_DATACENTER_CHANGED = yaml.load(YAML_DATACENTER_CHANGE)["data"]
 
 
-class DatacenterModuleSpec(unittest.TestCase,
-                           OneViewBaseTestCase):
+@pytest.mark.resource('datacenters')
+class TestDatacenterModule(OneViewBaseTest):
     """
-    OneViewBaseTestCase has tests for the main function and provides the mocks used in this test case.
+    OneViewBaseTest has tests for the main function and provides the mocks used in this test case.
     """
-
-    def setUp(self):
-        self.configure_mocks(self, DatacenterModule)
-        self.resource = self.mock_ov_client.datacenters
 
     def test_should_create_new_datacenter(self):
         self.resource.get_by.return_value = []
@@ -143,4 +138,4 @@ class DatacenterModuleSpec(unittest.TestCase,
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main([__file__])

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter.py
@@ -50,7 +50,7 @@ DICT_DEFAULT_DATACENTER = yaml.load(YAML_DATACENTER)["data"]
 DICT_DEFAULT_DATACENTER_CHANGED = yaml.load(YAML_DATACENTER_CHANGE)["data"]
 
 
-@pytest.mark.resource('datacenters')
+@pytest.mark.resource(TestDatacenterModule='datacenters')
 class TestDatacenterModule(OneViewBaseTest):
     """
     OneViewBaseTest has tests for the main function and provides the mocks used in this test case.

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
@@ -5,7 +5,7 @@ import pytest
 
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_datacenter_facts import DatacenterFactsModule
-from hpe_test_utils import FactsParamsTest
+from hpe_test_utils import OneViewBaseFactsTest
 
 PARAMS_GET_CONNECTED = dict(
     config='config.json',
@@ -14,14 +14,8 @@ PARAMS_GET_CONNECTED = dict(
 )
 
 
-@pytest.mark.resource('datacenters')
-class TestDatacenterFactsModule(FactsParamsTest):
-    @pytest.fixture(autouse=True)
-    def setUp(self, mock_ansible_module, mock_ov_client):
-        self.resource = mock_ov_client.datacenters
-        self.mock_ansible_module = mock_ansible_module
-        self.mock_ov_client = mock_ov_client
-
+@pytest.mark.resource(TestDatacenterFactsModule='datacenters')
+class TestDatacenterFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_datacenters(self):
         self.resource.get_all.return_value = {"name": "Data Center Name"}
 


### PR DESCRIPTION
##### SUMMARY
Added new oneview_datacenter module for managing [HPE OneView Datacenters](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/datacenters) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_datacenter`

##### ANSIBLE VERSION
```
ansible 2.5.0 (hpe-oneview/datacenter f0e9539293) last updated 2017/11/10 18:18:38 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/ansible/lib/ansible
  executable location = /ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Example of usage:
```yaml
- name: Add a Datacenter
  oneview_datacenter:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    state: present
    data:
        contents:
            # You can choose either resourceName or resourceUri to inform the Rack
            - resourceName: '{{ datacenter_content_rack_name }}' # option 1
              resourceUri: ''                                    # option 2
              x: 1000
              y: 1000
        depth: 6000
        name: "MyDatacenter"
        width: 5000
  no_log: true
  delegate_to: localhost

- name: Update the Datacenter with specified properties (no racks)
  oneview_datacenter:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    state: present
    data:
        contents: ~
        coolingCapacity: '5'
        coolingMultiplier: '1.5'
        costPerKilowattHour: '0.10'
        currency: USD
        defaultPowerLineVoltage: '220'
        deratingPercentage: '20.0'
        depth: 5000
        deratingType: NaJp
        name: "MyDatacenter"
        width: 4000
  no_log: true
  delegate_to: localhost

- name: Rename the Datacenter
  oneview_datacenter:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    state: present
    data:
        name: "MyDatacenter"
        newName: "My Datacenter"
  no_log: true
  delegate_to: localhost

- name: Remove the Datacenter
  oneview_datacenter:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    state: absent
    data:
        name: 'My Datacenter'
  no_log: true
  delegate_to: localhost
```
