### PR TITLE
- Add delimiter between verbose logs and intended messages on stdout pipe

### DIFF
--- a/bin/ansible-connection
+++ b/bin/ansible-connection
@@ -316,6 +316,7 @@ def main():
         sys.stderr.write(json.dumps(result))
     else:
         rc = 0
+        sys.stdout.write('\n#DELIM#\n')
         sys.stdout.write(json.dumps(result))
 
     sys.exit(rc)

--- a/lib/ansible/plugins/connection/persistent.py
+++ b/lib/ansible/plugins/connection/persistent.py
@@ -93,7 +93,7 @@ class Connection(ConnectionBase):
         stdin.close()
 
         if p.returncode == 0:
-            result = json.loads(to_text(stdout, errors='surrogate_then_replace'))
+            result = json.loads(to_text(stdout.split('\n#DELIM#\n')[-1], errors='surrogate_then_replace'))
         else:
             result = json.loads(to_text(stderr, errors='surrogate_then_replace'))
 


### PR DESCRIPTION
##### SUMMARY
ansible-connection will put verbose logs onto the pipe along with the intended messages written with sys.stdout.write()
e.g. verbose logs from plugin loader are written on the pipe.
```
38504 1511508031.90711: Loading Connection 'ssh' from /Users/kedarX/work/fork/ansible/lib/ansible/plugins/connection/ssh.py (found_in_cache=False, class_only=True)
 38504 1511508031.95799: assigned :doc
 38504 1511508031.95869: Loaded config def from plugin (connection/ssh)
#DELIM#
{"socket_path": "/Users/kedarX/.ansible/pc/32c8dad475", "messages": ["found existing local domain socket, using it!"]}
```
###SOLUTION ###
Use a delimiter to separate intended message from other logs.


Fixes #33250 


##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
ansible-connection
persistent

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0(devel)
```

