### PR TITLE
Fixes #31049 : Missing facts in SunOS module

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/sunos.py
+++ b/lib/ansible/module_utils/facts/hardware/sunos.py
@@ -199,6 +199,7 @@ class SunOSHardware(Hardware):
         # sderr:0:sd0,err:Vendor  ATA
 
         device_facts = {}
+        device_facts['devices'] = {}
 
         disk_stats = {
             'Product': 'product',


### PR DESCRIPTION
##### SUMMARY

Fixes #31049 .

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

SunOS

##### ANSIBLE VERSION

```
ansible 2.4.1.0
  config file = /home/jcea/hg/ansible/ansible.cfg
  configured module search path = [u'/home/jcea/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 16:03:25) [GCC 5.4.0 20160609]
```