### PR TITLE
dont warn on not matching 'all'

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -806,3 +806,20 @@ class CLI(with_metaclass(ABCMeta, object)):
         variable_manager.options_vars = load_options_vars(options, CLI.version_info(gitinfo=False))
 
         return loader, inventory, variable_manager
+
+    @staticmethod
+    def get_host_list(inventory, subset, pattern='all'):
+
+        no_hosts = False
+        if len(inventory.list_hosts()) == 0:
+            # Empty inventory
+            display.warning("provided hosts list is empty, only localhost is available. Note that the implicit localhost does not match 'all'")
+            no_hosts = True
+
+        inventory.subset(subset)
+
+        hosts = inventory.list_hosts(pattern)
+        if len(hosts) == 0 and no_hosts is False:
+            raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
+
+        return hosts

--- a/lib/ansible/cli/adhoc.py
+++ b/lib/ansible/cli/adhoc.py
@@ -112,19 +112,13 @@ class AdHocCLI(CLI):
 
         loader, inventory, variable_manager = self._play_prereqs(self.options)
 
-        no_hosts = False
-        if len(inventory.list_hosts()) == 0:
-            # Empty inventory
-            display.warning("provided hosts list is empty, only localhost is available")
-            no_hosts = True
-
-        inventory.subset(self.options.subset)
-        hosts = inventory.list_hosts(pattern)
-        if len(hosts) == 0:
-            if no_hosts is False and self.options.subset:
-                # Invalid limit
-                raise AnsibleError("Specified --limit does not match any hosts")
+        try:
+            hosts = CLI.get_host_list(inventory, self.options.subset, pattern)
+        except AnsibleError:
+            if self.options.subset:
+                raise
             else:
+                hosts = []
                 display.warning("No hosts matched, nothing to do")
 
         if self.options.listhosts:

--- a/lib/ansible/cli/console.py
+++ b/lib/ansible/cli/console.py
@@ -426,16 +426,7 @@ class ConsoleCLI(CLI, cmd.Cmd):
                                                  ask_vault_pass=self.options.ask_vault_pass)
         self.loader.set_vault_secrets(vault_secrets)
 
-        no_hosts = False
-        if len(self.inventory.list_hosts()) == 0:
-            # Empty inventory
-            no_hosts = True
-            display.warning("provided hosts list is empty, only localhost is available")
-
-        self.inventory.subset(self.options.subset)
-        hosts = self.inventory.list_hosts(self.pattern)
-        if len(hosts) == 0 and not no_hosts:
-            raise AnsibleError("Specified hosts and/or --limit does not match any hosts")
+        hosts = CLI.get_host_list(self.inventory, self.options.subset, self.pattern)
 
         self.groups = self.inventory.list_groups()
         self.hosts = [x.name for x in hosts]

--- a/lib/ansible/cli/playbook.py
+++ b/lib/ansible/cli/playbook.py
@@ -109,15 +109,7 @@ class PlaybookCLI(CLI):
         # limit if only implicit localhost was in inventory to start with.
         #
         # Fix this when we rewrite inventory by making localhost a real host (and thus show up in list_hosts())
-        no_hosts = False
-        if len(inventory.list_hosts()) == 0:
-            # Empty inventory
-            display.warning("provided hosts list is empty, only localhost is available")
-            no_hosts = True
-        inventory.subset(self.options.subset)
-        if len(inventory.list_hosts()) == 0 and no_hosts is False:
-            # Invalid limit
-            raise AnsibleError("Specified --limit does not match any hosts")
+        hosts = CLI.get_host_list(inventory, self.options.subset)
 
         # flush fact cache if requested
         if self.options.flush_cache:

--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -538,7 +538,7 @@ class InventoryManager(object):
             if implicit:
                 results.append(implicit)
 
-        if not results:
+        if not results and pattern != 'all':
             display.warning("Could not match supplied host pattern, ignoring: %s" % pattern)
         return results
 


### PR DESCRIPTION
##### SUMMARY

the implicit localhost warning shoudl be enough


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
