### PR TITLE
Handle "DisconnectHandler" in xmpppy ComonClient module

### DIFF
--- a/lib/ansible/modules/notification/jabber.py
+++ b/lib/ansible/modules/notification/jabber.py
@@ -154,7 +154,11 @@ def main():
         if not module.check_mode:
             conn.send(msg)
         time.sleep(1)
-        conn.disconnect()
+        try:
+            conn.disconnect()
+        except IOError as e:
+            if e.message != 'Disconnected from server.':
+                raise e
     except Exception as e:
         module.fail_json(msg="unable to send msg: %s" % to_native(e), exception=traceback.format_exc())
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Handle exception "DisconnectHandler" in ComonClient class of xmpppy module.  Without it we have error 'IOError: Disconnected from server.'  after message sending.

Handled exception is raised by class ComonClient:
```
    def DisconnectHandler(self):
        """ Default disconnect handler. Just raises an IOError.
            If you choosed to use this class in your production client,
            override this method or at least unregister it. """
        raise IOError('Disconnected from server.')
```
And it is expected step of disconnection procedure.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/notification/jabber.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/tomlee/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Jan 19 2017, 14:48:08) [GCC 6.3.0 20170118]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
