### PR TITLE
Fix Digital Ocean tags module data type

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean_tag.py
@@ -30,6 +30,7 @@ options:
   resource_id:
     description:
     - The ID of the resource to operate on.
+    - The data type of resource_id is changed from integer to string, from version 2.5.
   resource_type:
     description:
     - The type of resource to operate on. Currently, only tagging of
@@ -64,7 +65,7 @@ EXAMPLES = '''
 - name: tag a resource; creating the tag if it does not exists
   digital_ocean_tag:
     name: "{{ item }}"
-    resource_id: YYY
+    resource_id: "73333005"
     state: present
   with_items:
     - staging
@@ -73,7 +74,7 @@ EXAMPLES = '''
 - name: untag a resource
   digital_ocean_tag:
     name: staging
-    resource_id: YYY
+    resource_id: "73333005"
     state: absent
 
 # Deleting a tag also untags all the resources that have previously been
@@ -198,7 +199,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             name=dict(type='str', required=True),
-            resource_id=dict(aliases=['droplet_id'], type='int'),
+            resource_id=dict(aliases=['droplet_id'], type='str'),
             resource_type=dict(choices=['droplet'], default='droplet'),
             state=dict(choices=['present', 'absent'], default='present'),
             api_token=dict(aliases=['API_TOKEN'], no_log=True),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Digital Ocean changed their api to no longer accept an integer as a resource_id. This change is now breaking the digital_ocean_tag module. All requests are receiving a 400 response code because the data being sent is no longer valid. This addresses issue #33459 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
modules/cloud/digital_ocean_tag
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (bugfix/issue-33459 1cdf285ffd) last updated 2017/12/02 07:42:01 (GMT -400)
  config file = /Users/abond/ansible.cfg
  configured module search path = [u'/Users/abond/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Development/github/ansible/lib/ansible
  executable location = /Users/abond/Development/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Bad request that receives a 400 back from DO.
`{"resources": [{"resource_type": "droplet", "resource_id": 73333005}]}`

Working request that receives a 204 back from DO.
`'{"resources": [{"resource_type": "droplet", "resource_id": "73333005"}]}`
