### PR TITLE
firewalld: Implement zone operations

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -91,6 +91,12 @@ options:
 notes:
   - Not tested on any Debian based system.
   - Requires the python2 bindings of firewalld, which may not be installed by default if the distribution switched to python 3
+  - Zone transactions (creating, deleting) can be performed by using only the zone and state parameters "present" or "absent".
+    Note that zone transactions must explicitly be permanent. This is a limitation in firewalld.
+    This also means that you will have to reload firewalld after adding a zone that you wish to perfom immediate actions on.
+    The module will not take care of this for you implicitly because that would undo any previously performed immediate actions which were not
+    permanent. Therefor, if you require immediate access to a newly created zone it is recommended you reload firewalld immediately after the zone
+    creation returns with a changed state and before you perform any other immediate, non-permanent actions on that zone.
 requirements: [ 'firewalld >= 0.2.11' ]
 author: "Adam Miller (@maxamillion)"
 '''
@@ -142,6 +148,7 @@ EXAMPLES = '''
 - firewalld:
     zone: custom
     state: present
+    permanent: true
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -190,18 +197,21 @@ class FirewallTransaction(object):
     global module
 
     def __init__(self, fw, action_args=(), zone=None, desired_state=None,
-                 permanent=False, immediate=False, fw_offline=False):
+                 permanent=False, immediate=False, fw_offline=False,
+                 enabled_values=None, disabled_values=None):
         # type: (firewall.client, tuple, str, bool, bool, bool)
         """
         initializer the transaction
 
-        :fw:            firewall client instance
-        :action_args:   tuple, args to pass for the action to take place
-        :zone:          str,  firewall zone
-        :desired_state: str,  the desired state (enabled, disabled, etc)
-        :permanent:     bool, action should be permanent
-        :immediate:     bool, action should take place immediately
-        :fw_offline:    bool, action takes place as if the firewall were offline
+        :fw:              firewall client instance
+        :action_args:     tuple, args to pass for the action to take place
+        :zone:            str,  firewall zone
+        :desired_state:   str,  the desired state (enabled, disabled, etc)
+        :permanent:       bool, action should be permanent
+        :immediate:       bool, action should take place immediately
+        :fw_offline:      bool, action takes place as if the firewall were offline
+        :enabled_values:  str[], acceptable values for enabling something (default: enabled)
+        :disabled_values: str[], acceptable values for disabling something (default: disabled)
         """
 
         self.fw = fw
@@ -211,6 +221,8 @@ class FirewallTransaction(object):
         self.permanent = permanent
         self.immediate = immediate
         self.fw_offline = fw_offline
+        self.enabled_values = enabled_values or ["enabled"]
+        self.disabled_values = disabled_values or ["disabled"]
 
         # List of messages that we'll call module.fail_json or module.exit_json
         # with.
@@ -220,12 +232,6 @@ class FirewallTransaction(object):
         # types
         self.enabled_msg = None
         self.disabled_msg = None
-
-        # List of acceptable values to enable/diable something
-        # Right now these are only 1 each but in the event we want to add more
-        # later, this will make it easy.
-        self.enabled_values = ["enabled"]
-        self.disabled_values = ["disabled"]
 
     #####################
     # exception handling
@@ -741,10 +747,13 @@ class ZoneTransaction(FirewallTransaction):
     """
 
     def __init__(self, fw, action_args=None, zone=None, desired_state=None,
-                 permanent=True, immediate=False, fw_offline=False):
+                 permanent=True, immediate=False, fw_offline=False,
+                 enabled_values=None, disabled_values=None):
         super(ZoneTransaction, self).__init__(
             fw, action_args=action_args, desired_state=desired_state, zone=zone,
-            permanent=permanent, immediate=immediate, fw_offline=fw_offline)
+            permanent=permanent, immediate=immediate, fw_offline=fw_offline,
+            enabled_values=enabled_values or ["present"],
+            disabled_values=disabled_values or ["absent"])
 
         self.enabled_msg = "Added zone %s" % \
             (self.zone)
@@ -752,8 +761,11 @@ class ZoneTransaction(FirewallTransaction):
         self.disabled_msg = "Removed zone %s" % \
             (self.zone)
 
+        self.tx_not_permanent_error_msg = "Zone operations must be permanent. " \
+            "Make sure you didn't set the 'permanent' flag to 'false' or the 'immediate' flag to 'true'."
+
     def get_enabled_immediate(self):
-        raise NotImplementedError('Zone operations are always permanent')
+        module.fail_json(msg=self.tx_not_permanent_error_msg)
 
     def get_enabled_permanent(self):
         if self.zone in fw.config().getZoneNames():
@@ -762,13 +774,13 @@ class ZoneTransaction(FirewallTransaction):
             return False
 
     def set_enabled_immediate(self):
-        raise NotImplementedError('Zone operations are always permanent')
+        module.fail_json(msg=self.tx_not_permanent_error_msg)
 
     def set_enabled_permanent(self):
         fw.config().addZone(self.zone, FirewallClientZoneSettings())
 
     def set_disabled_immediate(self):
-        raise NotImplementedError('Zone operations are always permanent')
+        module.fail_json(msg=self.tx_not_permanent_error_msg)
 
     def set_disabled_permanent(self):
         zone_obj = self.fw.config().getZoneByName(self.zone)
@@ -985,13 +997,10 @@ def main():
             action_args=(),
             zone=zone,
             desired_state=desired_state,
-            permanent=True,
-            immediate=False,
+            permanent=permanent,
+            immediate=immediate,
             fw_offline=fw_offline
         )
-
-        transaction.enabled_values = ['present']
-        transaction.disabled_values = ['absent']
 
         changed, transaction_msgs = transaction.run()
         msgs = msgs + transaction_msgs


### PR DESCRIPTION
##### SUMMARY
Zones are removed or added when no other operations are used in
conjunction with the keywords 'present' or 'absent'.

This leads to a logical and natural syntax of:

- firewalld:
    zone: foo
    state: present

for adding or removing zones.

Signed-off-by: Felix Kaechele <felix@kaechele.ca>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
firewalld module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /home/felix/.ansible.cfg
  configured module search path = [u'/home/felix/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

