### PR TITLE
Fix value type in oracle-java7-installer debconf example

### DIFF
--- a/lib/ansible/modules/system/debconf.py
+++ b/lib/ansible/modules/system/debconf.py
@@ -73,7 +73,7 @@ EXAMPLES = '''
   debconf:
     name: oracle-java7-installer
     question: shared/accepted-oracle-license-v1-1
-    value: true
+    value: 'true'
     vtype: select
 
 - name: Specifying package you can register/return the list of questions and current values


### PR DESCRIPTION
##### SUMMARY
'true' needs to be quoted as a string, otherwise it is stored as boolean and ends up getting capitalized to 'True' when presented to debconf
Subsequent install of oracle-java7-installer / oracle-java8-installer fails with "oracle-license-v1-1 license could not be presented"

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
modules/system/debconf.py

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  config file = github/project/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.14 (default, Sep 25 2017, 09:54:19) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION

Actual:  value: true
```
debconf-show oracle-java7-installer
* shared/accepted-oracle-license-v1-1: True
```
apt: name=oracle-java7-installer
fails with: "oracle-license-v1-1 license could not be presented"


Expected:  value: 'true'
```
debconf-show oracle-java7-installer
* shared/accepted-oracle-license-v1-1: true
```
apt: name=oracle-java7-installer
succeeds
