### PR TITLE
Fix memory_reservation typo in docker_container module

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -860,7 +860,7 @@ class TaskParameters(DockerBaseClass):
             cpu_shares='cpu_shares',
             cpuset_cpus='cpuset_cpus',
             mem_limit='memory',
-            mem_reservation='mem_reservation',
+            mem_reservation='memory_reservation',
             memswap_limit='memory_swap',
             kernel_memory='kernel_memory',
         )


### PR DESCRIPTION
##### SUMMARY
Typo in memory_reservation option; the option was never read and used to setup the host config.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_container module

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel c3c5647f55)
```