### PR TITLE
add new net_tools module for fly ADN

### DIFF
--- a/lib/ansible/modules/net_tools/fly.py
+++ b/lib/ansible/modules/net_tools/fly.py
@@ -1,6 +1,13 @@
 #!/usr/bin/python
-# Copyright (c) 2017 AndyPi.co.uk
+# Copyright (c) 2017 Andrew Wilson AndyPi.co.uk
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.urls import open_url
+import json
+__metaclass__ = type
 
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
@@ -14,11 +21,11 @@ short_description: Fly.io API integration
 
 description:
     - "Create hostnames, link backends and add rules using Fly.io API"
-    
-version_added: "1.0"
+
+version_added: "2.5"
 
 author:
-    - Andy Wilson (@andypitech)
+    - Andy Wilson (@andy-pi)
 '''
 
 EXAMPLES = '''
@@ -39,30 +46,30 @@ EXAMPLES = '''
   register: results
 - name: Show fly hostname info
   debug:
-    msg: '{{ results.attributes }}'
+    msg: '{{ results.response.attributes }}'
 # Add new backend
-  - name: Add a fly backend (s3 bucket)
-    fly:
+- name: Add a fly backend (s3 bucket)
+  fly:
       command: add_backend
       fly_auth_key: "{{ fly_auth_key }}"
       site: "example-com"
       backend_name: "s3-1"
       backend_type: "aws_s3"
-      backend_settings: 
+      backend_settings:
         bucket: "my_bucket"
         region: "eu-west-1"
       register: result
-  - name: Show backend info
-    debug:
-      msg: '{{ result.id }}'
+- name: Show backend info
+  debug:
+      msg: '{{ result.response.id }}'
 # Add new rule
-  - name: Add a fly rule
-    fly:
+- name: Add a fly rule
+  fly:
       command: add_rule
       fly_auth_key: "{{ fly_auth_key }}"
       site: "example-com"
       hostname: "example.com"
-      backend_id: '{{ result.id }}'
+      backend_id: '{{ result.response.id }}'
       action_type: "rewrite"
       path: "/" # incoming path
       priority: "10"
@@ -75,7 +82,7 @@ create_hostname:
     description: create fly hostname
     returned: changed
     type: json
-    sample: {"changed": true, "failed": false, "response": {"dns_configured": false, "hostname": "example.com", "preview_hostname": "xyz.shw.io"}
+    sample: {"changed": true, "failed": false, "response": {"dns_configured": false, "hostname": "example.com", "preview_hostname": "xyz.shw.io"}}
 view_hostname:
     description: view a specific fly hostname
     returned: success
@@ -86,19 +93,25 @@ add_backend:
     returned: changed
     type: json
     sample: {"changed": true, "failed": false, "id": "123123123"}
-add_rule:   
+add_rule:
     description: add a fly rule
     returned: changed
     type: json
-    sample: {"changed": true, "failed": false, "response": {"data": {"attributes": {"action_type": "rewrite", "backend_id": "123123123", "hostname": "example.com", "http_header_key": "", "http_header_value_regex": "", "match_scheme": null, "path": "/", "path_replacement": "/index.html", "priority": 10, "redirect_url": null}, "id": "456456456", "type": "rules"}}}
+    sample: {"changed": true, "failed": false, "response": {"data": {"attributes": {"action_type": "rewrite",
+                                                                     "backend_id": "123123123",
+                                                                     "hostname": "example.com",
+                                                                     "http_header_key": "",
+                                                                     "http_header_value_regex": "",
+                                                                     "match_scheme": null,
+                                                                     "path": "/",
+                                                                     "path_replacement": "/index.html",
+                                                                     "priority": 10,
+                                                                     "redirect_url": null}, "id": "456456456", "type": "rules"}}}
 '''
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.urls import *
-
-
 api_endpoint = 'https://fly.io/api/v1/sites/'
+
 
 class Fly(object):
     def __init__(self, module):
@@ -109,37 +122,38 @@ class Fly(object):
         if v is None:
             self.module.fail_json(msg='Unable to load %s' % k)
         return v
-        
-    def hostname_add(self):  
+
+    def fly_simple_api_call(self, url, headers, payload=None):
+        error_msg=""
+        if payload is not None:
+            data = json.dumps(payload)
+        else:
+            data = None
+        resp = open_url(url, method="POST", headers=headers, validate_certs=False, data=data)
+        try:
+            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
+            self.module.exit_json(changed=True, response=resp_json['data'])
+        except (json.JSONDecodeError, UnicodeError) as e:
+            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), resp.read())
+            self.module.fail_json(msg=error_msg)
+
+    def hostname_add(self):
         fly_auth_key = self.get_key_or_fail('fly_auth_key')
         site = self.get_key_or_fail('site')
         hostname = self.get_key_or_fail('hostname')
         url = api_endpoint + site + '/hostnames'
