### PR TITLE
Vmware basic files operations networkless

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -3,7 +3,7 @@
 
 # Copyright: (c) 2017, Stéphane Travassac <stravassac () gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
+from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -152,6 +152,9 @@ EXAMPLES = '''
   delegate_to: localhost
 '''
 
+RETURN = r'''
+'''
+
 try:
     from pyVmomi import vim, vmodl
 except ImportError:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 module: vmware_guest_file_operation
 short_description: Files operation in a VMware guest operating system whithout network
 description:
-    - Module allows user to create,delete file or directory in the guest operating system.
+    - Module allows user to copy and fetch file and create,delete directory in the guest operating system.
 version_added: "2.5"
 author:
   - Stéphane Travassac (@stravassac)
@@ -28,6 +28,7 @@ notes:
 requirements:
     - "python >= 2.6"
     - PyVmomi
+    - requests
 options:
     datacenter:
         description:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -79,7 +79,27 @@ options:
     directory:
         description:
             - Create or delete directory
+            - 'Valid attributes are:'
+                - 'path: directory path to create or remove'
+                - 'operation: Valid values are create, delete'
+                - 'recurse: Valid values are True, False (not required, default False)'
         required: False
+    file_copy:
+        description:
+            - Copy file to vm networkless
+            - 'Valid attributes are:'
+                - 'src: file source absolute or relative'
+                - 'dest: file destination, path must be exist'
+                - 'overwrite: False or True (not required, default False)'
+        required: False
+    fetch_file:
+        description:
+            - Get file from vm networkless
+            - 'Valid attributes are:'
+                - 'src: The file on the remote system to fetch. This I(must) be a file, not a directory
+                - 'dest: file destination on localhost, path must be exist'
+        required: False
+
 '''
 
 EXAMPLES = '''
@@ -89,14 +109,48 @@ EXAMPLES = '''
     username: myUsername
     password: mySecret
     datacenter: myDatacenter
+    validate_certs: True
     folder: /vm
     vm_id: NameOfVM
     vm_username: root
     vm_password: superSecret
     directory:
       path: "/test"
-      state: present
+      operation: create
       recurse: no
+  delegate_to: localhost
+
+- name: copy file to vm
+  vmware_guest_file_operation:
+    hostname: myVSphere
+    username: myUsername
+    password: mySecret
+    datacenter: myDatacenter
+    validate_certs: True
+    folder: /vm
+    vm_id: NameOfVM
+    vm_username: root
+    vm_password: superSecret
+    copy:
+        src: "files/test.zip"
+        dest: "/root/test.zip"
+        overwrite: False
+  delegate_to: localhost
+
+- name: fetch file from vm
+  vmware_guest_file_operation:
+    hostname: myVSphere
+    username: myUsername
+    password: mySecret
+    datacenter: myDatacenter
+    validate_certs: True
+    folder: /vm
+    vm_id: NameOfVM
+    vm_username: root
+    vm_password: superSecret
+    fetch:
+        src: "/root/test.zip"
+        dest: "files/test.zip"
   delegate_to: localhost
 '''
 
@@ -104,57 +158,109 @@ try:
     from pyVmomi import vim, vmodl
 except ImportError:
     pass
+try:
+    import requests
+except ImportError:
+    REQUESTS_FOUND = False
+else:
+    REQUESTS_FOUND = True
 
+import os
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_bytes, to_native
 from ansible.module_utils.vmware import (connect_to_api, find_cluster_by_name, find_datacenter_by_name,
                                          find_vm_by_id, HAS_PYVMOMI, vmware_argument_spec)
 
 
-# https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/execute_program_in_vm.py
-def execute_command(content, vm, params):
-    vm_username = params['vm_username']
-    vm_password = params['vm_password']
-    program_path = params['vm_shell']
-    args = params['vm_shell_args']
-    env = params['vm_shell_env']
-    cwd = params['vm_shell_cwd']
 
