### PR TITLE
Port some tests away from nose as examples

### DIFF
--- a/test/units/module_utils/json_utils/test_filter_non_json_lines.py
+++ b/test/units/module_utils/json_utils/test_filter_non_json_lines.py
@@ -22,8 +22,6 @@ __metaclass__ = type
 
 import json
 
-from nose.tools import eq_, raises
-
 from ansible.compat.tests import unittest
 from ansible.module_utils.json_utils import _filter_non_json_lines
 

--- a/test/units/modules/cloud/amazon/test_api_gateway.py
+++ b/test/units/modules/cloud/amazon/test_api_gateway.py
@@ -20,14 +20,15 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from nose.plugins.skip import SkipTest
-import pytest
 import sys
+
+import pytest
+
 from ansible.module_utils.ec2 import HAS_BOTO3
 from units.modules.utils import set_module_args
 
 if not HAS_BOTO3:
-    raise SkipTest("test_api_gateway.py requires the `boto3` and `botocore` modules")
+    pytestmark = pytest.mark.skip("test_api_gateway.py requires the `boto3` and `botocore` modules")
 
 import ansible.modules.cloud.amazon.aws_api_gateway as agw
 

--- a/test/units/modules/cloud/amazon/test_data_pipeline.py
+++ b/test/units/modules/cloud/amazon/test_data_pipeline.py
@@ -15,20 +15,18 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import pytest
 import os
 import json
 import collections
+
+import pytest
 from . placebo_fixtures import placeboify, maybe_sleep
-from nose.plugins.skip import SkipTest
 
 from ansible.modules.cloud.amazon import data_pipeline
 from ansible.module_utils._text import to_text
 
-try:
-    import boto3
-except ImportError:
-    raise SkipTest("test_api_gateway.py requires the `boto3` and `botocore` modules")
+# test_api_gateway.py requires the `boto3` and `botocore` modules
+boto3 = pytest.importorskip('boto3')
 
 
 @pytest.fixture(scope='module')

--- a/test/units/modules/cloud/amazon/test_elb_application_lb.py
+++ b/test/units/modules/cloud/amazon/test_elb_application_lb.py
@@ -5,16 +5,17 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from nose.plugins.skip import SkipTest
 import json
-import pytest
 from copy import deepcopy
+
+import pytest
+
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils import basic
 from ansible.module_utils.ec2 import HAS_BOTO3
 
 if not HAS_BOTO3:
-    raise SkipTest("test_elb_application_lb.py requires the `boto3` and `botocore` modules")
+    pytestmark = pytest.mark.skip("test_elb_application_lb.py requires the `boto3` and `botocore` modules")
 
 import ansible.modules.cloud.amazon.elb_application_lb as elb_module
 

--- a/test/units/modules/cloud/amazon/test_lambda_policy.py
+++ b/test/units/modules/cloud/amazon/test_lambda_policy.py
@@ -21,13 +21,14 @@ from __future__ import (absolute_import, division, print_function)
 
 import copy
 
-from nose.plugins.skip import SkipTest
+import pytest
+
 from ansible.module_utils.aws.core import HAS_BOTO3
 from ansible.compat.tests.mock import MagicMock
 from units.modules.utils import set_module_args
 
 if not HAS_BOTO3:
-    raise SkipTest("test_api_gateway.py requires the `boto3` and `botocore` modules")
+    pytestmark = pytest.mark.skip("test_api_gateway.py requires the `boto3` and `botocore` modules")
 
 # these are here cause ... boto!
 from botocore.exceptions import ClientError

--- a/test/units/modules/cloud/amazon/test_s3.py
+++ b/test/units/modules/cloud/amazon/test_s3.py
@@ -5,8 +5,7 @@ import unittest
 try:
     import ansible.modules.cloud.amazon.s3 as s3
 except ImportError:
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("This test requires the s3 Python libraries")
+    pytestmark = pytest.mark.skip("This test requires the s3 Python libraries")
 
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 

--- a/test/units/plugins/filter/test_ipaddr.py
+++ b/test/units/plugins/filter/test_ipaddr.py
@@ -17,14 +17,12 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import pytest
+
 from ansible.compat.tests import unittest
 from ansible.plugins.filter.ipaddr import (ipaddr, _netmask_query, nthhost, next_nth_usable,
                                            previous_nth_usable, network_in_usable, network_in_network)
-try:
-    import netaddr
-except ImportError:
-    from nose.plugins.skip import SkipTest
-    raise SkipTest("This test  requires the `netaddr` python library")
+netaddr = pytest.importorskip('netaddr')
 
 
 class TestIpFilter(unittest.TestCase):


### PR DESCRIPTION
We don't need to use both nose and pytest.  Once we get rid of all uses
of nose we can remove the extra dependency

##### ISSUE TYPE
 - Test Pull Request

##### COMPONENT NAME
Various tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
