### PR TITLE
VMware: Add support for numCoresPerSocket

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -41,8 +41,11 @@
     guest_id: centos64Guest
     datacenter: "{{ (item|basename).split('_')[0] }}"
     hardware:
-        num_cpus: 1
+        num_cpus: 4
+        num_cpu_cores_per_socket: 2
         memory_mb: 512
+        hotadd_memory: true
+        hotadd_cpu: false
     disk:
         - size: 0gb
           type: thin
@@ -70,10 +73,9 @@
     guest_id: centos64Guest
     datacenter: "{{ (item|basename).split('_')[0] }}"
     hardware:
-        num_cpus: 1
+        num_cpus: 4
+        num_cpu_cores_per_socket: 2
         memory_mb: 512
-        hotadd_memory: true
-        hotadd_cpu: false
     disk:
         - size: 0gb
           type: thin


### PR DESCRIPTION
##### SUMMARY
This fix adds support for hardware parameter 'numCoresPerSocket'
in vmware_guest module. Also, adds integration tests for this change.

Fixes: #20406

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```