### PR TITLE
No hardcoding roadmaps

### DIFF
--- a/ROADMAP.rst
+++ b/ROADMAP.rst
@@ -12,18 +12,6 @@ These roadmaps are the team's *best guess* roadmaps based on the Ansible team's 
 - Add to the agenda of a `Core IRC Meetings <https://github.com/ansible/community/blob/master/meetings/README.md>`_ (preferred)
 - Ansible's google-group: ansible-devel
 - AnsibleFest conferences.
-- IRC freenode channel: #ansible-devel (this one may have things lost in lots of conversation, so a caution).
+- IRC Freenode channel: #ansible-devel (this one may have things lost in lots of conversation, so a caution).
 
-=======================================
-Current 2.5 Roadmap is open for comment
-=======================================
-We are starting to build the 2.5 Roadmap. We are seeking community feedback! That document is here:
- - `2.5 Roadmap Document <docs/docsite/rst/roadmap/ROADMAP_2_5.rst>`_
-
-
-
-**Old Roadmaps are found here:**
- - `2.4 Roadmap Document <docs/docsite/rst/roadmap/ROADMAP_2_4.rst>`_
- - `2.3 Roadmap Document <docs/docsite/rst/roadmap/ROADMAP_2_3.rst>`_
- - `2.2 Roadmap Document <docs/docsite/rst/roadmap/ROADMAP_2_2.rst>`_
- - `2.1 Roadmap Document <docs/docsite/rst/roadmap/ROADMAP_2_1.rst>`_
+Ansible Roadmaps can be found `here <http://docs.ansible.com/ansible/devel/roadmap/>`_.

--- a/docs/docsite/rst/committer_guidelines.rst
+++ b/docs/docsite/rst/committer_guidelines.rst
@@ -12,7 +12,7 @@ If you abuse the trust and break components and builds, etc., the trust level fa
 Features, High Level Design, and Roadmap
 ========================================
 
-As a core team member, you are an integral part of the team that develops the roadmap. Please be engaged, and push for the features and fixes that you want to see. Also keep in mind that Red Hat, as a company, will commit to certain features, fixes, APIs, etc. for various releases. Red Hat, the company, and the Ansible team must get these committed features (etc.) completed and released as scheduled. Obligations to users, the community, and customers must come first. Because of these commitments, a feature you want to develop yourself may not get into a release if it impacts a lot of other parts within Ansible.
+As a core team member, you are an integral part of the team that develops the `roadmap <http://docs.ansible.com/ansible/devel/roadmap/>`_. Please be engaged, and push for the features and fixes that you want to see. Also keep in mind that Red Hat, as a company, will commit to certain features, fixes, APIs, etc. for various releases. Red Hat, the company, and the Ansible team must get these committed features (etc.) completed and released as scheduled. Obligations to users, the community, and customers must come first. Because of these commitments, a feature you want to develop yourself may not get into a release if it impacts a lot of other parts within Ansible.
 
 Any other new features and changes to high level design should go through the proposal process (TBD), to ensure the community and core team have had a chance to review the idea and approve it. The core team has sole responsibility for merging new features based on proposals.
 

--- a/docs/docsite/rst/community/development_process.rst
+++ b/docs/docsite/rst/community/development_process.rst
@@ -8,7 +8,7 @@ This section discusses how the Ansible development and triage process works.
 Road Maps
 =========
 
-The Ansible Core team provides a road map for each upcoming release. These road maps can be found `here <http://docs.ansible.com/ansible/latest/roadmap/>`_.
+The Ansible Core team provides a road map for each upcoming release. These road maps can be found `here <http://docs.ansible.com/ansible/devel/roadmap/>`_.
 
 Pull Requests
 =============


### PR DESCRIPTION
##### SUMMARY
* Avoid having to remember to update multiple places that mention roadmaps
* Always link to `devel` (rather than `stable`) version of roadmaps

##### ISSUE TYPE
 - Docs Pull Request
