### PR TITLE
Documented use of ANSIBLE_STRATEGY=debug

### DIFF
--- a/docs/docsite/rst/playbooks_debugger.rst
+++ b/docs/docsite/rst/playbooks_debugger.rst
@@ -13,6 +13,9 @@ To use the ``debug`` strategy, change the ``strategy`` attribute like this::
       tasks:
       ...
 
+If you don't want change the code, you can define ``ANSIBLE_STRATEGY=debug``
+environment variable in order to enable the debugger.
+
 For example, run the playbook below::
 
     - hosts: test


### PR DESCRIPTION
##### SUMMARY
Documented use of ANSIBLE_STRATEGY=debug which may be more convenient than patching playbooks.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
2.4.2.0
```

##### ADDITIONAL INFORMATION
N/A