### PR TITLE
Fix issues with ironware modules

### DIFF
--- a/lib/ansible/module_utils/ironware.py
+++ b/lib/ansible/module_utils/ironware.py
@@ -96,6 +96,7 @@ def run_commands(module, commands, check_rc=True):
 
 
 def get_config(module, source='running', flags=None):
+    global _DEVICE_CONFIG
     if source is 'running' and flags is None and _DEVICE_CONFIG is not None:
         return _DEVICE_CONFIG
     else:

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -228,7 +228,7 @@ def run(module, result):
     if result['changed'] or module.params['save_when'] == 'always':
         result['changed'] = True
         if not module.check_mode:
-            cmd = {'command': 'write memory', 'output': 'text'}
+            cmd = {'command': 'write memory'}
             run_commands(module, [cmd])
 
 

--- a/lib/ansible/plugins/action/ironware.py
+++ b/lib/ansible/plugins/action/ironware.py
@@ -60,6 +60,8 @@ class ActionModule(_ActionModule):
         pc.private_key_file = provider['ssh_keyfile'] or self._play_context.private_key_file
         pc.timeout = int(provider['timeout'] or C.PERSISTENT_COMMAND_TIMEOUT)
         pc.become = provider['authorize'] or False
+        if pc.become:
+            pc.become_method = 'enable'
         pc.become_pass = provider['auth_pass']
 
         display.vvv('using connection plugin %s' % pc.connection, pc.remote_addr)
@@ -78,8 +80,8 @@ class ActionModule(_ActionModule):
         conn = Connection(socket_path)
         out = conn.get_prompt()
         if to_text(out, errors='surrogate_then_replace').strip().endswith(')#'):
-            display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-            conn.send_command('exit')
+            display.vvvv('wrong context, sending end to device', self._play_context.remote_addr)
+            conn.send_command('end')
 
         task_vars['ansible_socket'] = socket_path
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
 - authorize was not working as expected
 - use end command to get to exec context instead of exit
 - error due to mishandling of global variable _DEVICE_CONFIG
 - error when writing configuration
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/ironware

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (ironware_fix b3067e093c) last updated 2017/11/20 12:01:20 (GMT +1100)
  config file = /Users/paul.baker/.ansible.cfg
  configured module search path = [u'/Users/paul.baker/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/paul.baker/ansible/lib/ansible
  executable location = /Users/paul.baker/ansible/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
