### PR TITLE
Doc: Make documentation link clickable

### DIFF
--- a/lib/ansible/modules/notification/slack.py
+++ b/lib/ansible/modules/notification/slack.py
@@ -114,7 +114,8 @@ options:
       - 'danger'
   attachments:
     description:
-      - Define a list of attachments. This list mirrors the Slack JSON API. For more information, see https://api.slack.com/docs/attachments
+      - Define a list of attachments. This list mirrors the Slack JSON API.
+      - For more information, see also in the (U(https://api.slack.com/docs/attachments)).
     required: false
     default: None
 """


### PR DESCRIPTION
##### SUMMARY
This makes URL clickable in slack module.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/notification/slack.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```