-        payload={"data": { "attributes": { "hostname": hostname } } }
-        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
-        resp = open_url(url,method="POST",headers=headers,validate_certs=False,data=json.dumps(payload))
-        try:
-            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
-            self.module.exit_json(changed=True, response = resp_json['data']['attributes'])
-        except (json.JSONDecodeError, UnicodeError) as e:
-            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
-            self.module.fail_json(msg=error_msg)
+        payload = {"data": {"attributes": {"hostname": hostname}}}
+        headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % fly_auth_key}
+        self.fly_simple_api_call(url, headers, payload)
 
-        
-    def hostname_view(self): 
+    def hostname_view(self):
         fly_auth_key = self.get_key_or_fail('fly_auth_key')
         site = self.get_key_or_fail('site')
         hostname = self.get_key_or_fail('hostname')
         url = api_endpoint + site + '/hostnames/' + hostname
-        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
-        try: 
-            resp = open_url(url,method="GET",headers=headers,validate_certs=False)
-            try:
-                resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
-                self.module.exit_json(changed=True, response = resp_json['data']['attributes'])
-            except (json.JSONDecodeError, UnicodeError) as e:
-                error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
-                self.module.fail_json(msg=error_msg)
+        headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % fly_auth_key}
+        try:
+            self.fly_simple_api_call(url, headers)
         except:
             return False
 
@@ -149,65 +163,48 @@ class Fly(object):
         backend_name = self.get_key_or_fail('backend_name')
         backend_type = self.get_key_or_fail('backend_type')
         backend_settings = self.get_key_or_fail('backend_settings')
-        
         url = api_endpoint + site + '/backends'
-        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
-        # is this correct way to add settings?
-        payload = {"data": { "attributes": { "name": backend_name,
-                                             "type": backend_type,
-                                             "settings": backend_settings
-                    } } }
-                    
-        resp = open_url(url,method="POST",headers=headers,validate_certs=False,data=json.dumps(payload))
-        try:
-            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
-            self.module.exit_json(changed=True, id = resp_json['data']['id'])
-        except (json.JSONDecodeError, UnicodeError) as e:
-            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
-            self.module.fail_json(msg=error_msg)
-        
-    
-    def rules_add(self):  
+        headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % fly_auth_key}
+        payload = {"data": {"attributes": {"name": backend_name,
+                                           "type": backend_type,
+                                           "settings": backend_settings}}}
+        self.fly_simple_api_call(url, headers, payload)
+        # self.module.exit_json(changed=True, id = resp_json['data']['id'])
+
+    def rules_add(self):
         fly_auth_key = self.get_key_or_fail('fly_auth_key')
         site = self.get_key_or_fail('site')
         hostname = self.get_key_or_fail('hostname')
         backend_id = self.get_key_or_fail('backend_id')
-        action_type = self.get_key_or_fail('action_type') # an be "rewrite" or "redirect".
-        path = self.get_key_or_fail('path') # Path to match. For example /blog/.
-        if self.module.params['priority'] == None:
+        action_type = self.get_key_or_fail('action_type')  # an be "rewrite" or "redirect".
+        path = self.get_key_or_fail('path')  # Path to match. For example /blog/.
+        if not self.module.params['priority']:
             priority = "null"
         else:
-            priority=self.module.params['priority']
-        if self.module.params['path_replacement'] == None:
+            priority = self.module.params['priority']
+        if not self.module.params['path_replacement']:
             path_replacement = "null"
         else:
-            path_replacement=self.module.params['path_replacement']
+            path_replacement = self.module.params['path_replacement']
         url = api_endpoint + site + '/rules'
-        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
-        payload = {"data": { "attributes": {
+        headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % fly_auth_key}
+        payload = {"data": {"attributes": {
                               "hostname": hostname,
                               "backend_id": backend_id,
                               "action_type": action_type,
                               "path": path,
-                              "priority": priority, 
+                              "priority": priority,
                               "path_replacement": path_replacement
-                    } } }
-                    
-        resp = open_url(url,method="POST",headers=headers,validate_certs=False,data=json.dumps(payload))
-        try:
-            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
-            self.module.exit_json(changed=True, response = resp_json)
-        except (json.JSONDecodeError, UnicodeError) as e:
-            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
-            self.module.fail_json(msg=error_msg)
+                    }}}
+        self.fly_simple_api_call(url, headers, payload)
 
 
 def handle_request(module):
     fly = Fly(module)
     command = module.params['command']
     if command == 'create_hostname':
