### PR TITLE
Docs network best 2.5

### DIFF
--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -1,8 +1,8 @@
 .. network-best-practices:
 
-***************************************
+**************************************
 Network Best Practices for Ansible 2.5
-***************************************
+**************************************
 
 .. contents:: Topics
 
@@ -47,7 +47,7 @@ In our example, the inventory file defines the groups ``eos``, ``ios``, ``vyos``
 
 
 Connection & Credentials (group_vars)
--------------------------------------------
+-------------------------------------
 
 As Ansible is a flexible tool there are a number of ways of specifying connection information & credentials. We believe however that the best was is to use ``group_vars``.
 
@@ -136,6 +136,12 @@ Certain network platforms, such as eos and ios, have the concept of different pr
    ansible_become_method: enable
 
 For more information, see the :doc:`Ansible Privilege Escalation<become>` guide.
+
+
+Jump hosts
+^^^^^^^^^^
+
+If the Ansible Controller doesn't have a direct route to the remote device and you need to use a Jump Host, please see the :ref:`Ansible Network Proxy Command <network_delegate_to_vs_ProxyCommand>` guide for details on how to achieve this.
 
 Playbook
 --------

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -38,6 +38,21 @@ Concepts
 
 This section explains some fundamental concepts that you should understand when working with Ansible Networking.
 
+Structure
+----------
+
+The examples on this page use the following structure:
+
+.. code-block:: console
+
+   .
+   ├── facts-demo.yml
+   ├── group_vars
+   │   ├── eos.yml
+   │   └── ios.yml
+   └── inventory
+
+
 Inventory
 ---------
 
@@ -186,7 +201,7 @@ First, create a file called ``inventory``, containing:
 
 **Create a playbook**
 
-Next, create a playbook file called ``fetch-facts.yml`` containing the following:
+Next, create a playbook file called ``facts-demo.yml`` containing the following:
 
 .. code-block:: yaml
 
@@ -222,7 +237,7 @@ Next, create a playbook file called ``fetch-facts.yml`` containing the following
            var: hostvars['vyos01.example.net']
 
        - name: Write facts to disk using a template
-         copy:
+copy:
            content: |
              #jinja2: lstrip_blocks: True
              EOS device info:
@@ -292,7 +307,7 @@ To run the playbook, run the following from a console prompt:
 
 .. code-block:: console
 
