### PR TITLE
Fix eos integration test failure

### DIFF
--- a/lib/ansible/module_utils/eos.py
+++ b/lib/ansible/module_utils/eos.py
@@ -195,6 +195,7 @@ class Cli:
 
         rc, out, err = self.send_config(commands)
         if rc != 0:
+            self.exec_command('abort')
             self._module.fail_json(msg=to_text(err, errors='surrogate_then_replace'))
 
         self.exec_command('end')

--- a/lib/ansible/plugins/action/eos.py
+++ b/lib/ansible/plugins/action/eos.py
@@ -108,7 +108,7 @@ class ActionModule(_ActionModule):
             out = conn.get_prompt()
             while '(config' in to_text(out, errors='surrogate_then_replace').strip():
                 display.vvvv('wrong context, sending exit to device', self._play_context.remote_addr)
-                conn.send_command('exit')
+                conn.send_command('abort')
                 out = conn.get_prompt()
 
         result = super(ActionModule, self).run(tmp, task_vars)

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -114,7 +114,7 @@ class Connection(ConnectionBase):
             try:
                 cmd = json.loads(to_text(cmd, errors='surrogate_or_strict'))
                 kwargs = {'command': to_bytes(cmd['command'], errors='surrogate_or_strict')}
-                for key in ('prompt', 'answer', 'send_only'):
+                for key in ('prompt', 'answer', 'sendonly'):
                     if cmd.get(key) is not None:
                         kwargs[key] = to_bytes(cmd[key], errors='surrogate_or_strict')
                 return self.send(**kwargs)
@@ -270,7 +270,6 @@ class Connection(ConnectionBase):
             recv.seek(offset)
 
             window = self._strip(recv.read())
-
             if prompts and not handled:
                 handled = self._handle_prompt(window, prompts, answer)
 
@@ -279,14 +278,14 @@ class Connection(ConnectionBase):
                 resp = self._strip(self._last_response)
                 return self._sanitize(resp, command)
 
-    def send(self, command, prompt=None, answer=None, send_only=False):
+    def send(self, command, prompt=None, answer=None, sendonly=False):
         '''
         Sends the command to the device in the opened shell
         '''
         try:
             self._history.append(command)
             self._ssh_shell.sendall(b'%s\r' % command)
-            if send_only:
+            if sendonly:
                 return
             response = self.receive(command, prompt, answer)
             return to_text(response, errors='surrogate_or_strict')

--- a/test/integration/targets/eos_static_route/tests/cli/basic.yaml
+++ b/test/integration/targets/eos_static_route/tests/cli/basic.yaml
@@ -60,8 +60,8 @@
     aggregate:
       - { address: 192.168.4.0/24, next_hop: 192.168.0.1 }
       - { address: 192.168.5.0/24, next_hop: 192.168.0.1 }
-  authorize: yes
-  provider: "{{ cli }}"
+    authorize: yes
+    provider: "{{ cli }}"
   register: result
 
 - assert:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #33406
Fixes #33405

*  Fix typo in network_cli for sendonly
*  Send `abort` to remote device in case configuration fails
*  Fix indentation issue in eos_static_route integration test
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
eos_banner
eos_statis_route

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Integration test result.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$ ANSIBLE_ROLES_PATH=targets ansible-playbook -i inventory.network eos.yaml -vvvv --diff -e "limit_to=eos_banner"
<--snip-->
TASK [Has any previous test failed?] *************************************************************************************************************
task path: /Users/gnalawad/ansible/ganeshrn/ansible/test/integration/eos.yaml:121
skipping: [eos] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
META: ran handlers
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************
eos              : ok=39   changed=12   unreachable=0    failed=0 





$ ANSIBLE_ROLES_PATH=targets ansible-playbook -i inventory.network eos.yaml -vvvv --diff -e "limit_to=eos_static_route"
TASK [Has any previous test failed?] *************************************************************************************************************
task path: /Users/gnalawad/ansible/ganeshrn/ansible/test/integration/eos.yaml:121
skipping: [eos] => {
    "changed": false, 
    "skip_reason": "Conditional result was False"
}
META: ran handlers
META: ran handlers

PLAY RECAP ***************************************************************************************************************************************
eos            : ok=26   changed=8    unreachable=0    failed=0 
```
