### PR TITLE
update terminal plugin to use cli()

### DIFF
--- a/lib/ansible/plugins/terminal/aruba.py
+++ b/lib/ansible/plugins/terminal/aruba.py
@@ -19,11 +19,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text, to_bytes
 from ansible.plugins.terminal import TerminalBase
 
 
@@ -49,6 +47,6 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command(b'no pag')
+            self.cli('no pag')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/asa.py
+++ b/lib/ansible/plugins/terminal/asa.py
@@ -20,11 +20,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text, to_bytes
 from ansible.plugins.terminal import TerminalBase
+from ansible.module_utils._text import to_text
 
 
 class TerminalModule(TerminalBase):
@@ -44,9 +43,8 @@ class TerminalModule(TerminalBase):
             self.disable_pager()
 
     def disable_pager(self):
-        cmd = {u'command': u'no terminal pager'}
         try:
-            self._exec_cli_command(u'no terminal pager')
+            self.cli('no terminal pager')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to disable terminal pager')
 
@@ -54,15 +52,17 @@ class TerminalModule(TerminalBase):
         if self._get_prompt().strip().endswith(b'#'):
             return
 
-        cmd = {u'command': u'enable'}
+        prompt = None
+        answer = None
+
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
-            cmd[u'answer'] = passwd
+            prompt = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            answer = passwd
 
         try:
-            self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+            self.cli('enable', prompt, answer)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
 

--- a/lib/ansible/plugins/terminal/bigip.py
+++ b/lib/ansible/plugins/terminal/bigip.py
@@ -50,6 +50,6 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command(b'modify cli preference display-threshold 0 pager disabled')
+            self.cli('modify cli preference display-threshold 0 pager disabled')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -19,8 +19,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import re
-
 from ansible.plugins.terminal import TerminalBase
 from ansible.errors import AnsibleConnectionFailure
 
@@ -49,6 +47,6 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command('screen-length 0 temporary')
+            self.cli('screen-length 0 temporary')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/ce.py
+++ b/lib/ansible/plugins/terminal/ce.py
@@ -19,6 +19,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import re
+
 from ansible.plugins.terminal import TerminalBase
 from ansible.errors import AnsibleConnectionFailure
 

--- a/lib/ansible/plugins/terminal/dellos9.py
+++ b/lib/ansible/plugins/terminal/dellos9.py
@@ -22,9 +22,8 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_text
 from ansible.plugins.terminal import TerminalBase
 from ansible.errors import AnsibleConnectionFailure
 
@@ -47,7 +46,7 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command(b'terminal length 0')
+            self.cli('terminal length 0')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
@@ -55,13 +54,15 @@ class TerminalModule(TerminalBase):
         if self._get_prompt().endswith(b'#'):
             return
 
-        cmd = {u'command': u'enable'}
+        prompt = None
+        answer = None
+
         if passwd:
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
-            cmd[u'answer'] = passwd
+            prompt = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            answer = passwd
 
         try:
-            self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+            self.cli('enable', prompt, answer)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
 
@@ -72,8 +73,8 @@ class TerminalModule(TerminalBase):
             return
 
         if prompt.strip().endswith(b')#'):
-            self._exec_cli_command(b'end')
-            self._exec_cli_command(b'disable')
+            for cmd in ('end', 'disable'):
+                self.cli(cmd)
 
         elif prompt.endswith(b'#'):
-            self._exec_cli_command(b'disable')
+            self.cli('disable')

--- a/lib/ansible/plugins/terminal/enos.py
+++ b/lib/ansible/plugins/terminal/enos.py
@@ -34,11 +34,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_text
 from ansible.plugins.terminal import TerminalBase
 
 
@@ -62,8 +61,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'\n', b'terminal-length 0\n'):
-                self._exec_cli_command(cmd)
+            for cmd in ('\n', 'terminal-length 0\n'):
+                self.cli(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
@@ -71,21 +70,20 @@ class TerminalModule(TerminalBase):
         if self._get_prompt().endswith(b'#'):
             return
 
-        cmd = {u'command': u'enable'}
+        prompt = None
+        answer = None
+
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text
             # on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $",
-                                     errors='surrogate_or_strict')
-            cmd[u'answer'] = passwd
+            prompt = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            answer = passwd
 
         try:
-            self._exec_cli_command(to_bytes(json.dumps(cmd),
-                                   errors='surrogate_or_strict'))
+            self.cli('enable', prompt, answer)
         except AnsibleConnectionFailure:
-            msg = 'unable to elevate privilege to enable mode'
-            raise AnsibleConnectionFailure(msg)
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
 
     def on_unbecome(self):
         prompt = self._get_prompt()
@@ -94,8 +92,8 @@ class TerminalModule(TerminalBase):
             return
 
         if b'(config' in prompt:
-            self._exec_cli_command(b'end')
-            self._exec_cli_command(b'disable')
+            for cmd in ('end', 'disable'):
+                self.cli(cmd)
 
         elif prompt.endswith(b'#'):
-            self._exec_cli_command(b'disable')
+            self.cli('disable')

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -80,4 +80,4 @@ class TerminalModule(TerminalBase):
                 self.cli(cmd)
 
         elif prompt.endswith(b'#'):
-            self.cli(disable)
+            self.cli('disable')

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -19,11 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_text
 from ansible.plugins.terminal import TerminalBase
 
 
@@ -48,7 +47,7 @@ class TerminalModule(TerminalBase):
     def on_open_shell(self):
         try:
             for cmd in (b'terminal length 0', b'terminal width 512'):
