### PR TITLE
Issue 31723: Support for python3 in jenkins_script module

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -941,7 +941,7 @@ def fetch_url(module, url, data=None, headers=None, method=None,
     :kwarg last_mod_time: Default: None
     :kwarg int timeout:   Default: 10
 
-    :returns: A tuple of (**response**, **info**). Use ``response.body()`` to read the data.
+    :returns: A tuple of (**response**, **info**). Use ``response.read()`` to read the data.
         The **info** contains the 'status' and other meta data. When a HttpError (status > 400)
         occurred then ``info['body']`` contains the error response data::
 

--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -116,6 +116,7 @@ import json
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils._text import to_native
 
 
 def is_csrf_protection_enabled(module):
@@ -125,7 +126,7 @@ def is_csrf_protection_enabled(module):
     if info["status"] != 200:
         module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
 
-    content = resp.read()
+    content = to_native(resp.read())
     return json.loads(content).get('useCrumbs', False)
 
 
@@ -136,7 +137,7 @@ def get_crumb(module):
     if info["status"] != 200:
         module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
 
-    content = resp.read()
+    content = to_native(resp.read())
     return json.loads(content)
 
 
@@ -182,7 +183,7 @@ def main():
     if info["status"] != 200:
         module.fail_json(msg="HTTP error " + str(info["status"]) + " " + info["msg"])
 
-    result = resp.read()
+    result = to_native(resp.read())
 
     if 'Exception:' in result and 'at java.lang.Thread' in result:
         module.fail_json(msg="script failed with stacktrace:\n " + result)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make jenkins_script module compatible with python3 by convert bytes to str when necessary
Fixes #31723

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
jenkins_script
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /Users/ng186024/src/cit/td_jenkins_master/ansible/ansible.cfg
  configured module search path = ['/Users/ng186024/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ng186024/.virtualenvs/jenkins/lib/python3.6/site-packages/ansible
  executable location = /Users/ng186024/.virtualenvs/jenkins/bin/ansible
  python version = 3.6.0 (default, Jan 21 2017, 10:40:54) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
In python3, ansible's `fetch_url` utility function wraps `urllib.request.urlopen`.
For HTTP and HTTPS URLs, this function returns a `http.client.HTTPResponse` object slightly modified.
Calling `.read()` on an `HTTPResponse` object returns bytes (note the docstring fix).

Here, `to_native` is used to convert the bytestrings returned by `fetch_url` into unicode strings.
This is necessary because:
  1. Pre python3.6, `json.loads` requires passing a string, not a bytestring, as its argument
  2. In python3 generally, testing if a string is a substring of a bytestring
      using the 'in' operator will raise a `TypeError`

see:
  - https://docs.python.org/3/library/urllib.request.html#urllib.request.urlopen
  - https://docs.python.org/3/library/http.client.html#http.client.HTTPResponse.read
  - https://docs.python.org/3/library/json.html#json.loads
<!--- Paste verbatim command output below, e.g. before and after your change -->
### before:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: a bytes-like object is required, not 'str'
fatal: [sdvl3jenk042 -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):
  File \"/var/folders/g3/rt5fttrd1dx9gxpqhgh903znwg38nv/T/ansible_prohpe7i/ansible_module_jenkins_script.py\", line 196, in <module>
    main()
  File \"/var/folders/g3/rt5fttrd1dx9gxpqhgh903znwg38nv/T/ansible_prohpe7i/ansible_module_jenkins_script.py\", line 187, in main
    if 'Exception:' in result and 'at java.lang.Thread' in result:\nTypeError: a bytes-like object is required, not 'str'
", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
```

### after:
```
ok: [sdvl3jenk042 -> localhost]
```