### PR TITLE
Limit paramiko to < 2.4.0 for python 2.6.

### DIFF
--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -9,3 +9,4 @@ isort < 4.2.8 # 4.2.8 changes import sort order requirements which breaks previo
 pycrypto >= 2.6 # Need features found in 2.6 and greater
 ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
 idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
+paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6


### PR DESCRIPTION
##### SUMMARY

Limit paramiko to < 2.4.0 for python 2.6.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/runner/requirements/constraints.txt

##### ANSIBLE VERSION

```
ansible 2.5.0 (docker-default-2.6 0802a07e96) last updated 2017/11/20 19:45:24 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
