### PR TITLE
VMware: add trailing / in case of nested folders

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1278,13 +1278,17 @@ class PyVmomiHelper(PyVmomi):
 
         dcpath = compile_folder_path_for_object(datacenter)
 
+        # Nested folder does not have trailing /
+        if not dcpath.endswith('/'):
+            dcpath += '/'
+
         # Check for full path first in case it was already supplied
         if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm') or
                 self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
             fullpath = self.params['folder']
-        elif (self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm'):
+        elif self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm':
             fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])
-        elif (self.params['folder'].startswith('/')):
+        elif self.params['folder'].startswith('/'):
             fullpath = "%s%s/vm%s" % (dcpath, self.params['datacenter'], self.params['folder'])
         else:
             fullpath = "%s%s/vm/%s" % (dcpath, self.params['datacenter'], self.params['folder'])


### PR DESCRIPTION
##### SUMMARY
This fix adds a trailing / in case of nested folders.

Fixes: #28463

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/vmware/vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```