### PR TITLE
Adding artifactory_repo module and unit tests

### DIFF
--- a/lib/ansible/module_utils/artifactory.py
+++ b/lib/ansible/module_utils/artifactory.py
@@ -1,0 +1,287 @@
+# Copyright (c) 2017 Kyle Haley, <kylephaley@gmail.com>
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import ast
+import json
+
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.urls import open_url
+
+"""
+This is the general construction of the validation map passed in.
+URI_CONFIG_MAP["uri_key"] is a substring of the target artifactory URL,
+such as "api/repositories" or "api/security/groups". The need for URL substring
+exists since some modules may need to cover multiple URLs, such as a security
+module, which may need to touch on
+"api/security/groups" or "api/security/users" or "api/security/permissions".
+
+KEY_CONFIG_MAP = {
+    "config_key":
+        {"valid_values": list(),
+         "required_keys": list(),
+         "values_require_keys": dict(),
+         "always_required": bool}}
+
+URI_CONFIG_MAP = {
+    "uri_key": KEY_CONFIG_MAP}
+"""
+
+
+class ArtifactoryBase(object):
+    def __init__(self, username=None, password=None,
+                 auth_token=None, validate_certs=False, client_cert=None,
+                 client_key=None, force_basic_auth=False, config_map=None):
+        self.username = username
+        self.password = password
+        self.auth_token = auth_token
+
+        self.validate_certs = validate_certs
+        self.client_cert = client_cert
+        self.client_key = client_key
+        self.force_basic_auth = force_basic_auth
+
+        self.config_map = config_map
+
+        self.headers = {"Content-Type": "application/json"}
+        if auth_token:
+            self.headers["X-JFrog-Art-Api"] = auth_token
+
+    def convert_config_to_dict(self, config):
+        if isinstance(config, dict):
+            return config
+        else:
+            error_occurred = False
+            message = ""
+            try:
+                test_dict = ast.literal_eval(config)
+                if isinstance(test_dict, dict):
+                    config = test_dict
+                else:
+                    raise ValueError()
+            except ValueError as ve:
+                error_occurred = True
+                message = str(ve)
+            except SyntaxError as se:
+                error_occurred = True
+                message = str(se)
+
+            if error_occurred:
+                raise ConfigValueTypeMismatch("Configuration data provided "
+                                              "is not valid json.\n %s"
+                                              % message)
+        return config
+
+    def serialize_config_data(self, config_data):
+        if not config_data or not isinstance(config_data, dict):
+            raise InvalidConfigurationData("Config is null, empty, or is not"
+                                           " a dictionary.")
+        serial_config_data = json.dumps(config_data)
+        return serial_config_data
+
+    def query_artifactory(self, url, method, data=None):
+        if self.auth_token:
+            response = open_url(url, data=data, headers=self.headers,
+                                method=method,
+                                validate_certs=self.validate_certs,
+                                client_cert=self.client_cert,
+                                client_key=self.client_key,
+                                force_basic_auth=self.force_basic_auth)
+        else:
+            response = open_url(url, data=data, headers=self.headers,
+                                method=method,
+                                validate_certs=self.validate_certs,
+                                client_cert=self.client_cert,
+                                client_key=self.client_key,
+                                force_basic_auth=self.force_basic_auth,
+                                url_username=self.username,
+                                url_password=self.password)
+        return response
+
+    def validate_config_values(self, url, config_dict):
+        validation_dict = self.get_uri_key_map(url, self.config_map)
+        if not validation_dict or isinstance(validation_dict, bool):
+            return
+        for config_key in config_dict:
+            if config_key in validation_dict:
+                if "valid_values" in validation_dict[config_key]:
+                    valid_values = validation_dict[config_key]["valid_values"]
+                    config_val = config_dict[config_key]
+                    if valid_values and config_val not in valid_values:
+                        except_message = ("'%s' is not a valid value for "
+                                          "key '%s'"
+                                          % (config_val, config_key))
+                        raise InvalidConfigurationData(except_message)
+
+    def get_uri_key_map(self, url, uri_config_map):
+        if not url or not uri_config_map:
+            raise InvalidConfigurationData("url or config is None or empty."
+                                           " url: %s, config: %s"
+                                           % (url, uri_config_map))
+        temp = None
+        for uri_substr in uri_config_map:
+            if uri_substr in url:
+                temp = uri_config_map[uri_substr]
+                break
+        if temp:
+            return temp
+        else:
+            raise InvalidArtifactoryURL("The url '%s' could not be "
+                                        "mapped to a known set of "
+                                        "configuration rules." % url)
+
+    def validate_config_required_keys(self, url, config_dict):
+        req_keys = self.get_always_required_keys(url, config_dict)
+        for required in req_keys:
+            if required not in config_dict:
+                message = ("%s key is missing from config." % required)
+                raise InvalidConfigurationData(message)
+        return req_keys
+
+    def get_always_required_keys(self, url, config_dict):
+        """Return keys that are always required for creating a repo."""
+        validation_dict = self.get_uri_key_map(url, self.config_map)
+        req_keys = list()
+        # If the resulting validation dict is boolean True, then this just
+        # verifies that the url is correct for this module. Return empty list.
+        if not validation_dict or isinstance(validation_dict, bool):
+            return req_keys
+        for config_req in validation_dict:
+            if "always_required" in validation_dict[config_req]:
+                if validation_dict[config_req]["always_required"]:
+                    req_keys.append(config_req)
+        for config_key in config_dict:
+            if config_key in validation_dict:
+                valid_sub_dict = validation_dict[config_key]
+                # If config_key exists, check if other keys are required.
+                if "required_keys" in valid_sub_dict:
+                    if isinstance(valid_sub_dict["required_keys"], list):
+                        req_keys.extend(valid_sub_dict["required_keys"])
+                    else:
+                        raise InvalidConfigurationData(
+                            "Values defined in 'required_keys' should be"
+                            " a list. ['%s']['required_keys'] is not a"
+                            " list." % config_key)
+                # If config_key exists, check if the value of config_key
+                # requires other keys.
+                # If the value of the key 'rclass' is 'remote', then the 'url'
+                # key must be defined. The value in the mapping should be a
+                # list.
+                if "values_require_keys" in valid_sub_dict:
+                    config_value = config_dict[config_key]
+                    val_req_keys = valid_sub_dict["values_require_keys"]
+                    if val_req_keys and config_value in val_req_keys:
+                        if isinstance(val_req_keys[config_value], list):
+                            req_keys.extend(val_req_keys[config_value])
+                        else:
+                            raise InvalidConfigurationData(
+                                "Values defined in in the dict"
+                                " 'values_require_keys' should be lists."
+                                " ['values_require_keys']['%s'] is not a"
+                                " list." % config_value)
+        return req_keys
+
+
+class InvalidArtifactoryURL(Exception):
+    pass
+
+
+class ConfigValueTypeMismatch(Exception):
+    pass
+
+
+class InvalidConfigurationData(Exception):
+    pass
+
+
+TOP_LEVEL_FAIL = ("Conflicting config values. "
+                  "top level parameter {1} != {0}[{1}]. "
+                  "Only one config value need be set. ")
+
+
+def validate_top_level_params(top_level_param, module, config, config_hash,
+                              config_name, config_hash_name):
+    """Validate top-level params against different configuration sources.
+        These modules can have multiple configuration sources. If these sources
+        have identical keys, but different values, aggregate error messages to
+        alert the user for each one that does not match and the source.
+        return a list of those messages.
+    """
+    validation_fail_messages = []
+    config_hash_fail_msg = ""
+    config_fail_msg = ""
+    if not top_level_param or not module.params[top_level_param]:
+        return validation_fail_messages
+    value = module.params[top_level_param]
+    if isinstance(value, list):
+        value = sorted(value)
+    if config_hash and top_level_param in config_hash:
+        if isinstance(config_hash[top_level_param], list):
+            config_hash[top_level_param] = sorted(config_hash[top_level_param])
+        if value != config_hash[top_level_param]:
+            config_hash_fail_msg = TOP_LEVEL_FAIL.format(config_hash_name,
+                                                         top_level_param)
+            validation_fail_messages.append(config_hash_fail_msg)
+    if config and top_level_param in config:
+        if isinstance(config[top_level_param], list):
+            config[top_level_param] = sorted(config[top_level_param])
+        if value != config[top_level_param]:
+            config_fail_msg = TOP_LEVEL_FAIL.format(config_name,
+                                                    top_level_param)
+            validation_fail_messages.append(config_fail_msg)
+
+    return validation_fail_messages
+
+
+CONFIG_PARAM_FAIL = ("Conflicting config values. "
+                     "{1}[{0}] != "
+                     "{2}[{0}]. "
+                     "Only one config value need be "
+                     "set. ")
+
+
+def validate_config_params(config, config_hash, config_name, config_hash_name):
+    """Validate two different configuration sources.
+        These modules can have multiple configuration sources. If these sources
+        have identical keys, but different values, aggregate error messages to
+        alert the user for each one that does not match and the source.
+        return a list of those messages.
+    """
+    validation_fail_messages = []
+    if not config_hash or not config:
+        return validation_fail_messages
+    for key, val in iteritems(config):
+        if key in config_hash:
+            if isinstance(config_hash[key], list):
+                config_hash[key] = sorted(config_hash[key])
+            if isinstance(config[key], list):
+                config[key] = sorted(config[key])
+            if config_hash[key] != config[key]:
+                fail_msg = CONFIG_PARAM_FAIL.format(key, config_name,
+                                                    config_hash_name)
+                validation_fail_messages.append(fail_msg)
+    return validation_fail_messages

