### PR TITLE
Add additional mapping attributes for VM/Template registration

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -42,9 +42,10 @@ options:
             - "Name of the storage domain to manage. (Not required when state is I(imported))"
     state:
         description:
-            - "Should the storage domain be present/absent/maintenance/unattached/imported"
+            - "Should the storage domain be present/absent/maintenance/unattached/imported/update_ovf_store"
             - "I(imported) is supported since version 2.4."
-        choices: ['present', 'absent', 'maintenance', 'unattached']
+            - "I(update_ovf_store) is supported since version 2.5, currently if C(wait) is (true), we don't wait for update."
+        choices: ['present', 'absent', 'maintenance', 'unattached', 'update_ovf_store']
         default: present
     description:
         description:
@@ -194,6 +195,11 @@ EXAMPLES = '''
     nfs:
       address: 10.34.63.199
       path: /path/export
+
+# Update OVF_STORE:
+- ovirt_storage_domains:
+    state: update_ovf_store
+    name: domain
 
 # Create ISO NFS storage domain
 - ovirt_storage_domains:
@@ -478,7 +484,7 @@ def control_state(sd_module):
 def main():
     argument_spec = ovirt_full_argument_spec(
         state=dict(
-            choices=['present', 'absent', 'maintenance', 'unattached', 'imported'],
+            choices=['present', 'absent', 'maintenance', 'unattached', 'imported', 'update_ovf_store'],
             default='present',
         ),
         id=dict(default=None),
@@ -551,7 +557,10 @@ def main():
                 storage_domain=storage_domains_service.service(ret['id']).get()
             )
             ret['changed'] = storage_domains_module.changed
-
+        elif state == 'update_ovf_store':
+            ret = storage_domains_module.action(
+                action='update_ovf_store'
+            )
         module.exit_json(**ret)
     except Exception as e:
         module.fail_json(msg=str(e), exception=traceback.format_exc())

--- a/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_templates.py
@@ -72,6 +72,30 @@ options:
             - "C(source_profile_name): The prfile name related to the source network."
             - "C(target_profile_id): The id of the target profile id to be mapped to in the engine."
         version_added: "2.5"
+    cluster_mappings:
+        description:
+            - "Mapper which maps cluster name between Template's OVF and the destination cluster this Template should be registered to,
+               relevant when C(state) is registered.
+               Cluster mapping is described by the following dictionary:"
+            - "C(source_name): The name of the source cluster."
+            - "C(dest_name): The name of the destination cluster."
+        version_added: "2.5"
+    role_mappings:
+        description:
+            - "Mapper which maps role name between Template's OVF and the destination role this Template should be registered to,
+               relevant when C(state) is registered.
+               Role mapping is described by the following dictionary:"
+            - "C(source_name): The name of the source role."
+            - "C(dest_name): The name of the destination role."
+        version_added: "2.5"
+    domain_mappings:
+        description:
+            - "Mapper which maps aaa domain name between Template's OVF and the destination aaa domain this Template should be registered to,
+               relevant when C(state) is registered.
+               The aaa domain mapping is described by the following dictionary:"
+            - "C(source_name): The name of the source aaa domain."
+            - "C(dest_name): The name of the destination aaa domain."
+        version_added: "2.5"
     exclusive:
         description:
             - "When C(state) is I(exported) this parameter indicates if the existing templates with the
@@ -176,6 +200,22 @@ EXAMPLES = '''
         source_profile_name: mynetwork2
         target_profile_id: 4444-4444-4444-4444
 
+# Register template with mapping
+- ovirt_templates:
+    state: registered
+    storage_domain: mystorage
+    cluster: mycluster
+    id: 1111-1111-1111-1111
+    role_mappings:
+      - source_name: Role_A
+        dest_name: Role_B
+    domain_mappings:
+      - source_name: Domain_A
+        dest_name: Domain_B
+    cluster_mappings:
+      - source_name: cluster_A
+        dest_name: cluster_B
+
 # Import image from Glance s a template
 - ovirt_templates:
     state: imported
@@ -267,6 +307,58 @@ class TemplatesModule(BaseModule):
     def post_import_action(self, entity):
         self._service = self._connection.system_service().templates_service()
 
+
+def _get_role_mappings(module):
+    roleMappings = list()
+
+    for roleMapping in module.params['role_mappings']:
+        roleMappings.append(
+            otypes.RegistrationRoleMapping(
+                from_=otypes.Role(
+                    name=roleMapping['source_name'],
+                ) if roleMapping['source_name'] else None,
+                to=otypes.Role(
+                    name=roleMapping['dest_name'],
+                ) if roleMapping['dest_name'] else None,
+            )
+        )
+    return roleMappings
+
+
+def _get_domain_mappings(module):
+    domainMappings = list()
+
+    for domainMapping in module.params['domain_mappings']:
+        domainMappings.append(
+            otypes.RegistrationDomainMapping(
+                from_=otypes.Domain(
+                    name=domainMapping['source_name'],
+                ) if domainMapping['source_name'] else None,
+                to=otypes.Domain(
+                    name=domainMapping['dest_name'],
+                ) if domainMapping['dest_name'] else None,
+            )
+        )
+    return domainMappings
+
+
+def _get_cluster_mappings(module):
+    clusterMappings = list()
+
+    for clusterMapping in module.params['cluster_mappings']:
+        clusterMappings.append(
+            otypes.RegistrationClusterMapping(
+                from_=otypes.Cluster(
+                    name=clusterMapping['source_name'],
+                ),
+                to=otypes.Cluster(
+                    name=clusterMapping['dest_name'],
+                ),
+            )
+        )
+    return clusterMappings
+
+
 def _get_vnic_profile_mappings(module):
     vnicProfileMappings = list()
 
