### PR TITLE
Change default host_filter to gueststate

### DIFF
--- a/contrib/inventory/vmware_inventory.ini
+++ b/contrib/inventory/vmware_inventory.ini
@@ -67,8 +67,12 @@ password=vmware
 #   host_filters={{ config.guestid == 'rhel7_64Guest' }}
 #   host_filters={{ config.cpuhotremoveenabled != False }},{{ runtime.maxmemoryusage >= 512 }}
 #   host_filters={{ config.cpuhotremoveenabled != False }},{{ runtime.maxmemoryusage >= 512 }}
-# The default is only gueststate of 'running'
-#host_filters={{ guest.gueststate == "running" }}
+#   host_filters={{ runtime.powerstate == "poweredOn" }}
+#   host_filters={{ guest.gueststate == "notRunning" }}
+# The default value is powerstate of virtual machine equal to "poweredOn". (Changed in version 2.5)
+# Runtime state does not require to have vmware tools installed as compared to "guest.gueststate"
+#host_filters={{ runtime.powerstate == "poweredOn" }}
+
 
 
 # Groupby patterns enable the user to create groups via any possible jinja

--- a/contrib/inventory/vmware_inventory.py
+++ b/contrib/inventory/vmware_inventory.py
@@ -254,7 +254,7 @@ class VMWareInventory(object):
                          'resourceconfig',
             'alias_pattern': '{{ config.name + "_" + config.uuid }}',
             'host_pattern': '{{ guest.ipaddress }}',
-            'host_filters': '{{ guest.gueststate == "running" }}',
+            'host_filters': '{{ runtime.powerstate == "poweredOn" }}',
             'groupby_patterns': '{{ guest.guestid }},{{ "templates" if config.template else "guests"}}',
             'lower_var_keys': True,
             'custom_field_group_prefix': 'vmware_tag_',


### PR DESCRIPTION
##### SUMMARY
This fix changes default value of host_filter in vmware_inventory.py
and vmware_inventory.ini to 'runtime.powerstate' from 'guest.gueststate'.
This change is added as 'guest.gueststate' requires vmware tools to be
installed on given VM, which may not be the case everytime.

Fixes: #25086

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
contrib/inventory/vmware_inventory.ini
contrib/inventory/vmware_inventory.py

##### ANSIBLE VERSION
```
2.5devel
```