### PR TITLE
Adds missing url, public_ip_address, and port keys to cluster dict

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -243,11 +243,14 @@ def _collect_facts(resource):
         'db_name'           : resource['DBName'],
         'availability_zone' : resource['AvailabilityZone'],
         'maintenance_window': resource['PreferredMaintenanceWindow'],
+        'url'               : resource['Endpoint']['Address'],
+        'port'              : resource['Endpoint']['Port']
     }
 
     for node in resource['ClusterNodes']:
         if node['NodeRole'] in ('SHARED', 'LEADER'):
             facts['private_ip_address'] = node['PrivateIPAddress']
+            facts['public_ip_address'] = node['PublicIPAddress']
             break
 
     return facts


### PR DESCRIPTION
Adds missing url, public_ip_address, and port keys to cluster dict.

Fixes #33279.

Adds missing keys to _collect_facts function.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adds missing keys to cluster dict return value, as documented in http://docs.ansible.com/ansible/latest/redshift_module.html under "Return Values" header.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Adds missing keys to _collect_facts function.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

redshift

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/brad.chamberlain/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Jul 15 2017, 17:16:57) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.31)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
TASK [listener : debug] *************************************************************************
ok: [localhost] => {
    "redshift_instance": {
        "changed": true,
        "cluster": {
            "availability_zone": "us-east-1b",
            "create_time": 1511701596.487,
            "db_name": "dbname",
            "identifier": "id",
            "maintenance_window": "sun:10:00-sun:10:30",
            "private_ip_address": "172.31.10.246",
            "status": "available",
            "username": "admin"
        },
        "failed": false
    }
}
```
After:
```
TASK [listener : debug] *************************************************************************
ok: [localhost] => {
    "redshift_instance": {
        "changed": false,
        "cluster": {
            "availability_zone": "us-east-1b",
            "create_time": 1511704430.074,
            "db_name": "dbname",
            "identifier": "id",
            "maintenance_window": "wed:07:30-wed:08:00",
            "port": 5439,
            "private_ip_address": "172.31.9.219",
            "public_ip_address": "34.235.29.128",
            "status": "available",
            "url": "id.c4fneaywfxdp.us-east-1.redshift.amazonaws.com",
            "username": "admin"
        },
        "failed": false
    }
}
```