### PR TITLE
Add port arg to establish ssh connection in nxos_file_copy

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -56,9 +56,9 @@ options:
         their default values.
     required: false
     default: null
-  connect_port:
+  connect_ssh_port:
     description:
-      - Server port to connect to during transfer of file
+      - SSH port to connect to server during transfer of file
     required: false
     default: 22
     version_added: "2.5"
@@ -69,7 +69,7 @@ EXAMPLES = '''
     local_file: "./test_file.txt"
     remote_file: "test_file.txt"
     provider: "{{ cli }}"
-    connect_port: "{{ ansible_ssh_port }}"
+    connect_ssh_port: "{{ ansible_ssh_port }}"
 '''
 
 RETURN = '''
@@ -155,7 +155,7 @@ def transfer_file(module, dest):
     hostname = module.params.get('host') or provider.get('host')
     username = module.params.get('username') or provider.get('username')
     password = module.params.get('password') or provider.get('password')
-    connect_port = module.params.get('connect_port')
+    port = module.params.get('connect_ssh_port')
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -163,7 +163,7 @@ def transfer_file(module, dest):
         hostname=hostname,
         username=username,
         password=password,
-        port=connect_port)
+        port=port)
 
     full_remote_path = '{}{}'.format(module.params['file_system'], dest)
     scp = SCPClient(ssh.get_transport())
@@ -190,7 +190,7 @@ def main():
         local_file=dict(required=True),
         remote_file=dict(required=False),
         file_system=dict(required=False, default='bootflash:'),
-        connect_port=dict(required=False, type='int', default=22),
+        connect_ssh_port=dict(required=False, type='int', default=22),
     )
 
     argument_spec.update(nxos_argument_spec)

--- a/lib/ansible/modules/network/nxos/nxos_file_copy.py
+++ b/lib/ansible/modules/network/nxos/nxos_file_copy.py
@@ -56,6 +56,12 @@ options:
         their default values.
     required: false
     default: null
+  connect_port:
+    description:
+      - Server port to connect to during transfer of file
+    required: false
+    default: 22
+    version_added: "2.5"
 '''
 
 EXAMPLES = '''
@@ -63,6 +69,7 @@ EXAMPLES = '''
     local_file: "./test_file.txt"
     remote_file: "test_file.txt"
     provider: "{{ cli }}"
+    connect_port: "{{ ansible_ssh_port }}"
 '''
 
 RETURN = '''
@@ -148,13 +155,15 @@ def transfer_file(module, dest):
     hostname = module.params.get('host') or provider.get('host')
     username = module.params.get('username') or provider.get('username')
     password = module.params.get('password') or provider.get('password')
+    connect_port = module.params.get('connect_port')
 
     ssh = paramiko.SSHClient()
     ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
     ssh.connect(
         hostname=hostname,
         username=username,
-        password=password)
+        password=password,
+        port=connect_port)
 
     full_remote_path = '{}{}'.format(module.params['file_system'], dest)
     scp = SCPClient(ssh.get_transport())
@@ -181,6 +190,7 @@ def main():
         local_file=dict(required=True),
         remote_file=dict(required=False),
         file_system=dict(required=False, default='bootflash:'),
+        connect_port=dict(required=False, type='int', default=22),
     )
 
     argument_spec.update(nxos_argument_spec)

--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -24,6 +24,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
+      connect_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: &true
@@ -51,6 +52,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
+      connect_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/cli/sanity.yaml
@@ -24,7 +24,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
-      connect_port: "{{ ansible_ssh_port }}"
+      connect_ssh_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: &true
@@ -52,7 +52,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
-      connect_port: "{{ ansible_ssh_port }}"
+      connect_ssh_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_file_copy/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/nxapi/sanity.yaml
@@ -26,7 +26,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
-      connect_port: "{{ ansible_ssh_port }}"
+      connect_ssh_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: &true
@@ -55,7 +55,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
-      connect_port: "{{ ansible_ssh_port }}"
+      connect_ssh_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: *true

--- a/test/integration/targets/nxos_file_copy/tests/nxapi/sanity.yaml
+++ b/test/integration/targets/nxos_file_copy/tests/nxapi/sanity.yaml
@@ -26,6 +26,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
+      connect_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: &true
@@ -54,6 +55,7 @@
       username: "{{ ansible_ssh_user }}"
       password: "{{ ansible_ssh_pass }}"
       host: "{{ ansible_host }}"
+      connect_port: "{{ ansible_ssh_port }}"
     register: result
 
   - assert: *true


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add port arg to establish ssh connection in nxos_file_copy
A new ssh connection is created in the module. To establish a successful ssh connection, port has to be passed as argument in `ssh.connect()`. So a new option `connect_port` is added in arg spec which is the port for the ssh connection (default to port 22).
We cannot use provider/top level spec platform port here. It would conflict with Nxapi port.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/network/nxos/nxos_file_copy
test/integration/targets/nxos_file_copy/test/{cli,nxapi}/sanity.yaml
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```