### PR TITLE
mysql_db: Added skip lock tables option

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_db.py
+++ b/lib/ansible/modules/database/mysql/mysql_db.py
@@ -63,6 +63,12 @@ options:
     required: false
     default: true
     version_added: "2.1"
+  skip_lock_tables:
+    description:
+      - Option used to lock all tables before dumping them
+    required: false
+    default: false
+    version_added: "2.5"
 author: "Ansible Core Team"
 requirements:
    - mysql (command line binary)
@@ -137,7 +143,7 @@ def db_delete(cursor, db):
 
 
 def db_dump(module, host, user, password, db_name, target, all_databases, port, config_file, socket=None, ssl_cert=None, ssl_key=None, ssl_ca=None,
-            single_transaction=None, quick=None):
+            single_transaction=None, quick=None, skip_lock_tables=None):
     cmd = module.get_bin_path('mysqldump', True)
     # If defined, mysqldump demands --defaults-extra-file be the first option
     if config_file:
@@ -164,6 +170,8 @@ def db_dump(module, host, user, password, db_name, target, all_databases, port, 
         cmd += " --single-transaction=true"
     if quick:
         cmd += " --quick"
+    if skip_lock_tables:
+        cmd += " --skip-lock-tables"
 
     path = None
     if os.path.splitext(target)[-1] == '.gz':
@@ -271,6 +279,7 @@ def main():
             config_file=dict(default="~/.my.cnf", type='path'),
             single_transaction=dict(default=False, type='bool'),
             quick=dict(default=True, type='bool'),
+            skip_lock_tables=dict(default=False, type='bool'),
         ),
         supports_check_mode=True
     )
@@ -297,6 +306,7 @@ def main():
     login_host = module.params["login_host"]
     single_transaction = module.params["single_transaction"]
     quick = module.params["quick"]
+    skip_lock_tables = module.params["skip_lock_tables"]
 
     if state in ['dump', 'import']:
         if target is None:
@@ -340,7 +350,7 @@ def main():
                 rc, stdout, stderr = db_dump(module, login_host, login_user,
                                              login_password, db, target, all_databases,
                                              login_port, config_file, socket, ssl_cert, ssl_key,
-                                             ssl_ca, single_transaction, quick)
+                                             ssl_ca, single_transaction, quick, skip_lock_tables)
                 if rc != 0:
                     module.fail_json(msg="%s" % stderr)
                 else:


### PR DESCRIPTION
Option used to lock all tables before dumping them using the mysqldump option [--skip-lock-tables](https://dev.mysql.com/doc/refman/5.5/en/mysqldump.html#option_mysqldump_lock-tables).


##### SUMMARY
 I was inspired by this Issue #32097 which I found as I needed to skip lock tables in mysqldump, that issue was just closed with no resolution so I decided to fix it on my local anisble download. I had a playbook use the mysql_db ansible module and the playbook was failing as various tables were getting the error `Table 'db.table' doesn't exist when using LOCK TABLES\n"}`

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
 lib/ansible/modules/database/mysql/mysql_db.py

##### ANSIBLE VERSION
My current version is 2.4, this could be slated for 2.4 with a patch or 2.5 (doesn't matter to me)


##### ADDITIONAL INFORMATION
If a table is locked, and you run a mysqldump via ansible the entire dump fails. With this option, it just skips that table. This is a flag provided my MySQL as seen in their [documentation](https://dev.mysql.com/doc/refman/5.5/en/mysqldump.html#option_mysqldump_lock-tables).

Playbook
```
    - name: mysqldump database
      mysql_db: state=dump name=database target=/home/username/databasedump.sql login_user=root login_password=password skip_lock_tables=true
```
Debug Output
```
changed: [hostname] => {
    "changed": true,
    "db": "database",
    "failed": false,
    "invocation": {
        "module_args": {
            "collation": "",
            "config_file": "/root/.my.cnf",
            "connect_timeout": 30,
            "encoding": "",
            "login_host": "localhost",
            "login_password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "login_port": 3306,
            "login_unix_socket": null,
            "login_user": "root",
            "name": "database",
            "quick": true,
            "single_transaction": false,
            "skip_lock_tables": true,
            "ssl_ca": null,
            "ssl_cert": null,
            "ssl_key": null,
            "state": "dump",
            "target": "/home/username/databasedump.sql"
        }
    },
    "msg": ""
}
```
