### PR TITLE
VMware: Get virtual machine object using property

### DIFF
--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -889,13 +889,20 @@ class PyVmomi(object):
         user_desired_path = None
 
         if self.params['uuid']:
-            vm = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid")
+            vm_obj = find_vm_by_id(self.content, vm_id=self.params['uuid'], vm_id_type="uuid")
 
         elif self.params['name']:
-            vms = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])
+            objects = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])
+            vms = []
+
+            for temp_vm_object in objects:
+                for tem_vm_property in temp_vm_object.propSet:
+                    if tem_vm_property.val == self.params['name']:
+                        vms.append(temp_vm_object.obj)
+                        break
 
             # get_managed_objects_properties may return multiple virtual machine,
-            # following code tries to find user desired one depending on folder specified.
+            # following code tries to find user desired one depending upon the folder specified.
             if len(vms) > 1:
                 # We have found multiple virtual machines, decide depending upon folder value
                 if self.params['folder'] is None:
@@ -955,7 +962,7 @@ class PyVmomi(object):
                     if user_desired_path in actual_vm_folder_path:
                         vm_obj = vm
                         break
-            else:
+            elif vms:
                 # Unique virtual machine found.
                 vm_obj = vms[0]
 

--- a/lib/ansible/module_utils/vmware.py
+++ b/lib/ansible/module_utils/vmware.py
@@ -934,32 +934,16 @@ class PyVmomi(object):
                     self.module.fail_json(msg="vmware_guest found multiple virtual machines with same "
                                               "name [%s], please specify folder path other than blank "
                                               "or '/'" % self.params['name'])
-                elif user_folder == '/vm' or user_folder.startswith('/vm/'):
-                    # User provided VMware default vm folder with / or
+                elif user_folder.startswith('/vm/'):
                     # User provided nested folder under VMware default vm folder i.e. folder = /vm/india/finance
                     user_desired_path = "%s%s%s" % (dcpath, user_defined_dc, user_folder)
-                elif user_folder == 'vm':
-                    # User provided VMware default vm folder
-                    user_desired_path = "%s%s/vm" % (dcpath, user_defined_dc)
-                elif user_folder.startswith("%s%s/vm" % (dcpath, user_defined_dc)) or \
-                        user_folder.startswith("/%s" % user_defined_dc):
+                else:
                     # User defined datacenter is not nested i.e. dcpath = '/' , or
                     # User defined datacenter is nested i.e. dcpath = '/F0/DC0' or
-                    # User provided folder starts with / and datacenter i.e. folder = /ha-datacenter/
-                    user_desired_path = user_folder
-                elif user_folder.startswith('/'):
-                    # User defined folder is under VMware default vm folder i.e. folder = /india/finance
-                    user_desired_path = "%s%s/vm%s" % (dcpath, user_defined_dc, user_folder)
-                elif user_folder.startswith("%s/vm" % user_defined_dc):
+                    # User provided folder starts with / and datacenter i.e. folder = /ha-datacenter/ or
                     # User defined folder starts with datacenter without '/' i.e.
                     # folder = DC0/vm/india/finance or
                     # folder = DC0/vm
-                    user_desired_path = user_folder
-                elif user_folder == '%s' % user_defined_dc:
-                    # User defined folder is datacenter i.e. folder = 'DC0'
-                    user_desired_path = "%s%s/vm" % (dcpath, user_defined_dc)
-                else:
-                    # get_vm is not super cow !!!
                     user_desired_path = user_folder
 
                 for vm in vms:

--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -78,7 +78,6 @@ options:
     - '   folder: /folder1/datacenter1/vm'
     - '   folder: folder1/datacenter1/vm'
     - '   folder: /folder1/datacenter1/vm/folder2'
-    default: /vm
   hardware:
     description:
     - Manage some VM hardware attributes.
@@ -1436,15 +1435,18 @@ class PyVmomiHelper(PyVmomi):
         #   - multiple templates by the same name
         #   - static IPs
 
