### PR TITLE
Fix 'maintainers' key in BOTMETA for 'unixy'

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1095,7 +1095,7 @@ files:
     labels: networking
   lib/ansible/plugins/callback/unixy.py:
     support: community
-    maintaners: akatch
+    maintainers: akatch
   lib/ansible/plugins/cliconf/:
     maintainers: $team_networking
     labels: networking


### PR DESCRIPTION
##### SUMMARY
Fix 'maintainers' key in BOTMETA for 'unixy'
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
.github/BOTMETA.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix_unixy_botmeta b830efaa0b) last updated 2017/11/17 12:06:12 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.13 (default, Aug 16 2017, 12:56:26) [GCC 7.1.1 20170802 (Red Hat 7.1.1-7)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
