### PR TITLE
Fix ios_config integration test failures

### DIFF
--- a/test/integration/targets/ios_config/tests/cli/save.yaml
+++ b/test/integration/targets/ios_config/tests/cli/save.yaml
@@ -38,7 +38,7 @@
   ios_config:
     replace: line
     lines:
-      - "ip http server"
+      - "no ip http server"
     save_when: modified
     authorize: yes
   register: result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios_config/tests/cli/save.yaml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
$ ANSIBLE_ROLES_PATH=targets ansible-playbook -i inventory.network ios.yaml -e "limit_to=ios_config" -vvvv
TASK [ios_config : assert] ********************************************************************************************************************************************************
task path: /Users/gnalawad/ansible/ganeshrn/ansible/test/integration/targets/ios_config/tests/cli/save.yaml:55
fatal: [ios]: FAILED! => {
    "assertion": "result.changed == true",
    "changed": false,
    "evaluated_to": false
}

```
After:
```
$ ANSIBLE_ROLES_PATH=targets ansible-playbook -i inventory.network ios.yaml -e "limit_to=ios_config" -vvvv
PLAY RECAP ************************************************************************************************************************************************************************
ios            : ok=132  changed=37   unreachable=0    failed=0
```