### PR TITLE
Fix ansible-test race calling get_coverage_path.

### DIFF
--- a/test/runner/lib/executor.py
+++ b/test/runner/lib/executor.py
@@ -48,6 +48,7 @@ from lib.util import (
     find_pip,
     find_executable,
     raw_command,
+    get_coverage_path,
 )
 
 from lib.ansible_util import (
@@ -320,6 +321,8 @@ def command_network_integration(args):
     instances = []  # type: list [lib.thread.WrappedThread]
 
     if args.platform:
+        get_coverage_path(args)  # initialize before starting threads
+
         configs = dict((config['platform_version'], config) for config in args.metadata.instance_config)
 
         for platform_version in args.platform:
@@ -478,6 +481,8 @@ def command_windows_integration(args):
     instances = []  # type: list [lib.thread.WrappedThread]
 
     if args.windows:
+        get_coverage_path(args)  # initialize before starting threads
+
         configs = dict((config['platform_version'], config) for config in args.metadata.instance_config)
 
         for version in args.windows:


### PR DESCRIPTION
##### SUMMARY

Fix ansible-test race calling get_coverage_path.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-race-fix 25c0837b30) last updated 2017/11/15 12:00:25 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
