### PR TITLE
zabbix_host: documentation fix

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -192,7 +192,7 @@ EXAMPLES = '''
         port: 12345
     proxy: a.zabbix.proxy
 
-- name: Create a new host or update an existing host's tls settings
+- name: Update an existing host's TLS settings
   local_action:
     module: zabbix_host
     server_url: http://monitor.example.com


### PR DESCRIPTION
##### SUMMARY
Minor documentation fix in zabbix_host examples; the second example can only work as an update and not as a create as it is missing interface information.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
zabbix_host 

##### ANSIBLE VERSION
2.5.0