### PR TITLE
Add dnf and yum commands in "Installation" section

### DIFF
--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -101,7 +101,7 @@ Installing the Control Machine
 ``````````````````````````````
 .. _from_yum:
 
-Latest Release Via DNF or Yum
+Latest Release via DNF or Yum
 +++++++++++++++++++++++++++++
 
 On Fedora:

--- a/docs/docsite/rst/intro_installation.rst
+++ b/docs/docsite/rst/intro_installation.rst
@@ -101,8 +101,20 @@ Installing the Control Machine
 ``````````````````````````````
 .. _from_yum:
 
-Latest Release Via Yum
-++++++++++++++++++++++
+Latest Release Via DNF or Yum
++++++++++++++++++++++++++++++
+
+On Fedora:
+
+.. code-block:: bash
+
+    $ sudo dnf install ansible
+
+On RHEL and CentOS:
+
+.. code-block:: bash
+
+    $ sudo yum install ansible
 
 .. note:: We've changed how the Ansible community packages are distributed.
   For users of RHEL/CentOS/Scientific Linux version 7, the Ansible community RPM


### PR DESCRIPTION
Even though the command is very simple, it's good to be able to c&p it.
There were already commands for apt, emerge, pip, even direct installation
from git, so adding Fedora/RHEL/CentOS examples is reasonable.

Since yum is not installed by default on any supported Fedora releases
(F26 and F28 currently), recommend dnf.
