### PR TITLE
ACI Query: Update var name to be unique

### DIFF
--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -31,6 +31,7 @@
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+from copy import deepcopy
 
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils._text import to_bytes
@@ -707,7 +708,7 @@ class ACIModule(object):
         if child_configs:
             children = []
             for child in child_configs:
-                child_copy = child.copy()
+                child_copy = deepcopy(copy)
                 has_value = False
                 for root_key in child_copy.keys():
                     for final_keys, values in child_copy[root_key]['attributes'].items():

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -708,7 +708,7 @@ class ACIModule(object):
         if child_configs:
             children = []
             for child in child_configs:
-                child_copy = deepcopy(copy)
+                child_copy = deepcopy(child)
                 has_value = False
                 for root_key in child_copy.keys():
                     for final_keys, values in child_copy[root_key]['attributes'].items():

--- a/lib/ansible/module_utils/network/aci/aci.py
+++ b/lib/ansible/module_utils/network/aci/aci.py
@@ -322,13 +322,14 @@ class ACIModule(object):
         """
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
+        mo = obj['module_object']
 
         # State is present or absent
         if self.module.params['state'] != 'query':
             path = 'api/mo/uni/{}.json'.format(obj_rn)
             filter_string = '?rsp-prop-include=config-only' + child_includes
         # Query for all objects of the module's class
-        elif obj is None:
+        elif mo is None:
             path = 'api/class/{}.json'.format(obj_class)
             filter_string = ''
         # Query for a specific object in the module's class
@@ -351,7 +352,7 @@ class ACIModule(object):
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
         obj_filter = obj['filter_target']
-        obj = obj['module_object']
+        mo = obj['module_object']
 
         if not child_includes:
             self_child_includes = '?rsp-subtree=full&rsp-subtree-class=' + obj_class
@@ -363,13 +364,13 @@ class ACIModule(object):
             path = 'api/mo/uni/{}/{}.json'.format(parent_rn, obj_rn)
             filter_string = '?rsp-prop-include=config-only' + child_includes
         # Query for all objects of the module's class
-        elif obj is None and parent_obj is None:
+        elif mo is None and parent_obj is None:
             path = 'api/class/{}.json'.format(obj_class)
             filter_string = ''
         # Queries when parent object is provided
         elif parent_obj is not None:
             # Query for specific object in the module's class
-            if obj is not None:
+            if mo is not None:
                 path = 'api/mo/uni/{}/{}.json'.format(parent_rn, obj_rn)
                 filter_string = ''
             # Query for all object's of the module's class that belong to a specific parent object
@@ -400,7 +401,7 @@ class ACIModule(object):
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
         obj_filter = obj['filter_target']
-        obj = obj['module_object']
+        mo = obj['module_object']
 
         if not child_includes:
             self_child_includes = '&rsp-subtree=full&rsp-subtree-class=' + obj_class
@@ -417,7 +418,7 @@ class ACIModule(object):
             path = 'api/mo/uni/{}/{}/{}.json'.format(root_rn, parent_rn, obj_rn)
             filter_string = '?rsp-prop-include=config-only' + child_includes
         # Query for all objects of the module's class
-        elif obj is None and parent_obj is None and root_obj is None:
+        elif mo is None and parent_obj is None and root_obj is None:
             path = 'api/class/{}.json'.format(obj_class)
             filter_string = ''
         # Queries when root object is provided
@@ -425,7 +426,7 @@ class ACIModule(object):
             # Queries when parent object is provided
             if parent_obj is not None:
                 # Query for a specific object of the module's class
-                if obj is not None:
+                if mo is not None:
                     path = 'api/mo/uni/{}/{}/{}.json'.format(root_rn, parent_rn, obj_rn)
                     filter_string = ''
                 # Query for all objects of the module's class that belong to a specific parent object
@@ -433,7 +434,7 @@ class ACIModule(object):
                     path = 'api/mo/uni/{}/{}.json'.format(root_rn, parent_rn)
                     filter_string = self_child_includes.replace('&', '?', 1)
             # Query for all objects of the module's class that match the provided ID value and belong to a specefic root object
-            elif obj is not None:
+            elif mo is not None:
                 path = 'api/mo/uni/{}.json'.format(root_rn)
                 filter_string = '?rsp-subtree-filter=eq{}{}'.format(obj_filter, self_child_includes)
             # Query for all objects of the module's class that belong to a specific root object
@@ -444,7 +445,7 @@ class ACIModule(object):
         elif parent_obj is not None:
             # Query for all objects of the module's class that belong to any parent class
             # matching the provided ID values for both object and parent object
-            if obj is not None:
+            if mo is not None:
                 path = 'api/class/{}.json'.format(parent_class)
                 filter_string = '?query-target-filter=eq{}{}&rsp-subtree-filter=eq{}'.format(
                     parent_filter, self_child_includes, obj_filter)
@@ -483,7 +484,7 @@ class ACIModule(object):
         obj_class = obj['aci_class']
         obj_rn = obj['aci_rn']
         # obj_filter = obj['filter_target']
-        # obj = obj['module_object']
+        # mo = obj['module_object']
 
         # State is ablsent or present
         if self.module.params['state'] != 'query':


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
ACI Construct URL method used overlapping var names, which masked some minor issue for querying root level objects. This update renames the second var to keep them distinct.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aci.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.1
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
