### PR TITLE
Add option allowing the user to specify a custom cowpath

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -56,6 +56,15 @@ ANSIBLE_NOCOWS:
   - {key: nocows, section: defaults}
   type: boolean
   yaml: {key: display.i_am_no_fun}
+ANSIBLE_COWPATH:
+  name: Set path to cowsay command
+  default: null
+  description: Specify a custom cowsay path or swap in your cowsay implementation of choice
+  env: [{name: ANSIBLE_COWPATH}]
+  ini:
+  - {key: cowpath, section: defaults}
+  type: string
+  yaml: {key: display.cowpath}
 ANSIBLE_PIPELINING:
   name: Connection pipelining
   default: False

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -98,7 +98,12 @@ class Display:
         self._set_column_width()
 
     def set_cowsay_info(self):
-        if not C.ANSIBLE_NOCOWS:
+        if C.ANSIBLE_NOCOWS:
+            return
+
+        if C.ANSIBLE_COWPATH:
+            self.b_cowsay = C.ANSIBLE_COWPATH
+        else:
             for b_cow_path in b_COW_PATHS:
                 if os.path.exists(b_cow_path):
                     self.b_cowsay = b_cow_path


### PR DESCRIPTION
This allows the user to use custom cowsay implementations without shadowing common cowsay paths

##### SUMMARY
I added a config variable to enable users to specify their own cowsay path. Or to allow them to use their own cowsay implementation. I intend to use this config variable to use https://github.com/erkin/ponysay as my cow provider 
<img width="646" alt="screen shot 2017-12-03 at 2 30 45 pm" src="https://user-images.githubusercontent.com/1521093/33528949-4d8c0640-d837-11e7-84fc-d4c74de77b32.png">


##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
display

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (custom_cowsay 8a9844c0d7) last updated 2017/12/03 14:33:18 (GMT -400)
  config file = None
  configured module search path = ['/Users/bachmann/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/bachmann/code/ansible/lib/ansible
  executable location = /Users/bachmann/code/ansible/venv/bin/ansible
  python version = 3.6.2 (default, Jul 17 2017, 16:44:45) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```