### PR TITLE
add Azure user agent for Visual Studio Code extension

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -70,6 +70,7 @@ AZURE_COMMON_REQUIRED_IF = [
 
 ANSIBLE_USER_AGENT = 'Ansible/{0}'.format(ANSIBLE_VERSION)
 CLOUDSHELL_USER_AGENT_KEY = 'AZURE_HTTP_USER_AGENT'
+VSCODEEXT_USER_AGENT_KEY = 'VSCODEEXT_USER_AGENT'
 
 CIDR_PATTERN = re.compile(r"(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1"
                           r"[0-9]{2}|2[0-4][0-9]|25[0-5])(/([0-9]|[1-2][0-9]|3[0-2]))")
@@ -729,6 +730,9 @@ class AzureRMModuleBase(object):
         # Add user agent when running from Cloud Shell
         if CLOUDSHELL_USER_AGENT_KEY in os.environ:
             client.config.add_user_agent(os.environ[CLOUDSHELL_USER_AGENT_KEY])
+        # Add user agent when running from VSCode extension
+        if VSCODEEXT_USER_AGENT_KEY in os.environ:
+            client.config.add_user_agent(os.environ[VSCODEEXT_USER_AGENT_KEY])
 
         return client
 


### PR DESCRIPTION
##### SUMMARY
We're building [Visual Studio Code extension for Ansible](https://github.com/VSChina/vscode-ansible.git), user will be able to use VSCode to run Ansible CLI directly.
This fix enables Ansible Azure Modules to pick up user agent string from VSCode environment variables.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`azure_rm_common`

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 125c4b135d) last updated 2017/10/24 08:08:58 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /ansible/lib/ansible
  executable location = /ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
```

```
