### PR TITLE
Count ignored failed tasks and successful tasks with expected failure…

### DIFF
--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -15,6 +15,8 @@ DOCUMENTATION = '''
       - "Tasks show up in the report as follows:
         'ok': pass
         'failed' with 'EXPECTED FAILURE' in the task name: pass
+        'failed' with 'TOGGLE RESULT' in the task name: pass
+        'ok' with 'TOGGLE RESULT' in the task name: failure
         'failed' due to an exception: error
         'failed' for other reasons: failure
         'skipped': skipped"
@@ -37,6 +39,12 @@ DOCUMENTATION = '''
         description: Consider any tasks reporting "changed" as a junit test failure
         env:
           - name: JUNIT_FAIL_ON_CHANGE
+      fail_on_ignore:
+        name: JUnit fail on ignore
+        default: False
+        description: Consider failed tasks as a junit test failure even if ignore_on_error is set
+        env:
+          - name: JUNIT_FAIL_ON_IGNORE
     requirements:
       - whitelist in configuration
       - junit_xml (python lib)
@@ -73,6 +81,8 @@ class CallbackModule(CallbackBase):
     Tasks show up in the report as follows:
         'ok': pass
         'failed' with 'EXPECTED FAILURE' in the task name: pass
+        'failed' with 'TOGGLE RESULT' in the task name: pass
+        'ok' with 'TOGGLE RESULT' in the task name: failure
         'failed' due to an exception: error
         'failed' for other reasons: failure
         'skipped': skipped
@@ -83,6 +93,8 @@ class CallbackModule(CallbackBase):
         JUNIT_TASK_CLASS (optional): Configure the output to be one class per yaml file
                                      Default: False
         JUNIT_FAIL_ON_CHANGE (optional): Consider any tasks reporting "changed" as a junit test failure
+                                     Default: False
+        JUNIT_FAIL_ON_IGNORE (optional): Consider failed tasks as a junit test failure even if ignore_on_error is set
                                      Default: False
 
     Requires:
@@ -101,6 +113,7 @@ class CallbackModule(CallbackBase):
         self._output_dir = os.getenv('JUNIT_OUTPUT_DIR', os.path.expanduser('~/.ansible.log'))
         self._task_class = os.getenv('JUNIT_TASK_CLASS', 'False').lower()
         self._fail_on_change = os.getenv('JUNIT_FAIL_ON_CHANGE', 'False').lower()
+        self._fail_on_ignore = os.getenv('JUNIT_FAIL_ON_IGNORE', 'False').lower()
         self._playbook_path = None
         self._playbook_name = None
         self._play_name = None
@@ -159,7 +172,10 @@ class CallbackModule(CallbackBase):
         if self._fail_on_change == 'true' and status == 'ok' and result._result.get('changed', False):
             status = 'failed'
 
-        if 'EXPECTED FAILURE' in task_data.name:
+        # ignore failure if expected and toggle result if asked for
+        if status == 'failed' and 'EXPECTED FAILURE' in task_data.name:
+            status = 'ok'
+        elif 'TOGGLE RESULT' in task_data.name:
             if status == 'failed':
                 status = 'ok'
             elif status == 'ok':
@@ -251,7 +267,10 @@ class CallbackModule(CallbackBase):
         self._start_task(task)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        self._finish_task('failed', result)
+        if ignore_errors and self._fail_on_ignore != 'true':
+            self._finish_task('ok', result)
+        else:
+            self._finish_task('failed', result)
 
     def v2_runner_on_ok(self, result):
         self._finish_task('ok', result)

--- a/lib/ansible/plugins/callback/junit.py
+++ b/lib/ansible/plugins/callback/junit.py
@@ -159,8 +159,11 @@ class CallbackModule(CallbackBase):
         if self._fail_on_change == 'true' and status == 'ok' and result._result.get('changed', False):
             status = 'failed'
 
-        if status == 'failed' and 'EXPECTED FAILURE' in task_data.name:
-            status = 'ok'
+        if 'EXPECTED FAILURE' in task_data.name:
+            if status == 'failed':
+                status = 'ok'
+            elif status == 'ok':
+                status = 'failed'
 
         task_data.add_host(HostData(host_uuid, host_name, status, result))
 
@@ -248,10 +251,7 @@ class CallbackModule(CallbackBase):
         self._start_task(task)
 
     def v2_runner_on_failed(self, result, ignore_errors=False):
-        if ignore_errors:
-            self._finish_task('ok', result)
-        else:
-            self._finish_task('failed', result)
+        self._finish_task('failed', result)
 
     def v2_runner_on_ok(self, result):
         self._finish_task('ok', result)


### PR DESCRIPTION
… as failed tests.

##### SUMMARY

In a test suite one expects that all tests are executed at once and only at the end, the number of failed tests if given. This can be done with Ansible by setting `ignore_errors` but the result must still be counted as failure. This PR makes sure that:

1. ignored errors are nevertheless counted as errors in the resulting XML file
2. successful tasks with `EXPECTED FAILURE` are counted as failed tests

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

callback plugin junit.py

##### ANSIBLE VERSION

```
ansible 2.4.1.0
  config file = /somepath/ansible.cfg
  configured module search path = [u'/home/myuser/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

##### ADDITIONAL INFORMATION

After the PR, the following playbook goes completely through and the resulting logfile has the expected test results:

```yaml
- hosts: localhost
  gather_facts: no
  ignore_errors: yes # making sure that the tests go through completely
  tasks:
          - name: task succeeds and test succeeds
            debug:
                    msg: "successful task and successful test"
          - name: task succeeds but test fails due to EXPECTED FAILURE
            debug:
                    msg: "successful task and failed test"
          - name: task fails and test fails
            fail:
                    msg: "failed task and failed test"
          - name: task fails but test succeeds due to EXPECTED FAILURE
            fail:
                    msg: "failed task and successful test"
          - name: task skipped and test skipped
            fail:
                    msg: "skipped task and skipped test"
            when: false
```

As a further extension, it would be good to have an option to get a return code unequal 0 if at least of the tests fails, but I don't know if this can be influenced by a callback plug-in, and it can be done in a 2nd PR.