### PR TITLE
Fix and re-enable zypper* integration tests in CI.

### DIFF
--- a/test/integration/targets/zypper/aliases
+++ b/test/integration/targets/zypper/aliases
@@ -1,1 +1,2 @@
 destructive
+posix/ci/group1

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -189,6 +189,7 @@
 - name: install empty rpm
   zypper:
     name: "{{ output_dir | expanduser }}/zypper2/rpm-build/noarch/empty-1-0.noarch.rpm"
+    disable_gpg_check: yes
   register: zypper_result
 
 - name: check empty with rpm
@@ -281,60 +282,13 @@
       - zypper_patch.msg.startswith('Can not remove patches.')
 
 - name: try rm URL
-  zypper: name=http://download.opensuse.org/repositories/openSUSE:/Leap:/42.1/standard/x86_64/hello-2.9-6.2.x86_64.rpm state=absent
+  zypper: name=http://download.opensuse.org/repositories/openSUSE:/Leap:/{{ ansible_distribution_version }}/standard/x86_64/hello-2.9-6.2.x86_64.rpm state=absent
   ignore_errors: yes
   register: zypper_rm
 - assert:
     that: 
       - zypper_rm|failed
       - zypper_rm.msg.startswith('Can not remove via URL.')
-
-# use of version specific (42.1) data in the following
-- block:
-  # test for #1627
-  - name: in existing patch
-    zypper: name=openSUSE-2016-128 type=patch state=present
-  - name: in existing patch again
-    zypper: name=openSUSE-2016-128 type=patch state=present
-    register: zypper_patch
-  - assert:
-      that: not zypper_patch.changed
-
-  - name: in non-existing patch
-    zypper: name=openSUSE-1800-1 type=patch state=present
-    ignore_errors: yes
-    register: zypper_patch
-  - assert:
-      that: zypper_patch|failed
-
-  - name: remove pattern update_test
-    zypper: name=update_test type=pattern state=absent
-  - name: install pattern update_test
-    zypper: name=update_test type=pattern state=present
-    register: zypper_install_pattern1
-  - name: install pattern update_test again
-    zypper: name=update_test type=pattern state=present
-    register: zypper_install_pattern2
-  - assert:
-      that:
-        - zypper_install_pattern1|changed
-        - not zypper_install_pattern2|changed
-
-  - name: remove hello
-    zypper: name=hello state=absent
-  - name: install via URL
-    zypper: state=present name=http://download.opensuse.org/repositories/openSUSE:/Leap:/42.1/standard/x86_64/hello-2.9-6.2.x86_64.rpm
-    register: zypperin1
-  - name: test install
-    zypper: name=hello state=present
-    register: zypperin2
-  - assert:
-      that:
-        - zypperin1|success
-        - zypperin1|changed
-        - not zypperin2|changed
-  when: ansible_distribution == 'openSUSE Leap' and ansible_distribution_version == '42.1'
-
 
 # check for https://github.com/ansible/ansible/issues/20139
 - name: run updatecache

--- a/test/integration/targets/zypper_repository/aliases
+++ b/test/integration/targets/zypper_repository/aliases
@@ -1,1 +1,2 @@
 destructive
+posix/ci/group1

--- a/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
+++ b/test/integration/targets/zypper_repository/tasks/zypper_repository.yml
@@ -39,7 +39,7 @@
   zypper_repository:
     name: test
     state: present
-    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_42.1/
+    repo: http://download.videolan.org/pub/vlc/SuSE/Leap_{{ ansible_distribution_version }}/
   register: zypper_result
 
 - name: Verify change on URL only change
@@ -57,7 +57,7 @@
     name: testrefresh
     refresh: no
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
 
 - name: check refreshoption
   command: zypper -x lr testrefresh
@@ -72,7 +72,7 @@
     name: testprio
     priority: 55
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
 
 - name: check refreshoption
   command: zypper -x lr testprio
@@ -86,7 +86,7 @@
   zypper_repository:
     name: "{{item}}"
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
   with_items:
     - oss1
     - oss2
@@ -105,14 +105,14 @@
       - "zypper_result1.rc == 6"
       - "'not found' in zypper_result1.stderr"
       - "zypper_result2.rc == 0"
-      - "'http://download.opensuse.org/distribution/leap/42.1/repo/oss/' in zypper_result2.stdout"
+      - "'http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/' in zypper_result2.stdout"
 
 
 - name: reset oss repo (to not break zypper later)
   zypper_repository:
     name: OSS
     state: present
-    repo: http://download.opensuse.org/distribution/leap/42.1/repo/oss/
+    repo: http://download.opensuse.org/distribution/leap/{{ ansible_distribution_version }}/repo/oss/
     priority: 99
     refresh: yes
 
@@ -122,8 +122,8 @@
     state: present
     repo: "{{ item }}"
   with_items:
-    - http://download.opensuse.org/repositories/science/openSUSE_Leap_42.1/
-    - http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
+    - http://download.opensuse.org/repositories/science/openSUSE_Leap_{{ ansible_distribution_version }}/
+    - http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_{{ ansible_distribution_version }}/
 
 - name: check repo is updated by name
   command: zypper lr samename
@@ -136,7 +136,7 @@
 
 - name: remove last added repos (by URL to test that)
   zypper_repository:
-    repo: http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/
+    repo: http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_{{ ansible_distribution_version }}/
     state: absent
 
 - name: ensure zypper ref still works


### PR DESCRIPTION
##### SUMMARY

Fix and re-enable zypper* integration tests in CI.

(cherry picked from commit 781219bcfd14a67a06cdf10224827deca6c74316)

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

zypper* integration tests

##### ANSIBLE VERSION

```
ansible 2.3.3.0 (zypper-2.3 b94828878a) last updated 2017/11/17 15:18:42 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
