### PR TITLE
LDAP: Refactor and add ldap_passwd module

### DIFF
--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -1,0 +1,11 @@
+def gen_specs(**specs):
+    specs.update({
+        'bind_dn': dict(),
+        'bind_pw': dict(default='', no_log=True),
+        'dn': dict(required=True),
+        'server_uri': dict(default='ldapi:///'),
+        'start_tls': dict(default=False, type='bool'),
+        'validate_certs': dict(default=True, type='bool'),
+    })
+
+    return specs

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -1,3 +1,15 @@
+import traceback
+from ansible.module_utils._text import to_native
+
+try:
+    import ldap
+    import ldap.sasl
+    HAS_LDAP = True
+
+except ImportError:
+    HAS_LDAP = False
+
+
 def gen_specs(**specs):
     specs.update({
         'bind_dn': dict(),
@@ -9,3 +21,43 @@ def gen_specs(**specs):
     })
 
     return specs
+
+
+class LdapGeneric(object):
+    def __init__(self, module):
+        # Shortcuts
+        self.module = module
+        self.bind_dn = self.module.params['bind_dn']
+        self.bind_pw = self.module.params['bind_pw']
+        self.dn = self.module.params['dn']
+        self.server_uri = self.module.params['server_uri']
+        self.start_tls = self.module.params['start_tls']
+        self.verify_cert = self.module.params['validate_certs']
+
+        # Establish connection
+        self.connection = self._connect_to_ldap()
+
+    def _connect_to_ldap(self):
+        if not self.verify_cert:
+            ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+
+        connection = ldap.initialize(self.server_uri)
+
+        if self.start_tls:
+            try:
+                connection.start_tls_s()
+            except ldap.LDAPError as e:
+                self.module.fail_json(msg="Cannot start TLS.", details=to_native(e),
+                                      exception=traceback.format_exc())
+
+        try:
+            if self.bind_dn is not None:
+                connection.simple_bind_s(self.bind_dn, self.bind_pw)
+            else:
+                connection.sasl_interactive_bind_s('', ldap.sasl.external())
+        except ldap.LDAPError as e:
+            self.module.fail_json(
+                msg="Cannot bind to the server.", details=to_native(e),
+                exception=traceback.format_exc())
+
+        return connection

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -57,9 +57,11 @@ class LdapGeneric(object):
         self.connection = self._connect_to_ldap()
 
     def fail(self, msg, exn):
-        self.module.fail_json(msg=msg,
-                              details=to_native(exn),
-                              exception=traceback.format_exc())
+        self.module.fail_json(
+            msg=msg,
+            details=to_native(exn),
+            exception=traceback.format_exc()
+        )
 
     def _connect_to_ldap(self):
         if not self.verify_cert:

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
+
 # Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 # Copyright: (c) 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -1,3 +1,22 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 import traceback
 from ansible.module_utils._text import to_native
 

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -1,21 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
-
-# This file is part of Ansible by Red Hat
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 import traceback
 from ansible.module_utils._text import to_native

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
+# Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
+# Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+# Copyright: (c) 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# Copyright 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
-# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
 
 import traceback
 from ansible.module_utils._text import to_native
@@ -59,7 +63,7 @@ class LdapGeneric(object):
             try:
                 connection.start_tls_s()
             except ldap.LDAPError as e:
-                self.module.fail("Cannot start TLS.", e)
+                self.fail("Cannot start TLS.", e)
 
         try:
             if self.bind_dn is not None:
@@ -67,8 +71,6 @@ class LdapGeneric(object):
             else:
                 connection.sasl_interactive_bind_s('', ldap.sasl.external())
         except ldap.LDAPError as e:
-            self.module.fail_json(
-                msg="Cannot bind to the server.", details=to_native(e),
-                exception=traceback.format_exc())
+            self.fail("Cannot bind to the server.", e)
 
         return connection

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -56,6 +56,11 @@ class LdapGeneric(object):
         # Establish connection
         self.connection = self._connect_to_ldap()
 
+    def fail(self, msg, exn):
+        self.module.fail_json(msg=msg,
+                              details=to_native(exn),
+                              exception=traceback.format_exc())
+
     def _connect_to_ldap(self):
         if not self.verify_cert:
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
@@ -66,8 +71,7 @@ class LdapGeneric(object):
             try:
                 connection.start_tls_s()
             except ldap.LDAPError as e:
