### PR TITLE
modules/notification/email: Add encryption support

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -288,7 +288,7 @@ def main():
 
         # TODO: Implement proper PGP/MIME
         if attach_files:
-            module.fail_json(rc=1, msg='OpenPGP encryption does not yet support attachments')
+            module.fail_json(msg='OpenPGP encryption does not yet support attachments')
 
         gpg = gnupg.GPG()
         gpg.encoding = charset

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -119,12 +119,14 @@ options:
   gnupg:
     choices: [ true, false ]
     description:
-      - Use OpenPGP encryption for the mail; incompatible with attach.
-      - Defaults to C(false), unless gnupg_recipients is set.
+      - Use OpenPGP encryption for the mail; incompatible with I(attach).
+      - Defaults to C(false), unless I(gnupg_recipients) is set.
+    version_added: '2.5'
   gnupg_recipients:
     default: []
     description:
       - A list of OpenPGP key fingerprints to encrypt the mail to.
+    version_added: '2.5'
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -117,7 +117,8 @@ options:
     default: 20
     version_added: '2.3'
   pgp:
-    choices: [ true, false ]
+    type: bool
+    default: no
     description:
       - Use OpenPGP encryption for the mail; incompatible with I(attach).
       - Defaults to C(false), unless I(pgp_recipients) is set.

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -281,6 +281,10 @@ def main():
         except ImportError:
             module.fail_json(rc=1, msg='OpenPGP encryption requires python-gnupg')
 
+        # TODO: Implement proper PGP/MIME
+        if attach_files:
+            module.fail_json(rc=1, msg='OpenPGP encryption does not yet support attachments')
+
         gpg = gnupg.GPG()
         gpg.encoding = charset
 
@@ -289,10 +293,6 @@ def main():
             module.fail_json(rc=1, msg='OpenPGP encryption failure: %s' % encrypted.status)
 
         body = str(encrypted)
-
-        # TODO: Implement proper PGP/MIME
-        if attach_files:
-            module.fail_json(rc=1, msg='OpenPGP encryption does not yet support attachments')
 
     smtp = smtplib.SMTP(timeout=timeout)
 

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -225,9 +225,9 @@ from ansible.module_utils._text import to_native
 
 try:
     import gnupg
-    HAS_GNUPG=True
+    HAS_GNUPG = True
 except ImportError:
-    HAS_GNUPG=False
+    HAS_GNUPG = False
 
 
 def pgp_fingerprint(s):

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -276,7 +276,11 @@ def main():
         body = subject
 
     if pgp:
-        import gnupg
+        try:
+            import gnupg
+        except ImportError:
+            module.fail_json(rc=1, msg='OpenPGP encryption requires python-gnupg')
+
         gpg = gnupg.GPG()
         gpg.encoding = charset
 

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -288,7 +288,11 @@ def main():
         gpg = gnupg.GPG()
         gpg.encoding = charset
 
-        encrypted = gpg.encrypt(body, pgp_recipients or recipients)
+        if pgp_recipients:
+            encrypted = gpg.encrypt(body, pgp_recipients, always_trust=True)
+        else:
+            encrypted = gpg.encrypt(body, recipients)
+
         if not encrypted:
             module.fail_json(rc=1, msg='OpenPGP encryption failure: %s' % encrypted.status)
 

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -116,13 +116,13 @@ options:
     - Sets the timeout in seconds for connection attempts.
     default: 20
     version_added: '2.3'
-  gnupg:
+  pgp:
     choices: [ true, false ]
     description:
       - Use OpenPGP encryption for the mail; incompatible with I(attach).
-      - Defaults to C(false), unless I(gnupg_recipients) is set.
+      - Defaults to C(false), unless I(pgp_recipients) is set.
     version_added: '2.5'
-  gnupg_recipients:
+  pgp_recipients:
     default: []
     description:
       - A list of OpenPGP key fingerprints to encrypt the mail to.
