### PR TITLE
Fail when attempting to modify unmodifiable target group parameters

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -384,6 +384,11 @@ def create_or_update_target_group(connection, module):
     tg = get_target_group(connection, module)
 
     if tg:
+        diffs = [param for param in ['Port', 'Protocol', 'VpcId']
+                 if tg[param] != params[param]]
+        if diffs:
+            module.fail_json(msg="Cannot modify %s parameter(s) for a target group" %
+                             ", ".join(diffs))
         # Target group exists so check health check parameters match what has been passed
         health_check_params = dict()
 

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -384,8 +384,8 @@ def create_or_update_target_group(connection, module):
     tg = get_target_group(connection, module)
 
     if tg:
-        diffs = [param for param in ['Port', 'Protocol', 'VpcId']
-                 if tg[param] != params[param]]
+        diffs = [param for param in ('Port', 'Protocol', 'VpcId')
+                 if tg.get(param) != params.get(param)]
         if diffs:
             module.fail_json(msg="Cannot modify %s parameter(s) for a target group" %
                              ", ".join(diffs))


### PR DESCRIPTION
##### SUMMARY

As you can't modify Port, Protocol or VPC id for a target group, fail
when this happens rather than pretending to do it.

One could argue that the target group could be recreated rather than
failing, but this has massive knock on implications to other resources
that depend on the TG (all ASGs would need to be updated, the ELB
listener would need to be updated, etc)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
```
ansible 2.5.0 (detached HEAD ref: refs/) last updated 2017/11/24 11:42:26 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```
