### PR TITLE
ec2_metric_alarm: TreatMissingData feature

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
@@ -252,9 +252,14 @@ def create_metric_alarm(connection, module):
             'Dimensions': dimensions,
             'TreatMissingData': treat_missing_data
         }.items():
-            if alarm[key] != value:
-                changed = True
-                alarm[key] = value
+            try:
+                if alarm[key] != value:
+                    changed = True
+            except KeyError:
+                if value is not None:
+                    changed = True
+
+            alarm[key] = value
 
         for key, value in {
             'AlarmActions': alarm_actions,
@@ -268,21 +273,23 @@ def create_metric_alarm(connection, module):
 
         try:
             if changed:
-                connection.put_metric_alarm(AlarmName=alarm['AlarmName'],
-                                            MetricName=alarm['MetricName'],
-                                            Namespace=alarm['Namespace'],
-                                            Statistic=alarm['Statistic'],
-                                            ComparisonOperator=alarm['ComparisonOperator'],
-                                            Threshold=alarm['Threshold'],
-                                            Period=alarm['Period'],
-                                            EvaluationPeriods=alarm['EvaluationPeriods'],
-                                            Unit=alarm['Unit'],
-                                            AlarmDescription=alarm['AlarmDescription'],
-                                            Dimensions=alarm['Dimensions'],
-                                            AlarmActions=alarm['AlarmActions'],
-                                            InsufficientDataActions=alarm['InsufficientDataActions'],
-                                            OKActions=alarm['OKActions'],
-                                            TreatMissingData=alarm['TreatMissingData'])
+                connection.put_metric_alarm(
+                    AlarmName=alarm['AlarmName'],
+                    MetricName=alarm['MetricName'],
+                    Namespace=alarm['Namespace'],
+                    Statistic=alarm['Statistic'],
+                    ComparisonOperator=alarm['ComparisonOperator'],
+                    Threshold=alarm['Threshold'],
+                    Period=alarm['Period'],
+                    EvaluationPeriods=alarm['EvaluationPeriods'],
+                    Unit=alarm['Unit'],
+                    AlarmDescription=alarm['AlarmDescription'],
+                    Dimensions=alarm['Dimensions'],
+                    AlarmActions=alarm['AlarmActions'],
+                    InsufficientDataActions=alarm['InsufficientDataActions'],
+                    OKActions=alarm['OKActions'],
+                    TreatMissingData=alarm['TreatMissingData']
+                )
         except botocore.exceptions.ClientError as e:
             module.fail_json(msg=str(e))
 

--- a/test/sanity/pep8/legacy-files.txt
+++ b/test/sanity/pep8/legacy-files.txt
@@ -12,7 +12,6 @@ lib/ansible/modules/cloud/amazon/ec2_elb.py
 lib/ansible/modules/cloud/amazon/ec2_elb_lb.py
 lib/ansible/modules/cloud/amazon/ec2_eni_facts.py
 lib/ansible/modules/cloud/amazon/ec2_lc_facts.py
-lib/ansible/modules/cloud/amazon/ec2_metric_alarm.py
 lib/ansible/modules/cloud/amazon/ec2_scaling_policy.py
 lib/ansible/modules/cloud/amazon/ec2_snapshot.py
 lib/ansible/modules/cloud/amazon/ec2_snapshot_facts.py


### PR DESCRIPTION
##### SUMMARY
This introduces option for `TreatMissingData` in `ec2_metric_alarm` module.

There is alread pull request for this, but it was abandoned by the author. I rebased it and made sure things works correctly (as reported by someone from the community in referenced issues).

Existing pull request: #23407
Issues: 
* #28160
* #23493 

##### ISSUE TYPE
 - Feature Pull Request
 
##### COMPONENT NAME
ec2_metric_alarm module

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0
  config file = None
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

