### PR TITLE
StorageSystemModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
@@ -60,7 +60,6 @@ EXAMPLES = '''
             type: StoragePoolV2
             name: CPG_FC-AO
             deviceType: FC
-
   delegate_to: localhost
 
 - name: Add a StoreServ Storage System with one managed pool (API500 onwards)
@@ -82,7 +81,6 @@ EXAMPLES = '''
               - domain: TestDomain
                 name: CPG_FC-AO
                 deviceType: FC
-
   delegate_to: localhost
 
 - name: Remove the storage system by its IP (before API500)
@@ -95,7 +93,6 @@ EXAMPLES = '''
     data:
         credentials:
             ip_hostname: 172.18.11.12
-
   delegate_to: localhost
 
 - name: Remove the storage system by its IP (API500 onwards)
@@ -108,7 +105,6 @@ EXAMPLES = '''
     data:
         credentials:
             hostname: 172.18.11.12
-
   delegate_to: localhost
 '''
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
@@ -31,7 +31,7 @@ options:
                 - C(present) will ensure data properties are compliant with OneView.
                 - C(absent) will remove the resource from OneView, if it exists.
         choices: ['present', 'absent']
-        required: true
+        default: present
     data:
         description:
             - List with Storage System properties and its associated states.
@@ -139,10 +139,7 @@ class StorageSystemModule(OneViewModuleBase):
 
     def __init__(self):
         argument_spec = dict(
-            state=dict(
-                required=True,
-                choices=['present', 'absent']
-            ),
+            state=dict(default='present', choices=['present', 'absent']),
             data=dict(required=True, type='dict')
         )
         super(StorageSystemModule, self).__init__(additional_arg_spec=argument_spec,

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
@@ -137,12 +137,13 @@ class StorageSystemModule(OneViewModuleBase):
                                    "(credentials.ip_hostname if API version lower than 500 )."
     MSG_CREDENTIALS_MANDATORY = "The attribute 'credentials' is mandatory for Storage System creation."
 
+    argument_spec = dict(
+        state=dict(type='str', default='present', choices=['present', 'absent']),
+        data=dict(type='dict', required=True)
+    )
+
     def __init__(self):
-        argument_spec = dict(
-            state=dict(default='present', choices=['present', 'absent']),
-            data=dict(required=True, type='dict')
-        )
-        super(StorageSystemModule, self).__init__(additional_arg_spec=argument_spec,
+        super(StorageSystemModule, self).__init__(additional_arg_spec=self.argument_spec,
                                                   validate_etag_support=True)
 
         self.resource_client = self.oneview_client.storage_systems

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
@@ -138,13 +138,12 @@ class StorageSystemModule(OneViewModuleBase):
     MSG_CREDENTIALS_MANDATORY = "The attribute 'credentials' is mandatory for Storage System creation."
 
     argument_spec = dict(
-        state=dict(type='str', default='present', choices=['present', 'absent']),
+        state=dict(type='str', default='present', choices=['absent', 'present']),
         data=dict(type='dict', required=True)
     )
 
     def __init__(self):
-        super(StorageSystemModule, self).__init__(additional_arg_spec=self.argument_spec,
-                                                  validate_etag_support=True)
+        super(StorageSystemModule, self).__init__(additional_arg_spec=self.argument_spec, validate_etag_support=True)
 
         self.resource_client = self.oneview_client.storage_systems
 

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
@@ -1,0 +1,233 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_storage_system
+short_description: Manage OneView Storage System resources
+description:
+    - Provides an interface to manage Storage System resources. Can add, update and remove.
+version_added: "2.5"
+requirements:
+    - "hpOneView >= 3.1.0"
+author:
+    - Alex Monteiro (@aalexmonteiro)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Priyanka Sood (@soodpr)
+    - Ricardo Galeno (@ricardogpsf)
+options:
+    state:
+        description:
+            - Indicates the desired state for the Storage System resource.
+                - C(present) will ensure data properties are compliant with OneView.
+                - C(absent) will remove the resource from OneView, if it exists.
+        choices: ['present', 'absent']
+        required: true
+    data:
+        description:
+            - List with Storage System properties and its associated states.
+        required: true
+extends_documentation_fragment:
+    - oneview
+    - oneview.validateetag
+'''
+
+EXAMPLES = '''
+- name: Add a Storage System with one managed pool (before API500)
+  oneview_storage_system:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 300
+    state: present
+    data:
+        credentials:
+            ip_hostname: 172.18.11.12
+            username: username
+            password: password
+        managedDomain: TestDomain
+        managedPools:
+          - domain: TestDomain
+            type: StoragePoolV2
+            name: CPG_FC-AO
+            deviceType: FC
+
+  no_log: true
+  delegate_to: localhost
+
+- name: Add a StoreServ Storage System with one managed pool (API500 onwards)
+  oneview_storage_system:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: present
+    data:
+      credentials:
+          username: username
+          password: password
+      hostname: 172.18.11.12
+      family: StoreServ
+      deviceSpecificAttributes:
+          managedDomain: TestDomain
+          managedPools:
+              - domain: TestDomain
+                name: CPG_FC-AO
+                deviceType: FC
+
+  no_log: true
+  delegate_to: localhost
+
+- name: Remove the storage system by its IP (before API500)
+  oneview_storage_system:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 300
+    state: absent
+    data:
+        credentials:
+            ip_hostname: 172.18.11.12
+
+  no_log: true
+  delegate_to: localhost
+
+- name: Remove the storage system by its IP (API500 onwards)
+  oneview_storage_system:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    state: absent
+    data:
+        credentials:
+            hostname: 172.18.11.12
+
+  no_log: true
+  delegate_to: localhost
+'''
+
+RETURN = '''
+storage_system:
+    description: Has the OneView facts about the Storage System.
+    returned: On state 'present'. Can be null.
+    type: dict
+'''
+
+from ansible.module_utils.six.moves import filter
+from ansible.module_utils.oneview import OneViewModuleBase, OneViewModuleValueError
+
+
+class StorageSystemModule(OneViewModuleBase):
+    MSG_ADDED = 'Storage System added successfully.'
+    MSG_UPDATED = 'Storage System updated successfully.'
+    MSG_ALREADY_PRESENT = 'Storage System is already present.'
+    MSG_DELETED = 'Storage System deleted successfully.'
+    MSG_ALREADY_ABSENT = 'Storage System is already absent.'
+    MSG_MANDATORY_FIELDS_MISSING = "At least one mandatory field must be provided: name or credentials.hostname" \
+                                   "(credentials.ip_hostname if API version lower than 500 )."
+    MSG_CREDENTIALS_MANDATORY = "The attribute 'credentials' is mandatory for Storage System creation."
+
+    def __init__(self):
+        argument_spec = dict(
+            state=dict(
+                required=True,
+                choices=['present', 'absent']
+            ),
+            data=dict(required=True, type='dict')
+        )
+        super(StorageSystemModule, self).__init__(additional_arg_spec=argument_spec,
+                                                  validate_etag_support=True)
+
+        self.resource_client = self.oneview_client.storage_systems
+
+    def execute_module(self):
+        if self.oneview_client.api_version < 500:
+            resource = self.__get_resource_hostname('ip_hostname', 'newIp_hostname')
+        else:
+            resource = self.__get_resource_hostname('hostname', 'newHostname')
+
+        if self.state == 'present':
+            return self.__present(resource)
+        elif self.state == 'absent':
+            return self.resource_absent(resource, 'remove')
+
+    def __present(self, resource):
+        changed = False
+        msg = ''
+
+        if not resource:
+            if 'credentials' not in self.data:
+                raise OneViewModuleValueError(self.MSG_CREDENTIALS_MANDATORY)
+            if self.oneview_client.api_version < 500:
+                resource = self.oneview_client.storage_systems.add(self.data['credentials'])
+            else:
+                options = self.data['credentials'].copy()
+                options['family'] = self.data.get('family', None)
+                options['hostname'] = self.data.get('hostname', None)
+                resource = self.oneview_client.storage_systems.add(options)
+
+            changed = True
+            msg = self.MSG_ADDED
+
+        merged_data = resource.copy()
+        merged_data.update(self.data)
+
+        # remove password, it cannot be used in comparison
+        if 'credentials' in merged_data and 'password' in merged_data['credentials']:
+            del merged_data['credentials']['password']
+
+        # sets the uuid to all the storage pools that are in the 'managedPools' list
+        if self.oneview_client.api_version >= 500:
+            for pool in merged_data['deviceSpecificAttributes'].get('managedPools', []):
+                discovered_pools = resource.get('deviceSpecificAttributes', {}).get('discoveredPools', [])
+                pools_by_name = list(filter(lambda item: item.get('name') == pool.get('name') and item.get('domain') == pool.get('domain'), discovered_pools))
+                if pools_by_name:
+                    'uuid' in pool or pool.setdefault('uuid', pools_by_name[0].get('uuid'))
+
+        if not self.compare(resource, merged_data):
+            # update the resource
+            resource = self.oneview_client.storage_systems.update(merged_data)
+            if not changed:
+                changed = True
+                msg = self.MSG_UPDATED
+        else:
+            msg = self.MSG_ALREADY_PRESENT
+
+        return dict(changed=changed,
+                    msg=msg,
+                    ansible_facts=dict(storage_system=resource))
+
+    def __get_resource_hostname(self, hostname_key, new_hostname_key):
+        hostname = self.data.get(hostname_key, None)
+        if 'credentials' in self.data and hostname is None:
+            hostname = self.data['credentials'].get(hostname_key, None)
+        if hostname:
+            get_method = getattr(self.oneview_client.storage_systems, "get_by_{0}".format(hostname_key))
+            resource = get_method(hostname)
+            if self.data['credentials'].get(new_hostname_key):
+                self.data['credentials'][hostname_key] = self.data['credentials'].pop(new_hostname_key)
+            elif self.data.get(new_hostname_key):
+                self.data[hostname_key] = self.data.pop(new_hostname_key)
+            return resource
+        elif self.data.get('name'):
+            return self.oneview_client.storage_systems.get_by_name(self.data['name'])
+        else:
+            raise OneViewModuleValueError(self.MSG_MANDATORY_FIELDS_MISSING)
+
+
+def main():
+    StorageSystemModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_system.py
@@ -61,7 +61,6 @@ EXAMPLES = '''
             name: CPG_FC-AO
             deviceType: FC
 
-  no_log: true
   delegate_to: localhost
 
 - name: Add a StoreServ Storage System with one managed pool (API500 onwards)
@@ -84,7 +83,6 @@ EXAMPLES = '''
                 name: CPG_FC-AO
                 deviceType: FC
 
