### PR TITLE
Fix debug logs failing with persistent connection

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -154,54 +154,6 @@ class ConnectionProcess(object):
                     setattr(self.connection, '_connected', False)
         display.display('shutdown complete', log_only=True)
 
-    def do_EXEC(self, data):
-        cmd = data.split(b'EXEC: ')[1]
-        return self.connection.exec_command(cmd)
-
-    def do_PUT(self, data):
-        (op, src, dst) = shlex.split(to_native(data))
-        return self.connection.fetch_file(src, dst)
-
-    def do_FETCH(self, data):
-        (op, src, dst) = shlex.split(to_native(data))
-        return self.connection.put_file(src, dst)
-
-    def do_CONTEXT(self, data):
-        pc_data = data.split(b'CONTEXT: ', 1)[1]
-
-        if PY3:
-            pc_data = cPickle.loads(pc_data, encoding='bytes')
-        else:
-            pc_data = cPickle.loads(pc_data)
-
-        pc = PlayContext()
-        pc.deserialize(pc_data)
-
-        try:
-            self.connection.update_play_context(pc)
-        except AttributeError:
-            pass
-
-        return (0, 'ok', '')
-
-    def do_RUN(self, data):
-        timeout = self.play_context.timeout
-        while bool(timeout):
-            if os.path.exists(self.socket_path):
-                break
-            time.sleep(1)
-            timeout -= 1
-        socket_bytes = to_bytes(self.socket_path, errors='surrogate_or_strict')
-        return 0, b'\n#SOCKET_PATH#: %s\n' % socket_bytes, ''
-
-
-def communicate(sock, data):
-    send_data(sock, data)
-    rc = int(recv_data(sock), 10)
-    stdout = recv_data(sock)
-    stderr = recv_data(sock)
-    return (rc, stdout, stderr)
-
 
 def main():
     """ Called to initiate the connect to the remote device
@@ -315,10 +267,10 @@ def main():
 
     if 'exception' in result:
         rc = 1
-        sys.stderr.write(json.dumps(result))
+        sys.stderr.write('\n##RESPONSE##: %s\n' % json.dumps(result))
     else:
         rc = 0
-        sys.stdout.write(json.dumps(result))
+        sys.stdout.write('\n##RESPONSE##: %s\n' % json.dumps(result))
 
     sys.exit(rc)
 

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -25,7 +25,7 @@ import json
 from ansible import constants as C
 from ansible.module_utils._text import to_bytes, to_native, to_text
 from ansible.module_utils.six import PY3
-from ansible.module_utils.six.moves import cPickle
+from ansible.module_utils.six.moves import cPickle, StringIO
 from ansible.module_utils.connection import Connection, ConnectionError, send_data, recv_data
 from ansible.module_utils.service import fork_process
 from ansible.playbook.play_context import PlayContext
@@ -169,6 +169,9 @@ def main():
     else:
         stdin = sys.stdin
 
+    saved_stdout = sys.stdout
+    sys.stdout = StringIO()
+
     try:
         # read the play context data via stdin, which means depickling it
         cur_line = stdin.readline()
@@ -260,17 +263,19 @@ def main():
                         'exception': traceback.format_exc()
                     })
 
+    messages.append(sys.stdout.getvalue())
     result.update({
         'messages': messages,
         'socket_path': socket_path
     })
 
+    sys.stdout = saved_stdout
     if 'exception' in result:
         rc = 1
-        sys.stderr.write('\n##RESPONSE##: %s\n' % json.dumps(result))
+        sys.stderr.write(json.dumps(result))
     else:
         rc = 0
-        sys.stdout.write('\n##RESPONSE##: %s\n' % json.dumps(result))
+        sys.stdout.write(json.dumps(result))
 
     sys.exit(rc)
 

--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -13,11 +13,9 @@ except Exception:
 
 import fcntl
 import os
-import shlex
 import signal
 import socket
 import sys
-import time
 import traceback
 import errno
 import json
@@ -169,6 +167,7 @@ def main():
     else:
         stdin = sys.stdin
 
+    # Note: update the below log capture code after Display.display() is refactored.
     saved_stdout = sys.stdout
     sys.stdout = StringIO()
 

--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -813,19 +813,15 @@ class TaskExecutor:
         stdin.write(src)
 
         stdin.write(b'\n#END_INIT#\n')
+        stdin.flush()
 
         (stdout, stderr) = p.communicate()
         stdin.close()
 
-        out = stdout if p.returncode == 0 else stderr
-        if br"##RESPONSE##:" not in out:
-            return None
-
-        resp = out.split(br"##RESPONSE##:")
-        result = json.loads(to_text(resp[1].strip(), errors='surrogate_then_replace'))
-
-        if resp[0] and C.DEFAULT_DEBUG:
-            display.display(resp[0], color=C.COLOR_DEBUG)
+        if p.returncode == 0:
+            result = json.loads(to_text(stdout))
+        else:
+            result = json.loads(to_text(stderr))
 
         if 'messages' in result:
             for msg in result.get('messages'):

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -126,6 +126,8 @@ class Display:
                 # characters that are invalid in the user's locale
                 msg2 = to_text(msg2, self._output_encoding(stderr=stderr), errors='replace')
 
+            # Note: After Display() class is refactored need to update the log capture
+            # code in 'bin/ansible-connection' (and other relevant places).
             if not stderr:
                 fileobj = sys.stdout
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #33047

~*  As debug logs are written on stdout, it interrupts
   the communication between ansible-connection(background)
  process and main process. To avoid this add a string delimiter to exactly 
  identify the response string.~

*  ansible-connection which runs as a background process sends a
   json string (contains response received from remote device)
   to foreground ansible-playbook process over stdout.

*  If in case debug flag is enabled the connection_loader api
   invoked from ansible-connection `ssh = connection_loader.get('ssh', class_only=True)`
   results in emitting debug logs on stdout. This  spurious log
   interfere with the actual response and results in failure while
   reading json string in ansible-playbook process

* To avoid this save stdout of ansible-connection and redirect it string
  buffer to accumulate all the logs emitted by core API's

* Add these logs in `result['messages']` which is send a json string after reinstating saved stdout

*  Remove unwanted code in ansible-connection

* Add `stdin.flush()` after write to  handle buffer scenario in case of PY3
 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bin/ansible-connection
executor/task_executor.py
plugins/connection/persistent.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
