### PR TITLE
Fix `authorize: yes` and `become_method: enable`

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -296,21 +296,16 @@ def main():
             pc_data = to_text(init_data)
             try:
                 messages.extend(conn.update_play_context(pc_data))
-            except ConnectionError as exc:
+            except Exception as exc:
                 # Only network_cli has update_play context, so missing this is
                 # not fatal e.g. netconf
-                if exc.code == -32601:
+                if isinstance(exc, ConnectionError) and getattr(exc, 'code') == -32601:
                     pass
                 else:
                     result.update({
                         'error': to_text(exc),
                         'exception': traceback.format_exc()
                     })
-            except Exception as exc:
-                result.update({
-                    'error': to_text(exc),
-                    'exception': traceback.format_exc()
-                })
 
     result.update({
         'messages': messages,

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -26,7 +26,7 @@ from ansible import constants as C
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
-from ansible.module_utils.connection import send_data, recv_data
+from ansible.module_utils.connection import Connection, send_data, recv_data
 from ansible.module_utils.service import fork_process
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
@@ -293,6 +293,9 @@ def main():
 
         else:
             messages.append('found existing local domain socket, using it!')
+            conn = Connection(socket_path)
+            pc_data = to_text(init_data)
+            messages.extend(conn.update_play_context(pc_data))
 
     result.update({
         'messages': messages,

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -300,8 +300,13 @@ def main():
             except ConnectionError as exc:
                 # Only network_cli has update_play context, so missing this is
                 # not fatal e.g. netconf
-                if to_text(exc) != 'Method not found':
-                    raise
+                if exc.code == -32601:
+                    pass
+                else:
+                    result.update({
+                        'error': to_text(exc),
+                        'exception': traceback.format_exc()
+                    })
 
     result.update({
         'messages': messages,

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -26,7 +26,7 @@ from ansible import constants as C
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
 from ansible.module_utils.six.moves import cPickle
-from ansible.module_utils.connection import Connection, send_data, recv_data
+from ansible.module_utils.connection import Connection, ConnectionError, send_data, recv_data
 from ansible.module_utils.service import fork_process
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
@@ -295,7 +295,13 @@ def main():
             messages.append('found existing local domain socket, using it!')
             conn = Connection(socket_path)
             pc_data = to_text(init_data)
-            messages.extend(conn.update_play_context(pc_data))
+            try:
+                messages.extend(conn.update_play_context(pc_data))
+            except ConnectionError as exc:
+                # Only network_cli has update_play context, so missing this is
+                # not fatal e.g. netconf
+                if to_text(exc) != 'Method not found':
+                    raise
 
     result.update({
         'messages': messages,

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -31,7 +31,6 @@ from ansible.module_utils.service import fork_process
 from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import connection_loader
 from ansible.utils.path import unfrackpath, makedirs_safe
-from ansible.errors import AnsibleError
 from ansible.utils.display import Display
 from ansible.utils.jsonrpc import JsonRpcServer
 
@@ -307,6 +306,11 @@ def main():
                         'error': to_text(exc),
                         'exception': traceback.format_exc()
                     })
+            except Exception as exc:
+                result.update({
+                    'error': to_text(exc),
+                    'exception': traceback.format_exc()
+                })
 
     result.update({
         'messages': messages,

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -56,8 +56,10 @@ from collections import Sequence
 
 from ansible import constants as C
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils.six import BytesIO, binary_type
+from ansible.module_utils.six import PY3, BytesIO, binary_type
+from ansible.module_utils.six.moves import cPickle
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.playbook.play_context import PlayContext
 from ansible.plugins.loader import cliconf_loader, terminal_loader, connection_loader
 from ansible.plugins.connection import ConnectionBase
 from ansible.plugins.connection.local import Connection as LocalConnection
@@ -134,19 +136,27 @@ class Connection(ConnectionBase):
     def fetch_file(self, in_path, out_path):
         return self._local.fetch_file(in_path, out_path)
 
-    def update_play_context(self, play_context):
+    def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
+        if PY3:
+            pc_data = cPickle.loads(to_bytes(pc_data), encoding='bytes')
+        else:
+            pc_data = cPickle.loads(pc_data)
+        play_context = PlayContext()
+        play_context.deserialize(pc_data)
 
-        display.vvvv('updating play_context for connection', host=self._play_context.remote_addr)
-
+        messages = ['updating play_context for connection']
         if self._play_context.become is False and play_context.become is True:
             auth_pass = play_context.become_pass
             self._terminal.on_authorize(passwd=auth_pass)
+            messages.append('authorizing connection')
 
         elif self._play_context.become is True and not play_context.become:
             self._terminal.on_deauthorize()
+            messages.append('deauthorizing connection')
 
         self._play_context = play_context
+        return messages
 
     def _connect(self):
         '''

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -138,8 +138,9 @@ class Connection(ConnectionBase):
 
     def update_play_context(self, pc_data):
         """Updates the play context information for the connection"""
+        pc_data = to_bytes(pc_data)
         if PY3:
-            pc_data = cPickle.loads(to_bytes(pc_data), encoding='bytes')
+            pc_data = cPickle.loads(pc_data, encoding='bytes')
         else:
             pc_data = cPickle.loads(pc_data)
         play_context = PlayContext()

--- a/lib/ansible/plugins/terminal/eos.py
+++ b/lib/ansible/plugins/terminal/eos.py
@@ -61,7 +61,7 @@ class TerminalModule(TerminalBase):
 
         cmd = {u'command': u'enable'}
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompts'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -60,7 +60,7 @@ class TerminalModule(TerminalBase):
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            cmd[u'prompts'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
             cmd[u'answer'] = passwd
 
         try:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
This passes the new play context for each task as they come in to update the context for the forked process.

Also fixes the variable that enable prompts are stored in for ios/eos

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible-connection
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```