### PR TITLE
add pkcs11 support to Ansible ssh connection module

### DIFF
--- a/changelogs/fragments/32829-ssh-connection-module-add-pkcs11-support.yml
+++ b/changelogs/fragments/32829-ssh-connection-module-add-pkcs11-support.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - ssh - added pkcs11 support by using the pkcs11_provider option in the
+  - ssh - added pkcs11 support by adding the pkcs11_provider option in the
     ssh connection module. (https://www.github.com/ansible/ansible/pull/32829)

--- a/changelogs/fragments/32829-ssh-connection-module-add-pkcs11-support.yml
+++ b/changelogs/fragments/32829-ssh-connection-module-add-pkcs11-support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ssh - added pkcs11 support by using the pkcs11_provider option in the
+    ssh connection module. (https://www.github.com/ansible/ansible/pull/32829)

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -644,7 +644,7 @@ class Connection(ConnectionBase):
                           b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict'),
                           b'-P',
                           b'Enter PIN for ']
-        elif conn_password and len(pkcs11_provider) > 0:
+        elif not conn_password and pkcs11_provider:
             raise AnsibleError("To use pkcs11_provider you must specify a password/pin")
         elif conn_password:
             self.sshpass_pipe = os.pipe()

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -323,7 +323,7 @@ DOCUMENTATION = '''
           - name: timeout
         type: integer
       pkcs11_provider:
-        version_added: '2.7'
+        version_added: '2.12'
         default: ""
         description:
           - "PKCS11 SmartCard provider such as opensc, example: /usr/local/lib/opensc-pkcs11.so"

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -634,7 +634,7 @@ class Connection(ConnectionBase):
         # If we want to use password authentication, we have to set up a pipe to
         # write the password to sshpass.
         pkcs11_provider = self.get_option("pkcs11_provider")
-        if conn_password or len(pkcs11_provider) >= 1:
+        if conn_password or pkcs11_provider:
             if not self._sshpass_available():
                 raise AnsibleError("to use the 'ssh' connection type with passwords or pkcs11_provider, you must install the sshpass program")
 

--- a/lib/ansible/plugins/connection/ssh.py
+++ b/lib/ansible/plugins/connection/ssh.py
@@ -638,7 +638,7 @@ class Connection(ConnectionBase):
             if not self._sshpass_available():
                 raise AnsibleError("to use the 'ssh' connection type with passwords or pkcs11_provider, you must install the sshpass program")
 
-        if conn_password and len(pkcs11_provider) >= 1:
+        if conn_password and pkcs11_provider:
             self.sshpass_pipe = os.pipe()
             b_command += [b'sshpass',
                           b'-d' + to_bytes(self.sshpass_pipe[0], nonstring='simplerepr', errors='surrogate_or_strict'),
@@ -661,7 +661,7 @@ class Connection(ConnectionBase):
         #
 
         # pkcs11 mode allows the use of Smartcards or Yubikey devices
-        if conn_password and len(pkcs11_provider) > 0:
+        if conn_password and pkcs11_provider:
             self._add_args(b_command,
                            (b"-o", b"KbdInteractiveAuthentication=no",
                             b"-o", b"PreferredAuthentications=publickey",

--- a/test/units/plugins/connection/test_ssh.py
+++ b/test/units/plugins/connection/test_ssh.py
@@ -80,6 +80,8 @@ class TestConnectionBaseClass(unittest.TestCase):
         pc = PlayContext()
         new_stdin = StringIO()
         conn = connection_loader.get('ssh', pc, new_stdin)
+        conn.get_option = MagicMock()
+        conn.get_option.return_value = ""
         conn._build_command('ssh', 'ssh')
 
     def test_plugins_connection_ssh_exec_command(self):


### PR DESCRIPTION
##### SUMMARY
Ansible does not currently support PKCS#11 (PIV, CAC, smartcard) authentication.  With a simple modification to the ssh connection plugin, you can easily add support for PKCS#11.  Paramiko is in the process of adding PKCS11 support, after the support is added in the next stable release of Paramiko then its also possible to add PKCS11 support for the Ansible+Paramiko combination.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ssh connection plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.11.0.dev0
  config file = None
  configured module search path = ['/Users/dwhitesi/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.9/site-packages/ansible_core-2.11.0.dev0-py3.9.egg/ansible
  ansible collection location = /Users/dwhitesi/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.9.2 (default, Feb 19 2021, 17:09:53) [Clang 12.0.0 (clang-1200.0.32.29)]
  jinja version = 3.0.0a1
  libyaml = True
```


##### USAGE
```
$ export ANSIBLE_PKCS11_PROVIDER=/usr/local/lib/opensc-pkcs11.so
$ ansible-playbook -u USERNAME -b -k -K PLAYBOOK.yml --connection=ssh
SSH password: << Enter your PKCS11 Pin for your smartcard
SUDO password[defaults to SSH password]: << Enter your user account password for sudo
```

I use https://github.com/OpenSC/OpenSC for the middleware, this is the pkcs11-provider library that you point Ansible to with the pkcs11_provider ini setting or ANSIBLE_PKCS11_PROVIDER env variable.

I tested with a smartcard, a very common device you might use with Ansible pkcs11 would be a Yubikey device (https://www.yubico.com/product/yubikey-neo).

- David
