### PR TITLE
fix the return value of route53_zone

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_zone.py
+++ b/lib/ansible/modules/cloud/amazon/route53_zone.py
@@ -350,7 +350,7 @@ def main():
     elif state == 'absent':
         changed, result = delete(conn, module, matching_zones=zones)
 
-    module.exit_json(changed=changed, result=result)
+    module.exit_json(changed=changed, result=result, **result)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
All the values currently documented as return values are returned inside a 'result' key. So if you registered the output of the task as 'output', then you would need to do 'output.result.zone_id' instead of 'output.zone_id'.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`route53_zone`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

