### PR TITLE
win_stat: simplified tests before next change

### DIFF
--- a/test/integration/targets/win_stat/defaults/main.yml
+++ b/test/integration/targets/win_stat/defaults/main.yml
@@ -1,1 +1,1 @@
-win_stat_dir: "{{win_output_dir}}\\win_stat"
+win_stat_dir: '{{win_output_dir}}\win_stat'

--- a/test/integration/targets/win_stat/files/set_attributes.ps1
+++ b/test/integration/targets/win_stat/files/set_attributes.ps1
@@ -1,9 +1,0 @@
-$path = $args[0]
-$attr = $args[1]
-$item = Get-Item "$path"
-
-$attributes = $item.Attributes -split ','
-If ($attributes -notcontains $attr) {
-    $attributes += $attr
-}
-$item.Attributes = $attributes -join ','

--- a/test/integration/targets/win_stat/files/set_filedate.ps1
+++ b/test/integration/targets/win_stat/files/set_filedate.ps1
@@ -1,6 +1,0 @@
-$date = Get-Date -Year 2016 -Month 11 -Day 1 -Hour 7 -Minute 10 -Second 5 -Millisecond 0
-
-$item = Get-Item -Path "$($args[0])"
-$item.CreationTime = $date
-$item.LastAccessTime = $date
-$item.LastWriteTime = $date

--- a/test/integration/targets/win_stat/files/set_share.ps1
+++ b/test/integration/targets/win_stat/files/set_share.ps1
@@ -1,7 +1,0 @@
-$share_name = $args[1]
-$share_stat = Get-WmiObject -Class Win32_Share -Filter "name='$share_name'"
-If ($share_stat) {
-    $share_stat.Delete()
-}
-$wmi = [wmiClass] 'Win32_Share'
-$wmi.Create($args[0], $share_name, 0)

--- a/test/integration/targets/win_stat/tasks/main.yml
+++ b/test/integration/targets/win_stat/tasks/main.yml
@@ -1,556 +1,82 @@
-# test code for the win_stat module
-# (c) 2014, Chris Church <chris@ninemoreminutes.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-
-# - name: ensure the testing directory is cleared before the run
-#   win_file:
-#     path: "{{win_stat_dir}}"
-#     state: absent
-
 - name: remove win_stat testing directories for clean slate
   win_file:
-    path: "{{win_stat_dir}}"
+    path: '{{win_stat_dir}}'
     state: absent
 
-- name: ensure win testing directories exist
-  win_file:
-    path: "{{item}}"
-    state: directory
-  with_items:
-  - "{{win_stat_dir}}\\folder"
-  - "{{win_stat_dir}}\\folder space"
-  - "{{win_stat_dir}}\\nested"
-  - "{{win_stat_dir}}\\nested\\nested"
-  - "{{win_stat_dir}}\\shared"
-  - "{{win_stat_dir}}\\hidden"
-  - "{{win_stat_dir}}\\link-dest"
-  - "{{win_stat_dir}}\\junction-dest"
+# while most of the setup can be done with modules, it is quicker to do them
+# all in bulk than with with_items to save each round trip over WinRM
+- name: set test files and folders
+  win_shell: |
+    $ErrorActionPreference = "Stop"
+    $directories = @(
+        "folder",
+        "folder space",
+        "nested\nested",
+        "shared",
+        "hidden",
+        "link-dest",
+        "junction-dest"
+    )
 
-- name: create empty test files
-  win_file:
-    path: "{{item}}"
-    state: touch
-  with_items:
-  - "{{win_stat_dir}}\\nested\\file.ps1"
-  - "{{win_stat_dir}}\\nested\\read-only.ps1"
-  - "{{win_stat_dir}}\\nested\\archive.ps1"
-  - "{{win_stat_dir}}\\nested\\hidden.ps1"
-  - "{{win_stat_dir}}\\nested\\nested\\file.ps1"
-  - "{{win_stat_dir}}\\folder space\\file.ps1"
+    foreach ($directory in $directories) {
+        New-Item -Path "{{win_stat_dir}}\$directory" -ItemType Directory
+    }
 
-- name: populate files with a test string
-  win_lineinfile:
-    dest: "{{item}}"
-    line: abc
-  with_items:
-  - "{{win_stat_dir}}\\nested\\file.ps1"
-  - "{{win_stat_dir}}\\nested\\read-only.ps1"
-  - "{{win_stat_dir}}\\nested\\archive.ps1"
-  - "{{win_stat_dir}}\\nested\\hidden.ps1"
-  - "{{win_stat_dir}}\\nested\\nested\\file.ps1"
-  - "{{win_stat_dir}}\\folder space\\file.ps1"
+    $normal_content = "abc"
+    $normal_files = @(
+        "nested\file.ps1",
+        "nested\read-only.ps1",
+        "nested\archive.ps1",
+        "nested\hidden.ps1",
+        "nested\nested\file.ps1",
+        "folder space\file.ps1"
+    )
+    foreach ($file in $normal_files) {
+        New-Item -Path "{{win_stat_dir}}\$file" -ItemType File
+        [System.IO.File]::WriteAllText("{{win_stat_dir}}\$file", $normal_content)
+    }
 
-- name: create share
-  script: set_share.ps1 {{win_stat_dir}}\shared folder-share
+    $share_stat = Get-WmiObject -Class Win32_Share -Filter "name='folder-share'"
+    if ($share_stat) {
+        $share_stat.Delete()
+    }
+    $wmi = [wmiClass] 'Win32_Share'
+    $wmi.Create("{{win_stat_dir}}\shared", "folder-share", 0)
 
