### PR TITLE
Add vmware fact about 'Cores Per Socket'

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -274,6 +274,7 @@ def gather_vm_facts(content, vm):
         'hw_guest_id': vm.summary.guest.guestId,
         'hw_product_uuid': vm.config.uuid,
         'hw_processor_count': vm.config.hardware.numCPU,
+        'hw_cores_per_socket': vm.config.hardware.numCoresPerSocket,
         'hw_memtotal_mb': vm.config.hardware.memoryMB,
         'hw_interfaces': [],
         'guest_tools_status': _get_vm_prop(vm, ('guest', 'toolsRunningStatus')),

--- a/test/integration/targets/vmware_guest_facts/tasks/main.yml
+++ b/test/integration/targets/vmware_guest_facts/tasks/main.yml
@@ -67,6 +67,7 @@
     that:
       - "guest_facts_0001['instance']['hw_name'] == vm1 | basename"
       - "guest_facts_0001['instance']['hw_product_uuid'] is defined"
+      - "guest_facts_0001['instance']['hw_cores_per_socket'] is defined"
 
 - set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
 
@@ -90,6 +91,7 @@
       - "guest_facts_0002['instance']['hw_name'] == vm1 | basename"
       - "guest_facts_0002['instance']['hw_product_uuid'] is defined"
       - "guest_facts_0002['instance']['hw_product_uuid'] == vm1_uuid"
+      - "guest_facts_0002['instance']['hw_cores_per_socket'] is defined"
 
 # Testcase 0003: Get details about virtual machines without snapshots using UUID
 - name: get empty list of snapshots from virtual machine using UUID


### PR DESCRIPTION
##### SUMMARY
This fix adds new fact - 'Cores Per Socket' about vmware guest machine.
Also, adds integration test for this change.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/vmware.py
test/integration/targets/vmware_guest_facts/tasks/main.yml

##### ANSIBLE VERSION
```
2.5devel
```