### PR TITLE
Improve zypper refresh/clean for opensuse images.

### DIFF
--- a/test/utils/docker/opensuse42.2/Dockerfile
+++ b/test/utils/docker/opensuse42.2/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse:42.2
 
-RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
+RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force && \
     zypper --non-interactive install --force systemd-sysvinit && \
     zypper --non-interactive install --auto-agree-with-licenses --no-recommends \
     acl \
@@ -47,7 +47,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     which \
     zip \
     && \
-    zypper clean
+    zypper clean --all
 
 # systemd path differs from rhel
 ENV LIBSYSTEMD=/usr/lib/systemd/system

--- a/test/utils/docker/opensuse42.3/Dockerfile
+++ b/test/utils/docker/opensuse42.3/Dockerfile
@@ -1,6 +1,6 @@
 FROM opensuse:42.3
 
-RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
+RUN zypper --non-interactive --gpg-auto-import-keys refresh --services --force && \
     zypper --non-interactive install --force systemd-sysvinit && \
     zypper --non-interactive install --auto-agree-with-licenses --no-recommends \
     acl \
@@ -47,7 +47,7 @@ RUN zypper --non-interactive --gpg-auto-import-keys refresh && \
     which \
     zip \
     && \
-    zypper clean
+    zypper clean --all
 
 # systemd path differs from rhel
 ENV LIBSYSTEMD=/usr/lib/systemd/system


### PR DESCRIPTION
##### SUMMARY

Improve zypper refresh/clean for opensuse images.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

opensuse docker images

##### ANSIBLE VERSION

```
ansible 2.5.0 (opensuse-update c16ab54d00) last updated 2017/11/17 12:51:42 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