-   ansible-playbook -i inventory fetch-facts.yml
+   ansible-playbook -i inventory facts-demo.yml
 
 This should return output similar to the following:
 

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -1,0 +1,369 @@
+.. network-best-practices:
+
+***************************************
+Network Best Practices for Ansible 2.5
+***************************************
+
+.. contents:: Topics
+
+
+Overview
+========
+
+This document explains the best practices for using Ansible 2.5 to manage your network infrastructure.
+
+
+Audience
+--------
+
+* This example is intended for network or system administrators who want to understand how to use Ansible to manage network devices.
+
+
+Prerequisites
+-------------
+
+This example requires the following:
+
+* **Ansible 2.5** (or higher) installed. See :doc:`intro_installation` for more information.
+* One or more network devices that are compatible with Ansible.
+* Basic understanding of YAML :doc:`YAMLSyntax`.
+* Basic understanding of Jinja2 Templates. See :doc:`playbooks_templating` for more information.
+* Basic Linux command line use.
+* Basic knowledge of network switch & router configurations.
+
+
+
+Concepts
+========
+
+This section explains some fundamental concepts that you should understand when working with Ansible Networking.
+
+Inventory
+---------
+
+An ``inventory`` file is an INI-like configuration file that defines the mapping of hosts into groups.
+
+In our example, the inventory file defines the groups ``eos``, ``ios``, ``vyos`` and a "group of groups" called ``switches``. Further details about subgroups and inventory files can be found in the :ref:`Ansible inventory Group documentation <subgroups>`.
+
+
+Connection & Credentials (group_vars)
+-------------------------------------------
+
+As Ansible is a flexible tool there are a number of ways of specifying connection information & credentials. We believe however that the best was is to use ``group_vars``.
+
+**group_vars/eos.yml**
+
+.. code-block:: yaml
+
+   ansible_connection: network_cli
+   ansible_network_os: eos
+   ansible_user: myuser
+   ansible_ssh_pass: !vault |
+                     $ANSIBLE_VAULT;1.1;AES256
+                     37373735393636643261383066383235363664386633386432343236663533343730353361653735
+                     6131363539383931353931653533356337353539373165320a316465383138636532343463633236
+                     37623064393838353962386262643230303438323065356133373930646331623731656163623333
+                     3431353332343530650a373038366364316135383063356531633066343434623631303166626532
+                     9562
+   ansible_become: yes
+   ansible_become_method: enable
+
+**group_vars/ios.yml**
+
+.. code-block:: yaml
+
+   ansible_connection: network_cli
+   ansible_network_os: ios
+   ansible_user: myiosuser
+   ansible_ssh_pass: !vault |
+                     $ANSIBLE_VAULT;1.1;AES256
+                     34623431313336343132373235313066376238386138316466636437653938623965383732373130
+                     3466363834613161386538393463663861636437653866620a373136356366623765373530633735
+                     34323262363835346637346261653137626539343534643962376139366330626135393365353739
+                     3431373064656165320a333834613461613338626161633733343566666630366133623265303563
+                     8472
+   ansible_become: yes
+   ansible_become_method: enable
+
+**group_vars/vyos.yml**
+
+.. code-block:: yaml
+
+   ansible_connection: network_cli
+   ansible_network_os: vyos
+   ansible_user: myvyosuser
+   ansible_ssh_pass: !vault |
+                     $ANSIBLE_VAULT;1.1;AES256
+                     39336231636137663964343966653162353431333566633762393034646462353062633264303765
+                     6331643066663534383564343537343334633031656538370a333737656236393835383863306466
+                     62633364653238323333633337313163616566383836643030336631333431623631396364663533
+                     3665626431626532630a353564323566316162613432373738333064366130303637616239396438
+                     9853
+
+
+.. FIXME FUTURE Gundalow - Link to network auth & proxy page (to be written)
+
+.. warning:: Never store passwords in plain text
+
+The "Vault" feature of Ansible allows keeping sensitive data such as passwords or keys in encrypted files, rather than as plain text in your playbooks or roles. These vault files can then be distributed or placed in source control. See :doc:`playbooks_vault` for more information.
+
+:ansible_connection:
+
+  The ansible-connection setting tells Ansible how it should connect to a remote device. When working with Ansible Networking, setting this to ``ansible_connection: network_cli`` informs Ansible that the remote node is a network device with a limited execution environment. Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
+:ansible_network_os:
+  Informs Ansible which Network platform this hosts corresponds to. This is required when using ``network_cli``
+:ansible_user: The user to connect to the remote device (switch) as. Without this the user that is running ``ansible-playbook`` would be used.
+  Specifies which user on the network device the connection
+:ansible_ssh_pass:
+  The corresponding password for ``ansible_user`` to log in as. If not specified SSH key will be used.
+:ansible_become:
+  If enable mode (privilege mode) should be used, see the next section.
+:ansible_become_method:
+  Which type of `become` should be used, for ``network_cli`` the only valid choice is ``enable``.
+
+Privilege escalation
+^^^^^^^^^^^^^^^^^^^^
+
+Certain network platforms, such as eos and ios, have the concept of different privilege modes. Certain network modules, such as those that modify system state including users, will only work in high privilege states. Ansible version 2.5 added support for ``become`` when using ``connection: network_cli``. This allows privileges to be raised for the specific tasks that need them. Adding ``become: yes`` and ``become_method: enable`` informs Ansible to go into privilege mode before executing the task, as shown here:
+
+**group_vars/eos.yml**
+
+.. code-block:: yaml
+
+   ansible_connection: network_cli
+   ansible_network_os: eos
+   ansible_become: yes
+   ansible_become_method: enable
+
+For more information, see the :doc:`Ansible Privilege Escalation<become>` guide.
+
+Playbook
+--------
+
+Collect data
+^^^^^^^^^^^^
+
+Ansible facts modules gather system information 'facts' that are available to the rest of your playbook.
+
+Ansible Networking ships with a number of network-specific facts modules. In this example, we use the ``_facts`` modules :ref:`eos_facts <eos_facts>`, :ref:`ios_facts <ios_facts>` and :ref:`vyos_facts <vyos_facts>` to connect to the remote networking device. As the credentials are not explicitly passed via module arguments, Ansible uses the username and password from the inventory file.
+
+Ansible's "Network Fact modules" gather information from the system and store the results in facts prefixed with ``ansible_net_``. The data collected by these modules is documented in the `Return Values` section of the module docs, in this case :ref:`eos_facts <eos_facts>` and :ref:`vyos_facts <vyos_facts>`. We can use the facts, such as ``ansible_net_version`` late on in the "Display some facts" task.
+
+To ensure we call the correct mode (``*_facts``) the task is conditionally run based on the group defined in the inventory file, for more information on the use of conditionals in Ansible Playbooks see :ref:`the_when_statement`.
+
+
+Example
+=======
+
+In this example, we will create an inventory file containing some network switches, then run a playbook to connect to the network devices and return some information about them.
+
+**Create an inventory file**
+
+First, create a file called ``inventory``, containing:
+
+.. code-block:: ini
+
+   [switches:children]
+   eos
+   ios
+   vyos
+
+   [eos]
+   eos01.example.net
+
+   [ios]
+   ios01.example.net
+
+   [vyos]
+   vyos01.example.net
+
+
+**Create a playbook**
+
+Next, create a playbook file called ``fetch-facts.yml`` containing the following:
+
+.. code-block:: yaml
+
+   - name: "Demonstrate connecting to switches"
+     hosts: switches
+     gather_facts: no
+
+     tasks:
+       ###
+       # Collect data
+       #
+       - name: Gather facts (eos)
+         eos_facts:
+         when: "'eos' in group_names"
+
+       - name: Gather facts (ops)
+         ios_facts:
+         when: "'ios' in group_names"
+
+       - name: Gather facts (vyos)
+         vyos_facts:
+         when: "'vyos' in group_names"
+
+       ###
+       # Demonstrate variables
+       #
+       - name: Display some facts
+         debug:
+           msg: "The hostname is {{ ansible_net_hostname }} and the OS is {{ ansible_net_version }}"
+
+       - name: Facts from a specific host
+         debug:
+           var: hostvars['vyos01.example.net']
+
+       - name: Write facts to disk using a template
+         copy:
+           content: |
+             #jinja2: lstrip_blocks: True
+             EOS device info:
+               {% for host in groups['eos'] %}
+               Hostname: {{ hostvars[host].ansible_net_version }}
+               Version: {{ hostvars[host].ansible_net_version }}
+               Model: {{ hostvars[host].ansible_net_model }}
+               Serial: {{ hostvars[host].ansible_net_serialnum }}
+               {% endfor %}
+
+             IOS device info:
+               {% for host in groups['ios'] %}
+               Hostname: {{ hostvars[host].ansible_net_version }}
+               Version: {{ hostvars[host].ansible_net_version }}
+               Model: {{ hostvars[host].ansible_net_model }}
+               Serial: {{ hostvars[host].ansible_net_serialnum }}
+               {% endfor %}
+
+             VyOS device info:
+               {% for host in groups['vyos'] %}
+               Hostname: {{ hostvars[host].ansible_net_version }}
+               Version: {{ hostvars[host].ansible_net_version }}
+               Model: {{ hostvars[host].ansible_net_model }}
+               Serial: {{ hostvars[host].ansible_net_serialnum }}
+               {% endfor %}
+           dest: /tmp/switch-facts
+         run_once: yes
+
+       ###
+       # Get running configuration
+       #
+
+       - name: Backup switch (eos)
+         eos_config:
+           backup: yes
+         register: backup_eos_location
+         when: "'eos' in group_names"
+
+       - name: backup switch (vyos)
+         vyos_config:
+           backup: yes
+         register: backup_vyos_location
+         when: "'vyos' in group_names"
+
+       - name: Create backup dir
+         file:
+           path: "/tmp/backups/{{ inventory_hostname }}"
+           state: directory
+           recurse: yes
+
+       - name: Copy backup files into /tmp/backups/ (eos)
+         copy:
+           src: "{{ backup_eos_location.backup_path }}"
+           dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
+         when: "'eos' in group_names"
+
+       - name: Copy backup files into /tmp/backups/ (vyos)
+         copy:
+           src: "{{ backup_vyos_location.backup_path }}"
+           dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
+         when: "'vyos' in group_names"
+
+Running the playbook
+--------------------
+
+To run the playbook, run the following from a console prompt:
+
+.. code-block:: console
+
+   ansible-playbook -i inventory fetch-facts.yml
+
+This should return output similar to the following:
+
+.. code-block:: console
+
+   PLAY RECAP
+   eos01.example.net          : ok=7    changed=2    unreachable=0    failed=0
+   ios01.example.net          : ok=7    changed=2    unreachable=0    failed=0
+   vyos01.example.net         : ok=6    changed=2    unreachable=0    failed=0
+
+Next, look at the contents of the file we created containing the switch facts:
+
+.. code-block:: console
+
+   cat /tmp/switch-facts
+
+You can also look at the backup files:
+
+.. code-block:: console
+
+   find /tmp/backups
+
+
+If `ansible-playbook` fails, please follow the debug steps in :doc:`network_debug_troubleshooting`.
+
+
+Implementation Notes
+====================
+
+
+Demo variables
+--------------
+
+Although these tasks are not needed to write data to disk, they are used in this example to demonstrate some methods of accessing facts about the given devices or a named host.
+
+Ansible ``hostvars`` allows you to access variables from a named host. Without this we would return the details for the current host, rather than the named host.
+
+For more information, see :ref:`magic_variables_and_hostvars`.
+
+Get running configuration
+-------------------------
+
+The :ref:`eos_config <eos_config>` and :ref:`vyos_config <vyos_config>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
+
+To demonstrate how we can move the backup file to a different location we ``register`` the result and use the ``backup_path`` return value as source location to move the file into ``/tmp/backups/`` directory which we have created.
+
+Note that when using variables from tasks in this way we use double quotes (``"``) and double curly-brackets (``{{...}}`` to tell Ansible that this is a variable.
+
+Troubleshooting
+===============
+
+If you receive an connection error please double check the inventory and Playbook for typos or missing lines, if the issue still occurs follow the debug steps in :doc:`network_debug_troubleshooting`.
+
+
+Platform specific notes
+========================
+
+Juniper (junos)
+---------------
+
+From Ansible 2.5 the Juniper (``junos_*``) modules support netconf. This operates in the same was as the ``network_cli`` examples, apart from the ``netconf`` connection method must be specified:
+
+**group_vars/junos.yml**
+
+.. code-block:: yaml
+
+   ansible_connection: netconf
+   ansible_network_os: junos
+
+To enable ``netconf`` use the :ref:`junos_netconf <junos_netconf>` module with ``network_cli``.
+
+.. seealso::
+
+  * Network landing page
+  * intro_inventory
+  * playbooks_best_practices.html#best-practices-for-variables-and-vaults
+
+
+
+

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -237,7 +237,7 @@ Next, create a playbook file called ``facts-demo.yml`` containing the following:
            var: hostvars['vyos01.example.net']
 
        - name: Write facts to disk using a template
-copy:
+           copy:
            content: |
              #jinja2: lstrip_blocks: True
              EOS device info:

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -126,7 +126,7 @@ The "Vault" feature of Ansible allows keeping sensitive data such as passwords o
 
   The ansible-connection setting tells Ansible how it should connect to a remote device. When working with Ansible Networking, setting this to ``ansible_connection: network_cli`` informs Ansible that the remote node is a network device with a limited execution environment. Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
 :ansible_network_os:
-  Informs Ansible which Network platform this hosts corresponds to. This is required when using ``network_cli``
+  Informs Ansible which Network platform this hosts corresponds to. This is required when using ``network_cli`` or ``netconf``.
 :ansible_user: The user to connect to the remote device (switch) as. Without this the user that is running ``ansible-playbook`` would be used.
   Specifies which user on the network device the connection
 :ansible_ssh_pass:
@@ -150,7 +150,7 @@ Certain network platforms, such as eos and ios, have the concept of different pr
    ansible_become: yes
    ansible_become_method: enable
 
-For more information, see the :doc:`Ansible Privilege Escalation<become>` guide.
+For more information, see the :ref:`using become with network modules<become-and-networks>` guide.
 
 
 Jump hosts
@@ -215,15 +215,15 @@ Next, create a playbook file called ``facts-demo.yml`` containing the following:
        #
        - name: Gather facts (eos)
          eos_facts:
-         when: "'eos' in group_names"
+         when: ansible_network_os == 'eos'
 
        - name: Gather facts (ops)
          ios_facts:
-         when: "'ios' in group_names"
+         when: ansible_network_os == 'ios'
 
        - name: Gather facts (vyos)
          vyos_facts:
-         when: "'vyos' in group_names"
+         when: ansible_network_os == 'vyos'
 
        ###
        # Demonstrate variables
@@ -274,13 +274,13 @@ Next, create a playbook file called ``facts-demo.yml`` containing the following:
          eos_config:
            backup: yes
          register: backup_eos_location
-         when: "'eos' in group_names"
+         when: ansible_network_os == 'eos'
 
        - name: backup switch (vyos)
          vyos_config:
            backup: yes
          register: backup_vyos_location
-         when: "'vyos' in group_names"
+         when: ansible_network_os == 'vyos'
 
        - name: Create backup dir
          file:
@@ -292,13 +292,13 @@ Next, create a playbook file called ``facts-demo.yml`` containing the following:
          copy:
            src: "{{ backup_eos_location.backup_path }}"
            dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
-         when: "'eos' in group_names"
+         when: ansible_network_os == 'eos'
 
        - name: Copy backup files into /tmp/backups/ (vyos)
          copy:
            src: "{{ backup_vyos_location.backup_path }}"
            dest: "/tmp/backups/{{ inventory_hostname }}/{{ inventory_hostname }}.bck"
-         when: "'vyos' in group_names"
+         when: ansible_network_os == 'vyos'
 
 Running the playbook
 --------------------

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -363,9 +363,9 @@ If you receive an connection error please double check the inventory and Playboo
 
 .. seealso::
 
-  * intro_network
-  * intro_inventory
-  * playbooks_best_practices.html#best-practices-for-variables-and-vaults
+  * :doc:`intro_network`
+  * :doc:`intro_inventory`
+  * :ref:`Vault best practices <best-practices-for-variables-and-vaults>`
 
 
 

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -361,27 +361,9 @@ Troubleshooting
 
 If you receive an connection error please double check the inventory and Playbook for typos or missing lines, if the issue still occurs follow the debug steps in :doc:`network_debug_troubleshooting`.
 
-
-Platform specific notes
-========================
-
-Juniper (junos)
----------------
-
-From Ansible 2.5 the Juniper (``junos_*``) modules support netconf. This operates in the same was as the ``network_cli`` examples, apart from the ``netconf`` connection method must be specified:
-
-**group_vars/junos.yml**
-
-.. code-block:: yaml
-
-   ansible_connection: netconf
-   ansible_network_os: junos
-
-To enable ``netconf`` use the :ref:`junos_netconf <junos_netconf>` module with ``network_cli``.
-
 .. seealso::
 
-  * Network landing page
+  * intro_network
   * intro_inventory
   * playbooks_best_practices.html#best-practices-for-variables-and-vaults
 

--- a/docs/docsite/rst/network_best_practices_2.5.rst
+++ b/docs/docsite/rst/network_best_practices_2.5.rst
@@ -64,7 +64,7 @@ In our example, the inventory file defines the groups ``eos``, ``ios``, ``vyos``
 Connection & Credentials (group_vars)
 -------------------------------------
 
-As Ansible is a flexible tool there are a number of ways of specifying connection information & credentials. We believe however that the best was is to use ``group_vars``.
+Because Ansible is a flexible tool, there are a number of ways to specify connection information and credentials. We recommend using ``group_vars``.
 
 **group_vars/eos.yml**
 
@@ -118,13 +118,13 @@ As Ansible is a flexible tool there are a number of ways of specifying connectio
 
 .. FIXME FUTURE Gundalow - Link to network auth & proxy page (to be written)
 
-.. warning:: Never store passwords in plain text
+.. warning:: Never store passwords in plain text.
 
-The "Vault" feature of Ansible allows keeping sensitive data such as passwords or keys in encrypted files, rather than as plain text in your playbooks or roles. These vault files can then be distributed or placed in source control. See :doc:`playbooks_vault` for more information.
+The "Vault" feature of Ansible allows you to keep sensitive data such as passwords or keys in encrypted files, rather than as plain text in your playbooks or roles. These vault files can then be distributed or placed in source control. See :doc:`playbooks_vault` for more information.
 
 :ansible_connection:
 
-  The ansible-connection setting tells Ansible how it should connect to a remote device. When working with Ansible Networking, setting this to ``ansible_connection: network_cli`` informs Ansible that the remote node is a network device with a limited execution environment. Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
+  Ansible uses the ansible-connection setting to determine how to connect to a remote device. When working with Ansible Networking, set this to ``network_cli`` so Ansible treats the remote node as a network device with a limited execution environment. Without this setting, Ansible would attempt to use ssh to connect to the remote and execute the Python script on the network device, which would fail because Python generally isn't available on network devices.
 :ansible_network_os:
   Informs Ansible which Network platform this hosts corresponds to. This is required when using ``network_cli`` or ``netconf``.
 :ansible_user: The user to connect to the remote device (switch) as. Without this the user that is running ``ansible-playbook`` would be used.
@@ -352,14 +352,14 @@ Get running configuration
 
 The :ref:`eos_config <eos_config>` and :ref:`vyos_config <vyos_config>` modules have a ``backup:`` option that when set will cause the module to create a full backup of the current ``running-config`` from the remote device before any changes are made. The backup file is written to the ``backup`` folder in the playbook root directory. If the directory does not exist, it is created.
 
-To demonstrate how we can move the backup file to a different location we ``register`` the result and use the ``backup_path`` return value as source location to move the file into ``/tmp/backups/`` directory which we have created.
+To demonstrate how we can move the backup file to a different location, we register the result and move the file to the path stored in ``backup_path``.
 
 Note that when using variables from tasks in this way we use double quotes (``"``) and double curly-brackets (``{{...}}`` to tell Ansible that this is a variable.
 
 Troubleshooting
 ===============
 
-If you receive an connection error please double check the inventory and Playbook for typos or missing lines, if the issue still occurs follow the debug steps in :doc:`network_debug_troubleshooting`.
+If you receive an connection error please double check the inventory and Playbook for typos or missing lines. If the issue still occurs follow the debug steps in :doc:`network_debug_troubleshooting`.
 
 .. seealso::
 


### PR DESCRIPTION
##### SUMMARY
Document best practices for 2.5 Networking, which details:

* Correct way for credentials to be specified
* How to use ``network_cli``
* How to use ``netconf``
* What become mode is, and how to use it

This is best practice. It is assumed readers will have good working Ansible and Ansible Network knowledge by this point


In future PRs the following will be added
* Link to platform specific guides (eAPI, NETCONF, NXAPI, etc)
* A separate guide for Ansible 21.->2.4 will be created

##### ISSUE TYPE
 - Docs Pull Request

