### PR TITLE
better fix for include_X inheritance

### DIFF
--- a/lib/ansible/playbook/base.py
+++ b/lib/ansible/playbook/base.py
@@ -165,8 +165,6 @@ class Base(with_metaclass(BaseMeta, object)):
         'su', 'su_user', 'su_pass', 'su_exe', 'su_flags',
     ]
 
-    _inheritable = True
-
     def __init__(self):
 
         # initialize the data loader and variable manager, which will be provided

--- a/lib/ansible/playbook/role_include.py
+++ b/lib/ansible/playbook/role_include.py
@@ -48,8 +48,6 @@ class IncludeRole(TaskInclude):
     OTHER_ARGS = ('private', 'allow_duplicates')  # assigned to matching property
     VALID_ARGS = tuple(frozenset(BASE + FROM_ARGS + OTHER_ARGS))  # all valid args
 
-    _inheritable = False
-
     # =================================================================================
     # ATTRIBUTES
 

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -67,7 +67,7 @@ class Task(Base, Conditional, Taggable, Become):
     # might be possible to define others
 
     _args = FieldAttribute(isa='dict', default=dict())
-    _action = FieldAttribute(isa='string')
+    _action = FieldAttribute(isa='string', inherit=False)
 
     _async_val = FieldAttribute(isa='int', default=0, alias='async')
     _changed_when = FieldAttribute(isa='list', default=[])
@@ -77,7 +77,7 @@ class Task(Base, Conditional, Taggable, Become):
     _failed_when = FieldAttribute(isa='list', default=[])
     _loop = FieldAttribute()
     _loop_control = FieldAttribute(isa='class', class_type=LoopControl, inherit=False)
-    _name = FieldAttribute(isa='string', default='')
+    _name = FieldAttribute(isa='string', default='', inherit=False)
     _notify = FieldAttribute(isa='list')
     _poll = FieldAttribute(isa='int', default=10)
     _register = FieldAttribute(isa='string')

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -419,7 +419,7 @@ class Task(Base, Conditional, Taggable, Become):
         parent_value = None
         try:
             # attributes might not be inheritable for current or the partent but still should be for other ancestors
-            if self.action not in ('include_tasks', 'include_role'):
+            if getattr(self, 'action', None) not in ('include_tasks', 'include_role'):
                 value = self._attributes[attr]
             if self._parent and (value is None or extend):
                 if attr != 'when' or getattr(self._parent, 'statically_loaded', True):

--- a/lib/ansible/playbook/task.py
+++ b/lib/ansible/playbook/task.py
@@ -416,14 +416,16 @@ class Task(Base, Conditional, Taggable, Become):
         '''
 
         value = None
+        parent_value = None
         try:
-            value = self._attributes[attr]
+            # attributes might not be inheritable for current or the partent but still should be for other ancestors
+            if self.action not in ('include_tasks', 'include_role'):
+                value = self._attributes[attr]
             if self._parent and (value is None or extend):
                 if attr != 'when' or getattr(self._parent, 'statically_loaded', True):
-                    # vars are always inheritable, other attributes might not be for the partent but still should be for other ancestors
-                    if attr != 'vars' and not getattr(self._parent, '_inheritable', True) and hasattr(self._parent, '_get_parent_attribute'):
+                    if hasattr(self._parent, '_get_parent_attribute'):
                         parent_value = self._parent._get_parent_attribute(attr, extend=extend, prepend=prepend)
-                    else:
+                    elif getattr(self._parent, 'action', None) not in ('include_tasks', 'include_role'):
                         parent_value = getattr(self._parent, attr, None)
 
                     if extend:

--- a/lib/ansible/playbook/task_include.py
+++ b/lib/ansible/playbook/task_include.py
@@ -50,8 +50,6 @@ class TaskInclude(Task):
     @staticmethod
     def load(data, block=None, role=None, task_include=None, variable_manager=None, loader=None):
         t = TaskInclude(block=block, role=role, task_include=task_include)
-        if t.action == 'include_task':
-            t._inheritable = False
         return t.load_data(data, variable_manager=variable_manager, loader=loader)
 
     def copy(self, exclude_parent=False, exclude_tasks=False):


### PR DESCRIPTION
##### SUMMARY
this covers all corner cases when using `--tags tag1`

tasks.yml
```
- debug: msg=untagged
- debug msg=tagged
  tags: ['tag1']
```
so
```
    -  name: should only execute tagged
       include: tasks.yml

    - name: should execute both tasks
       include: tasks.yml
       tags: ['tag1']

    - name: should only execute tagged
      import_tasks: tasks.yml

    - name: should execute both tasks      
      import_tasks: tasks.yml
      tags: ['tag1']

    - name: should not execute any
      include_tasks: tasks.yml

    - name: should execute included only tagged
      include_tasks: tasks.yml
      tags: ['tag1']
```
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
include_tasks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```
