### PR TITLE
Pin Shippable build image to v5.4.1.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -61,8 +61,7 @@ build:
     - docker images drydock/u16pytall
   pre_ci_boot:
     image_name: drydock/u16pytall
-    image_tag: master
-    pull: false
+    image_tag: v5.4.1
     options: "--privileged=false --net=bridge"
   ci:
     - test/utils/shippable/timing.sh test/utils/shippable/shippable.sh

--- a/shippable.yml
+++ b/shippable.yml
@@ -57,8 +57,6 @@ matrix:
     - env: TEST=linux/ubuntu1604/3
     - env: TEST=linux/ubuntu1604py3/3
 build:
-  pre_ci:
-    - docker images drydock/u16pytall
   pre_ci_boot:
     image_name: drydock/u16pytall
     image_tag: v5.4.1


### PR DESCRIPTION
##### SUMMARY

Pin Shippable build image to v5.4.1.

This will allow tests to continue working after we update to a newer machine image on Shippable.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.3.3.0 (pin-ci-2.3 2b87b4da5d) last updated 2017/11/16 10:48:32 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