-    creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
-    cmdspec = vim.vm.guest.ProcessManager.ProgramSpec(arguments=args, envVariables=env, programPath=program_path, workingDirectory=cwd)
-    cmdpid = content.guestOperationsManager.processManager.StartProgramInGuest(vm=vm, auth=creds, spec=cmdspec)
-
-    return cmdpid
-
-def directory(content, vm, params):
-    vm_username = params['vm_username']
-    vm_password = params['vm_password']
+def directory(module, content, vm):
+    operations_permit = ['create','delete']
+    vm_username = module.params['vm_username']
+    vm_password = module.params['vm_password']
         
-    if "path" not in params["directory"]:
-        self.module.fail_json(msg="directory.path is mandatory")
-    if "state" not in params["directory"]:
-        self.module.fail_json(msg="directory.state is mandatory")
-    if not "recurse" in params["directory"]:
+    if "path" not in module.params["directory"]:
+        module.fail_json(msg="directory.path is mandatory")
+    if "operation" not in module.params["directory"]:
+        module.fail_json(msg="directory.operation is mandatory")
+    if not "recurse" in module.params["directory"]:
         recurse = False
     else:
-        recurse = params["directory"]['recurse']
-    state = params["directory"]['state']
-    path = params["directory"]['path']
+        recurse = module.params["directory"]['recurse']
+    operation = module.params["directory"]['operation']
+    path = module.params["directory"]['path']
+    if operation not in operations_permit:
+        module.fail_json(msg="directory.operation valid values are create, delete")
 
     creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
     file_manager = content.guestOperationsManager.fileManager
-    if state == "present":
+    if operation == "create":
         file_manager.MakeDirectoryInGuest(vm=vm, auth=creds, directoryPath=path,
                                                     createParentDirectories=recurse)
-    if state == "absent":
+    if operation == "delete":
         file_manager.DeleteDirectoryInGuest(vm=vm, auth=creds, directoryPath=path,
                                                     recursive=recurse)
 
 
-def file(content, vm, params):
-    vm_username = params['vm_username']
-    vm_password = params['vm_password']
-    vm_path = params['vm_path']
-    state = params['vm_state']
+def fetch(module,content, vm):
+    vm_username = module.params['vm_username']
+    vm_password = module.params['vm_password']
+    
+    if "src" not in module.params["fetch"]:
+        module.fail_json(msg="fetch.src is mandatory")
+    if "dest" not in module.params["fetch"]:
+        module.fail_json(msg="fetch.dest is mandatory")
+    
+    dest = module.params["fetch"]['dest']
+    src = module.params['fetch']['src']
+    
+    creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
+    file_manager = content.guestOperationsManager.fileManager
+
+    fileTransferInfo = file_manager.InitiateFileTransferFromGuest(vm=vm, auth=creds,
+                                                                              guestFilePath=src)
+    url = fileTransferInfo.url
+    f = requests.get(url, verify=module.params['validate_certs'])
+    with open(dest, "wb") as local_file:
+        local_file.write(f.content)
+
+def copy(module,content, vm):
+    vm_username = module.params['vm_username']
+    vm_password = module.params['vm_password']
+    
+    if "src" not in module.params["copy"]:
+        module.fail_json(msg="copy.src is mandatory")
+    if "dest" not in module.params["copy"]:
+        module.fail_json(msg="copy.dest is mandatory")
+    if "overwrite" in module.params["copy"]:
+        overwrite = module.params["copy"]["overwrite"]
+    else:
+        overwrite = False
+    
+    dest = module.params["copy"]['dest']
+    src = module.params['copy']['src']
+    b_src = to_bytes(src, errors='surrogate_or_strict')
+    if not os.path.exists(b_src):
+        module.fail_json(msg="Source %s not found" % (src))
+    if not os.access(b_src, os.R_OK):
+        module.fail_json(msg="Source %s not readable" % (src))
+    if os.path.isdir(b_src):
+        module.fail_json(msg="copy does not support copy of directory: %s" % (src))
+    
+    data = None
+    with open(b_src, "r") as local_file:
+          data = local_file.read()
+    file_size = os.path.getsize(b_src)    
+
+    creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
+    file_attributes = vim.vm.guest.FileManager.FileAttributes()
+    file_manager = content.guestOperationsManager.fileManager
+    url = file_manager.InitiateFileTransferToGuest(vm=vm, auth=creds, guestFilePath=dest,
+                                                           fileAttributes=file_attributes, overwrite=overwrite,
+                                                           fileSize=file_size)
+    r = requests.put(url, data=data, verify=module.params['validate_certs'])
+    if r.status_code <> 200:
+       raise Exception('initiateFileTransferToGuest : problem during file transfer') 
+   
 
 
 def main():
