### PR TITLE
Fix example with proceccModel in win_iis_webapppool

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapppool.py
+++ b/lib/ansible/modules/windows/win_iis_webapppool.py
@@ -133,7 +133,7 @@ EXAMPLES = r'''
     attributes:
       managedPipelineMode: Classic
       processModel.identityType: SpecificUser
-      processModel.username: '{{ansible_user}}'
+      processModel.userName: '{{ansible_user}}'
       processModel.password: '{{ansible_password}}'
       processModel.loadUserProfile: True
 


### PR DESCRIPTION
Update docs for win_iis_webapppool: The attribute processModel.userName have to be written i camelCase. Otherwise this fails silently.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Update docs for win_iis_webapppool: The attribute processModel.userName have to be written i camelCase. Otherwise the username is not set in IIS.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
win_iis_webapppool
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Documentation for attributes can be found here: https://docs.microsoft.com/en-us/iis/configuration/system.applicationhost/applicationpools/add/processmodel

Look at the end of the Attributes list.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
