### PR TITLE
removed superfluous `type` field from RecordSet constructor

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -324,7 +324,6 @@ class AzureRMRecordSet(AzureRMModuleBase):
         if self.results['changed']:
             if self.state == 'present':
                 record_set_args = dict(
-                    type=self.record_type,
                     ttl=self.time_to_live
                 )
 


### PR DESCRIPTION

##### SUMMARY
* fixes breaking change in Azure DNS Python SDK 1.2.0
* no apparent functional change (the arg appears to have been superfluous all along)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_dnsrecordset

##### ANSIBLE VERSION
2.5.0

##### ADDITIONAL INFORMATION
