### PR TITLE
Improve 'find' module with pattern search not limited to basename

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,0 @@
-##########################################################
-#### WhiteSource "Bolt for Github" configuration file ####
-##########################################################
-
-# Configuration #
-#---------------#
-ws.repo.scan=true
-vulnerable.check.run.conclusion.level=success

--- a/.whitesource
+++ b/.whitesource
@@ -1,0 +1,8 @@
+##########################################################
+#### WhiteSource "Bolt for Github" configuration file ####
+##########################################################
+
+# Configuration #
+#---------------#
+ws.repo.scan=true
+vulnerable.check.run.conclusion.level=success

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -33,7 +33,7 @@ options:
         default: '*'
         description:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
-            - The patterns restrict the list of files to be returned to those whose basenames match at
+            - The patterns restrict the list of files to be returned to those whose complete filenames match at
               least one of the patterns specified. Multiple patterns can be specified using a list.
         aliases: ['pattern']
     contains:
@@ -328,17 +328,17 @@ def main():
 
                     r = {'path': fsname}
                     if params['file_type'] == 'any':
-                        if pfilter(fsobj, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+                        if pfilter(fsname, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
                             r.update(statinfo(st))
                             filelist.append(r)
                     elif stat.S_ISDIR(st.st_mode) and params['file_type'] == 'directory':
-                        if pfilter(fsobj, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+                        if pfilter(fsname, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
 
                             r.update(statinfo(st))
                             filelist.append(r)
 
                     elif stat.S_ISREG(st.st_mode) and params['file_type'] == 'file':
-                        if pfilter(fsobj, params['patterns'], params['use_regex']) and \
+                        if pfilter(fsname, params['patterns'], params['use_regex']) and \
                            agefilter(st, now, age, params['age_stamp']) and \
                            sizefilter(st, size) and \
                            contentfilter(fsname, params['contains']):
@@ -349,7 +349,7 @@ def main():
                             filelist.append(r)
 
                     elif stat.S_ISLNK(st.st_mode) and params['file_type'] == 'link':
-                        if pfilter(fsobj, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
+                        if pfilter(fsname, params['patterns'], params['use_regex']) and agefilter(st, now, age, params['age_stamp']):
                             r.update(statinfo(st))
                             filelist.append(r)
 

--- a/lib/ansible/modules/files/find.py
+++ b/lib/ansible/modules/files/find.py
@@ -33,7 +33,7 @@ options:
         default: '*'
         description:
             - One or more (shell or regex) patterns, which type is controlled by C(use_regex) option.
-            - The patterns restrict the list of files to be returned to those whose complete filenames match at
+            - The patterns restrict the list of files to be returned to those whose basenames or complete filenames (since version 2.5) match at
               least one of the patterns specified. Multiple patterns can be specified using a list.
         aliases: ['pattern']
     contains:


### PR DESCRIPTION
##### SUMMARY
Improve 'find' module with pattern search not limited to basename.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`ansible/modules/files/find.py`

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 51c29570cd) last updated 2017/12/02 23:00:56 (GMT +000)
  config file = None
  configured module search path = [u'/opt/ansible/ansible/library']
  ansible python module location = /ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION

Before:
```
./hacking/test-module -m lib/ansible/modules/files/find.py -a '{"path":"/ansible/lib/ansible/modules", "pattern":".+/files/.+py$", "use_regex":"yes", "recurse":"yes"}' | tail -25
    "invocation": {
        "module_args": {
            "age": null, 
            "age_stamp": "mtime", 
            "contains": null, 
            "file_type": "file", 
            "follow": false, 
            "get_checksum": false, 
            "hidden": false, 
            "path": "/ansible/lib/ansible/modules", 
            "paths": [
                "/ansible/lib/ansible/modules"
            ], 
            "pattern": ".+/files/.+py$", 
            "patterns": [
                ".+/files/.+py$"
            ], 
            "recurse": true, 
            "size": null, 
            "use_regex": true
        }
    }, 
    "matched": 0, 
    "msg": ""
}
```

I've just changed: 
  * the first arg from `fsobj` to `fsname` for the 4 calls to `pfilter`.
  * updated the doc to specify that it can match the complete filename instead of just the basename

After:
```
./hacking/test-module -m lib/ansible/modules/files/find.py -a '{"path":"/ansible/lib/ansible/modules", "pattern":".+/files/.+py$", "use_regex":"yes", "recurse":"yes"}' | tail -25
    "invocation": {
        "module_args": {
            "age": null, 
            "age_stamp": "mtime", 
            "contains": null, 
            "file_type": "file", 
            "follow": false, 
            "get_checksum": false, 
            "hidden": false, 
            "path": "/ansible/lib/ansible/modules", 
            "paths": [
                "/ansible/lib/ansible/modules"
            ], 
            "pattern": ".+/files/.+py$", 
            "patterns": [
                ".+/files/.+py$"
            ], 
            "recurse": true, 
            "size": null, 
            "use_regex": true
        }
    }, 
    "matched": 21, 
    "msg": ""
}
```
