### PR TITLE
ovirt_vms: Fix issue in stopping stateless VMs

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -908,18 +908,23 @@ class VmsModule(BaseModule):
             ]
             # Stateless snapshot may be already removed:
             if snap_stateless:
+                """
+                We need to wait for Active snapshot ID, to be removed as it's current
+                stateless snapshot. Then we need to wait for staless snapshot ID to
+                be read, for use, because it will become active snapshot.
+                """
                 wait(
-                    service=snapshots_service.snapshot_service(snap_stateless[0].id),
+                    service=snapshots_service.snapshot_service(snap_active.id),
                     condition=lambda snap: snap is None,
                     wait=self.param('wait'),
                     timeout=self.param('timeout'),
                 )
-            wait(
-                service=snapshots_service.snapshot_service(snap_active.id),
-                condition=lambda snap: snap.snapshot_status == otypes.SnapshotStatus.OK,
-                wait=self.param('wait'),
-                timeout=self.param('timeout'),
-            )
+                wait(
+                    service=snapshots_service.snapshot_service(snap_stateless[0].id),
+                    condition=lambda snap: snap.snapshot_status == otypes.SnapshotStatus.OK,
+                    wait=self.param('wait'),
+                    timeout=self.param('timeout'),
+                )
         return True
 
     def __attach_disks(self, entity):


### PR DESCRIPTION
##### SUMMARY

Currently, the module is waiting for the stateless snapshot to go none while stopping a stateless VM. However, this condition will never happen as the stateless snapshot id will become active when the stateless snapshot is removed. So it will be in this loop indefinitely and finally will timeout after the timeout period.

For example, 354db0cf is the active snapshot before starting the VM.

```
engine=# select snapshot_id,description from snapshots where vm_id = 'd47d6843-a2d4-4ed7-80cf-493f9c3b0288';
             snapshot_id              | description 
--------------------------------------+-------------
 354db0cf-fbbf-4c2c-9273-1d0fa1bc5b2b | Active VM


```
After starting the VM  354db0cf, will be the stateless snapshot.

```
engine=# select snapshot_id,description from snapshots where vm_id = 'd47d6843-a2d4-4ed7-80cf-493f9c3b0288';
             snapshot_id              |    description     
--------------------------------------+--------------------
 59e7f639-07c3-41f4-889a-aaa79ffd21ee | Active VM
 354db0cf-fbbf-4c2c-9273-1d0fa1bc5b2b | stateless snapshot

```
Then if we shut down the VM, 354db0cf will become active again.

```
engine=# select snapshot_id,description from snapshots where vm_id = 'd47d6843-a2d4-4ed7-80cf-493f9c3b0288';
             snapshot_id              | description 
--------------------------------------+-------------
 354db0cf-fbbf-4c2c-9273-1d0fa1bc5b2b | Active VM
(1 row)
```

As per the current code, it will wait for 354db0cf to go none which will never happen.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME

ovirt_vms

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible --version
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  2 2016, 04:20:16) [GCC 4.8.5 20150623 (Red Hat 4.8.5-4)]

```


##### ADDITIONAL INFORMATION

Tested using the below tasks.

```
      - name: Shutting down VM
        ovirt_vms:
           auth: "{{ ovirt_auth }}"
           name: testvm
           state: stopped

      - name: Starting up VM
        ovirt_vms:
            auth: "{{ ovirt_auth }}"
            name: testvm
            state: running
```