### PR TITLE
Pin Shippable build image to v5.4.1.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -61,12 +61,9 @@ matrix:
     - env: TEST=code-smell INSTALL_DEPS=1
       python: 2.7
 build:
-  pre_ci:
-    - docker images drydock/u16pytall
   pre_ci_boot:
     image_name: drydock/u16pytall
-    image_tag: master
-    pull: false
+    image_tag: v5.4.1
     options: "--privileged=false --net=bridge"
   ci:
     - test/utils/shippable/ci.sh

--- a/shippable.yml
+++ b/shippable.yml
@@ -20,8 +20,8 @@ matrix:
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:centos7
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora24
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:fedora25
-    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuse42.1
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuse42.2
+    - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:opensuse42.3
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
     - env: TEST=integration TARGET=destructive IMAGE=ansible/ansible:ubuntu1604
@@ -31,8 +31,8 @@ matrix:
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:centos7 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora24 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:fedora25 PRIVILEGED=true
-    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuse42.1 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuse42.2 PRIVILEGED=true
+    - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:opensuse42.3 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1204 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1404 PRIVILEGED=true
     - env: TEST=integration TARGET=non_destructive IMAGE=ansible/ansible:ubuntu1604 PRIVILEGED=true
@@ -42,8 +42,8 @@ matrix:
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:centos7
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora24
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:fedora25
-    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuse42.1
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuse42.2
+    - env: TEST=integration TARGET=other IMAGE=ansible/ansible:opensuse42.3
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1204
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1404
     - env: TEST=integration TARGET=other IMAGE=ansible/ansible:ubuntu1604

--- a/test/integration/roles/test_pip/tasks/main.yml
+++ b/test/integration/roles/test_pip/tasks/main.yml
@@ -148,6 +148,15 @@
       - "not setuptools_check_mode.changed"
 
 
+# Upgrade pip in virtualenv
+- name: download get-pip.py
+  get_url:
+    url: https://bootstrap.pypa.io/get-pip.py
+    dest: "{{ output_dir }}"
+
+- name: install pip
+  command: "{{ output_dir }}/pipenv/bin/python {{ output_dir }}/get-pip.py"
+
 # Normal case
 - name: check for q package
   pip: name=q virtualenv={{ output_dir }}/pipenv state=present

--- a/test/integration/roles/test_zypper/tasks/zypper.yml
+++ b/test/integration/roles/test_zypper/tasks/zypper.yml
@@ -189,6 +189,7 @@
 - name: install empty rpm
   zypper:
     name: "{{ output_dir | expanduser }}/zypper2/rpm-build/noarch/empty-1-0.noarch.rpm"
+    disable_gpg_check: yes
   register: zypper_result
 
 - name: check empty with rpm
@@ -281,56 +282,10 @@
       - zypper_patch.msg.startswith('Can not remove patches.')
 
 - name: try rm URL
-  zypper: name=http://download.opensuse.org/repositories/openSUSE:/Leap:/42.1/standard/x86_64/hello-2.9-6.2.x86_64.rpm state=absent
+  zypper: name=http://download.opensuse.org/repositories/openSUSE:/Leap:/{{ ansible_distribution_version }}/standard/x86_64/hello-2.9-6.2.x86_64.rpm state=absent
   ignore_errors: yes
   register: zypper_rm
 - assert:
     that: 
       - zypper_rm|failed
       - zypper_rm.msg.startswith('Can not remove via URL.')
