### PR TITLE
ios_logging: change IOS command pipe to section to include (#33100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,8 @@ Ansible Changes By Release
   (https://github.com/ansible/ansible/pull/32710)
 * Fix nxos_snmp_host bug
   (https://github.com/ansible/ansible/pull/32916)
+* Make IOS devices consistent ios_logging
+  (https://github.com/ansible/ansible/pull/33100)
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -245,7 +245,7 @@ def map_config_to_obj(module):
     obj = []
     dest_group = ('console', 'host', 'monitor', 'buffered', 'on', 'facility')
 
-    data = get_config(module, flags=['| section logging'])
+    data = get_config(module, flags=['| include logging'])
 
     for line in data.split('\n'):
         match = re.search(r'logging (\S+)', line, re.M)


### PR DESCRIPTION
This improves compatibility with older IOS devices which do not
support "section" but "include" has been supported for a lot longer.
(cherry picked from commit a6e425e5a35b2baae7118cb6d64b0c33e7c20fcb)
