### PR TITLE
Split up cloud tests to avoid 1 hour CI limit.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -68,6 +68,11 @@ matrix:
     - env: T=cloud/default/2.7/2
     - env: T=cloud/default/3.6/2
 
+    - env: T=cloud/default/2.7/3
+    - env: T=cloud/default/3.6/3
+
+    - env: T=cloud/default/2.7/4
+    - env: T=cloud/default/3.6/4
 branches:
   except:
     - "*-patch-*"

--- a/test/integration/targets/aws_api_gateway/aliases
+++ b/test/integration/targets/aws_api_gateway/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/aws_lambda/aliases
+++ b/test/integration/targets/aws_lambda/aliases
@@ -1,4 +1,4 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws
 execute_lambda
 lambda

--- a/test/integration/targets/aws_s3/aliases
+++ b/test/integration/targets/aws_s3/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/azure_rm_virtualmachine/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+posix/ci/cloud/group3/azure
 destructive

--- a/test/integration/targets/azure_rm_virtualmachine_extension/aliases
+++ b/test/integration/targets/azure_rm_virtualmachine_extension/aliases
@@ -1,3 +1,3 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+posix/ci/cloud/group3/azure
 destructive

--- a/test/integration/targets/azure_rm_virtualmachineimage_facts/aliases
+++ b/test/integration/targets/azure_rm_virtualmachineimage_facts/aliases
@@ -1,3 +1,4 @@
 cloud/azure
-posix/ci/cloud/group2/azure
+posix/ci/cloud/group3/azure
+posix/ci/cloud/group3/smoketest
 destructive

--- a/test/integration/targets/ec2_ami/aliases
+++ b/test/integration/targets/ec2_ami/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws
 ec2_ami_facts

--- a/test/integration/targets/ec2_elb_lb/aliases
+++ b/test/integration/targets/ec2_elb_lb/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_group/aliases
+++ b/test/integration/targets/ec2_group/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_key/aliases
+++ b/test/integration/targets/ec2_key/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws
 skip/python3

--- a/test/integration/targets/ec2_metadata_facts/aliases
+++ b/test/integration/targets/ec2_metadata_facts/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-posix/ci/cloud/group1/aws
-posix/ci/cloud/group1/smoketest
+posix/ci/cloud/group4/aws
+posix/ci/cloud/group4/smoketest

--- a/test/integration/targets/ec2_tag/aliases
+++ b/test/integration/targets/ec2_tag/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vol/aliases
+++ b/test/integration/targets/ec2_vol/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc/aliases
+++ b/test/integration/targets/ec2_vpc/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc_route_table/aliases
+++ b/test/integration/targets/ec2_vpc_route_table/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ec2_vpc_subnet/aliases
+++ b/test/integration/targets/ec2_vpc_subnet/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/ecs_ecr/aliases
+++ b/test/integration/targets/ecs_ecr/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/elb_classic_lb/aliases
+++ b/test/integration/targets/elb_classic_lb/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/lambda_policy/aliases
+++ b/test/integration/targets/lambda_policy/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/rds_param_group/aliases
+++ b/test/integration/targets/rds_param_group/aliases
@@ -1,2 +1,2 @@
 cloud/aws
-posix/ci/cloud/group1/aws
+posix/ci/cloud/group4/aws

--- a/test/integration/targets/vcenter_license/aliases
+++ b/test/integration/targets/vcenter_license/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_cluster/aliases
+++ b/test/integration/targets/vmware_cluster/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_datacenter/aliases
+++ b/test/integration/targets/vmware_datacenter/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_dvs_portgroup/aliases
+++ b/test/integration/targets/vmware_dvs_portgroup/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_dvswitch/aliases
+++ b/test/integration/targets/vmware_dvswitch/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_guest/aliases
+++ b/test/integration/targets/vmware_guest/aliases
@@ -1,4 +1,4 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_facts/aliases
+++ b/test/integration/targets/vmware_guest_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_guest_find/aliases
+++ b/test/integration/targets/vmware_guest_find/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_guest_powerstate/aliases
+++ b/test/integration/targets/vmware_guest_powerstate/aliases
@@ -1,4 +1,4 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_snapshot/aliases
+++ b/test/integration/targets/vmware_guest_snapshot/aliases
@@ -1,4 +1,4 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 skip/python3
 destructive

--- a/test/integration/targets/vmware_guest_tools_wait/aliases
+++ b/test/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_host/aliases
+++ b/test/integration/targets/vmware_host/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_host_facts/aliases
+++ b/test/integration/targets/vmware_host_facts/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 

--- a/test/integration/targets/vmware_resource_pool/aliases
+++ b/test/integration/targets/vmware_resource_pool/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive

--- a/test/integration/targets/vmware_vswitch/aliases
+++ b/test/integration/targets/vmware_vswitch/aliases
@@ -1,3 +1,3 @@
-posix/ci/cloud/group1/vcenter
+posix/ci/cloud/group4/vcenter
 cloud/vcenter
 destructive


### PR DESCRIPTION
##### SUMMARY

Split up cloud tests to avoid 1 hour CI limit.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

cloud integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (ci-cloud-groups 77d1139f6c) last updated 2017/11/22 23:56:04 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
