### PR TITLE
ManagedSANFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
@@ -30,20 +30,13 @@ options:
     options:
       description:
         - "List with options to gather additional facts about Managed SAN.
-          Options allowed:
-          C(endpoints) gets the list of endpoints in the SAN identified by name.
-          C(wwn) gets the list of Managed SANs associated with an informed WWN C(locate)."
-    params:
-      description:
-        - List of params to delimit, filter and sort the list of resources.
-        - "params allowed:
-           C(start): The first item to return, using 0-based indexing.
-           C(count): The number of resources to return.
-           C(query): A general query string to narrow the list of resources returned.
-           C(sort): The sort order of the returned data set."
+        - Options allowed:
+            - C(endpoints) gets the list of endpoints in the SAN identified by name.
+            - C(wwn) gets the list of Managed SANs associated with an informed WWN C(locate)."
 
 extends_documentation_fragment:
     - oneview
+    - oneview.factsparams
 '''
 
 EXAMPLES = '''
@@ -137,11 +130,7 @@ from ansible.module_utils.oneview import OneViewModuleBase
 
 
 class ManagedSanFactsModule(OneViewModuleBase):
-    argument_spec = dict(
-        name=dict(type='str'),
-        options=dict(type='list'),
-        params=dict(type='dict')
-    )
+    argument_spec = dict(name=dict(type='str'), options=dict(type='list'), params=dict(type='dict'))
 
     def __init__(self):
         super(ManagedSanFactsModule, self).__init__(additional_arg_spec=self.argument_spec)

--- a/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
@@ -1,0 +1,184 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+module: oneview_managed_san_facts
+short_description: Retrieve facts about the OneView Managed SANs
+description:
+    - Retrieve facts about the OneView Managed SANs.
+version_added: "2.5"
+requirements:
+    - "hpOneView >= 3.0.0"
+author:
+    - Alex Monteiro (@aalexmonteiro)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Priyanka Sood (@soodpr)
+    - Ricardo Galeno (@ricardogpsf)
+options:
+    name:
+      description:
+        - Name of the Managed SAN.
+    options:
+      description:
+        - "List with options to gather additional facts about Managed SAN.
+          Options allowed:
+          C(endpoints) gets the list of endpoints in the SAN identified by name.
+          C(wwn) gets the list of Managed SANs associated with an informed WWN C(locate)."
+    params:
+      description:
+        - List of params to delimit, filter and sort the list of resources.
+        - "params allowed:
+           C(start): The first item to return, using 0-based indexing.
+           C(count): The number of resources to return.
+           C(query): A general query string to narrow the list of resources returned.
+           C(sort): The sort order of the returned data set."
+
+extends_documentation_fragment:
+    - oneview
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Managed SANs
+  oneview_managed_san_facts:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=managed_sans
+
+- name: Gather paginated, filtered and sorted facts about Managed SANs
+  oneview_managed_san_facts:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    params:
+      count: 3
+      query: imported eq true
+      start: 0
+      sort: name:ascending
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=managed_sans
+
+- name: Gather facts about a Managed SAN by name
+  oneview_managed_san_facts:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    name: "SAN1_0"
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=managed_sans
+
+- name: Gather facts about the endpoints in the SAN identified by name
+  oneview_managed_san_facts:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    name: "SAN1_0"
+    options:
+      - endpoints
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=managed_sans
+- debug: var=managed_san_endpoints
+
+- name: Gather facts about Managed SANs for an associated WWN
+  oneview_managed_san_facts:
+    hostname: 172.16.101.48
+    username: administrator
+    password: my_password
+    api_version: 500
+    options:
+      - wwn:
+         locate: "20:00:4A:2B:21:E0:00:01"
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=wwn_associated_sans
+'''
+
+RETURN = '''
+managed_sans:
+    description: The list of Managed SANs.
+    returned: Always, but can be null.
+    type: list
+
+managed_san_endpoints:
+    description: The list of endpoints in the SAN identified by name.
+    returned: When requested, but can be null.
+    type: dict
+
+wwn_associated_sans:
+    description: The list of associations between provided WWNs and the SANs.
+    returned: When requested, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class ManagedSanFactsModule(OneViewModuleBase):
+    argument_spec = dict(
+        name=dict(type='str'),
+        options=dict(type='list'),
+        params=dict(type='dict')
+    )
+
+    def __init__(self):
+        super(ManagedSanFactsModule, self).__init__(additional_arg_spec=self.argument_spec)
+
+        self.resource_client = self.oneview_client.managed_sans
+
+    def execute_module(self):
+        facts = dict()
+
+        name = self.module.params['name']
+
+        if name:
+            facts['managed_sans'] = [self.resource_client.get_by_name(name)]
+
+            if facts['managed_sans'] and 'endpoints' in self.options:
+                managed_san = facts['managed_sans'][0]
+                if managed_san:
+                    environmental_configuration = self.resource_client.get_endpoints(managed_san['uri'])
+                    facts['managed_san_endpoints'] = environmental_configuration
+
+        else:
+            facts['managed_sans'] = self.resource_client.get_all(**self.facts_params)
+
+        if self.options:
+            if self.options.get('wwn'):
+                wwn = self.__get_sub_options(self.options['wwn'])
+                facts['wwn_associated_sans'] = self.resource_client.get_wwn(wwn['locate'])
+
+        return dict(changed=False, ansible_facts=facts)
+
+    def __get_sub_options(self, option):
+        return option if isinstance(option, dict) else {}
+
+
+def main():
+    ManagedSanFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
@@ -46,7 +46,6 @@ EXAMPLES = '''
     username: administrator
     password: my_password
     api_version: 500
-  no_log: true
   delegate_to: localhost
 
 - debug: var=managed_sans
@@ -62,7 +61,6 @@ EXAMPLES = '''
       query: imported eq true
       start: 0
       sort: name:ascending
