### PR TITLE
vmware_dvs_portgroup: Updating parameter to match vmware_portgroup parameter

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_dvs_portgroup.py
@@ -70,7 +70,7 @@ options:
         required: False
         default: False
         version_added: '2.5'
-    security:
+    network_policy:
         description:
             - Dict which configures the different security values for portgroup.
             - 'Valid attributes are:'
@@ -152,7 +152,7 @@ EXAMPLES = '''
         num_ports: 120
         portgroup_type: earlyBinding
         state: present
-        security:
+        network_policy:
           promiscuous: yes
           forged_transmits: yes
           mac_changes: yes
@@ -193,9 +193,9 @@ class VMwareDvsPortgroup(object):
         self.dv_switch = None
         self.state = self.module.params['state']
         self.vlan_trunk = self.module.params['vlan_trunk']
-        self.security_promiscuous = self.module.params['security']['promiscuous']
-        self.security_forged_transmits = self.module.params['security']['forged_transmits']
-        self.security_mac_changes = self.module.params['security']['mac_changes']
+        self.security_promiscuous = self.module.params['network_policy']['promiscuous']
+        self.security_forged_transmits = self.module.params['network_policy']['forged_transmits']
+        self.security_mac_changes = self.module.params['network_policy']['mac_changes']
         self.policy_block_override = self.module.params['port_policy']['block_override']
         self.policy_ipfix_override = self.module.params['port_policy']['ipfix_override']
         self.policy_live_port_move = self.module.params['port_policy']['live_port_move']
@@ -321,7 +321,7 @@ def main():
             portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             vlan_trunk=dict(type='bool', default=False),
-            security=dict(
+            network_policy=dict(
                 type='dict',
                 options=dict(
                     promiscuous=dict(type='bool', default=False),

--- a/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/test/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -154,7 +154,7 @@
     num_ports: 32
     portgroup_type: earlyBinding
     state: present
-    security:
+    network_policy:
       promiscuous: yes
       forged_transmits: yes
       mac_changes: yes
@@ -190,7 +190,7 @@
     num_ports: 32
     portgroup_type: earlyBinding
     state: present
-    security:
+    network_policy:
       promiscuous: yes
       forged_transmits: yes
       mac_changes: no


### PR DESCRIPTION
##### SUMMARY
Updating the `vmware_dvs_portgroup` module to match the `vmware_portgroup` parameters (network_policy). 

this updates #32298 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ANSIBLE VERSION
```
ansible 2.5.0 (vmware_dvs_portgroup_security 3a1f6f9d5a) last updated 2017/11/19 15:19:41 (GMT +400)
  config file = None
  configured module search path = [u'/Users/pdellaer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pdellaer/GitHub/pdellaert/ansible/lib/ansible
  executable location = /Users/pdellaer/GitHub/pdellaert/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION
N/A
