### PR TITLE
Fix authorize in net agnostic modules

### DIFF
--- a/lib/ansible/modules/network/eos/eos_banner.py
+++ b/lib/ansible/modules/network/eos/eos_banner.py
@@ -130,9 +130,7 @@ def map_config_to_obj(module):
     output = run_commands(module, ['show banner %s' % module.params['banner']])
     obj = {'banner': module.params['banner'], 'state': 'absent'}
     if output:
-        if module.params['transport'] == 'cli':
-            obj['text'] = output[0]
-        else:
+        if module.params['transport'] == 'eapi':
             # On EAPI we need to extract the banner text from dict key
             # 'loginBanner'
             if module.params['banner'] == 'login':
@@ -141,6 +139,8 @@ def map_config_to_obj(module):
                 banner_response_key = 'motd'
             if isinstance(output[0], dict) and banner_response_key in output[0].keys():
                 obj['text'] = output[0]
+        else:
+            obj['text'] = output[0]
         obj['state'] = 'present'
     return obj
 

--- a/lib/ansible/plugins/action/net_base.py
+++ b/lib/ansible/plugins/action/net_base.py
@@ -70,6 +70,7 @@ class ActionModule(ActionBase):
             if 'authorize' in self.provider.keys():
                 play_context.become = self.provider['authorize'] or False
                 play_context.become_pass = self.provider['auth_pass']
+                play_context.become_method = 'enable'
 
             if self._play_context.connection == 'local':
                 socket_path = self._start_connection(play_context)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Also throw a change in for net_banner on eos over network_cli. This might need to be done more across eos (and maybe nxos?) as we assume `transport` is populated a lot.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/action/net_base

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```