### PR TITLE
Handle facts for HP-UX 9000/785 architecture

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/hpux.py
+++ b/lib/ansible/module_utils/facts/hardware/hpux.py
@@ -55,7 +55,7 @@ class HPUXHardware(Hardware):
         cpu_facts = {}
         collected_facts = collected_facts or {}
 
-        if collected_facts.get('ansible_architecture') == '9000/800':
+        if collected_facts.get('ansible_architecture') in ['9000/800', '9000/785']:
             rc, out, err = self.module.run_command("ioscan -FkCprocessor | wc -l", use_unsafe_shell=True)
             cpu_facts['processor_count'] = int(out.strip())
         # Working with machinfo mess
@@ -111,7 +111,7 @@ class HPUXHardware(Hardware):
         rc, out, err = self.module.run_command("/usr/bin/vmstat | tail -1", use_unsafe_shell=True)
         data = int(re.sub(' +', ' ', out).split(' ')[5].strip())
         memory_facts['memfree_mb'] = pagesize * data // 1024 // 1024
-        if collected_facts.get('ansible_architecture') == '9000/800':
+        if collected_facts.get('ansible_architecture') in ['9000/800', '9000/785']:
             try:
                 rc, out, err = self.module.run_command("grep Physical /var/adm/syslog/syslog.log")
                 data = re.search('.*Physical: ([0-9]*) Kbytes.*', out).groups()[0].strip()


### PR DESCRIPTION
##### SUMMARY
This fix adds support for HP-UX '9000/785' architecture.

Fixes: #31976

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/facts/hardware/hpux.py

##### ANSIBLE VERSION
```
2.5devel
```