### PR TITLE
shuts down persistent connections at end of play run

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -51,6 +51,8 @@ class ConnectionProcess(object):
         self.srv = JsonRpcServer()
         self.sock = None
 
+        self.connection = None
+
     def start(self):
         try:
             messages = list()
@@ -67,6 +69,7 @@ class ConnectionProcess(object):
             self.connection = connection_loader.get(self.play_context.connection, self.play_context, '/dev/null')
             self.connection.set_options()
             self.connection._connect()
+            self.connection._socket_path = self.socket_path
             self.srv.register(self.connection)
             messages.append('connection to remote device started successfully')
 
@@ -84,7 +87,7 @@ class ConnectionProcess(object):
 
     def run(self):
         try:
-            while True:
+            while self.connection.connected:
                 signal.signal(signal.SIGALRM, self.connect_timeout)
                 signal.signal(signal.SIGTERM, self.handler)
                 signal.alarm(C.PERSISTENT_CONNECT_TIMEOUT)
@@ -135,24 +138,19 @@ class ConnectionProcess(object):
     def shutdown(self):
         """ Shuts down the local domain socket
         """
-        if not os.path.exists(self.socket_path):
-            return
-
-        try:
-            if self.sock:
-                self.sock.close()
-            if self.connection:
-                self.connection.close()
-
-        except Exception:
-            pass
-
-        finally:
-            if os.path.exists(self.socket_path):
-                os.remove(self.socket_path)
-                setattr(self.connection, '_socket_path', None)
-                setattr(self.connection, '_connected', False)
-
+        if os.path.exists(self.socket_path):
+            try:
+                if self.sock:
+                    self.sock.close()
+                if self.connection:
+                    self.connection.close()
+            except:
+                pass
+            finally:
+                if os.path.exists(self.socket_path):
+                    os.remove(self.socket_path)
+                    setattr(self.connection, '_socket_path', None)
+                    setattr(self.connection, '_connected', False)
         display.display('shutdown complete', log_only=True)
 
     def do_EXEC(self, data):

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -209,6 +209,15 @@ class Connection(ConnectionBase):
 
         return 0, to_bytes(self._manager.session_id, errors='surrogate_or_strict'), b''
 
+    def reset(self):
+        '''
+        Reset the connection
+        '''
+        if self._socket_path:
+            display.vvvv('resetting persistent connection for socket_path %s' % self._socket_path, host=self._play_context.remote_addr)
+            self.close()
+        display.vvvv('reset call on connection instance', host=self._play_context.remote_addr)
+
     def close(self):
         if self._manager:
             self._manager.close_session()

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -231,7 +231,8 @@ class Connection(ConnectionBase):
         '''
         if self._socket_path:
             display.vvvv('resetting persistent connection for socket_path %s' % self._socket_path, host=self._play_context.remote_addr)
-            self.shutdown()
+            self.close()
+        display.vvvv('reset call on connection instance', host=self._play_context.remote_addr)
 
     def close(self):
         '''

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -175,6 +175,8 @@ class StrategyModule(StrategyBase):
             results = self._process_pending_results(iterator)
             host_results.extend(results)
 
+            self.update_active_connections(results)
+
             try:
                 included_files = IncludedFile.process_include_results(
                     host_results,

--- a/lib/ansible/plugins/strategy/linear.py
+++ b/lib/ansible/plugins/strategy/linear.py
@@ -292,6 +292,8 @@ class StrategyModule(StrategyBase):
 
                 host_results.extend(results)
 
+                self.update_active_connections(results)
+
                 try:
                     included_files = IncludedFile.process_include_results(
                         host_results,

--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -44,15 +44,10 @@ class JsonRpcServer(object):
             kwargs = params
 
         rpc_method = None
-
-        if method in ('shutdown', 'reset'):
-            rpc_method = getattr(self, 'shutdown')
-
-        else:
-            for obj in self._objects:
-                rpc_method = getattr(obj, method, None)
-                if rpc_method:
-                    break
+        for obj in self._objects:
+            rpc_method = getattr(obj, method, None)
+            if rpc_method:
+                break
 
         if not rpc_method:
             error = self.method_not_found()


### PR DESCRIPTION
This change will now track any created persistent connection and shut it
down at the end of the play run.  This change also includes an update to
properly honor the reset_connection meta handler.

