### PR TITLE
[WIP] Make VM name as optional parameter in vmware_guest

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -42,7 +42,7 @@ options:
     description:
     - Name of the VM to work with.
     - VM names in vCenter are not necessarily unique, which may be problematic, see C(name_match).
-    required: yes
+    - This is required if uuid is not supplied.
   name_match:
     description:
     - If multiple VMs matching the name, use the first or last found.
@@ -1516,7 +1516,7 @@ def main():
         is_template=dict(type='bool', default=False),
         annotation=dict(type='str', aliases=['notes']),
         customvalues=dict(type='list', default=[]),
-        name=dict(type='str', required=True),
+        name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
         folder=dict(type='str', default='/vm'),
@@ -1540,6 +1540,9 @@ def main():
                            supports_check_mode=True,
                            mutually_exclusive=[
                                ['cluster', 'esxi_hostname'],
+                           ],
+                           required_one_of=[
+                               ['name', 'uuid']
                            ],
                            )
 

--- a/test/integration/targets/vmware_guest/tasks/delete_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/delete_d1_c1_f0.yml
@@ -1,0 +1,80 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- debug: var=vcsim_instance
+
+- name: get a list of virtual machines from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+  register: vms
+
+- set_fact: vm1="{{ vms['json'][0] }}"
+
+- name: get a list of Datacenter from vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/govc_find?filter=DC
+  register: datacenters
+
+- set_fact: dc1="{{ datacenters['json'][0] }}"
+
+# Get details about virtual machines
+- name: get list of facts about virtual machines
+  vmware_guest_facts:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    datacenter: "{{ dc1 | basename }}"
+    name: "{{ vm1 | basename }}"
+    folder: "{{ vm1 | dirname }}"
+  register: guest_facts_0001
+
+- debug: msg="{{ guest_facts_0001 }}"
+
+- assert:
+    that:
+      - "guest_facts_0001['instance']['hw_product_uuid'] is defined"
+
+- set_fact: vm1_uuid="{{ guest_facts_0001['instance']['hw_product_uuid'] }}"
+
+- debug: var=vm1_uuid
+
+# Try to delete virtual machine using UUID
+- name: Delete virtual machine using UUID
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    uuid: "{{ vm1_uuid }}"
+    datacenter: "{{ dc1 | basename }}"
+    state: absent
+  register: delete_d1_c1_f0
+
+- debug: var=delete_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "delete_d1_c1_f0['changed'] == true"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -19,3 +19,4 @@
 - include: create_d1_c1_f0.yml
 - include: cdrom_d1_c1_f0.yml
 - include: create_rp_d1_c1_f0.yml
+- include: delete_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
This fix makes virtual machine name as optional param,
if uuid is provided in vmware_guest module.

Fixes: #32901

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/vmware_guest/tasks/delete_d1_c1_f0.yml
lib/ansible/modules/cloud/vmware/vmware_guest.py
test/integration/targets/vmware_guest/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```