### PR TITLE
cloud: ovirt: Don't require all iscsi params to be passed to host

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -499,12 +499,13 @@ def main():
             )
         elif state == 'iscsidiscover':
             host_id = get_id_by_name(hosts_service, module.params['name'])
+            iscsi_param = module.params['iscsi']
             iscsi_targets = hosts_service.service(host_id).iscsi_discover(
                 iscsi=otypes.IscsiDetails(
-                    port=int(module.params['iscsi']['port']) if module.params['iscsi']['port'].isdigit() else None,
-                    username=module.params['iscsi']['username'],
-                    password=module.params['iscsi']['password'],
-                    address=module.params['iscsi']['address'],
+                    port=int(iscsi_param.get('port', 3260)),
+                    username=iscsi_param.get('username'),
+                    password=iscsi_param.get('password'),
+                    address=iscsi_param.get('address'),
                 ),
             )
             ret = {
@@ -514,14 +515,15 @@ def main():
             }
         elif state == 'iscsilogin':
             host_id = get_id_by_name(hosts_service, module.params['name'])
+            iscsi_param = module.params['iscsi']
             ret = hosts_module.action(
                 action='iscsi_login',
                 iscsi=otypes.IscsiDetails(
-                    port=int(module.params['iscsi']['port']) if module.params['iscsi']['port'].isdigit() else None,
-                    username=module.params['iscsi']['username'],
-                    password=module.params['iscsi']['password'],
-                    address=module.params['iscsi']['address'],
-                    target=module.params['iscsi']['target'],
+                    port=int(iscsi_param.get('port', 3260)),
+                    username=iscsi_param.get('username'),
+                    password=iscsi_param.get('password'),
+                    address=iscsi_param.get('address'),
+                    target=iscsi_param.get('target'),
                 ),
             )
         elif state == 'started':

--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -304,7 +304,7 @@ class StorageDomainModule(BaseModule):
                     otypes.LogicalUnit(
                         id=lun_id,
                         address=storage.get('address'),
-                        port=storage.get('port', 3260),
+                        port=int(storage.get('port', 3260)),
                         target=storage.get('target'),
                         username=storage.get('username'),
                         password=storage.get('password'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: https://github.com/ansible/ansible/issues/32670

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