-  no_log: true
   delegate_to: localhost
 
 - debug: var=managed_sans
@@ -74,7 +72,6 @@ EXAMPLES = '''
     password: my_password
     api_version: 500
     name: "SAN1_0"
-  no_log: true
   delegate_to: localhost
 
 - debug: var=managed_sans
@@ -88,7 +85,6 @@ EXAMPLES = '''
     name: "SAN1_0"
     options:
       - endpoints
-  no_log: true
   delegate_to: localhost
 
 - debug: var=managed_sans
@@ -103,7 +99,6 @@ EXAMPLES = '''
     options:
       - wwn:
          locate: "20:00:4A:2B:21:E0:00:01"
-  no_log: true
   delegate_to: localhost
 
 - debug: var=wwn_associated_sans

--- a/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_managed_san_facts.py
@@ -151,12 +151,12 @@ class ManagedSanFactsModule(OneViewModuleBase):
 
         if self.options:
             if self.options.get('wwn'):
-                wwn = self.__get_sub_options(self.options['wwn'])
+                wwn = self._get_sub_options(self.options['wwn'])
                 facts['wwn_associated_sans'] = self.resource_client.get_wwn(wwn['locate'])
 
         return dict(changed=False, ansible_facts=facts)
 
-    def __get_sub_options(self, option):
+    def _get_sub_options(self, option):
         return option if isinstance(option, dict) else {}
 
 

--- a/test/units/modules/remote_management/oneview/hpe_test_utils.py
+++ b/test/units/modules/remote_management/oneview/hpe_test_utils.py
@@ -27,17 +27,16 @@ from hpOneView.oneview_client import OneViewClient
 class OneViewBaseTest(object):
     @pytest.fixture(autouse=True)
     def setUp(self, mock_ansible_module, mock_ov_client, request):
+        class_name = type(self).__name__
         marker = request.node.get_marker('resource')
-        self.resource = getattr(mock_ov_client, "%s" % (marker.args))
+        self.resource = getattr(mock_ov_client, "%s" % (marker.kwargs[class_name]))
         self.mock_ov_client = mock_ov_client
         self.mock_ansible_module = mock_ansible_module
 
     @pytest.fixture
     def testing_module(self):
         resource_name = type(self).__name__.replace('Test', '')
-        resource_module_path_name = resource_name.replace('Module', '')
-        resource_module_path_name = re.findall('[A-Z][^A-Z]*', resource_module_path_name)
-        resource_module_path_name = 'oneview_' + str.join('_', resource_module_path_name).lower()
+        resource_module_path_name = self.underscore(resource_name.replace('Module', ''))
 
         ansible = __import__('ansible')
         oneview_module = ansible.modules.remote_management.oneview
@@ -54,6 +53,11 @@ class OneViewBaseTest(object):
             raise Exception(message)
         return testing_module
 
+    def underscore(self, word):
+        word = re.findall('[A-Z][^A-Z]*', word)
+        word = 'oneview_' + str.join('_', word).lower()
+        return word
+
     def test_main_function_should_call_run_method(self, testing_module, mock_ansible_module):
         mock_ansible_module.params = {'config': 'config.json'}
 
@@ -64,7 +68,7 @@ class OneViewBaseTest(object):
             mock_run.assert_called_once()
 
 
-class FactsParamsTest(OneViewBaseTest):
+class OneViewBaseFactsTest(OneViewBaseTest):
     def test_should_get_all_using_filters(self, testing_module):
         self.resource.get_all.return_value = []
 

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
@@ -5,7 +5,7 @@ import pytest
 
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_datacenter_facts import DatacenterFactsModule
-from hpe_test_utils import FactsParamsTest
+from hpe_test_utils import OneViewBaseFactsTest
 
 PARAMS_GET_CONNECTED = dict(
     config='config.json',
@@ -14,14 +14,8 @@ PARAMS_GET_CONNECTED = dict(
 )
 
 
-@pytest.mark.resource('datacenters')
-class TestDatacenterFactsModule(FactsParamsTest):
-    @pytest.fixture(autouse=True)
-    def setUp(self, mock_ansible_module, mock_ov_client):
-        self.resource = mock_ov_client.datacenters
-        self.mock_ansible_module = mock_ansible_module
-        self.mock_ov_client = mock_ov_client
-
+@pytest.mark.resource(TestDatacenterFactsModule='datacenters')
+class TestDatacenterFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_datacenters(self):
         self.resource.get_all.return_value = {"name": "Data Center Name"}
 

--- a/test/units/modules/remote_management/oneview/test_oneview_managed_san_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_managed_san_facts.py
@@ -1,105 +1,67 @@
 # Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.compat.tests import unittest
+import pytest
+
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_managed_san_facts import ManagedSanFactsModule
-from hpe_test_utils import FactsParamsTestCase
+from hpe_test_utils import FactsParamsTest
 
 
-class ManagedSanFactsClientConfigurationSpec(unittest.TestCase,
-                                             FactsParamsTestCase):
+@pytest.mark.resource('managed_sans')
+class TestManagedSanFactsModule(FactsParamsTest):
     """
-    FactsParamsTestCase has common tests for the parameters support.
+    FactsParamsTest has common tests for the parameters support.
     """
-    ERROR_MSG = 'Fake message error'
 
     MANAGED_SAN_NAME = 'SAN1_0'
     MANAGED_SAN_URI = '/rest/fc-sans/managed-sans/cc64ee18-8f7d-4cdf-9bf8-a68f00e4af9c'
-    MANAGED_SAN_WWN = '20:00:4A:2B:21:E0:00:01'
-
-    PARAMS_GET_ALL = dict(
-        config='config.json',
-        name=None,
-        wwn=None
-    )
-
-    PARAMS_GET_BY_NAME = dict(
-        config='config.json',
-        name=MANAGED_SAN_NAME,
-        options=[]
-    )
-
-    PARAMS_GET_BY_NAME_WITH_OPTIONS = dict(
-        config='config.json',
-        name=MANAGED_SAN_NAME,
-        options=['endpoints']
-    )
-
-    PARAMS_GET_ASSOCIATED_WWN = dict(
-        config='config.json',
-        name=MANAGED_SAN_NAME,
-        options=[{'wwn': {'locate': MANAGED_SAN_WWN}}]
-    )
 
     MANAGED_SAN = dict(name=MANAGED_SAN_NAME, uri=MANAGED_SAN_URI)
 
-    ALL_MANAGED_SANS = [MANAGED_SAN,
-                        dict(name='SAN1_1', uri='/rest/fc-sans/managed-sans/928374892-asd-34234234-asd23')]
-
-    def setUp(self):
-        self.configure_mocks(self, ManagedSanFactsModule)
-        self.managed_sans = self.mock_ov_client.managed_sans
-        FactsParamsTestCase.configure_client_mock(self, self.managed_sans)
-
     def test_should_get_all(self):
-        self.managed_sans.get_all.return_value = self.ALL_MANAGED_SANS
-        self.mock_ansible_module.params = self.PARAMS_GET_ALL
+        ALL_MANAGED_SANS = [self.MANAGED_SAN, dict(name='SAN1_1', uri='/rest/fc-sans/managed-sans/928374892-asd-34234234-asd23')]
+        self.resource.get_all.return_value = ALL_MANAGED_SANS
+        self.mock_ansible_module.params = dict(config='config.json', name=None, wwn=None)
 
         ManagedSanFactsModule().run()
 
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=False,
-            ansible_facts=dict(managed_sans=self.ALL_MANAGED_SANS)
-        )
+        self.mock_ansible_module.exit_json.assert_called_once_with(changed=False, ansible_facts=dict(managed_sans=ALL_MANAGED_SANS))
 
     def test_should_get_by_name(self):
-        self.managed_sans.get_by_name.return_value = self.MANAGED_SAN
-        self.mock_ansible_module.params = self.PARAMS_GET_BY_NAME
+        self.resource.get_by_name.return_value = self.MANAGED_SAN
+        self.mock_ansible_module.params = dict(config='config.json', name=self.MANAGED_SAN_NAME, options=[])
 
         ManagedSanFactsModule().run()
 
-        self.managed_sans.get_by_name.assert_called_once_with(self.MANAGED_SAN_NAME)
-        self.mock_ansible_module.exit_json.assert_called_once_with(
-            changed=False,
-            ansible_facts=dict(managed_sans=[self.MANAGED_SAN])
-        )
+        self.resource.get_by_name.assert_called_once_with(self.MANAGED_SAN_NAME)
+        self.mock_ansible_module.exit_json.assert_called_once_with(changed=False, ansible_facts=dict(managed_sans=[self.MANAGED_SAN]))
 
     def test_should_get_by_name_with_options(self):
-        endpoints = [dict(uri='/rest/fc-sans/endpoints/20:00:00:02:AC:00:08:E2'),
-                     dict(uri='/rest/fc-sans/endpoints/20:00:00:02:AC:00:08:FF')]
+        endpoints = [dict(uri='/rest/fc-sans/endpoints/20:00:00:02:AC:00:08:E2'), dict(uri='/rest/fc-sans/endpoints/20:00:00:02:AC:00:08:FF')]
 
-        self.managed_sans.get_by_name.return_value = self.MANAGED_SAN
-        self.managed_sans.get_endpoints.return_value = endpoints
-        self.mock_ansible_module.params = self.PARAMS_GET_BY_NAME_WITH_OPTIONS
+        self.resource.get_by_name.return_value = self.MANAGED_SAN
+        self.resource.get_endpoints.return_value = endpoints
+        self.mock_ansible_module.params = dict(config='config.json', name=self.MANAGED_SAN_NAME, options=['endpoints'])
 
         ManagedSanFactsModule().run()
 
-        self.managed_sans.get_by_name.assert_called_once_with(self.MANAGED_SAN_NAME)
-        self.managed_sans.get_endpoints.assert_called_once_with(self.MANAGED_SAN_URI)
+        self.resource.get_by_name.assert_called_once_with(self.MANAGED_SAN_NAME)
+        self.resource.get_endpoints.assert_called_once_with(self.MANAGED_SAN_URI)
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(managed_sans=[self.MANAGED_SAN], managed_san_endpoints=endpoints)
         )
 
     def test_should_get_managed_san_for_an_associated_wwn(self):
-        self.managed_sans.get_by_name.return_value = self.MANAGED_SAN
-        self.managed_sans.get_wwn.return_value = self.MANAGED_SAN
-        self.mock_ansible_module.params = self.PARAMS_GET_ASSOCIATED_WWN
+        MANAGED_SAN_WWN = '20:00:4A:2B:21:E0:00:01'
+        self.resource.get_by_name.return_value = self.MANAGED_SAN
+        self.resource.get_wwn.return_value = self.MANAGED_SAN
+        self.mock_ansible_module.params = dict(config='config.json', name=self.MANAGED_SAN_NAME, options=[{'wwn': {'locate': MANAGED_SAN_WWN}}])
 
         ManagedSanFactsModule().run()
 
-        self.managed_sans.get_wwn.assert_called_once_with(self.MANAGED_SAN_WWN)
+        self.resource.get_wwn.assert_called_once_with(MANAGED_SAN_WWN)
         self.mock_ansible_module.exit_json.assert_called_once_with(
             changed=False,
             ansible_facts=dict(managed_sans=[self.MANAGED_SAN], wwn_associated_sans=self.MANAGED_SAN)
@@ -107,4 +69,4 @@ class ManagedSanFactsClientConfigurationSpec(unittest.TestCase,
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main([__file__])

--- a/test/units/modules/remote_management/oneview/test_oneview_managed_san_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_managed_san_facts.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from oneview_module_loader import OneViewModuleBase
+from ansible.modules.remote_management.oneview.oneview_managed_san_facts import ManagedSanFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+
+class ManagedSanFactsClientConfigurationSpec(unittest.TestCase,
+                                             FactsParamsTestCase):
+    """
+    FactsParamsTestCase has common tests for the parameters support.
+    """
+    ERROR_MSG = 'Fake message error'
+
+    MANAGED_SAN_NAME = 'SAN1_0'
+    MANAGED_SAN_URI = '/rest/fc-sans/managed-sans/cc64ee18-8f7d-4cdf-9bf8-a68f00e4af9c'
+    MANAGED_SAN_WWN = '20:00:4A:2B:21:E0:00:01'
+
+    PARAMS_GET_ALL = dict(
+        config='config.json',
+        name=None,
+        wwn=None
+    )
+
+    PARAMS_GET_BY_NAME = dict(
+        config='config.json',
+        name=MANAGED_SAN_NAME,
+        options=[]
+    )
+
+    PARAMS_GET_BY_NAME_WITH_OPTIONS = dict(
+        config='config.json',
+        name=MANAGED_SAN_NAME,
+        options=['endpoints']
+    )
+
+    PARAMS_GET_ASSOCIATED_WWN = dict(
+        config='config.json',
+        name=MANAGED_SAN_NAME,
+        options=[{'wwn': {'locate': MANAGED_SAN_WWN}}]
+    )
+
+    MANAGED_SAN = dict(name=MANAGED_SAN_NAME, uri=MANAGED_SAN_URI)
+
+    ALL_MANAGED_SANS = [MANAGED_SAN,
+                        dict(name='SAN1_1', uri='/rest/fc-sans/managed-sans/928374892-asd-34234234-asd23')]
+
+    def setUp(self):
+        self.configure_mocks(self, ManagedSanFactsModule)
+        self.managed_sans = self.mock_ov_client.managed_sans
+        FactsParamsTestCase.configure_client_mock(self, self.managed_sans)
+
+    def test_should_get_all(self):
+        self.managed_sans.get_all.return_value = self.ALL_MANAGED_SANS
+        self.mock_ansible_module.params = self.PARAMS_GET_ALL
+
+        ManagedSanFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(managed_sans=self.ALL_MANAGED_SANS)
+        )
+
+    def test_should_get_by_name(self):
+        self.managed_sans.get_by_name.return_value = self.MANAGED_SAN
+        self.mock_ansible_module.params = self.PARAMS_GET_BY_NAME
+
+        ManagedSanFactsModule().run()
+
+        self.managed_sans.get_by_name.assert_called_once_with(self.MANAGED_SAN_NAME)
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(managed_sans=[self.MANAGED_SAN])
+        )
+
+    def test_should_get_by_name_with_options(self):
+        endpoints = [dict(uri='/rest/fc-sans/endpoints/20:00:00:02:AC:00:08:E2'),
+                     dict(uri='/rest/fc-sans/endpoints/20:00:00:02:AC:00:08:FF')]
+
+        self.managed_sans.get_by_name.return_value = self.MANAGED_SAN
+        self.managed_sans.get_endpoints.return_value = endpoints
+        self.mock_ansible_module.params = self.PARAMS_GET_BY_NAME_WITH_OPTIONS
+
+        ManagedSanFactsModule().run()
+
+        self.managed_sans.get_by_name.assert_called_once_with(self.MANAGED_SAN_NAME)
+        self.managed_sans.get_endpoints.assert_called_once_with(self.MANAGED_SAN_URI)
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(managed_sans=[self.MANAGED_SAN], managed_san_endpoints=endpoints)
+        )
+
+    def test_should_get_managed_san_for_an_associated_wwn(self):
+        self.managed_sans.get_by_name.return_value = self.MANAGED_SAN
+        self.managed_sans.get_wwn.return_value = self.MANAGED_SAN
+        self.mock_ansible_module.params = self.PARAMS_GET_ASSOCIATED_WWN
+
+        ManagedSanFactsModule().run()
+
+        self.managed_sans.get_wwn.assert_called_once_with(self.MANAGED_SAN_WWN)
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(managed_sans=[self.MANAGED_SAN], wwn_associated_sans=self.MANAGED_SAN)
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/remote_management/oneview/test_oneview_managed_san_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_managed_san_facts.py
@@ -5,11 +5,11 @@ import pytest
 
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_managed_san_facts import ManagedSanFactsModule
-from hpe_test_utils import FactsParamsTest
+from hpe_test_utils import OneViewBaseFactsTest
 
 
-@pytest.mark.resource('managed_sans')
-class TestManagedSanFactsModule(FactsParamsTest):
+@pytest.mark.resource(TestManagedSanFactsModule='managed_sans')
+class TestManagedSanFactsModule(OneViewBaseFactsTest):
     """
     FactsParamsTest has common tests for the parameters support.
     """


### PR DESCRIPTION
##### SUMMARY
Added new oneview_managed_san_facts module for retrieving [HPE OneView Managed SANs](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/fc-sans/managed-sans) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_managed_san_facts`

##### ANSIBLE VERSION
```
ansible 2.5.0 (hpe-oneview/managed-san-facts b4d89df3d5) last updated 2017/11/13 12:25:59 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/ansible/lib/ansible
  executable location = /ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Example of usage:
```yaml
- name: Gather facts about all Managed SANs
  oneview_managed_san_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=managed_sans

- name: Gather paginated, filtered and sorted facts about Managed SANs
  oneview_managed_san_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    params:
      count: 3
      query: imported eq true
      start: 0
      sort: name:ascending
  no_log: true
  delegate_to: localhost

- debug: var=managed_sans

- name: Gather facts about a Managed SAN by name
  oneview_managed_san_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    name: "SAN1_0"
  no_log: true
  delegate_to: localhost

- debug: var=managed_sans

- name: Gather facts about the endpoints in the SAN identified by name
  oneview_managed_san_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    name: "SAN1_0"
    options:
      - endpoints
  no_log: true
  delegate_to: localhost

- debug: var=managed_sans
- debug: var=managed_san_endpoints

- name: Gather facts about Managed SANs for an associated WWN
  oneview_managed_san_facts:
    hostname: 172.16.101.48
    username: administrator
    password: my_password
    api_version: 500
    options:
      - wwn:
         locate: "20:00:4A:2B:21:E0:00:01"
  no_log: true
  delegate_to: localhost

- debug: var=wwn_associated_sans
```
