### PR TITLE
VMware: Add vmware guest param - maxMkConnections

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml
@@ -50,6 +50,7 @@
         # till the time.
         # memory_reservation: 512
         # memory_reservation_lock: False
+        max_connections: 10
     disk:
         - size: 0gb
           type: thin


### PR DESCRIPTION
##### SUMMARY
This fix adds functionality to configure vmware guest parameter called
'maxMkconnections'. Also, added integration test for this change.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py test/integration/targets/vmware_guest/tasks/create_d1_c1_f0.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```