### PR TITLE
Add ssl, validate_certs in InfluxDB modules

### DIFF
--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2017, Ansible Project
+# Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
+
+try:
+    import requests.exceptions
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
+
+try:
+    from influxdb import InfluxDBClient
+    from influxdb import exceptions
+    HAS_INFLUXDB = True
+except ImportError:
+    HAS_INFLUXDB = False
+
+
+class InfluxDb(object):
+    def __init__(self, module):
+        self.module = module
+        self.params = self.module.params
+        self.check_lib()
+        self.hostname = self.params['hostname']
+        self.port = self.params['port']
+        self.username = self.params['username']
+        self.password = self.params['password']
+        self.database_name = self.params['database_name']
+
+    def check_lib(self):
+        if not HAS_REQUESTS:
+            self.module.fail_json(msg='This module requires "requests" module.')
+
+        if not HAS_INFLUXDB:
+            self.module.fail_json(msg='This module requires influxdb python package.')
+
+    @staticmethod
+    def influxdb_argument_spec():
+        return dict(
+            hostname=dict(required=True, type='str'),
+            port=dict(default=8086, type='int'),
+            username=dict(default='root', type='str'),
+            password=dict(default='root', type='str', no_log=True),
+            database_name=dict(required=True, type='str'),
+            ssl=dict(default=False, type='bool'),
+            validate_certs=dict(default=True, type='bool'),
+            timeout=dict(default=None, type='int'),
+            retries=dict(default=3, type='int'),
+            proxies=dict(default={}, type='dict'),
+        )
+
+    def connect_to_influxdb(self):
+        return InfluxDBClient(
+            host=self.hostname,
+            port=self.port,
+            username=self.username,
+            password=self.password,
+            database=self.database_name,
+            ssl=self.params['ssl'],
+            verify_ssl=self.params['validate_certs'],
+            timeout=self.params['timeout'],
+            retries=self.params['retries'],
+            use_udp=self.params['use_udp'],
+            udp_port=self.params['udp_port'],
+            proxies=self.params['proxies'],
+        )

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -17,32 +17,14 @@ DOCUMENTATION = '''
 module: influxdb_database
 short_description: Manage InfluxDB databases
 description:
-    - Manage InfluxDB databases
+    - Manage InfluxDB databases.
 version_added: 2.1
 author: "Kamil Szczygiel (@kamsz)"
 requirements:
     - "python >= 2.6"
     - "influxdb >= 0.9"
+    - requests
 options:
-    hostname:
-        description:
-            - The hostname or IP address on which InfluxDB server is listening
-        required: true
-    username:
-        description:
-            - Username that will be used to authenticate against InfluxDB server
-        default: root
-        required: false
-    password:
-        description:
-            - Password that will be used to authenticate against InfluxDB server
-        default: root
-        required: false
-    port:
-        description:
-            - The port on which InfluxDB server is listening
-        default: 8086
-        required: false
     database_name:
         description:
             - Name of the database that will be created/destroyed
@@ -53,6 +35,7 @@ options:
         choices: ['present', 'absent']
         default: present
         required: false
+extends_documentation_fragment: influxdb.documentation
 '''
 
 EXAMPLES = '''
@@ -76,6 +59,8 @@ EXAMPLES = '''
       password: "{{influxdb_password}}"
       database_name: "{{influxdb_database_name}}"
       state: present
+      ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''
@@ -86,38 +71,11 @@ try:
     import requests.exceptions
     from influxdb import InfluxDBClient
     from influxdb import exceptions
-    HAS_INFLUXDB = True
 except ImportError:
-    HAS_INFLUXDB = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
-
-
-def influxdb_argument_spec():
-    return dict(
-        hostname=dict(required=True, type='str'),
-        port=dict(default=8086, type='int'),
-        username=dict(default='root', type='str'),
-        password=dict(default='root', type='str', no_log=True),
-        database_name=dict(required=True, type='str')
-    )
-
-
-def connect_to_influxdb(module):
-    hostname = module.params['hostname']
-    port = module.params['port']
-    username = module.params['username']
-    password = module.params['password']
-    database_name = module.params['database_name']
-
-    client = InfluxDBClient(
-        host=hostname,
-        port=port,
-        username=username,
-        password=password,
-        database=database_name
-    )
-    return client
+from ansible.module_utils.influxdb import InfluxDb
 
 
 def find_database(module, client, database_name):
@@ -155,7 +113,7 @@ def drop_database(module, client, database_name):
 
 
 def main():
-    argument_spec = influxdb_argument_spec()
+    argument_spec = InfluxDb.influxdb_argument_spec()
     argument_spec.update(
         state=dict(default='present', type='str', choices=['present', 'absent'])
     )
@@ -164,13 +122,11 @@ def main():
         supports_check_mode=True
     )
 
-    if not HAS_INFLUXDB:
-        module.fail_json(msg='influxdb python package is required for this module')
-
     state = module.params['state']
-    database_name = module.params['database_name']
 
-    client = connect_to_influxdb(module)
+    influxdb = InfluxDb(module)
+    client = influxdb.connect_to_influxdb()
+    database_name = influxdb.database_name
     database = find_database(module, client, database_name)
 
     if state == 'present':

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -23,26 +23,8 @@ author: "Kamil Szczygiel (@kamsz)"
 requirements:
     - "python >= 2.6"
     - "influxdb >= 0.9"
