### PR TITLE
Fix failure to adjust my name when doing copy pasta

### DIFF
--- a/hacking/fix_test_syntax.py
+++ b/hacking/fix_test_syntax.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-# (c) 2017, Michael DeHaan <matt@sivel.net>
+# (c) 2017, Matt Martz <matt@sivel.net>
 #
 # This file is part of Ansible
 #


### PR DESCRIPTION
##### SUMMARY
I copied some licensing text from another file, and failed to adjust the name to be myself.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
hacking/fix_test_syntax.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
