### PR TITLE
removed superfluous `type` field from RecordSet constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -186,7 +186,8 @@ Ansible Changes By Release
   https://github.com/ansible/ansible/pull/32986
 * Handle sets and datetime objects in inventory sources fixing tracebacks
   https://github.com/ansible/ansible/pull/32990
-
+* Fix for breaking change to Azure Python SDK DNS RecordSet constructor in azure-mgmt-dns==1.2.0
+  https://github.com/ansible/ansible/pull/33165
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
@@ -324,7 +324,6 @@ class AzureRMRecordSet(AzureRMModuleBase):
         if self.results['changed']:
             if self.state == 'present':
                 record_set_args = dict(
-                    type=self.record_type,
                     ttl=self.time_to_live
                 )
 


### PR DESCRIPTION

##### SUMMARY
backport of #33165 to stable-2.4 for 2.4.2rc1

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_dnsrecordset

##### ANSIBLE VERSION
2.4.2b3

##### ADDITIONAL INFORMATION
