### PR TITLE
Disable flakey `win_msg` integration test.

### DIFF
--- a/test/integration/targets/win_msg/aliases
+++ b/test/integration/targets/win_msg/aliases
@@ -1,1 +1,0 @@
-windows/ci/group2


### PR DESCRIPTION
##### SUMMARY

Disable flakey `win_msg` integration test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_msg integration test

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-win-msg efde5da4d3) last updated 2017/11/22 14:16:07 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
