### PR TITLE
Fix wrong number of arguments for format

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -105,7 +105,7 @@ def boto3_conn(module, conn_type=None, resource=None, region=None, endpoint=None
     try:
         return _boto3_conn(conn_type=conn_type, resource=resource, region=region, endpoint=endpoint, **params)
     except ValueError as e:
-        module.fail_json(msg="Couldn't connect to AWS: " % to_native(e))
+        module.fail_json(msg="Couldn't connect to AWS: %s" % to_native(e))
     except (botocore.exceptions.ProfileNotFound, botocore.exceptions.PartialCredentialsError) as e:
         module.fail_json(msg=to_native(e))
     except botocore.exceptions.NoRegionError as e:


### PR DESCRIPTION
##### SUMMARY
This fix adds wrong number of arguments for format in
ec2.py module_util.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/ec2.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```