### PR TITLE
Fixes ordered dict import

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_ucs.py
+++ b/lib/ansible/modules/network/f5/bigip_ucs.py
@@ -195,7 +195,10 @@ from ansible.module_utils.six import iteritems
 try:
     from collections import OrderedDict
 except ImportError:
-    pass
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        pass
 
 try:
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError

--- a/test/units/modules/network/f5/test_bigip_ucs.py
+++ b/test/units/modules/network/f5/test_bigip_ucs.py
@@ -16,10 +16,10 @@ if sys.version_info < (2, 7):
     raise SkipTest("F5 Ansible modules require Python >= 2.7")
 
 from ansible.compat.tests import unittest
-from ansible.compat.tests.mock import patch, Mock
+from ansible.compat.tests.mock import Mock
+from ansible.compat.tests.mock import patch
 from ansible.module_utils.f5_utils import AnsibleF5Client
 from ansible.module_utils.f5_utils import F5ModuleError
-from units.modules.utils import set_module_args
 
 try:
     from library.bigip_ucs import Parameters
@@ -28,6 +28,7 @@ try:
     from library.bigip_ucs import V1Manager
     from library.bigip_ucs import V2Manager
     from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+    from test.unit.modules.utils import set_module_args
 except ImportError:
     try:
         from ansible.modules.network.f5.bigip_ucs import Parameters
@@ -36,6 +37,7 @@ except ImportError:
         from ansible.modules.network.f5.bigip_ucs import V1Manager
         from ansible.modules.network.f5.bigip_ucs import V2Manager
         from ansible.module_utils.f5_utils import iControlUnexpectedHTTPError
+        from units.modules.utils import set_module_args
     except ImportError:
         raise SkipTest("F5 Ansible modules require the f5-sdk Python library")
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Make it try to fallback to a pypi package if its not found in what
ships with python

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip_ucs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Nov  4 2017, 22:29:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