-        preview_hostname=fly.hostname_view()
-        if preview_hostname == False:
+        preview_hostname = fly.hostname_view()
+        if not preview_hostname:
             fly.hostname_add()
         else:
             pass
@@ -220,7 +217,6 @@ def handle_request(module):
 
 
 def main():
-
     module = AnsibleModule(
         argument_spec=dict(
             command=dict(choices=['create_hostname', 'view_hostname', 'add_backend', 'add_rule'], required=True),
@@ -232,14 +228,12 @@ def main():
             backend_settings=dict(type='dict'),
             backend_id=dict(type='str'),
             action_type=dict(type='str'),
-            path =dict(type='str'),
-            priority =dict(type='str'),
+            path=dict(type='str'),
+            priority=dict(type='str'),
             path_replacement=dict(type='str')
         ),
     )
-    
     handle_request(module)
 
-
-if __name__ == '__main__':  
+if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/net_tools/fly.py
+++ b/lib/ansible/modules/net_tools/fly.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2017 Andrew Wilson AndyPi.co.uk
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import absolute_import, division, print_function
+
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
@@ -102,7 +104,7 @@ add_rule:
                                                                      "redirect_url": null}, "id": "456456456", "type": "rules"}}}
 '''
 
-from __future__ import absolute_import, division, print_function
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import open_url
@@ -194,7 +196,7 @@ class Fly(object):
                             "path": path,
                             "priority": priority,
                             "path_replacement": path_replacement
-                   }}}
+                            }}}
         self.fly_simple_api_call(url, headers, payload)
 
 

--- a/lib/ansible/modules/net_tools/fly.py
+++ b/lib/ansible/modules/net_tools/fly.py
@@ -2,13 +2,6 @@
 # Copyright (c) 2017 Andrew Wilson AndyPi.co.uk
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import absolute_import, division, print_function
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils._text import to_native, to_text
-from ansible.module_utils.urls import open_url
-import json
-__metaclass__ = type
-
 ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
@@ -81,22 +74,22 @@ RETURN = '''
 create_hostname:
     description: create fly hostname
     returned: changed
-    type: json
+    type: dictionary
     sample: {"changed": true, "failed": false, "response": {"dns_configured": false, "hostname": "example.com", "preview_hostname": "xyz.shw.io"}}
 view_hostname:
     description: view a specific fly hostname
     returned: success
-    type: json
+    type: dictionary
     sample: {"changed": false, "failed": false, "response": {"dns_configured": false, "hostname": "example.com", "preview_hostname": "xyz.shw.io"}}
 add_backend:
     description: add a fly backend
     returned: changed
-    type: json
+    type: dictionary
     sample: {"changed": true, "failed": false, "id": "123123123"}
 add_rule:
     description: add a fly rule
     returned: changed
