### PR TITLE
Fix typo in usage of encrypt_string command

### DIFF
--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -102,7 +102,7 @@ class VaultCLI(CLI):
             self.parser.add_option('--stdin-name', dest='encrypt_string_stdin_name',
                                    default=None,
                                    help="Specify the variable name for stdin")
-            self.parser.set_usage("usage: %prog encrypt-string [--prompt] [options] string_to_encrypt")
+            self.parser.set_usage("usage: %prog encrypt_string [--prompt] [options] string_to_encrypt")
         elif self.action == "rekey":
             self.parser.set_usage("usage: %prog rekey [options] file_name")
 


### PR DESCRIPTION
##### SUMMARY

This is just fixing a typo in vault's encrypt string command usage.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vault

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/valkra/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.0.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```
