### PR TITLE
Fix eos call to prompt()

### DIFF
--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -64,8 +64,6 @@ def recv_data(s):
 
 def exec_command(module, command):
     connection = Connection(module._socket_path)
-    if command == 'prompt()':
-        return 0, connection.get_prompt(), ''
     try:
         out = connection.exec_command(command)
     except ConnectionError as exc:

--- a/lib/ansible/module_utils/connection.py
+++ b/lib/ansible/module_utils/connection.py
@@ -64,6 +64,8 @@ def recv_data(s):
 
 def exec_command(module, command):
     connection = Connection(module._socket_path)
+    if command == 'prompt()':
+        return 0, connection.get_prompt(), ''
     try:
         out = connection.exec_command(command)
     except ConnectionError as exc:

--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -125,12 +125,6 @@ class Cli:
             command = self._module.jsonify(command)
         return exec_command(self._module, command)
 
-    def check_authorization(self):
-        for cmd in ['show clock', 'prompt()']:
-            rc, out, err = self.exec_command(cmd)
-            out = to_text(out, errors='surrogate_then_replace')
-        return out.endswith('#')
-
     def get_config(self, flags=None):
         """Retrieves the current config from the device or cache
         """
@@ -193,9 +187,6 @@ class Cli:
     def configure(self, commands):
         """Sends configuration commands to the remote device
         """
-        if not self.check_authorization():
-            self._module.fail_json(msg='configuration operations require privilege escalation')
-
         conn = get_connection(self)
 
         rc, out, err = self.exec_command('configure')
@@ -212,9 +203,6 @@ class Cli:
     def load_config(self, commands, commit=False, replace=False):
         """Loads the config commands onto the remote device
         """
-        if not self.check_authorization():
-            self._module.fail_json(msg='configuration operations require privilege escalation')
-
         use_session = os.getenv('ANSIBLE_EOS_USE_SESSIONS', True)
         try:
             use_session = int(use_session)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
`prompt()` is no longer a magic method you can send to connection.exec_command and get a prompt back. eos' module_utils still calls for it when trying to configure.

We seem to have two options:

* Give a response to `prompt()` (191ebf2)
* Remove the check entirely (as this PR does)

The latter one seems reasonable, as without the check, the error returned shows the command it tried to execute followed by `Invalid input (privileged mode required)`, which seems more useful than just `configuration operations require privilege escalation`
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/eos

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
