### PR TITLE
Add fix for setting manual MAC address

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -312,6 +312,7 @@ instance:
     sample: None
 '''
 
+import re
 import time
 
 HAS_PYVMOMI = False
@@ -469,13 +470,28 @@ class PyVmomiDeviceHelper(object):
         nic.device.connectable.startConnected = True
         nic.device.connectable.allowGuestControl = True
         nic.device.connectable.connected = True
-        if 'mac' in device_infos:
-            nic.device.addressType = 'assigned'
+        if 'mac' in device_infos and self.is_valid_mac_addr(device_infos['mac']):
+            nic.device.addressType = 'manual'
             nic.device.macAddress = device_infos['mac']
         else:
             nic.device.addressType = 'generated'
 
         return nic
+
+    @staticmethod
+    def is_valid_mac_addr(mac_addr):
+        """
+        Function to validate MAC address for given string
+        Args:
+            mac_addr: string to validate as MAC address
+
+        Returns: (Boolean) True if string is valid MAC address, otherwise False
+        """
+        ret = False
+        mac_addr_regex = re.compile('[0-9a-f]{2}([-:])[0-9a-f]{2}(\\1[0-9a-f]{2}){4}$')
+        if mac_addr_regex.match(mac_addr):
+            ret = True
+        return ret
 
 
 class PyVmomiCache(object):

--- a/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml
@@ -1,0 +1,61 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- debug: var=vcsim_instance
+
+- name: create new VMs with manual MAC address
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ item | basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    networks:
+        - name: VM Network
+          ip: 192.168.10.12
+          netmask: 255.255.255.0
+          gateway: 192.168.10.254
+          mac: aa:bb:cc:dd:aa:42
+    state: poweredoff
+    folder: "{{ item | dirname }}"
+  with_items:
+    - "/DC0/vm/DC0_H0_VM12"
+  register: clone_d1_c1_f0
+
+- debug: var=clone_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:42'"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -20,3 +20,4 @@
 - include: cdrom_d1_c1_f0.yml
 - include: create_rp_d1_c1_f0.yml
 - include: create_guest_invalid_d1_c1_f0.yml
+- include: mac_address_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
This fix adds ability to set MAC address maunally. Before adding
any MAC address, the value is validated. If value is not valid, then
MAC address is set to vCenter generated MAC address.
Also, added integration tests for this change.

Fixes: #21161

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/mac_address_d1_c1_f0.yml test/integration/targets/vmware_guest/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```