### PR TITLE
nxos_config and nxos_facts - fixes for N35 platform.  (#32762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,8 @@ Ansible Changes By Release
   (https://github.com/ansible/ansible/pull/32846)
 * Fix snmp bugs on Nexus 3500 platform
   (https://github.com/ansible/ansible/pull/32773)
+* nxos_config and nxos_facts - fixes for N35 platform
+  (https://github.com/ansible/ansible/pull/32762)
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -273,6 +273,7 @@ from ansible.module_utils.netcfg import NetworkConfig, dumps
 from ansible.module_utils.nxos import get_config, load_config, run_commands
 from ansible.module_utils.nxos import nxos_argument_spec
 from ansible.module_utils.nxos import check_args as nxos_check_args
+from ansible.module_utils.network_common import to_list
 
 
 def get_running_config(module, config=None):
@@ -294,6 +295,17 @@ def get_candidate(module):
         parents = module.params['parents'] or list()
         candidate.add(module.params['lines'], parents=parents)
     return candidate
+
+
+def execute_show_commands(module, commands, output='text'):
+    cmds = []
+    for command in to_list(commands):
+        cmd = { 'command': command,
+                'output': output,
+              }
+        cmds.append(cmd)
+    body = run_commands(module, cmds)
+    return body
 
 
 def main():
@@ -396,7 +408,7 @@ def main():
         module.params['save_when'] = 'always'
 
     if module.params['save_when'] != 'never':
-        output = run_commands(module, ['show running-config', 'show startup-config'])
+        output = execute_show_commands(module, ['show running-config', 'show startup-config'])
 
         running_config = NetworkConfig(indent=1, contents=output[0], ignore_lines=diff_ignore_lines)
         startup_config = NetworkConfig(indent=1, contents=output[1], ignore_lines=diff_ignore_lines)
@@ -413,7 +425,7 @@ def main():
 
     if module._diff:
         if not running_config:
-            output = run_commands(module, 'show running-config')
+            output = execute_show_commands(module, 'show running-config')
             contents = output[0]
         else:
             contents = running_config.config_text
@@ -430,7 +442,7 @@ def main():
 
         elif module.params['diff_against'] == 'startup':
             if not startup_config:
-                output = run_commands(module, 'show startup-config')
+                output = execute_show_commands(module, 'show startup-config')
                 contents = output[0]
             else:
                 contents = output[0]

--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -171,7 +171,7 @@ import re
 from ansible.module_utils.nxos import run_commands, get_config
 from ansible.module_utils.nxos import nxos_argument_spec, check_args
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import iteritems
+from ansible.module_utils.six import string_types, iteritems
 
 
 class FactsBase(object):
@@ -290,7 +290,7 @@ class Interfaces(FactsBase):
             self.facts['interfaces'] = self.populate_interfaces(data)
 
         data = self.run('show ipv6 interface', 'json')
-        if data:
+        if data and not isinstance(data, string_types):
             self.parse_ipv6_interfaces(data)
 
         data = self.run('show lldp neighbors')


### PR DESCRIPTION
* update nxos_facts to handle errors in n35 platform

* switch show commands to output text

* replace basestring which is not supported in python3

* do it like the other modules: use string_types

* incorporate PR review

(cherry picked from commit 1360ae65185fac68d9960506c38ccb20df8be6d0)

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request