### PR TITLE
azure_rm_virtualmachine : fix support for existing machines provisioned with a managed image

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -6,7 +6,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
-import json
 __metaclass__ = type
 
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -6,6 +6,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+import json
 __metaclass__ = type
 
 
@@ -1112,6 +1113,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                                 caching=vm_dict['properties']['storageProfile']['osDisk']['caching'],
                             ),
                             image_reference=self.compute_models.ImageReference(
+                                id=vm_dict['properties']['storageProfile']['imageReference']['id'],
+                            ) if 'id' in vm_dict['properties']['storageProfile']['imageReference'].keys() else self.compute_models.ImageReference(
                                 publisher=vm_dict['properties']['storageProfile']['imageReference']['publisher'],
                                 offer=vm_dict['properties']['storageProfile']['imageReference']['offer'],
                                 sku=vm_dict['properties']['storageProfile']['imageReference']['sku'],


### PR DESCRIPTION
##### SUMMARY

Allow the module to make changes to a machine already provisioned  with a managed image. Example from official doc:

```
- name: Deallocate
  azure_rm_virtualmachine:
    resource_group: Testing
    name: testvm002
    allocated: no
```

This would fail on a machine provisioned with a managed image (aka custom image) but unknown from ansible (example: machine provisioned with Terraform).

Fixes a bug in #32367

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

`azure_rm_virtualmachine`

##### ANSIBLE VERSION

```
2.5.0
```