### PR TITLE
Adding module enos_config and its UT files

### DIFF
--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'network'}
+                    'supported_by': 'community'}
 
 
 DOCUMENTATION = """
@@ -97,19 +97,6 @@ options:
     required: false
     default: line
     choices: ['line', 'block', 'config']
-  force:
-    description:
-      - The force argument instructs the module to not consider the
-        current devices running-config.  When set to true, this will
-        cause the module to push the contents of I(src) into the device
-        without first checking if already configured.
-      - Note this argument should be considered deprecated.  To achieve
-        the equivalent, set the C(match=none) which is idempotent.  This
-        argument will be removed in a future release.
-    required: false
-    default: false
-    choices: [ "yes", "no" ]
-    version_added: "2.5"
   config:
     description:
       - The module, by default, will connect to the remote device and
@@ -195,11 +182,6 @@ def check_args(module, warnings):
     if module.params['comment']:
         if len(module.params['comment']) > 60:
             module.fail_json(msg='comment argument cannot be more than 60 characters')
-    if module.params['force']:
-        warnings.append('The force argument is deprecated, please use '
-                        'match=none instead.  This argument will be '
-                        'removed in the future')
-
 
 def get_running_config(module):
     contents = module.params['config']
@@ -271,10 +253,6 @@ def main():
         match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
         replace=dict(default='line', choices=['line', 'block', 'config']),
 
-        # this argument is deprecated in favor of setting match: none
-        # it will be removed in a future version
-        force=dict(default=False, type='bool'),
-
         config=dict(),
         backup=dict(type='bool', default=False),
         comment=dict(default=DEFAULT_COMMIT_COMMENT),
@@ -294,9 +272,6 @@ def main():
                            mutually_exclusive=mutually_exclusive,
                            required_if=required_if,
                            supports_check_mode=True)
-
-    if module.params['force'] is True:
-        module.params['match'] = 'none'
 
     warnings = list()
     check_args(module, warnings)

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -55,7 +55,6 @@ options:
         mutually exclusive with I(lines).
     required: false
     default: null
-    version_added: "2.5"
   before:
     description:
       - The ordered set of commands to push on to the command stack if
@@ -118,7 +117,6 @@ options:
     required: false
     default: no
     choices: ['yes', 'no']
-    version_added: "2.5"
   comment:
     description:
       - Allows a commit description to be specified to be included
@@ -126,7 +124,6 @@ options:
         not changed or committed, this argument is ignored.
     required: false
     default: 'configured by enos_config'
-    version_added: "2.5"
   admin:
     description:
       - Enters into administration configuration mode for making config
@@ -134,13 +131,12 @@ options:
     required: false
     default: false
     choices: [ "yes", "no" ]
-    version_added: "2.5"
 """
 
 EXAMPLES = """
 - name: configure top level configuration
   enos_config:
-    lines: hostname {{ inventory_hostname }}
+    "lines: hostname {{ inventory_hostname }}"
 
 - name: configure interface settings
   enos_config:

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -183,7 +183,7 @@ def check_args(module, warnings):
         if len(module.params['comment']) > 60:
             module.fail_json(msg='comment argument cannot be more than 60 characters')
 
-            
+
 def get_running_config(module):
     contents = module.params['config']
     if not contents:

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -183,6 +183,7 @@ def check_args(module, warnings):
         if len(module.params['comment']) > 60:
             module.fail_json(msg='comment argument cannot be more than 60 characters')
 
+            
 def get_running_config(module):
     contents = module.params['config']
     if not contents:

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -1,0 +1,316 @@
+#!/usr/bin/python
+#
+# Copyright (C) 2017 Lenovo, Inc.
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+
+DOCUMENTATION = """
+---
+module: enos_config
+version_added: "2.5"
+author: "Anil Kumar Muraleedharan (@amuraleedhar)"
+short_description: Manage Lenovo ENOS configuration sections
+description:
+  - Lenovo ENOS configurations use a simple block indent file syntax
+    for segmenting configuration into sections.  This module provides
+    an implementation for working with ENOS configuration sections in
+    a deterministic way.
+extends_documentation_fragment: enos
+notes:
+  - Tested against ENOS 8.4.1.2
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntax as some commands are automatically modified by the
+        device config parser.
+    required: false
+    default: null
+    aliases: ['commands']
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  src:
+    description:
+      - Specifies the source path to the file that contains the configuration
+        or configuration template to load.  The path to the source file can
+        either be the full path on the Ansible control host or a relative
+        path from the playbook or role root directory.  This argument is
+        mutually exclusive with I(lines).
+    required: false
+    default: null
+    version_added: "2.5"
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system.
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a change needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  If match is set to I(exact), command lines
+        must be an equal match.  Finally, if match is set to I(none), the
+        module will not attempt to compare the source configuration with
+        the running configuration on the remote device.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact', 'none']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct.
+    required: false
+    default: line
+    choices: ['line', 'block', 'config']
+  force:
+    description:
+      - The force argument instructs the module to not consider the
+        current devices running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+      - Note this argument should be considered deprecated.  To achieve
+        the equivalent, set the C(match=none) which is idempotent.  This
+        argument will be removed in a future release.
+    required: false
+    default: false
+    choices: [ "yes", "no" ]
+    version_added: "2.5"
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuration to use as the base
+        config for comparison.
+    required: false
+    default: null
+  backup:
+    description:
+      - This argument will cause the module to create a full backup of
+        the current C(running-config) from the remote device before any
+        changes are made.  The backup file is written to the C(backup)
+        folder in the playbook root directory.  If the directory does not
+        exist, it is created.
+    required: false
+    default: no
+    choices: ['yes', 'no']
+    version_added: "2.5"
+  comment:
+    description:
+      - Allows a commit description to be specified to be included
+        when the configuration is committed.  If the configuration is
+        not changed or committed, this argument is ignored.
+    required: false
+    default: 'configured by enos_config'
+    version_added: "2.5"
+  admin:
+    description:
+      - Enters into administration configuration mode for making config
+        changes to the device.
+    required: false
+    default: false
+    choices: [ "yes", "no" ]
+    version_added: "2.5"
+"""
+
+EXAMPLES = """
+- name: configure top level configuration
+  enos_config:
+    lines: hostname {{ inventory_hostname }}
+
+- name: configure interface settings
+  enos_config:
+    lines:
+      - description test interface
+      - ip address 172.31.1.1 255.255.255.0
+    parents: interface GigabitEthernet0/0/0/0
+
+- name: load a config from disk and replace the current config
+  enos_config:
+    src: config.cfg
+    backup: yes
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: Only when lines is specified.
+  type: list
+  sample: ['...', '...']
+backup_path:
+  description: The full path to the backup file
+  returned: when backup is yes
+  type: string
+  sample: /playbooks/ansible/backup/enos01.2016-07-16@22:28:34
+"""
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.enos import load_config, get_config
+from ansible.module_utils.enos import enos_argument_spec
+from ansible.module_utils.enos import check_args as enos_check_args
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+
+
+DEFAULT_COMMIT_COMMENT = 'configured by enos_config'
+
+
+def check_args(module, warnings):
+    enos_check_args(module, warnings)
+    if module.params['comment']:
+        if len(module.params['comment']) > 60:
+            module.fail_json(msg='comment argument cannot be more than 60 characters')
+    if module.params['force']:
+        warnings.append('The force argument is deprecated, please use '
+                        'match=none instead.  This argument will be '
+                        'removed in the future')
+
+
+def get_running_config(module):
+    contents = module.params['config']
+    if not contents:
+        contents = get_config(module)
+    return NetworkConfig(indent=1, contents=contents)
+
+
+def get_candidate(module):
+    candidate = NetworkConfig(indent=1)
+    if module.params['src']:
+        candidate.load(module.params['src'])
+    elif module.params['lines']:
+        parents = module.params['parents'] or list()
+        candidate.add(module.params['lines'], parents=parents)
+    return candidate
+
+
+def run(module, result):
+    match = module.params['match']
+    replace = module.params['replace']
+    replace_config = replace == 'config'
+    path = module.params['parents']
+    comment = module.params['comment']
+    admin = module.params['admin']
+    check_mode = module.check_mode
+
+    candidate = get_candidate(module)
+
+    if match != 'none' and replace != 'config':
+        contents = get_running_config(module)
+        configobj = NetworkConfig(contents=contents, indent=1)
+        commands = candidate.difference(configobj, path=path, match=match,
+                                        replace=replace)
+    else:
+        commands = candidate.items
+
+    if commands:
+        commands = dumps(commands, 'commands').split('\n')
+
+        if any((module.params['lines'], module.params['src'])):
+            if module.params['before']:
+                commands[:0] = module.params['before']
+
+            if module.params['after']:
+                commands.extend(module.params['after'])
+
+            result['commands'] = commands
+
+        diff = load_config(module, commands, result['warnings'],
+                           not check_mode, replace_config, comment, admin)
+        if diff:
+            result['diff'] = dict(prepared=diff)
+            result['changed'] = True
+
+
+def main():
+    """main entry point for module execution
+    """
+    argument_spec = dict(
+        src=dict(type='path'),
+
+        lines=dict(aliases=['commands'], type='list'),
+        parents=dict(type='list'),
+
+        before=dict(type='list'),
+        after=dict(type='list'),
+
+        match=dict(default='line', choices=['line', 'strict', 'exact', 'none']),
+        replace=dict(default='line', choices=['line', 'block', 'config']),
+
+        # this argument is deprecated in favor of setting match: none
+        # it will be removed in a future version
+        force=dict(default=False, type='bool'),
+
+        config=dict(),
+        backup=dict(type='bool', default=False),
+        comment=dict(default=DEFAULT_COMMIT_COMMENT),
+        admin=dict(type='bool', default=False)
+    )
+
+    argument_spec.update(enos_argument_spec)
+
+    mutually_exclusive = [('lines', 'src')]
+
+    required_if = [('match', 'strict', ['lines']),
+                   ('match', 'exact', ['lines']),
+                   ('replace', 'block', ['lines']),
+                   ('replace', 'config', ['src'])]
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           required_if=required_if,
+                           supports_check_mode=True)
+
+    if module.params['force'] is True:
+        module.params['match'] = 'none'
+
+    warnings = list()
+    check_args(module, warnings)
+
+    result = dict(changed=False, warnings=warnings)
+
+    if module.params['backup']:
+        result['__backup__'] = get_config(module)
+
+    run(module, result)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -313,4 +313,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -145,9 +145,9 @@ EXAMPLES = """
 - name: configure interface settings
   enos_config:
     lines:
