### PR TITLE
maven_artifact: add verify_checksum option - fixes #31799

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -107,7 +107,7 @@ options:
             - If C(never), the md5 checksum will never be downloaded and verified.
             - If C(download), the md5 checksum will be downloaded and verified only after artifact download. This is the default.
             - If C(change), the md5 checksum will be downloaded and verified if the destination already exist,
-              to verify if they are identical. This was the behaviour before 2.5. Since it downloads the md5 before (maybe)
+              to verify if they are identical. This was the behaviour before 2.6. Since it downloads the md5 before (maybe)
               downloading the artifact, and since some repository software, when acting as a proxy/cache, return a 404 error
               if the artifact has not been cached yet, it may fail unexpectedly.
               If you still need it, you should consider using C(always) instead - if you deal with a checksum, it is better to
@@ -116,7 +116,7 @@ options:
         required: false
         default: 'download'
         choices: ['never', 'download', 'change', 'always']
-        version_added: "2.5"
+        version_added: "2.6"
 extends_documentation_fragment:
     - files
 '''

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -366,6 +366,9 @@ class MavenDownloader:
             f = open(filename, 'wb')
             self._write_chunks(response, f, report_hook=self.chunk_report)
             f.close()
+            with open(filename, 'wb') as f:
+                self._write_chunks(response, f, report_hook=self.chunk_report)
+
             if verify_download and not self.verify_md5(filename, url + ".md5"):
                 # if verify_change was set, the previous file would be deleted
                 os.remove(filename)
@@ -468,10 +471,10 @@ def main():
     keep_name = module.params["keep_name"]
     verify_checksum = module.params["verify_checksum"]
 
-    verify_download = verify_checksum == 'download' or verify_checksum == 'always'
-    verify_change = verify_checksum == 'change' or verify_checksum == 'always'
+    verify_download = verify_checksum in ['download', 'always']
+    verify_change = verify_checksum in ['change', 'always']
 
-    # downloader = MavenDownloader(module, repository_url, repository_username, repository_password)
+
     downloader = MavenDownloader(module, repository_url)
 
     try:

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -7,15 +7,12 @@
 # as a reference and starting point.
 #
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
-
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---
@@ -191,7 +188,6 @@ def split_pre_existing_dir(dirname):
     '''
     Return the first pre-existing directory and a list of the new directories that will be created.
     '''
-
     head, tail = os.path.split(dirname)
     b_head = to_bytes(head, errors='surrogate_or_strict')
     if not os.path.exists(b_head):
@@ -206,7 +202,6 @@ def adjust_recursive_directory_permissions(pre_existing_dir, new_directory_list,
     '''
     Walk the new directories list and make sure that permissions are as we would expect
     '''
-
     if new_directory_list:
         working_dir = os.path.join(pre_existing_dir, new_directory_list.pop(0))
         directory_args['path'] = working_dir
@@ -358,7 +353,6 @@ class MavenDownloader:
         if not artifact.version or artifact.version == "latest":
             artifact = Artifact(artifact.group_id, artifact.artifact_id, self.find_latest_version_available(artifact),
                                 artifact.classifier, artifact.extension)
-
         url = self.find_uri_for_artifact(artifact)
         error = None
         response = self._request(url, "Failed to download artifact " + str(artifact), lambda r: r)
@@ -384,7 +378,6 @@ class MavenDownloader:
         percent = round(percent * 100, 2)
         sys.stdout.write("Downloaded %d of %d bytes (%0.2f%%)\r" %
                          (bytes_so_far, total_size, percent))
-
         if bytes_so_far >= total_size:
             sys.stdout.write('\n')
 
@@ -424,7 +417,6 @@ class MavenDownloader:
 
 
 def main():
-
     module = AnsibleModule(
         argument_spec=dict(
             group_id=dict(default=None),
@@ -470,10 +462,8 @@ def main():
     b_dest = to_bytes(dest, errors='surrogate_or_strict')
     keep_name = module.params["keep_name"]
     verify_checksum = module.params["verify_checksum"]
-
     verify_download = verify_checksum in ['download', 'always']
     verify_change = verify_checksum in ['change', 'always']
-
 
     downloader = MavenDownloader(module, repository_url)
 
@@ -530,7 +520,6 @@ def main():
                          extension=extension, repository_url=repository_url, changed=changed)
     else:
         module.exit_json(state=state, dest=dest, changed=changed)
-
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY

Current version of `maven_artifact` module uses the md5 to check if the destination is different from the repository - if it has changed either on disk or in the repository.

Problems (see #31799):
- this not the purpose of this md5 (checking file integrity after download)
- it leads to 404 errors depending on the repository

`verify_checksum` new option allows the user to control how it is used: either check integrity on download (default) or track changes (previous behaviour) - or both.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME

maven_artifact

##### ANSIBLE VERSION

```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/turb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.1.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```