### PR TITLE
Additionally template args in role_include that affect role loading

### DIFF
--- a/lib/ansible/playbook/included_file.py
+++ b/lib/ansible/playbook/included_file.py
@@ -134,6 +134,17 @@ class IncludedFile:
                         include_file = templar.template(include_file)
                         inc_file = IncludedFile(include_file, include_variables, original_task)
                     else:
+                        # template the included role's name here
+                        role_name = include_variables.get('name', include_variables.get('role', None))
+                        if role_name is not None:
+                            role_name = templar.template(role_name)
+
+                        original_task._role_name = role_name
+                        for from_arg in original_task.FROM_ARGS:
+                            if from_arg in include_variables:
+                                from_key = from_arg.replace('_from', '')
+                                original_task._from_files[from_key] = templar.template(include_variables[from_arg])
+
                         inc_file = IncludedFile("role", include_variables, original_task, is_role=True)
 
                     try:

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -198,7 +198,7 @@ class StrategyModule(StrategyBase):
                             new_ir = included_file._task.copy()
                             new_ir.vars.update(included_file._args)
 
-                            new_blocks, handler_blocks = new_ir.get_block_list(
+                            new_blocks, handler_blocks = included_file._task.get_block_list(
                                 play=iterator._play,
                                 variable_manager=self._variable_manager,
                                 loader=self._loader,


### PR DESCRIPTION
This fixes many issues with role_include by correctly templating and
saving fields which affect role loading in the args for the role include.
