### PR TITLE
Update fish setup to use `source` instead of `.`

### DIFF
--- a/docs/docsite/rst/installation_guide/intro_installation.rst
+++ b/docs/docsite/rst/installation_guide/intro_installation.rst
@@ -331,7 +331,7 @@ Using Bash:
 
 Using Fish::
 
-    $ . ./hacking/env-setup.fish
+    $ source ./hacking/env-setup.fish
 
 If you want to suppress spurious warnings/errors, use::
 


### PR DESCRIPTION
##### SUMMARY
"The use of . is deprecated in favour of source, and . will be removed in a future version of fish."

source: https://fishshell.com/docs/current/commands.html#source

##### ISSUE TYPE
 - Docs Pull Request
