### PR TITLE
Fixes bug converning filenames with dots

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_certificate.py
@@ -248,11 +248,10 @@ class KeyParameters(Parameters):
 
     @property
     def key_filename(self):
-        fname, fext = os.path.splitext(self.name)
-        if fext == '':
-            return fname + '.key'
-        else:
+        if self.name.endswith('.key'):
             return self.name
+        else:
+            return self.name + '.key'
 
     @property
     def key_checksum(self):
@@ -308,11 +307,10 @@ class CertParameters(Parameters):
 
     @property
     def cert_filename(self):
-        fname, fext = os.path.splitext(self.name)
-        if fext == '':
-            return fname + '.crt'
-        else:
+        if self.name.endswith('.crt'):
             return self.name
+        else:
+            return self.name + '.crt'
 
     @property
     def cert_src(self):

--- a/lib/ansible/modules/network/f5/bigip_ssl_key.py
+++ b/lib/ansible/modules/network/f5/bigip_ssl_key.py
@@ -167,11 +167,10 @@ class Parameters(AnsibleF5Parameters):
 
     @property
     def key_filename(self):
-        fname, fext = os.path.splitext(self.name)
-        if fext == '':
-            return fname + '.key'
-        else:
+        if self.name.endswith('.key'):
             return self.name
+        else:
+            return self.name + '.key'
 
     @property
     def key_checksum(self):

--- a/test/units/modules/network/f5/test_bigip_ssl_certificate.py
+++ b/test/units/modules/network/f5/test_bigip_ssl_certificate.py
@@ -15,9 +15,9 @@ if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import patch, Mock
+from ansible.compat.tests.mock import Mock
+from ansible.compat.tests.mock import patch
 from ansible.module_utils.f5_utils import AnsibleF5Client
-from units.modules.utils import set_module_args
 
 try:
     from library.bigip_ssl_certificate import ArgumentSpec
@@ -27,6 +27,7 @@ try:
     from library.bigip_ssl_certificate import HAS_F5SDK
     from library.bigip_ssl_certificate import KeyManager
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_ssl_certificate import ArgumentSpec
@@ -36,6 +37,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_ssl_certificate import HAS_F5SDK
         from ansible.modules.network.f5.bigip_ssl_certificate import KeyManager
         from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 

--- a/test/units/modules/network/f5/test_bigip_ssl_key.py
+++ b/test/units/modules/network/f5/test_bigip_ssl_key.py
@@ -15,9 +15,9 @@ if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import patch, Mock
+from ansible.compat.tests.mock import Mock
+from ansible.compat.tests.mock import patch
 from ansible.module_utils.f5_utils import AnsibleF5Client
-from units.modules.utils import set_module_args
 
 try:
     from library.bigip_ssl_key import ArgumentSpec
@@ -25,6 +25,7 @@ try:
     from library.bigip_ssl_key import ModuleManager
     from library.bigip_ssl_key import HAS_F5SDK
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_ssl_key import ArgumentSpec
@@ -32,6 +33,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_ssl_key import ModuleManager
         from ansible.modules.network.f5.bigip_ssl_key import HAS_F5SDK
         from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The name detminator was incorrect. This fixes it and fixes unit
tests related things that were broken downstream

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_ssl_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Nov  4 2017, 22:29:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
