### PR TITLE
Fixes #33156 - Handle Cluster Option correctly

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1240,7 +1240,7 @@ class PyVmomiHelper(PyVmomi):
         if self.params['resource_pool']:
             resource_pool = self.select_resource_pool_by_name(self.params['resource_pool'])
         # next priority, esxi hostname given.
-        elif self.params['esxi_hostname']:
+        elif self.params['esxi_hostname'] or self.params['cluster']:
             host = self.select_host()
             resource_pool = self.select_resource_pool_by_host(host)
         # next priority, cluster given, take the root of the pool
@@ -1338,8 +1338,7 @@ class PyVmomiHelper(PyVmomi):
                 # create the relocation spec
                 relospec = vim.vm.RelocateSpec()
 
-                # Only select specific host when ESXi hostname is provided
-                if self.params['esxi_hostname']:
+                if self.params['esxi_hostname'] or self.params['cluster']:
                     relospec.host = self.select_host()
                 relospec.datastore = datastore
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes Bug #33156 - Which handles the Cluster option properly with finding a datastore.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/vmware/vmware_guest.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /home/jzimmett/.ansible.cfg
  configured module search path = [u'/home/jzimmett/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
