### PR TITLE
Fix junos integration test fixes as per connection refactor (#33050)

### DIFF
--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -36,6 +36,10 @@
     provider: "{{ netconf }}"
     port: 8022
 
+- name: wait for persistent socket to timeout
+  pause:
+    seconds: 120
+
 # This protects against the port override above not being honoured and a bug setting the port
 - name: Ensure we can NOT communicate over default port
   junos_command:
@@ -47,12 +51,15 @@
 - assert:
     that:
       - "result.failed == true"
-      - "'unable to open shell' in result.msg"
 
 - name: Set back netconf to default port
   junos_netconf:
     state: present
   register: result
+
+- name: wait for persistent socket to timeout
+  pause:
+    seconds: 120
 
 - name: Ensure we can communicate over netconf
   junos_command:

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -45,7 +45,7 @@
 
 - name: wait for persistent socket to timeout
   pause:
-    seconds: 150
+    seconds: 120
 
 - name: Ensure we can NOT talk via netconf
   junos_command:
@@ -57,7 +57,6 @@
 - assert:
     that:
       - "result.failed == true"
-      - "'unable to open shell' in result.msg"
 
 - name: re-enable netconf
   junos_netconf:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Merged to devel https://github.com/ansible/ansible/pull/33050
(cherry picked from commit ce04f6e961961a32b0c98ec8b06a4297bd0e3fb4)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
junos_netconf/tests/cli/changeport.yaml
junos_netconf/tests/cli/netconf.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
