### PR TITLE
Ensure that readonly result members are serialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,8 @@ Ansible Changes By Release
   https://github.com/ansible/ansible/pull/32990
 * Fix for breaking change to Azure Python SDK DNS RecordSet constructor in azure-mgmt-dns==1.2.0
   https://github.com/ansible/ansible/pull/33165
+* Fix for breaking change to Azure Python SDK that prevented some members from being returned in facts modules
+  https://github.com/ansible/ansible/pull/33169
 
 <a id="2.4.1"></a>
 

--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -508,7 +508,7 @@ class AzureRMModuleBase(object):
             self.log("dependencies: ")
             self.log(str(dependencies))
         serializer = Serializer(classes=dependencies)
-        return serializer.body(obj, class_name)
+        return serializer.body(obj, class_name, keep_readonly=True)
 
     def get_poller_result(self, poller, wait=5):
         '''


### PR DESCRIPTION
##### SUMMARY
* fix for breaking metadata change in various Azure Python SDK bits; some members were marked `readonly` for validation, which the default msrest serializer ignores. Added `keep_readonly` flag to serializer call to ensure they're preserved.
(cherry picked from commit 70e351036dfdeb0c862db2e642085a648e23a47f) #33169

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
azure_rm_common

##### ANSIBLE VERSION
2.4.2b3

##### ADDITIONAL INFORMATION
