### PR TITLE
make `instance_monitoring: false` take effect

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -54,7 +54,7 @@ options:
     description:
       - Instance type to use for the instance
     required: true
-    default: null
+    default: 'null'
     aliases: []
   image_id:
     description:
@@ -87,7 +87,8 @@ options:
   instance_monitoring:
     description:
       - Specifies whether instances are launched with detailed monitoring.
-    default: false
+    default: 'true'
+    choices: ['true', 'false']
   assign_public_ip:
     description:
       - Used for Auto Scaling groups that launch instances into an Amazon Virtual Private Cloud. Specifies whether to assign a public IP address
@@ -307,7 +308,7 @@ def create_launch_config(connection, module):
     if classic_link_vpc_id is not None:
         launch_config['ClassicLinkVPCId'] = classic_link_vpc_id
 
-    if instance_monitoring:
+    if instance_monitoring is not None:
         launch_config['InstanceMonitoring'] = {'Enabled': instance_monitoring}
 
     if classic_link_vpc_security_groups is not None:

--- a/lib/ansible/modules/cloud/amazon/ec2_lc.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_lc.py
@@ -54,7 +54,7 @@ options:
     description:
       - Instance type to use for the instance
     required: true
-    default: 'null'
+    default: null
     aliases: []
   image_id:
     description:
@@ -87,8 +87,7 @@ options:
   instance_monitoring:
     description:
       - Specifies whether instances are launched with detailed monitoring.
-    default: 'true'
-    choices: ['true', 'false']
+    default: false
   assign_public_ip:
     description:
       - Used for Auto Scaling groups that launch instances into an Amazon Virtual Private Cloud. Specifies whether to assign a public IP address


### PR DESCRIPTION
Fixes #33200
also fix/update docs. Amazon defaults to instance monitoring so
the default should reflect that.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change test for missing config value rather than just falsy-ness for the instance_monitor parameter. This means setting it to `false` correctly propagates to the actual launch configuration.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ec2_lc

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /Users/dmt/Code/infrastructure/ansible.cfg
  configured module search path = [u'/Users/dmt/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
