### PR TITLE
Change the default ansible-test docker image.

### DIFF
--- a/test/runner/test.py
+++ b/test/runner/test.py
@@ -524,7 +524,7 @@ def add_environments(parser, tox_version=False, tox_only=False):
                               metavar='IMAGE',
                               nargs='?',
                               default=None,
-                              const='ubuntu1604',
+                              const='default',
                               help='run from a docker container').completer = complete_docker
 
     environments.add_argument('--remote',


### PR DESCRIPTION
##### SUMMARY

Change the default ansible-test docker image.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-docker-default ca64dac3d4) last updated 2017/11/22 14:00:01 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.11 (default, Jan 22 2016, 08:29:18) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```