-- name: create links
-  win_command: cmd.exe /c mklink /{{item.type}} {{item.source}} {{item.target}}
-  with_items:
-  - { type: 'D', source: "{{win_stat_dir}}\\link", target: "{{win_stat_dir}}\\link-dest" }
-  - { type: 'H', source: "{{win_stat_dir}}\\nested\\hard-link.ps1", target: "{{win_stat_dir}}\\nested\\file.ps1" }
-  - { type: 'J', source: "{{win_stat_dir}}\\junction-link", target: "{{win_stat_dir}}\\junction-dest" }
+    cmd.exe /c mklink /D "{{win_stat_dir}}\link" "{{win_stat_dir}}\link-dest"
+    cmd.exe /c mklink /H "{{win_stat_dir}}\nested\hard-link.ps1" "{{win_stat_dir}}\nested\file.ps1"
+    cmd.exe /c mklink /J "{{win_stat_dir}}\junction-link" "{{win_stat_dir}}\junction-dest"
+  
+    $date = Get-Date -Year 2016 -Month 11 -Day 1 -Hour 7 -Minute 10 -Second 5 -Millisecond 0
+    Get-ChildItem -Path "{{win_stat_dir}}" -Recurse | ForEach-Object {
+        $_.CreationTime = $date
+        $_.LastAccessTime = $date
+        $_.LastWriteTime = $date
+    }
 
-- name: set modification date on files/folders
-  script: set_filedate.ps1 "{{item}}"
-  with_items:
-  - "{{win_stat_dir}}\\nested\\file.ps1"
-  - "{{win_stat_dir}}\\nested\\read-only.ps1"
-  - "{{win_stat_dir}}\\nested\\archive.ps1"
-  - "{{win_stat_dir}}\\nested\\hidden.ps1"
-  - "{{win_stat_dir}}\\nested\\nested\\file.ps1"
-  - "{{win_stat_dir}}\\folder space\\file.ps1"
-  - "{{win_stat_dir}}\\folder"
-  - "{{win_stat_dir}}\\folder space"
-  - "{{win_stat_dir}}\\nested"
-  - "{{win_stat_dir}}\\nested\\nested"
-  - "{{win_stat_dir}}\\shared"
-  - "{{win_stat_dir}}\\hidden"
-  - "{{win_stat_dir}}\\link-dest"
-  - "{{win_stat_dir}}\\junction-dest"
+    $attributes = @{
+        "hidden" = "Hidden"
+        "nested\read-only.ps1" = "ReadOnly"
+        "nested\archive.ps1" = "Archive"
+        "nested\hidden.ps1" = "Hidden"
+    }
 
-- name: set file attributes for test
-  script: set_attributes.ps1 {{item.path}} {{item.attr}}
-  with_items:
-  - { path: "{{win_stat_dir}}\\hidden", attr: "Hidden" }
-  - { path: "{{win_stat_dir}}\\nested\\read-only.ps1", attr: "ReadOnly" }
-  - { path: "{{win_stat_dir}}\\nested\\archive.ps1", attr: "Archive" }
-  - { path: "{{win_stat_dir}}\\nested\\hidden.ps1", attr: "Hidden" }
-# End setup of test files
+    foreach ($attribute in $attributes.GetEnumerator()) {
+        $item = Get-Item -Path "{{win_stat_dir}}\$($attribute.Name)"
+        $file_attributes = $item.Attributes -split ','
+        if ($file_attributes -notcontains $attribute.Value) {
+            $file_attributes += $attribute.Value
+        }
+        $item.Attributes = $file_attributes -join ','
+    }
+    # weird issue, need to access the file in anyway to get the correct date stats
+    Test-Path {{win_stat_dir}}\nested\hard-link.ps1
 
-- name: test win_stat module on file
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-  register: stat_file
+- block:
+  - include_tasks: tests.yml
 
