### PR TITLE
Fix tests as filters syntax in recently modified integration tests

### DIFF
--- a/test/integration/targets/openssl_publickey/tasks/main.yml
+++ b/test/integration/targets/openssl_publickey/tasks/main.yml
@@ -23,7 +23,7 @@
         path: '{{ output_dir }}/publickey-ssh.pub'
         privatekey_path: '{{ output_dir }}/privatekey.pem'
         format: OpenSSH
-      when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+      when: cryptography_version.stdout is version('1.4.0', '>=')
       register: publickey_ssh_idempotence
 
     - name: Generate publickey2 - standard

--- a/test/integration/targets/openssl_publickey/tests/validate.yml
+++ b/test/integration/targets/openssl_publickey/tests/validate.yml
@@ -31,8 +31,8 @@
 - name: Validate public key - OpenSSH format - test idempotence (issue 33256)
   assert:
     that:
-      - not publickey_ssh_idempotence|changed
-  when: cryptography_version.stdout|version_compare('1.4.0', '>=')
+      - publickey_ssh_idempotence is not changed
+  when: cryptography_version.stdout is version('1.4.0', '>=')
 
 - name: Validate publickey2 (test - Ensure key has been removed)
   stat:

--- a/test/integration/targets/selinux/tasks/selinux.yml
+++ b/test/integration/targets/selinux/tasks/selinux.yml
@@ -200,8 +200,8 @@
 - name: TEST 3 | Assert that status was not changed, the task failed, the msg contains proper information and SELinux was not changed
   assert:
     that:
-      - not _state_test1 | changed
-      - _state_test1 | failed
+      - _state_test1 is not changed
+      - _state_test1 is failed
       - _state_test1.msg == 'Policy non-existing-selinux-policy does not exist in /etc/selinux/'
       - ansible_selinux.config_mode == 'enforcing'
       - ansible_selinux.type == 'targeted'


### PR DESCRIPTION
##### SUMMARY

Following on https://github.com/ansible/ansible/pull/32361 this PR fixes tests as filters syntax to use proper `is` test syntax in newly modified files.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```