### PR TITLE
Fix DO_API_KEY environment variable check

### DIFF
--- a/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
+++ b/lib/ansible/modules/cloud/digital_ocean/digital_ocean.py
@@ -201,7 +201,7 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.basic import AnsibleModule, env_fallback
 
 
 class TimeoutError(Exception):
@@ -346,11 +346,7 @@ def core(module):
             module.fail_json(msg='Unable to load %s' % k)
         return v
 
-    try:
-        api_token = module.params['api_token'] or os.environ['DO_API_TOKEN'] or os.environ['DO_API_KEY']
-    except KeyError as e:
-        module.fail_json(msg='Unable to load %s' % e.message)
-
+    api_token = module.params['api_token']
     changed = True
     command = module.params['command']
     state = module.params['state']
@@ -432,7 +428,11 @@ def main():
         argument_spec=dict(
             command=dict(choices=['droplet', 'ssh'], default='droplet'),
             state=dict(choices=['active', 'present', 'absent', 'deleted'], default='present'),
-            api_token=dict(aliases=['API_TOKEN'], no_log=True),
+            api_token=dict(
+                aliases=['API_TOKEN'],
+                no_log=True,
+                fallback=(env_fallback, ['DO_API_TOKEN', 'DO_API_KEY'])
+            ),
             name=dict(type='str'),
             size_id=dict(),
             image_id=dict(),


### PR DESCRIPTION
##### SUMMARY
`os.environ['DO_API_TOKEN']` raised a `KeyError` preventing the check
for `os.environ['DO_API_KEY]` from being executed. Fix this by failing
only if the api token isn't set.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
digital_ocean

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 5693b8cced) last updated 2017/12/03 15:43:37 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/gurch/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gurch/Projects/ansible/lib/ansible
  executable location = /home/gurch/Envs/ansible-playbooks/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]

```
