### PR TITLE
Add Github handle to cloudscale_sever module author field

### DIFF
--- a/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
+++ b/lib/ansible/modules/cloud/cloudscale/cloudscale_server.py
@@ -31,7 +31,7 @@ notes:
     of the cloudscale.ch API. The module will silently ignore differences between the configured parameters and the running server if a server with the
     correct name or UUID exists. Only state changes will be applied.
 version_added: 2.3
-author: "Gaudenz Steinlin <gaudenz.steinlin@cloudscale.ch>"
+author: "Gaudenz Steinlin (@gaudenz) <gaudenz.steinlin@cloudscale.ch>"
 options:
   state:
     description:


### PR DESCRIPTION
##### SUMMARY
Add the github handle to the author field of the module. This was pointend out by @resmo in PR #33181.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
cloudscale_server

##### ANSIBLE VERSION
```
devel
```
