### PR TITLE
Adding extends_documenation_fragment in crypto/*

### DIFF
--- a/lib/ansible/modules/crypto/openssl_certificate.py
+++ b/lib/ansible/modules/crypto/openssl_certificate.py
@@ -183,7 +183,7 @@ options:
         description:
             - If set to True, the I(subject_alt_name) extension field must contain only these values.
         aliases: [ subjectAltName_strict ]
-
+extends_documentation_fragment: files
 notes:
     - All ASN.1 TIME values should be specified following the YYYYMMDDHHMMSSZ pattern.
       Date specified should be UTC. Minutes and seconds are mandatory.

--- a/lib/ansible/modules/crypto/openssl_csr.py
+++ b/lib/ansible/modules/crypto/openssl_csr.py
@@ -23,8 +23,7 @@ description:
     - "This module allows one to (re)generate OpenSSL certificate signing requests.
        It uses the pyOpenSSL python library to interact with openssl. This module supports
        the subjectAltName as well as the keyUsage and extendedKeyUsage extensions.
-       Note: At least one of common_name or subject_alt_name must be specified.
-       This module uses file common arguments to specify generated file permissions."
+       Note: At least one of common_name or subject_alt_name must be specified."
 requirements:
     - "python-pyOpenSSL >= 0.15"
 options:
@@ -132,6 +131,7 @@ options:
         aliases: [ 'extKeyUsage_critical', 'extendedKeyUsage_critical' ]
         description:
             - Should the extkeyUsage extension be considered as critical
+extends_documentation_fragment: files
 
 notes:
     - "If the certificate signing request already exists it will be checked whether subjectAltName,

--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -22,8 +22,7 @@ short_description: Generate an OpenSSL public key from its private key.
 description:
     - "This module allows one to (re)generate OpenSSL public keys from their private keys.
        It uses the pyOpenSSL python library to interact with openssl. Keys are generated
-       in PEM format. This module works only if the version of PyOpenSSL is recent enough (> 16.0.0).
-       This module uses file common arguments to specify generated file permissions."
+       in PEM format. This module works only if the version of PyOpenSSL is recent enough (> 16.0.0)."
 requirements:
     - "python-pyOpenSSL"
 options:
@@ -59,6 +58,7 @@ options:
         description:
             - The passphrase for the privatekey.
         version_added: "2.4"
+extends_documentation_fragment: files
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION


##### SUMMARY

All crypto modules uses file common arguments to specify generated file
permissions. This commits aims to add the extends_documentation_fragment
in the doc so it is automatically stated.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME

- openssl_csr
- openssl_publickey
- openssl_certificate

##### ANSIBLE VERSION

- devel


##### ADDITIONAL INFORMATION

- N/A