### PR TITLE
zabbix_host: make host_groups actually optional on update

### DIFF
--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -640,10 +640,11 @@ def main():
             host.delete_host(host_id, host_name)
             module.exit_json(changed=True, result="Successfully delete host %s" % host_name)
         else:
-            if not group_ids:
+            if not host_groups:
                 # if host_groups have not been specified when updating an existing host, just
                 # get the group_ids from the existing host without updating them.
-                group_ids = host.get_group_ids_by_group_names(host.get_host_groups_by_host_id(host_id))
+                host_groups = host.get_host_groups_by_host_id(host_id)
+                group_ids = host.get_group_ids_by_group_names(host_groups)
 
             if not force:
                 # get existing groups, interfaces and templates and merge them with ones provided as an argument

--- a/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
+++ b/lib/ansible/modules/monitoring/zabbix/zabbix_host.py
@@ -25,6 +25,7 @@ author:
     - "Tony Minfei Ding"
     - "Harrison Gu (@harrisongu)"
     - "Werner Dijkerman"
+    - "Eike Frost (@eikef)"
 requirements:
     - "python >= 2.6"
     - "zabbix-api >= 0.5.3"
@@ -640,7 +641,9 @@ def main():
             module.exit_json(changed=True, result="Successfully delete host %s" % host_name)
         else:
             if not group_ids:
-                module.fail_json(msg="Specify at least one group for updating host '%s'." % host_name)
+                # if host_groups have not been specified when updating an existing host, just
+                # get the group_ids from the existing host without updating them.
+                group_ids = host.get_group_ids_by_group_names(host.get_host_groups_by_host_id(host_id))
 
             if not force:
                 # get existing groups, interfaces and templates and merge them with ones provided as an argument


### PR DESCRIPTION
In zabbix_host, the host_groups parameter was effectively not optional thus far when updating a host. This PR fixes that by using the existing host's host groups when updating. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
2.5.0