### PR TITLE
allow ANSIBLE_KEEP_REMOTE_FILES for local test runner

### DIFF
--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -36,29 +36,16 @@ See the `list of supported platforms and versions <https://github.com/ansible/an
 Environment Variables
 ---------------------
 
-Having a generic note about the limitations of using --docker (or --remote) is probably better than specifically mentioning ANSIBLE_KEEP_REMOTE_FILES in relation to those options. The limitations would be:
-When using Environment Variables along with test cases to attempt and manipulate
-the test runtimes, there some limitations to keep in mind:
+When using environment variables to manipulate tests there some limitations to keep in mind. Environment variables are:
 
-* Environment variables are not propogated from the host to the container
-  (``--docker``) or remote (``--remote``) unless defined as whitelisted in
-  ``test/runner/lib/util.py`` in the ``common_environment`` function.
+* Not propagated from the host to the test environment when using the ``--docker`` or ``--remote`` options. 
+* Not exposed to the test environment unless whitelisted in ``test/runner/lib/util.py`` in the ``common_environment`` function.
+* Not exposed to the test environment when using the ``--tox`` option unless whitelisted in ``test/runner/tox.ini`` by the ``passenv`` definition.
 
-  *  As an example, this can be useful when using ``ansible-test shell
-    --docker`` to run local tests inside of a docker container with the testing
-    environment pre-setup and want to pass `ANSIBLE_KEEP_REMOTE_FILES=1` on to
-    the tests inside the container and follow the :ref:`Debugging
-    AnsibleModule-based modules <debugging_ansiblemodule_based_modules>`
-    practices. This can be useful for testing and debugging on operating systems
-    or Linux distributions other than what you have installed on your local
-    system.
-
-* Environemnt Variables are not propogated to the tests when using tox
-  (``--tox``) unless they are defined as whitelisted in ``test/runner/tox.ini``
-  by the ``passenv`` definition.
-* Most files from tests are not copied to the host from the container
-  (``--docker``) or remote (``--remote``)
-
+    Example: ``ANSIBLE_KEEP_REMOTE_FILES=1`` can be set when running ``ansible-test integration --tox``. However, using the ``--docker`` option would 
+    require running ``ansible-test shell`` to gain access to the Docker environment. Once at the shell prompt, the environment variable could be set 
+    and the tests executed. This is useful for debugging tests inside a container by following the 
+    :ref:`Debugging AnsibleModule-based modules <debugging_ansiblemodule_based_modules>` instructions.
 
 Interactive Shell
 =================

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -42,6 +42,14 @@ Use the ``ansible-test shell`` command to get an interactive shell in the same e
 * ``ansible-test shell --docker`` - Open a shell in the default docker container.
 * ``ansible-test shell --tox --python 3.6`` - Open a shell in the Python 3.6 ``tox`` environment.
 
+.. note:: When using ``ansible-test shell --docker`` to run local tests inside
+          of a docker container with the testing environment pre-setup, you can
+          optionally pass `ANSIBLE_KEEP_REMOTE_FILES=1` and follow the
+          :ref:`Debugging AnsibleModule-based modules
+          <debugging_ansiblemodule_based_modules>` practices. This can be
+          useful for testing and debugging on operating systems or Linux
+          distributions other than what you have installed on your local system.
+
 Code Coverage
 =============
 

--- a/docs/docsite/rst/dev_guide/testing_running_locally.rst
+++ b/docs/docsite/rst/dev_guide/testing_running_locally.rst
@@ -33,6 +33,32 @@ An API key is required to use this feature.
 
 See the `list of supported platforms and versions <https://github.com/ansible/ansible/blob/devel/test/runner/completion/remote.txt>`_ for additional details.
 
+Environment Variables
+---------------------
+
+Having a generic note about the limitations of using --docker (or --remote) is probably better than specifically mentioning ANSIBLE_KEEP_REMOTE_FILES in relation to those options. The limitations would be:
+When using Environment Variables along with test cases to attempt and manipulate
+the test runtimes, there some limitations to keep in mind:
+
+* Environment variables are not propogated from the host to the container
+  (``--docker``) or remote (``--remote``) unless defined as whitelisted in
+  ``test/runner/lib/util.py`` in the ``common_environment`` function.
+
+  *  As an example, this can be useful when using ``ansible-test shell
+    --docker`` to run local tests inside of a docker container with the testing
+    environment pre-setup and want to pass `ANSIBLE_KEEP_REMOTE_FILES=1` on to
+    the tests inside the container and follow the :ref:`Debugging
+    AnsibleModule-based modules <debugging_ansiblemodule_based_modules>`
+    practices. This can be useful for testing and debugging on operating systems
+    or Linux distributions other than what you have installed on your local
+    system.
+
+* Environemnt Variables are not propogated to the tests when using tox
+  (``--tox``) unless they are defined as whitelisted in ``test/runner/tox.ini``
+  by the ``passenv`` definition.
+* Most files from tests are not copied to the host from the container
+  (``--docker``) or remote (``--remote``)
+
 
 Interactive Shell
 =================
@@ -42,13 +68,6 @@ Use the ``ansible-test shell`` command to get an interactive shell in the same e
 * ``ansible-test shell --docker`` - Open a shell in the default docker container.
 * ``ansible-test shell --tox --python 3.6`` - Open a shell in the Python 3.6 ``tox`` environment.
 
-.. note:: When using ``ansible-test shell --docker`` to run local tests inside
-          of a docker container with the testing environment pre-setup, you can
-          optionally pass `ANSIBLE_KEEP_REMOTE_FILES=1` and follow the
-          :ref:`Debugging AnsibleModule-based modules
-          <debugging_ansiblemodule_based_modules>` practices. This can be
-          useful for testing and debugging on operating systems or Linux
-          distributions other than what you have installed on your local system.
 
 Code Coverage
 =============

--- a/test/runner/lib/util.py
+++ b/test/runner/lib/util.py
@@ -381,6 +381,7 @@ def common_environment():
         # MacOS High Sierra Compatibility
         # http://sealiesoftware.com/blog/archive/2017/6/5/Objective-C_and_fork_in_macOS_1013.html
         'OBJC_DISABLE_INITIALIZE_FORK_SAFETY',
+        'ANSIBLE_KEEP_REMOTE_FILES',
     )
 
     env.update(pass_vars(required=required, optional=optional))

--- a/test/runner/tox.ini
+++ b/test/runner/tox.ini
@@ -5,7 +5,7 @@ minversion = 2.5.0
 [testenv]
 changedir = {toxinidir}/../../
 commands = {posargs}
-passenv = HOME LC_ALL SHIPPABLE*
+passenv = HOME LC_ALL SHIPPABLE* ANSIBLE_KEEP_REMOTE_FILES
 args_are_paths = False
 deps = setuptools == 35.0.2
     wheel < 0.30.0 ; python_version < '2.7'


### PR DESCRIPTION
Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently, there is no way to run ansible tests via `ansible-test` inside a pre-staged docker container created via `ansible-test shell` with `ANSIBLE_KEEP_REMOTE_FILES` for debugging on different distros. This enables that use case and documents it.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$  ansible --version                             
ansible 2.5.0 (debug 91c60e896e) last updated 2017/11/28 16:25:50 (GMT -500)                                           
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']    
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible                                          
  executable location = /home/admiller/src/dev/ansible/bin/ansible                                                     
  python version = 3.6.3 (default, Oct  9 2017, 12:07:10) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)] 

```