-        # datacenters = get_all_objs(self.content, [vim.Datacenter])
+        self.folder = self.params.get('folder', None)
+        if self.folder is None:
+            self.module.fail_json(msg="Folder is required parameter while deploying new virtual machine")
+
+        # Prepend / if it was missing from the folder path, also strip trailing slashes
+        if not self.folder.startswith('/'):
+            self.folder = '/%(folder)s' % self.params
+        self.folder = self.folder.rstrip('/')
+
         datacenter = self.cache.find_obj(self.content, [vim.Datacenter], self.params['datacenter'])
         if datacenter is None:
             self.module.fail_json(msg='No datacenter named %(datacenter)s was found' % self.params)
-
-        # Prepend / if it was missing from the folder path, also strip trailing slashes
-        if not self.params['folder'].startswith('/'):
-            self.params['folder'] = '/%(folder)s' % self.params
-        self.params['folder'] = self.params['folder'].rstrip('/')
 
         dcpath = compile_folder_path_for_object(datacenter)
 
@@ -1453,15 +1455,15 @@ class PyVmomiHelper(PyVmomi):
             dcpath += '/'
 
         # Check for full path first in case it was already supplied
-        if (self.params['folder'].startswith(dcpath + self.params['datacenter'] + '/vm') or
-                self.params['folder'].startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
-            fullpath = self.params['folder']
-        elif self.params['folder'].startswith('/vm/') or self.params['folder'] == '/vm':
-            fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.params['folder'])
-        elif self.params['folder'].startswith('/'):
-            fullpath = "%s%s/vm%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+        if (self.folder.startswith(dcpath + self.params['datacenter'] + '/vm') or
+                self.folder.startswith(dcpath + '/' + self.params['datacenter'] + '/vm')):
+            fullpath = self.folder
+        elif self.folder.startswith('/vm/') or self.folder == '/vm':
+            fullpath = "%s%s%s" % (dcpath, self.params['datacenter'], self.folder)
+        elif self.folder.startswith('/'):
+            fullpath = "%s%s/vm%s" % (dcpath, self.params['datacenter'], self.folder)
         else:
-            fullpath = "%s%s/vm/%s" % (dcpath, self.params['datacenter'], self.params['folder'])
+            fullpath = "%s%s/vm/%s" % (dcpath, self.params['datacenter'], self.folder)
 
         f_obj = self.content.searchIndex.FindByInventoryPath(fullpath)
 
@@ -1471,10 +1473,10 @@ class PyVmomiHelper(PyVmomi):
             details = {
                 'datacenter': datacenter.name,
                 'datacenter_path': dcpath,
-                'folder': self.params['folder'],
+                'folder': self.folder,
                 'full_search_path': fullpath,
             }
-            self.module.fail_json(msg='No folder %s matched in the search path : %s' % (self.params['folder'], fullpath),
+            self.module.fail_json(msg='No folder %s matched in the search path : %s' % (self.folder, fullpath),
                                   details=details)
 
         destfolder = f_obj
@@ -1754,10 +1756,10 @@ def main():
         is_template=dict(type='bool', default=False),
         annotation=dict(type='str', aliases=['notes']),
         customvalues=dict(type='list', default=[]),
-        name=dict(type='str', required=True),
+        name=dict(type='str'),
         name_match=dict(type='str', choices=['first', 'last'], default='first'),
         uuid=dict(type='str'),
-        folder=dict(type='str', default='/vm'),
+        folder=dict(type='str'),
         guest_id=dict(type='str'),
         disk=dict(type='list', default=[]),
         cdrom=dict(type='dict', default={}),
@@ -1779,13 +1781,12 @@ def main():
                            mutually_exclusive=[
                                ['cluster', 'esxi_hostname'],
                            ],
+                           required_one_of=[
+                               ['name', 'uuid'],
+                           ],
                            )
 
     result = {'failed': False, 'changed': False}
-
-    # FindByInventoryPath() does not require an absolute path
-    # so we should leave the input folder path unmodified
-    module.params['folder'] = module.params['folder'].rstrip('/')
 
     pyv = PyVmomiHelper(module)
 


### PR DESCRIPTION
##### SUMMARY
This fixes get_vm method to use propertyCollector which
can efficiently find the virtual machine from given VMware
infrastructure using only name.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```