### PR TITLE
updated pamd rule args regexp to match file paths also

### DIFF
--- a/lib/ansible/modules/system/pamd.py
+++ b/lib/ansible/modules/system/pamd.py
@@ -286,7 +286,7 @@ class PamdRule(object):
                 r"""([\-A-Za-z0-9_]+)\s*         # Rule Type
                     \[([A-Za-z0-9_=\s]+)\]\s*    # Rule Control
                     ([A-Za-z0-9_\-\.]+)\s*         # Rule Path
-                    ([A-Za-z0-9,_=<>\-\s]*)""",  # Rule Args
+                    ([A-Za-z0-9,_=<>\-\s\./]*)""",  # Rule Args
                 re.X)
             complicated = True
         else:
@@ -294,7 +294,7 @@ class PamdRule(object):
                 r"""([\-A-Za-z0-9_]+)\s*        # Rule Type
                     ([A-Za-z0-9_]+)\s*          # Rule Control
                     ([A-Za-z0-9_\-\.]+)\s*        # Rule Path
-                    ([A-Za-z0-9,_=<>\-\s]*)""",  # Rule Args
+                    ([A-Za-z0-9,_=<>\-\s\./]*)""",  # Rule Args
                 re.X)
 
         result = pattern.match(stringline)

--- a/test/units/modules/system/test_pamd.py
+++ b/test/units/modules/system/test_pamd.py
@@ -45,6 +45,22 @@ class PamdRuleTestCase(unittest.TestCase):
         self.assertEqual(complicated, module_string.rstrip())
         self.assertEqual('try_first_pass', module.get_module_args_as_string())
 
+    def test_rule_with_arg(self):
+        line = "account       optional    pam_echo.so file=/etc/lockout.txt"
+        module = PamdRule.rulefromstring(stringline=line)
+        self.assertEqual(module.rule_type, 'account')
+        self.assertEqual(module.rule_control, 'optional')
+        self.assertEqual(module.rule_module_path, 'pam_echo.so')
+        self.assertEqual(module.rule_module_args, ['file=/etc/lockout.txt'])
+
+    def test_rule_with_args(self):
+        line = "account       optional    pam_echo.so file1=/etc/lockout1.txt file2=/etc/lockout2.txt"
+        module = PamdRule.rulefromstring(stringline=line)
+        self.assertEqual(module.rule_type, 'account')
+        self.assertEqual(module.rule_control, 'optional')
+        self.assertEqual(module.rule_module_path, 'pam_echo.so')
+        self.assertEqual(module.rule_module_args, ['file1=/etc/lockout1.txt', 'file2=/etc/lockout2.txt'])
+
     def test_less_than_in_args(self):
         rule = "auth requisite pam_succeed_if.so uid >= 1025 quiet_success"
         module = PamdRule.rulefromstring(stringline=rule)


### PR DESCRIPTION
##### SUMMARY
Changed the rule args regexp to include . and / so it'll catch file paths, e.g. pam_echo.so file=/tmp/blah.  @mscherer and @pilou- figured it out, I tested it and checked it in. Includes change to pamd and new unit test check(s) courtesy of @pilou-.

Fixes #33351 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
pamd module

##### ANSIBLE VERSION
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/etc/ansible/library']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /root/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```
