### PR TITLE
ios_logging: change IOS command pipe to section to include

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -245,7 +245,7 @@ def map_config_to_obj(module):
     obj = []
     dest_group = ('console', 'host', 'monitor', 'buffered', 'on', 'facility')
 
-    data = get_config(module, flags=['| section logging'])
+    data = get_config(module, flags=['| include logging'])
 
     for line in data.split('\n'):
         match = re.search(r'logging (\S+)', line, re.M)


### PR DESCRIPTION
This improves compatibility with older IOS devices which do not
support "section" but "include" has been supported for a lot longer.

##### SUMMARY
We support a mix of old and new Cisco devices, and some are currently running software trains that don't support the section command (e.g. 3750 switches).  This change allows the module to run on these platforms.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_logging