### PR TITLE
fix openssl csr to req in instructions to letsencrypt

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -69,7 +69,7 @@ options:
   csr:
     description:
       - "File containing the CSR for the new certificate."
-      - "Can be created with C(openssl csr ...)."
+      - "Can be created with C(openssl req ...)."
       - "The CSR may contain multiple Subject Alternate Names, but each one
          will lead to an individual challenge that must be fulfilled for the
          CSR to be signed."


### PR DESCRIPTION
##### SUMMARY
The letsencrypt module has documentation saying a CSR can be created using "openssl csr", but the correct command is "openssl req".
Fix this.

##### ISSUE TYPE

 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
git master and older
```


##### ADDITIONAL INFORMATION

[tigerste@rele ansible]$ openssl csr
openssl:Error: 'csr' is an invalid command.

