### PR TITLE
Add ability to append suffix to host names for Cloudforms Inventory

### DIFF
--- a/contrib/inventory/cloudforms.ini
+++ b/contrib/inventory/cloudforms.ini
@@ -27,6 +27,9 @@ clean_group_keys = True
 # Explode tags into nested groups / subgroups
 nest_tags = False
 
+# If set, ensure host name are suffixed with this value
+# suffix = example.org
+
 [cache]
 
 # Maximum time to trust the cache in seconds

--- a/contrib/inventory/cloudforms.ini
+++ b/contrib/inventory/cloudforms.ini
@@ -28,7 +28,8 @@ clean_group_keys = True
 nest_tags = False
 
 # If set, ensure host name are suffixed with this value
-# suffix = example.org
+# Note: This suffix *must* include the leading '.' as it is appended to the hostname as is
+# suffix = .example.org
 
 [cache]
 

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -174,6 +174,11 @@ class CloudFormsInventory(object):
         else:
             self.cloudforms_nest_tags = False
 
+        if config.has_option('cloudforms', 'suffix'):
+            self.cloudforms_suffix = config.get('cloudforms', 'suffix')
+        else:
+            self.cloudforms_suffix = None
+
         # Ansible related
         try:
             group_patterns = config.get('ansible', 'group_patterns')
@@ -280,6 +285,9 @@ class CloudFormsInventory(object):
             print("Updating cache...")
 
         for host in self._get_hosts():
+            if self.cloudforms_suffix is not None and not host['name'].endswith(self.cloudforms_suffix):
+                host['name'] = host['name'] + self.cloudforms_suffix
+
             # Ignore VMs that are not powered on
             if host['power_state'] != 'on':
                 if self.args.debug:

--- a/contrib/inventory/cloudforms.py
+++ b/contrib/inventory/cloudforms.py
@@ -29,6 +29,7 @@ from time import time
 import requests
 from requests.auth import HTTPBasicAuth
 import warnings
+from ansible.errors import AnsibleError
 
 try:
     import json
@@ -176,6 +177,8 @@ class CloudFormsInventory(object):
 
         if config.has_option('cloudforms', 'suffix'):
             self.cloudforms_suffix = config.get('cloudforms', 'suffix')
+            if self.cloudforms_suffix[0] != '.':
+                raise AnsibleError('Leading fullstop is required for Cloudforms suffix')
         else:
             self.cloudforms_suffix = None
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Allows for use of a suffix that will be appended to host names returned
from Cloudforms API if that suffix is not present.

For example with a suffix of 'example.org', the following results
would be shown for a particular Cloudforms host name:
someexample -> someexample.example.org
someexample.example.org -> someexample.example.org

The main use-case for this is when Cloudforms has short names rather
than FQDN and there is a desire to to use the FQDN as the name.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = [u'/Users/653321/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.1.0/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The primary use for this PR is to allow names to be shared across Inventory Sources in AWX as per PR https://github.com/ansible/awx/pull/769

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
