### PR TITLE
 - Fix authentication failure with paramiko when using password mode and

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -162,7 +162,7 @@ class Connection(ConnectionBase):
             return
 
         p = connection_loader.get('paramiko', self._play_context, '/dev/null')
-        p.set_options(direct={'look_for_keys': bool(self._play_context.password and not self._play_context.private_key_file)})
+        p.set_options(direct={'look_for_keys': not bool(self._play_context.password and not self._play_context.private_key_file)})
         p.force_persistence = self.force_persistence
         ssh = p._connect()
 
@@ -260,6 +260,10 @@ class Connection(ConnectionBase):
 
         while True:
             data = self._ssh_shell.recv(256)
+
+            # when a channel stream is closed, received data will be empty
+            if not data:
+                break
 
             recv.write(data)
             offset = recv.tell() - 256 if recv.tell() > 256 else 0


### PR DESCRIPTION
 - break out of loop when paramiko stream is closed

##### SUMMARY
Fixes 
#33300  - when using password, set look_for_keys to False
#33299 - break from while loop when data is empty string

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