@@ -282,6 +374,7 @@ def _get_vnic_profile_mappings(module):
         )
 
     return vnicProfileMappings
+
 
 def main():
     argument_spec = ovirt_full_argument_spec(
@@ -306,6 +399,9 @@ def main():
         template_image_disk_name=dict(default=None),
         seal=dict(type='bool'),
         vnic_profile_mappings=dict(default=[], type='list'),
+        cluster_mappings=dict(default=[], type='list'),
+        role_mappings=dict(default=[], type='list'),
+        domain_mappings=dict(default=[], type='list'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -428,7 +524,14 @@ def main():
                         name=module.params['cluster']
                     ) if module.params['cluster'] else None,
                     vnic_profile_mappings=_get_vnic_profile_mappings(module)
-                    if module.params['vnic_profile_mappings'] else None
+                    if module.params['vnic_profile_mappings'] else None,
+                    registration_configuration=otypes.RegistrationConfiguration(
+                        cluster_mappings=_get_cluster_mappings(module),
+                        role_mappings=_get_role_mappings(module),
+                        domain_mappings=_get_domain_mappings(module),
+                    ) if (module.params['cluster_mappings']
+                          or module.params['role_mappings']
+                          or module.params['domain_mappings']) else None
                 )
 
                 if module.params['wait']:

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -55,6 +55,10 @@ options:
             - "C(source_profile_name): The prfile name related to the source network."
             - "C(target_profile_id): The id of the target profile id to be mapped to in the engine."
         version_added: "2.5"
+    reassign_bad_macs:
+        description:
+            - "Boolean indication whether to reassign bad macs when C(state) is registered."
+        version_added: "2.5"
     template:
         description:
             - Name of the template, which should be used to create Virtual Machine.
@@ -427,7 +431,7 @@ EXAMPLES = '''
     cluster: mycluster
     id: 1111-1111-1111-1111
 
-- name: Register VM with vnic profile mappings
+- name: Register VM with vnic profile mappings and reassign bad macs
   ovirt_vms:
     state: registered
     storage_domain: mystorage
@@ -1225,6 +1229,7 @@ def main():
         cd_iso=dict(type='str'),
         boot_devices=dict(type='list'),
         vnic_profile_mappings=dict(default=[], type='list'),
+        reassign_bad_macs=dict(default=None, type='bool'),
         high_availability=dict(type='bool'),
         lease=dict(type='str'),
         stateless=dict(type='bool'),
@@ -1412,7 +1417,9 @@ def main():
                         name=module.params['cluster']
                     ) if module.params['cluster'] else None,
                     vnic_profile_mappings=_get_vnic_profile_mappings(module)
-                    if module.params['vnic_profile_mappings'] else None
+                    if module.params['vnic_profile_mappings'] else None,
+                    reassign_bad_macs=module.params['reassign_bad_macs']
+                    if module.params['reassign_bad_macs'] is not None else None
                 )
 
                 if module.params['wait']:


### PR DESCRIPTION
SUMMARY

Add additional mapping attributes for VM/Template registration

ISSUE TYPE

Feature Pull Request
COMPONENT NAME

lib/ansible/modules/cloud/ovirt/ovirt_templates.py
lib/ansible/modules/cloud/ovirt/ovirt_vms.py

ANSIBLE VERSION

ansible 2.4.0
ADDITIONAL INFORMATION

Add additional mappings params for entity registration

As part of the effort to support DR with oVirt
the "Register" operation is being added with a new mapping parameter
that describes the configuration of the registration.

The idea of supporting DR site to site in oVirt is to have 2 active
setups using storage replication between the primary setup and the
secondary setup.
Both setups will have active DCs, clusters, and hosts, although those
will not be identical.
The user can define a mapping which will be used to recover its setup.

Each mapping can be used to map any entity's attribute stored in the OVF
with its correlated entity.
For example, there could be a primary setup with an entity configured on cluster A.
We also keep an active secondary setup which only have cluster B.
Cluster B is compatible for that entity and in case of a DR scenario theoretically
the storage domain can be imported to the secondary setup and the use can
register the entity to cluster B.

In that case, we can automate the recovery process by defining a cluster mapping,
so once the entity will be registered its OVF will indicate it belongs to
cluster A but the mapping which will be sent will indicate that cluster B should
be valid for every thing that is configured on cluster A.
The engine should do the switch, and register the entity to cluster B in the
secondary site.

Cluster mapping is just one example.
The following list describes the different mappings which were
introduced:
LUN mapping
Role mapping
Permissions mapping
Affinity group mapping
Affinity label mapping

Each mapping will be used for its specific OVF's data once the register operation
will take place in the engine.