### PR TITLE
Homebrew Cask: Update _current_cask_is_installed to split on whitespace

### DIFF
--- a/lib/ansible/modules/packaging/os/homebrew_cask.py
+++ b/lib/ansible/modules/packaging/os/homebrew_cask.py
@@ -389,7 +389,7 @@ class HomebrewCask(object):
         if 'nothing to list' in err:
             return False
         elif rc == 0:
-            casks = [cask_.strip() for cask_ in out.split('\n') if cask_.strip()]
+            casks = [cask_.strip() for cask_ in out.split() if cask_.strip()]
             return self.current_cask in casks
         else:
             self.failed = True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix homebrew_cask.py to split installed casks on whitespace.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/packaging/os/homebrew_cask.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
± ansible --version
ansible 2.5.0 (homebrew_update 741df6953e) last updated 2017/11/28 23:13:03 (GMT -400)
  config file = /Users/dan/.ansible.cfg
  configured module search path = ['/Users/dan/src/ans/library']
  ansible python module location = /Users/dan/src/ans/lib/ansible
  executable location = /Users/dan/src/ans/bin/ansible
  python version = 3.6.3 (default, Oct 21 2017, 11:37:52) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
This is an updated version of [this](https://github.com/ansible/ansible/pull/31372) PR.