### PR TITLE
StoragePoolFactsModule for HPE OneView

### DIFF
--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_pool_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_pool_facts.py
@@ -13,17 +13,17 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: oneview_storage_pool_facts
-short_description: Retrieve facts about one or more Storage Pools.
+short_description: Retrieve facts about one or more Storage Pools
 description:
     - Retrieve facts about one or more of the Storage Pools from OneView.
 version_added: "2.5"
 requirements:
     - "hpOneView >= 4.0.0"
 author:
-    - Priyanka Sood (@soodpr)
-    - Madhav Bharadwaj (@madhav-bharadwaj)
-    - Ricardo Galeno (@ricardogpsf)
     - Alex Monteiro (@aalexmonteiro)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Priyanka Sood (@soodpr)
+    - Ricardo Galeno (@ricardogpsf)
 options:
     name:
       description:
@@ -117,9 +117,9 @@ from ansible.module_utils.oneview import OneViewModuleBase
 class StoragePoolFactsModule(OneViewModuleBase):
     def __init__(self):
         argument_spec = dict(
-            name=dict(required=False, type='str'),
-            params=dict(required=False, type='dict'),
-            options=dict(required=False, type='list')
+            name=dict(type='str'),
+            params=dict(type='dict'),
+            options=dict(type='list')
         )
         super(StoragePoolFactsModule, self).__init__(additional_arg_spec=argument_spec)
         self.resource_client = self.oneview_client.storage_pools

