### PR TITLE
sqs_queue: allow delivery delay to be 0 - fixes #33076

### DIFF
--- a/lib/ansible/modules/cloud/amazon/sqs_queue.py
+++ b/lib/ansible/modules/cloud/amazon/sqs_queue.py
@@ -233,7 +233,7 @@ def update_sqs_queue(queue,
 
 
 def set_queue_attribute(queue, attribute, value, check_mode=False):
-    if not value:
+    if not value and value != 0:
         return False
 
     try:


### PR DESCRIPTION
##### SUMMARY
Fixes #33076.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/sqs_queue.py

##### ANSIBLE VERSION
```
2.5.0
```
