### PR TITLE
vmware_guest regex filter for autoselect_datastore 

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -104,7 +104,7 @@ options:
     - ' - C(size_[tb,gb,mb,kb]) (integer): Disk storage size in specified unit.'
     - ' - C(type) (string): Valid values are:'
     - '   C(thin) thin disk, C(eagerzeroedthick) eagerzeroedthick disk, added in version 2.5, Default: C(None) thick disk, no eagerzero.'
-    - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, filter datastore selection.'
+    - ' - C(datastore) (string): Datastore to use for the disk. If C(autoselect_datastore) is enabled, optionally specify regex to match.'
     - ' - C(autoselect_datastore) (bool): select the less used datastore.'
   cdrom:
     description:
@@ -1140,7 +1140,7 @@ class PyVmomiHelper(PyVmomi):
                         # If datastore field is provided, filter destination datastores
                         if 'datastore' in self.params['disk'][0] and \
                                 isinstance(self.params['disk'][0]['datastore'], str) and \
-                                ds.name.find(self.params['disk'][0]['datastore']) < 0:
+                                re.match(self.params['disk'][0]['datastore'], ds.name) is None:
                             continue
 
                         datastore = ds


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Current module allows a list of datastore to be used to filter when autoselect_datastore is specified. This modification uses a regex to filter for auto selecting. This enables users to filter based off a naming convention. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
vmware_guest 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example: 
```
vmware_guest:
  name: newvm
  template: win-2016
  disk:
    - size_gb: 40
      datastore: nas.*
      autoselect_datastore: True
```