### PR TITLE
Add missing ansible-test --remote-terminate support.

### DIFF
--- a/test/runner/lib/thread.py
+++ b/test/runner/lib/thread.py
@@ -23,6 +23,7 @@ class WrappedThread(threading.Thread):
         super(WrappedThread, self).__init__()
         self._result = queue.Queue()
         self.action = action
+        self.result = None
 
     def run(self):
         """
@@ -41,9 +42,13 @@ class WrappedThread(threading.Thread):
         :rtype: any
         """
         result, exception = self._result.get()
+
         if exception:
             if sys.version_info[0] > 2:
                 raise exception[1].with_traceback(exception[2])
             # noinspection PyRedundantParentheses
             exec('raise exception[0], exception[1], exception[2]')  # pylint: disable=locally-disabled, exec-used
+
+        self.result = result
+
         return result

--- a/test/utils/shippable/network.sh
+++ b/test/utils/shippable/network.sh
@@ -41,7 +41,14 @@ else
 fi
 
 for version in "${python_versions[@]}"; do
+    # terminate remote instances on the final python version tested
+    if [ "${version}" = "${python_versions[-1]}" ]; then
+        terminate="always"
+    else
+        terminate="never"
+    fi
+
     # shellcheck disable=SC2086
     ansible-test network-integration --color -v --retry-on-error "${target}" --docker default --python "${version}" \
-        ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} "${platforms[@]}"
+        ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} "${platforms[@]}" --remote-terminate "${terminate}"
 done

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -67,7 +67,14 @@ for version in "${python_versions[@]}"; do
         ci="windows/ci/minimal/"
     fi
 
+    # terminate remote instances on the final python version tested
+    if [ "${version}" = "${python_versions[-1]}" ]; then
+        terminate="always"
+    else
+        terminate="never"
+    fi
+
     # shellcheck disable=SC2086
     ansible-test windows-integration --color -v --retry-on-error "${ci}" --docker default --python "${version}" ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
-        "${platforms[@]}" --changed-all-target "${changed_all_target}"
+        "${platforms[@]}" --changed-all-target "${changed_all_target}" --remote-terminate "${terminate}"
 done


### PR DESCRIPTION
##### SUMMARY

Add missing `ansible-test --remote-terminate` support to the `windows-integration` and `network-integration` commands. Previously these commands accepted the option, but did not support it.

This PR also enables use of `--remote-termianate always` for these commands in CI.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-terminate 787ff93c95) last updated 2017/11/14 15:39:22 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
