### PR TITLE
Add NoNameservers exception handler.

### DIFF
--- a/lib/ansible/plugins/lookup/dig.py
+++ b/lib/ansible/plugins/lookup/dig.py
@@ -296,6 +296,8 @@ class LookupModule(LookupBase):
             ret.append("")
         except dns.resolver.Timeout:
             ret.append('')
+        except dns.resolver.NoNameservers:
+            ret.append('')
         except dns.exception.DNSException as e:
             raise AnsibleError("dns.resolver unhandled exception %s" % to_native(e))
 


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This is needed when , for example, you are querying the master name
server and the zone is not configured on it, it will fail, when it
just need to follow as no other name servers are available to answer
the request. it may broke playbook of people not checking the output
and relying on this type of failure to stop the execution.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
dig lookup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/mbartsch/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
