### PR TITLE
Extending email notification module

### DIFF
--- a/lib/ansible/modules/notification/mail.py
+++ b/lib/ansible/modules/notification/mail.py
@@ -50,7 +50,7 @@ options:
     description:
     - The email-address(es) the mail is being 'blind' copied to.
     - This is a list, which may contain address and phrase portions.
-    replyto:
+  replyto:
     description:
       - The email-address the mail is being replied to.
       - May contain address and phrase portions.
@@ -413,7 +413,7 @@ def main():
                 msg.attach(part)
             except Exception as e:
                 module.fail_json(rc=1, msg="Failed to send mail: can't attach inline file %s: %s" %
-                                 (file, to_native(e)), exception=traceback.format_exc())
+                                 (filename, to_native(e)), exception=traceback.format_exc())
             i += 1
 
     composed = msg.as_string()


### PR DESCRIPTION
- Include reply-to address
- Add possibility to send alternative text message when choosing html
- Add attach_inline to add logos into html messages

##### SUMMARY
I've added reply-to as this is a required feature to allow sending as noreply@example.com to ignore any non-delivery reports or out-of-office messages, but give the ability to create a new ticket when replying to the notification.

It is also possible to send a notification in HTML format and with an alternative TEXT formatted body.

When formatting HTML notification you can now include inline images in your message.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
modules/notification/mail.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = ['/Users/rthill/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/rthill/Pyenv/ansible-dev/lib/python3.6/site-packages/ansible-2.5.0-py3.6.egg/ansible
  executable location = /Users/rthill/Pyenv/ansible-dev/bin/ansible
  python version = 3.6.3 (default, Oct  6 2017, 10:00:54) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
None