@@ -228,8 +228,8 @@ def main():
             subtype=dict(type='str', default='plain', choices=['html', 'plain']),
             secure=dict(type='str', default='try', choices=['always', 'never', 'starttls', 'try']),
             timeout=dict(type='int', default=20),
-            gnupg=dict(type='bool', default=False),
-            gnupg_recipients=dict(type='list', default=[])
+            pgp=dict(type='bool', default=False),
+            pgp_recipients=dict(type='list', default=[])
         ),
         required_together=[['password', 'username']],
     )
@@ -255,26 +255,26 @@ def main():
     secure_state = False
     sender_phrase, sender_addr = parseaddr(sender)
 
-    gnupg_recipients = module.params.get('gnupg_recipients')
-    gnupg = gnupg_recipients or module.params.get('gnupg')
+    pgp_recipients = module.params.get('pgp_recipients')
+    pgp = pgp_recipients or module.params.get('pgp')
 
     if not body:
         body = subject
 
-    if gnupg:
+    if pgp:
         import gnupg
         gpg = gnupg.GPG()
         gpg.encoding = charset
 
-        # TODO: Implement proper PGP/MIME
-        encrypted = gpg.encrypt(body, gnupg_recipients or recipients)
+        encrypted = gpg.encrypt(body, pgp_recipients or recipients)
         if not encrypted:
-            module.fail_json(rc=1, msg='GnuPG encryption failure: %s' % encrypted.status)
+            module.fail_json(rc=1, msg='OpenPGP encryption failure: %s' % encrypted.status)
 
         body = str(encrypted)
 
+        # TODO: Implement proper PGP/MIME
         if attach_files:
-            module.fail_json(rc=1, msg='GnuPG-encryption does not yet support attachments')
+            module.fail_json(rc=1, msg='OpenPGP encryption does not yet support attachments')
 
     smtp = smtplib.SMTP(timeout=timeout)
 

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -222,6 +222,12 @@ from email.header import Header
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 
+try:
+    import gnupg
+    HAS_GNUPG=True
+except ImportError:
+    HAS_GNUPG=False
+
 
 def main():
 
@@ -277,10 +283,8 @@ def main():
         body = subject
 
     if pgp:
-        try:
-            import gnupg
-        except ImportError:
-            module.fail_json(rc=1, msg='OpenPGP encryption requires python-gnupg')
+        if not HAS_GNUPG:
+            module.fail_json(msg='OpenPGP encryption requires python-gnupg')
 
         # TODO: Implement proper PGP/MIME
         if attach_files:

--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -146,6 +146,20 @@ EXAMPLES = r'''
     body: System {{ ansible_hostname }} has been successfully provisioned.
   delegate_to: localhost
 
+- name: Send an encrypted email to a bunch of users
+  mail:
+    to:
+      - jane@example.net
+      - j.d@example.doe
+    subject: Test secret
+    pgp: True
+
+- name: Send an encrypted email to a user, pinning the OpenPGP key
+  mail:
+    to: test@example.org
+    subject: Very secret secret
+    pgp_recipients: [ '0x772B11B4F2DC80E1212B3F41B0739AAD91B7CDC0' ]
+
 - name: Send e-mail to a bunch of users, attaching files
   mail:
     host: 127.0.0.1


### PR DESCRIPTION
##### SUMMARY
Allow sending OpenPGP-encrypted emails from Ansible.

This is useful when, for instance, setting randomly-generated passwords for newly-created users: the password can be sent to the user by encrypted email, rather than using a fixed password or sending it in plaintext.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
notification/mail

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/nbraud/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 17 2017, 18:50:44) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION

Tested using a [simple playbook](https://gist.github.com/nbraud/1fed127ad6c46e34905d1212e8218839).  (You will need to edit it, as the mail server, username and command for acquiring the password will be different.)

This does not include unit tests, as there is no infrastructure in place for testing the mail module (and doing so is way outside the scope of this PR).