### PR TITLE
openvswitch_db: Split key-value pairs correctly

### DIFF
--- a/lib/ansible/modules/network/ovs/openvswitch_db.py
+++ b/lib/ansible/modules/network/ovs/openvswitch_db.py
@@ -127,7 +127,7 @@ def map_config_to_obj(module):
     col_value = match.group(3)
     col_value_to_dict = {}
     if col_value and col_value != '{}':
-        for kv in col_value[1:-1].split(','):
+        for kv in col_value[1:-1].split(', '):
             k, v = kv.split('=')
             col_value_to_dict[k.strip()] = v.strip()
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Map values can contain commas, e.g.

```
    - name: Configure OVN bridge mapping
      openvswitch_db:
        state: present
        table: open_vswitch
        record: .
        col: external_ids
        key: ovn-bridge-mappings
        value: '"vmnet-static:br-vmnet-st,vmnet-dynamic:br-vmnet-dyn"'
```
Previous behaviour was splitting the value and raised an exception on second and further runs.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
openvswitch_db
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 1f3ca09af4) last updated 2017/11/28 13:37:25 (GMT +300)
  config file = /Users/xx/y/zz/ansible.cfg
  configured module search path = [u'/Users/xx/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/xx/GitHub/ansible/lib/ansible
  executable location = /usr/local/opt/pyenv/versions/ovirt/bin/ansible
  python version = 2.7.14 (default, Oct 25 2017, 17:44:40) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
fatal: [HOST]: FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "OpenSSH_7.5p1, LibreSSL 2.5.4\r\ndebug1: Reading configuration data /Users/user/.ssh/config\r\ndebug1: /Users/user/.ssh/config line 1: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 52: Applying options for *\r\ndebug1: /etc/ssh/ssh_config line 56: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug2: fd 3 setting O_NONBLOCK\r\ndebug2: mux_client_hello_exchange: master version 4\r\ndebug3: mux_client_forwards: request forwardings: 0 local, 0 remote\r\ndebug3: mux_client_request_session: entering\r\ndebug3: mux_client_request_alive: entering\r\ndebug3: mux_client_request_alive: done pid = 35181\r\ndebug3: mux_client_request_session: session request sent\r\ndebug1: mux_client_request_session: master session id: 2\r\ndebug3: mux_client_read_packet: read header failed: Broken pipe\r\ndebug2: Received exit status from master 1\r\nShared connection to X.X.X.X closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_KBnx6P/ansible_module_openvswitch_db.py\", line 195, in <module>\r\n    main()\r\n  File \"/tmp/ansible_KBnx6P/ansible_module_openvswitch_db.py\", line 180, in main\r\n    have = map_config_to_obj(module)\r\n  File \"/tmp/ansible_KBnx6P/ansible_module_openvswitch_db.py\", line 131, in map_config_to_obj\r\n    k, v = kv.split('=')\r\nValueError: need more than 1 value to unpack\r\n",
    "msg": "MODULE FAILURE",
    "rc": 1
}
```
After:
```
<HOST> (0, '\r\n{"invocation": {"module_args": {"ovs-vsctl": "/usr/bin/ovs-vsctl", "key": "ovn-bridge-mappings", "value": "\\"vmnet-static:br-vmnet-st,vmnet-dynamic:br-vmnet-dyn\\"", "record": ".", "state": "present", "timeout": 5, "table": "open_vswitch", "col": "external_ids"}}, "commands": [], "changed": false}\r\n', 'Shared connection to X.X.X.X closed.\r\n')
ok: [host] => {
    "changed": false,
    "commands": [],
    "invocation": {
        "module_args": {
            "col": "external_ids",
            "key": "ovn-bridge-mappings",
            "ovs-vsctl": "/usr/bin/ovs-vsctl",
            "record": ".",
            "state": "present",
            "table": "open_vswitch",
            "timeout": 5,
            "value": "\"vmnet-static:br-vmnet-st,vmnet-dynamic:br-vmnet-dyn\""
        }
    }
}
```