+    - requests
 options:
-    hostname:
-        description:
-            - The hostname or IP address on which InfluxDB server is listening
-        required: true
-    username:
-        description:
-            - Username that will be used to authenticate against InfluxDB server
-        default: root
-        required: false
-    password:
-        description:
-            - Password that will be used to authenticate against InfluxDB server
-        default: root
-        required: false
-    port:
-        description:
-            - The port on which InfluxDB server is listening
-        default: 8086
-        required: false
     database_name:
         description:
             - Name of the database where retention policy will be created
@@ -63,6 +45,7 @@ options:
         description:
             - Sets the retention policy as default retention policy
         required: true
+extends_documentation_fragment: influxdb.documentation
 '''
 
 EXAMPLES = '''
@@ -74,6 +57,8 @@ EXAMPLES = '''
       policy_name: test
       duration: 1h
       replication: 1
+      ssl: True
+      validate_certs: True
 
 - name: create 1 day retention policy
   influxdb_retention_policy:
@@ -98,6 +83,8 @@ EXAMPLES = '''
       policy_name: test
       duration: INF
       replication: 1
+      ssl: False
+      validate_certs: False
 '''
 
 RETURN = '''
@@ -110,38 +97,11 @@ try:
     import requests.exceptions
     from influxdb import InfluxDBClient
     from influxdb import exceptions
-    HAS_INFLUXDB = True
 except ImportError:
-    HAS_INFLUXDB = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
-
-
-def influxdb_argument_spec():
-    return dict(
-        hostname=dict(required=True, type='str'),
-        port=dict(default=8086, type='int'),
-        username=dict(default='root', type='str'),
-        password=dict(default='root', type='str', no_log=True),
-        database_name=dict(required=True, type='str')
-    )
-
-
-def connect_to_influxdb(module):
-    hostname = module.params['hostname']
-    port = module.params['port']
-    username = module.params['username']
-    password = module.params['password']
-    database_name = module.params['database_name']
-
-    client = InfluxDBClient(
-        host=hostname,
-        port=port,
-        username=username,
-        password=password,
-        database=database_name
-    )
-    return client
+from ansible.module_utils.influxdb import InfluxDb
 
 
 def find_retention_policy(module, client):
@@ -208,7 +168,7 @@ def alter_retention_policy(module, client, retention_policy):
 
 
 def main():
-    argument_spec = influxdb_argument_spec()
+    argument_spec = InfluxDb.influxdb_argument_spec()
     argument_spec.update(
         policy_name=dict(required=True, type='str'),
         duration=dict(required=True, type='str'),
@@ -220,10 +180,9 @@ def main():
         supports_check_mode=True
     )
 
-    if not HAS_INFLUXDB:
-        module.fail_json(msg='influxdb python package is required for this module')
+    influxdb = InfluxDb(module)
+    client = influxdb.connect_to_influxdb()
 
-    client = connect_to_influxdb(module)
     retention_policy = find_retention_policy(module, client)
 
     if retention_policy:

--- a/lib/ansible/utils/module_docs_fragments/influxdb.py
+++ b/lib/ansible/utils/module_docs_fragments/influxdb.py
@@ -1,0 +1,63 @@
+# Copyright: (c) 2017, Ansible Project
+# Copyright: (c) 2017, Abhijeet Kasurde (akasurde@redhat.com)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+class ModuleDocFragment(object):
+    # Parameters for influxdb modules
+    DOCUMENTATION = '''
+options:
+  hostname:
+    description:
+    - The hostname or IP address on which InfluxDB server is listening
+    required: true
+  username:
+    description:
+    - Username that will be used to authenticate against InfluxDB server
+    default: root
+  password:
+    description:
+    - Password that will be used to authenticate against InfluxDB server
+    default: root
+  port:
+    description:
+    - The port on which InfluxDB server is listening
+    default: 8086
+  validate_certs:
+    description:
+    - If set to C(no), the SSL certificates will not be validated.
+    - This should only set to C(no) used on personally controlled sites using self-signed certificates.
+    default: true
+    version_added: "2.5"
+  ssl:
+    description:
+    - Use https instead of http to connect to InfluxDB server.
+    default: False
+    version_added: "2.5"
+  timeout:
+    description:
+    - Number of seconds Requests will wait for client to establish a connection.
+    default: None
+    version_added: "2.5"
+  retries:
+    description:
+    - Number of retries client will try before aborting.
+    - C(0) indicates try until success.
+    default: 3
+    version_added: "2.5"
+  use_udp:
+    description:
+    - Use UDP to connect to InfluxDB server.
+    default: False
+    version_added: "2.5"
+  udp_port:
+    description:
+    - UDP port to connect to InfluxDB server.
+    default: 4444
+    version_added: "2.5"
+  proxies:
+    description:
+    - HTTP(S) proxy to use for Requests to connect to InfluxDB server.
+    default: None
+    version_added: "2.5"
+'''


### PR DESCRIPTION
##### SUMMARY
This fix adds ssl and validate_certs argument spec for InfluxDB
modules. Also, refactors code.

Fixes: #31923

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/influxdb.py
lib/ansible/modules/database/influxdb/influxdb_database.py lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
lib/ansible/utils/module_docs_fragments/influxdb.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```