### PR TITLE
Fix py3 docs build

### DIFF
--- a/docs/bin/dump_config.py
+++ b/docs/bin/dump_config.py
@@ -62,7 +62,7 @@ def main(args):
     output_name = os.path.join(output_dir, template_file.replace('.j2', ''))
     temp_vars = {'config_options': config_options}
 
-    with open(output_name, 'w') as f:
+    with open(output_name, 'wb') as f:
         f.write(template.render(temp_vars).encode('utf-8'))
 
     return 0

--- a/docs/templates/cli_rst.j2
+++ b/docs/templates/cli_rst.j2
@@ -77,7 +77,7 @@ Actions
 {% if actions[action]['options'] %}
 
 
-{% for option in actions[action]['options']|sort %}
+{% for option in actions[action]['options']|sort(attribute='options') %}
 .. option:: {% for switch in option['options'] if switch in actions[action]['option_names'] %}{{switch}} {% if option['arg'] %} <{{option['arg']}}>{% endif %}{% if not loop.last %}, {% endif %}{% endfor %}
 
    {{ (option['desc']) }}

--- a/docs/templates/config.rst.j2
+++ b/docs/templates/config.rst.j2
@@ -65,11 +65,11 @@ you can use the command line utility mentioned above (`ansible-config`) to brows
 {% if config['version_added'] %}
 :Version Added: {{config['version_added']}}
 {% endif %}
-{% for ini_map in config['ini']|sort %}
+{% for ini_map in config['ini']|sort(attribute='section') %}
 :Ini Section: {{ini_map['section']}}
 :Ini Key: {{ini_map['key']}}
 {% endfor %}
-{% for env_var_map in config['env']|sort %}
+{% for env_var_map in config['env']|sort(attribute='name') %}
 :Environment: :envvar:`{{env_var_map['name']}}`
 {% endfor %}
 {% if config['deprecated'] %}


### PR DESCRIPTION
##### SUMMARY
Currently docs cannot be built using python3, due to:

* Improper encoding passed to write
* unable to sort dictionaries in jinja

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
webdocs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
