### PR TITLE
Ironware module_utils cliconf plugin minor change

### DIFF
--- a/lib/ansible/module_utils/ironware.py
+++ b/lib/ansible/module_utils/ironware.py
@@ -61,7 +61,7 @@ def get_connection(module):
     global _CONNECTION
     if _CONNECTION:
         return _CONNECTION
-    _CONNECTION = Connection(module)
+    _CONNECTION = Connection(module._socket_path)
 
     return _CONNECTION
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As per refactor in connection framework PR #32521 
pass socket_path to Connection class while initiating
cliconf connection
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
module_utils/ironware.py
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
