### PR TITLE
Remove botocore from top-level execution in lambda_policy tests

### DIFF
--- a/test/units/modules/cloud/amazon/test_lambda_policy.py
+++ b/test/units/modules/cloud/amazon/test_lambda_policy.py
@@ -31,9 +31,13 @@ if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_api_gateway.py requires the `boto3` and `botocore` modules")
 
 # these are here cause ... boto!
-from botocore.exceptions import ClientError
 import ansible.modules.cloud.amazon.lambda_policy as lambda_policy
 from ansible.modules.cloud.amazon.lambda_policy import setup_module_object
+try:
+    from botocore.exceptions import ClientError
+except ImportError:
+    pass
+
 
 base_module_args = {
     "region": "us-west-1",
@@ -100,13 +104,12 @@ fake_policy_return = {
 
 error_response = {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Fake Testing Error'}}
 operation_name = 'FakeOperation'
-resource_not_found_e = ClientError(error_response, operation_name)
 
 
 def test_manage_state_adds_missing_permissions():
     lambda_client_double = MagicMock()
     # Policy actually: not present  Requested State: present  Should: create
-    lambda_client_double.get_policy.side_effect = resource_not_found_e
+    lambda_client_double.get_policy.side_effect = ClientError(error_response, operation_name)
     fake_module_params = copy.deepcopy(fake_module_params_present)
     module_double.params = fake_module_params
     lambda_policy.manage_state(module_double, lambda_client_double)
@@ -154,7 +157,7 @@ def test_manage_state_removes_unwanted_permissions():
 def test_manage_state_leaves_already_removed_permissions():
     lambda_client_double = MagicMock()
     # Policy actually: absent   Requested State: absent  Should: do nothing
-    lambda_client_double.get_policy.side_effect = resource_not_found_e
+    lambda_client_double.get_policy.side_effect = ClientError(error_response, operation_name)
     fake_module_params = copy.deepcopy(fake_module_params_absent)
     module_double.params = fake_module_params
     lambda_policy.manage_state(module_double, lambda_client_double)


### PR DESCRIPTION


##### SUMMARY
Even though the tests are skipped, the `ClientError` uses outside the
test cause a failure even though the tests never run

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
E   ImportError: No module named botocore.exceptions
```
