### PR TITLE
Add gr_name and pw_name in find module

### DIFF
--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -172,7 +172,9 @@ examined:
 '''
 
 import fnmatch
+import grp
 import os
+import pwd
 import re
 import stat
 import sys
@@ -263,6 +265,19 @@ def contentfilter(fsname, pattern):
 
 
 def statinfo(st):
+    pw_name = ""
+    gr_name = ""
+
+    try:  # user data
+        pw_name = pwd.getpwuid(st.st_uid).pw_name
+    except:
+        pass
+
+    try:  # group data
+        gr_name = grp.getgrgid(st.st_gid).gr_name
+    except:
+        pass
+
     return {
         'mode': "%04o" % stat.S_IMODE(st.st_mode),
         'isdir': stat.S_ISDIR(st.st_mode),
@@ -281,6 +296,8 @@ def statinfo(st):
         'atime': st.st_atime,
         'mtime': st.st_mtime,
         'ctime': st.st_ctime,
+        'gr_name': gr_name,
+        'pw_name': pw_name,
         'wusr': bool(st.st_mode & stat.S_IWUSR),
         'rusr': bool(st.st_mode & stat.S_IRUSR),
         'xusr': bool(st.st_mode & stat.S_IXUSR),

--- a/test/integration/targets/find/tasks/main.yml
+++ b/test/integration/targets/find/tasks/main.yml
@@ -81,3 +81,17 @@
       that:
           - 'find_test1.matched == 2'
           - 'find_test1.files | length == 2'
+
+- name: find the xml file
+  find:
+      paths: "{{ output_dir_test }}"
+      patterns: "*.xml"
+      recurse: yes
+  register: find_test2
+- debug: var=find_test2
+- name: validate gr_name and pw_name are defined
+  assert:
+      that:
+          - 'find_test2.matched == 1'
+          - 'find_test2.files[0].pw_name is defined'
+          - 'find_test2.files[0].gr_name is defined'


### PR DESCRIPTION
##### SUMMARY
The fix adds gr_name and pw_name in return output.
Integration test added.

Fixes: #25643

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/find.py
test/integration/targets/find/tasks/main.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```