### PR TITLE
Fix idempotency issue for network modules.

### DIFF
--- a/lib/ansible/utils/jsonrpc.py
+++ b/lib/ansible/utils/jsonrpc.py
@@ -83,7 +83,7 @@ class JsonRpcServer(object):
 
     def response(self, result=None):
         response = self.header()
-        response['result'] = result or 'ok'
+        response['result'] = result
         return response
 
     def error(self, code, message, data=None):


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #32837 

After the connection refactor if response value returned from
the remote device is empty in that case an `ok` return value is sent
to module side code. To avoid this do not overwrite the empty response
received from the remote device in `jsonrpc` reply.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_*
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
