### PR TITLE
Unixy stdout callback: Display name of play and list of play hosts

### DIFF
--- a/lib/ansible/plugins/callback/unixy.py
+++ b/lib/ansible/plugins/callback/unixy.py
@@ -95,11 +95,9 @@ class CallbackModule(CallbackBase):
             self._display.display("%s (via handler)... " % self.task_display_name)
 
     def v2_playbook_on_play_start(self, play):
-        # TODO display name of play and list of play hosts
-        # TODO don't display play name if no hosts in play
         name = play.get_name().strip()
-        if name:
-            msg = u"\n- %s -" % name
+        if name and play.hosts:
+            msg = u"\n- %s on hosts: %s -" % (name, ",".join(play.hosts))
         else:
             msg = u"---"
 


### PR DESCRIPTION
Don't display play name if no hosts in play

##### SUMMARY
Adds some logic to the unixy callback plugin's `v2_playbook_on_play_start` method to display the list of play hosts along with the play name, only when there are hosts in the play

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/callback/unixy.py 

##### ANSIBLE VERSION

```
ansible 2.5.0 (unixy-playname 1a2e619730) last updated 2017/11/10 16:02:40 (GMT -500)
  config file = /home/jb/src/ansible/ansible.cfg
  configured module search path = [u'/home/jb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jb/src/ansible/lib/ansible
  executable location = /home/jb/src/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
The suggestion was "don't display play name if no hosts in play", which I took to mean the `hosts` variable in the play definition. We could possibly use the computed list of hosts (`PlaybookExecutor._get_serialized_batches`) in this logic but it would require changing the method signature (optional arg?) of `v2_playbook_on_play_start`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
### Before ###
- myplay -
Gathering Facts...
  localhost ok
say hello...
  localhost done | stdout: hello

- Play recap -
  localhost                  : ok=2    changed=1    unreachable=0    failed=0

### After ###
- myplay on hosts: all -
Gathering Facts...
  localhost ok
say hello...
  localhost done | stdout: hello

- Play recap -
  localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
