### PR TITLE
openssl_publickey: Ensure format OpenSSH is idempotent

### DIFF
--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -212,11 +212,16 @@ class PublicKey(crypto_utils.OpenSSLObject):
                 return False
 
             try:
+                publickey_content = open(self.path, 'rb').read()
+                if self.format == 'OpenSSH':
+                    current_publickey = crypto_serialization.load_ssh_public_key(publickey_content, backend=default_backend())
+                    publickey_content = current_publickey.public_bytes(crypto_serialization.Encoding.PEM,
+                                                                       crypto_serialization.PublicFormat.SubjectPublicKeyInfo)
                 current_publickey = crypto.dump_publickey(
                     crypto.FILETYPE_ASN1,
-                    crypto.load_publickey(crypto.FILETYPE_PEM, open(self.path, 'rb').read())
+                    crypto.load_publickey(crypto.FILETYPE_PEM, publickey_content)
                 )
-            except crypto.Error:
+            except (crypto.Error, ValueError):
                 return False
 
             desired_publickey = crypto.dump_publickey(

--- a/test/integration/targets/openssl_publickey/tasks/main.yml
+++ b/test/integration/targets/openssl_publickey/tasks/main.yml
@@ -18,6 +18,14 @@
       # appeared in version 1.4 of cryptography
       when: cryptography_version.stdout|version_compare('1.4.0', '>=')
 
+    - name: Generate publickey - OpenSSH format - test idempotence (issue 33256)
+      openssl_publickey:
+        path: '{{ output_dir }}/publickey-ssh.pub'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        format: OpenSSH
+      when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+      register: publickey_ssh_idempotence
+
     - name: Generate publickey2 - standard
       openssl_publickey:
         path: '{{ output_dir }}/publickey2.pub'

--- a/test/integration/targets/openssl_publickey/tests/validate.yml
+++ b/test/integration/targets/openssl_publickey/tests/validate.yml
@@ -28,6 +28,12 @@
       - privatekey_publickey.stdout == '{{ publickey.content|b64decode }}'
   when: cryptography_version.stdout|version_compare('1.4.0', '>=')
 
+- name: Validate public key - OpenSSH format - test idempotence (issue 33256)
+  assert:
+    that:
+      - not publickey_ssh_idempotence|changed
+  when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+
 - name: Validate publickey2 (test - Ensure key has been removed)
   stat:
     path: '{{ output_dir }}/publickey2.pub'


### PR DESCRIPTION
##### SUMMARY

Currently the check() method for idempotence only assumes the public
key is under the form of a PEM file when its not always the case.

The module openssl_publickey allows one to generate OpenSSH format
publickey. This leads to idempotence not being detected. This commit
fixes that.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- openssl_publickey

##### ANSIBLE VERSION

- devel`

##### ADDITIONAL INFORMATION

Playbook to test this patch. Before not-idempotent, after idempotent.

```
---
- hosts: localhost
  tasks:

    - openssl_privatekey:
        path: "/tmp/id_rsa-testing"

    - openssl_publickey:
        privatekey_path: "/tmp/id_rsa-testing"
        path: "/tmp/yanis.pub"
        format: OpenSSH
```

Fixes https://github.com/ansible/ansible/issues/33256
