### PR TITLE
Deprecate Entity, EntityCollection and use subspec in network modules

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1929,14 +1929,23 @@ class AnsibleModule(object):
 
                 self._options_context.append(k)
 
+                key = None
+                for (name, value) in spec.items():
+                    # specifies how to map a single value to spec
+                    if value.get('key'):
+                        key = name
+                        break
+
                 if isinstance(params[k], dict):
                     elements = [params[k]]
                 else:
                     elements = params[k]
 
-                for param in elements:
+                for index, param in enumerate(elements):
                     if not isinstance(param, dict):
-                        self.fail_json(msg="value of %s must be of type dict or list of dict" % k)
+                        if key is None:
+                            self.fail_json(msg="options spec require a key argument to map it to a single value '%s'" % param)
+                        elements[index] = param = {key: param}
 
                     self._set_fallbacks(spec, param)
                     options_aliases = self._handle_aliases(spec, param)

--- a/lib/ansible/module_utils/network/common/utils.py
+++ b/lib/ansible/module_utils/network/common/utils.py
@@ -65,6 +65,10 @@ def sort_list(val):
 class Entity(object):
     """Transforms a dict to with an argument spec
 
+    This class has been deprecated as of Ansible 2.5 and will be
+    removed from the code in future release.
+    Please use the suboptions in module argument spec instead.
+
     This class will take a dict and apply an Ansible argument spec to the
     values.  The resulting dict will contain all of the keys in the param
     with appropriate values set.
@@ -183,7 +187,12 @@ class Entity(object):
 
 
 class EntityCollection(Entity):
-    """Extends ```Entity``` to handle a list of dicts """
+    """Extends ```Entity``` to handle a list of dicts
+
+    This class has been deprecated as of Ansible 2.5 and will be
+    removed from the code in future release.
+    Please use the suboptions in module argument spec instead.
+    """
 
     def __call__(self, iterable, strict=True):
         if iterable is None:
@@ -198,11 +207,21 @@ class EntityCollection(Entity):
 # these two are for backwards compatibility and can be removed once all of the
 # modules that use them are updated
 class ComplexDict(Entity):
+    """
+    This class has been deprecated as of Ansible 2.5 and will be
+    removed from the code in future release.
+    Please use the suboptions in module argument spec instead.
+    """
     def __init__(self, attrs, module, *args, **kwargs):
         super(ComplexDict, self).__init__(module, attrs, *args, **kwargs)
 
 
 class ComplexList(EntityCollection):
+    """
+    This class has been deprecated as of Ansible 2.5 and will be
+    removed from the code in future release.
+    Please use the suboptions in module argument spec instead.
+    """
     def __init__(self, attrs, module, *args, **kwargs):
         super(ComplexList, self).__init__(module, attrs, *args, **kwargs)
 

--- a/lib/ansible/module_utils/network/ios/ios.py
+++ b/lib/ansible/module_utils/network/ios/ios.py
@@ -27,8 +27,9 @@
 #
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
-from ansible.module_utils.network.common.utils import to_list, ComplexList
 from ansible.module_utils.connection import exec_command
+from ansible.module_utils.network.common.utils import to_list
+from ansible.module_utils.six import string_types
 
 _DEVICE_CONFIGS = {}
 
@@ -100,20 +101,12 @@ def get_config(module, flags=None):
         return cfg
 
 
-def to_commands(module, commands):
-    spec = {
-        'command': dict(key=True),
-        'prompt': dict(),
-        'answer': dict()
-    }
-    transform = ComplexList(spec, module)
-    return transform(commands)
-
-
 def run_commands(module, commands, check_rc=True):
     responses = list()
-    commands = to_commands(module, to_list(commands))
-    for cmd in commands:
+    for cmd in to_list(commands):
+        if isinstance(cmd, string_types):
+            cmd = {'command': cmd}
+
         cmd = module.jsonify(cmd)
         rc, out, err = exec_command(module, cmd)
         if check_rc and rc != 0:

--- a/lib/ansible/module_utils/network/iosxr/iosxr.py
+++ b/lib/ansible/module_utils/network/iosxr/iosxr.py
@@ -79,12 +79,6 @@ iosxr_argument_spec = {
     'provider': dict(type='dict', options=iosxr_provider_spec)
 }
 
-command_spec = {
-    'command': dict(),
-    'prompt': dict(default=None),
-    'answer': dict(default=None)
-}
-
 iosxr_top_spec = {
     'host': dict(removed_in_version=2.9),
     'port': dict(removed_in_version=2.9, type='int'),

--- a/lib/ansible/modules/network/eos/eos_command.py
+++ b/lib/ansible/modules/network/eos/eos_command.py
@@ -140,9 +140,8 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.six import string_types
 from ansible.module_utils.network.common.parsing import Conditional
-from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.network.eos.eos import run_commands
-from ansible.module_utils.network.eos.eos import eos_argument_spec, check_args
+from ansible.module_utils.network.eos.eos import eos_argument_spec
 
 VALID_KEYS = ['command', 'output', 'prompt', 'response']
 
@@ -157,16 +156,7 @@ def to_lines(stdout):
 
 
 def parse_commands(module, warnings):
-    spec = dict(
-        command=dict(key=True),
-        output=dict(),
-        prompt=dict(),
-        answer=dict()
-    )
-
-    transform = ComplexList(spec, module)
-    commands = transform(module.params['commands'])
-
+    commands = module.params['commands']
     if module.check_mode:
         for item in list(commands):
             if not item['command'].startswith('show'):
@@ -189,8 +179,15 @@ def to_cli(obj):
 def main():
     """entry point for module execution
     """
+    command_spec = dict(
+        command=dict(key=True),
+        output=dict(),
+        prompt=dict(),
+        answer=dict()
+    )
+
     argument_spec = dict(
-        commands=dict(type='list', required=True),
+        commands=dict(type='list', elements='dict', options=command_spec, required=True),
 
         wait_for=dict(type='list', aliases=['waitfor']),
         match=dict(default='all', choices=['all', 'any']),
@@ -207,7 +204,6 @@ def main():
     result = {'changed': False}
 
     warnings = list()
-    check_args(module, warnings)
     commands = parse_commands(module, warnings)
     if warnings:
         result['warnings'] = warnings

--- a/lib/ansible/modules/network/eos/eos_system.py
+++ b/lib/ansible/modules/network/eos/eos_system.py
@@ -129,7 +129,6 @@ session_name:
 import re
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.network.eos.eos import load_config, get_config
 from ansible.module_utils.network.eos.eos import eos_argument_spec
 
@@ -270,24 +269,10 @@ def map_params_to_obj(module):
     obj = {
         'hostname': module.params['hostname'],
         'domain_name': module.params['domain_name'],
-        'domain_list': module.params['domain_list']
+        'domain_list': module.params['domain_list'],
+        'lookup_source': module.params['lookup_source'],
+        'name_servers': module.params['name_servers'],
     }
-
-    lookup_source = ComplexList(dict(
-        interface=dict(key=True),
-        vrf=dict()
-    ), module)
-
-    name_servers = ComplexList(dict(
-        server=dict(key=True),
-        vrf=dict(default='default')
-    ), module)
-
-    for arg, cast in [('lookup_source', lookup_source), ('name_servers', name_servers)]:
-        if module.params[arg] is not None:
-            obj[arg] = cast(module.params[arg])
-        else:
-            obj[arg] = None
 
     return obj
 
@@ -295,6 +280,16 @@ def map_params_to_obj(module):
 def main():
     """ main entry point for module execution
     """
+    lookup_source_spec = dict(
+        interface=dict(key=True),
+        vrf=dict()
+    )
+
+    name_servers_spec = dict(
+        server=dict(key=True),
+        vrf=dict()
+    )
+
     argument_spec = dict(
         hostname=dict(),
 
@@ -302,10 +297,10 @@ def main():
         domain_list=dict(type='list', aliases=['domain_search']),
 
         # { interface: <str>, vrf: <str> }
-        lookup_source=dict(type='list'),
+        lookup_source=dict(type='list', elements='dict', options=lookup_source_spec),
 
         # { server: <str>; vrf: <str> }
-        name_servers=dict(type='list'),
+        name_servers=dict(type='list', elements='dict', options=name_servers_spec),
 
         state=dict(default='present', choices=['present', 'absent'])
     )
@@ -332,6 +327,7 @@ def main():
         result['changed'] = True
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -127,8 +127,8 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.iosxr.iosxr import run_command, iosxr_argument_spec
-from ansible.module_utils.network.iosxr.iosxr import command_spec
 from ansible.module_utils.network.common.parsing import Conditional
+from ansible.module_utils.network.common.utils import to_list
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
@@ -142,7 +142,7 @@ def to_lines(stdout):
 
 def parse_commands(module, warnings):
     commands = module.params['commands']
-    for item in list(commands):
+    for item in to_list(commands):
         try:
             command = item['command']
         except Exception:
@@ -163,8 +163,14 @@ def parse_commands(module, warnings):
 
 
 def main():
+    command_spec = dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    )
+
     spec = dict(
-        commands=dict(type='list', required=True),
+        commands=dict(type='list', elements='dict', options=command_spec, required=True),
 
         wait_for=dict(type='list', aliases=['waitfor']),
         match=dict(default='all', choices=['all', 'any']),
@@ -175,13 +181,10 @@ def main():
 
     spec.update(iosxr_argument_spec)
 
-    spec.update(command_spec)
-
     module = AnsibleModule(argument_spec=spec,
                            supports_check_mode=True)
 
     warnings = list()
-
     commands = parse_commands(module, warnings)
 
     wait_for = module.params['wait_for'] or list()

--- a/lib/ansible/modules/network/iosxr/iosxr_command.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_command.py
@@ -143,10 +143,7 @@ def to_lines(stdout):
 def parse_commands(module, warnings):
     commands = module.params['commands']
     for item in to_list(commands):
-        try:
-            command = item['command']
-        except Exception:
-            command = item
+        command = item['command']
         if module.check_mode and not command.startswith('show'):
             warnings.append(
                 'only show commands are supported when using check mode, not '

--- a/lib/ansible/modules/network/nxos/nxos_command.py
+++ b/lib/ansible/modules/network/nxos/nxos_command.py
@@ -147,8 +147,7 @@ import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.network.common.parsing import Conditional, FailedConditionalError
-from ansible.module_utils.network.common.utils import ComplexList
-from ansible.module_utils.network.nxos.nxos import check_args, nxos_argument_spec, run_commands
+from ansible.module_utils.network.nxos.nxos import nxos_argument_spec, run_commands
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
@@ -163,14 +162,7 @@ def to_lines(stdout):
 
 
 def parse_commands(module, warnings):
-    transform = ComplexList(dict(
-        command=dict(key=True),
-        output=dict(),
-        prompt=dict(),
-        answer=dict()
-    ), module)
-
-    commands = transform(module.params['commands'])
+    commands = module.params['commands']
 
     if module.check_mode:
         for item in list(commands):
@@ -194,9 +186,16 @@ def to_cli(obj):
 def main():
     """entry point for module execution
     """
+    command_spec = dict(
+        command=dict(key=True),
+        output=dict(),
+        prompt=dict(),
+        answer=dict()
+    )
+
     argument_spec = dict(
         # { command: <str>, output: <str>, prompt: <str>, response: <str> }
-        commands=dict(type='list', required=True),
+        commands=dict(type='list', elements='dict', options=command_spec, required=True),
 
         wait_for=dict(type='list', aliases=['waitfor']),
         match=dict(default='all', choices=['any', 'all']),
@@ -213,7 +212,6 @@ def main():
     result = {'changed': False}
 
     warnings = list()
-    check_args(module, warnings)
     commands = parse_commands(module, warnings)
     result['warnings'] = warnings
 

--- a/lib/ansible/modules/network/vyos/vyos_command.py
+++ b/lib/ansible/modules/network/vyos/vyos_command.py
@@ -137,7 +137,6 @@ import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
 from ansible.module_utils.network.common.parsing import Conditional
-from ansible.module_utils.network.common.utils import ComplexList
 from ansible.module_utils.six import string_types
 from ansible.module_utils.network.vyos.vyos import run_commands
 from ansible.module_utils.network.vyos.vyos import vyos_argument_spec
@@ -151,12 +150,7 @@ def to_lines(stdout):
 
 
 def parse_commands(module, warnings):
-    command = ComplexList(dict(
-        command=dict(key=True),
-        prompt=dict(),
-        answer=dict(),
-    ), module)
-    commands = command(module.params['commands'])
+    commands = module.params['commands']
     items = []
 
     for item in commands:
@@ -170,8 +164,15 @@ def parse_commands(module, warnings):
 
 
 def main():
+
+    command_spec = dict(
+        command=dict(key=True),
+        prompt=dict(),
+        answer=dict()
+    )
+
     spec = dict(
-        commands=dict(type='list', required=True),
+        commands=dict(type='list', elements='dict', options=command_spec, required=True),
 
         wait_for=dict(type='list', aliases=['waitfor']),
         match=dict(default='all', choices=['all', 'any']),

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -575,6 +575,25 @@ class TestModuleUtilsBasic(ModuleTestCase):
                 supports_check_mode=True,
             )
 
+        # should test ok, handles key argument
+        key_spec = dict(
+        foo=dict(key=True),
+        bar=dict()
+        )
+        args = json.dumps(dict(ANSIBLE_MODULE_ARGS={'foobar': ['test-1', 'test-2']}))
+        with swap_stdin_and_argv(stdin_data=args):
+            basic._ANSIBLE_ARGS = None
+            am = basic.AnsibleModule(
+                argument_spec=dict(foobar = dict(type='list', elements='dict', options=key_spec, required=True)),
+                no_log=True,
+                check_invalid_arguments=False,
+                add_file_common_args=True,
+                supports_check_mode=True
+            )
+            self.assertEqual(am.params['foobar'][0]['foo'], 'test-1')
+            self.assertEqual(am.params['foobar'][1]['foo'], 'test-2')
+
+
     def test_module_utils_basic_ansible_module_type_check(self):
         from ansible.module_utils import basic
 

--- a/test/units/module_utils/test_basic.py
+++ b/test/units/module_utils/test_basic.py
@@ -576,15 +576,12 @@ class TestModuleUtilsBasic(ModuleTestCase):
             )
 
         # should test ok, handles key argument
-        key_spec = dict(
-        foo=dict(key=True),
-        bar=dict()
-        )
+        key_spec = dict(foo=dict(key=True), bar=dict())
         args = json.dumps(dict(ANSIBLE_MODULE_ARGS={'foobar': ['test-1', 'test-2']}))
         with swap_stdin_and_argv(stdin_data=args):
             basic._ANSIBLE_ARGS = None
             am = basic.AnsibleModule(
-                argument_spec=dict(foobar = dict(type='list', elements='dict', options=key_spec, required=True)),
+                argument_spec=dict(foobar=dict(type='list', elements='dict', options=key_spec, required=True)),
                 no_log=True,
                 check_invalid_arguments=False,
                 add_file_common_args=True,
@@ -592,7 +589,6 @@ class TestModuleUtilsBasic(ModuleTestCase):
             )
             self.assertEqual(am.params['foobar'][0]['foo'], 'test-1')
             self.assertEqual(am.params['foobar'][1]['foo'], 'test-2')
-
 
     def test_module_utils_basic_ansible_module_type_check(self):
         from ansible.module_utils import basic


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #31323
*  As per proposal https://github.com/ansible/proposals/issues/76
   deprecate use of Entity, EntityCollection, ComplexDict, ComplexList
   and use subspec instead.

*  Refactor ios modules
*  Refactor nxos modules
*  Refactor iosxr modules
* Refactor vyos modules
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
module_utils/basic.py
module_utils/network/common/utils.py
module_utils/network/ios/ios.py
ios_command

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
