### PR TITLE
Fix ec2_group integration test

### DIFF
--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -172,6 +172,29 @@
       no_log: yes
 
     # ============================================================
+    - name: determine if there is a default VPC
+      set_fact:
+        defaultvpc: "{{ lookup('aws_account_attribute',
+                               attribute='default-vpc',
+                               region=aws_region,
+                               aws_access_key=aws_access_key,
+                               aws_secret_key=aws_secret_key,
+                               aws_security_token=security_token) }}"
+      register: default_vpc
+
+    # ============================================================
+    - name: create a VPC
+      ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "10.232.232.128/26"
+        <<: *aws_connection_info
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: "Created by ansible-test"
+      register: vpc_result
+
+    # ============================================================
     - name: test state=absent
       ec2_group:
         name: '{{ec2_group_name}}'
@@ -227,49 +250,158 @@
            - 'result.group_id.startswith("sg-")'
 
     # ============================================================
-    - name: test state=present for ipv6 (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
+    - name: tests IPv6 with the default VPC
+      block:
 
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
+        # ============================================================
+        - name: test state=present for ipv6 (expected changed=true)
+          ec2_group:
+            name: '{{ec2_group_name}}'
+            description: '{{ec2_group_description}}'
+            <<: *aws_connection_info
+            state: present
+            rules:
+            - proto: "tcp"
+              from_port: 8182
+              to_port: 8182
+              cidr_ipv6: "64:ff9b::/96"
+          register: result
 
-    # ============================================================
-    - name: test rules_egress state=present for ipv6 (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ipv6: "64:ff9b::/96"
-        rules_egress:
-        - proto: "tcp"
-          from_port: 8181
-          to_port: 8181
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
+        - name: assert state=present (expected changed=true)
+          assert:
+            that:
+               - 'result.changed'
+               - 'result.group_id.startswith("sg-")'
 
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
+        # ============================================================
+        - name: test rules_egress state=present for ipv6 (expected changed=true)
+          ec2_group:
+            name: '{{ec2_group_name}}'
+            description: '{{ec2_group_description}}'
+            <<: *aws_connection_info
+            state: present
+            rules:
+            - proto: "tcp"
+              from_port: 8182
+              to_port: 8182
+              cidr_ipv6: "64:ff9b::/96"
+            rules_egress:
+            - proto: "tcp"
+              from_port: 8181
+              to_port: 8181
+              cidr_ipv6: "64:ff9b::/96"
+          register: result
+
+        - name: assert state=present (expected changed=true)
+          assert:
+            that:
+               - 'result.changed'
+               - 'result.group_id.startswith("sg-")'
+
+      when: default_vpc
+
+    - name: test IPv6 with a specified VPC
+      block:
+
+        # ============================================================
+        - name: test state=present (expected changed=true)
+          ec2_group:
+            name: '{{ ec2_group_name }}-2'
+            description: '{{ ec2_group_description }}-2'
+            state: present
+            vpc_id: '{{ vpc_result.vpc.id }}'
+            <<: *aws_connection_info
+          register: result
+
+        - name: assert state=present (expected changed=true)
+          assert:
+            that:
+               - 'result.changed'
+               - 'result.group_id.startswith("sg-")'
+
+        # ============================================================
+        - name: test state=present for ipv6 (expected changed=true)
+          ec2_group:
+            name: '{{ ec2_group_name }}-2'
+            description: '{{ ec2_group_description }}-2'
+            state: present
+            vpc_id: '{{ vpc_result.vpc.id }}'
+            rules:
+            - proto: "tcp"
+              from_port: 8182
+              to_port: 8182
+              cidr_ipv6: "64:ff9b::/96"
+            <<: *aws_connection_info
+          register: result
+
+        - name: assert state=present (expected changed=true)
+          assert:
+            that:
+               - 'result.changed'
+               - 'result.group_id.startswith("sg-")'
+
+        # ============================================================
+
+        - name: test state=present for ipv6 (expected changed=true)
+          ec2_group:
+            name: '{{ ec2_group_name }}-2'
+            description: '{{ ec2_group_description }}-2'
+            state: present
+            vpc_id: '{{ vpc_result.vpc.id }}'
+            rules:
+            - proto: "tcp"
+              from_port: 8182
+              to_port: 8182
+              cidr_ipv6: "64:ff9b::/96"
+            <<: *aws_connection_info
+          register: result
+
+        - name: assert nothing changed
+          assert:
+            that:
+              - 'not result.changed'
+
+        # ============================================================
+        - name: test rules_egress state=present for ipv6 (expected changed=true)
+          ec2_group:
+            name: '{{ ec2_group_name }}-2'
+            description: '{{ ec2_group_description }}-2'
+            state: present
+            vpc_id: '{{ vpc_result.vpc.id }}'
+            rules:
+            - proto: "tcp"
+              from_port: 8182
+              to_port: 8182
+              cidr_ipv6: "64:ff9b::/96"
+            rules_egress:
+            - proto: "tcp"
+              from_port: 8181
+              to_port: 8181
+              cidr_ipv6: "64:ff9b::/96"
+            <<: *aws_connection_info
+          register: result
+
+        - name: assert state=present (expected changed=true)
+          assert:
+            that:
+               - 'result.changed'
+               - 'result.group_id.startswith("sg-")'
+
+        # ============================================================
+
+        - name: test state=absent (expected changed=true)
+          ec2_group:
+            name: '{{ ec2_group_name }}-2'
+            description: '{{ ec2_group_description }}-2'
+            state: absent
+            vpc_id: '{{ vpc_result.vpc.id }}'
+            <<: *aws_connection_info
+          register: result
+
+        - name: assert group was removed
+          assert:
+            that:
+              - 'result.changed'
 
     # ============================================================
     - name: test state=present for ipv4 (expected changed=true)
@@ -344,12 +476,12 @@
         - proto: "tcp"
           from_port: "8183"
           to_port: "8183"
-          cidr_ipv6: "64:ff9b::/96"
+          cidr_ip: "1.1.1.1/32"
         rules_egress:
         - proto: "tcp"
           from_port: "8184"
           to_port: "8184"
-          cidr_ipv6: "64:ff9b::/96"
+          cidr_ip: "1.1.1.1/32"
       register: result
 
     - name: assert state=present (expected changed=true)
@@ -374,7 +506,6 @@
         - proto: "tcp"
           from_port: "8186"
           to_port: "8186"
-          cidr_ipv6: "64:ff9b::/96"
           group_id: "{{result.group_id}}"
       register: result
 
@@ -457,54 +588,58 @@
           - 'result.group_id.startswith("sg-")'
 
     # ============================================================
+    - name: test using the default VPC
+      block:
 
-    - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
-        state: present
-        # set purge_rules to false so we don't get a false positive from previously added rules
-        purge_rules: false
-        rules:
-        - proto: "tcp"
-          ports:
-            - 8196
-          cidr_ipv6: '2001:db00::1/24'
-      register: result
+        - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true)
+          ec2_group:
+            name: '{{ec2_group_name}}'
+            description: '{{ec2_group_description}}'
+            ec2_region: '{{ec2_region}}'
+            ec2_access_key: '{{ec2_access_key}}'
+            ec2_secret_key: '{{ec2_secret_key}}'
+            security_token: '{{security_token}}'
+            state: present
+            # set purge_rules to false so we don't get a false positive from previously added rules
+            purge_rules: false
+            rules:
+            - proto: "tcp"
+              ports:
+                - 8196
+              cidr_ipv6: '2001:db00::1/24'
+          register: result
 
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-          - 'result.changed'
-          - 'result.group_id.startswith("sg-")'
+        - name: assert state=present (expected changed=true)
+          assert:
+            that:
+              - 'result.changed'
+              - 'result.group_id.startswith("sg-")'
 
-    # ============================================================
+        # ============================================================
 
-    - name: test adding a rule again with a IPv6 CIDR with host bits set (expected changed=false and a warning)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        # set purge_rules to false so we don't get a false positive from previously added rules
-        purge_rules: false
-        rules:
-        - proto: "tcp"
-          ports:
-            - 8196
-          cidr_ipv6: '2001:db00::1/24'
-      register: result
+        - name: test adding a rule again with a IPv6 CIDR with host bits set (expected changed=false and a warning)
+          ec2_group:
+            name: '{{ec2_group_name}}'
+            description: '{{ec2_group_description}}'
+            <<: *aws_connection_info
+            state: present
+            # set purge_rules to false so we don't get a false positive from previously added rules
+            purge_rules: false
+            rules:
+            - proto: "tcp"
+              ports:
+                - 8196
+              cidr_ipv6: '2001:db00::1/24'
+          register: result
 
-    - name: assert state=present (expected changed=false and a warning)
-      assert:
-        that:
-          # No way to assert for warnings?
-          - 'not result.changed'
-          - 'result.group_id.startswith("sg-")'
+        - name: assert state=present (expected changed=false and a warning)
+          assert:
+            that:
+              # No way to assert for warnings?
+              - 'not result.changed'
+              - 'result.group_id.startswith("sg-")'
+
+      when: default_vpc
 
     # ============================================================
     - name: test state=absent (expected changed=true)
@@ -519,17 +654,6 @@
         that:
            - 'result.changed'
            - 'not result.group_id'
-
-    - name: create a VPC
-      ec2_vpc_net:
-        name: "{{ resource_prefix }}-vpc"
-        state: present
-        cidr_block: "10.232.232.128/26"
-        <<: *aws_connection_info
-        tags:
-          Name: "{{ resource_prefix }}-vpc"
-          Description: "Created by ansible-test"
-      register: vpc_result
 
     - name: create security group in the VPC
       ec2_group:
@@ -771,8 +895,8 @@
         - proto: "tcp"
           ports:
           - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 2
+          cidr_ip: 1.1.1.1/24
+          rule_desc: ipv4 rule desc
         rules_egress:
         - proto: "tcp"
           ports:
@@ -895,6 +1019,13 @@
     - name: tidy up security group
       ec2_group:
         name: '{{ec2_group_name}}'
+        state: absent
+        <<: *aws_connection_info
+      ignore_errors: yes
+
+    - name: tidy up security group for IPv6 EC2-Classic tests
+      ec2_group:
+        name: '{{ ec2_group_name }}-2'
         state: absent
         <<: *aws_connection_info
       ignore_errors: yes

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -227,51 +227,6 @@
            - 'result.group_id.startswith("sg-")'
 
     # ============================================================
-    - name: test state=present for ipv6 (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
-    - name: test rules_egress state=present for ipv6 (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ipv6: "64:ff9b::/96"
-        rules_egress:
-        - proto: "tcp"
-          from_port: 8181
-          to_port: 8181
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
     - name: test state=present for ipv4 (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'
@@ -551,6 +506,59 @@
           - 'result.changed'
           - 'result.vpc_id == vpc_result.vpc.id'
           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test state=present for ipv6 (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test rules_egress state=present for ipv6 (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ipv6: "64:ff9b::/96"
+        rules_egress:
+        - proto: "tcp"
+          from_port: 8181
+          to_port: 8181
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
 
     # ============================================================
 

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -227,6 +227,51 @@
            - 'result.group_id.startswith("sg-")'
 
     # ============================================================
+    - name: test state=present for ipv6 (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        <<: *aws_connection_info
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test rules_egress state=present for ipv6 (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        <<: *aws_connection_info
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: 8182
+          to_port: 8182
+          cidr_ipv6: "64:ff9b::/96"
+        rules_egress:
+        - proto: "tcp"
+          from_port: 8181
+          to_port: 8181
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
     - name: test state=present for ipv4 (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'
@@ -287,6 +332,58 @@
           - result.ip_permissions|length == 2
           - result.ip_permissions[0].user_id_group_pairs or
             result.ip_permissions[1].user_id_group_pairs
+
+    # ============================================================
+    - name: test ip rules convert port numbers from string to int (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        <<: *aws_connection_info
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: "8183"
+          to_port: "8183"
+          cidr_ipv6: "64:ff9b::/96"
+        rules_egress:
+        - proto: "tcp"
+          from_port: "8184"
+          to_port: "8184"
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test group rules convert port numbers from string to int (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        <<: *aws_connection_info
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: "8185"
+          to_port: "8185"
+          group_id: "{{result.group_id}}"
+        rules_egress:
+        - proto: "tcp"
+          from_port: "8186"
+          to_port: "8186"
+          cidr_ipv6: "64:ff9b::/96"
+          group_id: "{{result.group_id}}"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
 
     # ============================================================
 
@@ -456,118 +553,7 @@
           - 'result.group_id.startswith("sg-")'
 
     # ============================================================
-    - name: test state=present for ipv6 (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
 
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
-    - name: test rules_egress state=present for ipv6 (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ipv6: "64:ff9b::/96"
-        rules_egress:
-        - proto: "tcp"
-          from_port: 8181
-          to_port: 8181
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
-    - name: test ip rules convert port numbers from string to int (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: "8183"
-          to_port: "8183"
-          cidr_ipv6: "64:ff9b::/96"
-        rules_egress:
-        - proto: "tcp"
-          from_port: "8184"
-          to_port: "8184"
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
-    - name: test group rules convert port numbers from string to int (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        ec2_region: '{{ec2_region}}'
-        ec2_access_key: '{{ec2_access_key}}'
-        ec2_secret_key: '{{ec2_secret_key}}'
-        security_token: '{{security_token}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: "8185"
-          to_port: "8185"
-          group_id: "{{result.group_id}}"
-        rules_egress:
-        - proto: "tcp"
-          from_port: "8186"
-          to_port: "8186"
-          cidr_ipv6: "64:ff9b::/96"
-          group_id: "{{result.group_id}}"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
     - name: test adding tags (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'

--- a/test/integration/targets/ec2_group/tasks/main.yml
+++ b/test/integration/targets/ec2_group/tasks/main.yml
@@ -289,58 +289,6 @@
             result.ip_permissions[1].user_id_group_pairs
 
     # ============================================================
-    - name: test ip rules convert port numbers from string to int (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: "8183"
-          to_port: "8183"
-          cidr_ipv6: "64:ff9b::/96"
-        rules_egress:
-        - proto: "tcp"
-          from_port: "8184"
-          to_port: "8184"
-          cidr_ipv6: "64:ff9b::/96"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-    # ============================================================
-    - name: test group rules convert port numbers from string to int (expected changed=true)
-      ec2_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
-        state: present
-        rules:
-        - proto: "tcp"
-          from_port: "8185"
-          to_port: "8185"
-          group_id: "{{result.group_id}}"
-        rules_egress:
-        - proto: "tcp"
-          from_port: "8186"
-          to_port: "8186"
-          cidr_ipv6: "64:ff9b::/96"
-          group_id: "{{result.group_id}}"
-      register: result
-
-    - name: assert state=present (expected changed=true)
-      assert:
-        that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-
-
-    # ============================================================
 
     - name: test adding a range of ports and ports given as strings (expected changed=true)
       ec2_group:
@@ -561,7 +509,65 @@
            - 'result.group_id.startswith("sg-")'
 
     # ============================================================
+    - name: test ip rules convert port numbers from string to int (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: "8183"
+          to_port: "8183"
+          cidr_ipv6: "64:ff9b::/96"
+        rules_egress:
+        - proto: "tcp"
+          from_port: "8184"
+          to_port: "8184"
+          cidr_ipv6: "64:ff9b::/96"
+      register: result
 
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
+    - name: test group rules convert port numbers from string to int (expected changed=true)
+      ec2_group:
+        name: '{{ec2_group_name}}'
+        description: '{{ec2_group_description}}'
+        ec2_region: '{{ec2_region}}'
+        ec2_access_key: '{{ec2_access_key}}'
+        ec2_secret_key: '{{ec2_secret_key}}'
+        security_token: '{{security_token}}'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        state: present
+        rules:
+        - proto: "tcp"
+          from_port: "8185"
+          to_port: "8185"
+          group_id: "{{result.group_id}}"
+        rules_egress:
+        - proto: "tcp"
+          from_port: "8186"
+          to_port: "8186"
+          cidr_ipv6: "64:ff9b::/96"
+          group_id: "{{result.group_id}}"
+      register: result
+
+    - name: assert state=present (expected changed=true)
+      assert:
+        that:
+           - 'result.changed'
+           - 'result.group_id.startswith("sg-")'
+
+    # ============================================================
     - name: test adding tags (expected changed=true)
       ec2_group:
         name: '{{ec2_group_name}}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Move some tasks of the integration test to be done in a VPC. These tasks use features that AWS doesn't support without a VPC.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_group

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix-ec2-group-integration-test 8f85753f8b) last updated 2017/11/16 15:50:23 (GMT +300)
  config file = /home/blomkim/.ansible.cfg
  configured module search path = [u'/home/blomkim/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/blomkim/src/ansible/lib/ansible
  executable location = /home/blomkim/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  6 2017, 17:19:19) [GCC 5.4.0]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
To reproduce:
Use a dedicated AWS account with IAM credentials set in `test/integration/cloud-config-aws.yml`.
`[vagrant@localhost ansible]$ ansible-test integration --docker -v ec2_group` starts up fine, but fails with:
```
TASK [ec2_group : test state=present for ipv6 (expected changed=true)] *********
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ClientError: An error occurred (InvalidParameter) when calling the AuthorizeSecurityGroupIngress operation: ipv6-ranges is not a valid parameter. IPv6 rules can only be specified for VPC security groups.
fatal: [localhost]: FAILED! => {"changed": false, "error": {"code": "InvalidParameter", "message": "ipv6-ranges is not a valid parameter. IPv6 rules can only be specified for VPC security groups."}, "msg": "Unable to authorize in for ip 64:ff9b::/96 security group 'ansible-test-localhost-18182520' - An error occurred (InvalidParameter) when calling the AuthorizeSecurityGroupIngress operation: ipv6-ranges is not a valid parameter. IPv6 rules can only be specified for VPC security groups.", "response_metadata": {"http_headers": {"connection": "close", "date": "Mon, 13 Nov 2017 13:30:34 GMT", "server": "AmazonEC2", "transfer-encoding": "chunked"}, "http_status_code": 400, "request_id": "1a0e6d4e-12c4-43dc-953a-6718ee823683", "retry_attempts": 0}}

