### PR TITLE
Netscaler - less intrusive algorithm for syncing cs_policybindings

### DIFF
--- a/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
@@ -689,7 +689,7 @@ def sync_cs_policybindings(client, module):
             log('Updating binding for policy %s' % key)
             csvserver_cspolicy_binding.delete(client, actual_bindings[key])
             configured_bindings[key].add()
-   
+
 def ssl_certkey_bindings_identical(client, module):
     log('Checking if ssl cert key bindings are identical')
     vservername = module.params['name']

--- a/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
@@ -667,18 +667,30 @@ def cs_policybindings_identical(client, module):
 
 def sync_cs_policybindings(client, module):
     log('Syncing cs policybindings')
+    actual_bindings = get_actual_policybindings(client, module)
+    configured_bindings = get_configured_policybindings(client, module)
 
-    # Delete all actual bindings
-    for binding in get_actual_policybindings(client, module).values():
-        log('Deleting binding for policy %s' % binding.policyname)
-        csvserver_cspolicy_binding.delete(client, binding)
+    # Delete actual bindings not in configured
+    delete_keys = list(set(actual_bindings.keys()) - set(configured_bindings.keys()))
+    for key in delete_keys:
+        log('Deleting binding for policy %s' % key)
+        csvserver_cspolicy_binding.delete(client, actual_bindings[key])
 
-    # Add all configured bindings
+    # Add configured bindings not in actual
+    add_keys = list(set(configured_bindings.keys()) - set(actual_bindings.keys()))
+    for key in add_keys:
+      log('Adding binding for policy %s' % key)
+      pdb.set_trace()
+      configured_bindings[key].add()
 
-    for binding in get_configured_policybindings(client, module).values():
-        log('Adding binding for policy %s' % binding.policyname)
-        binding.add()
-
+    # Update existing if changed
+    modify_keys = list(set(configured_bindings.keys()) & set(actual_bindings.keys()))
+    for key in modify_keys:
+      if not configured_bindings[key].has_equal_attributes(actual_bindings[key]):
+        log('Updating binding for policy %s' % key)
+        csvserver_cspolicy_binding.delete(client, actual_bindings[key])
+        configured_bindings[key].add()
+   
 
 def ssl_certkey_bindings_identical(client, module):
     log('Checking if ssl cert key bindings are identical')

--- a/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
@@ -679,19 +679,17 @@ def sync_cs_policybindings(client, module):
     # Add configured bindings not in actual
     add_keys = list(set(configured_bindings.keys()) - set(actual_bindings.keys()))
     for key in add_keys:
-      log('Adding binding for policy %s' % key)
-      pdb.set_trace()
-      configured_bindings[key].add()
+        log('Adding binding for policy %s' % key)
+        configured_bindings[key].add()
 
     # Update existing if changed
     modify_keys = list(set(configured_bindings.keys()) & set(actual_bindings.keys()))
     for key in modify_keys:
-      if not configured_bindings[key].has_equal_attributes(actual_bindings[key]):
-        log('Updating binding for policy %s' % key)
-        csvserver_cspolicy_binding.delete(client, actual_bindings[key])
-        configured_bindings[key].add()
+        if not configured_bindings[key].has_equal_attributes(actual_bindings[key]):
+            log('Updating binding for policy %s' % key)
+            csvserver_cspolicy_binding.delete(client, actual_bindings[key])
+            configured_bindings[key].add()
    
-
 def ssl_certkey_bindings_identical(client, module):
     log('Checking if ssl cert key bindings are identical')
     vservername = module.params['name']

--- a/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
+++ b/lib/ansible/modules/network/netscaler/netscaler_cs_vserver.py
@@ -690,6 +690,7 @@ def sync_cs_policybindings(client, module):
             csvserver_cspolicy_binding.delete(client, actual_bindings[key])
             configured_bindings[key].add()
 
+
 def ssl_certkey_bindings_identical(client, module):
     log('Checking if ssl cert key bindings are identical')
     vservername = module.params['name']


### PR DESCRIPTION
##### SUMMARY
When syncing a large number of content switching policies to an already existing content switching server, the current algorithm deletes all policies and then re-adds them if any policy has changed.

This leaves many policies unavailable for multiple seconds (when using greater than 100 policies) that have not been changed at all. Instead of deleting and adding all policies back again, this pull request only changes the policies that differ from the configuration.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
netscaler_cs_vserver

##### ANSIBLE VERSION

```
ansible 2.5.0 (cs_policy_binding_sync 145f91b78e) last updated 2017/11/13 14:13:55 (GMT +000)
  config file = None
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vagrant/ansible/lib/ansible
  executable location = /home/vagrant/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]`

```

##### ADDITIONAL INFORMATION
This algorithm is inspired by the netscaler_lb_vserver module's sync_service_bindings (https://github.com/ansible/ansible/blob/b0e7c71716a3ea4434c139530fbbfcc73489fc16/lib/ansible/modules/network/netscaler/netscaler_lb_vserver.py#L1178). 

