### PR TITLE
Change RPM dependency for RHEL 7.<=2 compatibility

### DIFF
--- a/packaging/rpm/ansible.spec
+++ b/packaging/rpm/ansible.spec
@@ -39,7 +39,7 @@ Requires: python-crypto
 
 # RHEL >=7
 %if 0%{?rhel} >= 7
-Requires: python2-cryptography
+Requires: python-cryptography
 %endif
 
 # RHEL > 5


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
When installing Ansible 2.4 as an RPM on a RHEL 7.2 machine, installation fails due to the python2-cryptography requirement defined in the RPM spec.  python2-cryptography is only available in RHEL 7.3 and above, obsoleting the python-cryptography package.  However, python2-cryptography provides python-cryptography as a capability, so requiring python-cryptography instead will ensure that the correct dependency is installed across all RHEL 7 minor releases.

I was able to successfully build and install the Ansible RPM from the stable-2.4 branch on both a RHEL 7.2 and RHEL 7.3 server when changing this dependency name.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
Packaging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/g527769/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ rpm -q --provides python2-cryptography
python-cryptography
python2-cryptography = 1.3.1-3.el7
python2-cryptography(x86-64) = 1.3.1-3.el7
```
```
$ cat /etc/redhat-release
Red Hat Enterprise Linux Server release 7.2 (Maipo)

$ sudo yum install ansible
...
Error: Package: ansible-2.4.1.0-1.el7.ans.noarch (ansible)
           Requires: python2-cryptography
```