-
-# use of version specific (42.1) data in the following
-- block:
-  # test for #1627
-  - name: in existing patch
-    zypper: name=openSUSE-2016-128 type=patch state=present
-  - name: in existing patch again
-    zypper: name=openSUSE-2016-128 type=patch state=present
-    register: zypper_patch
-  - assert:
-      that: not zypper_patch.changed
-
-  - name: in non-existing patch
-    zypper: name=openSUSE-1800-1 type=patch state=present
-    ignore_errors: yes
-    register: zypper_patch
-  - assert:
-      that: zypper_patch|failed
-
-  - name: remove pattern update_test
-    zypper: name=update_test type=pattern state=absent
-  - name: install pattern update_test
-    zypper: name=update_test type=pattern state=present
-    register: zypper_install_pattern1
-  - name: install pattern update_test again
-    zypper: name=update_test type=pattern state=present
-    register: zypper_install_pattern2
-  - assert:
-      that:
-        - zypper_install_pattern1|changed
-        - not zypper_install_pattern2|changed
-
-  - name: remove hello
-    zypper: name=hello state=absent
-  - name: install via URL
-    zypper: state=present name=http://download.opensuse.org/repositories/openSUSE:/Leap:/42.1/standard/x86_64/hello-2.9-6.2.x86_64.rpm
-    register: zypperin1
-  - name: test install
-    zypper: name=hello state=present
-    register: zypperin2
-  - assert:
-      that:
-        - zypperin1|success
-        - zypperin1|changed
-        - not zypperin2|changed
-  when: ansible_distribution == 'openSUSE Leap' and ansible_distribution_version == '42.1'

--- a/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/roles/test_zypper_repository/tasks/zypper_repository.yml
@@ -39,7 +39,7 @@
   zypper_repository:
     name: test
     state: present
-    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_42.1/
+    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_{{ ansible_distribution_version }}/
   register: zypper_result
 
 - name: Verify change on URL only change
@@ -57,7 +57,7 @@
     name: testrefresh
     refresh: no
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
 
 - name: check refreshoption
   command: zypper -x lr testrefresh
@@ -72,7 +72,7 @@
     name: testprio
     priority: 55
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
 
 - name: check refreshoption
   command: zypper -x lr testprio
@@ -86,7 +86,7 @@
   zypper_repository:
     name: "{{item}}"
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
   with_items:
     - oss1
     - oss2
@@ -105,14 +105,14 @@
       - "zypper_result1.rc == 6"
       - "'not found' in zypper_result1.stderr"
       - "zypper_result2.rc == 0"
-      - "'http://download.opensuse.org/distribution/leap/42.1/repo/oss/' in zypper_result2.stdout"
+      - "'http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/' in zypper_result2.stdout"
 
 
 - name: reset oss repo (to not break zypper later)
   zypper_repository:
     name: OSS
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
     priority: 99
     refresh: yes
 
@@ -122,8 +122,8 @@
     state: present
     repo: "{{ item }}"
   with_items:
-    - http://download.opensuse.org/repositories/science/openSUSE_Leap_42.1/
-    - http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
+    - http://download.opensuse.org/repositories/science/openSUSE_Leap_{{ ansible_distribution_version }}/
+    - http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_{{ ansible_distribution_version }}/
 
 - name: check repo is updated by name
   command: zypper lr samename
@@ -136,7 +136,7 @@
 
 - name: remove last added repos (by URL to test that)
   zypper_repository:
-    repo: http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
+    repo: http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_{{ ansible_distribution_version }}/
     state: absent
 
 - name: ensure zypper ref still works

--- a/test/utils/shippable/sanity-requirements.txt
+++ b/test/utils/shippable/sanity-requirements.txt
@@ -4,3 +4,4 @@ jinja2
 setuptools<33.0.0
 mock
 voluptuous==0.8.8
+cryptography < 2.1.0  # cryptography 2.1.0 requires a newer pip

--- a/test/utils/tox/requirements.txt
+++ b/test/utils/tox/requirements.txt
@@ -2,6 +2,7 @@
 # Test requirements
 #
 
+paramiko < 2.4.0 ; python_version < '2.7'  # paramiko 2.4.0 drops support for python 2.6
 nose
 mock >= 1.0.1, < 1.1
 passlib


### PR DESCRIPTION
##### SUMMARY

Pin Shippable build image to v5.4.1.

This will allow tests to continue working after we update to a newer machine image on Shippable.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.2.3.0 (pin-ci-2.2 38413ca45a) last updated 2017/11/16 11:38:20 (GMT -700)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = 
  configured module search path = Default w/o overrides
```
