### PR TITLE
Fix junos cliconf commit api

### DIFF
--- a/lib/ansible/plugins/cliconf/junos.py
+++ b/lib/ansible/plugins/cliconf/junos.py
@@ -72,7 +72,12 @@ class Cliconf(CliconfBase):
     def get(self, command, prompt=None, answer=None, sendonly=False):
         return self.send_command(command, prompt=prompt, answer=answer, sendonly=sendonly)
 
-    def commit(self, comment=None):
+    def commit(self, *args, **kwargs):
+        """Execute commit command on remote device.
+        :kwargs:
+            comment: Optional commit description.
+        """
+        comment = kwargs.get('comment', None)
         command = b'commit'
         if comment:
             command += b' comment {0}'.format(comment)


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
* To maintain a single api call across
  netconf and cli transport from module code change 
  signature of commit api to accept generic args.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/cliconf/junos.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
