### PR TITLE
Some fixes for tiny grammar and punctuation errors in the windows guides.

### DIFF
--- a/docs/docsite/rst/windows_setup.rst
+++ b/docs/docsite/rst/windows_setup.rst
@@ -102,7 +102,7 @@ WinRM Setup
 ```````````
 Once Powershell has been upgraded to at least version 3.0, the final step is for the
 WinRM service to be configured so that Ansible can connect to it. There are two
-main components of the WinRM service that governs how Ansible can interface with
+main components of the WinRM service that govern how Ansible can interface with
 the Windows host: the ``listener`` and the ``service`` configuration settings.
 
 Details about each component can be read below, but the script
@@ -169,7 +169,7 @@ In the example above there are two listeners activated; one is listening on
 port 5985 over HTTP and the other is listening on port 5986 over HTTPS. Some of
 the key options that are useful to understand are:
 
-* ``Transport``: Whether the listener is run over HTTP or HTTPS, it is
+* ``Transport``: Whether the listener is run over HTTP or HTTPS.  It is
   recommended to use a listener over HTTPS as the data is encrypted without
   any further changes required.
 

--- a/docs/docsite/rst/windows_usage.rst
+++ b/docs/docsite/rst/windows_usage.rst
@@ -10,7 +10,7 @@ This document covers details specific to using Ansible for Windows.
 Use Cases
 `````````
 Ansible can be used to orchestrate a multitude of tasks on Windows servers. 
-Below are some examples and info about common tasks.
+Below are some examples and information about common tasks.
 
 Installing Software
 -------------------

--- a/docs/docsite/rst/windows_winrm.rst
+++ b/docs/docsite/rst/windows_winrm.rst
@@ -25,7 +25,7 @@ with the Ansible package, but can be installed by running the following::
 Authentication Options
 ``````````````````````
 When connecting to a Windows host, there are several different options that can be used
-when authentication with an account. The authentication type may be set on inventory 
+when authenticating with an account. The authentication type may be set on inventory 
 hosts or groups with the ``ansible_winrm_transport`` variable.
 
 The following matrix is a high level overview of the options:
@@ -349,7 +349,7 @@ In the section that starts with:
 
     [domain_realm]
 
-Add a line like the following for each domain that Ansible needs access for:
+Add a line like the following for each domain that Ansible needs access to:
 
 ::
 
@@ -659,7 +659,7 @@ for each authentication option. See the section on authentication above for more
 
 Limitations
 ```````````
-Due to the design of the WinRM protocol , there are a few limitations
+Due to the design of the WinRM protocol, there are a few limitations
 when using WinRM that can cause issues when creating playbooks for Ansible.
 These include:
 
@@ -672,7 +672,7 @@ These include:
 * Some programs fail to install with WinRM due to no credential delegation or
   because they access forbidden Windows API like WUA over WinRM.
 
-* Commands under WinRM are done under a non-interactive session, which can prevent
+* Commands under WinRM are run under a non-interactive session, which can prevent
   certain commands or executables from running.
 
 * You cannot run a process that interacts with ``DPAPI``, which is used by some 
@@ -682,12 +682,12 @@ Some of these limitations can be mitigated by doing one of the following:
 
 * Set ``ansible_winrm_transport`` to ``credssp`` or ``kerberos`` (with
   ``ansible_winrm_kerberos_delegation=true``) to bypass the double hop issue
-  and access network resources
+  and access network resources.
 
 * Use ``become`` to bypass all WinRM restrictions and run a command as it would
   locally. Unlike using an authentication transport like ``credssp``, this will
   also remove the non-interactive restriction and API restrictions like WUA and
-  DPAPI
+  DPAPI.
 
 * Use a scheduled task to run a command which can be created with the
   ``win_scheduled_task`` module. Like ``become``, this bypasses all WinRM


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Documentation tidy up.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
windows detailed guides
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
``
`ansible 2.5.0 (detailed_guide_win_tidy eac2e54c83) last updated 2017/11/20 19:21:51 (GMT +100)
  config file = None
  configured module search path = [u'/home/jon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jon/ansible-dev/lib/ansible
  executable location = /home/jon/ansible-dev/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Just some tiny corrections I noticed while preparing to delete scratch docs from the wiki
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
