### PR TITLE
Use v1 jobs endpoint

### DIFF
--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -218,7 +218,7 @@ KIND_URL = {
     "deployment": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments",
     "horizontalpodautoscaler": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",  # NOQA
     "ingress": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
-    "job": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
+    "job": "/apis/batch/v1/namespaces/{namespace}/jobs",
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 


### PR DESCRIPTION
##### SUMMARY
Fixes #33340

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
lib/ansible/modules/clustering/kubernetes.py

##### ANSIBLE VERSION
```
ansible 2.4
```


##### ADDITIONAL INFORMATION
Proposed job api endpoint works with the latest Ansible and Kubernetes versions