### PR TITLE
Add itertools.product as a filter

### DIFF
--- a/lib/ansible/plugins/filter/mathstuff.py
+++ b/lib/ansible/plugins/filter/mathstuff.py
@@ -147,6 +147,7 @@ class FilterModule(object):
             'union': union,
 
             # combinatorial
+            'product': itertools.product,
             'permutations': itertools.permutations,
             'combinations': itertools.combinations,
 


### PR DESCRIPTION
##### SUMMARY

itertools.product would be useful to have when you need to specify lots of things all at once.

For instance I was setting up certbot, and I have a list of domains and subdomains I want to make bundled certificates for. `product` makes doing this super easy and nice.

Here's an example task where this would be useful:

```
- hosts: loadbalancers
  gather_facts: no
  vars:
    domains:
    - parrot.com
    - parrot.ca
    subdomains:
    - ~
    - dead
    - napping
    - bereftoflife
  tasks:
  - command: >
      certbot certonly 
      --cert-name {{domains|first}} 
      -d {{subdomains | product(domains)
           |map('select')
           |map('join', '.')
           |join(',')}}
```

I assume there are similar cases for other people, like creating many directories with identical structures.

##### ISSUE TYPE
 - Feature Pull Request
