### PR TITLE
consul removed check for service name in parse_service

### DIFF
--- a/lib/ansible/modules/clustering/consul.py
+++ b/lib/ansible/modules/clustering/consul.py
@@ -389,8 +389,6 @@ def parse_service(module):
             module.params.get('service_port'),
             module.params.get('tags'),
         )
-    elif not module.params.get('service_name'):
-        module.fail_json(msg="service_name is required to configure a service.")
 
 
 class ConsulService():


### PR DESCRIPTION
##### SUMMARY
Removed check in parse_service, as it was causing issues with registering Node level Checks.

Per the module documentation, you can omit service name if you are creating a Node level health check.  In parse_service it causes an error if service name is not set, with this check removed the function will return a null which will checked in the add function at 252.  

```
if not service and not check:
        module.fail_json(msg='a name and port are required to register a service')
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
consul

##### ANSIBLE VERSION
```
ansible 2.4.1.0
```