--- a/lib/ansible/modules/remote_management/oneview/oneview_storage_pool_facts.py
+++ b/lib/ansible/modules/remote_management/oneview/oneview_storage_pool_facts.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2016-2017, Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: oneview_storage_pool_facts
+short_description: Retrieve facts about one or more Storage Pools.
+description:
+    - Retrieve facts about one or more of the Storage Pools from OneView.
+version_added: "2.5"
+requirements:
+    - "hpOneView >= 4.0.0"
+author:
+    - Priyanka Sood (@soodpr)
+    - Madhav Bharadwaj (@madhav-bharadwaj)
+    - Ricardo Galeno (@ricardogpsf)
+    - Alex Monteiro (@aalexmonteiro)
+options:
+    name:
+      description:
+        - Storage Pool name.
+    options:
+      description:
+        - "List with options to gather additional facts about Storage Pools.
+          Options allowed:
+          C(reachableStoragePools) gets the list of reachable Storage pools based on the network param.
+          If the network param is not specified it gets all of them."
+extends_documentation_fragment:
+    - oneview
+    - oneview.factsparams
+'''
+
+EXAMPLES = '''
+- name: Gather facts about all Storage Pools
+  oneview_storage_pool_facts:
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_pools
+
+- name: Gather paginated, filtered and sorted facts about Storage Pools
+  oneview_storage_pool_facts:
+    params:
+      start: 0
+      count: 3
+      sort: 'name:descending'
+      filter: status='OK'
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_pools
+
+- name: Gather facts about a Storage Pool by name
+  oneview_storage_pool_facts:
+    name: "CPG_FC-AO"
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_pools
+
+- name: Gather facts about the reachable Storage Pools
+  oneview_storage_pool_facts:
+    options:
+      - reachableStoragePools
+    params:
+      sort: 'name:ascending'
+      filter: status='OK'
+      networks:
+        - /rest/network/123456A
+        - /rest/network/123456B
+    hostname: 10.101.42.57
+    username: administrator
+    password: serveradmin
+    api_version: 500
+  no_log: true
+  delegate_to: localhost
+
+- debug: var=storage_pools_reachable_storage_pools
+'''
+
+RETURN = '''
+storage_pools:
+    description: Has all the OneView facts about the Storage Pools.
+    returned: Always, but can be null.
+    type: dict
+
+storage_pools_reachable_storage_pools:
+    description: Has all the OneView facts about the Reachable Storage Pools.
+    returned: Always, but can be null.
+    type: dict
+'''
+
+from ansible.module_utils.oneview import OneViewModuleBase
+
+
+class StoragePoolFactsModule(OneViewModuleBase):
+    def __init__(self):
+        argument_spec = dict(
+            name=dict(required=False, type='str'),
+            params=dict(required=False, type='dict'),
+            options=dict(required=False, type='list')
+        )
+        super(StoragePoolFactsModule, self).__init__(additional_arg_spec=argument_spec)
+        self.resource_client = self.oneview_client.storage_pools
+
+    def execute_module(self):
+        facts = {}
+        networks = self.facts_params.pop('networks', None)
+        if self.module.params.get('name'):
+            storage_pool = self.oneview_client.storage_pools.get_by('name', self.module.params['name'])
+        else:
+            storage_pool = self.oneview_client.storage_pools.get_all(**self.facts_params)
+
+        if networks:
+            self.facts_params['networks'] = networks
+
+        facts['storage_pools'] = storage_pool
+        self.__get_options(facts)
+        return dict(changed=False, ansible_facts=facts)
+
+    def __get_options(self, facts):
+        if self.options:
+            if self.options.get('reachableStoragePools'):
+                query_params = self.module.params.get('params') or {}
+                facts['storage_pools_reachable_storage_pools'] = \
+                    self.resource_client.get_reachable_storage_pools(**query_params)
+
+
+def main():
+    StoragePoolFactsModule().run()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/remote_management/oneview/hpe_test_utils.py
+++ b/test/units/modules/remote_management/oneview/hpe_test_utils.py
@@ -28,7 +28,7 @@ class OneViewBaseTest(object):
     @pytest.fixture(autouse=True)
     def setUp(self, mock_ansible_module, mock_ov_client, request):
         marker = request.node.get_marker('resource')
-        self.resource = getattr(mock_ov_client, "%s" % (marker.args))
+        self.resource = getattr(mock_ov_client, "%s" % (marker.kwargs['name']))
         self.mock_ov_client = mock_ov_client
         self.mock_ansible_module = mock_ansible_module
 
@@ -64,7 +64,7 @@ class OneViewBaseTest(object):
             mock_run.assert_called_once()
 
 
-class FactsParamsTest(OneViewBaseTest):
+class OneViewBaseFactsTest(OneViewBaseTest):
     def test_should_get_all_using_filters(self, testing_module):
         self.resource.get_all.return_value = []
 

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
@@ -14,12 +14,12 @@ PARAMS_GET_CONNECTED = dict(
 )
 
 
-@pytest.mark.resource(name='datacenters')
+@pytest.mark.resource(TestDatacenterFactsModule='datacenters')
 class TestDatacenterFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_datacenters(self):
         self.resource.get_all.return_value = {"name": "Data Center Name"}
 
-        self.mock_ansible_module.params = dict(config='config.json',)
+        self.mock_ansible_module.params = dict(config='config.json')
 
         DatacenterFactsModule().run()
 
@@ -68,6 +68,7 @@ class TestDatacenterFactsModule(OneViewBaseFactsTest):
             ansible_facts={'datacenter_visual_content': None,
                            'datacenters': []}
         )
+
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_datacenter_facts.py
@@ -5,7 +5,7 @@ import pytest
 
 from oneview_module_loader import OneViewModuleBase
 from ansible.modules.remote_management.oneview.oneview_datacenter_facts import DatacenterFactsModule
-from hpe_test_utils import FactsParamsTest
+from hpe_test_utils import OneViewBaseFactsTest
 
 PARAMS_GET_CONNECTED = dict(
     config='config.json',
@@ -14,14 +14,8 @@ PARAMS_GET_CONNECTED = dict(
 )
 
 
-@pytest.mark.resource('datacenters')
-class TestDatacenterFactsModule(FactsParamsTest):
-    @pytest.fixture(autouse=True)
-    def setUp(self, mock_ansible_module, mock_ov_client):
-        self.resource = mock_ov_client.datacenters
-        self.mock_ansible_module = mock_ansible_module
-        self.mock_ov_client = mock_ov_client
-
+@pytest.mark.resource(name='datacenters')
+class TestDatacenterFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_datacenters(self):
         self.resource.get_all.return_value = {"name": "Data Center Name"}
 
@@ -74,3 +68,6 @@ class TestDatacenterFactsModule(FactsParamsTest):
             ansible_facts={'datacenter_visual_content': None,
                            'datacenters': []}
         )
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_pool_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_pool_facts.py
@@ -1,0 +1,77 @@
+# Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.compat.tests import unittest
+from ansible.modules.remote_management.oneview.oneview_storage_pool_facts import StoragePoolFactsModule
+from hpe_test_utils import FactsParamsTestCase
+
+ERROR_MSG = 'Fake message error'
+
+PARAMS_GET_ALL = dict(
+    config='config.json',
+    name=None
+)
+
+PARAMS_GET_BY_NAME = dict(
+    config='config.json',
+    name="Test Storage Pools"
+)
+
+PARAMS_GET_REACHABLE_STORAGE_POOLS = dict(
+    config='config.json',
+    name="Test Storage Pools",
+    options=["reachableStoragePools"],
+    params={
+        'networks': ['rest/fake/network']
+    }
+)
+
+
+class StoragePoolFactsSpec(unittest.TestCase,
+                           FactsParamsTestCase):
+    def setUp(self):
+        self.configure_mocks(self, StoragePoolFactsModule)
+        self.storage_pools = self.mock_ov_client.storage_pools
+        FactsParamsTestCase.configure_client_mock(self, self.storage_pools)
+        self.mock_ov_client.api_version = 300
+
+    def test_should_get_all_storage_pool(self):
+        self.storage_pools.get_all.return_value = {"name": "Storage Pool Name"}
+        self.mock_ansible_module.params = PARAMS_GET_ALL
+
+        StoragePoolFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_pools=({"name": "Storage Pool Name"}))
+        )
+
+    def test_should_get_storage_pool_by_name(self):
+        self.storage_pools.get_by.return_value = {"name": "Storage Pool Name"}
+        self.mock_ansible_module.params = PARAMS_GET_BY_NAME
+
+        StoragePoolFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(storage_pools=({"name": "Storage Pool Name"}))
+        )
+
+    def test_should_get_reachable_storage_pools(self):
+        self.mock_ov_client.api_version = 500
+        self.storage_pools.get_by.return_value = {"name": "Storage Pool Name"}
+        self.storage_pools.get_reachable_storage_pools.return_value = [{'reachable': 'test'}]
+        self.mock_ansible_module.params = PARAMS_GET_REACHABLE_STORAGE_POOLS
+
+        StoragePoolFactsModule().run()
+
+        self.mock_ansible_module.exit_json.assert_called_once_with(
+            changed=False,
+            ansible_facts=dict(
+                storage_pools_reachable_storage_pools=[{'reachable': 'test'}],
+                storage_pools={"name": "Storage Pool Name"})
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_pool_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_pool_facts.py
@@ -27,7 +27,7 @@ PARAMS_GET_REACHABLE_STORAGE_POOLS = dict(
 )
 
 
-@pytest.mark.resource(name='storage_pools')
+@pytest.mark.resource(TestStoragePoolFactsModule='storage_pools')
 class TestStoragePoolFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_storage_pool(self):
         self.resource.get_all.return_value = {"name": "Storage Pool Name"}

--- a/test/units/modules/remote_management/oneview/test_oneview_storage_pool_facts.py
+++ b/test/units/modules/remote_management/oneview/test_oneview_storage_pool_facts.py
@@ -1,11 +1,11 @@
 # Copyright: (c) 2016-2017 Hewlett Packard Enterprise Development LP
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.compat.tests import unittest
-from ansible.modules.remote_management.oneview.oneview_storage_pool_facts import StoragePoolFactsModule
-from hpe_test_utils import FactsParamsTestCase
+import pytest
 
-ERROR_MSG = 'Fake message error'
+from oneview_module_loader import OneViewModuleBase
+from ansible.modules.remote_management.oneview.oneview_storage_pool_facts import StoragePoolFactsModule
+from hpe_test_utils import OneViewBaseFactsTest
 
 PARAMS_GET_ALL = dict(
     config='config.json',
@@ -27,16 +27,10 @@ PARAMS_GET_REACHABLE_STORAGE_POOLS = dict(
 )
 
 
-class StoragePoolFactsSpec(unittest.TestCase,
-                           FactsParamsTestCase):
-    def setUp(self):
-        self.configure_mocks(self, StoragePoolFactsModule)
-        self.storage_pools = self.mock_ov_client.storage_pools
-        FactsParamsTestCase.configure_client_mock(self, self.storage_pools)
-        self.mock_ov_client.api_version = 300
-
+@pytest.mark.resource(name='storage_pools')
+class TestStoragePoolFactsModule(OneViewBaseFactsTest):
     def test_should_get_all_storage_pool(self):
-        self.storage_pools.get_all.return_value = {"name": "Storage Pool Name"}
+        self.resource.get_all.return_value = {"name": "Storage Pool Name"}
         self.mock_ansible_module.params = PARAMS_GET_ALL
 
         StoragePoolFactsModule().run()
@@ -47,7 +41,7 @@ class StoragePoolFactsSpec(unittest.TestCase,
         )
 
     def test_should_get_storage_pool_by_name(self):
-        self.storage_pools.get_by.return_value = {"name": "Storage Pool Name"}
+        self.resource.get_by.return_value = {"name": "Storage Pool Name"}
         self.mock_ansible_module.params = PARAMS_GET_BY_NAME
 
         StoragePoolFactsModule().run()
@@ -59,8 +53,8 @@ class StoragePoolFactsSpec(unittest.TestCase,
 
     def test_should_get_reachable_storage_pools(self):
         self.mock_ov_client.api_version = 500
-        self.storage_pools.get_by.return_value = {"name": "Storage Pool Name"}
-        self.storage_pools.get_reachable_storage_pools.return_value = [{'reachable': 'test'}]
+        self.resource.get_by.return_value = {"name": "Storage Pool Name"}
+        self.resource.get_reachable_storage_pools.return_value = [{'reachable': 'test'}]
         self.mock_ansible_module.params = PARAMS_GET_REACHABLE_STORAGE_POOLS
 
         StoragePoolFactsModule().run()
@@ -74,4 +68,4 @@ class StoragePoolFactsSpec(unittest.TestCase,
 
 
 if __name__ == '__main__':
-    unittest.main()
+    pytest.main([__file__])


### PR DESCRIPTION
##### SUMMARY
Added new oneview_storage_pool_facts module for retrieving [HPE OneView Storage Pools](http://h17007.www1.hpe.com/docs/enterprise/servers/oneview3.1/cic-api/en/api-docs/current/index.html#rest/storage-pools) resource and unit tests.

Related issue for more information: [HPE OneView support](https://github.com/ansible/ansible/issues/28354)

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
`oneview_storage_pool_facts`

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0 (hpe-oneview/storage-pool-facts ade6edbb36) last updated 2017/11/07 17:08:10 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /oneview-ansible/ansible/lib/ansible
  executable location = /oneview-ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Oct 10 2017, 02:49:49) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
Notes:
- To run the example you need an Oneview Appliance with some Storage Pool managed and to use the version 500 of Oneview REST API.

Example of usage:
```yaml
- name: Gather facts about all Storage Pools
  oneview_storage_pool_facts:
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_pools

- name: Gather paginated, filtered and sorted facts about Storage Pools
  oneview_storage_pool_facts:
    params:
      start: 0
      count: 3
      sort: 'name:descending'
      filter: status='OK'
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_pools

- name: Gather facts about a Storage Pool by name
  oneview_storage_pool_facts:
    name: "CPG_FC-AO"
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_pools

- name: Gather facts about the reachable Storage Pools
  oneview_storage_pool_facts:
    options:
      - reachableStoragePools
    params:
      sort: 'name:ascending'
      filter: status='OK'
      networks:
        - /rest/network/123456A
        - /rest/network/123456B
    hostname: 10.101.42.57
    username: administrator
    password: serveradmin
    api_version: 500
  no_log: true
  delegate_to: localhost

- debug: var=storage_pools_reachable_storage_pools
```
