### PR TITLE
Added new module win_disk_facts

### DIFF
--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -1,6 +1,6 @@
 #!powershell
-# This file is part of Ansible
 
+# Copyright: (c) 2017, Marc Tschapek <marc.tschapek@itelligence.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -1,0 +1,47 @@
+#!powershell
+# This file is part of Ansible
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+# Create a new result object
+$result = @{
+    changed = $false
+    ansible_facts = @{
+        ansible_disk = @{
+        } 
+    }
+}
+
+# Search disks
+try {
+    $disk = Get-Disk
+} catch {
+    Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
+}
+if ($disk) {
+    $diskcount = $disk | Measure-Object | Select-Object  -ExpandProperty Count
+    $result.ansible_facts.ansible_disk.total_disks_found = "$diskcount"
+    $i = 0
+    foreach ($disks in $disk) {
+        $result.ansible_facts.ansible_disk["disk_$($i)"] += @{}
+        $result.ansible_facts.ansible_disk."disk_$($i)".number = "$([string]$disks.Number)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".size = "$($Size = $disks.Size / 1GB)$($Size)gb"
+        $result.ansible_facts.ansible_disk."disk_$($i)".location = "$([string]$disks.Location)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".serial_number = "$([string]$disks.SerialNumber)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = "$([string]$disks.UniqueId)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".operational_status = "$([string]$DOperSt = $disks.OperationalStatus)$DOperSt"
+        $result.ansible_facts.ansible_disk."disk_$($i)".partition_style = "$([string]$DPartStyle = $disks.PartitionStyle)$DPartStyle"
+        $result.ansible_facts.ansible_disk."disk_$($i)".read_only = "$([string]$DROState = $disks.IsReadOnly)$DROState"
+        $i++
+    }
+} else {
+        $result.ansible_facts.ansible_disk.total_disks_found = "0"
+        Fail-Json -obj $result -message "No disks could be found on the target"
+}
+
+# Return result
+Exit-Json -obj $result

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -28,22 +28,94 @@ if ($disk) {
     $i = 0
     foreach ($disks in $disk) {
         $result.ansible_facts.ansible_disk["disk_$($i)"] += @{}
-        $result.ansible_facts.ansible_disk."disk_$($i)".number = "$([string]$disks.Number)"
+        $pdisk = Get-PhysicalDisk | Where-Object {
+                                                            $_.SerialNumber -eq $disks.SerialNumber
+                                                          }
+        if ($pdisk) {
+            $result.ansible_facts.ansible_disk["disk_$($i)"]["physical_disk)"] += @{}
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].media_type = $pdisk.MediaType
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].device_id = $pdisk.DeviceId
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].friendly_name = $pdisk.FriendlyName
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].operational_status = $pdisk.OperationalStatus
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].health_status = $pdisk.HealthStatus
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].usage = $pdisk.Usage
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].supported_usages = $pdisk.SupportedUsages
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].spindle_speed = $pdisk.SpindleSpeed
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].can_pool = $pdisk.CanPool
+            if ($pdisk.CanPool) {
+                $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].cannot_pool_reason = $pdisk.CannotPoolReason
+            }   
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].object_id = $pdisk.ObjectId
+            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].unique_id = $pdisk.UniqueId
+        }
+        $result.ansible_facts.ansible_disk."disk_$($i)".number = $disks.Number
         $result.ansible_facts.ansible_disk."disk_$($i)".size = "$($Size = $disks.Size / 1GB)$($Size)gb"