-                self.module.fail_json(msg="Cannot start TLS.", details=to_native(e),
-                                      exception=traceback.format_exc())
+                self.module.fail("Cannot start TLS.", e)
 
         try:
             if self.bind_dn is not None:

--- a/lib/ansible/module_utils/ldap.py
+++ b/lib/ansible/module_utils/ldap.py
@@ -23,8 +23,8 @@ from ansible.module_utils._text import to_native
 try:
     import ldap
     import ldap.sasl
-    HAS_LDAP = True
 
+    HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+# (c) 2016, Peter Sagerson <psagers@ignorare.net>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 # Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -15,7 +17,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = r"""
+DOCUMENTATION = """
 ---
 module: ldap_attr
 short_description: Add or remove LDAP attribute values.
@@ -66,7 +68,7 @@ extends_documentation_fragment: ldap.documentation
 """
 
 
-EXAMPLES = r"""
+EXAMPLES = """
 - name: Configure directory number 1 for example.com
   ldap_attr:
     dn: olcDatabase={1}hdb,cn=config
@@ -139,7 +141,7 @@ EXAMPLES = r"""
 """
 
 
-RETURN = r"""
+RETURN = """
 modlist:
   description: list of modified parameters
   returned: success
@@ -151,10 +153,12 @@ import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible.module_utils.ldap import LdapGeneric, gen_specs, HAS_LDAP
+from ansible.module_utils.ldap import LdapGeneric, gen_specs
 
 try:
     import ldap
+
+    HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -1,21 +1,21 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-# (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
-# (c) 2016, Peter Sagerson <psagers@ignorare.net>
-#
+# Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
+# Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 ---
 module: ldap_attr
 short_description: Add or remove LDAP attribute values.
@@ -66,7 +66,7 @@ extends_documentation_fragment: ldap.documentation
 """
 
 
-EXAMPLES = """
+EXAMPLES = r"""
 - name: Configure directory number 1 for example.com
   ldap_attr:
     dn: olcDatabase={1}hdb,cn=config
@@ -139,7 +139,7 @@ EXAMPLES = """
 """
 
 
-RETURN = """
+RETURN = r"""
 modlist:
   description: list of modified parameters
   returned: success

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -198,9 +198,7 @@ class LdapAttr(LdapGeneric):
             results = self.connection.search_s(
                 self.dn, ldap.SCOPE_BASE, attrlist=[self.name])
         except ldap.LDAPError as e:
-            self.module.fail_json(
-                msg="Cannot search for attribute %s" % self.name,
-                details=to_native(e))
+            self.fail("Cannot search for attribute %s" % self.name, e)
 
         current = results[0][1].get(self.name, [])
         modlist = []

--- a/lib/ansible/modules/net_tools/ldap/ldap_attr.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_attr.py
@@ -42,33 +42,10 @@ author:
 requirements:
   - python-ldap
 options:
-  bind_dn:
-    description:
-      - A DN to bind with. If this is omitted, we'll try a SASL bind with
-        the EXTERNAL mechanism. If this is blank, we'll use an anonymous
-        bind.
-  bind_pw:
-    description:
-      - The password to use with I(bind_dn).
-  dn:
-    description:
-      - The DN of the entry to modify.
-    required: true
   name:
     description:
       - The name of the attribute to modify.
     required: true
-  server_uri:
-    description:
-      - A URI to the LDAP server. The default value lets the underlying
-        LDAP client library look for a UNIX domain socket in its default
-        location.
-    default: ldapi:///
-  start_tls:
-    description:
-      - If true, we'll use the START_TLS LDAP extension.
-    type: bool
-    default: 'no'
   state:
     description:
       - The state of the attribute values. If C(present), all given
@@ -85,13 +62,7 @@ options:
         strings. The complex argument format is required in order to pass
         a list of strings (see examples).
     required: true
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be
-        used on sites using self-signed certificates.
-    type: bool
-    default: 'yes'
-    version_added: "2.4"
+extends_documentation_fragment: ldap.documentation
 """
 
 
@@ -188,6 +159,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
+from ansible.module_utils.ldap import gen_specs
 
 
 class LdapAttr(object):
