### PR TITLE
 Included support to AIX group of subsystems on service module

### DIFF
--- a/test/legacy/aix_services.yml
+++ b/test/legacy/aix_services.yml
@@ -1,0 +1,24 @@
+---
+- name: Services/Subsystems tests for AIX
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: spooler shutdown
+      service:
+        name: spooler
+        state: started
+
+    - name: stopping sendmail
+      service:
+        name: sendmail
+        state: stopped
+
+    - name: starting sendmail
+      service:
+        name: sendmail
+        state: started
+
+    - name: starting an inexistent subsystem and group subsystem
+      service:
+        name: fakeservice
+        state: stopped


### PR DESCRIPTION
##### SUMMARY
AIX systems has subsystems as services but also uses group subsystems.
This change enables the possibility to use also the group of susbsystems such as spooler, nfs, cluster, roc, etc.

For example, spooler is a group subsystem to services daemon, writesrv, and lpd.

When the service name is informed, first the module will check if the name is a subsystem, if not it will check if the name is a group subsystem and also it subsystems states.

This change makes services more flexible with AIX systems.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/system/service.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (service_aix_group_subsystem 9aefaea6a7) last updated 2017/11/17 17:00:20 (GMT +200)
  config file = None
  configured module search path = ['/Users/kairo/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/kairo/Dev/Ansible/modules/service_aix_group_subsystem/ansible/lib/ansible
  executable location = /Users/kairo/Dev/Ansible/modules/service_aix_group_subsystem/ansible/bin/ansible
  python version = 3.6.3 (v3.6.3:2c5fed86e0, Oct  3 2017, 00:32:08) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]`
```

##### ADDITIONAL INFORMATION

It is an example using subsystems and also group of subsystems

Current services state:

```
[lpar21:root:/home/root:] lssrc -g spooler
Subsystem         Group            PID          Status
 qdaemon          spooler                       inoperative
 writesrv         spooler                       inoperative
 lpd              spooler                       inoperative

[lpar21:root:/home/root:] lssrc -s sendmail
Subsystem         Group            PID          Status
 sendmail         mail             13697208     active
```

Example playbook

```yaml
---
- name: Services/Subsystems configuration
  hosts: lpar21
  tasks:
    - name: spooler shutdown
      service:
        name: spooler
        state: started

    - name: stopping sendmail
      service:
        name: sendmail
        state: stopped

    - name: starting sendmail
      service:
        name: sendmail
        state: started

    - name: starting an inexistent subsystem and group subsystem
      service:
        name: fakeservice
        state: stopped
```

Running:

```
ansible-playbook -i .inventory playbooks/pb-services.yml -v
No config file found; using defaults

PLAY [Services/Subsystems configuration] *******************************************************************************

TASK [Gathering Facts] *************************************************************************************************
ok: [lpar21]

TASK [spooler shutdown] ************************************************************************************************
changed: [lpar21] => {"changed": true, "name": "spooler", "state": "started"}

TASK [stopping sendmail] ***********************************************************************************************
changed: [lpar21] => {"changed": true, "name": "sendmail", "state": "stopped"}

TASK [starting sendmail] ***********************************************************************************************
changed: [lpar21] => {"changed": true, "name": "sendmail", "state": "started"}

TASK [starting an inexistent subsystem and group subsystem] ************************************************************
fatal: [lpar21]: FAILED! => {"changed": false, "msg": "0513-086 The fakeservice Group is not on file.\n"}
	to retry, use: --limit @/Users/kairo/Dev/Ansible/playbooks/pb-services.retry

PLAY RECAP *************************************************************************************************************
lpar21                     : ok=4    changed=3    unreachable=0    failed=1
```

State after playbook
```
[lpar21_en0:root:/home/root:] lssrc -g spooler
Subsystem         Group            PID          Status
 qdaemon          spooler          8912998      active
 writesrv         spooler          15532120     active
 lpd              spooler          16056456     active

[lpar21_en0:root:/home/root:] lssrc -s sendmail
Subsystem         Group            PID          Status
 sendmail         mail             14680132     active
```