### PR TITLE
Assure hostname summary is well aligned

### DIFF
--- a/lib/ansible/plugins/callback/dense.py
+++ b/lib/ansible/plugins/callback/dense.py
@@ -482,7 +482,8 @@ class CallbackModule_dense(CallbackModule_default):
         hosts = sorted(stats.processed.keys())
         for h in hosts:
             t = stats.summarize(h)
-            self._display.display(u"%s : %s %s %s %s" % (
+            # 63 is the maximum hostname length allowed by RFC 1035
+            self._display.display(u"%-63s : %s %s %s %s" % (
                 hostcolor(h, t),
                 colorize(u'ok', t['ok'], C.COLOR_OK),
                 colorize(u'changed', t['changed'], C.COLOR_CHANGED),

--- a/lib/ansible/plugins/callback/selective.py
+++ b/lib/ansible/plugins/callback/selective.py
@@ -240,8 +240,10 @@ class CallbackModule(CallbackBase):
             else:
                 color = 'ok'
 
-            msg = '{0}    : ok={1}\tchanged={2}\tfailed={3}\tunreachable={4}'.format(
-                host, s['ok'], s['changed'], s['failures'], s['unreachable'])
+            # 63 is the maximum hostname length allowed by RFC 1035
+            msg = '{0:63} : ok={1}\tchanged={2}\tfailed={3}\tunreachable={4}' \
+                  .format(host, s['ok'], s['changed'],
+                          s['failures'], s['unreachable'])
             print(colorize(msg, color))
 
     def v2_runner_on_skipped(self, result, **kwargs):


### PR DESCRIPTION
##### SUMMARY
Allocate enough space so long hostnames
do no break colum formatting.

RFC 1035 states that maximum hostname
length is 63 chars.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
output

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2.0
```

