### PR TITLE
Cast int for expire field to avoid call failure to sensu API

### DIFF
--- a/lib/ansible/modules/monitoring/sensu_silence.py
+++ b/lib/ansible/modules/monitoring/sensu_silence.py
@@ -263,7 +263,7 @@ def main():
         argument_spec=dict(
             check=dict(required=False),
             creator=dict(required=False),
-            expire=dict(required=False),
+            expire=dict(type='int', required=False),
             expire_on_resolve=dict(type='bool', required=False),
             reason=dict(required=False),
             state=dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION
##### SUMMARY
Expire field of sensu_silence module was not casting int which makes calls to Sensu API fail.

Please see traces and debug analysis below and the expected field values on https://sensuapp.org/docs/1.1/api/silenced-api.html

##### ISSUE TYPE
BUG: Silence call fails

##### ANSIBLE VERSION
```
ansible 2.5.0 (sensu_silence_cast_int 4103c3331a) last updated 2017/11/23 18:01:56 (GMT +100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/pintoj/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pintoj/Desktop/ansible_work/GIT/ansible_upstream/lib/ansible
  executable location = /home/pintoj/Desktop/ansible_work/GIT/ansible_upstream/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Before change:
```
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "invocation": {
        "module_args": {
            "check": null, 
            "creator": "pintoj", 
            "expire": "3600", 
            "expire_on_resolve": null, 
            "reason": "Pipeline", 
            "state": "present", 
            "subscription": "client:myclient.dev.myorg", 
            "url": "http://sensu-api.dev.myorg"
        }
    }, 
    "msg": "Failed to silence client:myclient.dev.myorg. Reason: HTTP Error 400: Bad Request"
}
```
TCP dump which shows string expire field:
```
Frame 12: 365 bytes on wire (2920 bits), 365 bytes captured (2920 bits) on interface 0
Linux cooked capture
Internet Protocol Version 4, Src: X.X.X.X, Dst: Y.Y.Y.Y
Transmission Control Protocol, Src Port: 54422, Dst Port: 80, Seq: 1, Ack: 1, Len: 309
Hypertext Transfer Protocol
    POST /silenced HTTP/1.1\r\n
        [Expert Info (Chat/Sequence): POST /silenced HTTP/1.1\r\n]
            [POST /silenced HTTP/1.1\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Request Method: POST
        Request URI: /silenced
        Request Version: HTTP/1.1
    Accept-Encoding: identity\r\n
    Content-Length: 117\r\n
        [Content length: 117]
    Host: sensu-api.dev.myorg\r\n
    Content-Type: application/json\r\n
    Connection: close\r\n
    User-Agent: ansible-httpget\r\n
    \r\n
    [Full request URI: http://sensu-api.dev.myorg/silenced]
    [HTTP request 1/1]
    [Response in frame: 13]
    File Data: 117 bytes
JavaScript Object Notation: application/json
    Object
        Member Key: creator
            String value: pintoj
            Key: creator
        Member Key: reason
            String value: Pipeline
            Key: reason
        Member Key: expire
            String value: 3600
            Key: expire
        Member Key: subscription
            String value: client:myclient.dev.myorg
            Key: subscription
```

After change:

```
changed: [localhost] => {
    "changed": true, 
    "invocation": {
        "module_args": {
            "check": null, 
            "creator": "pintoj", 
            "expire": 3600, 
            "expire_on_resolve": null, 
            "reason": "Pipeline", 
            "state": "present", 
            "subscription": "client:myclient.dev.myorg", 
            "url": "http://sensu-api.dev.myorg"
        }
    }, 
    "msg": "success", 
    "result": ""
}
```

TCP Dump which shows int expire field:
```
Frame 12: 363 bytes on wire (2904 bits), 363 bytes captured (2904 bits) on interface 0
Linux cooked capture
Internet Protocol Version 4, Src: X.X.X.X, Dst: Y.Y.Y.Y
Transmission Control Protocol, Src Port: 54412, Dst Port: 80, Seq: 1, Ack: 1, Len: 307
Hypertext Transfer Protocol
    POST /silenced HTTP/1.1\r\n
        [Expert Info (Chat/Sequence): POST /silenced HTTP/1.1\r\n]
            [POST /silenced HTTP/1.1\r\n]
            [Severity level: Chat]
            [Group: Sequence]
        Request Method: POST
        Request URI: /silenced
        Request Version: HTTP/1.1
    Accept-Encoding: identity\r\n
    Content-Length: 115\r\n
        [Content length: 115]
    Host: sensu-api.dev.myorg\r\n
    Content-Type: application/json\r\n
    Connection: close\r\n
    User-Agent: ansible-httpget\r\n
    \r\n
    [Full request URI: http://sensu-api.dev.myorg/silenced]
    [HTTP request 1/1]
    [Response in frame: 13]
    File Data: 115 bytes
JavaScript Object Notation: application/json
    Object
        Member Key: creator
            String value: pintoj
            Key: creator
        Member Key: reason
            String value: Pipeline
            Key: reason
        Member Key: expire
            Number value: 3600
            Key: expire
        Member Key: subscription
            String value: client:myclient.dev.myorg
            Key: subscription
```