### PR TITLE
VMware: add support for memory_reservation

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -89,6 +89,9 @@ options:
     - ' - C(num_cpus) (integer): Number of CPUs.'
     - ' - C(num_cpu_cores_per_socket) (integer): Number of Cores Per Socket. Value should be multiple of C(num_cpus).'
     - ' - C(scsi) (string): Valid values are C(buslogic), C(lsilogic), C(lsilogicsas) and C(paravirtual) (default).'
+    - ' - C(memory_reservation) (integer): Amount of memory in MB to set resource limits for memory. version_added: 2.5'
+    - " - C(memory_reservation_lock) (boolean): If set true, memory resource reservation for VM
+          will always be equal to the VM's memory size. version_added: 2.5"
   guest_id:
     description:
     - Set the guest ID (Debian, RHEL, Windows...).
@@ -221,6 +224,8 @@ EXAMPLES = r'''
       num_cpus: 6
       num_cpu_cores_per_socket: 3
       scsi: paravirtual
+      memory_reservation: 512
+      memory_reservation_lock: True
     cdrom:
       type: iso
       iso_path: "[datastore1] livecd.iso"
@@ -656,6 +661,25 @@ class PyVmomiHelper(PyVmomi):
             if 'hotadd_cpu' in self.params['hardware']:
                 self.configspec.cpuHotAddEnabled = bool(self.params['hardware']['hotadd_cpu'])
                 if vm_obj is None or self.configspec.cpuHotAddEnabled != vm_obj.config.cpuHotAddEnabled:
+                    self.change_detected = True
+
+            if 'memory_reservation' in self.params['hardware']:
+                memory_reservation_mb = 0
+                try:
+                    memory_reservation_mb = int(self.params['hardware']['memory_reservation'])
+                except ValueError as e:
+                    self.module.fail_json(msg="Failed to set memory_reservation value."
+                                              "Valid value for memory_reservation value in MB (integer): %s" % e)
+
+                mem_alloc = vim.ResourceAllocationInfo()
+                mem_alloc.reservation = memory_reservation_mb
+                self.configspec.memoryAllocation = mem_alloc
+                if vm_obj is None or self.configspec.memoryAllocation.reservation != vm_obj.config.memoryAllocation.reservation:
+                    self.change_detected = True
+
+            if 'memory_reservation_lock' in self.params['hardware']:
+                self.configspec.memoryReservationLockedToMax = bool(self.params['hardware']['memory_reservation_lock'])
+                if vm_obj is None or self.configspec.memoryReservationLockedToMax != vm_obj.config.memoryReservationLockedToMax:
                     self.change_detected = True
 
     def configure_cdrom(self, vm_obj):

--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -46,6 +46,10 @@
         memory_mb: 512
         hotadd_memory: true
         hotadd_cpu: false
+        # vcsim does not support this changes so commenting
+        # till the time.
+        # memory_reservation: 512
+        # memory_reservation_lock: False
     disk:
         - size: 0gb
           type: thin


### PR DESCRIPTION
##### SUMMARY
This fix adds functionality to support memory_reservation and
memory_reservation_lock while managing Virtual Machine.

Fixes: #20407

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```