### PR TITLE
Update github_release.py

### DIFF
--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -103,7 +103,7 @@ EXAMPLES = '''
     action: latest_release
 
 - name: Create a new release
-  github:
+  github_release:
     token: tokenabc1234567890
     user: testuser
     repo: testrepo


### PR DESCRIPTION
Documentation fix. The module "github" does not exist.

See [details](https://github.com/ansible/ansible/issues/33389)

Closes #33389 .