@@ -294,20 +266,14 @@ class LdapAttr(object):
 
 def main():
     module = AnsibleModule(
-        argument_spec={
-            'bind_dn': dict(default=None),
-            'bind_pw': dict(default='', no_log=True),
-            'dn': dict(required=True),
-            'name': dict(required=True),
-            'params': dict(type='dict'),
-            'server_uri': dict(default='ldapi:///'),
-            'start_tls': dict(default=False, type='bool'),
-            'state': dict(
+        argument_spec=gen_specs(
+            name=dict(required=True),
+            params=dict(type='dict'),
+            state=dict(
                 default='present',
                 choices=['present', 'absent', 'exact']),
-            'values': dict(required=True, type='raw'),
-            'validate_certs': dict(default=True, type='bool'),
-        },
+            values=dict(required=True, type='raw'),
+        ),
         supports_check_mode=True,
     )
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+# (c) 2016, Peter Sagerson <psagers@ignorare.net>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -1,21 +1,21 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
-# (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
-# (c) 2016, Peter Sagerson <psagers@ignorare.net>
-#
+# Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
+# Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 ---
 module: ldap_entry
 short_description: Add or remove LDAP entries.
@@ -60,7 +60,7 @@ extends_documentation_fragment: ldap.documentation
 """
 
 
-EXAMPLES = """
+EXAMPLES = r"""
 - name: Make sure we have a parent entry for users
   ldap_entry:
     dn: ou=users,dc=example,dc=com
@@ -100,7 +100,7 @@ EXAMPLES = """
 """
 
 
-RETURN = """
+RETURN = r"""
 # Default return values
 """
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -36,18 +36,6 @@ author:
 requirements:
   - python-ldap
 options:
-  bind_dn:
-    description:
-      - A DN to bind with. If this is omitted, we'll try a SASL bind with
-        the EXTERNAL mechanism. If this is blank, we'll use an anonymous
-        bind.
-  bind_pw:
-    description:
-      - The password to use with I(bind_dn).
-  dn:
-    description:
-      - The DN of the entry to add or remove.
-    required: true
   attributes:
     description:
       - If I(state=present), attributes necessary to create an entry. Existing
@@ -63,29 +51,12 @@ options:
       - List of options which allows to overwrite any of the task or the
         I(attributes) options. To remove an option, set the value of the option
         to C(null).
-  server_uri:
-    description:
-      - A URI to the LDAP server. The default value lets the underlying
-        LDAP client library look for a UNIX domain socket in its default
-        location.
-    default: ldapi:///
-  start_tls:
-    description:
-      - If true, we'll use the START_TLS LDAP extension.
-    type: bool
-    default: 'no'
   state:
     description:
       - The target state of the entry.
     choices: [present, absent]
     default: present
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be
-        used on sites using self-signed certificates.
-    type: bool
-    default: 'yes'
-    version_added: "2.4"
+extends_documentation_fragment: ldap.documentation
 """
 
 
@@ -145,6 +116,7 @@ except ImportError:
     HAS_LDAP = False
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ldap import gen_specs
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
@@ -250,18 +222,12 @@ class LdapEntry(object):
 
 def main():
     module = AnsibleModule(
-        argument_spec={
-            'attributes': dict(default={}, type='dict'),
-            'bind_dn': dict(),
-            'bind_pw': dict(default='', no_log=True),
-            'dn': dict(required=True),
-            'objectClass': dict(type='raw'),
-            'params': dict(type='dict'),
-            'server_uri': dict(default='ldapi:///'),
-            'start_tls': dict(default=False, type='bool'),
-            'state': dict(default='present', choices=['present', 'absent']),
-            'validate_certs': dict(default=True, type='bool'),
-        },
+        argument_spec=gen_specs(
+            attributes=dict(default={}, type='dict'),
+            objectClass=dict(type='raw'),
+            params=dict(type='dict'),
+            state=dict(default='present', choices=['present', 'absent']),
+        ),
         supports_check_mode=True,
     )
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_entry.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_entry.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 # Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -15,7 +17,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = r"""
+DOCUMENTATION = """
 ---
 module: ldap_entry
 short_description: Add or remove LDAP entries.
@@ -60,7 +62,7 @@ extends_documentation_fragment: ldap.documentation
 """
 
 
-EXAMPLES = r"""
+EXAMPLES = """
 - name: Make sure we have a parent entry for users
   ldap_entry:
     dn: ou=users,dc=example,dc=com
@@ -100,7 +102,7 @@ EXAMPLES = r"""
 """
 
 
-RETURN = r"""
+RETURN = """
 # Default return values
 """
 
@@ -109,11 +111,12 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
-from ansible.module_utils.ldap import LdapGeneric, gen_specs, HAS_LDAP
+from ansible.module_utils.ldap import LdapGeneric, gen_specs
 
 try:
     import ldap.modlist
-    # HAS_LDAP imported from ansible.module_utils.ldap
+
+    HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -91,18 +91,18 @@ class LdapPasswd(LdapGeneric):
 
     def passwd_check(self):
         try:
-            u_con = ldap.initialize(self.server_uri)
+            tmp_con = ldap.initialize(self.server_uri)
         except ldap.LDAPError as e:
             self.fail("Cannot initialize LDAP connection", e)
 
         if self.start_tls:
             try:
-                u_con.start_tls_s()
+                tmp_con.start_tls_s()
             except ldap.LDAPError as e:
                 self.fail("Cannot start TLS.", e)
 
         try:
-            u_con.simple_bind_s(self.dn, self.passwd)
+            tmp_con.simple_bind_s(self.dn, self.passwd)
         except ldap.INVALID_CREDENTIALS:
             return True
         except ldap.LDAPError as e:
@@ -110,7 +110,7 @@ class LdapPasswd(LdapGeneric):
         else:
             return False
         finally:
-            u_con.unbind()
+            tmp_con.unbind()
 
     def passwd_set(self):
         # Exit early if the password is already valid

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -9,9 +9,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
 
 
 DOCUMENTATION = """
@@ -54,7 +56,7 @@ EXAMPLES = """
     dn: "{{ item.key }}"
     passwd: "{{ item.value }}"
   with_dict:
-    alice: "alice123123"
+    alice: alice123123
     bob:   "|30b!"
     admin: "{{ vault_secret }}"
 """

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -1,0 +1,124 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Keller Fuchs <kellerfuchs@hashbang.sh>
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = """
+---
+module: ldap_passwd
+short_description: Set passwords in LDAP.
+description:
+  - Set a password for an LDAP entry.  This module only asserts that
+    a given password is valid for a given entry.  To assert the
+    existence of an entry, see M(ldap_entry).
+notes:
+  - The default authentication settings will attempt to use a SASL EXTERNAL
+    bind over a UNIX domain socket. This works well with the default Ubuntu
+    install for example, which includes a cn=peercred,cn=external,cn=auth ACL
+    rule allowing root to modify the server configuration. If you need to use
+    a simple bind to access your server, pass the credentials in I(bind_dn)
+    and I(bind_pw).
+version_added: '2.6'
+author:
+  - Keller Fuchs (@kellerfuchs)
+requirements:
+  - python-ldap
+options:
+  passwd:
+    required: true
+    default: null
+    description:
+      - The (plaintext) password to be set for I(dn).
+extends_documentation_fragment: ldap.documentation
+"""
+
+EXAMPLES = """
+- name: Set a password for the admin user
+  ldap_passwd:
+    dn: cn=admin,dc=example,dc=com
+    passwd: "{{ vault_secret }}"
+
+- name: Setting passwords in bulk
+  ldap_passwd:
+    dn: "{{ item.key }}"
+    passwd: "{{ item.value }}"
+  with_dict:
+    alice: "alice123123"
+    bob:   "|30b!"
+    admin: "{{ vault_secret }}"
+"""
+
+RETURN = """
+modlist:
+  description: list of modified parameters
+  returned: success
+  type: list
+  sample: '[[2, "olcRootDN", ["cn=root,dc=example,dc=com"]]]'
+"""
+
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.ldap import LdapGeneric, gen_specs, HAS_LDAP
+from ansible.module_utils._text import to_native
+
+
+class LdapPasswd(LdapGeneric):
+    def __init__(self, module):
+        LdapGeneric.__init__(self, module)
+
+        # Shortcuts
+        self.passwd = self.module.params['passwd']
+
+    def passwd_c(self):
+        return self.connection.compare_s(self.dn, 'userPassword', self.passwd) == 0
+
+    def passwd_s(self):
+        # Exit early if the password is already valid
+        if not self.passwd_c():
+            return False
+
+        # Change the password (or throw an exception)
+        self.connection.passwd_s(self.dn, None, self.passwd)
+
+        # We successfully changed the password  \o/
+        return True
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=gen_specs(passwd=dict(type='str', no_log=True)),
+        supports_check_mode=True,
+    )
+
+    if not HAS_LDAP:
+        module.fail_json(
+            msg="Missing required 'ldap' module (pip install python-ldap).")
+
+    ldap = LdapPasswd(module)
+
+    try:
+        if module.check_mode:
+            module.exit_json(changed=ldap.passwd_c())
+        else:
+            module.exit_json(changed=ldap.passwd_s())
+    except Exception as e:
+        module.fail_json(msg="Passwd action failed.",
+                         details=to_native(e),
+                         exception=traceback.format_exc())
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -124,7 +124,7 @@ class LdapPasswd(LdapGeneric):
 
 def main():
     module = AnsibleModule(
-        argument_spec=gen_specs(passwd=dict(type='str', no_log=True)),
+        argument_spec=gen_specs(passwd=dict(no_log=True)),
         supports_check_mode=True,
     )
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -73,11 +73,12 @@ modlist:
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ldap import LdapGeneric, gen_specs, HAS_LDAP
+from ansible.module_utils.ldap import LdapGeneric, gen_specs
 from ansible.module_utils._text import to_native
 
 try:
     import ldap
