### PR TITLE
Add Python 3.7-dev to the default docker image.

### DIFF
--- a/test/runner/Dockerfile
+++ b/test/runner/Dockerfile
@@ -10,7 +10,10 @@ RUN apt-get update -y && \
     curl \
     gcc \
     git \
+    libbz2-dev \
     libffi-dev \
+    libreadline-dev \
+    libsqlite3-dev \
     libxml2-dev \
     libxslt1-dev \
     locales \
@@ -24,6 +27,12 @@ RUN apt-get update -y && \
     shellcheck \
     && \
     apt-get clean
+
+ADD https://raw.githubusercontent.com/pyenv/pyenv-installer/master/bin/pyenv-installer /tmp/pyenv-installer
+RUN bash -c 'PYENV_ROOT=/usr/local/opt/pyenv bash /tmp/pyenv-installer'
+RUN bash -c 'PYENV_ROOT=/usr/local/opt/pyenv /usr/local/opt/pyenv/bin/pyenv install 3.7-dev'
+RUN ln -s /usr/local/opt/pyenv/versions/3.7-dev/bin/python3.7 /usr/local/bin/python3.7
+RUN ln -s /usr/local/opt/pyenv/versions/3.7-dev/bin/pip3.7 /usr/local/bin/pip3.7
 
 RUN rm /etc/apt/apt.conf.d/docker-clean
 RUN locale-gen en_US.UTF-8

--- a/test/runner/docker/requirements.sh
+++ b/test/runner/docker/requirements.sh
@@ -5,6 +5,7 @@ python_versions=(
     2.7
     3.5
     3.6
+    3.7
 )
 
 requirements=()

--- a/test/runner/lib/classification.py
+++ b/test/runner/lib/classification.py
@@ -509,6 +509,12 @@ class PathMapper(object):
                     }
 
         if path.startswith('test/runner/'):
+            if dirname == 'test/runner' and name in (
+                    'Dockerfile',
+                    '.dockerignore',
+            ):
+                return minimal  # not used by tests, only used to build the default container
+
             return all_tests(self.args)  # test infrastructure, run all tests
 
         if path.startswith('test/utils/shippable/'):


### PR DESCRIPTION
##### SUMMARY

Add Python 3.7-dev to the default docker image.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

default docker test image

##### ANSIBLE VERSION

```
ansible 2.5.0 (docker-python-3.7 20b760176c) last updated 2017/11/20 16:43:13 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
