### PR TITLE
fixed: win_copy failure from a VirtualBox share to a local path

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -87,14 +87,6 @@ Function Copy-File($source, $dest) {
         }
         $diff += "+$dest`n"
 
-        # make sure we set the attributes accordingly
-        if (-not $check_mode) {
-            $source_file = Get-Item -Path $source -Force
-            $dest_file = Get-Item -Path $dest -Force
-            $dest_file.Attributes = $source_file.Attributes
-            $dest_file.SetAccessControl($source_file.GetAccessControl())
-        }
-
         $result.changed = $true
     }
 
@@ -119,13 +111,6 @@ Function Copy-Folder($source, $dest) {
         New-Item -Path $dest -ItemType Container -WhatIf:$check_mode | Out-Null
         $diff += "+$dest\`n"
         $result.changed = $true
-
-        if (-not $check_mode) {
-            $source_folder = Get-Item -Path $source -Force
-            $dest_folder = Get-Item -Path $source -Force
-            $dest_folder.Attributes = $source_folder.Attributes
-            $dest_folder.SetAccessControl($source_folder.GetAccessControl())
-        }
     }
 
     $child_items = Get-ChildItem -Path $source -Force


### PR DESCRIPTION
##### SUMMARY
In the case when a source file/folder is on a VirtualBox share then `win_copy` task fails.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/windows/win_copy.ps1`

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /data/ansible/ansible.cfg
  configured module search path = [u'/home/server/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Create a playbook with a `win_copy` task
```
  - name: Copy file from VirtualBox share
    win_copy:
      src: \\vboxsvr\share\file
      dest: c:\local\path
      remote_src: true
```
Run it against a host

At first time task fails. But file `c:\local\path` appears (as it intended to). Subsequent task calls succeed (as file already exists).
##### before
```
TASK [Copy file from VirtualBox share] ********************************************************************************************************************************************************************************************
task path: /data/ansible/quickbuild-agents.yml:56
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/windows/win_copy.ps1
<172.20...> ESTABLISH WINRM CONNECTION FOR USER: IEUser on PORT 5985 TO 172.20...
EXEC (via pipeline wrapper)
fatal: [172.20...]: FAILED! => {
    "changed": false, 
    "dest": "c:\\local\\path", 
    "module_stderr": "An error occurred while creating the pipeline.\r\n    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordE \r\n   xception\r\n    + FullyQualifiedErrorId : RuntimeException\r\n \r\nException calling \"GetAccessControl\" with \"0\" argument(s): \"Method failed with \r\nunexpected error code 1.\"\r\nAt line:95 char:13\r\n+             $dest_file.SetAccessControl($source_file.GetAccessControl ...\r\n+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\r\n    + CategoryInfo          : NotSpecified: (:) [], ParentContainsErrorRecordE \r\n   xception\r\n    + FullyQualifiedErrorId : InvalidOperationException\r\n \r\n\r\n", 
    "module_stdout": "", 
    "msg": "MODULE FAILURE", 
    "rc": 1, 
    "src": "\\\\vboxsvr\\share\\file"
}
        to retry, use: --limit @/data/ansible/quickbuild-agents.retry
  
PLAY RECAP ********************************************************************************************************************************************************************************************************
172.20...             : ok=0    changed=0    unreachable=0    failed=1 
```

The reason is that `.GetAccessControl` method fails somehow for a file/folder on a VirtualBox share.

```
  PS c:\Users\vboxuser> $file = Get-Item -Path \\vboxsvr\share\file
  PS c:\Users\vboxuser> $file.GetAccessControl();
  Exception calling "GetAccessControl" with "0" argument(s): "Method
  failed with unexpected error code 1."
  ...
```

Fix it by suppressing the error, just print out a warning.
##### after
```
TASK [Copy file from VirtualBox share] ********************************************************************************************************************************************************************************************
task path: /data/ansible/quickbuild-agents.yml:56
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/windows/win_copy.ps1
<172.20...> ESTABLISH WINRM CONNECTION FOR USER: IEUser on PORT 5985 TO 172.20...
EXEC (via pipeline wrapper)
 [WARNING]: Fail to copy access control

changed: [172.20...] => {
    "changed": true, 
    "checksum": "8f9185b1fb80dee64e511e222c1a9742eff7837f", 
    "dest": "c:\\local\\path", 
    "operation": "file_copy", 
    "original_basename": "file", 
    "size": 134122400, 
    "src": "\\\\vboxsvr\\share\\file"
}
```

