### PR TITLE
Add a 'validate' parameter to the juniper_package network module

### DIFF
--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: junos_package
-version_added: "2.1"
+version_added: "2.5"
 author: "Peter Sprygada (@privateip)"
 short_description: Installs packages on remote devices running Junos
 description:

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -61,6 +61,15 @@ options:
     required: false
     default: false
     choices: ['true', 'false']
+  validate:
+    description:
+      - The I(validate) argument is responsible for instructing the remote
+        device to skip checking the current device configuration
+        compatibility with the package being installed. When set to false
+        validation is not performed.
+    required: false
+    default: true
+    choices: ['true', 'false']
   force:
     description:
       - The I(force) argument instructs the module to bypass the package
@@ -135,12 +144,14 @@ def install_package(module, device):
     junos = SW(device)
     package = module.params['src']
     no_copy = module.params['no_copy']
+    validate = module.params['validate']
 
     def progress_log(dev, report):
         module.log(report)
 
     module.log('installing package')
-    result = junos.install(package, progress=progress_log, no_copy=no_copy)
+    result = junos.install(package, progress=progress_log, no_copy=no_copy,
+                           validate=validate)
 
     if not result:
         module.fail_json(msg='Unable to install package on device')
@@ -158,6 +169,7 @@ def main():
         version=dict(),
         reboot=dict(type='bool', default=True),
         no_copy=dict(default=False, type='bool'),
+        validate=dict(default=True, type='bool'),
         force=dict(type='bool', default=False),
         transport=dict(default='netconf', choices=['netconf'])
     )

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -16,7 +16,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: junos_package
-version_added: "2.5"
+version_added: "2.1"
 author: "Peter Sprygada (@privateip)"
 short_description: Installs packages on remote devices running Junos
 description:
@@ -67,6 +67,7 @@ options:
         device to skip checking the current device configuration
         compatibility with the package being installed. When set to false
         validation is not performed.
+    version_added: 2.5
     required: false
     default: true
     choices: ['true', 'false']


### PR DESCRIPTION
Add a 'validate' parameter to the juniper_package module to optionally skip checking configuration compatibility against the JUNOS package being installed by `juniper_package`

##### SUMMARY
Update the juniper_package network module so that device configuration validation checks can optionally be skipped. This may be required when forcing an update between major releases of JUNOS.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/network/junos/junos_package.py


##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/jmillay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jmillay/.virtualenvs/dev/lib/python2.7/site-packages/ansible
  executable location = /Users/jmillay/.virtualenvs/dev/bin/ansible
  python version = 2.7.13 (default, Dec 18 2016, 07:03:39) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
Tested on Juniper SRX-100 and SRX-210. Example playbook task:
```
- name: "Install {{ junos_package }} on device"
  junos_package:
    src: "{{ junos_package }}"
    reboot: false
    no_copy: false
    force: true
    validate: false
    provider:
      username: "{{ username }}"
      password: ""
      host: "{{ ansible_ssh_host }}"
```