@@ -166,7 +272,9 @@ def main():
                               vm_id_type=dict(default='vm_name', type='str', choices=['inventory_path', 'uuid', 'dns_name', 'vm_name']),
                               vm_username=dict(type='str', required=True),
                               vm_password=dict(type='str', no_log=True, required=True),
-                              directory=dict(type='dict', default={})
+                              directory=dict(type='dict', default={}),
+                              copy=dict(type='dict', default={}),
+                              fetch=dict(type='dict', default={})
                               ))
 
     module = AnsibleModule(argument_spec=argument_spec,
@@ -176,6 +284,10 @@ def main():
 
     if not HAS_PYVMOMI:
         module.fail_json(changed=False, msg='pyvmomi is required for this module')
+    
+    if not REQUESTS_FOUND:
+            self.module.fail_json(
+                msg='requests library is required for this module')
 
     datacenter_name = module.params['datacenter']
     cluster_name = module.params['cluster']
@@ -203,8 +315,12 @@ def main():
         module.fail_json(msg='Unable to find virtual machine.')
 
     try:
-        if 'directory' in module.params:
-            msg = directory(content, vm, module.params)
+        if len(module.params['directory']) > 0:
+            msg = directory(module, content, vm)
+        if len(module.params['copy']) > 0:
+            msg = copy(module, content, vm)
+        if len(module.params['fetch']) > 0:
+            msg = fetch(module, content, vm)
         module.exit_json(changed=True, uuid=vm.summary.config.uuid, msg=msg)
     except vmodl.RuntimeFault as runtime_fault:
         module.fail_json(changed=False, msg=runtime_fault.msg)

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -1,0 +1,218 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Stéphane Travassac <stravassac () gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: vmware_guest_file_operation
+short_description: Files operation in a VMware guest operating system whithout network
+description:
+    - Module allows user to create,delete file or directory in the guest operating system.
+version_added: "2.5"
+author:
+  - Stéphane Travassac (@stravassac)
+notes:
+    - Tested on vSphere 6
+    - Only the first match against vm_id is used, even if there are multiple matches
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+options:
+    datacenter:
+        description:
+            - The datacenter hosting the virtual machine.
+            - If set, it will help to speed up virtual machine search.
+    cluster:
+        description:
+            - The cluster hosting the virtual machine.
+            - If set, it will help to speed up virtual machine search.
+    folder:
+        description:
+            - Destination folder, absolute or relative path to find an existing guest or create the new guest.
+            - The folder should include the datacenter. ESX's datacenter is ha-datacenter
+            - 'Examples:'
+            - '   folder: /ha-datacenter/vm'
+            - '   folder: ha-datacenter/vm'
+            - '   folder: /datacenter1/vm'
+            - '   folder: datacenter1/vm'
+            - '   folder: /datacenter1/vm/folder1'
+            - '   folder: datacenter1/vm/folder1'
+            - '   folder: /folder1/datacenter1/vm'
+            - '   folder: folder1/datacenter1/vm'
+            - '   folder: /folder1/datacenter1/vm/folder2'
+            - '   folder: vm/folder2'
+            - '   folder: folder2'
+        default: /vm
+        version_added: "2.4"
+    vm_id:
+        description:
+            - Name of the virtual machine to work with.
+        required: True
+    vm_id_type:
+        description:
+            - The VMware identification method by which the virtual machine will be identified.
+        default: vm_name
+        choices:
+            - 'uuid'
+            - 'dns_name'
+            - 'inventory_path'
+            - 'vm_name'
+    vm_username:
+        description:
+            - The user to login-in to the virtual machine.
+        required: True
+    vm_password:
+        description:
+            - The password used to login-in to the virtual machine.
+        required: True
+    directory:
+        description:
+            - Create or delete directory
+        required: False
+'''
+
+EXAMPLES = '''
+- name: Create directory inside a vm
+  vmware_guest_file_operation:
+    hostname: myVSphere
+    username: myUsername
+    password: mySecret
+    datacenter: myDatacenter
+    folder: /vm
+    vm_id: NameOfVM
+    vm_username: root
+    vm_password: superSecret
+    directory:
+      path: "/test"
+      state: present
+      recurse: no
+  delegate_to: localhost
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.vmware import (connect_to_api, find_cluster_by_name, find_datacenter_by_name,
+                                         find_vm_by_id, HAS_PYVMOMI, vmware_argument_spec)
+
+
+# https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/execute_program_in_vm.py
+def execute_command(content, vm, params):
+    vm_username = params['vm_username']
+    vm_password = params['vm_password']
+    program_path = params['vm_shell']
+    args = params['vm_shell_args']
+    env = params['vm_shell_env']
+    cwd = params['vm_shell_cwd']
+
+    creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
+    cmdspec = vim.vm.guest.ProcessManager.ProgramSpec(arguments=args, envVariables=env, programPath=program_path, workingDirectory=cwd)
+    cmdpid = content.guestOperationsManager.processManager.StartProgramInGuest(vm=vm, auth=creds, spec=cmdspec)
+
+    return cmdpid
+
+def directory(content, vm, params):
+    vm_username = params['vm_username']
+    vm_password = params['vm_password']
+        
+    if "path" not in params["directory"]:
+        self.module.fail_json(msg="directory.path is mandatory")
+    if "state" not in params["directory"]:
+        self.module.fail_json(msg="directory.state is mandatory")
+    if not "recurse" in params["directory"]:
+        recurse = False
+    else:
+        recurse = params["directory"]['recurse']
+    state = params["directory"]['state']
+    path = params["directory"]['path']
+
+    creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
+    file_manager = content.guestOperationsManager.fileManager
+    if state == "present":
+        file_manager.MakeDirectoryInGuest(vm=vm, auth=creds, directoryPath=path,
+                                                    createParentDirectories=recurse)
+    if state == "absent":
+        file_manager.DeleteDirectoryInGuest(vm=vm, auth=creds, directoryPath=path,
+                                                    recursive=recurse)
+
+
+def file(content, vm, params):
+    vm_username = params['vm_username']
+    vm_password = params['vm_password']
+    vm_path = params['vm_path']
+    state = params['vm_state']
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(datacenter=dict(type='str'),
+                              cluster=dict(type='str'),
+                              folder=dict(type='str', default='/vm'),
+                              vm_id=dict(type='str', required=True),
+                              vm_id_type=dict(default='vm_name', type='str', choices=['inventory_path', 'uuid', 'dns_name', 'vm_name']),
+                              vm_username=dict(type='str', required=True),
+                              vm_password=dict(type='str', no_log=True, required=True),
+                              directory=dict(type='dict', default={})
+                              ))
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=False,
+                           required_if=[['vm_id_type', 'inventory_path', ['folder']]],
+                           )
+
+    if not HAS_PYVMOMI:
+        module.fail_json(changed=False, msg='pyvmomi is required for this module')
+
+    datacenter_name = module.params['datacenter']
+    cluster_name = module.params['cluster']
+    folder = module.params['folder']
+    content = connect_to_api(module)
+
+    datacenter = None
+    if datacenter_name:
+        datacenter = find_datacenter_by_name(content, datacenter_name)
+        if not datacenter:
+            module.fail_json(changed=False, msg="Unable to find %(datacenter)s datacenter" % module.params)
+
+    cluster = None
+    if cluster_name:
+        cluster = find_cluster_by_name(content, cluster_name, datacenter)
+        if not cluster:
+            module.fail_json(changed=False, msg="Unable to find %(cluster)s cluster" % module.params)
+
+    if module.params['vm_id_type'] == 'inventory_path':
+        vm = find_vm_by_id(content, vm_id=module.params['vm_id'], vm_id_type="inventory_path", folder=folder)
+    else:
+        vm = find_vm_by_id(content, vm_id=module.params['vm_id'], vm_id_type=module.params['vm_id_type'], datacenter=datacenter, cluster=cluster)
+
+    if not vm:
+        module.fail_json(msg='Unable to find virtual machine.')
+
+    try:
+        if 'directory' in module.params:
+            msg = directory(content, vm, module.params)
+        module.exit_json(changed=True, uuid=vm.summary.config.uuid, msg=msg)
+    except vmodl.RuntimeFault as runtime_fault:
+        module.fail_json(changed=False, msg=runtime_fault.msg)
+    except vmodl.MethodFault as method_fault:
+        module.fail_json(changed=False, msg=method_fault.msg)
+    except Exception as e:
+        module.fail_json(changed=False, msg=str(e))
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -192,14 +192,14 @@ def directory(module, content, vm):
             file_manager.MakeDirectoryInGuest(vm=vm, auth=creds, directoryPath=path,
                                               createParentDirectories=recurse)
         except Exception as e:
