### PR TITLE
Small correction to import_role documentation

### DIFF
--- a/lib/ansible/modules/utilities/logic/import_role.py
+++ b/lib/ansible/modules/utilities/logic/import_role.py
@@ -23,7 +23,7 @@ description:
   - Much like the `roles:` keyword, this task loads a role, but it allows you to control it when the role tasks run in
     between other tasks of the play.
   - Most keywords, loops and conditionals will only be applied to the imported tasks, not to this statement itself. If
-    you want the opposite behaviour, use M(include_role) instead.
+    you want the opposite behavior, use M(include_role) instead. To better understand the difference you can read U(https://docs.ansible.com/ansible/latest/playbooks_reuse_includes.html).
 version_added: "2.4"
 options:
   name:
@@ -63,7 +63,7 @@ EXAMPLES = """
 - hosts: all
   tasks:
     - import_role:
-       name: myrole
+        name: myrole
 
     - name: Run tasks/other.yaml instead of 'main'
       import_role:

--- a/lib/ansible/modules/utilities/logic/import_role.py
+++ b/lib/ansible/modules/utilities/logic/import_role.py
@@ -23,7 +23,8 @@ description:
   - Much like the `roles:` keyword, this task loads a role, but it allows you to control it when the role tasks run in
     between other tasks of the play.
   - Most keywords, loops and conditionals will only be applied to the imported tasks, not to this statement itself. If
-    you want the opposite behavior, use M(include_role) instead. To better understand the difference you can read U(https://docs.ansible.com/ansible/latest/playbooks_reuse_includes.html).
+    you want the opposite behavior, use M(include_role) instead. To better understand the difference you can read
+    U(https://docs.ansible.com/ansible/latest/playbooks_reuse_includes.html).
 version_added: "2.4"
 options:
   name:


### PR DESCRIPTION
##### SUMMARY
Corrected
- indentation in an example
- spelling from British English to American English
 
Added
- link to documentation

Fix #33176 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
module import_role

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION

I'm not sure if I correctly linked to the article. Should I use some kind of the Sphinx magic?