### PR TITLE
Include both groups and hosts when pattern-matching with --limit

### DIFF
--- a/lib/ansible/inventory/manager.py
+++ b/lib/ansible/inventory/manager.py
@@ -524,12 +524,12 @@ class InventoryManager(object):
         if matching_groups:
             for groupname in matching_groups:
                 results.extend(self._inventory.groups[groupname].get_hosts())
-        else:
-            # pattern might match host
-            matching_hosts = self._match_list(self._inventory.hosts, pattern)
-            if matching_hosts:
-                for hostname in matching_hosts:
-                    results.append(self._inventory.hosts[hostname])
+
+        # check if pattern matches host
+        matching_hosts = self._match_list(self._inventory.hosts, pattern)
+        if matching_hosts:
+            for hostname in matching_hosts:
+                results.append(self._inventory.hosts[hostname])
 
         if not results and pattern in C.LOCALHOST:
             # get_host autocreates implicit when needed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #32906. As per [this](https://github.com/ansible/ansible/blob/afc460c9437bad282651609857f73990060ebbc4/lib/ansible/inventory/manager.py#L420-L421) docstring, pattern matching with `--limit` should include the hosts found within matched groups, as well as any other matched hosts. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
`inventory`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/abed/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Additional information can be found on the issue page (#32906). Corrected output is as follows:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
playbook: main.yml

  play #1 (all): test play	TAGS: []
    pattern: ['all']
    hosts (6):
      dev-mongo0
      dev-test2
      dev-mongo2
      dev-mongo1
      dev-test1
      dev-test0
```
