### PR TITLE
Homebrew: Update _uninstall_current_package to use the --force option

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew.py
+++ b/lib/ansible/modules/packaging/os/homebrew.py
@@ -695,7 +695,7 @@ class Homebrew(object):
             raise HomebrewException(self.message)
 
         opts = (
-            [self.brew_path, 'uninstall']
+            [self.brew_path, 'uninstall', '--force']
             + self.install_options
             + [self.current_package]
         )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Make the uninstall task in the Homebrew module use the `--force` flag.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/packaging/os/homebrew.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
± ansible --version
ansible 2.5.0 (homebrew_update 741df6953e) last updated 2017/11/28 23:13:03 (GMT -400)
  config file = /Users/dan/.ansible.cfg
  configured module search path = ['/Users/dan/src/ans/library']
  ansible python module location = /Users/dan/src/ans/lib/ansible
  executable location = /Users/dan/src/ans/bin/ansible
  python version = 3.6.3 (default, Oct 21 2017, 11:37:52) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This PR is required for Homebrew to fully remove packages.  Before, you had to rerun the Homebrew module multiple times to clean out a package.  This is an important bugfix and I hope it can be merged soon.  :)