### PR TITLE
Update vmware_dvswitch.py

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -19,7 +19,7 @@ module: vmware_dvswitch
 short_description: Create or remove a distributed vSwitch
 description:
     - Create or remove a distributed vSwitch
-version_added: "2.5"
+version_added: 2.0
 author: "Joseph Callen (@jcpowermac)"
 notes:
     - Tested on vSphere 5.5
@@ -37,8 +37,10 @@ options:
         required: True
     switch_version:
         description:
-            - The version of the switch to create. Needed if you have a vcenter version > ESXi version to join DVS. If not specified version=version of vcenter
+            - The version of the switch to create. 
+            - Needed if you have a vcenter version > ESXi version to join DVS. If not specified version=version of vcenter
         required: False
+        version_added: 2.5
     mtu:
         description:
             - The switch maximum transmission unit

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -37,7 +37,7 @@ options:
         required: True
     switch_version:
         description:
-            - The version of the switch to create. 
+            - The version of the switch to create.
             - Needed if you have a vcenter version > ESXi version to join DVS. If not specified version=version of vcenter
         required: False
         version_added: 2.5

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -37,8 +37,8 @@ options:
         required: True
     switch_version:
         description:
-            - The version of the switch to create. Needed if you have a vcenter version > ESXi version to join this DVS. If not specified ersion = version of vcenter
-        required: False    
+            - The version of the switch to create. Needed if you have a vcenter version > ESXi version to join DVS. If not specified version=version of vcenter
+        required: False
     mtu:
         description:
             - The switch maximum transmission unit
@@ -157,7 +157,7 @@ class VMwareDVSwitch(object):
         spec.productInfo = vim.dvs.ProductSpec()
         spec.productInfo.name = "DVS"
         spec.productInfo.vendor = "VMware"
-        spec.productInfo.version = self.switch_version 
+        spec.productInfo.version = self.switch_version
 
         for count in range(1, self.uplink_quantity + 1):
             spec.configSpec.uplinkPortPolicy.uplinkPortName.append("uplink%d" % count)

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -19,7 +19,7 @@ module: vmware_dvswitch
 short_description: Create or remove a distributed vSwitch
 description:
     - Create or remove a distributed vSwitch
-version_added: 2.4
+version_added: "2.5"
 author: "Joseph Callen (@jcpowermac)"
 notes:
     - Tested on vSphere 5.5

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -19,7 +19,7 @@ module: vmware_dvswitch
 short_description: Create or remove a distributed vSwitch
 description:
     - Create or remove a distributed vSwitch
-version_added: 2.0
+version_added: 2.5
 author: "Joseph Callen (@jcpowermac)"
 notes:
     - Tested on vSphere 5.5

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -35,6 +35,10 @@ options:
         description:
             - The name of the switch to create or remove
         required: True
+    switch_version:
+        description:
+            - The version of the switch to create. Needed if you have a vcenter version > ESXi version to join this DVS. If not specified ersion = version of vcenter
+        required: False    
     mtu:
         description:
             - The switch maximum transmission unit
@@ -77,6 +81,7 @@ EXAMPLES = '''
     password: vcenter_password
     datacenter_name: datacenter
     switch_name: dvSwitch
+    switch_version: 6.0
     mtu: 9000
     uplink_quantity: 2
     discovery_proto: lldp
@@ -106,6 +111,7 @@ class VMwareDVSwitch(object):
         self.module = module
         self.dvs = None
         self.switch_name = self.module.params['switch_name']
+        self.switch_version = self.module.params['switch_version']
         self.datacenter_name = self.module.params['datacenter_name']
         self.mtu = self.module.params['mtu']
         self.uplink_quantity = self.module.params['uplink_quantity']
@@ -151,6 +157,7 @@ class VMwareDVSwitch(object):
         spec.productInfo = vim.dvs.ProductSpec()
         spec.productInfo.name = "DVS"
         spec.productInfo.vendor = "VMware"
+        spec.productInfo.version = self.switch_version 
 
         for count in range(1, self.uplink_quantity + 1):
             spec.configSpec.uplinkPortPolicy.uplinkPortName.append("uplink%d" % count)

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -202,6 +202,7 @@ def main():
     argument_spec.update(dict(datacenter_name=dict(required=True, type='str'),
                               switch_name=dict(required=True, type='str'),
                               mtu=dict(required=True, type='int'),
+                              switch_version=dict(type='str'),
                               uplink_quantity=dict(required=True, type='int'),
                               discovery_proto=dict(required=True, choices=['cdp', 'lldp'], type='str'),
                               discovery_operation=dict(required=True, choices=['both', 'none', 'advertise', 'listen'], type='str'),

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -22,7 +22,7 @@ description:
 version_added: 2.0
 author: "Joseph Callen (@jcpowermac)"
 notes:
-    - Tested on vSphere 5.5
+    - Tested on vSphere 6.5
 requirements:
     - "python >= 2.6"
     - PyVmomi
@@ -37,7 +37,7 @@ options:
         required: True
     switch_version:
         description:
-            - The version of the switch to create.
+            - The version of the switch to create. Can be 6.5.0, 6.0.0, 5.5.0, 5.1.0, 5.0.0 with a vcenter running vSphere 6.5
             - Needed if you have a vcenter version > ESXi version to join DVS. If not specified version=version of vcenter
         required: False
         version_added: 2.5
@@ -83,7 +83,7 @@ EXAMPLES = '''
     password: vcenter_password
     datacenter_name: datacenter
     switch_name: dvSwitch
-    switch_version: 6.0
+    switch_version: 6.0.0
     mtu: 9000
     uplink_quantity: 2
     discovery_proto: lldp

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -19,7 +19,7 @@ module: vmware_dvswitch
 short_description: Create or remove a distributed vSwitch
 description:
     - Create or remove a distributed vSwitch
-version_added: 2.0
+version_added: 2.4
 author: "Joseph Callen (@jcpowermac)"
 notes:
     - Tested on vSphere 5.5

--- a/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvswitch.py
@@ -19,7 +19,7 @@ module: vmware_dvswitch
 short_description: Create or remove a distributed vSwitch
 description:
     - Create or remove a distributed vSwitch
-version_added: 2.5
+version_added: 2.0
 author: "Joseph Callen (@jcpowermac)"
 notes:
     - Tested on vSphere 5.5


### PR DESCRIPTION
##### SUMMARY
Add version parameter  in dvswitch to be able to create a dvswitch with a lower version than vcenter
##### ISSUE TYPE
 - Feature Pull Request
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ansible/lib/Ansible/modules/cloud/vmware/vmware_dvswitch.py

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
According https://github.com/vmware/pyvmomi/blob/master/docs/vim/DistributedVirtualSwitch/CreateSpec.rst
One may read :
productInfo (vim.dvs.ProductSpec, optional):

Product information for this switch implementation. If you do not specify this property, the Server will use the latest version to create the DistributedVirtualSwitch .

And here : https://github.com/vmware/pyvmomi/blob/master/docs/vim/dvs/ProductSpec.rst
Attributes:
<..>
version (str, optional):
Dot-separated version string. For example, "1.2".