-      - description test interface
-      - ip address 172.31.1.1 255.255.255.0
-    parents: interface GigabitEthernet0/0/0/0
+      - enable
+      - ip ospf enable
+    parents: interface ip 13
 
 - name: load a config from disk and replace the current config
   enos_config:

--- a/test/units/modules/network/enos/enos_module.py
+++ b/test/units/modules/network/enos/enos_module.py
@@ -115,4 +115,3 @@ class TestEnosModule(unittest.TestCase):
 
     def load_fixtures(self, commands=None):
         pass
-

--- a/test/units/modules/network/enos/enos_module.py
+++ b/test/units/modules/network/enos/enos_module.py
@@ -1,4 +1,4 @@
-# (c) 2016 Red Hat Inc.
+# Copyright (C) 2017 Lenovo, Inc.
 #
 # This file is part of Ansible
 #
@@ -22,8 +22,15 @@ __metaclass__ = type
 import os
 import json
 
-from units.modules.utils import AnsibleExitJson, AnsibleFailJson, ModuleTestCase
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import patch
+from ansible.module_utils import basic
+from ansible.module_utils._text import to_bytes
 
+
+def set_module_args(args):
+    args = json.dumps({'ANSIBLE_MODULE_ARGS': args})
+    basic._ANSIBLE_ARGS = to_bytes(args)
 
 fixture_path = os.path.join(os.path.dirname(__file__), 'fixtures')
 fixture_data = {}