+    HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -87,7 +87,7 @@ class LdapPasswd(LdapGeneric):
         # Shortcuts
         self.passwd = self.module.params['passwd']
 
-    def passwd_c(self):
+    def passwd_check(self):
         u_con = ldap.initialize(self.server_uri)
 
         if self.start_tls:
@@ -110,13 +110,13 @@ class LdapPasswd(LdapGeneric):
         finally:
             u_con.unbind()
 
-    def passwd_s(self):
+    def passwd_set(self):
         # Exit early if the password is already valid
-        if not self.passwd_c():
+        if not self.passwd_check():
             return False
 
         # Change the password (or throw an exception)
-        self.connection.passwd_s(self.dn, None, self.passwd)
+        self.connection.passwd_set(self.dn, None, self.passwd)
 
         # We successfully changed the password  \o/
         return True
@@ -136,9 +136,9 @@ def main():
 
     try:
         if module.check_mode:
-            module.exit_json(changed=ldap.passwd_c())
+            module.exit_json(changed=ldap.passwd_check())
         else:
-            module.exit_json(changed=ldap.passwd_s())
+            module.exit_json(changed=ldap.passwd_set())
     except Exception as e:
         module.fail_json(msg="Passwd action failed.",
                          details=to_native(e),

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2017, Keller Fuchs <kellerfuchs@hashbang.sh>
+# Copyright: (c) 2017-2018, Keller Fuchs <kellerfuchs@hashbang.sh>
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -124,7 +124,7 @@ class LdapPasswd(LdapGeneric):
         except ldap.LDAPError as e:
             self.fail("Unable to set password", e)
 
-        # We successfully changed the password  \o/
+        # Password successfully changed
         return True
 
 

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -94,17 +94,14 @@ class LdapPasswd(LdapGeneric):
             try:
                 u_con.start_tls_s()
             except ldap.LDAPError as e:
-                self.module.fail_json(msg="Cannot start TLS.", details=to_native(e),
-                                      exception=traceback.format_exc())
+                self.fail("Cannot start TLS.", e)
 
         try:
             u_con.simple_bind_s(self.dn, self.passwd)
         except ldap.INVALID_CREDENTIALS:
             return True
         except ldap.LDAPError as e:
-            self.module.fail_json(
-                msg="Cannot bind to the server.", details=to_native(e),
-                exception=traceback.format_exc())
+            self.fail("Cannot bind to the server.", e)
         else:
             return False
         finally:
@@ -140,9 +137,7 @@ def main():
         else:
             module.exit_json(changed=ldap.passwd_set())
     except Exception as e:
-        module.fail_json(msg="Passwd action failed.",
-                         details=to_native(e),
-                         exception=traceback.format_exc())
+        ldap.fail("Passwd action failed.", e)
 
 
 if __name__ == '__main__':

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -1,6 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+
 # Copyright: (c) 2017-2018, Keller Fuchs <kellerfuchs@hashbang.sh>
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -14,7 +16,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = r"""
+DOCUMENTATION = """
 ---
 module: ldap_passwd
 short_description: Set passwords in LDAP.
@@ -43,7 +45,7 @@ options:
 extends_documentation_fragment: ldap.documentation
 """
 
-EXAMPLES = r"""
+EXAMPLES = """
 - name: Set a password for the admin user
   ldap_passwd:
     dn: cn=admin,dc=example,dc=com
@@ -59,7 +61,7 @@ EXAMPLES = r"""
     admin: "{{ vault_secret }}"
 """
 
-RETURN = r"""
+RETURN = """
 modlist:
   description: list of modified parameters
   returned: success

--- a/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
+++ b/lib/ansible/modules/net_tools/ldap/ldap_passwd.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
-
 # Copyright: (c) 2017-2018, Keller Fuchs <kellerfuchs@hashbang.sh>
-#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -16,7 +14,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = """
+DOCUMENTATION = r"""
 ---
 module: ldap_passwd
 short_description: Set passwords in LDAP.
@@ -45,7 +43,7 @@ options:
 extends_documentation_fragment: ldap.documentation
 """
 
-EXAMPLES = """
+EXAMPLES = r"""
 - name: Set a password for the admin user
   ldap_passwd:
     dn: cn=admin,dc=example,dc=com
@@ -61,7 +59,7 @@ EXAMPLES = """
     admin: "{{ vault_secret }}"
 """
 
-RETURN = """
+RETURN = r"""
 modlist:
   description: list of modified parameters
   returned: success
@@ -69,15 +67,12 @@ modlist:
   sample: '[[2, "olcRootDN", ["cn=root,dc=example,dc=com"]]]'
 """
 
-
-import traceback
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ldap import LdapGeneric, gen_specs
-from ansible.module_utils._text import to_native
 
 try:
     import ldap
+
     HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
@@ -142,8 +137,8 @@ def main():
 
     if module.check_mode:
         module.exit_json(changed=ldap.passwd_check())
-    else:
-        module.exit_json(changed=ldap.passwd_set())
+
+    module.exit_json(changed=ldap.passwd_set())
 
 
 if __name__ == '__main__':

--- a/lib/ansible/utils/module_docs_fragments/ldap.py
+++ b/lib/ansible/utils/module_docs_fragments/ldap.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
 # Copyright 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
-# Copyright 2016      Peter Sagerson <psagers@ignorare.net>
 # Copyright 2016      Jiri Tyr <jiri.tyr@gmail.com>
+# Copyright 2016      Peter Sagerson <psagers@ignorare.net>
 
 # This file is part of Ansible by Red Hat
 #

--- a/lib/ansible/utils/module_docs_fragments/ldap.py
+++ b/lib/ansible/utils/module_docs_fragments/ldap.py
@@ -1,57 +1,40 @@
 # -*- coding: utf-8 -*-
-
-# Copyright 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
-# Copyright 2016      Jiri Tyr <jiri.tyr@gmail.com>
-# Copyright 2016      Peter Sagerson <psagers@ignorare.net>
-
-# This file is part of Ansible by Red Hat
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
+# Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
+# Copyright: (c) 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):
-    # Standard files documentation fragment
-    DOCUMENTATION = '''
+    # Standard LDAP documentation fragment
+    DOCUMENTATION = r'''
 options:
   bind_dn:
     description:
-      - A DN to bind with. If this is omitted, we'll try a SASL bind with
-        the EXTERNAL mechanism. If this is blank, we'll use an anonymous
-        bind.
+    - A DN to bind with. If this is omitted, we'll try a SASL bind with the EXTERNAL mechanism.
+    - If this is blank, we'll use an anonymous bind.
   bind_pw:
     description:
-      - The password to use with I(bind_dn).
+    - The password to use with I(bind_dn).
   dn:
     required: true
     description:
-      - The DN of the entry to add or remove.
+    - The DN of the entry to add or remove.
   server_uri:
     default: ldapi:///
     description:
-      - A URI to the LDAP server. The default value lets the underlying
-        LDAP client library look for a UNIX domain socket in its default
-        location.
+    - A URI to the LDAP server.
+    - The default value lets the underlying LDAP client library look for a UNIX domain socket in its default location.
   start_tls:
     default: 'no'
     type: bool
     description:
-      - If true, we'll use the START_TLS LDAP extension.
+    - If true, we'll use the START_TLS LDAP extension.
   validate_certs:
     default: 'yes'
     type: bool
     description:
-      - If C(no), SSL certificates will not be validated. This should only be
-        used on sites using self-signed certificates.
+    - If set to C(no), SSL certificates will not be validated.
+    - This should only be used on sites using self-signed certificates.
     version_added: "2.4"
 '''

--- a/lib/ansible/utils/module_docs_fragments/ldap.py
+++ b/lib/ansible/utils/module_docs_fragments/ldap.py
@@ -1,40 +1,42 @@
 # -*- coding: utf-8 -*-
+
 # Copyright: (c) 2016, Peter Sagerson <psagers@ignorare.net>
 # Copyright: (c) 2016, Jiri Tyr <jiri.tyr@gmail.com>
 # Copyright: (c) 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+#
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
 class ModuleDocFragment(object):
     # Standard LDAP documentation fragment
-    DOCUMENTATION = r'''
+    DOCUMENTATION = '''
 options:
   bind_dn:
     description:
-    - A DN to bind with. If this is omitted, we'll try a SASL bind with the EXTERNAL mechanism.
-    - If this is blank, we'll use an anonymous bind.
+      - A DN to bind with. If this is omitted, we'll try a SASL bind with the EXTERNAL mechanism.
+      - If this is blank, we'll use an anonymous bind.
   bind_pw:
     description:
-    - The password to use with I(bind_dn).
+      - The password to use with I(bind_dn).
   dn:
     required: true
     description:
-    - The DN of the entry to add or remove.
+      - The DN of the entry to add or remove.
   server_uri:
     default: ldapi:///
     description:
-    - A URI to the LDAP server.
-    - The default value lets the underlying LDAP client library look for a UNIX domain socket in its default location.
+      - A URI to the LDAP server.
+      - The default value lets the underlying LDAP client library look for a UNIX domain socket in its default location.
   start_tls:
     default: 'no'
     type: bool
     description:
-    - If true, we'll use the START_TLS LDAP extension.
+      - If true, we'll use the START_TLS LDAP extension.
   validate_certs:
     default: 'yes'
     type: bool
     description:
-    - If set to C(no), SSL certificates will not be validated.
-    - This should only be used on sites using self-signed certificates.
+      - If set to C(no), SSL certificates will not be validated.
+      - This should only be used on sites using self-signed certificates.
     version_added: "2.4"
 '''

--- a/lib/ansible/utils/module_docs_fragments/ldap.py
+++ b/lib/ansible/utils/module_docs_fragments/ldap.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2017 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+
+# This file is part of Ansible by Red Hat
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class ModuleDocFragment(object):
+    # Standard files documentation fragment
+    DOCUMENTATION = '''
+options:
+  bind_dn:
+    description:
+      - A DN to bind with. If this is omitted, we'll try a SASL bind with
+        the EXTERNAL mechanism. If this is blank, we'll use an anonymous
+        bind.
+  bind_pw:
+    description:
+      - The password to use with I(bind_dn).
+  dn:
+    required: true
+    description:
+      - The DN of the entry to add or remove.
+  server_uri:
+    default: ldapi:///
+    description:
+      - A URI to the LDAP server. The default value lets the underlying
+        LDAP client library look for a UNIX domain socket in its default
+        location.
+  start_tls:
+    default: 'no'
+    type: bool
+    description:
+      - If true, we'll use the START_TLS LDAP extension.
+  validate_certs:
+    default: 'yes'
+    type: bool
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be
+        used on sites using self-signed certificates.
+    version_added: "2.4"
+'''

--- a/lib/ansible/utils/module_docs_fragments/ldap.py
+++ b/lib/ansible/utils/module_docs_fragments/ldap.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Copyright 2017 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+# Copyright 2017-2018 Keller Fuchs (@kellerfuchs) <kellerfuchs@hashbang.sh>
+# Copyright 2016      Peter Sagerson <psagers@ignorare.net>
+# Copyright 2016      Jiri Tyr <jiri.tyr@gmail.com>
 
 # This file is part of Ansible by Red Hat
 #


### PR DESCRIPTION
##### SUMMARY
- [x] Refactor `ldap_attr` and `ldap_entry`, pulling shared code, documentation and specs in `__init__`.
- [x] Add a `ldap_passwd` module.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
notification/ldap

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/user/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 17 2017, 18:50:44) [GCC 7.2.0]
```

##### Additional information

I needed such a module while working on [LDAP-related automation](https://github.com/hashbang/admin-tools/pull/112).