### PR TITLE
Created configurable parameters for NetApp ontap connection

### DIFF
--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -79,7 +79,7 @@ def ontap_sf_host_argument_spec():
         major_api_version=dict(require=False, type='int'),
         minor_api_version=dict(require=False, type='int'),
         port=dict(require=False, type='int'),
-        server_type=dict(require=False, type='str', choices=['FILER','DFM']),
+        server_type=dict(require=False, type='str', choices=['FILER', 'DFM']),
         transport_type=dict(require=False, type='str', choices=['HTTP', 'HTTPS']),
     )
 

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -76,6 +76,11 @@ def ontap_sf_host_argument_spec():
         hostname=dict(required=True, type='str'),
         username=dict(required=True, type='str', aliases=['user']),
         password=dict(required=True, type='str', aliases=['pass'], no_log=True),
+        major_api_version=dict(require=False, type='int'),
+        minor_api_version=dict(require=False, type='int'),
+        port=dict(require=False, type='int'),
+        server_type=dict(require=False, type='str', choices=['FILER','DFM']),
+        transport_type=dict(require=False, type='str', choices=['HTTP', 'HTTPS']),
     )
 
 
@@ -106,11 +111,26 @@ def setup_ontap_zapi(module, vserver=None):
         server.set_password(password)
         if vserver:
             server.set_vserver(vserver)
-        # Todo : Replace hard-coded values with configurable parameters.
-        server.set_api_version(major=1, minor=21)
-        server.set_port(80)
-        server.set_server_type('FILER')
-        server.set_transport_type('HTTP')
+        if module.params['major_api_version'] and module.params['minor_api_version']:
+            server.set_api_version(major=major_api_version, minor=minor_api_version)
+        else:
+            server.set_api_version(major=1, minor=21)
+
+        if module.params['port']:
+            server.set_port(module.params['port'])
+        else:
+            server.set_port(80)
+
+        if module.params['server_type']:
+            server.set_server_type(module.params['server_type'])
+        else:
+            server.set_server_type('FILER')
+
+        if module.params['transport_type']:
+            server.set_transport_type(module.params['transport_type'])
+        else:
+            server.set_transport_type('HTTP')
+
         return server
     else:
         module.fail_json(msg="the python NetApp-Lib module is required")

--- a/lib/ansible/module_utils/netapp.py
+++ b/lib/ansible/module_utils/netapp.py
@@ -112,7 +112,7 @@ def setup_ontap_zapi(module, vserver=None):
         if vserver:
             server.set_vserver(vserver)
         if module.params['major_api_version'] and module.params['minor_api_version']:
-            server.set_api_version(major=major_api_version, minor=minor_api_version)
+            server.set_api_version(major=module.params['major_api_version'], minor=module.params['minor_api_version'])
         else:
             server.set_api_version(major=1, minor=21)
 

--- a/lib/ansible/modules/storage/netapp/na_cdot_user.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_user.py
@@ -132,6 +132,7 @@ class NetAppCDOTUser(object):
             role_name=dict(required=False, type='str'),
 
             vserver=dict(required=True, type='str'),
+
         ))
 
         self.module = AnsibleModule(
@@ -154,7 +155,7 @@ class NetAppCDOTUser(object):
         self.role_name = p['role_name']
 
         self.vserver = p['vserver']
-
+        
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:

--- a/lib/ansible/modules/storage/netapp/na_cdot_user.py
+++ b/lib/ansible/modules/storage/netapp/na_cdot_user.py
@@ -132,7 +132,6 @@ class NetAppCDOTUser(object):
             role_name=dict(required=False, type='str'),
 
             vserver=dict(required=True, type='str'),
-
         ))
 
         self.module = AnsibleModule(
@@ -155,7 +154,7 @@ class NetAppCDOTUser(object):
         self.role_name = p['role_name']
 
         self.vserver = p['vserver']
-        
+
         if HAS_NETAPP_LIB is False:
             self.module.fail_json(msg="the python NetApp-Lib module is required")
         else:


### PR DESCRIPTION
##### SUMMARY
Fixes #33292 adds ability for user to specify NetApp Ontap module values for port, api_version, server_type and transport_type rather than only hard coded

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
module_utils/netapp.py

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
This is in response to a ToDo for adding these as parameters