-            module.fail_json(msg=e)
+            module.fail_json(msg="Failed to Create directory into Vm due %s" % e)
 
     if operation == "delete":
         try:
             file_manager.DeleteDirectoryInGuest(vm=vm, auth=creds, directoryPath=path,
                                                 recursive=recurse)
         except Exception as e:
-            module.fail_json(changed=False, msg=e)
+            module.fail_json(changed=False, msg="Failed to Delete directory into Vm due %s" % e)
 
     return True
 
@@ -223,7 +223,7 @@ def fetch(module, content, vm):
         fileTransferInfo = file_manager.InitiateFileTransferFromGuest(vm=vm, auth=creds,
                                                                       guestFilePath=src)
     except Exception as e:
-        module.fail_json(changed=False, msg=e)
+        module.fail_json(changed=False, msg="Failed to Fetch file from Vm due %s" % e)
 
     url = fileTransferInfo.url
     resp, info = urls.fetch_url(module, url, method="GET")
@@ -269,7 +269,7 @@ def copy(module, content, vm):
                                                        fileAttributes=file_attributes, overwrite=overwrite,
                                                        fileSize=file_size)
     except Exception as e:
-        module.fail_json(changed=False, msg=e)
+        module.fail_json(changed=False, msg="Failed to Copy file to Vm due %s" % e)
 
     resp, info = urls.fetch_url(module, url, data=data, method="PUT")
 

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -186,7 +186,6 @@ def directory(module, content, vm):
         except vim.fault.FileAlreadyExists:
             result['changed'] = False
             result['msg'] = "Guest directory %s already exist" % path
