### PR TITLE
Allow Cloudformation to pass in raw template_body

### DIFF
--- a/test/units/modules/cloud/amazon/test_cloudformation.py
+++ b/test/units/modules/cloud/amazon/test_cloudformation.py
@@ -128,4 +128,4 @@ def test_missing_template_body(placeboify):
         )
     assert exc_info.match('FAIL')
     assert not m.exit_args
-    assert "Either 'template' or 'template_url' is required when the stack does not exist." == m.exit_kwargs['msg']
+    assert "Either 'template', 'template_body' or 'template_url' is required when the stack does not exist." == m.exit_kwargs['msg']


### PR DESCRIPTION
##### SUMMARY
Update the Cloudformation module to allow for the full template body in raw format to be passed in as an alternative to reading it from either a local/remote file. 

There are scenarios such as creating a bunch of CF stacks within a with_items loop that this would help a lot in as instead of creating temporary template files we can just pass in the raw body which is no different to the existing setup of reading the raw body out of a file and passing it into stack_params['TemplateBody'].

There is an existing closed issue with this exact request as well - although I'm not sure why it got closed.

Fixes #22736.

##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
modules/cloud/amazon/cloudformation.py

##### ANSIBLE VERSION
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/etherdaemon/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/etherdaemon/python_virtualenvs/tools/lib/python2.7/site-packages/ansible
  executable location = /Users/etherdaemon/python_virtualenvs/tools/bin/ansible
  python version = 2.7.13 (default, Apr  4 2017, 08:47:57) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.38)]```

```


##### ADDITIONAL INFORMATION
This allows passing in Jinja2 templates or raw yaml/json body into the module instead of having to create temporary files as a step beforehand and delete the temporary file after this module call.

