### PR TITLE
Fix a small typo (RFX->RFC) in vault.rst

### DIFF
--- a/docs/docsite/rst/vault.rst
+++ b/docs/docsite/rst/vault.rst
@@ -400,6 +400,6 @@ hexlify()'ied result of:
       - the plaintext
 
         - the original plaintext
-        - padding up to the AES256 blocksize. (The data used for padding is based on `RFX5652 <https://tools.ietf.org/html/rfc5652#section-6.3>`_)
+        - padding up to the AES256 blocksize. (The data used for padding is based on `RFC5652 <https://tools.ietf.org/html/rfc5652#section-6.3>`_)
 
 


### PR DESCRIPTION
A small typo: RFX -> RFC.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request
