### PR TITLE
Ensure that readonly result members are serialized

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -528,7 +528,7 @@ class AzureRMModuleBase(object):
             self.log("dependencies: ")
             self.log(str(dependencies))
         serializer = Serializer(classes=dependencies)
-        return serializer.body(obj, class_name)
+        return serializer.body(obj, class_name, keep_readonly=True)
 
     def get_poller_result(self, poller, wait=5):
         '''


### PR DESCRIPTION
##### SUMMARY
* fix for breaking metadata change in various Azure Python SDK bits; some members were marked `readonly` for validation, which the default msrest serializer ignores. Added `keep_readonly` flag to serializer call to ensure they're preserved.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common

##### ANSIBLE VERSION
2.5.0

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
