### PR TITLE
Fix typo in documentation

### DIFF
--- a/lib/ansible/plugins/lookup/password.py
+++ b/lib/ansible/plugins/lookup/password.py
@@ -48,7 +48,7 @@ DOCUMENTATION = """
     notes:
       - A great alternative to the password lookup plugin,
         if you don't need to generate random passwords on a per-host basis,
-        would be to use Using Vault in playbooks.
+        would be to use Vault in playbooks.
         Read the documentation there and consider using it first,
         it will be more desirable for most applications.
       - If the file already exists, no data will be written to it.


### PR DESCRIPTION
##### SUMMARY
Fixed a typo for the documentation in 'lookup password' plugin

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
password.py

##### ANSIBLE VERSION
```
2.4.1.0
```


##### ADDITIONAL INFORMATION

