### PR TITLE
minor sentence accuracy improvement

### DIFF
--- a/docs/docsite/rst/playbooks_tests.rst
+++ b/docs/docsite/rst/playbooks_tests.rst
@@ -69,7 +69,7 @@ The ``version`` test can also be used to evaluate the ``ansible_distribution_ver
 
     {{ ansible_distribution_version is version('12.04', '>=') }}
 
-If ``ansible_distribution_version`` is greater than or equal to 12, this test returns True, otherwise False.
+If ``ansible_distribution_version`` is greater than or equal to 12.04, this test returns True, otherwise False.
 
 The ``version`` test accepts the following operators::
 


### PR DESCRIPTION
##### SUMMARY
Discussion of the parameter `12.04` in the explanatory paragraph should not be rounded since the function in the example, `version_compare()`, does not round. 

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
Docs>Tests

##### ANSIBLE VERSION
Doesn't apply to a specific version. Sorry if this causes problems, but i'm making the edit directly on github so there's no simple way to include this.

##### ADDITIONAL INFORMATION