### PR TITLE
Fixes #33521, remove temp file.

### DIFF
--- a/lib/ansible/modules/net_tools/basics/get_url.py
+++ b/lib/ansible/modules/net_tools/basics/get_url.py
@@ -538,6 +538,8 @@ def main():
         changed = True
     else:
         changed = False
+        if os.path.exists(tmpsrc):
+            os.remove(tmpsrc)
 
     if checksum != '':
         destination_checksum = module.digest_from_file(dest, algorithm)


### PR DESCRIPTION
##### SUMMARY
Fixes #33521.

Remove temporary file when `force=yes` and destination file checksum is equal to downloaded file checksum.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/home/me/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /path/to/virtualenv/ansible/local/lib/python2.7/site-packages/ansible
  executable location = /path/to/virtualenv/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 19 2016, 06:48:10) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
See #33521.
