### PR TITLE
ec2_key: fix fingerprint generation in tests

### DIFF
--- a/test/integration/targets/ec2_key/tasks/main.yml
+++ b/test/integration/targets/ec2_key/tasks/main.yml
@@ -219,8 +219,7 @@
            - 'result.key.name == "{{ec2_key_name}}"'
            - '"fingerprint" in result.key'
            - '"private_key" not in result.key'
-           # FIXME - why don't the fingerprints match?
-           # - 'result.key.fingerprint == "{{fingerprint}}"'
+           - 'result.key.fingerprint == "{{fingerprint}}"'
 
     # ============================================================
     - name: test state=absent with key_material
@@ -267,8 +266,7 @@
            - 'result.results[0].key.name == "{{ec2_key_name}}"'
            - '"fingerprint" in result.results[0].key'
            - '"private_key" not in result.results[0].key'
-           # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
-           # - 'result.key.fingerprint == "{{fingerprint}}"'
+           - 'result.results[0].key.fingerprint == "{{fingerprint}}"'
 
     # ============================================================
     - name: test state=present with key_material with_files (expect changed=false)
@@ -296,8 +294,7 @@
            - 'result.results[0].key.name == "{{ec2_key_name}}"'
            - '"fingerprint" in result.results[0].key'
            - '"private_key" not in result.results[0].key'
-           # FIXME - why doesn't result.key.fingerprint == {{fingerprint}}
-           # - 'result.key.fingerprint == "{{fingerprint}}"'
+           - 'result.results[0].key.fingerprint == "{{fingerprint}}"'
 
     # ============================================================
     - name: test state=absent with key_material (expect changed=true)

--- a/test/integration/targets/setup_sshkey/tasks/main.yml
+++ b/test/integration/targets/setup_sshkey/tasks/main.yml
@@ -33,7 +33,7 @@
     - prepare
 
 - name: record fingerprint
-  shell: ssh-keygen -lf {{sshkey.stdout}}.pub
+  shell: openssl rsa -in {{sshkey.stdout}} -pubout -outform DER 2>/dev/null | openssl md5 -c
   register: fingerprint
   tags:
     - prepare


### PR DESCRIPTION
##### SUMMARY
Fix the way the fingerprint of the keypair is generated and enable checks verifying the fingerprint.

AWS generates the fingerprint of a keypair created using third-party tools differently, as mentioned in their docs -

> If you created your key pair using a third-party tool and uploaded the public key to AWS, you can use the OpenSSL tools to generate a fingerprint from the private key file on your local machine:

`$ openssl rsa -in path_to_private_key -pubout -outform DER | openssl md5 -c`

>The output should match the fingerprint that's displayed in the console.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
`ec2_key`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
```
