### PR TITLE
VMware: fix vmPathName on VM creation

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1371,7 +1371,7 @@ class PyVmomiHelper(PyVmomi):
                 self.configspec.files = vim.vm.FileInfo(logDirectory=None,
                                                         snapshotDirectory=None,
                                                         suspendDirectory=None,
-                                                        vmPathName="[" + datastore_name + "] " + self.params["name"])
+                                                        vmPathName="[" + datastore_name + "]")
 
                 clone_method = 'CreateVM_Task'
                 resource_pool = self.get_resource_pool()

--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -21,3 +21,5 @@
 - include: create_rp_d1_c1_f0.yml
 - include: create_guest_invalid_d1_c1_f0.yml
 - include: mac_address_d1_c1_f0.yml
+- include: disk_type_d1_c1_f0.yml
+#- include: template_d1_c1_f0.yml


### PR DESCRIPTION
##### SUMMARY

When creating a VM on a standalone ESX wasn't set correctly.

Before this patch for a VM name `vm.subdomain.domain` the vmPathName
was:
```
[datastore] vm.subdomain.domain
```
which lead to a the vmdk:
```
[datastore] vm.subdomain.vmdk
```

It create a conflict (same vmdk) when you try to create a second VM
named `vm.subdomain.domain-2` in the same datastore.

# To solve this issue

https://kb.vmware.com/s/article/2051649 :

> To work around the split directory issue in vSphere Web Services SDK
> 4.1, specify only the datastore name for the properties fileName and
> vmPathName in VirtualMachineConfigSpec.

`[datastore]` is a valid vmPathName, it has the effect to create the
vmdk:
```
[datastore] vm.subdomain.domain/vm.subdomain.domain.vmdk
```
which is the standard.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

vmware_guest

##### ANSIBLE VERSION

```
ansible 2.5.0 (vmware_guest 3015a8f4e0) last updated 2017/11/27 21:42:57 (GMT +200)
  config file = /home/max/.ansible.cfg
  configured module search path = ['/home/max/.ansible/modules']
  ansible python module location = /home/max/Documents/repositories-github/ansible/lib/ansible
  executable location = /home/max/Documents/repositories-github/ansible/bin/ansible
  python version = 3.6.3 (default, Oct 24 2017, 14:48:20) [GCC 7.2.0]
```