### PR TITLE
Allow `foreman_ssl_verify` to be a string.

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -85,7 +85,7 @@ class ForemanInventory(object):
             self.foreman_url = config.get('foreman', 'url')
             self.foreman_user = config.get('foreman', 'user')
             self.foreman_pw = config.get('foreman', 'password', raw=True)
-            self.foreman_ssl_verify = config.getboolean('foreman', 'ssl_verify')
+            self.foreman_ssl_verify = config.get('foreman', 'ssl_verify')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError) as e:
             print("Error parsing configuration: %s" % e, file=sys.stderr)
             return False


### PR DESCRIPTION
Allow `foreman_ssl_verify` to be a string so `requests.Session().verify`
can be set to a CA_BUNDLE file or directory with certificates of trusted
CAs.

##### SUMMARY
Allow `foreman_ssl_verify` config option to be a string so `requests.Session().verify`
can be set to a CA_BUNDLE file or directory with certificates of trusted
CAs.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
contrib/inventory/foreman.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (foreman_ssl_verify_path 34561525b9) last updated 2017/12/04 15:58:37 (GMT +200)
  config file = None
  configured module search path = [u'/Users/maarten/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/maarten/Devel/maartenq/ansible/lib/ansible
  executable location = /Users/maarten/Devel/maartenq/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 27 2017, 12:15:00) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
```
