### PR TITLE
cloudstack: fix spelling of "affinity_type"

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_affinitygroup.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_affinitygroup.py
@@ -36,11 +36,12 @@ options:
     description:
       - Name of the affinity group.
     required: true
-  affinty_type:
+  affinity_type:
     description:
       - Type of the affinity group. If not specified, first found affinity type is used.
     required: false
     default: null
+    aliases: [ affinty_type ]
   description:
     description:
       - Description of the affinity group.
@@ -80,7 +81,7 @@ EXAMPLES = '''
 - local_action:
     module: cs_affinitygroup
     name: haproxy
-    affinty_type: host anti-affinity
+    affinity_type: host anti-affinity
 
 # Remove a affinity group
 - local_action:
@@ -160,7 +161,7 @@ class AnsibleCloudStackAffinityGroup(AnsibleCloudStack):
         return self.affinity_group
 
     def get_affinity_type(self):
-        affinity_type = self.module.params.get('affinty_type')
+        affinity_type = self.module.params.get('affinity_type') or self.module.params.get('affinty_type')
 
         affinity_types = self.query_api('listAffinityGroupTypes', )
         if affinity_types:
@@ -217,7 +218,8 @@ def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
         name=dict(required=True),
-        affinty_type=dict(),
+        affinty_type=dict(removed_in_version='2.9'),
+        affinity_type=dict(),
         description=dict(),
         state=dict(choices=['present', 'absent'], default='present'),
         domain=dict(),
@@ -229,6 +231,9 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_together=cs_required_together(),
+        mutually_exclusive=(
+            ['affinity_type', 'affinty_type'],
+        ),
         supports_check_mode=True
     )
 

--- a/test/integration/targets/cs_affinitygroup/tasks/main.yml
+++ b/test/integration/targets/cs_affinitygroup/tasks/main.yml
@@ -22,7 +22,7 @@
 - name: test fail unknown affinity type
   cs_affinitygroup:
     name: "{{ cs_resource_prefix }}_ag"
-    affinty_type: unexistent affinity type
+    affinity_type: unexistent affinity type
   register: ag
   ignore_errors: true
 - name: verify test fail unknown affinity type


### PR DESCRIPTION
##### SUMMARY
Fix spelling of `affinity_type` (not `affinty_type`).

However, to not break existing playbook, add an undocumented alias for
`affinty_type`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudstack

##### ANSIBLE VERSION
2.4.0.0