-    type: json
+    type: dictionary
     sample: {"changed": true, "failed": false, "response": {"data": {"attributes": {"action_type": "rewrite",
                                                                      "backend_id": "123123123",
                                                                      "hostname": "example.com",
@@ -109,6 +102,12 @@ add_rule:
                                                                      "redirect_url": null}, "id": "456456456", "type": "rules"}}}
 '''
 
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.urls import open_url
+import json
+__metaclass__ = type
 
 api_endpoint = 'https://fly.io/api/v1/sites/'
 
@@ -124,7 +123,7 @@ class Fly(object):
         return v
 
     def fly_simple_api_call(self, url, headers, payload=None):
-        error_msg=""
+        error_msg = ""
         if payload is not None:
             data = json.dumps(payload)
         else:
@@ -189,13 +188,13 @@ class Fly(object):
         url = api_endpoint + site + '/rules'
         headers = {'Content-Type': 'application/json', 'Authorization': 'Bearer %s' % fly_auth_key}
         payload = {"data": {"attributes": {
-                              "hostname": hostname,
-                              "backend_id": backend_id,
-                              "action_type": action_type,
-                              "path": path,
-                              "priority": priority,
-                              "path_replacement": path_replacement
-                    }}}
+                            "hostname": hostname,
+                            "backend_id": backend_id,
+                            "action_type": action_type,
+                            "path": path,
+                            "priority": priority,
+                            "path_replacement": path_replacement
+                   }}}
         self.fly_simple_api_call(url, headers, payload)
 
 

--- a/lib/ansible/modules/net_tools/fly.py
+++ b/lib/ansible/modules/net_tools/fly.py
@@ -1,0 +1,245 @@
+#!/usr/bin/python
+# Copyright (c) 2017 AndyPi.co.uk
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+DOCUMENTATION = '''
+---
+module: fly
+
+short_description: Fly.io API integration
+
+description:
+    - "Create hostnames, link backends and add rules using Fly.io API"
+    
+version_added: "1.0"
+
+author:
+    - Andy Wilson (@andypitech)
+'''
+
+EXAMPLES = '''
+# Add new hostname
+- name: Create a fly hostname
+  fly:
+    command: create_hostname
+    fly_auth_key: "{{ fly_auth_key }}"
+    site: "example-com"
+    hostname: "example.com"
+# View hostname information
+- name: View a fly hostname
+  fly:
+    command: view_hostname
+    fly_auth_key: "{{ fly_auth_key }}"
+    site: "example-com"
+    hostname: "example.com"
+  register: results
+- name: Show fly hostname info
+  debug:
+    msg: '{{ results.attributes }}'
+# Add new backend
+  - name: Add a fly backend (s3 bucket)
+    fly:
+      command: add_backend
+      fly_auth_key: "{{ fly_auth_key }}"
+      site: "example-com"
+      backend_name: "s3-1"
+      backend_type: "aws_s3"
+      backend_settings: 
+        bucket: "my_bucket"
+        region: "eu-west-1"
+      register: result
+  - name: Show backend info
+    debug:
+      msg: '{{ result.id }}'
+# Add new rule
+  - name: Add a fly rule
+    fly:
+      command: add_rule
+      fly_auth_key: "{{ fly_auth_key }}"
+      site: "example-com"
+      hostname: "example.com"
+      backend_id: '{{ result.id }}'
+      action_type: "rewrite"
+      path: "/" # incoming path
+      priority: "10"
+      path_replacement: "/index.html" # rewrite to this path on the backend
+
+'''
+
+RETURN = '''
+create_hostname:
+    description: create fly hostname
+    returned: changed
+    type: json
+    sample: {"changed": true, "failed": false, "response": {"dns_configured": false, "hostname": "example.com", "preview_hostname": "xyz.shw.io"}
+view_hostname:
+    description: view a specific fly hostname
+    returned: success
+    type: json
+    sample: {"changed": false, "failed": false, "response": {"dns_configured": false, "hostname": "example.com", "preview_hostname": "xyz.shw.io"}}
+add_backend:
+    description: add a fly backend
+    returned: changed
+    type: json
+    sample: {"changed": true, "failed": false, "id": "123123123"}
+add_rule:   
+    description: add a fly rule
+    returned: changed
+    type: json
+    sample: {"changed": true, "failed": false, "response": {"data": {"attributes": {"action_type": "rewrite", "backend_id": "123123123", "hostname": "example.com", "http_header_key": "", "http_header_value_regex": "", "match_scheme": null, "path": "/", "path_replacement": "/index.html", "priority": 10, "redirect_url": null}, "id": "456456456", "type": "rules"}}}
+'''
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
+
+
+api_endpoint = 'https://fly.io/api/v1/sites/'
+
+class Fly(object):
+    def __init__(self, module):
+        self.module = module
+
+    def get_key_or_fail(self, k):
+        v = self.module.params[k]
+        if v is None:
+            self.module.fail_json(msg='Unable to load %s' % k)
+        return v
+        
+    def hostname_add(self):  
+        fly_auth_key = self.get_key_or_fail('fly_auth_key')
+        site = self.get_key_or_fail('site')
+        hostname = self.get_key_or_fail('hostname')
+        url = api_endpoint + site + '/hostnames'
+        payload={"data": { "attributes": { "hostname": hostname } } }
+        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
+        resp = open_url(url,method="POST",headers=headers,validate_certs=False,data=json.dumps(payload))
+        try:
+            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
+            self.module.exit_json(changed=True, response = resp_json['data']['attributes'])
+        except (json.JSONDecodeError, UnicodeError) as e:
+            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
+            self.module.fail_json(msg=error_msg)
+
+        
+    def hostname_view(self): 
+        fly_auth_key = self.get_key_or_fail('fly_auth_key')
+        site = self.get_key_or_fail('site')
+        hostname = self.get_key_or_fail('hostname')
+        url = api_endpoint + site + '/hostnames/' + hostname
+        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
+        try: 
+            resp = open_url(url,method="GET",headers=headers,validate_certs=False)
+            try:
+                resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
+                self.module.exit_json(changed=True, response = resp_json['data']['attributes'])
+            except (json.JSONDecodeError, UnicodeError) as e:
+                error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
+                self.module.fail_json(msg=error_msg)
+        except:
+            return False
+
+    def backend_add(self):
+        fly_auth_key = self.get_key_or_fail('fly_auth_key')
+        site = self.get_key_or_fail('site')
+        backend_name = self.get_key_or_fail('backend_name')
+        backend_type = self.get_key_or_fail('backend_type')
+        backend_settings = self.get_key_or_fail('backend_settings')
+        
+        url = api_endpoint + site + '/backends'
+        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
+        # is this correct way to add settings?
+        payload = {"data": { "attributes": { "name": backend_name,
+                                             "type": backend_type,
+                                             "settings": backend_settings
+                    } } }
+                    
+        resp = open_url(url,method="POST",headers=headers,validate_certs=False,data=json.dumps(payload))
+        try:
+            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
+            self.module.exit_json(changed=True, id = resp_json['data']['id'])
+        except (json.JSONDecodeError, UnicodeError) as e:
+            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
+            self.module.fail_json(msg=error_msg)
+        
+    
+    def rules_add(self):  
+        fly_auth_key = self.get_key_or_fail('fly_auth_key')
+        site = self.get_key_or_fail('site')
+        hostname = self.get_key_or_fail('hostname')
+        backend_id = self.get_key_or_fail('backend_id')
+        action_type = self.get_key_or_fail('action_type') # an be "rewrite" or "redirect".
+        path = self.get_key_or_fail('path') # Path to match. For example /blog/.
+        if self.module.params['priority'] == None:
+            priority = "null"
+        else:
+            priority=self.module.params['priority']
+        if self.module.params['path_replacement'] == None:
+            path_replacement = "null"
+        else:
+            path_replacement=self.module.params['path_replacement']
+        url = api_endpoint + site + '/rules'
+        headers = {'Content-Type':'application/json', 'Authorization': 'Bearer %s' %fly_auth_key}
+        payload = {"data": { "attributes": {
+                              "hostname": hostname,
+                              "backend_id": backend_id,
+                              "action_type": action_type,
+                              "path": path,
+                              "priority": priority, 
+                              "path_replacement": path_replacement
+                    } } }
+                    
+        resp = open_url(url,method="POST",headers=headers,validate_certs=False,data=json.dumps(payload))
+        try:
+            resp_json = json.loads(to_text(resp.read(), errors='surrogate_then_strict'))
+            self.module.exit_json(changed=True, response = resp_json)
+        except (json.JSONDecodeError, UnicodeError) as e:
+            error_msg += "; Failed to parse API response with error {0}: {1}".format(to_native(e), content)
+            self.module.fail_json(msg=error_msg)
+
+
+def handle_request(module):
+    fly = Fly(module)
+    command = module.params['command']
+    if command == 'create_hostname':
+        preview_hostname=fly.hostname_view()
+        if preview_hostname == False:
+            fly.hostname_add()
+        else:
+            pass
+    elif command == 'view_hostname':
+        fly.hostname_view()
+    elif command == 'add_backend':
+        fly.backend_add()
+    elif command == 'add_rule':
+        fly.rules_add()
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            command=dict(choices=['create_hostname', 'view_hostname', 'add_backend', 'add_rule'], required=True),
+            fly_auth_key=dict(aliases=['API_TOKEN'], no_log=True, required=True),
+            site=dict(type='str', required=True),
+            hostname=dict(type='str'),
+            backend_name=dict(type='str'),
+            backend_type=dict(type='str'),
+            backend_settings=dict(type='dict'),
+            backend_id=dict(type='str'),
+            action_type=dict(type='str'),
+            path =dict(type='str'),
+            priority =dict(type='str'),
+            path_replacement=dict(type='str')
+        ),
+    )
+    
+    handle_request(module)
+
+
+if __name__ == '__main__':  
+    main()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New module Fly allows users to create hostnames, link backends and add rules using Application Delvivery Network Fly's API.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
fly

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
  ansible python module location = /home/ubuntu/workspace/ansible-roles/env/lib/python3.5/site-packages/ansible
  executable location = /home/ubuntu/workspace/ansible-roles/env/bin/ansible
  python version = 3.5.1 (default, Dec 18 2015, 00:00:00) [GCC 4.8.4]
```