### PR TITLE
Add missing comma in lists

### DIFF
--- a/lib/ansible/modules/cloud/misc/virt.py
+++ b/lib/ansible/modules/cloud/misc/virt.py
@@ -120,7 +120,7 @@ VIRT_SUCCESS = 0
 VIRT_UNAVAILABLE = 2
 
 ALL_COMMANDS = []
-VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'pause', 'shutdown', 'status', 'start', 'stop' 'undefine', 'unpause']
+VM_COMMANDS = ['create', 'define', 'destroy', 'get_xml', 'pause', 'shutdown', 'status', 'start', 'stop', 'undefine', 'unpause']
 HOST_COMMANDS = ['freemem', 'info', 'list_vms', 'nodeinfo', 'virttype']
 ALL_COMMANDS.extend(VM_COMMANDS)
 ALL_COMMANDS.extend(HOST_COMMANDS)

--- a/lib/ansible/modules/network/nxos/nxos_bgp.py
+++ b/lib/ansible/modules/network/nxos/nxos_bgp.py
@@ -615,7 +615,7 @@ def main():
         enforce_first_as=dict(required=False, type='bool'),
         event_history_cli=dict(required=False, choices=['true', 'false', 'default', 'size_small', 'size_medium', 'size_large', 'size_disable']),
         event_history_detail=dict(required=False, choices=['true', 'false', 'default', 'size_small', 'size_medium', 'size_large', 'size_disable']),
-        event_history_events=dict(required=False, choices=['true', 'false', 'default' 'size_small', 'size_medium', 'size_large', 'size_disable']),
+        event_history_events=dict(required=False, choices=['true', 'false', 'default', 'size_small', 'size_medium', 'size_large', 'size_disable']),
         event_history_periodic=dict(required=False, choices=['true', 'false', 'default', 'size_small', 'size_medium', 'size_large', 'size_disable']),
         fast_external_fallover=dict(required=False, type='bool'),
         flush_routes=dict(required=False, type='bool'),

--- a/lib/ansible/modules/network/panos/panos_security_policy.py
+++ b/lib/ansible/modules/network/panos/panos_security_policy.py
@@ -280,7 +280,7 @@ def security_rule_exists(device, sec_rule):
         # look for only pre-rulebase ATM
         rule_base = pandevice.policies.PreRulebase.refreshall(device)
 
-    match_check = ['name', 'description', 'group_profile', 'antivirus', 'vulnerability'
+    match_check = ['name', 'description', 'group_profile', 'antivirus', 'vulnerability',
                    'spyware', 'url_filtering', 'file_blocking', 'data_filtering',
                    'wildfire_analysis', 'type', 'action', 'tag', 'log_start', 'log_end']
     list_check = ['tozone', 'fromzone', 'source', 'source_user', 'destination', 'category',

--- a/lib/ansible/modules/network/panos/panos_security_rule.py
+++ b/lib/ansible/modules/network/panos/panos_security_rule.py
@@ -291,7 +291,7 @@ def find_rule(rulebase, rule_name):
 
 def rule_is_match(propose_rule, current_rule):
 
-    match_check = ['name', 'description', 'group_profile', 'antivirus', 'vulnerability'
+    match_check = ['name', 'description', 'group_profile', 'antivirus', 'vulnerability',
                    'spyware', 'url_filtering', 'file_blocking', 'data_filtering',
                    'wildfire_analysis', 'type', 'action', 'tag', 'log_start', 'log_end']
     list_check = ['tozone', 'fromzone', 'source', 'source_user', 'destination', 'category',


### PR DESCRIPTION
##### SUMMARY
This fix adds missing comma in different modules.
This removes implicit string concatenation in given list.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/misc/virt.py
lib/ansible/modules/network/nxos/nxos_bgp.py lib/ansible/modules/network/panos/panos_security_policy.py lib/ansible/modules/network/panos/panos_security_rule.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```