### PR TITLE
get existing network via inspect_network

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -155,6 +155,7 @@ from ansible.module_utils.docker_common import AnsibleDockerClient, DockerBaseCl
 
 try:
     from docker import utils
+    from docker.errors import NotFound
     if HAS_DOCKER_PY_2:
         from docker.types import IPAMPool, IPAMConfig
 except:
@@ -208,14 +209,10 @@ class DockerNetworkManager(object):
             self.absent()
 
     def get_existing_network(self):
-        networks = self.client.networks(names=[self.parameters.network_name])
-        # check if a user is trying to find network by its Id
-        if not networks:
-            networks = self.client.networks(ids=[self.parameters.network_name])
-        if not networks:
+        try:
+            return self.client.inspect_network(self.parameters.network_name)
+        except NotFound:
             return None
-        else:
-            return networks[0]
 
     def has_different_config(self, net):
         '''


### PR DESCRIPTION
##### SUMMARY
This PR fixes #33045. Since Docker API v1.28 the networks endpoint does not return connected containers any more. I changed get_existing_container to use inspect_network, which should be supported since docker-py 1.7.0 (I tested with docker-py 1.10.6).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vagrant/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
N/A