@@ -47,9 +54,18 @@ def load_fixture(name):
     return data
 
 
-class TestEnosModule(ModuleTestCase):
+class AnsibleExitJson(Exception):
+    pass
 
-    def execute_module(self, failed=False, changed=False, commands=None, sort=True, defaults=False):
+
+class AnsibleFailJson(Exception):
+    pass
+
+
+class TestEnosModule(unittest.TestCase):
+
+    def execute_module(self, failed=False, changed=False, commands=None,
+                       sort=True, defaults=False):
 
         self.load_fixtures(commands)
 
@@ -62,23 +78,36 @@ class TestEnosModule(ModuleTestCase):
 
         if commands is not None:
             if sort:
-                self.assertEqual(sorted(commands), sorted(result['commands']), result['commands'])
+                self.assertEqual(sorted(commands), sorted(result['commands']),
+                                 result['commands'])
             else:
-                self.assertEqual(commands, result['commands'], result['commands'])
+                self.assertEqual(commands, result['commands'],
+                                 result['commands'])
 
         return result
 
     def failed(self):
-        with self.assertRaises(AnsibleFailJson) as exc:
-            self.module.main()
+        def fail_json(*args, **kwargs):
+            kwargs['failed'] = True
+            raise AnsibleFailJson(kwargs)
+
+        with patch.object(basic.AnsibleModule, 'fail_json', fail_json):
+            with self.assertRaises(AnsibleFailJson) as exc:
+                self.module.main()
 
         result = exc.exception.args[0]
         self.assertTrue(result['failed'], result)
         return result
 
     def changed(self, changed=False):