-        $result.ansible_facts.ansible_disk."disk_$($i)".partition_style = "$([string]$DPartStyle = $disks.PartitionStyle)$DPartStyle"
-        $result.ansible_facts.ansible_disk."disk_$($i)".partition_count = "$([string]$disks.NumberOfPartitions)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".operational_status = "$([string]$DOperSt = $disks.OperationalStatus)$DOperSt"
-        $result.ansible_facts.ansible_disk."disk_$($i)".sector_size = "$([string]$disks.PhysicalSectorSize)byte"
-        $result.ansible_facts.ansible_disk."disk_$($i)".read_only = "$([string]$DROState = $disks.IsReadOnly)$DROState"
-        $result.ansible_facts.ansible_disk."disk_$($i)".boot_disk = "$([string]$BootState = $disks.IsBoot)$BootState"
-        $result.ansible_facts.ansible_disk."disk_$($i)".system_disk = "$([string]$SystemState = $disks.IsSystem)$SystemState"
-        $result.ansible_facts.ansible_disk."disk_$($i)".clustered = "$([string]$ClusteredState = $disks.IsClustered)$ClusteredState"
-        $result.ansible_facts.ansible_disk."disk_$($i)".model = "$([string]$disks.Model)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".firmware_version = "$([string]$disks.FirmwareVersion)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".location = "$([string]$disks.Location)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".serial_number = "$([string]$disks.SerialNumber)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = "$([string]$disks.UniqueId)"    
-        $result.ansible_facts.ansible_disk."disk_$($i)".guid = "$([string]$disks.Guid)"    
+        $result.ansible_facts.ansible_disk."disk_$($i)".bus_type = $disks.BusType
+        $result.ansible_facts.ansible_disk."disk_$($i)".friendly_name = $disks.FriendlyName
+        $result.ansible_facts.ansible_disk."disk_$($i)".partition_style = $disks.PartitionStyle
+        $result.ansible_facts.ansible_disk."disk_$($i)".partition_count = $disks.NumberOfPartitions
+        $result.ansible_facts.ansible_disk."disk_$($i)".operational_status = $disks.OperationalStatus
+        $result.ansible_facts.ansible_disk."disk_$($i)".sector_size = "$($disks.PhysicalSectorSize)byte"
+        $result.ansible_facts.ansible_disk."disk_$($i)".read_only = $disks.IsReadOnly
+        $result.ansible_facts.ansible_disk."disk_$($i)".bootable = $disks.IsBoot
+        $result.ansible_facts.ansible_disk."disk_$($i)".system_disk = $disks.IsSystem
+        $result.ansible_facts.ansible_disk."disk_$($i)".clustered = $disks.IsClustered
+        $result.ansible_facts.ansible_disk."disk_$($i)".manufacturer = $disks.Manufacturer
+        $result.ansible_facts.ansible_disk."disk_$($i)".model = $disks.Model
+        $result.ansible_facts.ansible_disk."disk_$($i)".firmware_version = $disks.FirmwareVersion
+        $result.ansible_facts.ansible_disk."disk_$($i)".location = $disks.Location
+        $result.ansible_facts.ansible_disk."disk_$($i)".serial_number = $disks.SerialNumber
+        $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = $disks.UniqueId
+        $result.ansible_facts.ansible_disk."disk_$($i)".guid = "$([string]$disks.Guid)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".path = $disks.Path
+        $part = Get-Partition -DiskNumber $i -ErrorAction SilentlyContinue
+        if ($part) {
+            $j = 0
+            foreach ($parts in $part) {
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"] += @{}
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].type = $parts.Type
+                if ($disks.PartitionStyle -eq "GPT") {
+                    $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].gpt_type = $parts.GptType
+                    $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].no_default_driveletter = $parts.NoDefaultDriveLetter
+                } elseif ($disks.PartitionStyle -eq "MBR") {
+                    $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].mbr_type = $parts.MbrType
+                    $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].active = $parts.IsActive
+                }
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].number = $parts.PartitionNumber
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].size = $parts.Size
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].drive_letter = "$([string]$parts.DriveLetter)"
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].transition_state = $parts.TransitionState
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].offset = $parts.Offset             
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].hidden = $parts.IsHidden
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].shadow_copy = $parts.IsShadowCopy
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].guid = "$([string]$parts.Guid)"
+                $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"].access_paths = "$([string]$parts.AccessPaths)"
+                $vol = Get-Volume -Partition $parts -ErrorAction SilentlyContinue
+                if ($vol) {
+                    $k = 0
+                    foreach ($vols in $vol) {
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"] += @{}
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].size = "$($volSize = $vols.Size / 1GB)$($volSize)gb"
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].size_remaining = "$($volSizeRe = $vols.SizeRemaining / 1GB)$($volSizeRe)gb"
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].type = $vols.FileSystem
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].label = $vols.FileSystemLabel
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].health_status = $vols.HealthStatus
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].drive_type = $vols.DriveType
+                        if ([System.Environment]::OSVersion.Version.Major -ge 10) {
+                            $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].allocation_unit_size = "$($vols.AllocationUnitSize)byte"
+                        } else {
+                            $volsPath = ($vols.Path.TrimStart("\\?\")).TrimEnd("\")
+                            $BlockSize = (Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volsPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
+                            $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].allocation_unit_size = "$($BlockSize / 1KB)kb"
+                        }
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].object_id = $vols.ObjectId
+                        $result.ansible_facts.ansible_disk["disk_$($i)"]["partition_$($j)"]["volume_$($k)"].path = $vols.Path
+                        $k++
+                    }
+                }
+                $j++
+            }
+        }
         $i++
     }
 } else {

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -46,9 +46,6 @@ if ($disk) {
         $result.ansible_facts.ansible_disk."disk_$($i)".serial_number = "$([string]$disks.SerialNumber)"
         $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = "$([string]$disks.UniqueId)"    
         $result.ansible_facts.ansible_disk."disk_$($i)".guid = "$([string]$disks.Guid)"
-
-
-        
         $i++
     }
 } else {

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -23,8 +23,8 @@ try {
     Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
 }
 if ($disk) {
-    $diskcount = $disk | Measure-Object | Select-Object  -ExpandProperty Count
-    $result.ansible_facts.ansible_disk.total_disks_found = "$diskcount"
+    [string]$diskcount = $disk | Measure-Object | Select-Object  -ExpandProperty Count
+    $result.ansible_facts.ansible_disk.total_disks_found = $diskcount
     $i = 0
     foreach ($disks in $disk) {
         $result.ansible_facts.ansible_disk["disk_$($i)"] += @{}

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -33,7 +33,7 @@ if ($disk) {
                                                           }
         if ($pdisk) {
             $result.ansible_facts.ansible_disk["disk_$($i)"]["physical_disk)"] += @{}
-            $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].media_type = $pdisk.MediaType
+            #$result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].media_type = $pdisk.MediaType
             $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].device_id = $pdisk.DeviceId
             $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].friendly_name = $pdisk.FriendlyName
             $result.ansible_facts.ansible_disk."disk_$($i)"["physical_disk)"].operational_status = $pdisk.OperationalStatus

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -37,15 +37,13 @@ if ($disk) {
         $result.ansible_facts.ansible_disk."disk_$($i)".read_only = "$([string]$DROState = $disks.IsReadOnly)$DROState"
         $result.ansible_facts.ansible_disk."disk_$($i)".boot_disk = "$([string]$BootState = $disks.IsBoot)$BootState"
         $result.ansible_facts.ansible_disk."disk_$($i)".system_disk = "$([string]$SystemState = $disks.IsSystem)$SystemState"
-        $result.ansible_facts.ansible_disk."disk_$($i)".scale_out = "$([string]$ScaleOutState = $disks.IsScaleOut)$ScaleOutState"
-        $result.ansible_facts.ansible_disk."disk_$($i)".highly_available = "$([string]$HiglyAvailState = $disks.IsHighlyAvailable)$HiglyAvailState"
         $result.ansible_facts.ansible_disk."disk_$($i)".clustered = "$([string]$ClusteredState = $disks.IsClustered)$ClusteredState"
         $result.ansible_facts.ansible_disk."disk_$($i)".model = "$([string]$disks.Model)"
         $result.ansible_facts.ansible_disk."disk_$($i)".firmware_version = "$([string]$disks.FirmwareVersion)"
         $result.ansible_facts.ansible_disk."disk_$($i)".location = "$([string]$disks.Location)"
         $result.ansible_facts.ansible_disk."disk_$($i)".serial_number = "$([string]$disks.SerialNumber)"
         $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = "$([string]$disks.UniqueId)"    
-        $result.ansible_facts.ansible_disk."disk_$($i)".guid = "$([string]$disks.Guid)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".guid = "$([string]$disks.Guid)"    
         $i++
     }
 } else {

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -30,12 +30,25 @@ if ($disk) {
         $result.ansible_facts.ansible_disk["disk_$($i)"] += @{}
         $result.ansible_facts.ansible_disk."disk_$($i)".number = "$([string]$disks.Number)"
         $result.ansible_facts.ansible_disk."disk_$($i)".size = "$($Size = $disks.Size / 1GB)$($Size)gb"
+        $result.ansible_facts.ansible_disk."disk_$($i)".partition_style = "$([string]$DPartStyle = $disks.PartitionStyle)$DPartStyle"
+        $result.ansible_facts.ansible_disk."disk_$($i)".partition_count = "$([string]$disks.NumberOfPartitions)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".operational_status = "$([string]$DOperSt = $disks.OperationalStatus)$DOperSt"
+        $result.ansible_facts.ansible_disk."disk_$($i)".sector_size = "$([string]$disks.PhysicalSectorSize)byte"
+        $result.ansible_facts.ansible_disk."disk_$($i)".read_only = "$([string]$DROState = $disks.IsReadOnly)$DROState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".boot_disk = "$([string]$BootState = $disks.IsBoot)$BootState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".system_disk = "$([string]$SystemState = $disks.IsSystem)$SystemState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".scale_out = "$([string]$ScaleOutState = $disks.IsScaleOut)$ScaleOutState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".highly_available = "$([string]$HiglyAvailState = $disks.IsHighlyAvailable)$HiglyAvailState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".clustered = "$([string]$ClusteredState = $disks.IsClustered)$ClusteredState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".model = "$([string]$disks.Model)"
+        $result.ansible_facts.ansible_disk."disk_$($i)".firmware_version = "$([string]$disks.FirmwareVersion)"
         $result.ansible_facts.ansible_disk."disk_$($i)".location = "$([string]$disks.Location)"
         $result.ansible_facts.ansible_disk."disk_$($i)".serial_number = "$([string]$disks.SerialNumber)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = "$([string]$disks.UniqueId)"
-        $result.ansible_facts.ansible_disk."disk_$($i)".operational_status = "$([string]$DOperSt = $disks.OperationalStatus)$DOperSt"
-        $result.ansible_facts.ansible_disk."disk_$($i)".partition_style = "$([string]$DPartStyle = $disks.PartitionStyle)$DPartStyle"
-        $result.ansible_facts.ansible_disk."disk_$($i)".read_only = "$([string]$DROState = $disks.IsReadOnly)$DROState"
+        $result.ansible_facts.ansible_disk."disk_$($i)".unique_id = "$([string]$disks.UniqueId)"    
+        $result.ansible_facts.ansible_disk."disk_$($i)".guid = "$([string]$disks.Guid)"
+
+
+        
         $i++
     }
 } else {

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -47,8 +47,8 @@ foreach ($disk in $disks) {
     }
     if ($pdisk) {
         $disk_info["physical_disk"] += @{
-            size = "$($pSize = "{0:N3}" -f ($pdisk.Size / 1GB))$($pSize)gb"
-            allocated_size = "$($pAllocSize = "{0:N3}" -f ($pdisk.AllocatedSize / 1GB))$($pAllocSize)gb"
+            size = "$($pSize = "{0:N3}" -f ($pdisk.Size / 1GB))$($pSize)GiB"
+            allocated_size = "$($pAllocSize = "{0:N3}" -f ($pdisk.AllocatedSize / 1GB))$($pAllocSize)GiB"
             device_id = $pdisk.DeviceId
             friendly_name = $pdisk.FriendlyName
             operational_status = $pdisk.OperationalStatus
@@ -77,28 +77,28 @@ foreach ($disk in $disks) {
         $vdisk = Get-VirtualDisk -PhysicalDisk $pdisk -ErrorAction SilentlyContinue
         if ($vdisk) {
             $disk_info["virtual_disk"] += @{
-                size = "$($vDSize = "{0:N3}" -f ($vdisk.Size / 1GB))$($vDSize)gb"
-                allocated_size = "$($vDAllocSize = "{0:N3}" -f ($vdisk.AllocatedSize / 1GB))$($vDAllocSize)gb"
-                footprint_on_pool = "$($vDPrint = "{0:N3}" -f ($vdisk.FootprintOnPool / 1GB))$($vDPrint)gb"
+                size = "$($vDSize = "{0:N3}" -f ($vdisk.Size / 1GB))$($vDSize)GiB"
+                allocated_size = "$($vDAllocSize = "{0:N3}" -f ($vdisk.AllocatedSize / 1GB))$($vDAllocSize)GiB"
+                footprint_on_pool = "$($vDPrint = "{0:N3}" -f ($vdisk.FootprintOnPool / 1GB))$($vDPrint)GiB"
                 name = $vdisk.name
                 friendly_name = $vdisk.FriendlyName
                 operational_status = $vdisk.OperationalStatus
                 health_status = $vdisk.HealthStatus
                 provisioning_type = $vdisk.ProvisioningType
-                allocation_unit_size = "$($vdisk.AllocationUnitSize / 1KB)kb"
+                allocation_unit_size = "$($vdisk.AllocationUnitSize / 1KB)KiB"
                 media_type = $vdisk.MediaType
                 parity_layout = $vdisk.ParityLayout
                 access = $vdisk.Access
                 detached_reason = $vdisk.DetachedReason
                 write_cache_size = "$($vdisk.WriteCacheSize)s/byte/bytes/"
                 fault_domain_awareness = $vdisk.FaultDomainAwareness
-                inter_leave = "$($vDLeave = "{0:N3}" -f ($vdisk.InterLeave / 1KB))$($vDLeave)kb"
+                inter_leave = "$($vDLeave = "{0:N3}" -f ($vdisk.InterLeave / 1KB))$($vDLeave)KiB"
                 deduplication_enabled = $vdisk.IsDeduplicationEnabled
                 enclosure_aware = $vdisk.IsEnclosureAware
                 manual_attach = $vdisk.IsManualAttach
                 snapshot = $vdisk.IsSnapshot
                 tiered = $vdisk.IsTiered
-                physical_sector_size = "$($vdisk.PhysicalSectorSize / 1KB)kb"
+                physical_sector_size = "$($vdisk.PhysicalSectorSize / 1KB)KiB"
                 logical_sector_size = "$($vdisk.LogicalSectorSize)s/byte/bytes/"
                 available_copies = $vdisk.NumberOfAvailableCopies
                 columns = $vdisk.NumberOfColumns
@@ -114,7 +114,7 @@ foreach ($disk in $disks) {
         }
     }
     $disk_info.number = $disk.Number
-    $disk_info.size = "$($disk.Size / 1GB)gb"
+    $disk_info.size = "$($disk.Size / 1GB)GiB"
     $disk_info.bus_type = $disk.BusType
     $disk_info.friendly_name = $disk.FriendlyName
     $disk_info.partition_style = $disk.PartitionStyle
@@ -139,7 +139,7 @@ foreach ($disk in $disks) {
         foreach ($part in $parts) {
             $partition_info  = @{
                 number = $part.PartitionNumber
-                size = "$($pSize = "{0:N3}" -f ($part.Size /1GB))$($pSize)gb"
+                size = "$($pSize = "{0:N3}" -f ($part.Size /1GB))$($pSize)GiB"
                 type = $part.Type
                 drive_letter = $part.DriveLetter
                 transition_state = $part.TransitionState
@@ -161,8 +161,8 @@ foreach ($disk in $disks) {
                 $partition_info["volumes"]  += @()
                 foreach ($vol in $vols) {
                     $volume_info  = @{
-                        size = "$($vSize = "{0:N3}" -f ($vol.Size / 1GB))$($vSize)gb"
-                        size_remaining = "$($vSizeRe = "{0:N3}" -f ($vol.SizeRemaining / 1GB))$($vSizeRe)gb"
+                        size = "$($vSize = "{0:N3}" -f ($vol.Size / 1GB))$($vSize)GiB"
+                        size_remaining = "$($vSizeRe = "{0:N3}" -f ($vol.SizeRemaining / 1GB))$($vSizeRe)GiB"
                         type = $vol.FileSystem
                         label = $vol.FileSystemLabel
                         health_status = $vol.HealthStatus
@@ -171,11 +171,11 @@ foreach ($disk in $disks) {
                         path = $vol.Path
                     }
                     if ([System.Environment]::OSVersion.Version.Major -ge 10) {
-                        $volume_info.allocation_unit_size = "$($vol.AllocationUnitSize /1KB)kb"
+                        $volume_info.allocation_unit_size = "$($vol.AllocationUnitSize /1KB)KiB"
                     } else {
                         $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
                         $BlockSize = (Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
-                        $volume_info.allocation_unit_size = "$($BlockSize / 1KB)kb"
+                        $volume_info.allocation_unit_size = "$($BlockSize / 1KB)KiB"
                     }
                     $partition_info.volumes  += $volume_info
                 }

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
+#AnsibleRequires -OSVersion 6.2
 $ErrorActionPreference = "Stop"
 Set-StrictMode -Version 2.0
 
@@ -11,170 +12,163 @@ Set-StrictMode -Version 2.0
 $result = @{
     changed = $false
     ansible_facts = @{
-        ansible_disk = @(
-        )
+        total_disks = 0
+        disks = @()
     }
 }
 
 # Search disks
-if (Get-Command 'Get-Disk') {
-    try {
-        $disks = Get-Disk
-    } catch {
-        Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
+try {
+    $disks = Get-Disk
+} catch {
+    Fail-Json -obj $result -message "Failed to search the disks on the target: $($_.Exception.Message)"
+}
+[int32]$diskcount = $disks | Measure-Object | Select-Object  -ExpandProperty Count
+$result.ansible_facts.total_disks = $diskcount
+foreach ($disk in $disks) {
+    $disk_info = @{}
+    $pdisk = Get-PhysicalDisk -ErrorAction SilentlyContinue | Where-Object {
+        $_.DeviceId -eq $disk.Number
     }
-    if ($disks) {
-        [int32]$diskcount = $disks | Measure-Object | Select-Object  -ExpandProperty Count
-        $result.ansible_facts.ansible_disk += @{total_disks_found = $diskcount}
-        foreach ($disk in $disks) {
-            $disk_results = @{}
-            $pdisk = Get-PhysicalDisk -ErrorAction SilentlyContinue | Where-Object {
-                $_.DeviceId -eq $disk.Number
-            }
-            if ($pdisk) {
-                $disk_results["physical_disk"] += @{
-                    #media_type = $pdisk.MediaType
-                    size = "$($pSize = "{0:N3}" -f ($pdisk.Size / 1GB))$($pSize)gb"
-                    allocated_size = "$($pAllocSize = "{0:N3}" -f ($pdisk.AllocatedSize / 1GB))$($pAllocSize)gb"
-                    device_id = $pdisk.DeviceId
-                    friendly_name = $pdisk.FriendlyName
-                    operational_status = $pdisk.OperationalStatus
-                    health_status = $pdisk.HealthStatus
-                    bus_type = $pdisk.BusType
-                    usage_type = $pdisk.Usage
-                    supported_usages = $pdisk.SupportedUsages
-                    spindle_speed = "$($pdisk.SpindleSpeed)rpm"
-                    firmware_version = $pdisk.FirmwareVersion
-                    physical_location = $pdisk.PhysicalLocation
-                    manufacturer = $pdisk.Manufacturer
-                    model = $pdisk.Model
-                    can_pool = $pdisk.CanPool
-                    indication_enabled = "$([string]$pdisk.IsIndicationEnabled)"
-                    partial = $pdisk.IsPartial
-                    serial_number = $pdisk.SerialNumber
-                    object_id = $pdisk.ObjectId
-                    unique_id = $pdisk.UniqueId
-                }
-                if (-not $pdisk.CanPool) {
-                    $disk_results.physical_disk.cannot_pool_reason = $pdisk.CannotPoolReason
-                }   
-                $vdisk = Get-VirtualDisk -PhysicalDisk $pdisk -ErrorAction SilentlyContinue
-                if ($vdisk) {
-                    $disk_results["virtual_disk"] += @{
-                        size = "$($vDSize = "{0:N3}" -f ($vdisk.Size / 1GB))$($vDSize)gb"
-                        allocated_size = "$($vDAllocSize = "{0:N3}" -f ($vdisk.AllocatedSize / 1GB))$($vDAllocSize)gb"
-                        footprint_on_pool = "$($vDPrint = "{0:N3}" -f ($vdisk.FootprintOnPool / 1GB))$($vDPrint)gb"
-                        name = "$([string]$vdisk.name)"
-                        friendly_name = $vdisk.FriendlyName
-                        operational_status = $vdisk.OperationalStatus
-                        health_status = $vdisk.HealthStatus
-                        provisioning_type = $vdisk.ProvisioningType
-                        allocation_unit_size = "$($vdisk.AllocationUnitSize / 1KB)kb"
-                        media_type = $vdisk.MediaType
-                        parity_layout = "$([string]$vdisk.ParityLayout)"
-                        access = $vdisk.Access
-                        detached_reason = $vdisk.DetachedReason
-                        write_cache_size = "$($vdisk.WriteCacheSize)byte"
-                        fault_domain_awareness = $vdisk.FaultDomainAwareness
-                        inter_leave = "$($vDLeave = "{0:N3}" -f ($vdisk.InterLeave / 1KB))$($vDLeave)kb"
-                        deduplication_enabled = $vdisk.IsDeduplicationEnabled
-                        enclosure_aware = $vdisk.IsEnclosureAware
-                        manual_attach = $vdisk.IsManualAttach
-                        snapshot = $vdisk.IsSnapshot
-                        tiered = $vdisk.IsTiered
-                        physical_sector_size = "$($vdisk.PhysicalSectorSize / 1KB)kb"
-                        logical_sector_size = "$($vdisk.LogicalSectorSize)byte"
-                        available_copies = "$([string]$vdisk.NumberOfAvailableCopies)"
-                        columns = $vdisk.NumberOfColumns
-                        groups = $vdisk.NumberOfGroups
-                        physical_disk_redundancy = $vdisk.PhysicalDiskRedundancy
-                        read_cache_size = $vdisk.ReadCacheSize
-                        request_no_spof = $vdisk.RequestNoSinglePointOfFailure
-                        resiliency_setting_name = $vdisk.ResiliencySettingName
-                        object_id = $vdisk.ObjectId
-                        unique_id_format = $vdisk.UniqueIdFormat
-                        unique_id = $vdisk.UniqueId
-                    }
-                }
-            }
-            $disk_results.number = $disk.Number
-            $disk_results.size = "$($disk.Size / 1GB)gb"
-            $disk_results.bus_type = $disk.BusType
-            $disk_results.friendly_name = $disk.FriendlyName
-            $disk_results.partition_style = $disk.PartitionStyle
-            $disk_results.partition_count = $disk.NumberOfPartitions
-            $disk_results.operational_status = $disk.OperationalStatus
-            $disk_results.sector_size = "$($disk.PhysicalSectorSize)byte"
-            $disk_results.read_only = $disk.IsReadOnly
-            $disk_results.bootable = $disk.IsBoot
-            $disk_results.system_disk = $disk.IsSystem
-            $disk_results.clustered = $disk.IsClustered
-            $disk_results.manufacturer = $disk.Manufacturer
-            $disk_results.model = $disk.Model
-            $disk_results.firmware_version = $disk.FirmwareVersion
-            $disk_results.location = $disk.Location
-            $disk_results.serial_number = $disk.SerialNumber
-            $disk_results.unique_id = $disk.UniqueId
-            $disk_results.guid = "$([string]$disk.Guid)"
-            $disk_results.path = $disk.Path
-            $parts = Get-Partition -DiskNumber $($disk.Number) -ErrorAction SilentlyContinue
-            if ($parts) {
-                $disk_results["partitions"]  += @()
-                foreach ($part in $parts) {
-                    $partition_results  = @{
-                        number = $part.PartitionNumber
-                        size = "$($pSize = "{0:N3}" -f ($part.Size /1GB))$($pSize)gb"
-                        type = $part.Type
-                        drive_letter = "$([string]$part.DriveLetter)"
-                        transition_state = $part.TransitionState
-                        offset = $part.Offset             
-                        hidden = $part.IsHidden
-                        shadow_copy = $part.IsShadowCopy
-                        guid = "$([string]$part.Guid)"
-                        access_paths = "$([string]$part.AccessPaths)"
-                    }
-                    if ($disks.PartitionStyle -eq "GPT") {
-                        $partition_results.gpt_type = $part.GptType
-                        $partition_results.no_default_driveletter = $part.NoDefaultDriveLetter
-                    } elseif ($disks.PartitionStyle -eq "MBR") {
-                        $partition_results.mbr_type = $part.MbrType
-                        $partition_results.active = $part.IsActive
-                    }
-                    $vols = Get-Volume -Partition $part -ErrorAction SilentlyContinue
-                    if ($vols) {
-                        $partition_results["volumes"]  += @()
-                        foreach ($vol in $vols) {
-                            $volume_results  = @{
-                                size = "$($vSize = "{0:N3}" -f ($vol.Size / 1GB))$($vSize)gb"
-                                size_remaining = "$($vSizeRe = "{0:N3}" -f ($vol.SizeRemaining / 1GB))$($vSizeRe)gb"
-                                type = $vol.FileSystem
-                                label = $vol.FileSystemLabel
-                                health_status = $vol.HealthStatus
-                                drive_type = $vol.DriveType
-                                object_id = $vol.ObjectId
-                                path = $vol.Path
-                            }
-                            if ([System.Environment]::OSVersion.Version.Major -ge 10) {
-                                $volume_results.allocation_unit_size = "$($vol.AllocationUnitSize /1KB)kb"
-                            } else {
-                                $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
-                                $BlockSize = (Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
-                                $volume_results.allocation_unit_size = "$($BlockSize / 1KB)kb"
-                            }
-                            $partition_results.volumes  += $volume_results
-                        }
-                    }
-                $disk_results.partitions += $partition_results
-                }
-            }
-            $result.ansible_facts.ansible_disk += $disk_results
+    if ($pdisk) {
+        $disk_info["physical_disk"] += @{
+            size = "$($pSize = "{0:N3}" -f ($pdisk.Size / 1GB))$($pSize)gb"
+            allocated_size = "$($pAllocSize = "{0:N3}" -f ($pdisk.AllocatedSize / 1GB))$($pAllocSize)gb"
+            device_id = $pdisk.DeviceId
+            friendly_name = $pdisk.FriendlyName
+            operational_status = $pdisk.OperationalStatus
+            health_status = $pdisk.HealthStatus
+            bus_type = $pdisk.BusType
+            usage_type = $pdisk.Usage
+            supported_usages = $pdisk.SupportedUsages
+            spindle_speed = "$($pdisk.SpindleSpeed)rpm"
+            firmware_version = $pdisk.FirmwareVersion
+            physical_location = $pdisk.PhysicalLocation
+            manufacturer = $pdisk.Manufacturer
+            model = $pdisk.Model
+            can_pool = $pdisk.CanPool
+            indication_enabled = $pdisk.IsIndicationEnabled
+            partial = $pdisk.IsPartial
+            serial_number = $pdisk.SerialNumber
+            object_id = $pdisk.ObjectId
+            unique_id = $pdisk.UniqueId
         }
-    } else {
-            $result.ansible_facts.ansible_disk.total_disks_found = "0"
-            Fail-Json -obj $result -message "No disks could be found on the target"
+        if ([single]"$([System.Environment]::OSVersion.Version.Major).$([System.Environment]::OSVersion.Version.Minor)" -ge 6.3) {
+            $disk_info.physical_disk.media_type = $pdisk.MediaType
+        }
+        if (-not $pdisk.CanPool) {
+            $disk_info.physical_disk.cannot_pool_reason = $pdisk.CannotPoolReason
+        }   
+        $vdisk = Get-VirtualDisk -PhysicalDisk $pdisk -ErrorAction SilentlyContinue
+        if ($vdisk) {
+            $disk_info["virtual_disk"] += @{
+                size = "$($vDSize = "{0:N3}" -f ($vdisk.Size / 1GB))$($vDSize)gb"
+                allocated_size = "$($vDAllocSize = "{0:N3}" -f ($vdisk.AllocatedSize / 1GB))$($vDAllocSize)gb"
+                footprint_on_pool = "$($vDPrint = "{0:N3}" -f ($vdisk.FootprintOnPool / 1GB))$($vDPrint)gb"
+                name = $vdisk.name
+                friendly_name = $vdisk.FriendlyName
+                operational_status = $vdisk.OperationalStatus
+                health_status = $vdisk.HealthStatus
+                provisioning_type = $vdisk.ProvisioningType
+                allocation_unit_size = "$($vdisk.AllocationUnitSize / 1KB)kb"
+                media_type = $vdisk.MediaType
+                parity_layout = $vdisk.ParityLayout
+                access = $vdisk.Access
+                detached_reason = $vdisk.DetachedReason
+                write_cache_size = "$($vdisk.WriteCacheSize)s/byte/bytes/"
+                fault_domain_awareness = $vdisk.FaultDomainAwareness
+                inter_leave = "$($vDLeave = "{0:N3}" -f ($vdisk.InterLeave / 1KB))$($vDLeave)kb"
+                deduplication_enabled = $vdisk.IsDeduplicationEnabled
+                enclosure_aware = $vdisk.IsEnclosureAware
+                manual_attach = $vdisk.IsManualAttach
+                snapshot = $vdisk.IsSnapshot
+                tiered = $vdisk.IsTiered
+                physical_sector_size = "$($vdisk.PhysicalSectorSize / 1KB)kb"
+                logical_sector_size = "$($vdisk.LogicalSectorSize)s/byte/bytes/"
+                available_copies = $vdisk.NumberOfAvailableCopies
+                columns = $vdisk.NumberOfColumns
+                groups = $vdisk.NumberOfGroups
+                physical_disk_redundancy = $vdisk.PhysicalDiskRedundancy
+                read_cache_size = $vdisk.ReadCacheSize
+                request_no_spof = $vdisk.RequestNoSinglePointOfFailure
+                resiliency_setting_name = $vdisk.ResiliencySettingName
+                object_id = $vdisk.ObjectId
+                unique_id_format = $vdisk.UniqueIdFormat
+                unique_id = $vdisk.UniqueId
+            }
+        }
     }
-} else {
-    Fail-Json -obj $result -message "The required PowerShell Cmdlets of module Storage (e.g. Get-Disk) are not available in your PowerShell version $($host.Version.Major).$($host.Version.Minor)"
+    $disk_info.number = $disk.Number
+    $disk_info.size = "$($disk.Size / 1GB)gb"
+    $disk_info.bus_type = $disk.BusType
+    $disk_info.friendly_name = $disk.FriendlyName
+    $disk_info.partition_style = $disk.PartitionStyle
+    $disk_info.partition_count = $disk.NumberOfPartitions
+    $disk_info.operational_status = $disk.OperationalStatus
+    $disk_info.sector_size = "$($disk.PhysicalSectorSize)s/byte/bytes/"
+    $disk_info.read_only = $disk.IsReadOnly
+    $disk_info.bootable = $disk.IsBoot
+    $disk_info.system_disk = $disk.IsSystem
+    $disk_info.clustered = $disk.IsClustered
+    $disk_info.manufacturer = $disk.Manufacturer
+    $disk_info.model = $disk.Model
+    $disk_info.firmware_version = $disk.FirmwareVersion
+    $disk_info.location = $disk.Location
+    $disk_info.serial_number = $disk.SerialNumber
+    $disk_info.unique_id = $disk.UniqueId
+    $disk_info.guid = $disk.Guid
+    $disk_info.path = $disk.Path
+    $parts = Get-Partition -DiskNumber $($disk.Number) -ErrorAction SilentlyContinue
+    if ($parts) {
+        $disk_info["partitions"]  += @()
+        foreach ($part in $parts) {
+            $partition_info  = @{
+                number = $part.PartitionNumber
+                size = "$($pSize = "{0:N3}" -f ($part.Size /1GB))$($pSize)gb"
+                type = $part.Type
+                drive_letter = $part.DriveLetter
+                transition_state = $part.TransitionState
+                offset = $part.Offset             
+                hidden = $part.IsHidden
+                shadow_copy = $part.IsShadowCopy
+                guid = $part.Guid
+                access_paths = $part.AccessPaths
+            }
+            if ($disks.PartitionStyle -eq "GPT") {
+                $partition_info.gpt_type = $part.GptType
+                $partition_info.no_default_driveletter = $part.NoDefaultDriveLetter
+            } elseif ($disks.PartitionStyle -eq "MBR") {
+                $partition_info.mbr_type = $part.MbrType
+                $partition_info.active = $part.IsActive
+            }
+            $vols = Get-Volume -Partition $part -ErrorAction SilentlyContinue
+            if ($vols) {
+                $partition_info["volumes"]  += @()
+                foreach ($vol in $vols) {
+                    $volume_info  = @{
+                        size = "$($vSize = "{0:N3}" -f ($vol.Size / 1GB))$($vSize)gb"
+                        size_remaining = "$($vSizeRe = "{0:N3}" -f ($vol.SizeRemaining / 1GB))$($vSizeRe)gb"
+                        type = $vol.FileSystem
+                        label = $vol.FileSystemLabel
+                        health_status = $vol.HealthStatus
+                        drive_type = $vol.DriveType
+                        object_id = $vol.ObjectId
+                        path = $vol.Path
+                    }
+                    if ([System.Environment]::OSVersion.Version.Major -ge 10) {
+                        $volume_info.allocation_unit_size = "$($vol.AllocationUnitSize /1KB)kb"
+                    } else {
+                        $volPath = ($vol.Path.TrimStart("\\?\")).TrimEnd("\")
+                        $BlockSize = (Get-CimInstance -Query "SELECT BlockSize FROM Win32_Volume WHERE DeviceID like '%$volPath%'" -ErrorAction SilentlyContinue | Select-Object BlockSize).BlockSize
+                        $volume_info.allocation_unit_size = "$($BlockSize / 1KB)kb"
+                    }
+                    $partition_info.volumes  += $volume_info
+                }
+            }
+        $disk_info.partitions += $partition_info
+        }
+    }
+    $result.ansible_facts.disks += $disk_info
 }
 
 # Return result

--- a/lib/ansible/modules/windows/win_disk_facts.ps1
+++ b/lib/ansible/modules/windows/win_disk_facts.ps1
@@ -17,6 +17,21 @@ $result = @{
     }
 }
 
+# Functions 
+function Test-Admin {
+        $CurrentUser = New-Object Security.Principal.WindowsPrincipal $([Security.Principal.WindowsIdentity]::GetCurrent())
+        $IsAdmin = $CurrentUser.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)
+
+        return $IsAdmin
+}
+
+# Check admin rights
+if (-not (Test-Admin)) {
+    $result.Remove("total_disks")
+    $result.Remove("disks")
+    Fail-Json -obj $result -message "Cmdlet was not started with elevated rights"
+}
+
 # Search disks
 try {
     $disks = Get-Disk

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -69,7 +69,7 @@ ansible_facts:
                     type: string
                     sample: "3"
                 disk_identifier:
-                    description: 
+                    description:
                       - Detailed information about one particular disk.
                       - The identifier is displayed as a digit in order to structure the output but is not the actual number of the particular disk.
                       - Please see the containing return property "number" to get the actual disk number of the particular disk.
@@ -177,9 +177,10 @@ ansible_facts:
                             type: string
                             sample: "\\\\?\\scsi#disk&ven_red_hat&prod_virtio#4&23208fd0&1&000000#{<id>}"
                         partition_identifier:
-                            description: 
+                            description:
                               - Detailed information about one particular partition on the specified disk.
-                              - The identifier is displayed as a digit in order to structure the output but is not the actual number of the particular partition.
+                              - The identifier is displayed as a digit in order to structure the output but is not
+                                the actual number of the particular partition.
                               - Please see the containing return property "number" to get the actual partition number.
                             returned: if existent
                             type: complex
@@ -190,7 +191,7 @@ ansible_facts:
                                     type: string
                                     sample: "1"
                                 size:
-                                    description: 
+                                    description:
                                       - Size in gb of the particular partition.
                                       - Accurate to three decimal places.
                                     returned: always
@@ -257,9 +258,10 @@ ansible_facts:
                                     type: string
                                     sample: "\\\\?\\Volume{85bdc4a8-f8eb-11e6-80fa-806e6f6e6963}\\"
                                 volume_identifier:
-                                    description: 
+                                    description:
                                       - Detailed information about one particular volume on the specified partition.
-                                      - Please note that volumes have no "number" property and the identifier is displayed as a digit in order to structure the output.
+                                      - Please note that volumes have no "number" property and the identifier is displayed
+                                        as a digit in order to structure the output.
                                     returned: if existent
                                     type: complex
                                     contains:
@@ -373,7 +375,7 @@ ansible_facts:
                                     type: string
                                     sample: "false"
                                 cannot_pool_reason:
-                                    description: Information why the particular physical disk can't be added to a storage pool.
+                                    description: Information why the particular physical disk can not be added to a storage pool.
                                     returned: if can_pool property has value false
                                     type: string
                                     sample: "Insufficient Capacity"
@@ -381,7 +383,7 @@ ansible_facts:
                                     description: Object ID of the particular physical disk.
                                     returned: always
                                     type: string
-                                    sample: "{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_PhysicalDisk.ObjectId=\"{<object_id>}:PD:{<pd>}\"
+                                    sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_PhysicalDisk.ObjectId=\"{<object_id>}:PD:{<pd>}\"'
                                 unique_id:
                                     description: Unique ID of the particular physical disk.
                                     returned: always

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -27,16 +27,16 @@ notes:
 
 EXAMPLES = r'''
 - name: get disk facts
-   win_disk_facts:
+  win_disk_facts:
 - name: output first disk size
-   debug:
-       var: ansible_facts.ansible_disk.disk_0.size
+  debug:
+    var: ansible_facts.ansible_disk.disk_0.size
 
 - name: get disk facts
-   win_disk_facts:
+  win_disk_facts:
 - name: output second disk serial number
-   debug:
-       var: ansible_facts.ansible_disk.disk_1.serial_number
+  debug:
+    var: ansible_facts.ansible_disk.disk_1.serial_number
 '''
 
 RETURN = r'''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Marc Tschapek <marc.tschapek@itelligence.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = r'''
+---
+module: win_disk_facts
+version_added: '2.5'
+short_description: Show disks and disks information of the target host
+description:
+   - With the module you can retrieve and output detailed information about the attached disks on the target.
+requirements:
+    - Windows 8.1 / Windows 2012R2 (NT 6.3) or newer
+author:
+    - Marc Tschapek (@marqelme)
+notes:
+  - You can use this module in combination with the win_disk_management module in order to retrieve the disks status
+    on the target.
+'''
+
+EXAMPLES = r'''
+- name: get disk facts
+   win_disk_facts:
+- name: output first disk size
+   debug:
+       var: ansible_facts.ansible_disk.disk_0.size
+
+- name: get disk facts
+   win_disk_facts:
+- name: output second disk serial number
+   debug:
+       var: ansible_facts.ansible_disk.disk_1.serial_number
+'''
+
+RETURN = r'''
+changed:
+    description: Whether anything was changed.
+    returned: always
+    type: boolean
+    sample: true
+msg:
+    description: Possible error message on failure.
+    returned: failed
+    type: string
+    sample: "No disks could be found on the target"
+ansible_facts:
+    description: Dictionary containing all the detailed information about the disks of the target.
+    returned: always
+    type: complex
+    contains:
+        ansible_disk:
+            description: Detailed information about found disks on the target.
+            returned: always
+            type: complex
+            contains:
+                total_disks_found:
+                    description: Count of found disks on the target.
+                    returned: success or failed
+                    type: string
+                    sample: "3"
+                disk_number:
+                    description: Detailed information about one particular disk.
+                    returned: success or failed
+                    type: complex
+                    contains:
+                        number:
+                            description: Number of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "0"
+                        size:
+                            description: Size in gb of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "100gb"
+                        location:
+                            description: Location of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "PCIROOT(0)#PCI(0400)#SCSI(P00T00L00)"
+                        serial_number:
+                            description: Serial number of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "b62beac80c3645e5877f"
+                        unique_id:
+                            description: Unique ID of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "3141463431303031"
+                        operational_status:
+                            description: Operational status of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "Online"
+                        partition_style:
+                            description: Partition style of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "MBR"
+                        read_only:
+                            description: Read only status of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "False"
+'''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -13,9 +13,9 @@ DOCUMENTATION = r'''
 ---
 module: win_disk_facts
 version_added: '2.5'
-short_description: Show disks and disks information of the target host
+short_description: Show the attached disks and disk information of the target host
 description:
-   - With the module you can retrieve and output detailed information about the attached disks on the target.
+   - With the module you can retrieve and output detailed information about the attached disks of the target.
 requirements:
     - Windows 8.1 / Windows 2012R2 (NT 6.3) or newer
 author:

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -71,15 +71,65 @@ ansible_facts:
                     type: complex
                     contains:
                         number:
-                            description: Number of the particular disk on the target.
+                            description: Number of the particular disk.
                             returned: always
                             type: string
                             sample: "0"
                         size:
-                            description: Size in gb of the particular disk on the target.
+                            description: Size in gb of the particular disk.
                             returned: always
                             type: string
                             sample: "100gb"
+                        partition_style:
+                            description: Partition style of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "MBR"
+                        partition_count:
+                            description: Number of partitions on the particular disk.
+                            returned: always
+                            type: string
+                            sample: "4"
+                        operational_status:
+                            description: Operational status of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "Online"
+                        sector_size:
+                            description: Sector size of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "512"
+                        read_only:
+                            description: Read only status of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "True"
+                        boot_disk:
+                            description: Information whether the particular disk is a bootable disk.
+                            returned: always
+                            type: string
+                            sample: "False"
+                        system_disk:
+                            description: Information whether the particular disk is a system disk.
+                            returned: always
+                            type: string
+                            sample: "True"
+                        clustered:
+                            description: Information whether the particular disk is clustered (part of a failover cluster).
+                            returned: always
+                            type: string
+                            sample: "False"
+                        model:
+                            description: Model specification of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "VirtIO"
+                        firmware_version:
+                            description: Firmware version of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "0001"
                         location:
                             description: Location of the particular disk on the target.
                             returned: always
@@ -95,19 +145,9 @@ ansible_facts:
                             returned: always
                             type: string
                             sample: "3141463431303031"
-                        operational_status:
-                            description: Operational status of the particular disk on the target.
-                            returned: always
+                        guid:
+                            description: GUID of the particular disk on the target.
+                            returned: if available
                             type: string
-                            sample: "Online"
-                        partition_style:
-                            description: Partition style of the particular disk on the target.
-                            returned: always
-                            type: string
-                            sample: "MBR"
-                        read_only:
-                            description: Read only status of the particular disk on the target.
-                            returned: always
-                            type: string
-                            sample: "False"
+                            sample: "{efa5f928-57b9-47fc-ae3e-902e85fbe77f}"
 '''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -15,7 +15,8 @@ module: win_disk_facts
 version_added: '2.5'
 short_description: Show the attached disks and disk information of the target host
 description:
-   - With the module you can retrieve and output detailed information about the attached disks of the target.
+   - With the module you can retrieve and output detailed information about the attached disks of the target and
+     it's volumes and partitions if existent.
 requirements:
     - Windows 8.1 / Windows 2012R2 (NT 6.3) or newer
 author:
@@ -23,6 +24,8 @@ author:
 notes:
   - You can use this module in combination with the win_disk_management module in order to retrieve the disks status
     on the target.
+  - In order to understand all the returned properties and values please visit the following site and open the respective MSFT class
+    https://msdn.microsoft.com/en-us/library/windows/desktop/hh830612(v=vs.85).aspx
 '''
 
 EXAMPLES = r'''
@@ -65,13 +68,16 @@ ansible_facts:
                     returned: success or failed
                     type: string
                     sample: "3"
-                disk_number:
-                    description: Detailed information about one particular disk.
+                disk_identifier:
+                    description: 
+                      - Detailed information about one particular disk.
+                      - The identifier is displayed as a digit in order to structure the output but is not the actual number of the particular disk.
+                      - Please see the containing return property "number" to get the actual disk number of the particular disk.
                     returned: success or failed
                     type: complex
                     contains:
                         number:
-                            description: Number of the particular disk.
+                            description: Disk number of the particular disk.
                             returned: always
                             type: string
                             sample: "0"
@@ -80,6 +86,16 @@ ansible_facts:
                             returned: always
                             type: string
                             sample: "100gb"
+                        bus_type:
+                            description: Bus type of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "SCSI"
+                        friendly_name:
+                            description: Friendly name of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "Red Hat VirtIO SCSI Disk Device"
                         partition_style:
                             description: Partition style of the particular disk.
                             returned: always
@@ -99,27 +115,32 @@ ansible_facts:
                             description: Sector size of the particular disk.
                             returned: always
                             type: string
-                            sample: "512"
+                            sample: "512byte"
                         read_only:
                             description: Read only status of the particular disk.
                             returned: always
                             type: string
-                            sample: "True"
-                        boot_disk:
+                            sample: "true"
+                        bootable:
                             description: Information whether the particular disk is a bootable disk.
                             returned: always
                             type: string
-                            sample: "False"
+                            sample: "false"
                         system_disk:
                             description: Information whether the particular disk is a system disk.
                             returned: always
                             type: string
-                            sample: "True"
+                            sample: "true"
                         clustered:
                             description: Information whether the particular disk is clustered (part of a failover cluster).
                             returned: always
                             type: string
-                            sample: "False"
+                            sample: "false"
+                        manufacturer:
+                            description: Manufacturer of the particular disk.
+                            returned: always
+                            type: string
+                            sample: "Red Hat"
                         model:
                             description: Model specification of the particular disk.
                             returned: always
@@ -147,7 +168,233 @@ ansible_facts:
                             sample: "3141463431303031"
                         guid:
                             description: GUID of the particular disk on the target.
-                            returned: if available
+                            returned: if existent
                             type: string
                             sample: "{efa5f928-57b9-47fc-ae3e-902e85fbe77f}"
+                        path:
+                            description: Path of the particular disk on the target.
+                            returned: always
+                            type: string
+                            sample: "\\\\?\\scsi#disk&ven_red_hat&prod_virtio#4&23208fd0&1&000000#{<id>}"
+                        partition_identifier:
+                            description: 
+                              - Detailed information about one particular partition on the specified disk.
+                              - The identifier is displayed as a digit in order to structure the output but is not the actual number of the particular partition.
+                              - Please see the containing return property "number" to get the actual partition number.
+                            returned: if existent
+                            type: complex
+                            contains:
+                                number:
+                                    description: Number of the particular partition.
+                                    returned: always
+                                    type: string
+                                    sample: "1"
+                                size:
+                                    description: 
+                                      - Size in gb of the particular partition.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "0.031gb"
+                                type:
+                                    description: Type of the particular partition.
+                                    returned: always
+                                    type: string
+                                    sample: "IFS"
+                                gpt_type:
+                                    description: gpt type of the particular partition.
+                                    returned: if partition_style property of the particular disk has value "GPT"
+                                    type: string
+                                    sample: "{e3c9e316-0b5c-4db8-817d-f92df00215ae}"
+                                no_default_driveletter:
+                                    description: Information whether the particular partition has a default drive letter or not.
+                                    returned: if partition_style property of the particular disk has value "GPT"
+                                    type: string
+                                    sample: "true"
+                                mbr_type:
+                                    description: mbr type of the particular partition.
+                                    returned: f partition_style property of the particular disk has value "MBR"
+                                    type: string
+                                    sample: "7"
+                                active:
+                                    description: Information whether the particular partition is an active partition or not.
+                                    returned: f partition_style property of the particular disk has value "MBR"
+                                    type: string
+                                    sample: "true"
+                                drive_letter:
+                                    description: Drive letter of the particular partition.
+                                    returned: if existent
+                                    type: string
+                                    sample: "C"
+                                transition_state:
+                                    description: Transition state of the particular partition.
+                                    returned: always
+                                    type: string
+                                    sample: "1"
+                                offset:
+                                    description: Offset of the particular partition.
+                                    returned: always
+                                    type: string
+                                    sample: "368050176"
+                                hidden:
+                                    description: Information whether the particular partition is hidden or not.
+                                    returned: always
+                                    type: string
+                                    sample: "true"
+                                shadow_copy:
+                                    description: Information whether the particular partition is a shadow copy of another partition.
+                                    returned: always
+                                    type: string
+                                    sample: "false"
+                                guid:
+                                    description: GUID of the particular partition.
+                                    returned: if existent
+                                    type: string
+                                    sample: "{302e475c-6e64-4674-a8e2-2f1c7018bf97}"
+                                access_paths:
+                                    description: Access paths of the particular partition.
+                                    returned: if existent
+                                    type: string
+                                    sample: "\\\\?\\Volume{85bdc4a8-f8eb-11e6-80fa-806e6f6e6963}\\"
+                                volume_identifier:
+                                    description: 
+                                      - Detailed information about one particular volume on the specified partition.
+                                      - Please note that volumes have no "number" property and the identifier is displayed as a digit in order to structure the output.
+                                    returned: if existent
+                                    type: complex
+                                    contains:
+                                        size:
+                                            description:
+                                              - Size in gb of the particular volume.
+                                              - Accurate to three decimal places.
+                                            returned: always
+                                            type: string
+                                            sample: "0,342gb"
+                                        size_remaining:
+                                            description:
+                                              - Remaining size in gb of the particular volume.
+                                              - Accurate to three decimal places.
+                                            returned: always
+                                            type: string
+                                            sample: "0,146gb"
+                                        type:
+                                            description: File system type of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "NTFS"
+                                        label:
+                                            description: File system label of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "System Reserved"
+                                        health_status:
+                                            description: Health status of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "Healthy"
+                                        drive_type:
+                                            description: Drive type of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "Fixed"
+                                        allocation_unit_size:
+                                            description: Allocation unit size of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "64kb"
+                                        object_id:
+                                            description: Object ID of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "\\\\?\\Volume{85bdc4a9-f8eb-11e6-80fa-806e6f6e6963}\\"
+                                        path:
+                                            description: Path of the particular volume.
+                                            returned: always
+                                            type: string
+                                            sample: "\\\\?\\Volume{85bdc4a9-f8eb-11e6-80fa-806e6f6e6963}\\"
+                        physical_disk:
+                            description: Detailed information about physical disk properties of the particular disk.
+                            returned: if existent
+                            type: complex
+                            contains:
+                                media_type:
+                                    description: Media type of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "UnSpecified"
+                                device_id:
+                                    description: Device ID of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "0"
+                                friendly_name:
+                                    description: Friendly name of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "PhysicalDisk0"
+                                operational_status:
+                                    description: Operational status of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "OK"
+                                health_status:
+                                    description: Health status of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Healthy"
+                                usage_type:
+                                    description: Usage type of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Auto-Select"
+                                supported_usages:
+                                    description: Supported usage types of the particular physical disk.
+                                    returned: always
+                                    type: complex
+                                    contains:
+                                        Count:
+                                            description: Count of supported usage types.
+                                            returned: always
+                                            type: string
+                                            sample: "5"
+                                        value:
+                                            description: List of supported usage types.
+                                            returned: always
+                                            type: string
+                                            sample: "Auto-Select, Hot Spare"
+                                spindle_speed:
+                                    description: Spindle speed in rpm of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "4294967295rpm"
+                                can_pool:
+                                    description: Information whether the particular physical disk can be added to a storage pool.
+                                    returned: always
+                                    type: string
+                                    sample: "false"
+                                cannot_pool_reason:
+                                    description: Information why the particular physical disk can't be added to a storage pool.
+                                    returned: if can_pool property has value false
+                                    type: string
+                                    sample: "Insufficient Capacity"
+                                object_id:
+                                    description: Object ID of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_PhysicalDisk.ObjectId=\"{<object_id>}:PD:{<pd>}\"
+                                unique_id:
+                                    description: Unique ID of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "3141463431303031"
+                        virtual_disk:
+                            description: Detailed information about virtual disk properties of the particular disk.
+                            returned: if existent
+                            type: complex
+                            contains:
+                                friendly_name:
+                                    description: Friendly name of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Prod2 Virtual Disk"
 '''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -62,10 +62,10 @@ ansible_facts:
                     type: int
                     sample: 0
                 size:
-                    description: Size in gb of the particular disk.
+                    description: Size in Gibibyte of the particular disk.
                     returned: always
                     type: string
-                    sample: "100gb"
+                    sample: "100GiB"
                 bus_type:
                     description: Bus type of the particular disk.
                     returned: always
@@ -168,11 +168,11 @@ ansible_facts:
                             sample: 1
                         size:
                             description:
-                              - Size in gb of the particular partition.
+                              - Size in Gibibyte of the particular partition.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "0.031gb"
+                            sample: "0.031GiB"
                         type:
                             description: Type of the particular partition.
                             returned: always
@@ -240,18 +240,18 @@ ansible_facts:
                             contains:
                                 size:
                                     description:
-                                      - Size in gb of the particular volume.
+                                      - Size in Gibibyte of the particular volume.
                                       - Accurate to three decimal places.
                                     returned: always
                                     type: string
-                                    sample: "0,342gb"
+                                    sample: "0,342GiB"
                                 size_remaining:
                                     description:
-                                      - Remaining size in gb of the particular volume.
+                                      - Remaining size in Gibibyte of the particular volume.
                                       - Accurate to three decimal places.
                                     returned: always
                                     type: string
-                                    sample: "0,146gb"
+                                    sample: "0,146GiB"
                                 type:
                                     description: File system type of the particular volume.
                                     returned: always
@@ -273,10 +273,10 @@ ansible_facts:
                                     type: string
                                     sample: "Fixed"
                                 allocation_unit_size:
-                                    description: Allocation unit size in kb of the particular volume.
+                                    description: Allocation unit size in Kibibyte of the particular volume.
                                     returned: always
                                     type: string
-                                    sample: "64kb"
+                                    sample: "64KiB"
                                 object_id:
                                     description: Object ID of the particular volume.
                                     returned: always
@@ -299,18 +299,18 @@ ansible_facts:
                             sample: "UnSpecified"
                         size:
                             description:
-                              - Size in gb of the particular physical disk.
+                              - Size in Gibibyte of the particular physical disk.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "200gb"
+                            sample: "200GiB"
                         allocated_size:
                             description:
-                              - Allocated size in gb of the particular physical disk.
+                              - Allocated size in Gibibyte of the particular physical disk.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "100gb"
+                            sample: "100GiB"
                         device_id:
                             description: Device ID of the particular physical disk.
                             returned: always
@@ -418,25 +418,25 @@ ansible_facts:
                     contains:
                         size:
                             description:
-                              - Size in gb of the particular virtual disk.
+                              - Size in Gibibyte of the particular virtual disk.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "300gb"
+                            sample: "300GiB"
                         allocated_size:
                             description:
-                              - Allocated size in gb of the particular virtual disk.
+                              - Allocated size in Gibibyte of the particular virtual disk.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "100gb"
+                            sample: "100GiB"
                         footprint_on_pool:
                             description:
-                              - Footprint on pool in gb of the particular virtual disk.
+                              - Footprint on pool in Gibibyte of the particular virtual disk.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "100gb"
+                            sample: "100GiB"
                         name:
                             description: Name of the particular virtual disk.
                             returned: always
@@ -463,10 +463,10 @@ ansible_facts:
                             type: string
                             sample: "Thin"
                         allocation_unit_size:
-                            description: Allocation unit size in kb of the particular virtual disk.
+                            description: Allocation unit size in Kibibyte of the particular virtual disk.
                             returned: always
                             type: string
-                            sample: "4kb"
+                            sample: "4KiB"
                         media_type:
                             description: Media type of the particular virtual disk.
                             returned: always
@@ -499,11 +499,11 @@ ansible_facts:
                             sample: "PhysicalDisk"
                         inter_leave:
                             description:
-                              - Inter leave in kb of the particular virtual disk.
+                              - Inter leave in Kibibyte of the particular virtual disk.
                               - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "100kb"
+                            sample: "100KiB"
                         deduplication_enabled:
                             description: Information whether deduplication is enabled for the particular virtual disk.
                             returned: always
@@ -530,10 +530,10 @@ ansible_facts:
                             type: string
                             sample: "True"
                         physical_sector_size:
-                            description: Physical sector size in kb of the particular virtual disk.
+                            description: Physical sector size in Kibibyte of the particular virtual disk.
                             returned: always
                             type: string
-                            sample: "4kb"
+                            sample: "4KiB"
                         logical_sector_size:
                             description: Logical sector size in byte of the particular virtual disk.
                             returned: always

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -505,7 +505,7 @@ ansible_facts:
                             type: string
                             sample: "100kb"
                         deduplication_enabled:
-                            description:  Information whether deduplication is enabled for the particular virtual disk.
+                            description: Information whether deduplication is enabled for the particular virtual disk.
                             returned: always
                             type: string
                             sample: "True"

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -18,7 +18,7 @@ description:
    - With the module you can retrieve and output detailed information about the attached disks of the target and
      it's volumes and partitions if existent.
 requirements:
-    - Windows 8.1 / Windows 2012R2 (NT 6.3) / PowerShell 4.0 or newer
+    - Windows 8.1 / Windows 2012 (NT 6.2)
 author:
     - Marc Tschapek (@marqelme)
 notes:
@@ -31,13 +31,13 @@ EXAMPLES = r'''
   win_disk_facts:
 - name: output first disk size
   debug:
-    var: ansible_facts.ansible_disk.disk_0.size
+    var: ansible_facts.disks[0].size
 
 - name: get disk facts
   win_disk_facts:
 - name: output second disk serial number
   debug:
-    var: ansible_facts.ansible_disk.disk_1.serial_number
+    var: ansible_facts.disks[0].serial_number
 '''
 
 RETURN = r'''
@@ -46,555 +46,547 @@ ansible_facts:
     returned: always
     type: complex
     contains:
-        ansible_disk:
-            description: Detailed information about found disks on the target.
-            returned: always
-            type: complex
+        total_disks:
+            description: Count of found disks on the target.
+            returned: if disks were found
+            type: int
+            sample: 3
+        disks:
+            description: Detailed information about one particular disk.
+            returned: if disks were found
+            type: list
             contains:
-                total_disks_found:
-                    description: Count of found disks on the target.
-                    returned: if disks were found
+                number:
+                    description: Disk number of the particular disk.
+                    returned: always
+                    type: int
+                    sample: 0
+                size:
+                    description: Size in gb of the particular disk.
+                    returned: always
                     type: string
-                    sample: "3"
-                disks:
-                    description:
-                      - Detailed information about one particular disk.
-                    returned: if disks were found
-                    type: complex
+                    sample: "100gb"
+                bus_type:
+                    description: Bus type of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "SCSI"
+                friendly_name:
+                    description: Friendly name of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "Red Hat VirtIO SCSI Disk Device"
+                partition_style:
+                    description: Partition style of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "MBR"
+                partition_count:
+                    description: Number of partitions on the particular disk.
+                    returned: always
+                    type: int
+                    sample: 4
+                operational_status:
+                    description: Operational status of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "Online"
+                sector_size:
+                    description: Sector size in byte of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "512s/byte/bytes/"
+                read_only:
+                    description: Read only status of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "true"
+                bootable:
+                    description: Information whether the particular disk is a bootable disk.
+                    returned: always
+                    type: string
+                    sample: "false"
+                system_disk:
+                    description: Information whether the particular disk is a system disk.
+                    returned: always
+                    type: string
+                    sample: "true"
+                clustered:
+                    description: Information whether the particular disk is clustered (part of a failover cluster).
+                    returned: always
+                    type: string
+                    sample: "false"
+                manufacturer:
+                    description: Manufacturer of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "Red Hat"
+                model:
+                    description: Model specification of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "VirtIO"
+                firmware_version:
+                    description: Firmware version of the particular disk.
+                    returned: always
+                    type: string
+                    sample: "0001"
+                location:
+                    description: Location of the particular disk on the target.
+                    returned: always
+                    type: string
+                    sample: "PCIROOT(0)#PCI(0400)#SCSI(P00T00L00)"
+                serial_number:
+                    description: Serial number of the particular disk on the target.
+                    returned: always
+                    type: string
+                    sample: "b62beac80c3645e5877f"
+                unique_id:
+                    description: Unique ID of the particular disk on the target.
+                    returned: always
+                    type: string
+                    sample: "3141463431303031"
+                guid:
+                    description: GUID of the particular disk on the target.
+                    returned: if existent
+                    type: string
+                    sample: "{efa5f928-57b9-47fc-ae3e-902e85fbe77f}"
+                path:
+                    description: Path of the particular disk on the target.
+                    returned: always
+                    type: string
+                    sample: "\\\\?\\scsi#disk&ven_red_hat&prod_virtio#4&23208fd0&1&000000#{<id>}"
+                partitions:
+                    description: Detailed information about one particular partition on the specified disk.
+                    returned: if existent
+                    type: list
                     contains:
                         number:
-                            description: Disk number of the particular disk.
+                            description: Number of the particular partition.
+                            returned: always
+                            type: int
+                            sample: 1
+                        size:
+                            description:
+                              - Size in gb of the particular partition.
+                              - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "0"
+                            sample: "0.031gb"
+                        type:
+                            description: Type of the particular partition.
+                            returned: always
+                            type: string
+                            sample: "IFS"
+                        gpt_type:
+                            description: gpt type of the particular partition.
+                            returned: if partition_style property of the particular disk has value "GPT"
+                            type: string
+                            sample: "{e3c9e316-0b5c-4db8-817d-f92df00215ae}"
+                        no_default_driveletter:
+                            description: Information whether the particular partition has a default drive letter or not.
+                            returned: if partition_style property of the particular disk has value "GPT"
+                            type: string
+                            sample: "true"
+                        mbr_type:
+                            description: mbr type of the particular partition.
+                            returned: if partition_style property of the particular disk has value "MBR"
+                            type: int
+                            sample: 7
+                        active:
+                            description: Information whether the particular partition is an active partition or not.
+                            returned: if partition_style property of the particular disk has value "MBR"
+                            type: string
+                            sample: "true"
+                        drive_letter:
+                            description: Drive letter of the particular partition.
+                            returned: if existent
+                            type: string
+                            sample: "C"
+                        transition_state:
+                            description: Transition state of the particular partition.
+                            returned: always
+                            type: int
+                            sample: 1
+                        offset:
+                            description: Offset of the particular partition.
+                            returned: always
+                            type: int
+                            sample: 368050176
+                        hidden:
+                            description: Information whether the particular partition is hidden or not.
+                            returned: always
+                            type: string
+                            sample: "true"
+                        shadow_copy:
+                            description: Information whether the particular partition is a shadow copy of another partition.
+                            returned: always
+                            type: string
+                            sample: "false"
+                        guid:
+                            description: GUID of the particular partition.
+                            returned: if existent
+                            type: string
+                            sample: "{302e475c-6e64-4674-a8e2-2f1c7018bf97}"
+                        access_paths:
+                            description: Access paths of the particular partition.
+                            returned: if existent
+                            type: string
+                            sample: "\\\\?\\Volume{85bdc4a8-f8eb-11e6-80fa-806e6f6e6963}\\"
+                        volumes:
+                            description: Detailed information about one particular volume on the specified partition.
+                            returned: if existent
+                            type: list
+                            contains:
+                                size:
+                                    description:
+                                      - Size in gb of the particular volume.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "0,342gb"
+                                size_remaining:
+                                    description:
+                                      - Remaining size in gb of the particular volume.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "0,146gb"
+                                type:
+                                    description: File system type of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "NTFS"
+                                label:
+                                    description: File system label of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "System Reserved"
+                                health_status:
+                                    description: Health status of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "Healthy"
+                                drive_type:
+                                    description: Drive type of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "Fixed"
+                                allocation_unit_size:
+                                    description: Allocation unit size in kb of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "64kb"
+                                object_id:
+                                    description: Object ID of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "\\\\?\\Volume{85bdc4a9-f8eb-11e6-80fa-806e6f6e6963}\\"
+                                path:
+                                    description: Path of the particular volume.
+                                    returned: always
+                                    type: string
+                                    sample: "\\\\?\\Volume{85bdc4a9-f8eb-11e6-80fa-806e6f6e6963}\\"
+                physical_disk:
+                    description: Detailed information about physical disk properties of the particular disk.
+                    returned: if existent
+                    type: complex
+                    contains:
+                        media_type:
+                            description: Media type of the particular physical disk.
+                            returned: always
+                            type: string
+                            sample: "UnSpecified"
                         size:
-                            description: Size in gb of the particular disk.
+                            description:
+                              - Size in gb of the particular physical disk.
+                              - Accurate to three decimal places.
+                            returned: always
+                            type: string
+                            sample: "200gb"
+                        allocated_size:
+                            description:
+                              - Allocated size in gb of the particular physical disk.
+                              - Accurate to three decimal places.
                             returned: always
                             type: string
                             sample: "100gb"
+                        device_id:
+                            description: Device ID of the particular physical disk.
+                            returned: always
+                            type: string
+                            sample: "0"
+                        friendly_name:
+                            description: Friendly name of the particular physical disk.
+                            returned: always
+                            type: string
+                            sample: "PhysicalDisk0"
+                        operational_status:
+                            description: Operational status of the particular physical disk.
+                            returned: always
+                            type: string
+                            sample: "OK"
+                        health_status:
+                            description: Health status of the particular physical disk.
+                            returned: always
+                            type: string
+                            sample: "Healthy"
                         bus_type:
-                            description: Bus type of the particular disk.
+                            description: Bus type of the particular physical disk.
                             returned: always
                             type: string
                             sample: "SCSI"
-                        friendly_name:
-                            description: Friendly name of the particular disk.
+                        usage_type:
+                            description: Usage type of the particular physical disk.
                             returned: always
                             type: string
-                            sample: "Red Hat VirtIO SCSI Disk Device"
-                        partition_style:
-                            description: Partition style of the particular disk.
+                            sample: "Auto-Select"
+                        supported_usages:
+                            description: Supported usage types of the particular physical disk.
+                            returned: always
+                            type: complex
+                            contains:
+                                Count:
+                                    description: Count of supported usage types.
+                                    returned: always
+                                    type: int
+                                    sample: 5
+                                value:
+                                    description: List of supported usage types.
+                                    returned: always
+                                    type: string
+                                    sample: "Auto-Select, Hot Spare"
+                        spindle_speed:
+                            description: Spindle speed in rpm of the particular physical disk.
                             returned: always
                             type: string
-                            sample: "MBR"
-                        partition_count:
-                            description: Number of partitions on the particular disk.
+                            sample: "4294967295rpm"
+                        physical_location:
+                            description: Physical location of the particular physical disk.
                             returned: always
                             type: string
-                            sample: "4"
-                        operational_status:
-                            description: Operational status of the particular disk.
-                            returned: always
-                            type: string
-                            sample: "Online"
-                        sector_size:
-                            description: Sector size in byte of the particular disk.
-                            returned: always
-                            type: string
-                            sample: "512byte"
-                        read_only:
-                            description: Read only status of the particular disk.
-                            returned: always
-                            type: string
-                            sample: "true"
-                        bootable:
-                            description: Information whether the particular disk is a bootable disk.
-                            returned: always
-                            type: string
-                            sample: "false"
-                        system_disk:
-                            description: Information whether the particular disk is a system disk.
-                            returned: always
-                            type: string
-                            sample: "true"
-                        clustered:
-                            description: Information whether the particular disk is clustered (part of a failover cluster).
-                            returned: always
-                            type: string
-                            sample: "false"
+                            sample: "Integrated : Adapter 3 : Port 0 : Target 0 : LUN 0"
                         manufacturer:
-                            description: Manufacturer of the particular disk.
+                            description: Manufacturer of the particular physical disk.
                             returned: always
                             type: string
-                            sample: "Red Hat"
+                            sample: "SUSE"
                         model:
-                            description: Model specification of the particular disk.
+                            description: Model of the particular physical disk.
                             returned: always
                             type: string
-                            sample: "VirtIO"
-                        firmware_version:
-                            description: Firmware version of the particular disk.
+                            sample: "Xen Block"
+                        can_pool:
+                            description: Information whether the particular physical disk can be added to a storage pool.
                             returned: always
                             type: string
-                            sample: "0001"
-                        location:
-                            description: Location of the particular disk on the target.
+                            sample: "false"
+                        cannot_pool_reason:
+                            description: Information why the particular physical disk can not be added to a storage pool.
+                            returned: if can_pool property has value false
+                            type: string
+                            sample: "Insufficient Capacity"
+                        indication_enabled:
+                            description: Information whether indication is enabled for the particular physical disk.
                             returned: always
                             type: string
-                            sample: "PCIROOT(0)#PCI(0400)#SCSI(P00T00L00)"
+                            sample: "True"
+                        partial:
+                            description: Information whether the particular physical disk is partial.
+                            returned: always
+                            type: string
+                            sample: "False"
                         serial_number:
-                            description: Serial number of the particular disk on the target.
+                            description: Serial number of the particular physical disk.
                             returned: always
                             type: string
                             sample: "b62beac80c3645e5877f"
+                        object_id:
+                            description: Object ID of the particular physical disk.
+                            returned: always
+                            type: string
+                            sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_PhysicalDisk.ObjectId=\"{<object_id>}:PD:{<pd>}\"'
                         unique_id:
-                            description: Unique ID of the particular disk on the target.
+                            description: Unique ID of the particular physical disk.
                             returned: always
                             type: string
                             sample: "3141463431303031"
-                        guid:
-                            description: GUID of the particular disk on the target.
-                            returned: if existent
-                            type: string
-                            sample: "{efa5f928-57b9-47fc-ae3e-902e85fbe77f}"
-                        path:
-                            description: Path of the particular disk on the target.
+                virtual_disk:
+                    description: Detailed information about virtual disk properties of the particular disk.
+                    returned: if existent
+                    type: complex
+                    contains:
+                        size:
+                            description:
+                              - Size in gb of the particular virtual disk.
+                              - Accurate to three decimal places.
                             returned: always
                             type: string
-                            sample: "\\\\?\\scsi#disk&ven_red_hat&prod_virtio#4&23208fd0&1&000000#{<id>}"
-                        partitions:
+                            sample: "300gb"
+                        allocated_size:
                             description:
-                              - Detailed information about one particular partition on the specified disk.
+                              - Allocated size in gb of the particular virtual disk.
+                              - Accurate to three decimal places.
+                            returned: always
+                            type: string
+                            sample: "100gb"
+                        footprint_on_pool:
+                            description:
+                              - Footprint on pool in gb of the particular virtual disk.
+                              - Accurate to three decimal places.
+                            returned: always
+                            type: string
+                            sample: "100gb"
+                        name:
+                            description: Name of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "vDisk1"
+                        friendly_name:
+                            description: Friendly name of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "Prod2 Virtual Disk"
+                        operational_status:
+                            description: Operational status of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "OK"
+                        health_status:
+                            description: Health status of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "Healthy"
+                        provisioning_type:
+                            description: Provisioning type of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "Thin"
+                        allocation_unit_size:
+                            description: Allocation unit size in kb of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "4kb"
+                        media_type:
+                            description: Media type of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "Unspecified"
+                        parity_layout:
+                            description: Parity layout of the particular virtual disk.
                             returned: if existent
-                            type: complex
-                            contains:
-                                number:
-                                    description: Number of the particular partition.
-                                    returned: always
-                                    type: string
-                                    sample: "1"
-                                size:
-                                    description:
-                                      - Size in gb of the particular partition.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "0.031gb"
-                                type:
-                                    description: Type of the particular partition.
-                                    returned: always
-                                    type: string
-                                    sample: "IFS"
-                                gpt_type:
-                                    description: gpt type of the particular partition.
-                                    returned: if partition_style property of the particular disk has value "GPT"
-                                    type: string
-                                    sample: "{e3c9e316-0b5c-4db8-817d-f92df00215ae}"
-                                no_default_driveletter:
-                                    description: Information whether the particular partition has a default drive letter or not.
-                                    returned: if partition_style property of the particular disk has value "GPT"
-                                    type: string
-                                    sample: "true"
-                                mbr_type:
-                                    description: mbr type of the particular partition.
-                                    returned: f partition_style property of the particular disk has value "MBR"
-                                    type: string
-                                    sample: "7"
-                                active:
-                                    description: Information whether the particular partition is an active partition or not.
-                                    returned: f partition_style property of the particular disk has value "MBR"
-                                    type: string
-                                    sample: "true"
-                                drive_letter:
-                                    description: Drive letter of the particular partition.
-                                    returned: if existent
-                                    type: string
-                                    sample: "C"
-                                transition_state:
-                                    description: Transition state of the particular partition.
-                                    returned: always
-                                    type: string
-                                    sample: "1"
-                                offset:
-                                    description: Offset of the particular partition.
-                                    returned: always
-                                    type: string
-                                    sample: "368050176"
-                                hidden:
-                                    description: Information whether the particular partition is hidden or not.
-                                    returned: always
-                                    type: string
-                                    sample: "true"
-                                shadow_copy:
-                                    description: Information whether the particular partition is a shadow copy of another partition.
-                                    returned: always
-                                    type: string
-                                    sample: "false"
-                                guid:
-                                    description: GUID of the particular partition.
-                                    returned: if existent
-                                    type: string
-                                    sample: "{302e475c-6e64-4674-a8e2-2f1c7018bf97}"
-                                access_paths:
-                                    description: Access paths of the particular partition.
-                                    returned: if existent
-                                    type: string
-                                    sample: "\\\\?\\Volume{85bdc4a8-f8eb-11e6-80fa-806e6f6e6963}\\"
-                                volumes:
-                                    description:
-                                      - Detailed information about one particular volume on the specified partition.
-                                    returned: if existent
-                                    type: complex
-                                    contains:
-                                        size:
-                                            description:
-                                              - Size in gb of the particular volume.
-                                              - Accurate to three decimal places.
-                                            returned: always
-                                            type: string
-                                            sample: "0,342gb"
-                                        size_remaining:
-                                            description:
-                                              - Remaining size in gb of the particular volume.
-                                              - Accurate to three decimal places.
-                                            returned: always
-                                            type: string
-                                            sample: "0,146gb"
-                                        type:
-                                            description: File system type of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "NTFS"
-                                        label:
-                                            description: File system label of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "System Reserved"
-                                        health_status:
-                                            description: Health status of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "Healthy"
-                                        drive_type:
-                                            description: Drive type of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "Fixed"
-                                        allocation_unit_size:
-                                            description: Allocation unit size in kb of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "64kb"
-                                        object_id:
-                                            description: Object ID of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "\\\\?\\Volume{85bdc4a9-f8eb-11e6-80fa-806e6f6e6963}\\"
-                                        path:
-                                            description: Path of the particular volume.
-                                            returned: always
-                                            type: string
-                                            sample: "\\\\?\\Volume{85bdc4a9-f8eb-11e6-80fa-806e6f6e6963}\\"
-                        physical_disk:
-                            description: Detailed information about physical disk properties of the particular disk.
+                            type: int
+                            sample: 1
+                        access:
+                            description: Access of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "Read/Write"
+                        detached_reason:
+                            description: Detached reason of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "None"
+                        write_cache_size:
+                            description: Write cache size in byte of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "100s/byte/bytes/"
+                        fault_domain_awareness:
+                            description: Fault domain awareness of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "PhysicalDisk"
+                        inter_leave:
+                            description:
+                              - Inter leave in kb of the particular virtual disk.
+                              - Accurate to three decimal places.
+                            returned: always
+                            type: string
+                            sample: "100kb"
+                        deduplication_enabled:
+                            description:  Information whether deduplication is enabled for the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "True"
+                        enclosure_aware:
+                            description: Information whether the particular virtual disk is enclosure aware.
+                            returned: always
+                            type: string
+                            sample: "False"
+                        manual_attach:
+                            description: Information whether the particular virtual disk is manual attached.
+                            returned: always
+                            type: string
+                            sample: "True"
+                        snapshot:
+                            description: Information whether the particular virtual disk is a snapshot.
+                            returned: always
+                            type: string
+                            sample: "False"
+                        tiered:
+                            description: Information whether the particular virtual disk is tiered.
+                            returned: always
+                            type: string
+                            sample: "True"
+                        physical_sector_size:
+                            description: Physical sector size in kb of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "4kb"
+                        logical_sector_size:
+                            description: Logical sector size in byte of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "512s/byte/bytes/"
+                        available_copies:
+                            description: Number of the available copies of the particular virtual disk.
                             returned: if existent
-                            type: complex
-                            contains:
-                                media_type:
-                                    description: Media type of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "UnSpecified"
-                                size:
-                                    description:
-                                      - Size in gb of the particular physical disk.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "200gb"
-                                allocated_size:
-                                    description:
-                                      - Allocated size in gb of the particular physical disk.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "100gb"
-                                device_id:
-                                    description: Device ID of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "0"
-                                friendly_name:
-                                    description: Friendly name of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "PhysicalDisk0"
-                                operational_status:
-                                    description: Operational status of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "OK"
-                                health_status:
-                                    description: Health status of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Healthy"
-                                bus_type:
-                                    description: Bus type of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "SCSI"
-                                usage_type:
-                                    description: Usage type of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Auto-Select"
-                                supported_usages:
-                                    description: Supported usage types of the particular physical disk.
-                                    returned: always
-                                    type: complex
-                                    contains:
-                                        Count:
-                                            description: Count of supported usage types.
-                                            returned: always
-                                            type: string
-                                            sample: "5"
-                                        value:
-                                            description: List of supported usage types.
-                                            returned: always
-                                            type: string
-                                            sample: "Auto-Select, Hot Spare"
-                                spindle_speed:
-                                    description: Spindle speed in rpm of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "4294967295rpm"
-                                physical_location:
-                                    description: Physical location of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Integrated : Adapter 3 : Port 0 : Target 0 : LUN 0"
-                                manufacturer:
-                                    description: Manufacturer of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "SUSE"
-                                model:
-                                    description: Model of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Xen Block"
-                                can_pool:
-                                    description: Information whether the particular physical disk can be added to a storage pool.
-                                    returned: always
-                                    type: string
-                                    sample: "false"
-                                cannot_pool_reason:
-                                    description: Information why the particular physical disk can not be added to a storage pool.
-                                    returned: if can_pool property has value false
-                                    type: string
-                                    sample: "Insufficient Capacity"
-                                indication_enabled:
-                                    description: Information whether indication is enabled for the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "True"
-                                partial:
-                                    description: Information whether the particular physical disk is partial.
-                                    returned: always
-                                    type: string
-                                    sample: "False"
-                                serial_number:
-                                    description: Serial number of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "b62beac80c3645e5877f"
-                                object_id:
-                                    description: Object ID of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_PhysicalDisk.ObjectId=\"{<object_id>}:PD:{<pd>}\"'
-                                unique_id:
-                                    description: Unique ID of the particular physical disk.
-                                    returned: always
-                                    type: string
-                                    sample: "3141463431303031"
-                        virtual_disk:
-                            description: Detailed information about virtual disk properties of the particular disk.
-                            returned: if existent
-                            type: complex
-                            contains:
-                                size:
-                                    description:
-                                      - Size in gb of the particular virtual disk.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "300gb"
-                                allocated_size:
-                                    description:
-                                      - Allocated size in gb of the particular virtual disk.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "100gb"
-                                footprint_on_pool:
-                                    description:
-                                      - Footprint on pool in gb of the particular virtual disk.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "100gb"
-                                name:
-                                    description: Name of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "vDisk1"
-                                friendly_name:
-                                    description: Friendly name of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Prod2 Virtual Disk"
-                                operational_status:
-                                    description: Operational status of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "OK"
-                                health_status:
-                                    description: Health status of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Healthy"
-                                provisioning_type:
-                                    description: Provisioning type of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Thin"
-                                allocation_unit_size:
-                                    description: Allocation unit size in kb of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "4kb"
-                                media_type:
-                                    description: Media type of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Unspecified"
-                                parity_layout:
-                                    description: Parity layout of the particular virtual disk.
-                                    returned: if existent
-                                    type: string
-                                    sample: "1"
-                                access:
-                                    description: Access of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Read/Write"
-                                detached_reason:
-                                    description: Detached reason of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "None"
-                                write_cache_size:
-                                    description: Write cache size in byte of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "100byte"
-                                fault_domain_awareness:
-                                    description: Fault domain awareness of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "PhysicalDisk"
-                                inter_leave:
-                                    description:
-                                      - Inter leave in kb of the particular virtual disk.
-                                      - Accurate to three decimal places.
-                                    returned: always
-                                    type: string
-                                    sample: "100kb"
-                                deduplication_enabled:
-                                    description:  Information whether deduplication is enabled for the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "True"
-                                enclosure_aware:
-                                    description: Information whether the particular virtual disk is enclosure aware.
-                                    returned: always
-                                    type: string
-                                    sample: "False"
-                                manual_attach:
-                                    description: Information whether the particular virtual disk is manual attached.
-                                    returned: always
-                                    type: string
-                                    sample: "True"
-                                snapshot:
-                                    description: Information whether the particular virtual disk is a snapshot.
-                                    returned: always
-                                    type: string
-                                    sample: "False"
-                                tiered:
-                                    description: Information whether the particular virtual disk is tiered.
-                                    returned: always
-                                    type: string
-                                    sample: "True"
-                                physical_sector_size:
-                                    description: Physical sector size in kb of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "4kb"
-                                logical_sector_size:
-                                    description: Logical sector size in byte of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "512byte"
-                                available_copies:
-                                    description: Number of the available copies of the particular virtual disk.
-                                    returned: if existent
-                                    type: string
-                                    sample: "1"
-                                columns:
-                                    description: Number of the columns of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "2"
-                                groups:
-                                    description: Number of the groups of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "1"
-                                physical_disk_redundancy:
-                                    description: Type of the physical disk redundancy of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "1"
-                                read_cache_size:
-                                    description: Read cache size in byte of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "0"
-                                request_no_spof:
-                                    description: Information whether the particular virtual disk requests no single point of failure.
-                                    returned: always
-                                    type: string
-                                    sample: "True"
-                                resiliency_setting_name:
-                                    description: Type of the physical disk redundancy of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "1"
-                                object_id:
-                                    description: Object ID of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_VirtualDisk.ObjectId=\"{<object_id>}:VD:{<vd>}\"'
-                                unique_id:
-                                    description: Unique ID of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "260542E4C6B01D47A8FA7630FD90FFDE"
-                                unique_id_format:
-                                    description: Unique ID format of the particular virtual disk.
-                                    returned: always
-                                    type: string
-                                    sample: "Vendor Specific"
+                            type: int
+                            sample: 1
+                        columns:
+                            description: Number of the columns of the particular virtual disk.
+                            returned: always
+                            type: int
+                            sample: 2
+                        groups:
+                            description: Number of the groups of the particular virtual disk.
+                            returned: always
+                            type: int
+                            sample: 1
+                        physical_disk_redundancy:
+                            description: Type of the physical disk redundancy of the particular virtual disk.
+                            returned: always
+                            type: int
+                            sample: 1
+                        read_cache_size:
+                            description: Read cache size in byte of the particular virtual disk.
+                            returned: always
+                            type: int
+                            sample: 0
+                        request_no_spof:
+                            description: Information whether the particular virtual disk requests no single point of failure.
+                            returned: always
+                            type: string
+                            sample: "True"
+                        resiliency_setting_name:
+                            description: Type of the physical disk redundancy of the particular virtual disk.
+                            returned: always
+                            type: int
+                            sample: 1
+                        object_id:
+                            description: Object ID of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_VirtualDisk.ObjectId=\"{<object_id>}:VD:{<vd>}\"'
+                        unique_id:
+                            description: Unique ID of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "260542E4C6B01D47A8FA7630FD90FFDE"
+                        unique_id_format:
+                            description: Unique ID format of the particular virtual disk.
+                            returned: always
+                            type: string
+                            sample: "Vendor Specific"
 '''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -18,14 +18,12 @@ description:
    - With the module you can retrieve and output detailed information about the attached disks of the target and
      it's volumes and partitions if existent.
 requirements:
-    - Windows 8.1 / Windows 2012R2 (NT 6.3) or newer
+    - Windows 8.1 / Windows 2012R2 (NT 6.3) / PowerShell 4.0 or newer
 author:
     - Marc Tschapek (@marqelme)
 notes:
-  - You can use this module in combination with the win_disk_management module in order to retrieve the disks status
-    on the target.
   - In order to understand all the returned properties and values please visit the following site and open the respective MSFT class
-    https://msdn.microsoft.com/en-us/library/windows/desktop/hh830612(v=vs.85).aspx
+    U(https://msdn.microsoft.com/en-us/library/windows/desktop/hh830612.aspx)
 '''
 
 EXAMPLES = r'''
@@ -43,16 +41,6 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-changed:
-    description: Whether anything was changed.
-    returned: always
-    type: boolean
-    sample: true
-msg:
-    description: Possible error message on failure.
-    returned: failed
-    type: string
-    sample: "No disks could be found on the target"
 ansible_facts:
     description: Dictionary containing all the detailed information about the disks of the target.
     returned: always
@@ -65,15 +53,13 @@ ansible_facts:
             contains:
                 total_disks_found:
                     description: Count of found disks on the target.
-                    returned: success or failed
+                    returned: if disks were found
                     type: string
                     sample: "3"
-                disk_identifier:
+                disks:
                     description:
                       - Detailed information about one particular disk.
-                      - The identifier is displayed as a digit in order to structure the output but is not the actual number of the particular disk.
-                      - Please see the containing return property "number" to get the actual disk number of the particular disk.
-                    returned: success or failed
+                    returned: if disks were found
                     type: complex
                     contains:
                         number:
@@ -112,7 +98,7 @@ ansible_facts:
                             type: string
                             sample: "Online"
                         sector_size:
-                            description: Sector size of the particular disk.
+                            description: Sector size in byte of the particular disk.
                             returned: always
                             type: string
                             sample: "512byte"
@@ -176,12 +162,9 @@ ansible_facts:
                             returned: always
                             type: string
                             sample: "\\\\?\\scsi#disk&ven_red_hat&prod_virtio#4&23208fd0&1&000000#{<id>}"
-                        partition_identifier:
+                        partitions:
                             description:
                               - Detailed information about one particular partition on the specified disk.
-                              - The identifier is displayed as a digit in order to structure the output but is not
-                                the actual number of the particular partition.
-                              - Please see the containing return property "number" to get the actual partition number.
                             returned: if existent
                             type: complex
                             contains:
@@ -257,11 +240,9 @@ ansible_facts:
                                     returned: if existent
                                     type: string
                                     sample: "\\\\?\\Volume{85bdc4a8-f8eb-11e6-80fa-806e6f6e6963}\\"
-                                volume_identifier:
+                                volumes:
                                     description:
                                       - Detailed information about one particular volume on the specified partition.
-                                      - Please note that volumes have no "number" property and the identifier is displayed
-                                        as a digit in order to structure the output.
                                     returned: if existent
                                     type: complex
                                     contains:
@@ -300,7 +281,7 @@ ansible_facts:
                                             type: string
                                             sample: "Fixed"
                                         allocation_unit_size:
-                                            description: Allocation unit size of the particular volume.
+                                            description: Allocation unit size in kb of the particular volume.
                                             returned: always
                                             type: string
                                             sample: "64kb"
@@ -324,6 +305,20 @@ ansible_facts:
                                     returned: always
                                     type: string
                                     sample: "UnSpecified"
+                                size:
+                                    description:
+                                      - Size in gb of the particular physical disk.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "200gb"
+                                allocated_size:
+                                    description:
+                                      - Allocated size in gb of the particular physical disk.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "100gb"
                                 device_id:
                                     description: Device ID of the particular physical disk.
                                     returned: always
@@ -344,6 +339,11 @@ ansible_facts:
                                     returned: always
                                     type: string
                                     sample: "Healthy"
+                                bus_type:
+                                    description: Bus type of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "SCSI"
                                 usage_type:
                                     description: Usage type of the particular physical disk.
                                     returned: always
@@ -369,6 +369,21 @@ ansible_facts:
                                     returned: always
                                     type: string
                                     sample: "4294967295rpm"
+                                physical_location:
+                                    description: Physical location of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Integrated : Adapter 3 : Port 0 : Target 0 : LUN 0"
+                                manufacturer:
+                                    description: Manufacturer of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "SUSE"
+                                model:
+                                    description: Model of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Xen Block"
                                 can_pool:
                                     description: Information whether the particular physical disk can be added to a storage pool.
                                     returned: always
@@ -379,6 +394,21 @@ ansible_facts:
                                     returned: if can_pool property has value false
                                     type: string
                                     sample: "Insufficient Capacity"
+                                indication_enabled:
+                                    description: Information whether indication is enabled for the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "True"
+                                partial:
+                                    description: Information whether the particular physical disk is partial.
+                                    returned: always
+                                    type: string
+                                    sample: "False"
+                                serial_number:
+                                    description: Serial number of the particular physical disk.
+                                    returned: always
+                                    type: string
+                                    sample: "b62beac80c3645e5877f"
                                 object_id:
                                     description: Object ID of the particular physical disk.
                                     returned: always
@@ -394,9 +424,177 @@ ansible_facts:
                             returned: if existent
                             type: complex
                             contains:
+                                size:
+                                    description:
+                                      - Size in gb of the particular virtual disk.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "300gb"
+                                allocated_size:
+                                    description:
+                                      - Allocated size in gb of the particular virtual disk.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "100gb"
+                                footprint_on_pool:
+                                    description:
+                                      - Footprint on pool in gb of the particular virtual disk.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "100gb"
+                                name:
+                                    description: Name of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "vDisk1"
                                 friendly_name:
                                     description: Friendly name of the particular virtual disk.
                                     returned: always
                                     type: string
                                     sample: "Prod2 Virtual Disk"
+                                operational_status:
+                                    description: Operational status of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "OK"
+                                health_status:
+                                    description: Health status of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Healthy"
+                                provisioning_type:
+                                    description: Provisioning type of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Thin"
+                                allocation_unit_size:
+                                    description: Allocation unit size in kb of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "4kb"
+                                media_type:
+                                    description: Media type of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Unspecified"
+                                parity_layout:
+                                    description: Parity layout of the particular virtual disk.
+                                    returned: if existent
+                                    type: string
+                                    sample: "1"
+                                access:
+                                    description: Access of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Read/Write"
+                                detached_reason:
+                                    description: Detached reason of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "None"
+                                write_cache_size:
+                                    description: Write cache size in byte of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "100byte"
+                                fault_domain_awareness:
+                                    description: Fault domain awareness of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "PhysicalDisk"
+                                inter_leave:
+                                    description:
+                                      - Inter leave in kb of the particular virtual disk.
+                                      - Accurate to three decimal places.
+                                    returned: always
+                                    type: string
+                                    sample: "100kb"
+                                deduplication_enabled:
+                                    description:  Information whether deduplication is enabled for the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "True"
+                                enclosure_aware:
+                                    description: Information whether the particular virtual disk is enclosure aware.
+                                    returned: always
+                                    type: string
+                                    sample: "False"
+                                manual_attach:
+                                    description: Information whether the particular virtual disk is manual attached.
+                                    returned: always
+                                    type: string
+                                    sample: "True"
+                                snapshot:
+                                    description: Information whether the particular virtual disk is a snapshot.
+                                    returned: always
+                                    type: string
+                                    sample: "False"
+                                tiered:
+                                    description: Information whether the particular virtual disk is tiered.
+                                    returned: always
+                                    type: string
+                                    sample: "True"
+                                physical_sector_size:
+                                    description: Physical sector size in kb of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "4kb"
+                                logical_sector_size:
+                                    description: Logical sector size in byte of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "512byte"
+                                available_copies:
+                                    description: Number of the available copies of the particular virtual disk.
+                                    returned: if existent
+                                    type: string
+                                    sample: "1"
+                                columns:
+                                    description: Number of the columns of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "2"
+                                groups:
+                                    description: Number of the groups of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "1"
+                                physical_disk_redundancy:
+                                    description: Type of the physical disk redundancy of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "1"
+                                read_cache_size:
+                                    description: Read cache size in byte of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "0"
+                                request_no_spof:
+                                    description: Information whether the particular virtual disk requests no single point of failure.
+                                    returned: always
+                                    type: string
+                                    sample: "True"
+                                resiliency_setting_name:
+                                    description: Type of the physical disk redundancy of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "1"
+                                object_id:
+                                    description: Object ID of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_VirtualDisk.ObjectId=\"{<object_id>}:VD:{<vd>}\"'   
+                                unique_id:
+                                    description: Unique ID of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "260542E4C6B01D47A8FA7630FD90FFDE"
+                                unique_id_format:
+                                    description: Unique ID format of the particular virtual disk.
+                                    returned: always
+                                    type: string
+                                    sample: "Vendor Specific"                                 
 '''

--- a/lib/ansible/modules/windows/win_disk_facts.py
+++ b/lib/ansible/modules/windows/win_disk_facts.py
@@ -586,7 +586,7 @@ ansible_facts:
                                     description: Object ID of the particular virtual disk.
                                     returned: always
                                     type: string
-                                    sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_VirtualDisk.ObjectId=\"{<object_id>}:VD:{<vd>}\"'   
+                                    sample: '{1}\\\\HOST\\root/Microsoft/Windows/Storage/Providers_v2\\SPACES_VirtualDisk.ObjectId=\"{<object_id>}:VD:{<vd>}\"'
                                 unique_id:
                                     description: Unique ID of the particular virtual disk.
                                     returned: always
@@ -596,5 +596,5 @@ ansible_facts:
                                     description: Unique ID format of the particular virtual disk.
                                     returned: always
                                     type: string
-                                    sample: "Vendor Specific"                                 
+                                    sample: "Vendor Specific"
 '''

--- a/test/integration/targets/win_disk_facts/aliases
+++ b/test/integration/targets/win_disk_facts/aliases
@@ -1,0 +1,1 @@
+windows/ci/group2

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -1,0 +1,13 @@
+# NOTE: The win_disk_facts module only works on Win2012R2+
+
+- name: Test Windows capabilities
+  raw: Get-Command Get-Disk -ErrorAction SilentlyContinue; return $?
+  failed_when: no
+  register: new_diskfacts
+
+- name: Only run tests when Windows is capable
+  when: new_diskfacts.rc == 0
+  block:
+
+  - name: Test in normal mode
+    include: tests.yml

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -1,13 +1,22 @@
 # NOTE: The win_disk_facts module only works on Win2012R2+
 
+- name: register os version (seems integration tests don't gather this fact)
+  raw: powershell.exe "gwmi Win32_OperatingSystem | select -expand version"
+  register: os_version
+  changed_when: False
+
+- name: check if module fails gracefully when older than 2012
+  win_disk_facts:
+    name: "Gather facts"
+  when: os_version.stdout_lines[0]  is version('6.2','lt')
+  check_mode: yes
+  register: old_os_check
+  failed_when: old_os_check.msg != 'The win_disk_facts Ansible module is only available on Server 2012 (6.2) and newer'
+    
 - name: Test Windows capabilities
   raw: Get-Command Get-Disk -ErrorAction SilentlyContinue; return $?
   failed_when: no
   register: new_diskfacts
-
-- name: Fail if Windows is not capable
-  fail: msg="Cmdlet Get-Disk is not available in your Windows version"
-  when: new_diskfacts.rc != 0
 
 - name: Only run tests when Windows is capable
   when: new_diskfacts.rc == 0

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -2,8 +2,11 @@
 
 - name: Test Windows capabilities
   raw: Get-Command Get-Disk -ErrorAction SilentlyContinue; return $?
-  failed_when: no
   register: new_diskfacts
+
+- name: Fail if Windows is not capable
+  fail: msg="Cmdlet Get-Disk is not available in your Windows version"
+  when: new_diskfacts.rc == 1
 
 - name: Only run tests when Windows is capable
   when: new_diskfacts.rc == 0

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -1,25 +1,12 @@
 # NOTE: The win_disk_facts module only works on Win2012R2+
 
-- name: register os version (seems integration tests don't gather this fact)
-  raw: powershell.exe "gwmi Win32_OperatingSystem | select -expand version"
-  register: os_version
-  changed_when: False
-
-- name: check if module fails gracefully when older than 2012
-  win_disk_facts:
-    name: "Gather facts"
-  when: os_version.stdout_lines[0]  is version('6.2','lt')
-  check_mode: yes
-  register: old_os_check
-  failed_when: old_os_check.msg != 'The win_disk_facts Ansible module is only available on Server 2012 (6.2) and newer'
-    
-- name: Test Windows capabilities
-  raw: Get-Command Get-Disk -ErrorAction SilentlyContinue; return $?
-  failed_when: no
-  register: new_diskfacts
+- name: check whether storage module is available (windows 2008 r2 or later)
+  raw: PowerShell -Command Import-Module Storage
+  register: win_feature_has_storage_module
+  ignore_errors: true
 
 - name: Only run tests when Windows is capable
-  when: new_diskfacts.rc == 0
+  when: (win_feature_has_storage_module|success) and (ansible_powershell_version is defined) and (ansible_powershell_version >= 3)
   block:
 
   - name: Test in normal mode

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -3,10 +3,11 @@
 - name: Test Windows capabilities
   raw: Get-Command Get-Disk -ErrorAction SilentlyContinue; return $?
   register: new_diskfacts
+  failed_when: new_diskfacts.rc != 0
 
 - name: Fail if Windows is not capable
   fail: msg="Cmdlet Get-Disk is not available in your Windows version"
-  when: new_diskfacts.rc == 1
+  when: new_diskfacts.rc != 0
 
 - name: Only run tests when Windows is capable
   when: new_diskfacts.rc == 0

--- a/test/integration/targets/win_disk_facts/tasks/main.yml
+++ b/test/integration/targets/win_disk_facts/tasks/main.yml
@@ -2,8 +2,8 @@
 
 - name: Test Windows capabilities
   raw: Get-Command Get-Disk -ErrorAction SilentlyContinue; return $?
+  failed_when: no
   register: new_diskfacts
-  failed_when: new_diskfacts.rc != 0
 
 - name: Fail if Windows is not capable
   fail: msg="Cmdlet Get-Disk is not available in your Windows version"

--- a/test/integration/targets/win_disk_facts/tasks/tests.yml
+++ b/test/integration/targets/win_disk_facts/tasks/tests.yml
@@ -1,0 +1,9 @@
+- name: get disk facts on the target
+  win_disk_facts:
+  register: disks_found
+
+- name: assert disk facts
+  assert:
+    that:
+    - disks_found.changed == false
+    - not disks_found.ansible_facts.ansible_disk.total_disks_found == '0'

--- a/test/integration/targets/win_disk_facts/tasks/tests.yml
+++ b/test/integration/targets/win_disk_facts/tasks/tests.yml
@@ -6,4 +6,12 @@
   assert:
     that:
     - disks_found.changed == false
-    #- not disks_found.ansible_facts.ansible_disk.total_disks_found == '0'
+    - disks_found.ansible_facts.disks[0].size is defined
+    - disks_found.ansible_facts.disks[0].number is defined
+    - disks_found.ansible_facts.disks[0].operational_status is defined
+    - disks_found.ansible_facts.disks[0].read_only is defined
+    - disks_found.ansible_facts.disks[0].clustered is defined
+    - disks_found.ansible_facts.disks[0].location is defined
+    - disks_found.ansible_facts.disks[0].guid is defined
+    - disks_found.ansible_facts.disks[0].path is defined
+    - disks_found.ansible_facts.disks[0].bootable is defined

--- a/test/integration/targets/win_disk_facts/tasks/tests.yml
+++ b/test/integration/targets/win_disk_facts/tasks/tests.yml
@@ -6,4 +6,4 @@
   assert:
     that:
     - disks_found.changed == false
-    - not disks_found.ansible_facts.ansible_disk.total_disks_found == '0'
+    #- not disks_found.ansible_facts.ansible_disk.total_disks_found == '0'


### PR DESCRIPTION
##### SUMMARY
This change adds new Windows Ansible module win_disk_facts.

With the module you can retrieve and output detailed information about the attached disks on the target.

##### ISSUE TYPE
 - New Module Pull Request


##### COMPONENT NAME
lib/ansible/modules/windows/win_disk_facts.ps1

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
You can use this module in combination with the win_disk_management module in order to retrieve the disks status on the target.

```yaml
- name: get disk facts
  win_disk_facts:

- name: output first disk size
  debug:
    var: ansible_facts.disks[0].size

- name: get disk facts
  win_disk_facts:

- name: output second disk serial number
  debug:
    var: ansible_facts.disks[0].serial_number
```

No changes because the module is a new module.

