### PR TITLE
hacking/test-module: fix Python 3 compatibility

### DIFF
--- a/hacking/test-module
+++ b/hacking/test-module
@@ -41,7 +41,7 @@ from ansible.parsing.utils.jsonify import jsonify
 from ansible.parsing.splitter import parse_kv
 import ansible.executor.module_common as module_common
 import ansible.constants as C
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_native, to_text
 
 try:
     import json
@@ -152,7 +152,7 @@ def boilerplate_module(modfile, args, interpreters, check, destfile):
         task_vars=task_vars
     )
 
-    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
+    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in to_native(module_data):
         module_style = 'ansiballz'
 
     modfile2_path = os.path.expanduser(destfile)


### PR DESCRIPTION
##### SUMMARY
`hacking/test-module`: fix Python 3 compatibility

Tested with Python 2.7 and Python 3.6

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hacking/test-module

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 0324d5e850) last updated 2017/11/20 02:15:48 (GMT +200)
```

##### ADDITIONAL INFORMATION
```
Exception was:
Traceback (most recent call last):
  File "./hacking/test-module", line 268, in <module>
    main()
  File "./hacking/test-module", line 249, in main
    (modfile, modname, module_style) = boilerplate_module(options.module_path, options.module_args, interpreters, options.check, options.filename)
  File "./hacking/test-module", line 155, in boilerplate_module
    if module_style == 'new' and 'ANSIBALLZ_WRAPPER = True' in module_data:
TypeError: a bytes-like object is required, not 'str'
```