### PR TITLE
patch.py: use absolute path for p.dest (Fixes #33262)

### DIFF
--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -154,6 +154,7 @@ def main():
     if p.dest and not os.access(p.dest, os.W_OK):
         module.fail_json(msg="dest %s doesn't exist or not writable" % (p.dest))
 
+    p.dest = os.path.abspath(p.dest)
     if p.basedir and not os.path.exists(p.basedir):
         module.fail_json(msg="basedir %s doesn't exist" % (p.basedir))
 
@@ -167,7 +168,7 @@ def main():
     def patch_func(opts):
         return module.run_command('%s %s' % (patch_bin, ' '.join(opts)))
 
-    # patch need an absolute file name
+    # patch needs an absolute file name
     p.src = os.path.abspath(p.src)
 
     changed = False


### PR DESCRIPTION
##### SUMMARY
Patch fails to find a file specified with dest=relative/path in ansible 2.4.1. This commit fixes this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/files/patch.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0
```

##### ADDITIONAL INFORMATION
See #33262