-  no_log: true
   delegate_to: localhost
 
 - name: Remove the storage system by its IP (before API500)
@@ -98,7 +96,6 @@ EXAMPLES = '''
         credentials:
             ip_hostname: 172.18.11.12
 
-  no_log: true
   delegate_to: localhost
 
 - name: Remove the storage system by its IP (API500 onwards)
@@ -112,7 +109,6 @@ EXAMPLES = '''
         credentials:
             hostname: 172.18.11.12
 
-  no_log: true
   delegate_to: localhost
 '''
 

--- a/test/units/modules/remote_management/oneview/conftest.py
+++ b/test/units/modules/remote_management/oneview/conftest.py
@@ -1,5 +1,6 @@
-# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
 import pytest
 
 from mock import Mock, patch
@@ -9,9 +10,10 @@ from hpOneView.oneview_client import OneViewClient
 
 @pytest.fixture
 def mock_ov_client():
-    patcher_json_file = patch.object(OneViewClient, 'from_json_file')
-    client = patcher_json_file.start()
-    return client.return_value
+    client = Mock()
+    OneViewClient.from_json_file = lambda x: client
+    client.api_version = 300
+    return client
 
 
 @pytest.fixture

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -5,7 +5,6 @@ import pytest
 import yaml
 
 from ansible.compat.tests import mock
-from hpe_test_utils import mock_ov_client, mock_ansible_module
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_storage_system import StorageSystemModule
 
@@ -298,3 +297,7 @@ def test_should_do_nothing_when_storage_system_not_exist(resource, mock_ansible_
         changed=False,
         msg=StorageSystemModule.MSG_ALREADY_ABSENT
     )
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -104,10 +104,6 @@ del DICT_DEFAULT_STORAGE_SYSTEM_500['credentials']['password']
 
 class TestStorageSystemModule(OneViewBaseTest):
     @pytest.fixture
-    def testing_class(self):
-        return StorageSystemModule
-
-    @pytest.fixture
     def resource(self, mock_ov_client):
         return mock_ov_client.storage_systems
 

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import yaml
+
 from ansible.compat.tests import unittest, mock
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_storage_system import StorageSystemModule

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -1,0 +1,292 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import yaml
+from ansible.compat.tests import unittest, mock
+from oneview_module_loader import OneViewModuleBase
+from ansible.modules.remote_management.oneview.oneview_storage_system import StorageSystemModule
+from hpe_test_utils import OneViewBaseTestCase
+
+YAML_STORAGE_SYSTEM = """
+        config: "{{ config }}"
+        state: present
+        data:
+            credentials:
+                ip_hostname: '{{ storage_system_ip_hostname }}'
+                username: '{{ storage_system_username }}'
+                password: '{{ storage_system_password }}'
+            managedDomain: TestDomain
+            managedPools:
+              - domain: TestDomain
+                type: StoragePoolV2
+                name: CPG_FC-AO
+                deviceType: FC
+          """
+
+YAML_STORAGE_SYSTEM_500 = """
+        config: "{{ config }}"
+        state: present
+        data:
+            credentials:
+                username: user
+                password: pass
+            hostname: '10.0.0.0'
+            family: StoreServ
+            deviceSpecificAttributes:
+                managedDomain: TestDomain
+                managedPools:
+                  - domain: TestDomain
+                    name: CPG_FC-AO
+                    deviceType: FC
+          """
+
+YAML_STORAGE_SYSTEM_BY_NAME = """
+    config: "{{ config }}"
+    state: present
+    data:
+        name: SSName
+        managedDomain: TestDomain
+        managedPools:
+          - domain: TestDomain
+            type: StoragePoolV2
+            name: CPG_FC-AO
+            deviceType: FC
+      """
+
+YAML_STORAGE_SYSTEM_CHANGES = """
+        config: "{{ config }}"
+        state: present
+        data:
+            credentials:
+                ip_hostname: '{{ storage_system_ip_hostname }}'
+                newIp_hostname: 'New IP Hostname'
+                username: '{{ storage_system_username }}'
+                password: '{{ storage_system_password }}'
+            managedDomain: TestDomain
+            managedPools:
+              - domain: TestDomain
+                type: StoragePoolV2
+                name: CPG_FC-AO
+                deviceType: FC
+      """
+
+YAML_STORAGE_SYSTEM_CHANGES_500 = """
+        config: "{{ config }}"
+        state: present
+        data:
+            credentials:
+                username: '{{ storage_system_username }}'
+                password: '{{ storage_system_password }}'
+            hostname: '{{ storage_system_ip_hostname }}'
+            newHostname: 'New IP Hostname'
+            managedDomain: TestDomain
+            managedPools:
+              - domain: TestDomain
+                name: CPG_FC-AO
+                deviceType: FC
+      """
+
+YAML_STORAGE_SYSTEM_ABSENT = """
+        config: "{{ config }}"
+        state: absent
+        data:
+            credentials:
+                ip_hostname: 172.18.11.12
+"""
+
+DICT_DEFAULT_STORAGE_SYSTEM = yaml.load(YAML_STORAGE_SYSTEM)["data"]
+del DICT_DEFAULT_STORAGE_SYSTEM['credentials']['password']
+DICT_DEFAULT_STORAGE_SYSTEM_500 = yaml.load(YAML_STORAGE_SYSTEM_500)["data"]
+del DICT_DEFAULT_STORAGE_SYSTEM_500['credentials']['password']
+
+
+class StorageSystemModuleSpec(unittest.TestCase,
+                              OneViewBaseTestCase):
+    def setUp(self):
+        self.configure_mocks(self, StorageSystemModule)
+        self.resource = self.mock_ov_client.storage_systems
+        self.mock_ov_client.api_version = 300
+
+    def test_should_add_new_storage_system_with_credentials_from_api300(self):
+        self.resource.get_by_ip_hostname.return_value = None
+        self.resource.add.return_value = {"name": "name"}
+        self.resource.update.return_value = {"name": "name"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_ADDED,
+            ansible_facts=dict(storage_system={"name": "name"})
+        )
+
+    def test_should_add_new_storage_system_with_credentials_from_api500(self):
+        self.mock_ov_client.api_version = 500
+        self.resource.get_by_hostname.return_value = None
+        self.resource.add.return_value = {
+            "deviceSpecificAttributes": {
+                "discoveredPools": [
+                    {
+                        "name": "CPG_FC-AO",
+                        "uuid": "abc-123",
+                        "domain": "OtherDomain"
+                    },
+                    {
+                        "name": "CPG_FC-AO",
+                        "uuid": "def-456",
+                        "domain": "TestDomain"
+                    }
+                ]
+            }
+        }
+        self.resource.update.return_value = {"name": "name"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_500)
+
+        StorageSystemModule().run()
+
+        self.resource.add.assert_called_once_with(
+            {
+                'username': 'user',
+                'password': 'pass',
+                'hostname': '10.0.0.0',
+                'family': 'StoreServ'
+            }
+        )
+        self.resource.update.assert_called_with(
+            {
+                'credentials': {
+                    'username': 'user'
+                },
+                'hostname': '10.0.0.0',
+                'family': 'StoreServ',
+                'deviceSpecificAttributes': {
+                    'managedDomain': 'TestDomain',
+                    'managedPools': [{
+                        'domain': 'TestDomain',
+                        'name': 'CPG_FC-AO',
+                        'deviceType': 'FC',
+                        'uuid': 'def-456'
+                    }]
+                }
+            }
+        )
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_ADDED,
+            ansible_facts=dict(storage_system={"name": "name"})
+        )
+
+    def test_should_not_update_when_data_is_equals(self):
+        self.resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+        self.resource.update.return_value = {"name": "name"}
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=StorageSystemModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(storage_system=DICT_DEFAULT_STORAGE_SYSTEM)
+        )
+
+    def test_should_not_update_when_data_is_equals_using_name(self):
+        dict_by_name = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)["data"]
+
+        self.resource.get_by_name.return_value = dict_by_name
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=StorageSystemModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(storage_system=dict_by_name.copy())
+        )
+
+    def test_should_fail_with_missing_required_attributes(self):
+        self.mock_ansible_module.params = {"state": "present",
+                                           "config": "config",
+                                           "data":
+                                               {"field": "invalid"}}
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_MANDATORY_FIELDS_MISSING)
+
+    def test_should_fail_when_credentials_attribute_is_missing(self):
+        self.resource.get_by_name.return_value = []
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_CREDENTIALS_MANDATORY)
+
+    def test_update_when_data_has_modified_attributes(self):
+        data_merged = DICT_DEFAULT_STORAGE_SYSTEM.copy()
+        data_merged['credentials']['newIp_hostname'] = '10.10.10.10'
+
+        self.resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+        self.resource.update.return_value = data_merged
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_UPDATED,
+            ansible_facts=dict(storage_system=data_merged)
+        )
+
+    def test_update_when_data_has_modified_attributes_when_api500(self):
+        self.mock_ov_client.api_version = 500
+        data_merged = DICT_DEFAULT_STORAGE_SYSTEM_500.copy()
+        data_merged['credentials']['newHostname'] = '10.10.10.10'
+
+        self.resource.get_by_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM_500
+        self.resource.update.return_value = data_merged
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES_500)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_UPDATED,
+            ansible_facts=dict(storage_system=data_merged)
+        )
+
+    def test_should_remove_storage_system(self):
+        self.resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_DELETED
+        )
+
+    def test_should_do_nothing_when_storage_system_not_exist(self):
+        self.resource.get_by_ip_hostname.return_value = []
+
+        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
+
+        StorageSystemModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=StorageSystemModule.MSG_ALREADY_ABSENT
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -102,13 +102,8 @@ DICT_DEFAULT_STORAGE_SYSTEM_500 = yaml.load(YAML_STORAGE_SYSTEM_500)["data"]
 del DICT_DEFAULT_STORAGE_SYSTEM_500['credentials']['password']
 
 
+@pytest.mark.resource('storage_systems')
 class TestStorageSystemModule(OneViewBaseTest):
-    @pytest.fixture(autouse=True)
-    def setUp(self, mock_ansible_module, mock_ov_client):
-        self.resource = mock_ov_client.storage_systems
-        self.mock_ansible_module = mock_ansible_module
-        self.mock_ov_client = mock_ov_client
-
     def test_should_add_new_storage_system_with_credentials_from_api300(self):
         self.resource.get_by_ip_hostname.return_value = None
         self.resource.add.return_value = {"name": "name"}

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -5,6 +5,7 @@ import pytest
 import yaml
 
 from ansible.compat.tests import mock
+from hpe_test_utils import OneViewBaseTest
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_storage_system import StorageSystemModule
 
@@ -101,203 +102,197 @@ DICT_DEFAULT_STORAGE_SYSTEM_500 = yaml.load(YAML_STORAGE_SYSTEM_500)["data"]
 del DICT_DEFAULT_STORAGE_SYSTEM_500['credentials']['password']
 
 
-@pytest.fixture
-def resource(mock_ov_client):
-    return mock_ov_client.storage_systems
+class TestStorageSystemModule(OneViewBaseTest):
+    @pytest.fixture
+    def testing_class(self):
+        return StorageSystemModule
 
+    @pytest.fixture
+    def resource(self, mock_ov_client):
+        return mock_ov_client.storage_systems
 
-def test_should_add_new_storage_system_with_credentials_from_api300(resource, mock_ansible_module):
-    resource.get_by_ip_hostname.return_value = None
-    resource.add.return_value = {"name": "name"}
-    resource.update.return_value = {"name": "name"}
+    def test_should_add_new_storage_system_with_credentials_from_api300(self, resource, mock_ansible_module):
+        resource.get_by_ip_hostname.return_value = None
+        resource.add.return_value = {"name": "name"}
+        resource.update.return_value = {"name": "name"}
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
 
-    StorageSystemModule().run()
+        StorageSystemModule().run()
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=True,
-        msg=StorageSystemModule.MSG_ADDED,
-        ansible_facts=dict(storage_system={"name": "name"})
-    )
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_ADDED,
+            ansible_facts=dict(storage_system={"name": "name"})
+        )
 
-
-def test_should_add_new_storage_system_with_credentials_from_api500(resource, mock_ansible_module, mock_ov_client):
-    mock_ov_client.api_version = 500
-    resource.get_by_hostname.return_value = None
-    resource.add.return_value = {
-        "deviceSpecificAttributes": {
-            "discoveredPools": [
-                {
-                    "name": "CPG_FC-AO",
-                    "uuid": "abc-123",
-                    "domain": "OtherDomain"
-                },
-                {
-                    "name": "CPG_FC-AO",
-                    "uuid": "def-456",
-                    "domain": "TestDomain"
-                }
-            ]
-        }
-    }
-    resource.update.return_value = {"name": "name"}
-
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_500)
-
-    StorageSystemModule().run()
-
-    resource.add.assert_called_once_with(
-        {
-            'username': 'user',
-            'password': 'pass',
-            'hostname': '10.0.0.0',
-            'family': 'StoreServ'
-        }
-    )
-    resource.update.assert_called_with(
-        {
-            'credentials': {
-                'username': 'user'
-            },
-            'hostname': '10.0.0.0',
-            'family': 'StoreServ',
-            'deviceSpecificAttributes': {
-                'managedDomain': 'TestDomain',
-                'managedPools': [{
-                    'domain': 'TestDomain',
-                    'name': 'CPG_FC-AO',
-                    'deviceType': 'FC',
-                    'uuid': 'def-456'
-                }]
+    def test_should_add_new_storage_system_with_credentials_from_api500(self, resource, mock_ansible_module, mock_ov_client):
+        mock_ov_client.api_version = 500
+        resource.get_by_hostname.return_value = None
+        resource.add.return_value = {
+            "deviceSpecificAttributes": {
+                "discoveredPools": [
+                    {
+                        "name": "CPG_FC-AO",
+                        "uuid": "abc-123",
+                        "domain": "OtherDomain"
+                    },
+                    {
+                        "name": "CPG_FC-AO",
+                        "uuid": "def-456",
+                        "domain": "TestDomain"
+                    }
+                ]
             }
         }
-    )
+        resource.update.return_value = {"name": "name"}
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=True,
-        msg=StorageSystemModule.MSG_ADDED,
-        ansible_facts=dict(storage_system={"name": "name"})
-    )
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_500)
 
+        StorageSystemModule().run()
 
-def test_should_not_update_when_data_is_equals(resource, mock_ansible_module):
-    resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
-    resource.update.return_value = {"name": "name"}
+        resource.add.assert_called_once_with(
+            {
+                'username': 'user',
+                'password': 'pass',
+                'hostname': '10.0.0.0',
+                'family': 'StoreServ'
+            }
+        )
+        resource.update.assert_called_with(
+            {
+                'credentials': {
+                    'username': 'user'
+                },
+                'hostname': '10.0.0.0',
+                'family': 'StoreServ',
+                'deviceSpecificAttributes': {
+                    'managedDomain': 'TestDomain',
+                    'managedPools': [{
+                        'domain': 'TestDomain',
+                        'name': 'CPG_FC-AO',
+                        'deviceType': 'FC',
+                        'uuid': 'def-456'
+                    }]
+                }
+            }
+        )
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_ADDED,
+            ansible_facts=dict(storage_system={"name": "name"})
+        )
 
-    StorageSystemModule().run()
+    def test_should_not_update_when_data_is_equals(self, resource, mock_ansible_module):
+        resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+        resource.update.return_value = {"name": "name"}
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=False,
-        msg=StorageSystemModule.MSG_ALREADY_PRESENT,
-        ansible_facts=dict(storage_system=DICT_DEFAULT_STORAGE_SYSTEM)
-    )
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
 
+        StorageSystemModule().run()
 
-def test_should_not_update_when_data_is_equals_using_name(resource, mock_ansible_module):
-    dict_by_name = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)["data"]
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=StorageSystemModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(storage_system=DICT_DEFAULT_STORAGE_SYSTEM)
+        )
 
-    resource.get_by_name.return_value = dict_by_name
+    def test_should_not_update_when_data_is_equals_using_name(self, resource, mock_ansible_module):
+        dict_by_name = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)["data"]
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
+        resource.get_by_name.return_value = dict_by_name
 
-    StorageSystemModule().run()
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=False,
-        msg=StorageSystemModule.MSG_ALREADY_PRESENT,
-        ansible_facts=dict(storage_system=dict_by_name.copy())
-    )
+        StorageSystemModule().run()
 
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=StorageSystemModule.MSG_ALREADY_PRESENT,
+            ansible_facts=dict(storage_system=dict_by_name.copy())
+        )
 
-def test_should_fail_with_missing_required_attributes(resource, mock_ansible_module):
-    mock_ansible_module.params = {
-        'state': 'present',
-        'config': 'config',
-        'data': {
-            'field': 'invalid'
+    def test_should_fail_with_missing_required_attributes(self, resource, mock_ansible_module):
+        mock_ansible_module.params = {
+            'state': 'present',
+            'config': 'config',
+            'data': {
+                'field': 'invalid'
+            }
         }
-    }
 
-    StorageSystemModule().run()
+        StorageSystemModule().run()
 
-    mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_MANDATORY_FIELDS_MISSING)
+        mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_MANDATORY_FIELDS_MISSING)
 
+    def test_should_fail_when_credentials_attribute_is_missing(self, resource, mock_ansible_module):
+        resource.get_by_name.return_value = []
 
-def test_should_fail_when_credentials_attribute_is_missing(resource, mock_ansible_module):
-    resource.get_by_name.return_value = []
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
+        StorageSystemModule().run()
 
-    StorageSystemModule().run()
+        mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_CREDENTIALS_MANDATORY)
 
-    mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_CREDENTIALS_MANDATORY)
+    def test_update_when_data_has_modified_attributes(self, resource, mock_ansible_module):
+        data_merged = DICT_DEFAULT_STORAGE_SYSTEM.copy()
+        data_merged['credentials']['newIp_hostname'] = '10.10.10.10'
 
+        resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+        resource.update.return_value = data_merged
 
-def test_update_when_data_has_modified_attributes(resource, mock_ansible_module):
-    data_merged = DICT_DEFAULT_STORAGE_SYSTEM.copy()
-    data_merged['credentials']['newIp_hostname'] = '10.10.10.10'
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES)
 
-    resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
-    resource.update.return_value = data_merged
+        StorageSystemModule().run()
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES)
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_UPDATED,
+            ansible_facts=dict(storage_system=data_merged)
+        )
 
-    StorageSystemModule().run()
+    def test_update_when_data_has_modified_attributes_when_api500(self, resource, mock_ansible_module, mock_ov_client):
+        mock_ov_client.api_version = 500
+        data_merged = DICT_DEFAULT_STORAGE_SYSTEM_500.copy()
+        data_merged['credentials']['newHostname'] = '10.10.10.10'
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=True,
-        msg=StorageSystemModule.MSG_UPDATED,
-        ansible_facts=dict(storage_system=data_merged)
-    )
+        resource.get_by_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM_500
+        resource.update.return_value = data_merged
 
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES_500)
 
-def test_update_when_data_has_modified_attributes_when_api500(resource, mock_ansible_module, mock_ov_client):
-    mock_ov_client.api_version = 500
-    data_merged = DICT_DEFAULT_STORAGE_SYSTEM_500.copy()
-    data_merged['credentials']['newHostname'] = '10.10.10.10'
+        StorageSystemModule().run()
 
-    resource.get_by_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM_500
-    resource.update.return_value = data_merged
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_UPDATED,
+            ansible_facts=dict(storage_system=data_merged)
+        )
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES_500)
+    def test_should_remove_storage_system(self, resource, mock_ansible_module):
+        resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
 
-    StorageSystemModule().run()
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=True,
-        msg=StorageSystemModule.MSG_UPDATED,
-        ansible_facts=dict(storage_system=data_merged)
-    )
+        StorageSystemModule().run()
 
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=True,
+            msg=StorageSystemModule.MSG_DELETED
+        )
 
-def test_should_remove_storage_system(resource, mock_ansible_module):
-    resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+    def test_should_do_nothing_when_storage_system_not_exist(self, resource, mock_ansible_module):
+        resource.get_by_ip_hostname.return_value = []
 
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
+        mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
 
-    StorageSystemModule().run()
+        StorageSystemModule().run()
 
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=True,
-        msg=StorageSystemModule.MSG_DELETED
-    )
-
-
-def test_should_do_nothing_when_storage_system_not_exist(resource, mock_ansible_module):
-    resource.get_by_ip_hostname.return_value = []
-
-    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
-
-    StorageSystemModule().run()
-
-    mock_ansible_module.exit_json.assert_called_once_with(
-        changed=False,
-        msg=StorageSystemModule.MSG_ALREADY_ABSENT
-    )
-
+        mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            msg=StorageSystemModule.MSG_ALREADY_ABSENT
+        )
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_system.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import pytest
 import yaml
 
-from ansible.compat.tests import unittest, mock
+from ansible.compat.tests import mock
+from hpe_test_utils import mock_ov_client, mock_ansible_module
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_storage_system import StorageSystemModule
-from hpe_test_utils import OneViewBaseTestCase
 
 YAML_STORAGE_SYSTEM = """
         config: "{{ config }}"
@@ -101,193 +102,199 @@ DICT_DEFAULT_STORAGE_SYSTEM_500 = yaml.load(YAML_STORAGE_SYSTEM_500)["data"]
 del DICT_DEFAULT_STORAGE_SYSTEM_500['credentials']['password']
 
 
-class StorageSystemModuleSpec(unittest.TestCase,
-                              OneViewBaseTestCase):
-    def setUp(self):
-        self.configure_mocks(self, StorageSystemModule)
-        self.resource = self.mock_ov_client.storage_systems
-        self.mock_ov_client.api_version = 300
+@pytest.fixture
+def resource(mock_ov_client):
+    return mock_ov_client.storage_systems
 
-    def test_should_add_new_storage_system_with_credentials_from_api300(self):
-        self.resource.get_by_ip_hostname.return_value = None
-        self.resource.add.return_value = {"name": "name"}
-        self.resource.update.return_value = {"name": "name"}
 
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
+def test_should_add_new_storage_system_with_credentials_from_api300(resource, mock_ansible_module):
+    resource.get_by_ip_hostname.return_value = None
+    resource.add.return_value = {"name": "name"}
+    resource.update.return_value = {"name": "name"}
 
-        StorageSystemModule().run()
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
 
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=True,
-            msg=StorageSystemModule.MSG_ADDED,
-            ansible_facts=dict(storage_system={"name": "name"})
-        )
+    StorageSystemModule().run()
 
-    def test_should_add_new_storage_system_with_credentials_from_api500(self):
-        self.mock_ov_client.api_version = 500
-        self.resource.get_by_hostname.return_value = None
-        self.resource.add.return_value = {
-            "deviceSpecificAttributes": {
-                "discoveredPools": [
-                    {
-                        "name": "CPG_FC-AO",
-                        "uuid": "abc-123",
-                        "domain": "OtherDomain"
-                    },
-                    {
-                        "name": "CPG_FC-AO",
-                        "uuid": "def-456",
-                        "domain": "TestDomain"
-                    }
-                ]
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=True,
+        msg=StorageSystemModule.MSG_ADDED,
+        ansible_facts=dict(storage_system={"name": "name"})
+    )
+
+
+def test_should_add_new_storage_system_with_credentials_from_api500(resource, mock_ansible_module, mock_ov_client):
+    mock_ov_client.api_version = 500
+    resource.get_by_hostname.return_value = None
+    resource.add.return_value = {
+        "deviceSpecificAttributes": {
+            "discoveredPools": [
+                {
+                    "name": "CPG_FC-AO",
+                    "uuid": "abc-123",
+                    "domain": "OtherDomain"
+                },
+                {
+                    "name": "CPG_FC-AO",
+                    "uuid": "def-456",
+                    "domain": "TestDomain"
+                }
+            ]
+        }
+    }
+    resource.update.return_value = {"name": "name"}
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_500)
+
+    StorageSystemModule().run()
+
+    resource.add.assert_called_once_with(
+        {
+            'username': 'user',
+            'password': 'pass',
+            'hostname': '10.0.0.0',
+            'family': 'StoreServ'
+        }
+    )
+    resource.update.assert_called_with(
+        {
+            'credentials': {
+                'username': 'user'
+            },
+            'hostname': '10.0.0.0',
+            'family': 'StoreServ',
+            'deviceSpecificAttributes': {
+                'managedDomain': 'TestDomain',
+                'managedPools': [{
+                    'domain': 'TestDomain',
+                    'name': 'CPG_FC-AO',
+                    'deviceType': 'FC',
+                    'uuid': 'def-456'
+                }]
             }
         }
-        self.resource.update.return_value = {"name": "name"}
+    )
 
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_500)
-
-        StorageSystemModule().run()
-
-        self.resource.add.assert_called_once_with(
-            {
-                'username': 'user',
-                'password': 'pass',
-                'hostname': '10.0.0.0',
-                'family': 'StoreServ'
-            }
-        )
-        self.resource.update.assert_called_with(
-            {
-                'credentials': {
-                    'username': 'user'
-                },
-                'hostname': '10.0.0.0',
-                'family': 'StoreServ',
-                'deviceSpecificAttributes': {
-                    'managedDomain': 'TestDomain',
-                    'managedPools': [{
-                        'domain': 'TestDomain',
-                        'name': 'CPG_FC-AO',
-                        'deviceType': 'FC',
-                        'uuid': 'def-456'
-                    }]
-                }
-            }
-        )
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=True,
-            msg=StorageSystemModule.MSG_ADDED,
-            ansible_facts=dict(storage_system={"name": "name"})
-        )
-
-    def test_should_not_update_when_data_is_equals(self):
-        self.resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
-        self.resource.update.return_value = {"name": "name"}
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=False,
-            msg=StorageSystemModule.MSG_ALREADY_PRESENT,
-            ansible_facts=dict(storage_system=DICT_DEFAULT_STORAGE_SYSTEM)
-        )
-
-    def test_should_not_update_when_data_is_equals_using_name(self):
-        dict_by_name = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)["data"]
-
-        self.resource.get_by_name.return_value = dict_by_name
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=False,
-            msg=StorageSystemModule.MSG_ALREADY_PRESENT,
-            ansible_facts=dict(storage_system=dict_by_name.copy())
-        )
-
-    def test_should_fail_with_missing_required_attributes(self):
-        self.mock_ansible_module.params = {"state": "present",
-                                           "config": "config",
-                                           "data":
-                                               {"field": "invalid"}}
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_MANDATORY_FIELDS_MISSING)
-
-    def test_should_fail_when_credentials_attribute_is_missing(self):
-        self.resource.get_by_name.return_value = []
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_CREDENTIALS_MANDATORY)
-
-    def test_update_when_data_has_modified_attributes(self):
-        data_merged = DICT_DEFAULT_STORAGE_SYSTEM.copy()
-        data_merged['credentials']['newIp_hostname'] = '10.10.10.10'
-
-        self.resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
-        self.resource.update.return_value = data_merged
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=True,
-            msg=StorageSystemModule.MSG_UPDATED,
-            ansible_facts=dict(storage_system=data_merged)
-        )
-
-    def test_update_when_data_has_modified_attributes_when_api500(self):
-        self.mock_ov_client.api_version = 500
-        data_merged = DICT_DEFAULT_STORAGE_SYSTEM_500.copy()
-        data_merged['credentials']['newHostname'] = '10.10.10.10'
-
-        self.resource.get_by_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM_500
-        self.resource.update.return_value = data_merged
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES_500)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=True,
-            msg=StorageSystemModule.MSG_UPDATED,
-            ansible_facts=dict(storage_system=data_merged)
-        )
-
-    def test_should_remove_storage_system(self):
-        self.resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=True,
-            msg=StorageSystemModule.MSG_DELETED
-        )
-
-    def test_should_do_nothing_when_storage_system_not_exist(self):
-        self.resource.get_by_ip_hostname.return_value = []
-
-        self.mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
-
-        StorageSystemModule().run()
-
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=False,
-            msg=StorageSystemModule.MSG_ALREADY_ABSENT
-        )
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=True,
+        msg=StorageSystemModule.MSG_ADDED,
+        ansible_facts=dict(storage_system={"name": "name"})
+    )
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_should_not_update_when_data_is_equals(resource, mock_ansible_module):
+    resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+    resource.update.return_value = {"name": "name"}
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=False,
+        msg=StorageSystemModule.MSG_ALREADY_PRESENT,
+        ansible_facts=dict(storage_system=DICT_DEFAULT_STORAGE_SYSTEM)
+    )
+
+
+def test_should_not_update_when_data_is_equals_using_name(resource, mock_ansible_module):
+    dict_by_name = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)["data"]
+
+    resource.get_by_name.return_value = dict_by_name
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=False,
+        msg=StorageSystemModule.MSG_ALREADY_PRESENT,
+        ansible_facts=dict(storage_system=dict_by_name.copy())
+    )
+
+
+def test_should_fail_with_missing_required_attributes(resource, mock_ansible_module):
+    mock_ansible_module.params = {
+        'state': 'present',
+        'config': 'config',
+        'data': {
+            'field': 'invalid'
+        }
+    }
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_MANDATORY_FIELDS_MISSING)
+
+
+def test_should_fail_when_credentials_attribute_is_missing(resource, mock_ansible_module):
+    resource.get_by_name.return_value = []
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_BY_NAME)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.fail_json.assert_called_once_with(exception=mock.ANY, msg=StorageSystemModule.MSG_CREDENTIALS_MANDATORY)
+
+
+def test_update_when_data_has_modified_attributes(resource, mock_ansible_module):
+    data_merged = DICT_DEFAULT_STORAGE_SYSTEM.copy()
+    data_merged['credentials']['newIp_hostname'] = '10.10.10.10'
+
+    resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+    resource.update.return_value = data_merged
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=True,
+        msg=StorageSystemModule.MSG_UPDATED,
+        ansible_facts=dict(storage_system=data_merged)
+    )
+
+
+def test_update_when_data_has_modified_attributes_when_api500(resource, mock_ansible_module, mock_ov_client):
+    mock_ov_client.api_version = 500
+    data_merged = DICT_DEFAULT_STORAGE_SYSTEM_500.copy()
+    data_merged['credentials']['newHostname'] = '10.10.10.10'
+
+    resource.get_by_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM_500
+    resource.update.return_value = data_merged
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_CHANGES_500)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=True,
+        msg=StorageSystemModule.MSG_UPDATED,
+        ansible_facts=dict(storage_system=data_merged)
+    )
+
+
+def test_should_remove_storage_system(resource, mock_ansible_module):
+    resource.get_by_ip_hostname.return_value = DICT_DEFAULT_STORAGE_SYSTEM
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=True,
+        msg=StorageSystemModule.MSG_DELETED
+    )
+
+
+def test_should_do_nothing_when_storage_system_not_exist(resource, mock_ansible_module):
+    resource.get_by_ip_hostname.return_value = []
+
+    mock_ansible_module.params = yaml.load(YAML_STORAGE_SYSTEM_ABSENT)
+
+    StorageSystemModule().run()
+
+    mock_ansible_module.exit_json.assert_called_once_with(
+        changed=False,
+        msg=StorageSystemModule.MSG_ALREADY_ABSENT
+    )


### PR DESCRIPTION
##### SUMMARY
Added new oneview_storage_system module for managing [HPE OneView Storage Systems](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/storage-systems) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_storage_system`

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```

##### ADDITIONAL INFORMATION
Note: to run the example you need an Oneview Appliance.
Example of usage:
```yaml
- name: Add a Storage System with one managed pool (before API500)
  oneview_storage_system:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 300
    state: present
    data:
        credentials:
            ip_hostname: 172.18.11.12
            username: username
            password: password
        managedDomain: TestDomain
        managedPools:
          - domain: TestDomain
            type: StoragePoolV2
            name: CPG_FC-AO
            deviceType: FC

  delegate_to: localhost

- name: Add a StoreServ Storage System with one managed pool (API500 onwards)
  oneview_storage_system:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    state: present
    data:
      credentials:
          username: username
          password: password
      hostname: 172.18.11.12
      family: StoreServ
      deviceSpecificAttributes:
          managedDomain: TestDomain
          managedPools:
              - domain: TestDomain
                name: CPG_FC-AO
                deviceType: FC

  delegate_to: localhost

- name: Remove the storage system by its IP (before API500)
  oneview_storage_system:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 300
    state: absent
    data:
        credentials:
            ip_hostname: 172.18.11.12

  delegate_to: localhost

- name: Remove the storage system by its IP (API500 onwards)
  oneview_storage_system:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    state: absent
    data:
        credentials:
            hostname: 172.18.11.12

  delegate_to: localhost
```
