### PR TITLE
loopback doesn't support passive_interface

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
+++ b/lib/ansible/modules/network/nxos/nxos_interface_ospf.py
@@ -296,6 +296,8 @@ def state_present(module, existing, proposed, candidate):
             if existing_commands[key] == proposed_commands[key]:
                 continue
 
+        if key == 'ip ospf passive-interface' and module.params.get('interface').upper().startswith('LO'):
+            module.fail_json(msg='loopback interface does not support passive_interface')
         if value is True:
             commands.append(key)
         elif value is False:

--- a/test/units/modules/network/nxos/test_nxos_interface_ospf.py
+++ b/test/units/modules/network/nxos/test_nxos_interface_ospf.py
@@ -50,3 +50,7 @@ class TestNxosInterfaceOspfModule(TestNxosModule):
     def test_nxos_interface_ospf(self):
         set_module_args(dict(interface='ethernet1/32', ospf=1, area=1))
         self.execute_module(changed=True, commands=['interface Ethernet1/32', 'ip router ospf 1 area 0.0.0.1'])
+
+    def test_loopback_interface_failed(self):
+        set_module_args(dict(interface='loopback0', ospf=1, area=0, passive_interface=True))
+        self.execute_module(failed=True, changed=False)


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/33245
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_interface_ospf
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```