### PR TITLE
AWS S3: fix method call for fakes3 S3 backend

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -556,12 +556,17 @@ def get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url):
         params = dict(module=module, conn_type='client', resource='s3', use_ssl=rgw.scheme == 'https', region=location, endpoint=s3_url, **aws_connect_kwargs)
     elif is_fakes3(s3_url):
         fakes3 = urlparse(s3_url)
+        port = fakes3.port
         if fakes3.scheme == 'fakes3s':
             protocol = "https"
+            if port is None:
+                port = 443
         else:
             protocol = "http"
+            if port is None:
+                port = 80
         params = dict(module=module, conn_type='client', resource='s3', region=location,
-                      endpoint="%s://%s:%s" % (protocol, fakes3.hostname, to_text(fakes3.port)),
+                      endpoint="%s://%s:%s" % (protocol, fakes3.hostname, to_text(port)),
                       use_ssl=fakes3.scheme == 'fakes3s', **aws_connect_kwargs)
     elif is_walrus(s3_url):
         walrus = urlparse(s3_url).hostname

--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -555,15 +555,14 @@ def get_s3_connection(module, aws_connect_kwargs, location, rgw, s3_url):
         rgw = urlparse(s3_url)
         params = dict(module=module, conn_type='client', resource='s3', use_ssl=rgw.scheme == 'https', region=location, endpoint=s3_url, **aws_connect_kwargs)
     elif is_fakes3(s3_url):
-        for kw in ['is_secure', 'host', 'port'] and list(aws_connect_kwargs.keys()):
-            del aws_connect_kwargs[kw]
         fakes3 = urlparse(s3_url)
         if fakes3.scheme == 'fakes3s':
             protocol = "https"
         else:
             protocol = "http"
-        params = dict(service_name='s3', endpoint_url="%s://%s:%s" % (protocol, fakes3.hostname, to_text(fakes3.port)),
-                      use_ssl=fakes3.scheme == 'fakes3s', region_name=None, **aws_connect_kwargs)
+        params = dict(module=module, conn_type='client', resource='s3', region=location,
+                      endpoint="%s://%s:%s" % (protocol, fakes3.hostname, to_text(fakes3.port)),
+                      use_ssl=fakes3.scheme == 'fakes3s', **aws_connect_kwargs)
     elif is_walrus(s3_url):
         walrus = urlparse(s3_url).hostname
         params = dict(module=module, conn_type='client', resource='s3', region=location, endpoint=walrus, **aws_connect_kwargs)


### PR DESCRIPTION
##### SUMMARY
Using `fakes3` urls does not work anymore, this change fixes the method calls and let boto3 get the credentials as if it was using the normal s3 backend.

Fixes #33083

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/marco/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/marco/exoscale/ansible-exoscale-s3/.venv/lib/python2.7/site-packages/ansible
  executable location = /home/marco/exoscale/ansible-exoscale-s3/.venv/bin/ansible
  python version = 2.7.14 (default, Oct 18 2017, 13:27:01) [GCC 7.2.0]
```