### PR TITLE
allow smartos vmadm to create docker vms

### DIFF
--- a/lib/ansible/modules/cloud/smartos/vmadm.py
+++ b/lib/ansible/modules/cloud/smartos/vmadm.py
@@ -78,6 +78,11 @@ options:
     required: false
     description:
       - Domain value for C(/etc/hosts).
+  docker:
+    required: false
+    description:
+      - Docker images need this flag enabled along with the I(brand) set to C(lx).
+    version_added: "2.5"
   filesystems:
       required: false
       description:
@@ -607,7 +612,7 @@ def main():
         ],
         'bool': [
             'archive_on_delete', 'autoboot', 'debug', 'delegate_dataset',
-            'firewall_enabled', 'force', 'indestructible_delegated',
+            'docker', 'firewall_enabled', 'force', 'indestructible_delegated',
             'indestructible_zoneroot', 'maintain_resolvers', 'nowait'
         ],
         'int': [


### PR DESCRIPTION
##### SUMMARY
vmadm allows creating vms with docker images. the current vmadm.py will fail saying that docker in not an allowed option

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/smartos/vmadm.py

##### ANSIBLE VERSION
ansible 2.4.1.0
devel
