### PR TITLE
Add missing msg in fail_json

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
+++ b/lib/ansible/modules/cloud/amazon/aws_acm_facts.py
@@ -313,7 +313,7 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if not HAS_BOTO3:
-        module.fail_json('boto3 and botocore are required by this module')
+        module.fail_json(msg='boto3 and botocore are required by this module')
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     client = boto3_conn(module, conn_type='client', resource='acm',

--- a/lib/ansible/modules/cloud/cloudstack/cs_host.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_host.py
@@ -577,7 +577,7 @@ class AnsibleCloudStackHost(AnsibleCloudStack):
                 return None
             elif host['resourcestate'] != 'PrepareForMaintenance':
                 return host
-        self.fail_json("Polling for maintenance timed out")
+        self.fail_json(msg="Polling for maintenance timed out")
 
     def get_result(self, host):
         super(AnsibleCloudStackHost, self).get_result(host)

--- a/lib/ansible/modules/network/junos/junos_package.py
+++ b/lib/ansible/modules/network/junos/junos_package.py
@@ -136,7 +136,7 @@ def connect(module):
         device.timeout = get_param(module, 'timeout') or 10
     except ConnectError:
         exc = get_exception()
-        module.fail_json('unable to connect to %s: %s' % (host, str(exc)))
+        module.fail_json(msg='unable to connect to %s: %s' % (host, str(exc)))
 
     return device
 


### PR DESCRIPTION
##### SUMMARY
This fix adds msg keyword in fail_json in aws_acm_facts module.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/aws_acm_facts.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```