### PR TITLE
docker_container: allow arbitrary log_driver

### DIFF
--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -182,16 +182,9 @@ options:
       - Setting this will force container to be restarted.
   log_driver:
     description:
-      - Specify the logging driver. Docker uses json-file by default.
-    choices:
-      - none
-      - json-file
-      - syslog
-      - journald
-      - gelf
-      - fluentd
-      - awslogs
-      - splunk
+      - Specify the logging driver. Docker uses I(json-file) by default.
+      - See L(here,https://docs.docker.com/config/containers/logging/configure/) for possible choices.
+    required: false
   log_options:
     description:
       - Dictionary of options specific to the chosen log_driver. See https://docs.docker.com/engine/admin/logging/overview/
@@ -2102,9 +2095,7 @@ def main():
         kill_signal=dict(type='str'),
         labels=dict(type='dict'),
         links=dict(type='list'),
-        log_driver=dict(type='str',
-                        choices=['none', 'json-file', 'syslog', 'journald', 'gelf', 'fluentd', 'awslogs', 'splunk'],
-                        default=None),
+        log_driver=dict(type='str'),
         log_options=dict(type='dict', aliases=['log_opt']),
         mac_address=dict(type='str'),
         memory=dict(type='str', default='0'),


### PR DESCRIPTION
##### SUMMARY

Docker supports [logging plugins](https://docs.docker.com/engine/admin/logging/plugins)
so it no longer makes sense to limit the log_driver option to a fixed set of choices.

This change allows any log_driver value to be used.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

docker_container (`lib/ansible/modules/cloud/docker/docker_container.py`)

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel b1f4ea6154) last updated 2017/12/05 12:28:34 (GMT +200)
  config file = /Users/vincentrischmann/.ansible.cfg
  configured module search path = [u'/Users/vincentrischmann/dev/devtools/ansible/library']
  ansible python module location = /Users/vincentrischmann/dev/devtools/ansible/lib/ansible
  executable location = /Users/vincentrischmann/dev/devtools/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```

##### ADDITIONAL INFORMATION
Tested with the following playbook:

```---
- hosts:
    - foo.bar.com

  tasks:
    - name: create the container
      docker_container:
        name: redis1
        image: redis
        log_driver: kafka-log-driver
        log_options:
          kafka-brokers: foobar:9092
          kafka-cluster-name: foo
          topic: logs
```

`kafka-log-driver` is our in house log driver that we installed as a plugin.

Here's the error without this patch:

```
[I] Vincents-MacBook-Pro ~/d/ansible (master ✚) $ ansible-playbook -D -i hosts playbooks/foobar.yml                                                                                                                                   

PLAY [foo.bar.com] **********************************************************************************************************************************************************************************************************************

TASK [create the container] ******************************************************************************************************************************************************************************************************************
fatal: [foo.bar.com]: FAILED! => {"changed": false, "msg": "value of log_driver must be one of: none, json-file, syslog, journald, gelf, fluentd, awslogs, splunk, got: internal-log-driver"}
	to retry, use: --limit @/Users/vincentrischmann/dev/ansible/playbooks/foobar.retry

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
foo.bar.com           : ok=0    changed=0    unreachable=0    failed=1

```

With the patch everything works fine:

```
[I] Vincents-MacBook-Pro ~/d/ansible (master ✚) $ ansible-playbook -D -i hosts playbooks/foobar.yml                                                                                                                                   

PLAY [foo.bar.com] **********************************************************************************************************************************************************************************************************************

TASK [create the container] ******************************************************************************************************************************************************************************************************************
changed: [foo.bar.com]

PLAY RECAP ***********************************************************************************************************************************************************************************************************************************
foo.bar.com           : ok=1    changed=1    unreachable=0    failed=0
```