### PR TITLE
Fixed simple typo on galaxy page

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -139,7 +139,7 @@ Installing multiple roles from multiple files
 
 At a basic level, including requirements files allows you to break up bits of roles into smaller files. Role includes pull in roles from other files.
 
-Use the following command to install roles includes in *requirements.yml*  + *webserver,yml*
+Use the following command to install roles includes in *requirements.yml*  + *webserver.yml*
 
 ::
 


### PR DESCRIPTION
##### SUMMARY
Just a simple (one character) typo fix on the Ansible Galaxy doc page (http://docs.ansible.com/ansible/latest/galaxy.html)

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`docs/docsite/rst/galaxy.rst
`