-- name: check actual for file
-  assert:
-    that:
-    - stat_file.stat.attributes == 'Archive'
-    - stat_file.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
-    - stat_file.stat.creationtime == 1477984205
-    - stat_file.stat.exists == True
-    - stat_file.stat.extension == '.ps1'
-    - stat_file.stat.filename == 'file.ps1'
-    - stat_file.stat.isarchive == True
-    - stat_file.stat.isdir == False
-    - stat_file.stat.ishidden == False
-    - stat_file.stat.islnk == False
-    - stat_file.stat.isreadonly == False
-    - stat_file.stat.isshared == False
-    - stat_file.stat.lastaccesstime == 1477984205
-    - stat_file.stat.lastwritetime == 1477984205
-    - stat_file.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_file.stat.owner == 'BUILTIN\Administrators'
-    - stat_file.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
-    - stat_file.stat.size == 3
-
-- name: test win_stat module on file without md5
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-    get_md5: False
-  register: stat_file_md5
-
-- name: check actual for file without md5
-  assert:
-    that:
-    - stat_file_md5.stat.attributes == 'Archive'
-    - stat_file_md5.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
-    - stat_file_md5.stat.creationtime == 1477984205
-    - stat_file_md5.stat.exists == True
-    - stat_file_md5.stat.extension == '.ps1'
-    - stat_file_md5.stat.filename == 'file.ps1'
-    - stat_file_md5.stat.isarchive == True
-    - stat_file_md5.stat.isdir == False
-    - stat_file_md5.stat.ishidden == False
-    - stat_file_md5.stat.islnk == False
-    - stat_file_md5.stat.isreadonly == False
-    - stat_file_md5.stat.isshared == False
-    - stat_file_md5.stat.lastaccesstime == 1477984205
-    - stat_file_md5.stat.lastwritetime == 1477984205
-    - stat_file_md5.stat.md5 is not defined
-    - stat_file_md5.stat.owner == 'BUILTIN\Administrators'
-    - stat_file_md5.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
-    - stat_file_md5.stat.size == 3
-
-- name: test win_stat module on file with sha256
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-    checksum_algorithm: sha256
-  register: stat_file_sha256
-
-- name: check actual for file with sha256
-  assert:
-    that:
-    - stat_file_sha256.stat.attributes == 'Archive'
-    - stat_file_sha256.stat.checksum == 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
-    - stat_file_sha256.stat.creationtime == 1477984205
-    - stat_file_sha256.stat.exists == True
-    - stat_file_sha256.stat.extension == '.ps1'
-    - stat_file_sha256.stat.filename == 'file.ps1'
-    - stat_file_sha256.stat.isarchive == True
-    - stat_file_sha256.stat.isdir == False
-    - stat_file_sha256.stat.ishidden == False
-    - stat_file_sha256.stat.islnk == False
-    - stat_file_sha256.stat.isreadonly == False
-    - stat_file_sha256.stat.isshared == False
-    - stat_file_sha256.stat.lastaccesstime == 1477984205
-    - stat_file_sha256.stat.lastwritetime == 1477984205
-    - stat_file_sha256.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_file_sha256.stat.owner == 'BUILTIN\Administrators'
-    - stat_file_sha256.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
-    - stat_file_sha256.stat.size == 3
-
-- name: test win_stat module on file with sha384
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-    checksum_algorithm: sha384
-  register: stat_file_sha384
-
-- name: check actual for file with sha384
-  assert:
-    that:
-    - stat_file_sha384.stat.attributes == 'Archive'
-    - stat_file_sha384.stat.checksum == 'cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7'
-    - stat_file_sha384.stat.creationtime == 1477984205
-    - stat_file_sha384.stat.exists == True
-    - stat_file_sha384.stat.extension == '.ps1'
-    - stat_file_sha384.stat.filename == 'file.ps1'
-    - stat_file_sha384.stat.isarchive == True
-    - stat_file_sha384.stat.isdir == False
-    - stat_file_sha384.stat.ishidden == False
-    - stat_file_sha384.stat.islnk == False
-    - stat_file_sha384.stat.isreadonly == False
-    - stat_file_sha384.stat.isshared == False
-    - stat_file_sha384.stat.lastaccesstime == 1477984205
-    - stat_file_sha384.stat.lastwritetime == 1477984205
-    - stat_file_sha384.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_file_sha384.stat.owner == 'BUILTIN\Administrators'
-    - stat_file_sha384.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
-    - stat_file_sha384.stat.size == 3
-
-- name: test win_stat module on file with sha512
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\file.ps1"
-    checksum_algorithm: sha512
-  register: stat_file_sha512
-
-- name: check actual for file with sha512
-  assert:
-    that:
-    - stat_file_sha512.stat.attributes == 'Archive'
-    - stat_file_sha512.stat.checksum == 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f'
-    - stat_file_sha512.stat.creationtime == 1477984205
-    - stat_file_sha512.stat.exists == True
-    - stat_file_sha512.stat.extension == '.ps1'
-    - stat_file_sha512.stat.filename == 'file.ps1'
-    - stat_file_sha512.stat.isarchive == True
-    - stat_file_sha512.stat.isdir == False
-    - stat_file_sha512.stat.ishidden == False
-    - stat_file_sha512.stat.islnk == False
-    - stat_file_sha512.stat.isreadonly == False
-    - stat_file_sha512.stat.isshared == False
-    - stat_file_sha512.stat.lastaccesstime == 1477984205
-    - stat_file_sha512.stat.lastwritetime == 1477984205
-    - stat_file_sha512.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_file_sha512.stat.owner == 'BUILTIN\Administrators'
-    - stat_file_sha512.stat.path == win_output_dir + '\\win_stat\\nested\\file.ps1'
-    - stat_file_sha512.stat.size == 3
-
-- name: test win_stat on hidden file
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\hidden.ps1"
-  register: stat_file_hidden
-
-- name: check actual for hidden file
-  assert:
-    that:
-    - stat_file_hidden.stat.attributes == 'Hidden, Archive'
-    - stat_file_hidden.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
-    - stat_file_hidden.stat.creationtime == 1477984205
-    - stat_file_hidden.stat.exists == True
-    - stat_file_hidden.stat.extension == '.ps1'
-    - stat_file_hidden.stat.filename == 'hidden.ps1'
-    - stat_file_hidden.stat.isarchive == True
-    - stat_file_hidden.stat.isdir == False
-    - stat_file_hidden.stat.ishidden == True
-    - stat_file_hidden.stat.islnk == False
-    - stat_file_hidden.stat.isreadonly == False
-    - stat_file_hidden.stat.isshared == False
-    - stat_file_hidden.stat.lastaccesstime == 1477984205
-    - stat_file_hidden.stat.lastwritetime == 1477984205
-    - stat_file_hidden.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_file_hidden.stat.owner == 'BUILTIN\Administrators'
-    - stat_file_hidden.stat.path == win_output_dir + '\\win_stat\\nested\\hidden.ps1'
-    - stat_file_hidden.stat.size == 3
-
-- name: test win_stat on readonly file
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\read-only.ps1"
-  register: stat_readonly
-
-- name: check actual for readonly file
-  assert:
-    that:
-    - stat_readonly.stat.attributes == 'ReadOnly, Archive'
-    - stat_readonly.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
-    - stat_readonly.stat.creationtime == 1477984205
-    - stat_readonly.stat.exists == True
-    - stat_readonly.stat.extension == '.ps1'
-    - stat_readonly.stat.filename == 'read-only.ps1'
-    - stat_readonly.stat.isarchive == True
-    - stat_readonly.stat.isdir == False
-    - stat_readonly.stat.ishidden == False
-    - stat_readonly.stat.islnk == False
-    - stat_readonly.stat.isreadonly == True
-    - stat_readonly.stat.isshared == False
-    - stat_readonly.stat.lastaccesstime == 1477984205
-    - stat_readonly.stat.lastwritetime == 1477984205
-    - stat_readonly.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_readonly.stat.owner == 'BUILTIN\Administrators'
-    - stat_readonly.stat.path == win_output_dir + '\\win_stat\\nested\\read-only.ps1'
-    - stat_readonly.stat.size == 3
-
-# Requires more work once modular powershell utils are in
-- name: weird issue, need to access the file in anyway to get the correct date stats
-  win_command: powershell.exe Test-Path {{win_output_dir}}\win_stat\nested\hard-link.ps1
-
-- name: test win_stat on hard link file
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested\\hard-link.ps1"
-  register: stat_hard_link
-
-- name: check actual for hard link file
-  assert:
-    that:
-    - stat_hard_link.stat.attributes == 'Archive'
-    - stat_hard_link.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
-    - stat_hard_link.stat.creationtime == 1477984205
-    - stat_hard_link.stat.exists == True
-    - stat_hard_link.stat.extension == '.ps1'
-    - stat_hard_link.stat.filename == 'hard-link.ps1'
-    - stat_hard_link.stat.isarchive == True
-    - stat_hard_link.stat.isdir == False
-    - stat_hard_link.stat.ishidden == False
-    - stat_hard_link.stat.islnk == False
-    - stat_hard_link.stat.isreadonly == False
-    - stat_hard_link.stat.isshared == False
-    - stat_hard_link.stat.lastaccesstime == 1477984205
-    - stat_hard_link.stat.lastwritetime == 1477984205
-    - stat_hard_link.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
-    - stat_hard_link.stat.owner == 'BUILTIN\Administrators'
-    - stat_hard_link.stat.path == win_output_dir + '\\win_stat\\nested\\hard-link.ps1'
-    - stat_hard_link.stat.size == 3
-
-- name: test win_stat on directory
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\nested"
-  register: stat_directory
-
-- name: check actual for directory
-  assert:
-    that:
-    - stat_directory.stat.attributes == 'Directory'
-    - stat_directory.stat.checksum is not defined
-    - stat_directory.stat.creationtime == 1477984205
-    - stat_directory.stat.exists == True
-    - stat_directory.stat.extension is not defined
-    - stat_directory.stat.filename == 'nested'
-    - stat_directory.stat.isarchive == False
-    - stat_directory.stat.isdir == True
-    - stat_directory.stat.ishidden == False
-    - stat_directory.stat.islnk == False
-    - stat_directory.stat.isreadonly == False
-    - stat_directory.stat.isshared == False
-    - stat_directory.stat.lastaccesstime == 1477984205
-    - stat_directory.stat.lastwritetime == 1477984205
-    - stat_directory.stat.md5 is not defined
-    - stat_directory.stat.owner == 'BUILTIN\Administrators'
-    - stat_directory.stat.path == win_output_dir + '\\win_stat\\nested'
-    - stat_directory.stat.size == 15
-
-- name: test win_stat on empty directory
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\folder"
-  register: stat_directory_empty
-
-- name: check actual for empty directory
-  assert:
-    that:
-    - stat_directory_empty.stat.attributes == 'Directory'
-    - stat_directory_empty.stat.checksum is not defined
-    - stat_directory_empty.stat.creationtime == 1477984205
-    - stat_directory_empty.stat.exists == True
-    - stat_directory_empty.stat.extension is not defined
-    - stat_directory_empty.stat.filename == 'folder'
-    - stat_directory_empty.stat.isarchive == False
-    - stat_directory_empty.stat.isdir == True
-    - stat_directory_empty.stat.ishidden == False
-    - stat_directory_empty.stat.islnk == False
-    - stat_directory_empty.stat.isreadonly == False
-    - stat_directory_empty.stat.isshared == False
-    - stat_directory_empty.stat.lastaccesstime == 1477984205
-    - stat_directory_empty.stat.lastwritetime == 1477984205
-    - stat_directory_empty.stat.md5 is not defined
-    - stat_directory_empty.stat.owner == 'BUILTIN\Administrators'
-    - stat_directory_empty.stat.path == win_output_dir + '\\win_stat\\folder'
-    - stat_directory_empty.stat.size == 0
-
-- name: test win_stat on directory with space in name
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\folder space"
-  register: stat_directory_space
-
-- name: check actual for directory with space in name
-  assert:
-    that:
-    - stat_directory_space.stat.attributes == 'Directory'
-    - stat_directory_space.stat.checksum is not defined
-    - stat_directory_space.stat.creationtime == 1477984205
-    - stat_directory_space.stat.exists == True
-    - stat_directory_space.stat.extension is not defined
-    - stat_directory_space.stat.filename == 'folder space'
-    - stat_directory_space.stat.isarchive == False
-    - stat_directory_space.stat.isdir == True
-    - stat_directory_space.stat.ishidden == False
-    - stat_directory_space.stat.islnk == False
-    - stat_directory_space.stat.isreadonly == False
-    - stat_directory_space.stat.isshared == False
-    - stat_directory_space.stat.lastaccesstime == 1477984205
-    - stat_directory_space.stat.lastwritetime == 1477984205
-    - stat_directory_space.stat.md5 is not defined
-    - stat_directory_space.stat.owner == 'BUILTIN\Administrators'
-    - stat_directory_space.stat.path == win_output_dir + '\\win_stat\\folder space'
-    - stat_directory_space.stat.size == 3
-
-- name: test win_stat on hidden directory
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\hidden"
-  register: stat_hidden
-
-- name: check actual for hidden directory
-  assert:
-    that:
-    - stat_hidden.stat.attributes == 'Hidden, Directory'
-    - stat_hidden.stat.checksum is not defined
-    - stat_hidden.stat.creationtime == 1477984205
-    - stat_hidden.stat.exists == True
-    - stat_hidden.stat.extension is not defined
-    - stat_hidden.stat.filename == 'hidden'
-    - stat_hidden.stat.isarchive == False
-    - stat_hidden.stat.isdir == True
-    - stat_hidden.stat.ishidden == True
-    - stat_hidden.stat.islnk == False
-    - stat_hidden.stat.isreadonly == False
-    - stat_hidden.stat.isshared == False
-    - stat_hidden.stat.lastaccesstime == 1477984205
-    - stat_hidden.stat.lastwritetime == 1477984205
-    - stat_hidden.stat.md5 is not defined
-    - stat_hidden.stat.owner == 'BUILTIN\Administrators'
-    - stat_hidden.stat.path == win_output_dir + '\\win_stat\\hidden'
-    - stat_hidden.stat.size == 0
-
-- name: test win_stat on shared directory
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\shared"
-  register: stat_shared
-
-- name: check actual for shared directory
-  assert:
-    that:
-    - stat_shared.stat.attributes == 'Directory'
-    - stat_shared.stat.checksum is not defined
-    - stat_shared.stat.creationtime == 1477984205
-    - stat_shared.stat.exists == True
-    - stat_shared.stat.extension is not defined
-    - stat_shared.stat.filename == 'shared'
-    - stat_shared.stat.isarchive == False
-    - stat_shared.stat.isdir == True
-    - stat_shared.stat.ishidden == False
-    - stat_shared.stat.islnk == False
-    - stat_shared.stat.isreadonly == False
-    - stat_shared.stat.isshared == True
-    - stat_shared.stat.lastaccesstime == 1477984205
-    - stat_shared.stat.lastwritetime == 1477984205
-    - stat_shared.stat.md5 is not defined
-    - stat_shared.stat.owner == 'BUILTIN\Administrators'
-    - stat_shared.stat.path == win_output_dir + '\\win_stat\\shared'
-    - stat_shared.stat.sharename == 'folder-share'
-    - stat_shared.stat.size == 0
-
-- name: test win_stat on symlink
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\link"
-  register: stat_symlink
-
-# I cannot change modification time on links so we are resorting to checking the dict against known valuea
-- name: assert symlink actual
-  assert:
-    that:
-    - stat_symlink.stat.attributes == 'Directory, ReparsePoint'
-    - stat_symlink.stat.creationtime is defined
-    - stat_symlink.stat.exists == True
-    - stat_symlink.stat.filename == 'link'
-    - stat_symlink.stat.isarchive == False
-    - stat_symlink.stat.isdir == True
-    - stat_symlink.stat.ishidden == False
-    - stat_symlink.stat.islnk == True
-    - stat_symlink.stat.isreadonly == False
-    - stat_symlink.stat.isshared == False
-    - stat_symlink.stat.lastaccesstime is defined
-    - stat_symlink.stat.lastwritetime is defined
-    - stat_symlink.stat.lnk_source == win_output_dir + '\\win_stat\\link-dest'
-    - stat_symlink.stat.owner == 'BUILTIN\\Administrators'
-    - stat_symlink.stat.path == win_output_dir + '\\win_stat\\link'
-    - stat_symlink.stat.size is not defined
-    - stat_symlink.stat.checksum is not defined
-    - stat_symlink.stat.md5 is not defined
-
-- name: test win_stat on junction
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\junction-link"
-  register: stat_junction_point
-
-- name: assert symlink actual
-  assert:
-    that:
-    - stat_junction_point.stat.attributes == 'Directory, ReparsePoint'
-    - stat_junction_point.stat.creationtime is defined
-    - stat_junction_point.stat.exists == True
-    - stat_junction_point.stat.filename == 'junction-link'
-    - stat_junction_point.stat.isarchive == False
-    - stat_junction_point.stat.isdir == True
-    - stat_junction_point.stat.ishidden == False
-    - stat_junction_point.stat.islnk == True
-    - stat_junction_point.stat.isreadonly == False
-    - stat_junction_point.stat.isshared == False
-    - stat_junction_point.stat.lastaccesstime is defined
-    - stat_junction_point.stat.lastwritetime is defined
-    - stat_junction_point.stat.lnk_source == win_output_dir + '\\win_stat\\junction-dest'
-    - stat_junction_point.stat.owner == 'BUILTIN\\Administrators'
-    - stat_junction_point.stat.path == win_output_dir + '\\win_stat\\junction-link'
-    - stat_junction_point.stat.size is not defined
-    - stat_junction_point.stat.checksum is not defined
-    - stat_junction_point.stat.md5 is not defined
-
-- name: test win_stat module non-existent path
-  win_stat:
-    path: "{{win_output_dir}}\\win_stat\\this_file_should_not_exist"
-  register: win_stat_missing
-
-- name: check win_stat missing result
-  assert: 
-    that:
-      - not win_stat_missing.stat.exists
-      - not win_stat_missing|failed
-      - not win_stat_missing|changed
-
-- name: test win_stat module without path argument
-  action: win_stat
-  register: win_stat_no_args
-  ignore_errors: true
-
-- name: check win_stat result with no path argument
-  assert:
-    that:
-      - win_stat_no_args|failed
-      - win_stat_no_args.msg
-      - not win_stat_no_args|changed
-
-- name: remove testing folder
-  win_file:
-    path: "{{win_output_dir}}\\win_stat"
-    state: absent
-
-- name: get stat of pagefile
-  win_stat:
-    path: C:\pagefile.sys
-  register: pagefile_stat
-
-- name: assert get stat of pagefile
-  assert:
-    that:
-    - pagefile_stat.stat.exists == True
+  always:
+  - name: remove testing folder
+    win_file:
+      path: '{{win_stat_dir}}'
+      state: absent

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -1,0 +1,439 @@
+---
+- name: test win_stat module on file
+  win_stat:
+    path: '{{win_stat_dir}}\nested\file.ps1'
+  register: stat_file
+
+- name: check actual for file
+  assert:
+    that:
+    - stat_file.stat.attributes == 'Archive'
+    - stat_file.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file.stat.creationtime == 1477984205
+    - stat_file.stat.exists == True
+    - stat_file.stat.extension == '.ps1'
+    - stat_file.stat.filename == 'file.ps1'
+    - stat_file.stat.isarchive == True
+    - stat_file.stat.isdir == False
+    - stat_file.stat.ishidden == False
+    - stat_file.stat.islnk == False
+    - stat_file.stat.isreadonly == False
+    - stat_file.stat.isshared == False
+    - stat_file.stat.lastaccesstime == 1477984205
+    - stat_file.stat.lastwritetime == 1477984205
+    - stat_file.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file.stat.owner == 'BUILTIN\Administrators'
+    - stat_file.stat.path == win_stat_dir + '\\nested\\file.ps1'
+    - stat_file.stat.size == 3
+
+- name: test win_stat module on file without md5
+  win_stat:
+    path: '{{win_stat_dir}}\nested\file.ps1'
+    get_md5: False
+  register: stat_file_md5
+
+- name: check actual for file without md5
+  assert:
+    that:
+    - stat_file_md5.stat.attributes == 'Archive'
+    - stat_file_md5.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file_md5.stat.creationtime == 1477984205
+    - stat_file_md5.stat.exists == True
+    - stat_file_md5.stat.extension == '.ps1'
+    - stat_file_md5.stat.filename == 'file.ps1'
+    - stat_file_md5.stat.isarchive == True
+    - stat_file_md5.stat.isdir == False
+    - stat_file_md5.stat.ishidden == False
+    - stat_file_md5.stat.islnk == False
+    - stat_file_md5.stat.isreadonly == False
+    - stat_file_md5.stat.isshared == False
+    - stat_file_md5.stat.lastaccesstime == 1477984205
+    - stat_file_md5.stat.lastwritetime == 1477984205
+    - stat_file_md5.stat.md5 is not defined
+    - stat_file_md5.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_md5.stat.path == win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_md5.stat.size == 3
+
+- name: test win_stat module on file with sha256
+  win_stat:
+    path: '{{win_stat_dir}}\nested\file.ps1'
+    checksum_algorithm: sha256
+  register: stat_file_sha256
+
+- name: check actual for file with sha256
+  assert:
+    that:
+    - stat_file_sha256.stat.attributes == 'Archive'
+    - stat_file_sha256.stat.checksum == 'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad'
+    - stat_file_sha256.stat.creationtime == 1477984205
+    - stat_file_sha256.stat.exists == True
+    - stat_file_sha256.stat.extension == '.ps1'
+    - stat_file_sha256.stat.filename == 'file.ps1'
+    - stat_file_sha256.stat.isarchive == True
+    - stat_file_sha256.stat.isdir == False
+    - stat_file_sha256.stat.ishidden == False
+    - stat_file_sha256.stat.islnk == False
+    - stat_file_sha256.stat.isreadonly == False
+    - stat_file_sha256.stat.isshared == False
+    - stat_file_sha256.stat.lastaccesstime == 1477984205
+    - stat_file_sha256.stat.lastwritetime == 1477984205
+    - stat_file_sha256.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_sha256.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_sha256.stat.path == win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_sha256.stat.size == 3
+
+- name: test win_stat module on file with sha384
+  win_stat:
+    path: '{{win_stat_dir}}\nested\file.ps1'
+    checksum_algorithm: sha384
+  register: stat_file_sha384
+
+- name: check actual for file with sha384
+  assert:
+    that:
+    - stat_file_sha384.stat.attributes == 'Archive'
+    - stat_file_sha384.stat.checksum == 'cb00753f45a35e8bb5a03d699ac65007272c32ab0eded1631a8b605a43ff5bed8086072ba1e7cc2358baeca134c825a7'
+    - stat_file_sha384.stat.creationtime == 1477984205
+    - stat_file_sha384.stat.exists == True
+    - stat_file_sha384.stat.extension == '.ps1'
+    - stat_file_sha384.stat.filename == 'file.ps1'
+    - stat_file_sha384.stat.isarchive == True
+    - stat_file_sha384.stat.isdir == False
+    - stat_file_sha384.stat.ishidden == False
+    - stat_file_sha384.stat.islnk == False
+    - stat_file_sha384.stat.isreadonly == False
+    - stat_file_sha384.stat.isshared == False
+    - stat_file_sha384.stat.lastaccesstime == 1477984205
+    - stat_file_sha384.stat.lastwritetime == 1477984205
+    - stat_file_sha384.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_sha384.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_sha384.stat.path == win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_sha384.stat.size == 3
+
+- name: test win_stat module on file with sha512
+  win_stat:
+    path: '{{win_stat_dir}}\nested\file.ps1'
+    checksum_algorithm: sha512
+  register: stat_file_sha512
+
+- name: check actual for file with sha512
+  assert:
+    that:
+    - stat_file_sha512.stat.attributes == 'Archive'
+    - stat_file_sha512.stat.checksum == 'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f'
+    - stat_file_sha512.stat.creationtime == 1477984205
+    - stat_file_sha512.stat.exists == True
+    - stat_file_sha512.stat.extension == '.ps1'
+    - stat_file_sha512.stat.filename == 'file.ps1'
+    - stat_file_sha512.stat.isarchive == True
+    - stat_file_sha512.stat.isdir == False
+    - stat_file_sha512.stat.ishidden == False
+    - stat_file_sha512.stat.islnk == False
+    - stat_file_sha512.stat.isreadonly == False
+    - stat_file_sha512.stat.isshared == False
+    - stat_file_sha512.stat.lastaccesstime == 1477984205
+    - stat_file_sha512.stat.lastwritetime == 1477984205
+    - stat_file_sha512.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_sha512.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_sha512.stat.path == win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_sha512.stat.size == 3
+
+- name: test win_stat on hidden file
+  win_stat:
+    path: '{{win_stat_dir}}\nested\hidden.ps1'
+  register: stat_file_hidden
+
+- name: check actual for hidden file
+  assert:
+    that:
+    - stat_file_hidden.stat.attributes == 'Hidden, Archive'
+    - stat_file_hidden.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_file_hidden.stat.creationtime == 1477984205
+    - stat_file_hidden.stat.exists == True
+    - stat_file_hidden.stat.extension == '.ps1'
+    - stat_file_hidden.stat.filename == 'hidden.ps1'
+    - stat_file_hidden.stat.isarchive == True
+    - stat_file_hidden.stat.isdir == False
+    - stat_file_hidden.stat.ishidden == True
+    - stat_file_hidden.stat.islnk == False
+    - stat_file_hidden.stat.isreadonly == False
+    - stat_file_hidden.stat.isshared == False
+    - stat_file_hidden.stat.lastaccesstime == 1477984205
+    - stat_file_hidden.stat.lastwritetime == 1477984205
+    - stat_file_hidden.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_file_hidden.stat.owner == 'BUILTIN\Administrators'
+    - stat_file_hidden.stat.path == win_stat_dir + '\\nested\\hidden.ps1'
+    - stat_file_hidden.stat.size == 3
+
+- name: test win_stat on readonly file
+  win_stat:
+    path: '{{win_stat_dir}}\nested\read-only.ps1'
+  register: stat_readonly
+
+- name: check actual for readonly file
+  assert:
+    that:
+    - stat_readonly.stat.attributes == 'ReadOnly, Archive'
+    - stat_readonly.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_readonly.stat.creationtime == 1477984205
+    - stat_readonly.stat.exists == True
+    - stat_readonly.stat.extension == '.ps1'
+    - stat_readonly.stat.filename == 'read-only.ps1'
+    - stat_readonly.stat.isarchive == True
+    - stat_readonly.stat.isdir == False
+    - stat_readonly.stat.ishidden == False
+    - stat_readonly.stat.islnk == False
+    - stat_readonly.stat.isreadonly == True
+    - stat_readonly.stat.isshared == False
+    - stat_readonly.stat.lastaccesstime == 1477984205
+    - stat_readonly.stat.lastwritetime == 1477984205
+    - stat_readonly.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_readonly.stat.owner == 'BUILTIN\Administrators'
+    - stat_readonly.stat.path == win_stat_dir + '\\nested\\read-only.ps1'
+    - stat_readonly.stat.size == 3
+
+- name: test win_stat on hard link file
+  win_stat:
+    path: '{{win_stat_dir}}\nested\hard-link.ps1'
+  register: stat_hard_link
+
+- name: check actual for hard link file
+  assert:
+    that:
+    - stat_hard_link.stat.attributes == 'Archive'
+    - stat_hard_link.stat.checksum == 'a9993e364706816aba3e25717850c26c9cd0d89d'
+    - stat_hard_link.stat.creationtime == 1477984205
+    - stat_hard_link.stat.exists == True
+    - stat_hard_link.stat.extension == '.ps1'
+    - stat_hard_link.stat.filename == 'hard-link.ps1'
+    - stat_hard_link.stat.isarchive == True
+    - stat_hard_link.stat.isdir == False
+    - stat_hard_link.stat.ishidden == False
+    - stat_hard_link.stat.islnk == False
+    - stat_hard_link.stat.isreadonly == False
+    - stat_hard_link.stat.isshared == False
+    - stat_hard_link.stat.lastaccesstime == 1477984205
+    - stat_hard_link.stat.lastwritetime == 1477984205
+    - stat_hard_link.stat.md5 == '900150983cd24fb0d6963f7d28e17f72'
+    - stat_hard_link.stat.owner == 'BUILTIN\Administrators'
+    - stat_hard_link.stat.path == win_stat_dir + '\\nested\\hard-link.ps1'
+    - stat_hard_link.stat.size == 3
+
+- name: test win_stat on directory
+  win_stat:
+    path: '{{win_stat_dir}}\nested'
+  register: stat_directory
+
+- name: check actual for directory
+  assert:
+    that:
+    - stat_directory.stat.attributes == 'Directory'
+    - stat_directory.stat.checksum is not defined
+    - stat_directory.stat.creationtime == 1477984205
+    - stat_directory.stat.exists == True
+    - stat_directory.stat.extension is not defined
+    - stat_directory.stat.filename == 'nested'
+    - stat_directory.stat.isarchive == False
+    - stat_directory.stat.isdir == True
+    - stat_directory.stat.ishidden == False
+    - stat_directory.stat.islnk == False
+    - stat_directory.stat.isreadonly == False
+    - stat_directory.stat.isshared == False
+    - stat_directory.stat.lastaccesstime == 1477984205
+    - stat_directory.stat.lastwritetime == 1477984205
+    - stat_directory.stat.md5 is not defined
+    - stat_directory.stat.owner == 'BUILTIN\Administrators'
+    - stat_directory.stat.path == win_stat_dir + '\\nested'
+    - stat_directory.stat.size == 15
+
+- name: test win_stat on empty directory
+  win_stat:
+    path: '{{win_stat_dir}}\folder'
+  register: stat_directory_empty
+
+- name: check actual for empty directory
+  assert:
+    that:
+    - stat_directory_empty.stat.attributes == 'Directory'
+    - stat_directory_empty.stat.checksum is not defined
+    - stat_directory_empty.stat.creationtime == 1477984205
+    - stat_directory_empty.stat.exists == True
+    - stat_directory_empty.stat.extension is not defined
+    - stat_directory_empty.stat.filename == 'folder'
+    - stat_directory_empty.stat.isarchive == False
+    - stat_directory_empty.stat.isdir == True
+    - stat_directory_empty.stat.ishidden == False
+    - stat_directory_empty.stat.islnk == False
+    - stat_directory_empty.stat.isreadonly == False
+    - stat_directory_empty.stat.isshared == False
+    - stat_directory_empty.stat.lastaccesstime == 1477984205
+    - stat_directory_empty.stat.lastwritetime == 1477984205
+    - stat_directory_empty.stat.md5 is not defined
+    - stat_directory_empty.stat.owner == 'BUILTIN\Administrators'
+    - stat_directory_empty.stat.path == win_stat_dir + '\\folder'
+    - stat_directory_empty.stat.size == 0
+
+- name: test win_stat on directory with space in name
+  win_stat:
+    path: '{{win_stat_dir}}\folder space'
+  register: stat_directory_space
+
+- name: check actual for directory with space in name
+  assert:
+    that:
+    - stat_directory_space.stat.attributes == 'Directory'
+    - stat_directory_space.stat.checksum is not defined
+    - stat_directory_space.stat.creationtime == 1477984205
+    - stat_directory_space.stat.exists == True
+    - stat_directory_space.stat.extension is not defined
+    - stat_directory_space.stat.filename == 'folder space'
+    - stat_directory_space.stat.isarchive == False
+    - stat_directory_space.stat.isdir == True
+    - stat_directory_space.stat.ishidden == False
+    - stat_directory_space.stat.islnk == False
+    - stat_directory_space.stat.isreadonly == False
+    - stat_directory_space.stat.isshared == False
+    - stat_directory_space.stat.lastaccesstime == 1477984205
+    - stat_directory_space.stat.lastwritetime == 1477984205
+    - stat_directory_space.stat.md5 is not defined
+    - stat_directory_space.stat.owner == 'BUILTIN\Administrators'
+    - stat_directory_space.stat.path == win_stat_dir + '\\folder space'
+    - stat_directory_space.stat.size == 3
+
+- name: test win_stat on hidden directory
+  win_stat:
+    path: '{{win_stat_dir}}\hidden'
+  register: stat_hidden
+
+- name: check actual for hidden directory
+  assert:
+    that:
+    - stat_hidden.stat.attributes == 'Hidden, Directory'
+    - stat_hidden.stat.checksum is not defined
+    - stat_hidden.stat.creationtime == 1477984205
+    - stat_hidden.stat.exists == True
+    - stat_hidden.stat.extension is not defined
+    - stat_hidden.stat.filename == 'hidden'
+    - stat_hidden.stat.isarchive == False
+    - stat_hidden.stat.isdir == True
+    - stat_hidden.stat.ishidden == True
+    - stat_hidden.stat.islnk == False
+    - stat_hidden.stat.isreadonly == False
+    - stat_hidden.stat.isshared == False
+    - stat_hidden.stat.lastaccesstime == 1477984205
+    - stat_hidden.stat.lastwritetime == 1477984205
+    - stat_hidden.stat.md5 is not defined
+    - stat_hidden.stat.owner == 'BUILTIN\Administrators'
+    - stat_hidden.stat.path == win_stat_dir + '\\hidden'
+    - stat_hidden.stat.size == 0
+
+- name: test win_stat on shared directory
+  win_stat:
+    path: '{{win_stat_dir}}\shared'
+  register: stat_shared
+
+- name: check actual for shared directory
+  assert:
+    that:
+    - stat_shared.stat.attributes == 'Directory'
+    - stat_shared.stat.checksum is not defined
+    - stat_shared.stat.creationtime == 1477984205
+    - stat_shared.stat.exists == True
+    - stat_shared.stat.extension is not defined
+    - stat_shared.stat.filename == 'shared'
+    - stat_shared.stat.isarchive == False
+    - stat_shared.stat.isdir == True
+    - stat_shared.stat.ishidden == False
+    - stat_shared.stat.islnk == False
+    - stat_shared.stat.isreadonly == False
+    - stat_shared.stat.isshared == True
+    - stat_shared.stat.lastaccesstime == 1477984205
+    - stat_shared.stat.lastwritetime == 1477984205
+    - stat_shared.stat.md5 is not defined
+    - stat_shared.stat.owner == 'BUILTIN\Administrators'
+    - stat_shared.stat.path == win_stat_dir + '\\shared'
+    - stat_shared.stat.sharename == 'folder-share'
+    - stat_shared.stat.size == 0
+
+- name: test win_stat on symlink
+  win_stat:
+    path: '{{win_stat_dir}}\link'
+  register: stat_symlink
+
+# I cannot change modification time on links so we don't check those values
+- name: assert symlink actual
+  assert:
+    that:
+    - stat_symlink.stat.attributes == 'Directory, ReparsePoint'
+    - stat_symlink.stat.creationtime is defined
+    - stat_symlink.stat.exists == True
+    - stat_symlink.stat.filename == 'link'
+    - stat_symlink.stat.isarchive == False
+    - stat_symlink.stat.isdir == True
+    - stat_symlink.stat.ishidden == False
+    - stat_symlink.stat.islnk == True
+    - stat_symlink.stat.isreadonly == False
+    - stat_symlink.stat.isshared == False
+    - stat_symlink.stat.lastaccesstime is defined
+    - stat_symlink.stat.lastwritetime is defined
+    - stat_symlink.stat.lnk_source == win_stat_dir + '\\link-dest'
+    - stat_symlink.stat.owner == 'BUILTIN\\Administrators'
+    - stat_symlink.stat.path == win_stat_dir + '\\link'
+    - stat_symlink.stat.size is not defined
+    - stat_symlink.stat.checksum is not defined
+    - stat_symlink.stat.md5 is not defined
+
+- name: test win_stat on junction
+  win_stat:
+    path: '{{win_stat_dir}}\junction-link'
+  register: stat_junction_point
+
+- name: assert symlink actual
+  assert:
+    that:
+    - stat_junction_point.stat.attributes == 'Directory, ReparsePoint'
+    - stat_junction_point.stat.creationtime is defined
+    - stat_junction_point.stat.exists == True
+    - stat_junction_point.stat.filename == 'junction-link'
+    - stat_junction_point.stat.isarchive == False
+    - stat_junction_point.stat.isdir == True
+    - stat_junction_point.stat.ishidden == False
+    - stat_junction_point.stat.islnk == True
+    - stat_junction_point.stat.isreadonly == False
+    - stat_junction_point.stat.isshared == False
+    - stat_junction_point.stat.lastaccesstime is defined
+    - stat_junction_point.stat.lastwritetime is defined
+    - stat_junction_point.stat.lnk_source == win_stat_dir + '\\junction-dest'
+    - stat_junction_point.stat.owner == 'BUILTIN\\Administrators'
+    - stat_junction_point.stat.path == win_stat_dir + '\\junction-link'
+    - stat_junction_point.stat.size is not defined
+    - stat_junction_point.stat.checksum is not defined
+    - stat_junction_point.stat.md5 is not defined
+
+- name: test win_stat module non-existent path
+  win_stat:
+    path: '{{win_stat_dir}}\this_file_should_not_exist'
+  register: win_stat_missing
+
+- name: check win_stat missing result
+  assert: 
+    that:
+      - not win_stat_missing.stat.exists
+      - not win_stat_missing|failed
+      - not win_stat_missing|changed
+
+- name: test win_stat module without path argument
+  win_stat:
+  register: win_stat_no_args
+  failed_when: "win_stat_no_args.msg != 'Get-AnsibleParam: Missing required argument: path'"
+
+# https://github.com/ansible/ansible/issues/30258
+- name: get stat of pagefile
+  win_stat:
+    path: C:\pagefile.sys
+  register: pagefile_stat
+
+- name: assert get stat of pagefile
+  assert:
+    that:
+    - pagefile_stat.stat.exists == True


### PR DESCRIPTION
##### SUMMARY
I am going to update win_stat in order to take advantage of the new symlink utils and I wanted to update the tests in a previous PR to make them more efficient and easier to read. I did this in a separate PR so it is clear to see the tests are running fine independently of the changes that will be required for the symlink stuff.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_stat

##### ANSIBLE VERSION
```
2.5
```