### PR TITLE
Use module formatting for plugin DOCUMENTATION

### DIFF
--- a/lib/ansible/plugins/callback/profile_tasks.py
+++ b/lib/ansible/plugins/callback/profile_tasks.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
       - Ansible callback plugin for timing individual tasks and overall execution time.
       - "Mashup of 2 excellent original works: https://github.com/jlafon/ansible-profile,
          https://github.com/junaid18183/ansible_home/blob/master/ansible_plugins/callback_plugins/timestamp.py.old"
-      - "Format: ``<task start timestamp> (<length of previous task>) <current elapsed playbook execution time>``"
+      - "Format: C(<task start timestamp> (<length of previous task>) <current elapsed playbook execution time>)"
       - It also lists the top/bottom time consuming tasks in the summary (configurable)
       - Before 2.4 only the environment variables were available for configuration.
     requirements:

--- a/lib/ansible/plugins/connection/paramiko_ssh.py
+++ b/lib/ansible/plugins/connection/paramiko_ssh.py
@@ -29,7 +29,7 @@ DOCUMENTATION = """
       remote_user:
         description:
             - User to login/authenticate as
-            - Can be set from the CLI via the ``--user`` or ``-u`` options.
+            - Can be set from the CLI via the C(--user) or C(-u) options.
         vars:
             - name: ansible_user
             - name: ansible_ssh_user
@@ -47,7 +47,7 @@ DOCUMENTATION = """
       password:
         description:
           - Secret used to either login the ssh server or as a passphrase for ssh keys that require it
-          - Can be set from the CLI via the ``--ask-pass`` option.
+          - Can be set from the CLI via the C(--ask-pass) option.
         vars:
             - name: ansible_password
             - name: ansible_ssh_pass

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -10,11 +10,11 @@ DOCUMENTATION = '''
     version_added: "2.4"
     short_description: Uses Jinja2 to construct vars and groups based on existing inventory.
     description:
-        - Uses a YAML configuration file with a valid YAML or ``.config`` extension to define var expressions and group conditionals
+        - Uses a YAML configuration file with a valid YAML or C(.config) extension to define var expressions and group conditionals
         - The Jinja2 conditionals that qualify a host for membership.
         - The JInja2 exprpessions are calculated and assigned to the variables
         - Only variables already available from previous inventories or the fact cache can be used for templating.
-        - When ``strict`` is False, failed expressions will be ignored (assumes vars were missing).
+        - When I(strict) is False, failed expressions will be ignored (assumes vars were missing).
     extends_documentation_fragment:
       - constructed
 '''

--- a/lib/ansible/plugins/lookup/config.py
+++ b/lib/ansible/plugins/lookup/config.py
@@ -10,7 +10,7 @@ DOCUMENTATION = """
     short_description: Lookup current Ansilbe configuration values
     description:
       - Retrieves the value of an Ansible configuration setting.
-      - You can use ``ansible-config list`` to see all available settings.
+      - You can use C(ansible-config list) to see all available settings.
     options:
       _terms:
         description: The key(s) to look up

--- a/lib/ansible/plugins/lookup/mongodb.py
+++ b/lib/ansible/plugins/lookup/mongodb.py
@@ -32,7 +32,7 @@ DOCUMENTATION = '''
         connect_string:
             description:
                 - Can be any valid MongoDB connection string, supporting authentication, replicasets, etc.
-                - "More info at https://docs.mongodb.org/manual/reference/connection-string/"
+                - "More info at U(https://docs.mongodb.org/manual/reference/connection-string/)"
             default: "mongodb://localhost/"
         database:
             description:


### PR DESCRIPTION
##### SUMMARY
Use module formatting, rather than RST

Fixes issues like https://docs.ansible.com/ansible/devel/plugins/connection/paramiko_ssh.html#options
showing
`Can be set from the CLI via the ``--user`` or ``-u`` options.`

http://docs.ansible.com/ansible/latest/dev_guide/developing_modules_documenting.html#formatting-options

##### ISSUE TYPE
 - Docs Pull Request

