### PR TITLE
firewalld - fail offline operations on old lib version

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -158,6 +158,7 @@ try:
         fw.getDefaultZone()
     except AttributeError:
         # Firewalld is not currently running, permanent-only operations
+        fw_offline = True
 
         # Import other required parts of the firewalld API
         #
@@ -167,7 +168,6 @@ try:
         from firewall.client import FirewallClientZoneSettings
         fw = Firewall_test()
         fw.start()
-        fw_offline = True
 
 except ImportError:
     import_failure = True
@@ -749,11 +749,6 @@ def main():
         supports_check_mode=True
     )
 
-    if import_failure:
-        module.fail_json(
-            msg='firewalld and its python module are required for this module, version 0.2.11 or newer required (0.3.9 or newer for offline operations)'
-        )
-
     if fw_offline:
         # Pre-run version checking
         if FW_VERSION < "0.3.9":
@@ -770,6 +765,11 @@ def main():
         except AttributeError:
             module.fail_json(msg="firewalld connection can't be established,\
                     installed version (%s) likely too old. Requires firewalld >= 0.2.11" % FW_VERSION)
+
+    if import_failure:
+        module.fail_json(
+            msg='firewalld and its python module are required for this module, version 0.2.11 or newer required (0.3.9 or newer for offline operations)'
+        )
 
     permanent = module.params['permanent']
     desired_state = module.params['state']


### PR DESCRIPTION

Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This fixes an issue where the check for an import error would occur
before checking to see if firewalld is in "offline mode" and if it
is, then checking to ensure the version of the firewall python
library was new enough to support offline operations. This patch
will now fail with a correct error message in the scenario that
someone attempts to perform an offline operation but has a version
of the firewall python library that is too old.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
firewalld

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.5.0 (firewalld 66f889176f) last updated 2017/11/22 09:00:45 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible
  executable location = /home/admiller/src/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Aug 16 2017, 12:56:26) [GCC 7.1.1 20170802 (Red Hat 7.1.1-7)]
```
