### PR TITLE
Fix typo in examples section for elasticsearch_plugin module.

### DIFF
--- a/lib/ansible/modules/database/misc/elasticsearch_plugin.py
+++ b/lib/ansible/modules/database/misc/elasticsearch_plugin.py
@@ -87,7 +87,7 @@ EXAMPLES = '''
 # Install a specific version of Elasticsearch Head in Elasticsearch 2.x
 - elasticsearch_plugin:
     name: mobz/elasticsearch-head
-    versino: 2.0.0
+    version: 2.0.0
 
 # Uninstall Elasticsearch head plugin in Elasticsearch 2.x
 - elasticsearch_plugin:


### PR DESCRIPTION
##### SUMMARY

Typo fix for `elasticsearch_plugin` documentation (examples section). Simple `versino` -> `version` change.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
`elasticsearch_plugin`

##### ANSIBLE VERSION
N/A

##### ADDITIONAL INFORMATION
N/A