### PR TITLE
Fix handler race condition with strategy free

### DIFF
--- a/lib/ansible/plugins/strategy/__init__.py
+++ b/lib/ansible/plugins/strategy/__init__.py
@@ -751,7 +751,8 @@ class StrategyBase:
         handler.name = saved_name
 
         if notified_hosts is None:
-            notified_hosts = self._notified_handlers[handler._uuid]
+            # Avoid reference's concurrent updates
+            notified_hosts = set(self._notified_handlers[handler._uuid])
 
         run_once = False
         try:
@@ -816,8 +817,10 @@ class StrategyBase:
                     display.warning(str(e))
                     continue
 
-        # wipe the notification list
-        self._notified_handlers[handler._uuid] = []
+        # remove hosts from notification list
+        left_notified_hosts = set(self._notified_handlers[handler._uuid])
+        left_notified_hosts -= notified_hosts
+        self._notified_handlers[handler._uuid] = list(left_notified_hosts)
         display.debug("done running handlers, result is: %s" % result)
         return result
 


### PR DESCRIPTION
##### SUMMARY
When a handler was notified after queuing tasks, it ignored
hosts left to be queued and wiped the list. Only queued hosts
are removed from notification list.

`notified_hosts` is changed as it was a reference that was
also concurrently updated.

Fixes #31504

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Strategy module

##### ANSIBLE VERSION
```
ansible 2.4.2.0 (stable-2.4 4433544eb0)
```

##### ADDITIONAL INFORMATION
See #31504