-        with self.assertRaises(AnsibleExitJson) as exc:
-            self.module.main()
+        def exit_json(*args, **kwargs):
+            if 'changed' not in kwargs:
+                kwargs['changed'] = False
+            raise AnsibleExitJson(kwargs)
+
+        with patch.object(basic.AnsibleModule, 'exit_json', exit_json):
+            with self.assertRaises(AnsibleExitJson) as exc:
+                self.module.main()
 
         result = exc.exception.args[0]
         self.assertEqual(result['changed'], changed, result)
@@ -86,3 +115,4 @@ class TestEnosModule(ModuleTestCase):
 
     def load_fixtures(self, commands=None):
         pass
+

--- a/test/units/modules/network/enos/fixtures/enos_config_config.cfg
+++ b/test/units/modules/network/enos/fixtures/enos_config_config.cfg
@@ -1,0 +1,47 @@
+Current configuration:
+!
+version "8.4.3.12"
+switch-type "Lenovo RackSwitch G8272"
+iscli-new
+!
+!
+access https enable
+
+snmp-server location "Location:,Room:,Rack:Rack 3,LRU:40"
+snmp-server read-community "public"
+snmp-server trap-source 128
+!
+!
+!
+no system dhcp
+no system default-ip mgt
+hostname router
+!
+!
+!
+!interface ip 1
+!       addr <default>
+!       enable
+!
+interface ip 13
+        ip address 1.2.3.4 255.255.255.0
+        enable
+        exit
+!
+interface ip 128
+        ip address 10.241.105.24 255.255.255.0
+        enable
+        exit
+!
+ip gateway 4 address 10.241.105.1
+ip gateway 4 enable
+!
+!
+!
+!
+router bgp
+        as 100
+!
+!
+end
+

--- a/test/units/modules/network/enos/fixtures/enos_config_src.cfg
+++ b/test/units/modules/network/enos/fixtures/enos_config_src.cfg
@@ -1,0 +1,6 @@
+!
+hostname foo
+!
+interface ip 13
+ no ip ospf enable
+!

--- a/test/units/modules/network/enos/test_enos_config.py
+++ b/test/units/modules/network/enos/test_enos_config.py
@@ -102,11 +102,6 @@ class TestEnosConfigModule(TestEnosModule):
         commands = parents + lines
         self.execute_module(changed=True, commands=commands)
 
-    def test_enos_config_force(self):
-        lines = ['hostname router']
-        set_module_args(dict(lines=lines, force=True))
-        self.execute_module(changed=True, commands=lines)
-
     def test_enos_config_match_none(self):
         lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
         parents = ['interface ip 13']

--- a/test/units/modules/network/enos/test_enos_config.py
+++ b/test/units/modules/network/enos/test_enos_config.py
@@ -128,4 +128,3 @@ class TestEnosConfigModule(TestEnosModule):
         set_module_args(dict(lines=lines, parents=parents, match='exact'))
         commands = parents + lines
         self.execute_module(changed=True, commands=commands, sort=False)
-

