### PR TITLE
suppress the Policy when doing changeset work

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudformation.py
+++ b/lib/ansible/modules/cloud/amazon/cloudformation.py
@@ -5,13 +5,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-# upcoming features:
-# - Ted's multifile YAML concatenation
-# - changesets (and blocking/waiting for them)
-# - finish AWSRetry conversion
-# - move create/update code out of main
-# - unit tests
-
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['stableinterface'],
                     'supported_by': 'core'}
@@ -540,9 +533,8 @@ def main():
         stack_params['NotificationARNs'] = []
 
     # can't check the policy when verifying.
-    if module.params['stack_policy'] is not None and not module.check_mode:
+    if module.params['stack_policy'] is not None and not module.check_mode and not module.params['create_changeset']:
         stack_params['StackPolicyBody'] = open(module.params['stack_policy'], 'r').read()
-
 
     template_parameters = module.params['template_parameters']
     stack_params['Parameters'] = [{'ParameterKey':k, 'ParameterValue':str(v)} for k, v in template_parameters.items()]


### PR DESCRIPTION
##### SUMMARY
Avoid setting StackPolicy when creating a changeset. It doesn't work. Marking this a 'bugfix' because it barfs an exception if these two options are used together.

Also deleting old comments I put in there when I rewrote this.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`cloudformation.py`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