-            pass
         except vim.fault.GuestPermissionDenied:
             module.fail_json(msg="Permission denied for path %s" % path, uuid=vm.summary.config.uuid)
         except vim.fault.InvalidGuestLogin:
@@ -203,7 +202,6 @@ def directory(module, content, vm):
         except vim.fault.FileNotFound:
             result['changed'] = False
             result['msg'] = "Guest directory %s not exists" % path
-            pass
         except vim.fault.FileFault as e:
             module.fail_json(msg="FileFault:%s" % e.msg, uuid=vm.summary.config.uuid)
         except vim.fault.GuestPermissionDenied:
@@ -236,7 +234,6 @@ def fetch(module, content, vm):
         result['changed'] = False
         result['msg'] = "Guest file %s not exists" % src
         return result
-        pass
     except vim.fault.FileFault as e:
         module.fail_json(msg="FileFault:%s" % e.msg, uuid=vm.summary.config.uuid)
     except vim.fault.GuestPermissionDenied:
@@ -297,7 +294,6 @@ def copy(module, content, vm):
         result['changed'] = False
         result['msg'] = "Guest file %s already exists" % dest
         return result
-        pass
     except vim.fault.FileFault as e:
         module.fail_json(msg="FileFault:%s" % e, uuid=vm.summary.config.uuid)
     except vim.fault.GuestPermissionDenied:
