### PR TITLE
VMware: Provide clear error message after failure

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1580,8 +1580,9 @@ def main():
     # VM doesn't exist
     else:
         if module.params['state'] in ['poweredon', 'poweredoff', 'present', 'restarted', 'suspended']:
-            # Create it ...
             result = pyv.deploy_vm()
+            if result['failed']:
+                module.fail_json(msg='Failed to create a virtual machine : %s' % result['msg'])
 
     if result['failed']:
         module.fail_json(**result)

--- a/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml
@@ -1,0 +1,68 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#- name: Wait for Flask controller to come up online
+#  wait_for:
+#    host: "{{ vcsim }}"
+#    port: 5000
+#    state: started
+#
+#- name: kill vcsim
+#  uri:
+#    url: http://{{ vcsim }}:5000/killall
+#- name: start vcsim with no folders
+#  uri:
+#    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+#  register: vcsim_instance
+#
+#- name: Wait for Flask controller to come up online
+#  wait_for:
+#    host: "{{ vcsim }}"
+#    port: 443
+#    state: started
+#
+#- debug: var=vcsim_instance
+#
+#- name: get a list of Datacenter from vcsim
+#  uri:
+#    url: http://{{ vcsim }}:5000/govc_find?filter=DC
+#  register: datacenters
+#
+#- set_fact: dc1="{{ datacenters['json'][0] }}"
+#
+#- name: get a list of virtual machines from vcsim
+#  uri:
+#    url: http://{{ vcsim }}:5000/govc_find?filter=VM
+#  register: vms
+#
+#- set_fact: vm1="{{ vms['json'][0] }}"
+#
+#- name: create new virtual machine with invalid guest id
+#  vmware_guest:
+#    validate_certs: False
+#    hostname: "{{ vcsim }}"
+#    username: "{{ vcsim_instance['json']['username'] }}"
+#    password: "{{ vcsim_instance['json']['password'] }}"
+#    name: "{{ 'invalid_vm_' + vm1 | basename }}"
+#    guest_id: "invalid_guest_id"
+#    datacenter: "{{ (vm1|basename).split('_')[0] }}"
+#    hardware:
+#        num_cpus: 1
+#        memory_mb: 512
+#    disk:
+#        - size: 0gb
+#          type: thin
+#          autoselect_datastore: True
+#    state: present
+#    folder: "{{ vm1 | dirname }}"
+#  register: invalid_guest_0001_d1_c1_f0
+#  ignore_errors: yes
+#
+#- debug: var=invalid_guest_0001_d1_c1_f0
+#
+#- name: assert that changes were made
+#  assert:
+#    that:
+#        - "invalid_guest_0001_d1_c1_f0['changed'] == false"
+#        - "'configSpec.guestId' in invalid_guest_0001_d1_c1_f0['msg']"

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -19,3 +19,4 @@
 - include: create_d1_c1_f0.yml
 - include: cdrom_d1_c1_f0.yml
 - include: create_rp_d1_c1_f0.yml
+- include: create_guest_invalid_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY
This fix adds clear error message to user about failure rather
than showing full dictionary result.
Also, adds integration test for this change.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py test/integration/targets/vmware_guest/tasks/create_guest_invalid_d1_c1_f0.yml test/integration/targets/vmware_guest/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```