### PR TITLE
Fix css of elbow indentation for firefox

### DIFF
--- a/docs/docsite/_themes/srtd/static/css/theme.css
+++ b/docs/docsite/_themes/srtd/static/css/theme.css
@@ -4898,6 +4898,12 @@ table {
     height: inherit
 }
 
+@-moz-document url-prefix() {
+    .return-value-column td {
+        height: 100%
+    }
+}
+
 .cell-border {
     padding: 4px;
     border-left: 1px solid #000;

--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -213,17 +213,6 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
 
 .. raw:: html
 
-    <style>
-        .outer-elbow-container{display: flex;height:100%;flex-direction:row;}
-        .elbow-placeholder{border-left:1px solid #000;height:100%;width:30px;}
-        .elbow-key{height:100%;padding:4px;border-top:1px solid #000;flex-grow:1;border-left:1px solid #000;}
-        .elbow-blocker{height:0;overflow:hidden;}
-        .return-value-column{height:1px}
-        .return-value-column td{height:inherit}
-        .cell-border{padding:4px;border-left:1px solid #000; border-top:1px solid #000;height:100%;}
-        .documentation-table{border-right:1px solid #000;border-bottom:1px solid #000;}
-    </style>
-
     <table border=0 cellpadding=0 class="documentation-table">
         <tr>
             <th class="head"><div class="cell-border">name</div></th>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix css of the return and options table in the documentation.
Followup to #33143 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
webdocs
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
New build of the documentation after changes:
http://ventx.wf.s3-website.eu-central-1.amazonaws.com/ansible-doc/0bfe14f/
Testsite with indented documentation:
http://ventx.wf.s3-website.eu-central-1.amazonaws.com/ansible-doc/0bfe14f/ec2_instance_facts_module.html
<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
