### PR TITLE
radware/vdirect_runnable: Fixing bug when returned 404 status code considered as invalid

### DIFF
--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -294,7 +294,7 @@ class VdirectRunnable(object):
         result = self.client.runnable.run(data, self.type, self.name, self.action_name)
         result_to_return = {'msg': ''}
         if result[rest_client.RESP_STATUS] == 200:
-            if result[rest_client.RESP_DATA]['status'] == 200 and result[rest_client.RESP_DATA]['success']:
+            if result[rest_client.RESP_DATA]['success']:
                 if self.type == WORKFLOW_TEMPLATE_RUNNABLE_TYPE:
                     result_to_return['msg'] = WORKFLOW_CREATION_SUCCESS
                 elif self.type == CONFIGURATION_TEMPLATE_RUNNABLE_TYPE:

--- a/test/units/modules/network/radware/test_vdirect_runnable.py
+++ b/test/units/modules/network/radware/test_vdirect_runnable.py
@@ -261,6 +261,10 @@ class TestManager(unittest.TestCase):
             res = vdirectRunnable.run()
             assert res == MODULE_RESULT
 
+            RUN_RESULT[self.module_mock.rest_client.RESP_DATA]['status'] = 404
+            vdirectRunnable.run()
+            assert res == MODULE_RESULT
+
             RUN_RESULT[self.module_mock.rest_client.RESP_STATUS] = 400
             RUN_RESULT[self.module_mock.rest_client.RESP_REASON] = "Reason"
             RUN_RESULT[self.module_mock.rest_client.RESP_STR] = "Details"


### PR DESCRIPTION
##### SUMMARY
In case of workflow delete action, the returned 404 status code in response data
considered as invalid although it's a valid code for not found (deleted)
entity.

Removed verification of the status. Only success should be verified since its the only identifier of success of the action.

Fixes #33524

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module network/radware/vdirect_runnable

##### ANSIBLE VERSION
ansible 2.4


