### PR TITLE
Fixes #32926 - Updated to get correct docker network

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_network.py
+++ b/lib/ansible/modules/cloud/docker/docker_network.py
@@ -208,14 +208,12 @@ class DockerNetworkManager(object):
             self.absent()
 
     def get_existing_network(self):
-        networks = self.client.networks(names=[self.parameters.network_name])
-        # check if a user is trying to find network by its Id
-        if not networks:
-            networks = self.client.networks(ids=[self.parameters.network_name])
-        if not networks:
-            return None
-        else:
-            return networks[0]
+        networks = self.client.networks()
+        network = None
+        for n in networks:
+            if n['Name'] == self.parameters.network_name or n['Id'] == self.parameters.network_name:
+                network = n
+        return network
 
     def has_different_config(self, net):
         '''


### PR DESCRIPTION
##### SUMMARY
Fixes #32926 - Updated to get correct docker network
Previously If a docker network named foobar exist, ansible will not create a network called foo.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docker_network

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (bugfix_32926 4d7666df76) last updated 2017/11/30 15:30:44 (GMT +550)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/arun/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/arun/Projects/bingoarun/ansible/lib/ansible
  executable location = /home/arun/Projects/bingoarun/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
In current state the module is using the filter options available in [docker network api](https://github.com/docker/docker-py/blob/1ce93ac6e75f0aaf83aededcc165e1e9fe49c52e/docker/api/network.py )  (line 13 to 36) to filter the list of networks by name or ID. It is not an effective method as the network is returned even if the substring is present. (i.e foobar is returned if we lookup for foo). Hence the filter arguments should not be used for retrieving unique network. 
This bug was introduced in [this commit.](https://github.com/ansible/ansible/commit/272c0ce68c714836da03c7962c68b4dd99dce1e3)

Now I have restored this module to the previous method with correct network retrieval both by name and ID.
 
##### STEPS TO REPRODUCE
```
- hosts: all
  tasks:
  - name: Delete foobar
    docker_network:
      name: foobar
      state: absent

  - name: Delete foo
    docker_network:
      name: foo
      state: absent

  - name: Create foobar
    docker_network:
      name: foobar
      driver: bridge
      state: present

  - name: Create foo
    docker_network:
      name: foo
      driver: bridge
      state: present
```
##### EXPECTED RESULTS
The first two tasks should make sure that there are no networks with the names that I later want to create. The next two tasks should create two networks, one named foobar and one named foo.

##### ACTUAL RESULTS
The last task will be marked as OK, but should be changed. No network named foo was created.
```
$ ansible-playbook playbook.yaml 

PLAY [all] ***********************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [Delete foobar] *************************************************************************************************************************
changed: [localhost]

TASK [Delete foo] ****************************************************************************************************************************
changed: [localhost]

TASK [Create foobar] *************************************************************************************************************************
changed: [localhost]

TASK [Create foo] ****************************************************************************************************************************
ok: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=5    changed=3    unreachable=0    failed=0   

```
```
$ docker network list
NETWORK ID          NAME                DRIVER              SCOPE
3ed938dbc5cb        bridge              bridge              local
ce8f670aa1d8        foobar              bridge              local
76f1a9ca182b        host                host                local
97ca79d5b311        none                null                local

```
##### AFTER FIXING
'foo' network is created successfully. 
```
$ ansible-playbook playbook.yaml  

PLAY [all] ***********************************************************************************************************************************

TASK [Gathering Facts] ***********************************************************************************************************************
ok: [localhost]

TASK [Delete foobar] *************************************************************************************************************************
changed: [localhost]

TASK [Delete foo] ****************************************************************************************************************************
ok: [localhost]

TASK [Create foobar] *************************************************************************************************************************
changed: [localhost]

TASK [Create foo] ****************************************************************************************************************************
changed: [localhost]

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=5    changed=3    unreachable=0    failed=0   
```
```
$ docker network list
NETWORK ID          NAME                DRIVER              SCOPE
3ed938dbc5cb        bridge              bridge              local
a737aeabfb8d        foo                 bridge              local
4b2c157cb48e        foobar              bridge              local
76f1a9ca182b        host                host                local
97ca79d5b311        none                null                local
```