### PR TITLE
VMware: fix hw_guest_ha_state fact

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -280,7 +280,7 @@ def gather_vm_facts(content, vm):
         'hw_datastores': [],
         'hw_files': [],
         'hw_esxi_host': None,
-        'hw_guest_ha_state': vm.summary.runtime.dasVmProtection,
+        'hw_guest_ha_state': None,
         'hw_is_template': vm.config.template,
         'hw_folder': None,
         'guest_tools_status': _get_vm_prop(vm, ('guest', 'toolsRunningStatus')),
@@ -299,6 +299,8 @@ def gather_vm_facts(content, vm):
     if vm.summary.runtime.host:
         host = vm.summary.runtime.host
         facts['hw_esxi_host'] = host.summary.config.name
+    if vm.summary.runtime.dasVmProtection:
+        facts['hw_guest_ha_state'] = vm.summary.runtime.dasVmProtection.dasProtected
 
     datastores = vm.datastore
     for ds in datastores:


### PR DESCRIPTION
##### SUMMARY

vm.summary.runtime.dasVmProtection isn't printable/json-able.

If we try to pass it to exit_json, it raise an exception:
```
TypeError: Value of unknown type: <class 'pyVmomi.VmomiSupport.vim.vm.RuntimeInfo.DasProtectionState'>, (vim.vm.RuntimeInfo.DasProtectionState) ...
```

[vm.summary.runtime.dasVmProtection](https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.vm.RuntimeInfo.html) is of type [VirtualMachineRuntimeInfoDasProtectionState](https://www.vmware.com/support/developer/converter-sdk/conv60_apireference/vim.vm.RuntimeInfo.DasProtectionState.html) which contain a dasProtected properties, which is a boolean.

So if vm.summary.runtime.dasVmProtection is defined, we want to return
vm.summary.runtime.dasVmProtection.dasProtected (not the whole object).

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

vmware utils

##### ANSIBLE VERSION

```
ansible 2.5.0 (utils_vmware da29f42d9b) last updated 2017/11/27 22:33:32 (GMT +200)
  config file = /home/max/.ansible.cfg
  configured module search path = ['/home/max/.ansible/modules']
  ansible python module location = /home/max/Documents/repositories-github/ansible/lib/ansible
  executable location = /home/max/Documents/repositories-github/ansible/bin/ansible
  python version = 3.6.3 (default, Oct 24 2017, 14:48:20) [GCC 7.2.0]
```