-                self._exec_cli_command(cmd)
+                self.cli(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
@@ -56,15 +55,17 @@ class TerminalModule(TerminalBase):
         if self._get_prompt().endswith(b'#'):
             return
 
-        cmd = {u'command': u'enable'}
+        prompt = None
+        answer = None
+
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
-            cmd[u'answer'] = passwd
+            prompt = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            answer = passwd
 
         try:
-            self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+            self.cli('enable', prompt, answer)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
 
@@ -75,8 +76,8 @@ class TerminalModule(TerminalBase):
             return
 
         if b'(config' in prompt:
-            self._exec_cli_command(b'end')
-            self._exec_cli_command(b'disable')
+            for cmd in ('end', 'disable'):
+                self.cli(cmd)
 
         elif prompt.endswith(b'#'):
-            self._exec_cli_command(b'disable')
+            self.cli(disable)

--- a/lib/ansible/plugins/terminal/iosxr.py
+++ b/lib/ansible/plugins/terminal/iosxr.py
@@ -20,7 +20,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import re
-import json
 
 from ansible.plugins.terminal import TerminalBase
 from ansible.errors import AnsibleConnectionFailure
@@ -48,6 +47,6 @@ class TerminalModule(TerminalBase):
     def on_open_shell(self):
         try:
             for cmd in (b'terminal length 0', b'terminal width 512', b'terminal exec prompt no-timestamp'):
-                self._exec_cli_command(cmd)
+                self.cli(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/junos.py
+++ b/lib/ansible/plugins/terminal/junos.py
@@ -49,8 +49,8 @@ class TerminalModule(TerminalBase):
             prompt = self._get_prompt()
             if prompt.strip().endswith(b'%'):
                 display.vvv('starting cli', self._connection._play_context.remote_addr)
-                self._exec_cli_command('cli')
-            for c in (b'set cli timestamp disable', b'set cli screen-length 0', b'set cli screen-width 1024'):
-                self._exec_cli_command(c)
+                self.cli('cli')
+            for c in ('set cli timestamp disable', 'set cli screen-length 0', 'set cli screen-width 1024'):
+                self.cli(c)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/mlnxos.py
+++ b/lib/ansible/plugins/terminal/mlnxos.py
@@ -19,11 +19,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
 import re
 
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils._text import to_text, to_bytes
+from ansible.module_utils._text import to_text
 from ansible.plugins.terminal import TerminalBase
 
 
@@ -42,7 +41,7 @@ class TerminalModule(TerminalBase):
     def on_open_shell(self):
         try:
             for cmd in self.init_commands:
-                self._exec_cli_command(cmd)
+                self.cli(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')
 
@@ -50,21 +49,20 @@ class TerminalModule(TerminalBase):
         if self._get_prompt().endswith(b'#'):
             return
 
-        cmd = {u'command': u'enable'}
+        prompt = None
+        answer = None
+
         if passwd:
             # Note: python-3.5 cannot combine u"" and r"" together.  Thus make
             # an r string and use to_text to ensure it's text on both py2 and
             # py3.
-            cmd[u'prompt'] = to_text(r"[\r\n]?password: $",
-                                     errors='surrogate_or_strict')
-            cmd[u'answer'] = passwd
+            prompt = to_text(r"[\r\n]?password: $", errors='surrogate_or_strict')
+            answer = passwd
 
         try:
-            self._exec_cli_command(to_bytes(json.dumps(cmd),
-                                            errors='surrogate_or_strict'))
+            self.cli('enable', prompt, answer)
         except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure(
-                'unable to elevate privilege to enable mode')
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
 
     def on_deauthorize(self):
         prompt = self._get_prompt()
@@ -73,8 +71,8 @@ class TerminalModule(TerminalBase):
             return
 
         if b'(config' in prompt:
-            self._exec_cli_command(b'exit')
-            self._exec_cli_command(b'disable')
+            for cmd in ('exit', 'disable'):
+                self.cli(cmd)
 
         elif prompt.endswith(b'#'):
-            self._exec_cli_command(b'disable')
+            self.cli('disable')

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -48,7 +48,7 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'terminal length 0', b'terminal width 511'):
+            for cmd in ('terminal length 0', 'terminal width 511'):
                 self.cli(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/nxos.py
+++ b/lib/ansible/plugins/terminal/nxos.py
@@ -49,6 +49,6 @@ class TerminalModule(TerminalBase):
     def on_open_shell(self):
         try:
             for cmd in (b'terminal length 0', b'terminal width 511'):
-                self._exec_cli_command(cmd)
+                self.cli(cmd)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/sros.py
+++ b/lib/ansible/plugins/terminal/sros.py
@@ -38,6 +38,6 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            self._exec_cli_command(b'environment no more')
+            self.cli('environment no more')
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')

--- a/lib/ansible/plugins/terminal/vyos.py
+++ b/lib/ansible/plugins/terminal/vyos.py
@@ -43,8 +43,8 @@ class TerminalModule(TerminalBase):
 
     def on_open_shell(self):
         try:
-            for cmd in (b'set terminal length 0', b'set terminal width 512'):
-                self._exec_cli_command(cmd)
-            self._exec_cli_command(b'set terminal length %d' % self.terminal_length)
+            for cmd in ('set terminal length 0', 'set terminal width 512'):
+                self.cli(cmd)
+            self.cli('set terminal length %d' % self.terminal_length)
         except AnsibleConnectionFailure:
             raise AnsibleConnectionFailure('unable to set terminal parameters')


### PR DESCRIPTION
This change adds a new method to TerminalBase for sending cli commands
across the connection.  The base method will handle the conversion to
bytes and commands no longer need to be json encoded.

This deprecates the use of _exec_cli_command() method and all plugins
have been updated to use the new cli() method instead.  The deprecated
method will be removed in N+4 releases.