--- a/test/units/modules/network/enos/test_enos_config.py
+++ b/test/units/modules/network/enos/test_enos_config.py
@@ -1,0 +1,131 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.enos import enos_config
+from .enos_module import TestEnosModule, load_fixture, set_module_args
+
+
+class TestEnosConfigModule(TestEnosModule):
+
+    module = enos_config
+
+    def setUp(self):
+        self.patcher_get_config = patch('ansible.modules.network.enos.enos_config.get_config')
+        self.mock_get_config = self.patcher_get_config.start()
+        self.patcher_exec_command = patch('ansible.modules.network.enos.enos_config.load_config')
+        self.mock_exec_command = self.patcher_exec_command.start()
+
+    def tearDown(self):
+        self.patcher_get_config.stop()
+        self.patcher_exec_command.stop()
+
+    def load_fixtures(self, commands=None):
+        config_file = 'enos_config_config.cfg'
+        self.mock_get_config.return_value = load_fixture(config_file)
+        self.mock_exec_command.return_value = 'dummy diff'
+
+    def test_enos_config_unchanged(self):
+        src = load_fixture('enos_config_config.cfg')
+        set_module_args(dict(src=src))
+        self.execute_module()
+
+    def test_enos_config_src(self):
+        src = load_fixture('enos_config_src.cfg')
+        set_module_args(dict(src=src))
+        commands = ['hostname foo', 'interface ip 13',
+                    'no ip ospf enable']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_enos_config_backup(self):
+        set_module_args(dict(backup=True))
+        result = self.execute_module()
+        self.assertIn('__backup__', result)
+
+    def test_enos_config_lines_wo_parents(self):
+        set_module_args(dict(lines=['hostname foo']))
+        commands = ['hostname foo']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_enos_config_lines_w_parents(self):
+        set_module_args(dict(lines=['shutdown'], parents=['interface ip 13']))
+        commands = ['interface ip 13', 'shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_enos_config_before(self):
+        set_module_args(dict(lines=['hostname foo'], before=['test1', 'test2']))
+        commands = ['test1', 'test2', 'hostname foo']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_enos_config_after(self):
+        set_module_args(dict(lines=['hostname foo'], after=['test1', 'test2']))
+        commands = ['hostname foo', 'test1', 'test2']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_enos_config_before_after_no_change(self):
+        set_module_args(dict(lines=['hostname router'],
+                             before=['test1', 'test2'],
+                             after=['test3', 'test4']))
+        self.execute_module()
+
+    def test_enos_config_config(self):
+        config = 'hostname localhost'
+        set_module_args(dict(lines=['hostname router'], config=config))
+        commands = ['hostname router']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_enos_config_replace_block(self):
+        lines = ['description test string', 'test string']
+        parents = ['interface ip 13']
+        set_module_args(dict(lines=lines, replace='block', parents=parents))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands)
+
+    def test_enos_config_force(self):
+        lines = ['hostname router']
+        set_module_args(dict(lines=lines, force=True))
+        self.execute_module(changed=True, commands=lines)
+
+    def test_enos_config_match_none(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string']
+        parents = ['interface ip 13']
+        set_module_args(dict(lines=lines, parents=parents, match='none'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_enos_config_match_strict(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'exit']
+        parents = ['interface ip 13']
+        set_module_args(dict(lines=lines, parents=parents, match='strict'))
+        commands = parents + ['exit']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_enos_config_match_exact(self):
+        lines = ['ip address 1.2.3.4 255.255.255.0', 'description test string',
+                 'shutdown']
+        parents = ['interface ip 13']
+        set_module_args(dict(lines=lines, parents=parents, match='exact'))
+        commands = parents + lines
+        self.execute_module(changed=True, commands=commands, sort=False)
+


### PR DESCRIPTION
SUMMARY

Creating the config module for enos from Lenovo.

ISSUE TYPE

New Module Pull Request

COMPONENT NAME

lib/ansible/modules/network/enos/enos_config.py
test/units/modules/network/enos/fixtures/enos_config_config.cfg
test/units/modules/network/enos/fixtures/enos_config_src.cfg
test/units/modules/network/enos/test_enos_config.py

ANSIBLE VERSION

ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

ADDITIONAL INFORMATION

This is an effort to create modules for enos based switches from Lenovo.