### PR TITLE
Add from_ast filter that uses ast.literal_eval

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -19,6 +19,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import ast
 import base64
 import crypt
 import glob
@@ -479,6 +480,9 @@ class FilterModule(object):
 
             # uuid
             'to_uuid': to_uuid,
+
+            # ast
+            'from_ast': ast.literal_eval,
 
             # json
             'to_json': to_json,


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Allows for loading ast literals stored as strings. For example, if an
ast literal is stored in an option in an ini file, this makes that value
accessible to additional filters.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
filter

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /home/cognifloyd/path/to/ansible.cfg
  configured module search path = [u'/home/cognifloyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cognifloyd/v/st2/lib/python2.7/site-packages/ansible
  executable location = /home/cognifloyd/v/st2/bin/ansible
  python version = 2.7.14 (default, Nov  5 2017, 02:04:56) [GCC 5.4.0]
```
