### PR TITLE
openssl_publickey: Do not fail on empty existing file

### DIFF
--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -211,10 +211,13 @@ class PublicKey(crypto_utils.OpenSSLObject):
             if not os.path.exists(self.privatekey_path):
                 return False
 
-            current_publickey = crypto.dump_publickey(
-                crypto.FILETYPE_ASN1,
-                crypto.load_publickey(crypto.FILETYPE_PEM, open(self.path, 'rb').read())
-            )
+            try:
+                current_publickey = crypto.dump_publickey(
+                    crypto.FILETYPE_ASN1,
+                    crypto.load_publickey(crypto.FILETYPE_PEM, open(self.path, 'rb').read())
+                )
+            except crypto.Error:
+                return False
 
             desired_publickey = crypto.dump_publickey(
                 crypto.FILETYPE_ASN1,

--- a/test/integration/targets/openssl_publickey/tasks/main.yml
+++ b/test/integration/targets/openssl_publickey/tasks/main.yml
@@ -48,6 +48,16 @@
         privatekey_passphrase: ansible
       register: publickey3_idempotence
 
+    - name: Generate empty file that will hold a public key (issue 33072)
+      file:
+        path: '{{ output_dir }}/publickey4.pub'
+        state: touch
+
+    - name: Generate publickey in empty existing file (issue 33072)
+      openssl_publickey:
+        path: '{{ output_dir }}/publickey4.pub'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+
     - import_tasks: ../tests/validate.yml
 
   when: pyopenssl_version.stdout|version_compare('16.0.0', '>=')

--- a/test/integration/targets/openssl_publickey/tests/validate.yml
+++ b/test/integration/targets/openssl_publickey/tests/validate.yml
@@ -59,3 +59,19 @@
   assert:
     that:
       - not publickey3_idempotence|changed
+
+- name: Validate publickey4 (test - privatekey modulus)
+  shell: 'openssl rsa -noout -modulus -in {{ output_dir }}/privatekey.pem | openssl md5'
+  register: privatekey4_modulus
+  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+
+- name: Validate publickey4 (test - publickey modulus)
+  shell: 'openssl rsa -pubin -noout -modulus < {{ output_dir }}/publickey4.pub  | openssl md5'
+  register: publickey4_modulus
+  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')
+
+- name: Validate publickey4 (assert)
+  assert:
+    that:
+      - publickey4_modulus.stdout == privatekey4_modulus.stdout
+  when: openssl_version.stdout|version_compare('0.9.8zh', '>=')


### PR DESCRIPTION
##### SUMMARY

Currently during the check phase, the code considers the file to be
a public key if the file exist - which is not necessarily true. It can be any
file leading to failure when trying to dump the public key of the file.

This commits aims to ensure that the file is actually a publickey else
returns false for the check.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- openssl_publickey

##### ANSIBLE VERSION

- devel

##### ADDITIONAL INFORMATION

```
- tempfile:
    state: file
    suffix: ".pub"
  register: temploc

- openssl_privatekey:
    path: "/root/.ssh/id_rsa-testing"

- openssl_publickey:
    privatekey_path: "/root/.ssh/id_rsa-testing"
    path: "/root/.ssh/id_rsa-testing.pub"
    format: OpenSSH

- openssl_publickey:
    privatekey_path: "/root/.ssh/id_rsa-testing"
    path: "/tmp/id_rsa-testing.pub"
    format: OpenSSH

- openssl_publickey:
    privatekey_path: "/root/.ssh/id_rsa-testing"
    path: "{{ temploc.path }}"
    format: OpenSSH
```

Fixes: https://github.com/ansible/ansible/issues/33072
