### PR TITLE
This PR removes 'md5' as it only compares two hashes.

### DIFF
--- a/lib/ansible/modules/crypto/openssl_publickey.py
+++ b/lib/ansible/modules/crypto/openssl_publickey.py
@@ -221,7 +221,7 @@ class PublicKey(crypto_utils.OpenSSLObject):
                 crypto_utils.load_privatekey(self.privatekey_path, self.privatekey_passphrase)
             )
 
-            return hashlib.md5(current_publickey).hexdigest() == hashlib.md5(desired_publickey).hexdigest()
+            return current_publickey == desired_publickey
 
         if not state_and_perms:
             return state_and_perms


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
As comparing two hashes so no need to have md5, so removing it.


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Name of the lib/ansible/modules/crypto/openssl_publickey.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```
