### PR TITLE
Update tags format returned for ec2_vpc_nat_gateway_facts

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py
@@ -89,7 +89,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import (ec2_argument_spec, get_aws_connection_info, boto3_conn,
-                                      camel_dict_to_snake_dict, ansible_dict_to_boto3_filter_list, HAS_BOTO3)
+                                      camel_dict_to_snake_dict, ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict, HAS_BOTO3)
 
 
 def date_handler(obj):
@@ -98,6 +98,7 @@ def date_handler(obj):
 
 def get_nat_gateways(client, module, nat_gateway_id=None):
     params = dict()
+    nat_gateways = list()
 
     params['Filter'] = ansible_dict_to_boto3_filter_list(module.params.get('filters'))
     params['NatGatewayIds'] = module.params.get('nat_gateway_ids')
@@ -107,7 +108,16 @@ def get_nat_gateways(client, module, nat_gateway_id=None):
     except Exception as e:
         module.fail_json(msg=str(e.message))
 
-    return [camel_dict_to_snake_dict(gateway) for gateway in result['NatGateways']]
+    for gateway in result['NatGateways']:
+        # Turn the boto3 result into ansible_friendly_snaked_names
+        converted_gateway = camel_dict_to_snake_dict(gateway)
+        if 'tags' in converted_gateway:
+            # Turn the boto3 result into ansible friendly tag dictionary
+            converted_gateway['tags'] = boto3_tag_list_to_ansible_dict(converted_gateway['tags'])
+
+        nat_gateways.append(converted_gateway)
+
+    return nat_gateways
 
 
 def main():


### PR DESCRIPTION

##### SUMMARY
Update existing facts module to return an Ansible friendly tags result on returned nat gateways instead of the AWS {'Key", 'Value'} result which is really horrible. This brings it inline with other facts modules and utilises an existing EC2 utility function.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_nat_gateway_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/Etherdaemon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/Etherdaemon/python_virtualenvs/ansibletrial/lib/python2.7/site-packages/ansible
  executable location = /Users/Etherdaemon/python_virtualenvs/ansibletrial/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:46:44) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE CHANGE
```
TASK [aws_retrieve_details : Debugging nat gateways AFTER CHANGE] **************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": false,
        "failed": false,
        "result": [
            {
                "create_time": "2017-11-26T03:32:54+00:00",
                "nat_gateway_addresses": [
                    {
                        "allocation_id": "eipalloc-XXXX",
                        "network_interface_id": "eni-XXXXX",
                        "private_ip": "2.2.2.2",
                        "public_ip": "1.1.1.1"
                    }
                ],
                "nat_gateway_id": "nat-XXXXX",
                "state": "available",
                "subnet_id": "subnet-XXXXX",
                "tags": [
                    {
                        "key": "Name",
                        "value": "development"
                    },
                    {
                        "key": "aws_account",
                        "value": "personal"
                    }
                ],
                "vpc_id": "vpc-XXXX"
            }
        ]
    }
}
```

AFTER CHANGE
```
TASK [aws_retrieve_details : Debugging nat gateways AFTER CHANGE] **************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": {
        "changed": false,
        "failed": false,
        "result": [
            {
                "create_time": "2017-11-26T03:32:54+00:00",
                "nat_gateway_addresses": [
                    {
                        "allocation_id": "eipalloc-XXXX",
                        "network_interface_id": "eni-XXXXX",
                        "private_ip": "2.2.2.2",
                        "public_ip": "1.1.1.1"
                    }
                ],
                "nat_gateway_id": "nat-XXXXX",
                "state": "available",
                "subnet_id": "subnet-XXXXX",
                "tags": {
                    "Name": "development",
                    "aws_account": "personal"
                },
                "vpc_id": "vpc-XXXX"
            }
        ]
    }
}

```