--- a/lib/ansible/modules/packaging/artifactory_repo.py
+++ b/lib/ansible/modules/packaging/artifactory_repo.py
@@ -1,0 +1,703 @@
+#!/usr/bin/python
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+
+DOCUMENTATION = '''
+---
+module: artifactory_repo
+
+short_description: Provides management operations for repositories in JFrog Artifactory
+
+version_added: "2.5"
+
+description:
+    - "Provides basic management operations against repositories JFrog Artifactory 5+."
+
+options:
+    artifactory_url:
+        description:
+            - The target URL for managing artifactory. For certain operations,
+              you can include the repository key appended to the end of the
+              url.
+        required: true
+    name:
+        description:
+            - Name of the target repo to perform CRUD operations against.
+        required: true
+    repo_position:
+        description:
+            - Sets the resolution order for which repos of the same type are
+              queried. This governs the order local, remote repositories
+              and other virtual repositories are listed in the virtual
+              repository configuration. By default, this is ignored so that
+              the order is governed by the order of creation.
+        required: false
+    repo_config:
+        description:
+            - The configuration for the given repository as a json formatted
+              string. This configuration must conform to JFrog Artifactory
+              Repository Configuration JSON published at jfrog.com . Basic
+              validation is performed against required fields for Artifactory
+              5+ for required fields in create/replace calls, which is the
+              following... 'rclass' must be defined for all create calls. If
+              creating a 'virtual' repository, 'packageType'
+              must be defined with an appropriate type. If creating
+              a 'remote' repository, 'url' must be defined in the
+              configuration.
+        required: false
+    username:
+        description:
+            - username to be used in Basic Auth against Artifactory. Not
+              required if using auth_token for basic auth.
+        required: false
+    password:
+        description:
+            - password to be used in Basic Auth against Artifactory. Not
+              required if using auth_token for basic auth.
+        required: false
+    auth_token:
+        description:
+            - authentication token to be used in Basic Auth against
+              Artifactory. Not required if using username/password for basic
+              auth.
+        required: false
+    validate_certs:
+        description:
+            - True to validate SSL certificates, False otherwise.
+        required: false
+        choices:
+          - True
+          - False
+        default: False
+    client_cert:
+        description:
+            - PEM formatted certificate chain file to be used for SSL client
+              authentication. This file can also include the key as well, and
+              if the key is included, I(client_key) is not required
+        required: false
+    client_key:
+        description:
+            - PEM formatted file that contains your private key to be used for
+              SSL client authentication. If I(client_cert) contains both the
+              certificate and key, this option is not required.
+        required: false
+    force_basic_auth:
+        description:
+            - The library used by the uri module only sends authentication
+              information when a webservice responds to an initial request
+              with a 401 status. Since some basic auth services do not properly
+              send a 401, logins will fail. This option forces the sending of
+              the Basic authentication header upon initial request.
+        required: false
+        choices:
+          - True
+          - False
+        default: False
+    state:
+        description:
+            - The state the repository should be in. 'present' ensures that a
+              repository exists, but not replaced.
+              'absent' ensures that the repository is deleted.
+              'read' will return the configuration if the repository exists.
+              'list' will return a list of all repositories that currently
+              exist in the target artifactory. The configuration supplied
+              will overwrite the configuration that exists. If you wish to, for
+              instance, append new repositories to a virtual repository, you
+              will need to construct the complete list outside of the module
+              and pass it in.
+        required: false
+        choices:
+          - present
+          - absent
+          - read
+          - list
+        default: read
+    rclass:
+        description:
+            - The type of remote repository you wish to create.
+        required: false
+        choices:
+          - local
+          - remote
+          - virtual
+    url:
+        description:
+            - The url for the repository.
+        required: false
+    packageType:
+        description:
+            - The packageType of the repository.
+        required: false
+        choices:
+          - bower
+          - chef
+          - composer
+          - conan
+          - debian
+          - docker
+          - gems
+          - generic
+          - gitlfs
+          - gradle
+          - ivy
+          - maven
+          - npm
+          - nuget
+          - puppet
+          - pypi
+          - sbt
+          - vagrant
+          - yum
+    repo_config_dict:
+        description:
+            - A dictionary in yaml format of valid configuration values. These
+              dictionary key/value pairs match the configuration spec of
+              repo_config.
+        required: false
+    repoLayoutRef:
+        description:
+            - The name of the target layout for this repository.
+        required: false
+
+author:
+    - Kyle Haley (@quadewarren)
+'''
+
+EXAMPLES = '''
+# Create a local repository in artifactory with auth_token with minimal
+# config requirements
+- name: create test-local-creation repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    auth_token: my_token
+    name: test-local-creation
+    state: present
+    repo_config: '{"rclass": "local"}'
+
+# Create a local repository in artifactory with auth_token using top level params
+# config requirements
+- name: create test-local-creation repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    auth_token: my_token
+    name: test-local-creation
+    state: present
+    rclass: local
+
+# Create a local repository in artifactory with multiple levels of params
+# config requirements
+- name: create test-local-creation repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    auth_token: my_token
+    name: test-local-creation
+    state: present
+    rclass: local
+    repo_config_dict:
+        packageType: generic
+    repo_config: '{"description": "Test description"}'
+
+# Delete a local repository in artifactory with auth_token
+- name: delete test-local-delete repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    auth_token: your_token
+    name: test-local-delete
+    state: absent
+
+# Create a remote repository in artifactory with username/password with
+# minimal config requirements
+- name: create test-remote-creation repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    username: your_username
+    password: your_pass
+    name: test-remote-creation
+    state: present
+    repo_config: '{"rclass": "remote", "url": "http://http://host:port/some-repo"}'
+
+# Create a virtual repository in artifactory with auth_token with
+# minimal config requirements
+- name: create test-remote-creation repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    auth_token: your_token
+    name: test-virtual-creation
+    state: present
+    repo_config: '{"rclass": "virtual", "packageType": "generic"}'
+
+# Update a virtual repository in artifactory with username/password
+- name: update test-virtual-update repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    username: your_username
+    password: your_pass
+    name: test-virtual-update
+    state: present
+    repo_config: '{"description": "New public description."}'
+  register: test_virtual_config
+
+# Repository config is in response for successful create/update calls,
+# regardless if call resulted in a change. Successful delete calls
+# contain the config of the repo just before deletion for later use in play.
+- name: dump test_virtual_config config json
+  debug:
+    msg: '{{ test_virtual_config.config }}'
+
+# Update a virtual repository with a config hash
+# Configuration provided replaces the existing configuration, so
+# if you want to append values to an existing list, that list needs to be
+# constructed outside of the module and passed in.
+- name: update test-virtual-update repo
+  artifactory_repo:
+    artifactory_url: https://artifactory.repo.example.com
+    auth_token: your_token
+    name: test-virtual-update
+    state: present
+    repo_config_dict:
+      description: "Another new public description"
+      repositories:
+        - pypi-remote
+        - mypi-local
+'''
+
+RETURN = '''
+original_message:
+    description:
+        - A brief sentence describing what action the module was attempting
+          to take against which repository and what artifactory url.
+    returned: success
+    type: str
+message:
+    description: The result of the attempted action.
+    returned: success
+    type: str
+config:
+    description:
+        - The configuration of a successfully created repository, an updated
+          repository (whether or not changed=True), or the config
+          of a repository that was successfully deleted.
+    returned: success
+    type: dict
+'''
+
+
+import ast
+import json
+
+import ansible.module_utils.artifactory as art_base
+import ansible.module_utils.six.moves.urllib.error as urllib_error
+
+from ansible.module_utils.basic import AnsibleModule
+
+
+LOCAL_RCLASS = "local"
+REMOTE_RCLASS = "remote"
+VIRTUAL_RCLASS = "virtual"
+
+VALID_RCLASSES = [LOCAL_RCLASS, REMOTE_RCLASS, VIRTUAL_RCLASS]
+
+VALID_PACKAGETYPES = ["bower",
+                      "chef",
+                      "composer",
+                      "conan",
+                      "debian",
+                      "docker",
+                      "gems",
+                      "generic",
+                      "gitlfs",
+                      "gradle",
+                      "ivy",
+                      "maven",
+                      "npm",
+                      "nuget",
+                      "puppet",
+                      "pypi",
+                      "sbt",
+                      "vagrant",
+                      "yum"]
+
+KEY_CONFIG_MAP = {
+    "rclass":
+        {"valid_values": VALID_RCLASSES,
+         "values_require_keys":
+            {VIRTUAL_RCLASS: ["packageType"],
+             REMOTE_RCLASS: ["url"]},
+         "always_required": True},
+    "packageType":
+        {"valid_values": VALID_PACKAGETYPES}}
+
+URI_CONFIG_MAP = {"api/repositories": KEY_CONFIG_MAP}
+
+
+class ArtifactoryRepoManagement(art_base.ArtifactoryBase):
+    def __init__(self, artifactory_url, repo=None, repo_position=None,
+                 repo_config=None, username=None, password=None,
+                 auth_token=None, validate_certs=False, client_cert=None,
+                 client_key=None, force_basic_auth=False, config_map=None):
+        super(ArtifactoryRepoManagement, self).__init__(
+            username=username,
+            password=password,
+            auth_token=auth_token,
+            validate_certs=validate_certs,
+            client_cert=client_cert,
+            client_key=client_key,
+            force_basic_auth=force_basic_auth,
+            config_map=config_map)
+        self.artifactory_url = artifactory_url
+        self.repo = repo
+        self.repo_position = repo_position
+        self.repo_config = repo_config
+
+        if self.repo:
+            self.working_url = '%s/%s' % (self.artifactory_url, self.repo)
+        else:
+            self.working_url = self.artifactory_url
+
+    def get_repositories(self):
+        return self.query_artifactory(self.artifactory_url, 'GET')
+
+    def get_repository_config(self):
+        return self.query_artifactory(self.working_url, 'GET')
+
+    def delete_repository(self):
+        return self.query_artifactory(self.working_url, 'DELETE')
+
+    def create_repository(self):
+        method = 'PUT'
+        serial_config_data = self.get_valid_conf(method)
+        create_repo_url = self.working_url
+        if self.repo_position:
+            if isinstance(self.repo_position, int):
+                create_repo_url = '%s?pos=%d' % (create_repo_url,
+                                                 self.repo_position)
+            else:
+                raise ValueError("repo_position must be an integer.")
+
+        return self.query_artifactory(create_repo_url, method,
+                                      data=serial_config_data)
+
+    def update_repository_config(self):
+        method = 'POST'
+        serial_config_data = self.get_valid_conf(method)
+        return self.query_artifactory(self.working_url, method,
+                                      data=serial_config_data)
+
+    def get_valid_conf(self, method):
+        config_dict = self.convert_config_to_dict(self.repo_config)
+        if method == 'PUT':
+            self.validate_config_required_keys(self.artifactory_url,
+                                               config_dict)
+        self.validate_config_values(self.artifactory_url, config_dict)
+        serial_config_data = self.serialize_config_data(config_dict)
+        return serial_config_data
+
+
+def run_module():
+    state_map = ['present', 'absent', 'read', 'list']
+    rclass_state_map = VALID_RCLASSES
+    packageType_state_map = VALID_PACKAGETYPES
+    module_args = dict(
+        artifactory_url=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        repo_position=dict(type='int', default=None),
+        repo_config=dict(type='str', default=None),
+        username=dict(type='str', default=None),
+        password=dict(type='str', no_log=True, default=None),
+        auth_token=dict(type='str', no_log=True, default=None),
+        validate_certs=dict(type='bool', default=False),
+        client_cert=dict(type='path', default=None),
+        client_key=dict(type='path', default=None),
+        force_basic_auth=dict(type='bool', default=False),
+        state=dict(type='str', default='read', choices=state_map),
+        rclass=dict(type='str', default=None, choices=rclass_state_map),
+        packageType=dict(type='str', default=None,
+                         choices=packageType_state_map),
+        url=dict(type='str', default=None),
+        repoLayoutRef=dict(type='str', default=None),
+        repo_config_dict=dict(type='dict', default=dict()),
+    )
+
+    result = dict(
+        changed=False,
+        original_message='',
+        message='',
+        config=dict()
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        required_together=[['username', 'password']],
+        required_one_of=[['password', 'auth_token']],
+        mutually_exclusive=[['password', 'auth_token']],
+        required_if=[['state', 'present', ['artifactory_url', 'name']],
+                     ['state', 'absent', ['artifactory_url', 'name']],
+                     ['state', 'list', ['artifactory_url', 'name']],
+                     ['state', 'read', ['artifactory_url', 'name']]],
+        supports_check_mode=True,
+    )
+
+    artifactory_url = module.params['artifactory_url']
+    repository = module.params['name']
+    repo_position = module.params['repo_position']
+    repo_config = module.params['repo_config']
+    username = module.params['username']
+    password = module.params['password']
+    auth_token = module.params['auth_token']
+    validate_certs = module.params['validate_certs']
+    client_cert = module.params['client_cert']
+    client_key = module.params['client_key']
+    force_basic_auth = module.params['force_basic_auth']
+    state = module.params['state']
+    repo_config_dict = module.params['repo_config_dict']
+
+    if repo_config:
+        # temporarily convert to dict for validation
+        repo_config = ast.literal_eval(repo_config)
+
+    fail_messages = []
+
+    fails = art_base.validate_config_params(repo_config, repo_config_dict,
+                                            'repo_config', 'repo_config_dict')
+    fail_messages.extend(fails)
+
+    fails = art_base.validate_top_level_params('rclass', module, repo_config,
+                                               repo_config_dict, 'repo_config',
+                                               'repo_config_dict')
+    fail_messages.extend(fails)
+    fails = art_base.validate_top_level_params('packageType', module,
+                                               repo_config, repo_config_dict,
+                                               'repo_config',
+                                               'repo_config_dict')
+    fail_messages.extend(fails)
+    fails = art_base.validate_top_level_params('url', module, repo_config,
+                                               repo_config_dict, 'repo_config',
+                                               'repo_config_dict')
+    fail_messages.extend(fails)
+    fails = art_base.validate_top_level_params('repoLayoutRef',
+                                               module, repo_config,
+                                               repo_config_dict, 'repo_config',
+                                               'repo_config_dict')
+    fail_messages.extend(fails)
+
+    # Populate failure messages
+    failure_message = "".join(fail_messages)
+
+    # Conflicting config values should not be resolved
+    if failure_message:
+        module.fail_json(msg=failure_message, **result)
+
+    repo_dict = dict()
+    if module.params['name']:
+        repo_dict['key'] = module.params['name']
+    if module.params['rclass']:
+        repo_dict['rclass'] = module.params['rclass']
+    if module.params['packageType']:
+        repo_dict['packageType'] = module.params['packageType']
+    if module.params['url']:
+        repo_dict['url'] = module.params['url']
+    if module.params['repoLayoutRef']:
+        repo_dict['repoLayoutRef'] = module.params['repoLayoutRef']
+    if repo_config:
+        repo_dict.update(repo_config)
+    if repo_config_dict:
+        repo_dict.update(repo_config_dict)
+    repo_config = json.dumps(repo_dict)
+
+    result['original_message'] = ("Perform state '%s' against repo '%s' "
+                                  "within artifactory '%s'"
+                                  % (state, repository, artifactory_url))
+
+    artifactory_repo = ArtifactoryRepoManagement(
+        artifactory_url=artifactory_url,
+        repo=repository,
+        repo_position=repo_position,
+        repo_config=repo_config,
+        username=username,
+        password=password,
+        auth_token=auth_token,
+        validate_certs=validate_certs,
+        client_cert=client_cert,
+        client_key=client_key,
+        force_basic_auth=force_basic_auth,
+        config_map=URI_CONFIG_MAP)
+
+    repository_exists = False
+    try:
+        artifactory_repo.get_repository_config()
+        repository_exists = True
+    except urllib_error.HTTPError as http_e:
+        if http_e.getcode() == 400:
+            # Instead of throwing a 404, a 400 is thrown if a repo doesn't
+            # exist. Have to fall through and assume the repo doesn't exist
+            # and that another error did not occur. If there is another problem
+            # it will have to be caught by try/catch blocks further below.
+            pass
+        else:
+            message = ("HTTP response code was '%s'. Response message was"
+                       " '%s'. " % (http_e.getcode(), http_e.read()))
+            fail_messages.append(message)
+    except urllib_error.URLError as url_e:
+        message = ("A generic URLError was thrown. URLError: %s" % str(url_e))
+        fail_messages.append(message)
+
+    try:
+        # Now that configs are lined up, verify required values in configs
+        if state == 'present':
+            artifactory_repo.validate_config_values(artifactory_url,
+                                                    repo_dict)
+            if not repository_exists:
+                artifactory_repo.validate_config_required_keys(artifactory_url,
+                                                               repo_dict)
+    except art_base.ConfigValueTypeMismatch as cvtm:
+        fail_messages.append(cvtm.message + ". ")
+    except art_base.InvalidConfigurationData as icd:
+        fail_messages.append(icd.message + ". ")
+    except art_base.InvalidArtifactoryURL as iau:
+        fail_messages.append(iau.message + ". ")
+
+    # Populate failure messages
+    failure_message = "".join(fail_messages)
+
+    if failure_message:
+        module.fail_json(msg=failure_message, **result)
+
+    if module.check_mode:
+        result['message'] = 'check_mode success'
+        module.exit_json(**result)
+
+    repo_not_exists_msg = ("Repository '%s' does not exist." % repository)
+    resp_is_invalid_failure = ("An unknown error occurred while attempting to "
+                               "'%s' repo '%s'. Response should "
+                               "not be None.")
+    try:
+        if state == 'list':
+            result['message'] = ("List of all repos against "
+                                 "artifactory_url: %s" % artifactory_url)
+            resp = artifactory_repo.get_repositories()
+            result['config'] = json.loads(resp.read())
+        elif state == 'read':
+            if not repository_exists:
+                result['message'] = repo_not_exists_msg
+            else:
+                resp = artifactory_repo.get_repository_config()
+                if resp:
+                    result['message'] = ("Successfully read config "
+                                         "on repo '%s'." % repository)
+                    result['config'] = json.loads(resp.read())
+                    result['changed'] = True
+                else:
+                    failure_message = (resp_is_invalid_failure
+                                       % (state, repository))
+        elif state == 'present':
+            # If the repo doesn't exist, create it.
+            # If the repo does exist, perform an update on it ONLY if
+            # configuration supplied has values that don't match the remote
+            # config.
+            if not repository_exists:
+                result['message'] = ('Attempting to create repo: %s'
+                                     % repository)
+                resp = artifactory_repo.create_repository()
+                if resp:
+                    result['message'] = resp.read()
+                    result['changed'] = True
+                else:
+                    failure_message = (resp_is_invalid_failure
+                                       % (state, repository))
+            else:
+                result['message'] = ('Attempting to update repo: %s'
+                                     % repository)
+                current_config = artifactory_repo.get_repository_config()
+                current_config = json.loads(current_config.read())
+                desired_config = ast.literal_eval(repo_config)
+                # Compare desired config with current config against repo.
+                # If config values are identical, don't update.
+                resp = None
+                for key in current_config:
+                    if key in desired_config:
+                        if desired_config[key] != current_config[key]:
+                            resp = artifactory_repo.update_repository_config()
+                # To guarantee idempotence. If underlying libraries don't
+                # throw an exception, it could incorrectly report a success
+                # when there was actually a failure.
+                if resp:
+                    result['message'] = ("Successfully updated config "
+                                         "on repo '%s'." % repository)
+                    result['changed'] = True
+                else:
+                    # Config values were identical.
+                    result['message'] = ("Repo '%s' was not updated because "
+                                         "config was identical." % repository)
+            # Attach the repository config to result
+            current_config = artifactory_repo.get_repository_config()
+            result['config'] = json.loads(current_config.read())
+        elif state == 'absent':
+            if not repository_exists:
+                result['message'] = repo_not_exists_msg
+            else:
+                # save config for output on successful delete so it can be
+                # used later in play if recreating repositories
+                current_config = artifactory_repo.get_repository_config()
+                resp = artifactory_repo.delete_repository()
+                if resp:
+                    result['message'] = ("Successfully deleted repo '%s'."
+                                         % repository)
+                    result['changed'] = True
+                    result['config'] = json.loads(current_config.read())
+                else:
+                    failure_message = (resp_is_invalid_failure
+                                       % (state, repository))
+    except urllib_error.HTTPError as http_e:
+        message = ("HTTP response code was '%s'. Response message was"
+                   " '%s'. " % (http_e.getcode(), http_e.read()))
+        failure_message = message
+    except urllib_error.URLError as url_e:
+        message = ("A generic URLError was thrown. URLError: %s"
+                   % str(url_e))
+        failure_message = message
+    except SyntaxError as s_e:
+        message = ("%s. Response from artifactory was malformed: '%s' . "
+                   % (str(s_e), resp))
+        failure_message = message
+    except ValueError as v_e:
+        message = ("%s. Response from artifactory was malformed: '%s' . "
+                   % (str(v_e), resp))
+        failure_message = message
+    except art_base.ConfigValueTypeMismatch as cvtm:
+        failure_message = cvtm.message
+    except art_base.InvalidConfigurationData as icd:
+        failure_message = icd.message
+
+    if failure_message:
+        module.fail_json(msg=failure_message, **result)
+
+    module.exit_json(**result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/units/module_utils/test_artifactory.py
+++ b/test/units/module_utils/test_artifactory.py
@@ -1,0 +1,385 @@
+import ansible.module_utils.artifactory as artifactory
+import ast
+import json
+
+from ansible.compat.tests.unittest import TestCase
+
+
+class TestArtifactoryBaseClass(TestCase):
+    def setUp(self):
+        self.key_config_map = {
+            "test_key":
+                {"valid_values": ['sweet', 'deal'],
+                 "values_require_keys":
+                    {"deal": ["key_value_test"]},
+                 "always_required": True},
+            "key_value_test":
+                {"valid_values": ["value_test", "value_not_req_key",
+                                  "another_key"],
+                 "values_require_keys":
+                    {"value_test": ["requires_this_key"],
+                     "another_key": ["another_key"]}},
+            "another_key":
+                {"valid_values": ["valid_value"],
+                 "required_keys": ["another_key_needs_me"]}}
+
+        self.uri_key_map = {"a/cherry": self.key_config_map}
+        self.uri_key_map["would/you/like/to/try/again"] = True
+        self.uri_key_map["explicitly/block/url"] = False
+        self.art_base = artifactory.ArtifactoryBase(
+            username="user", password="pass", config_map=self.uri_key_map)
+
+    def test_convert_config_to_dict_valid_dict(self):
+        valid_dict = {"valid": "dict"}
+        resp = self.art_base.convert_config_to_dict(valid_dict)
+        self.assertIsInstance(resp, dict)
+        self.assertEqual(valid_dict, resp)
+
+    def test_convert_config_to_dict_valid_dict_string(self):
+        valid_dict_str = '{"valid": "dict"}'
+        resp = self.art_base.convert_config_to_dict(valid_dict_str)
+        valid_dict = ast.literal_eval(valid_dict_str)
+        self.assertIsInstance(resp, dict)
+        self.assertEqual(valid_dict, resp)
+
+    def test_convert_config_to_dict_invalid_dict_string_bad_syntax(self):
+        valid_dict_str = '{"valid": }'
+        with self.assertRaises(artifactory.ConfigValueTypeMismatch):
+            self.art_base.convert_config_to_dict(valid_dict_str)
+
+    def test_convert_config_to_dict_invalid_syntax(self):
+        valid_dict_str = 'not_valid'
+        with self.assertRaises(artifactory.ConfigValueTypeMismatch):
+            self.art_base.convert_config_to_dict(valid_dict_str)
+
+    def test_convert_config_to_dict_invalid_string_bool_not_dict(self):
+        valid_dict_str = 'True'
+        with self.assertRaises(artifactory.ConfigValueTypeMismatch):
+            self.art_base.convert_config_to_dict(valid_dict_str)
+
+    def test_serialize_config_data_valid_double_quote(self):
+        valid_dict = {"valid": "dict"}
+        resp = self.art_base.serialize_config_data(valid_dict)
+        self.assertIsInstance(resp, str)
+        valid_dict_str = json.dumps(valid_dict)
+        self.assertEqual(valid_dict_str, resp)
+
+    def test_serialize_config_data_valid_single_quote(self):
+        valid_dict = {'valid': 'dict'}
+        resp = self.art_base.serialize_config_data(valid_dict)
+        self.assertIsInstance(resp, str)
+        valid_dict_str = json.dumps(valid_dict)
+        self.assertEqual(valid_dict_str, resp)
+
+    def test_serialize_config_data_invalid_str_not_dict(self):
+        valid_dict = "{'valid': 'dict'}"
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.serialize_config_data(valid_dict)
+
+    def test_serialize_config_data_invalid_none(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.serialize_config_data(None)
+
+    def test_serialize_config_data_invalid_empty_str(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.serialize_config_data("")
+
+    def test_serialize_config_data_invalid_empty_dict(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.serialize_config_data(dict())
+
+    def test_get_uri_key_map_valid_url_to_map_w_dict(self):
+        resp = self.art_base.get_uri_key_map("a/cherry", self.uri_key_map)
+        self.assertIsInstance(resp, dict)
+        self.assertEqual(self.key_config_map, resp)
+
+    def test_get_uri_key_map_valid_url_to_map_w_bool(self):
+        resp = self.art_base.get_uri_key_map("would/you/like/to/try/again",
+                                             self.uri_key_map)
+        self.assertIsInstance(resp, bool)
+        self.assertTrue(resp)
+        self.assertEqual(self.uri_key_map["would/you/like/to/try/again"], resp)
+
+    def test_get_uri_key_map_invalid_no_uri_match(self):
+        with self.assertRaises(artifactory.InvalidArtifactoryURL):
+            self.art_base.get_uri_key_map("uri/not/exist", self.uri_key_map)
+
+    def test_get_uri_key_map_invalid_explicit_block_url(self):
+        with self.assertRaises(artifactory.InvalidArtifactoryURL):
+            self.art_base.get_uri_key_map("explicitly/block/url",
+                                          self.uri_key_map)
+
+    def test_get_uri_key_map_invalid_config_is_none(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.get_uri_key_map("bad/config/is/None",
+                                          None)
+
+    def test_get_uri_key_map_invalid_config_is_empty(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.get_uri_key_map("bad/config/is/empty",
+                                          dict())
+
+    def test_get_uri_key_map_invalid_url_is_none(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.get_uri_key_map(None, self.uri_key_map)
+
+    def test_get_uri_key_map_invalid_url_is_empty(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            self.art_base.get_uri_key_map("", self.uri_key_map)
+
+    def test_validate_config_values_valid_url_and_dict_bool(self):
+        resp = self.art_base.validate_config_values(
+            "would/you/like/to/try/again", self.uri_key_map)
+        self.assertEqual(resp, None)
+
+    def test_validate_config_values_valid_key_value(self):
+        test_config = {"test_key": "sweet"}
+        self.art_base.validate_config_values("a/cherry", test_config)
+
+    def test_validate_config_values_invalid_key_value(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"test_key": "not_sweet"}
+            self.art_base.validate_config_values("a/cherry", test_config)
+
+    def test_validate_config_values_valid_key_not_defined(self):
+        test_config = {"valid_key": "but_not_defined_in_map"}
+        self.art_base.validate_config_values("a/cherry", test_config)
+
+    def test_validate_config_values_invalid_uri(self):
+        with self.assertRaises(artifactory.InvalidArtifactoryURL):
+            test_config = {"test_key": "sweet"}
+            self.art_base.validate_config_values("not/cherry", test_config)
+
+    def test_validate_config_required_keys_valid_always_req_key_defined(self):
+        test_config = {"test_key": "sweet"}
+        self.art_base.validate_config_required_keys("a/cherry", test_config)
+
+    def test_validate_config_required_keys_valid_always_req_not_defined(self):
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"missing": "test_key_which_is_required"}
+            self.art_base.validate_config_required_keys(
+                "a/cherry", test_config)
+
+    def test_validate_config_required_keys_valid_key_values_require(self):
+        # The value of key_value_test does require additional keys
+        test_config = {"test_key": "sweet",
+                       "key_value_test": "value_test",
+                       "requires_this_key": "because_of_value_test"}
+        self.art_base.validate_config_required_keys(
+            "a/cherry", test_config)
+
+    def test_validate_config_required_keys_valid_key_values_not_require(self):
+        # The value of key_value_test does not require additional keys
+        test_config = {"test_key": "sweet",
+                       "key_value_test": "value_not_req_key"}
+        self.art_base.validate_config_required_keys(
+            "a/cherry", test_config)
+
+    def test_validate_config_required_keys_invalid_missing_val_req_key(self):
+        # The value of key_value_test does require "requires_this_key". It is
+        # missing, so an exception is thrown.
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"test_key": "sweet",
+                           "key_value_test": "value_test",
+                           "missing_required_key": "because_of_value_test"}
+            self.art_base.validate_config_required_keys(
+                "a/cherry", test_config)
+
+    def test_validate_config_required_keys_valid_key_requires(self):
+        # The key "another_key" requires "good_value_needs_me"
+        test_config = {"test_key": "sweet",
+                       "another_key": "valid_value",
+                       "another_key_needs_me": "another_key_needs_me"}
+        self.art_base.validate_config_required_keys(
+            "a/cherry", test_config)
+
+    def test_validate_config_required_keys_invalid_missing_required_key(self):
+        # The value of key_value_test does require additional keys
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"test_key": "sweet",
+                           "another_key": "valid_value",
+                           "missing_required_key": "another_key_needs_me"}
+            self.art_base.validate_config_required_keys(
+                "a/cherry", test_config)
+
+    def test_validate_config_required_keys_test_chain_of_requirements(self):
+        # The key/pair test_key/deal requires key_value_test. The key/pair
+        # key_value_test/another_key requires the key another_key. The key/pair
+        # another_key/valid_value requires key another_key_needs_me
+        test_config = {"test_key": "deal",
+                       "key_value_test": "another_key",
+                       "another_key": "valid_value",
+                       "another_key_needs_me": "another_key_needs_me"}
+        self.art_base.validate_config_required_keys(
+            "a/cherry", test_config)
+
+    def test_validate_config_required_keys_break_first_in_chain(self):
+        # The key/pair test_key/deal requires key_value_test. The key/pair
+        # key_value_test/another_key requires the key another_key. The key/pair
+        # another_key/valid_value requires key another_key_needs_me
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"test_key": "deal",
+                           "not_key_value_test": "another_key",
+                           "another_key": "valid_value",
+                           "another_key_needs_me": "another_key_needs_me"}
+            self.art_base.validate_config_required_keys(
+                "a/cherry", test_config)
+
+    def test_validate_config_required_keys_break_second_in_chain(self):
+        # The key/pair test_key/deal requires key_value_test. The key/pair
+        # key_value_test/another_key requires the key another_key. The key/pair
+        # another_key/valid_value requires key another_key_needs_me
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"test_key": "deal",
+                           "key_value_test": "another_key",
+                           "not_another_key": "valid_value",
+                           "another_key_needs_me": "another_key_needs_me"}
+            self.art_base.validate_config_required_keys(
+                "a/cherry", test_config)
+
+    def test_validate_config_required_keys_break_third_in_chain(self):
+        # The key/pair test_key/deal requires key_value_test. The key/pair
+        # key_value_test/another_key requires the key another_key. The key/pair
+        # another_key/valid_value requires key another_key_needs_me
+        with self.assertRaises(artifactory.InvalidConfigurationData):
+            test_config = {"test_key": "deal",
+                           "key_value_test": "another_key",
+                           "another_key": "valid_value",
+                           "not_another_key_needs_me": "another_key_needs_me"}
+            self.art_base.validate_config_required_keys(
+                "a/cherry", test_config)
+
+
+class TestArtifactoryValidationFunctions(TestCase):
+    def setUp(self):
+        self.module = self.FakeModule()
+        self.module.params['rclass'] = 'local'
+
+        self.config = dict()
+        self.config['rclass'] = 'local'
+
+        self.config_dict = dict()
+        self.config_dict['rclass'] = 'local'
+        self.top_level_fail = artifactory.TOP_LEVEL_FAIL
+        self.fail_msg = artifactory.CONFIG_PARAM_FAIL
+
+    class FakeModule:
+        def __init__(self):
+            self.params = dict()
+
+    def test_top_level_valid_all_equal(self):
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_valid_repo_config_top_level_equal(self):
+        self.config_dict = dict()
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_valid_repo_config_dict_top_level_equal(self):
+        self.config = dict()
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_valid_top_level_not_exist(self):
+        self.module.params['rclass'] = None
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_valid_top_level_repo_config_not_exist(self):
+        self.config = None
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_valid_top_level_repo_config_dict_not_exist(self):
+        self.config_dict = None
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_invalid_top_level_not_exist_passed_in(self):
+        val_fail_msgs = artifactory.validate_top_level_params(
+            None, self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_top_level_invalid_mismatch_repo_config_top_level(self):
+        self.module.params["rclass"] = 'remote'
+        self.config_dict = dict()
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 1)
+        self.assertEqual(val_fail_msgs[0],
+                         self.top_level_fail.format('config', 'rclass'))
+
+    def test_top_level_invalid_mismatch_repo_config_dict_top_level(self):
+        self.module.params["rclass"] = 'remote'
+        self.config = dict()
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 1)
+        self.assertEqual(val_fail_msgs[0],
+                         self.top_level_fail.format('config_dict', 'rclass'))
+
+    def test_top_level_invalid_all_mismatch(self):
+        self.module.params["rclass"] = 'remote'
+        self.config['rclass'] = 'virtual'
+        val_fail_msgs = artifactory.validate_top_level_params(
+            'rclass', self.module, self.config, self.config_dict, 'config',
+            'config_dict')
+        self.assertEqual(len(val_fail_msgs), 2)
+        self.assertEqual(val_fail_msgs[0],
+                         self.top_level_fail.format('config_dict',
+                                                    'rclass'))
+        self.assertEqual(val_fail_msgs[1],
+                         self.top_level_fail.format('config',
+                                                    'rclass'))
+
+    def test_config_params_valid(self):
+        val_fail_msgs = artifactory.validate_config_params(
+            self.config, self.config_dict, 'config', 'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_config_params_mismatch_dict_to_repo(self):
+        self.config['rclass'] = 'virtual'
+        val_fail_msgs = artifactory.validate_config_params(
+            self.config, self.config_dict, 'config', 'config_dict')
+        self.assertEqual(len(val_fail_msgs), 1)
+        self.assertEqual(val_fail_msgs[0],
+                         self.fail_msg.format('rclass', 'config',
+                                              'config_dict'))
+
+    def test_config_params_mismatch_dict_to_repo_multi(self):
+        self.config['rclass'] = 'virtual'
+        self.config['test'] = 'this'
+        self.config_dict['test'] = 'me'
+        val_fail_msgs = artifactory.validate_config_params(
+            self.config, self.config_dict, 'config', 'config_dict')
+        self.assertEqual(len(val_fail_msgs), 2)
+        self.assertTrue(self.fail_msg.format('test', 'config', 'config_dict')
+                        in val_fail_msgs)
+        self.assertTrue(self.fail_msg.format('rclass', 'config', 'config_dict')
+                        in val_fail_msgs)
+
+    def test_config_params_invalid_repo_config_none_passed_in(self):
+        val_fail_msgs = artifactory.validate_config_params(
+            None, self.config_dict, 'config', 'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)
+
+    def test_config_params_invalid_repo_config_dict_none_passed_in(self):
+        val_fail_msgs = artifactory.validate_config_params(
+            self.config, None, 'config', 'config_dict')
+        self.assertEqual(len(val_fail_msgs), 0)

--- a/test/units/modules/packaging/test_artifactory_repo.py
+++ b/test/units/modules/packaging/test_artifactory_repo.py
@@ -1,0 +1,239 @@
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.compat.tests.unittest import TestCase
+from ansible.module_utils import artifactory as ar_base
+from ansible.modules.packaging import artifactory_repo as ar
+
+from contextlib import contextmanager
+
+from units.modules.utils import set_module_args, AnsibleExitJson, AnsibleFailJson, ModuleTestCase
+
+
+class TestArtifactoryRepoManagement(TestCase):
+
+    def setUp(self):
+        self.fake_url = "http://www.fake.com/api/repositories"
+        self.base_update_conf = dict(repoLayoutRef="standard-default",
+                                     url="fake2.com")
+        self.repo_uri_map = ar.URI_CONFIG_MAP
+
+    @contextmanager
+    def _stubs(self, url=None, repo=None, test_config=None, responses=None):
+        with patch("ansible.module_utils.artifactory.ArtifactoryBase."
+                   "query_artifactory") as query_resp:
+            if not url:
+                temp_url = self.fake_url
+            else:
+                temp_url = url
+            if not test_config:
+                temp_test_config = self.base_update_conf
+            else:
+                temp_test_config = self.base_update_conf
+                self.base_update_conf.update(test_config)
+            temp_test_config = json.dumps(temp_test_config)
+            self.build_out_test_contruct(temp_url, repo, temp_test_config)
+            if responses:
+                http_responses = []
+                for resp in responses:
+                    http_responses.append(resp)
+                query_resp.side_effect = http_responses
+            yield query_resp
+
+    def build_out_test_contruct(self, url, repo, test_config):
+        self.arm = ar.ArtifactoryRepoManagement(
+            artifactory_url=url,
+            repo=repo,
+            repo_config=test_config,
+            config_map=self.repo_uri_map)
+
+    def test_get_valid_conf_valid_conf_post(self):
+        with self._stubs():
+            self.arm.get_valid_conf("POST")
+
+    def test_get_valid_conf_invalid_conf_is_none_on_post(self):
+        self.base_update_conf = None
+        with self.assertRaises(ar_base.ConfigValueTypeMismatch):
+            with self._stubs():
+                self.arm.get_valid_conf("POST")
+
+    def test_get_valid_conf_valid_conf_put(self):
+        with self._stubs(test_config=dict(rclass='local')):
+            self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_conf_is_none_on_put(self):
+        self.base_update_conf = None
+        with self.assertRaises(ar_base.ConfigValueTypeMismatch):
+            with self._stubs():
+                self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_conf_is_missing_req_key_put(self):
+        with self.assertRaises(ar_base.InvalidConfigurationData):
+            with self._stubs():
+                self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_valid_remote_conf(self):
+        # rclass>remote requires url key exists
+        # url already exists within the base_update_conf dict
+        with self._stubs(test_config=dict(rclass='remote')):
+            self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_conf_is_missing_req_key_remote(self):
+        # rclass>remote requires url key exists
+        # Pop url key to verify map is working
+        self.base_update_conf.pop('url', None)
+        with self.assertRaises(ar_base.InvalidConfigurationData):
+            with self._stubs(test_config=dict(rclass='remote')):
+                self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_valid_virtual_conf(self):
+        with self._stubs(test_config=dict(rclass='virtual',
+                                          packageType='bower')):
+            self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_conf_is_missing_req_key_virtual(self):
+        # rclass>virtual requires packageType key exists
+        with self.assertRaises(ar_base.InvalidConfigurationData):
+            with self._stubs(test_config=dict(rclass='virtual')):
+                self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_conf_bad_packageType_virtual(self):
+        # rclass>virtual requires packageType key exists
+        with self.assertRaises(ar_base.InvalidConfigurationData):
+            with self._stubs(test_config=dict(rclass='virtual',
+                                              packageType='bad_type')):
+                self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_rclass_put(self):
+        with self.assertRaises(ar_base.InvalidConfigurationData):
+            with self._stubs(test_config=dict(rclass='bad_rclass')):
+                self.arm.get_valid_conf("PUT")
+
+    def test_get_valid_conf_invalid_rclass_post(self):
+        with self.assertRaises(ar_base.InvalidConfigurationData):
+            with self._stubs(test_config=dict(rclass='bad_rclass')):
+                self.arm.get_valid_conf("POST")
+
+    def test_get_valid_conf_invalid_artifactory_url(self):
+        self.fake_url = "bad.url.com"
+        with self.assertRaises(ar_base.InvalidArtifactoryURL):
+            with self._stubs(test_config=dict(rclass='local')):
+                self.arm.get_valid_conf("PUT")
+
+
+class TestArtifactoryRepoModule(ModuleTestCase):
+    def setUp(self):
+        super(TestArtifactoryRepoModule, self).setUp()
+        self.module = ar
+        self.fake_url = "http://www.fake.com/api/repositories"
+
+    def failed(self):
+        with self.assertRaises(AnsibleFailJson) as exc:
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertTrue(result['failed'], result)
+        return result
+
+    def changed(self, changed=False):
+        with self.assertRaises(AnsibleExitJson) as exc:
+            self.module.main()
+
+        result = exc.exception.args[0]
+        self.assertEqual(result['changed'], changed, result)
+        return result
+
+    class FakeHttpResp:
+        def __init__(self, resp):
+            self.resp = resp
+
+        def read(self):
+            return self.resp
+
+    @contextmanager
+    def _stubs(self, responses=None):
+        with patch("ansible.module_utils.artifactory.ArtifactoryBase."
+                   "query_artifactory") as query_resp:
+            if responses:
+                http_responses = []
+                for resp in responses:
+                    http_responses.append(resp)
+                query_resp.side_effect = http_responses
+            yield query_resp
+
+    def test_missing_artifactory_url_and_repo(self):
+        set_module_args(dict())
+        result = self.failed()
+        self.assertTrue("missing required arguments" in result["msg"])
+        self.assertTrue("name" in result["msg"])
+        self.assertTrue("artifactory_url" in result["msg"])
+
+    def test_missing_repo(self):
+        set_module_args(dict(artifactory_url=self.fake_url))
+        result = self.failed()
+        self.assertTrue("missing required arguments" in result["msg"])
+        self.assertTrue("name" in result["msg"])
+
+    def test_missing_artifactory_url(self):
+        set_module_args(dict(name='test'))
+        result = self.failed()
+        self.assertTrue("missing required arguments" in result["msg"])
+        self.assertTrue("artifactory_url" in result["msg"])
+
+    def test_with_artifactory_url_and_repo(self):
+        set_module_args(dict(artifactory_url=self.fake_url, name='test'))
+        result = self.failed()
+        self.assertTrue("one of the following is required" in result["msg"])
+        self.assertTrue("password" in result["msg"])
+        self.assertTrue("auth_token" in result["msg"])
+
+    def test_with_invalid_rclass(self):
+        set_module_args(dict(artifactory_url=self.fake_url, name='test',
+                             auth_token='derp', rclass='blech'))
+        result = self.failed()
+        fail_msg = ("value of rclass must be one of: local, remote, "
+                    "virtual, got: blech")
+        self.assertEqual(result['msg'], fail_msg)
+        self.assertTrue("value of rclass must be one of" in result["msg"])
+        self.assertTrue("local" in result["msg"])
+        self.assertTrue("remote" in result["msg"])
+        self.assertTrue("virtual" in result["msg"])
+
+    def test_with_invalid_packageType(self):
+        set_module_args(dict(artifactory_url=self.fake_url, name='test',
+                             auth_token='derp', packageType='blech'))
+        result = self.failed()
+        self.assertTrue("value of packageType must be one of" in result["msg"])
+        for valid_pack in ar.VALID_PACKAGETYPES:
+            self.assertTrue(valid_pack in result["msg"])
+
+    def test_with_artifactory_url_repo_auth_token(self):
+        repo = 'test'
+        set_module_args(dict(artifactory_url=self.fake_url, name=repo,
+                             auth_token='derp', state='read'))
+        http_resp = '[{"key": "%s"}]' % repo
+        fake_http1 = self.FakeHttpResp(http_resp)
+        fake_http2 = self.FakeHttpResp(http_resp)
+        responses = [fake_http1, fake_http2]
+        with self._stubs(responses) as query:
+            result = self.changed(changed=True)
+            succ_msg = "Successfully read config on repo '%s'." % repo
+            self.assertEqual(result['message'], succ_msg)
+            self.assertEqual(query.call_count, 2)
+
+    def test_with_artifactory_url_repo_auth_token_state_present(self):
+        repo = 'test'
+        set_module_args(dict(artifactory_url=self.fake_url, name=repo,
+                             auth_token='derp', state='present',
+                             rclass='local'))
+        http_resp = '{"key": "%s"}' % repo
+        fake_http1 = self.FakeHttpResp("[%s]" % http_resp)
+        fake_http2 = self.FakeHttpResp(http_resp)
+        fake_http3 = self.FakeHttpResp(http_resp)
+        responses = [fake_http1, fake_http2, fake_http3]
+        with self._stubs(responses) as query:
+            result = self.changed()
+            succ_msg = ("Repo '%s' was not updated because config was "
+                        "identical." % repo)
+            self.assertEqual(result['message'], succ_msg)
+            self.assertEqual(query.call_count, 3)


### PR DESCRIPTION
##### SUMMARY

Create an Ansible module that allows for managing repositories in JFrog Artifactory 5+. This module provides full CRUD for automating the management of different repositories in an organization.

##### ISSUE TYPE

 - New Module Pull Request

##### COMPONENT NAME

lib/ansible/modules/packaging/artifactory_repo.py

##### ANSIBLE VERSION
```
ansible 2.5.0
```

##### ADDITIONAL INFORMATION

Provide CRUD against JFrog Repository via Ansible. This allows teams to control repository configuration via source control and template those configurations out and manage them via this module.