@@ -340,8 +336,7 @@ def main():
                                   type='dict',
                                   default=None,
                                   options=dict(
-                                      src=dict(required=True, type='str'),
-                                      dest=dict(required=True, type='str'),
+                                      src=dict(required=True, type='str'), dest=dict(required=True, type='str'),
                                       overwrite=dict(required=False, type='bool', default=False)
                                   )
                               ),
@@ -349,14 +344,12 @@ def main():
                                   type='dict',
                                   default=None,
                                   options=dict(
-                                      src=dict(required=True, type='str'),
-                                      dest=dict(required=True, type='str'),
+                                      src=dict(required=True, type='str'), dest=dict(required=True, type='str'),
                                   )
                               )
                               ))
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=False,
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,
                            required_if=[
                                ['vm_id_type', 'inventory_path', ['folder']]
                            ],

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -350,15 +350,9 @@ def main():
                               ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,
-                           required_if=[
-                               ['vm_id_type', 'inventory_path', ['folder']]
-                           ],
-                           mutually_exclusive=[
-                               ['directory', 'copy', 'fetch']
-                           ],
-                           required_one_of=[
-                               ['directory', 'copy', 'fetch']
-                           ],
+                           required_if=[['vm_id_type', 'inventory_path', ['folder']]],
+                           mutually_exclusive=[['directory', 'copy', 'fetch']],
+                           required_one_of=[['directory', 'copy', 'fetch']],
                            )
 
     if not HAS_PYVMOMI:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -330,23 +330,20 @@ def main():
                                       operation=dict(required=True, type='str',
                                                      choices=['create', 'delete']),
                                       recurse=dict(required=False, type='bool', default=False)
-                                  )
-                              ),
+                                  )),
                               copy=dict(
                                   type='dict',
                                   default=None,
                                   options=dict(
                                       src=dict(required=True, type='str'), dest=dict(required=True, type='str'),
                                       overwrite=dict(required=False, type='bool', default=False)
-                                  )
-                              ),
+                                  )),
                               fetch=dict(
                                   type='dict',
                                   default=None,
-                                  options=dict(
-                                      src=dict(required=True, type='str'), dest=dict(required=True, type='str'),
-                                  )
-                              )
+                                  options=dict(src=dict(required=True, type='str'),
+                                               dest=dict(required=True, type='str'),
+                                               ))
                               ))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False,

--- a/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest_file_operation.py
@@ -40,7 +40,7 @@ options:
         description:
             - Destination folder, absolute or relative path to find an existing guest or create the new guest.
             - The folder should include the datacenter. ESX's datacenter is ha-datacenter
-            - use only if vm_id_type is inventory_path
+            - Used only if C(vm_id_type) is C(inventory_path).
             - 'Examples:'
             - '   folder: /ha-datacenter/vm'
             - '   folder: ha-datacenter/vm'
@@ -229,7 +229,7 @@ def fetch(module, content, vm):
         fileTransferInfo = file_manager.InitiateFileTransferFromGuest(vm=vm, auth=creds,
                                                                       guestFilePath=src)
     except vim.fault.FileNotFound:
-        module.fail_json(msg="Guest file %s not exists" % src, uuid=vm.summary.config.uuid)
+        module.fail_json(msg="Guest file %s does not exist" % src, uuid=vm.summary.config.uuid)
     except vim.fault.FileFault as e:
         module.fail_json(msg="FileFault:%s" % e.msg, uuid=vm.summary.config.uuid)
     except vim.fault.GuestPermissionDenied:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
On VMware add possibility to copy file from localhost  to VM, fetch file from VM and manage directory on VM without network link (vmware-tools must be installed) 
Useful with module vmware_vm_shell
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request
 
##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest_file_operation

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/stephane/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/stephane/virtualenvs/ansible-dev/local/lib/python2.7/site-packages/ansible
  executable location = /home/stephane/virtualenvs/ansible-dev/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
