### PR TITLE
Initial commit for fortios_cmdb

### DIFF
--- a/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
+++ b/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
@@ -16,7 +16,6 @@
 #
 # the lib use python logging can get it if the following is set in your
 # Ansible config.
-# log_path = /var/log/ansible.log in your conf..
 
 from __future__ import (absolute_import, division, print_function)
 
@@ -277,17 +276,8 @@ version:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-import logging
 
 fos = None
-
-formatter = logging.Formatter('%(asctime)s %(name)-12s '
-                              '%(levelname)-8s %(message)s')
-logger = logging.getLogger('fortiosapi')
-hdlr = logging.FileHandler('/var/tmp/ansible-fortiosconfig.log')
-hdlr.setFormatter(formatter)
-logger.addHandler(hdlr)
-logger.setLevel(logging.DEBUG)
 
 AVAILABLE_ENDPOINTS = [
     'system resource',

--- a/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
+++ b/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
@@ -1,0 +1,698 @@
+#!/usr/bin/python
+# Copyright 2017 Fortinet, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# the lib use python logging can get it if the following is set in your
+# Ansible config.
+# log_path = /var/log/ansible.log in your conf..
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'status': ['preview'],
+                    'supported_by': 'community',
+                    'metadata_version': '1.1'}
+
+
+DOCUMENTATION = '''
+---
+module: fortios_cmdb_set
+short_description: Module to configure all aspects of fortios and fortigate.
+description:
+    - This module is able to configure a fortios or fortigate by \
+    allowing the user to set every configuration endpoint from a fortios \
+    or fortigate device. The module transforms the playbook into \
+    the needed REST API calls.
+
+version_added: "1.2"
+author: "Nicolas Thomas / thomnico / (nthomas at fortinet.com) and \
+ Miguel Angel Munoz / mamunozgonzalez / (magonzalez at fortinet.com)"
+notes:
+    - "Requires fortiosapi library developed by Fortinet"
+    - "Run as a local_action in your playbook"
+requirements:
+    - fortiosapi>=0.9.8
+options:
+    host:
+        description:
+            - FortiOS or fortigate IP adress.
+        required: true
+
+    username:
+        description:
+            - FortiOS or fortigate username.
+        required: true
+
+    password:
+        description:
+            - FortiOS or fortigate password.
+
+    vdom:
+        description:
+            - Virtual domain, among those defined previously. A vdom is a \
+            virtual instance of the fortigate that can be configured and \
+            used as a different unit.
+        default: root
+
+    endpoint:
+        description:
+            - Defines the resource to be accessed, from the following choice
+        required: true
+        choices: [system resource, system vdom-resource, alertemail setting, \
+         antivirus heuristic, antivirus profile, antivirus quarantine, \
+         antivirus settings, application.casi profile, application custom, \
+         application internet-service, application internet-service-custom, \
+         application list, application name, application rule-settings, \
+         certificate ca, certificate crl, certificate local, dlp filepattern, \
+         dlp fp-doc-source, dlp fp-sensitivity, dlp sensor, dlp settings, \
+         dnsfilter profile, dnsfilter urlfilter, endpoint-control client, \
+         endpoint-control forticlient-registration-syn, \
+         endpoint-control profile, endpoint-control registered-forticlient, \
+         endpoint-control settings, extender-controller extender, \
+         firewall.ipmacbinding setting, \
+         firewall.ipmacbinding table, firewall.schedule group, \
+         firewall.schedule onetime, firewall.schedule recurring, \
+         firewall.service category, firewall.service custom, \
+         firewall.service group, firewall.shaper per-ip-shaper, \
+         firewall.shaper traffic-shaper, firewall.ssl setting, \
+         firewall DoS-policy, firewall DoS-policy6, firewall address, \
+         firewall address6, firewall addrgrp, firewall addrgrp6, \
+         firewall auth-portal, firewall central-snat-map, \
+         firewall dnstranslation, firewall explicit-proxy-address, \
+         firewall explicit-proxy-addrgrp, firewall explicit-proxy-policy, \
+         firewall identity-based-route, firewall interface-policy, \
+         firewall interface-policy6, firewall ip-translation, \
+         firewall ippool, firewall ippool6, firewall ipv6-eh-filter, \
+         firewall ldb-monitor, firewall local-in-policy, \
+         firewall local-in-policy6, firewall multicast-address, \
+         firewall multicast-address6, firewall multicast-policy, \
+         firewall multicast-policy6, firewall policy, firewall policy46, \
+         firewall policy6, firewall policy64, firewall profile-group, \
+         firewall profile-protocol-options, firewall shaping-policy, \
+         firewall sniffer, firewall ssl-server, firewall ssl-ssh-profile, \
+         firewall ttl-policy, firewall vip, firewall vip46, firewall vip6, \
+         firewall vip64, firewall vipgrp, firewall vipgrp46, firewall vipgrp6, \
+         firewall vipgrp64, ftp-proxy explicit, gui console, icap profile, \
+         icap server, ips custom, ips dbinfo, ips decoder, ips global, \
+         ips rule, ips rule-settings, ips sensor, ips settings, \
+         log.disk filter, log.disk setting, log.fortianalyzer filter, \
+         log.fortianalyzer override-filter, log.fortianalyzer override-setting, \
+         log.fortianalyzer setting, log.fortianalyzer2 filter, \
+         log.fortianalyzer2 setting, log.fortianalyzer3 filter, \
+         log.fortianalyzer3 setting, log.fortiguard filter, \
+         log.fortiguard override-filter, log.fortiguard override-setting, \
+         log.fortiguard setting, log.memory filter, log.memory global-setting, \
+         log.memory setting, log.null-device filter, log.null-device setting, \
+         log.syslogd filter, log.syslogd override-filter, \
+         log.syslogd override-setting, log.syslogd setting, \
+         log.syslogd2 filter, log.syslogd2 setting, log.syslogd3 filter, \
+         log.syslogd3 setting, log.syslogd4 filter, log.syslogd4 setting, \
+         log.webtrends filter, log.webtrends setting, log custom-field, \
+         log eventfilter, log gui-display, log setting, log threat-weight, \
+         netscan assets, netscan settings, report chart, report dataset, \
+         report layout, report setting, report style, report theme, \
+         router access-list, router access-list6, router aspath-list, \
+         router auth-path, router bfd, router bgp, router community-list, \
+         router isis, router key-chain, router multicast, \
+         router multicast-flow,router multicast6, router ospf, router ospf6, \
+         router policy, router policy6, router prefix-list, \
+         router prefix-list6, router rip, router ripng, router route-map, \
+         router setting, router static, router static6, spamfilter bwl, \
+         spamfilter bword, spamfilter dnsbl, spamfilter fortishield, \
+         spamfilter iptrust, spamfilter mheader, spamfilter options, \
+         spamfilter profile, switch-controller managed-switch, \
+         system.autoupdate push-update, system.autoupdate schedule, \
+         system.autoupdate tunneling, system.dhcp server, system.dhcp6 server, \
+         system.replacemsg admin, system.replacemsg alertmail, \
+         system.replacemsg auth, system.replacemsg device-detection-portal, \
+         system.replacemsg ec, system.replacemsg fortiguard-wf, \
+         system.replacemsg ftp, system.replacemsg http, system.replacemsg mail, \
+         system.replacemsg nac-quar, system.replacemsg nntp, \
+         system.replacemsg spam, system.replacemsg sslvpn, \
+         system.replacemsg traffic-quota, system.replacemsg utm, \
+         system.replacemsg webproxy, system.snmp community, \
+         system.snmp sysinfo, system.snmp user, system accprofile,system admin, \
+         system alarm, system arp-table, system auto-install, \
+         system auto-script, system central-management, system cluster-sync, \
+         system config backup, system config restore, system console, \
+         system custom-language, system ddns, system dedicated-mgmt, \
+         system dns, system dns-database, system dns-server, \
+         system dscp-based-priority, system email-server, system fips-cc, \
+         system fm, system fortiguard, system fortimanager, \
+         system fortisandbox, system fsso-polling, system geoip-override, \
+         system global, system gre-tunnel, system ha, system ha-monitor, \
+         system interface, system ipip-tunnel, system ips-urlfilter-dns, \
+         system ipv6-neighbor-cache, system ipv6-tunnel, system link-monitor, \
+         system mac-address-table, system management-tunnel, \
+         system mobile-tunnel, system nat64, system netflow, \
+         system network-visibility, system nst, system ntp, system object-tag, \
+         system password-policy, system password-policy-guest-admin, \
+         system probe-response, system proxy-arp, system replacemsg-group, \
+         system replacemsg-image, system resource-limits, \
+         system session-helper,system session-ttl, system settings, \
+         system sflow, system sit-tunnel, system sms-server, system storage, \
+         system switch-interface, system tos-based-priority, system vdom, \
+         system vdom-dns, system vdom-link, system vdom-netflow, \
+         system vdom-property, system vdom-radius-server, system vdom-sflow, \
+         system virtual-wan-link, system virtual-wire-pair, system wccp, \
+         system zone, user adgrp, user device, user device-access-list, \
+         user device-category, user device-group, user fortitoken, user fsso, \
+         user fsso-polling, user group, user ldap, user local, \
+         user password-policy, user peer, user peergrp, user pop3, user radius, \
+         user security-exempt-list, user setting, user tacacs+, voip profile, \
+         vpn.certificate ca, vpn.certificate crl, vpn.certificate local, \
+         vpn.certificate ocsp-server, vpn.certificate remote, \
+         vpn.certificate setting, vpn.ipsec concentrator, \
+         vpn.ipsec forticlient, vpn.ipsec manualkey, \
+         vpn.ipsec manualkey-interface, vpn.ipsec phase1, \
+         vpn.ipsec phase1-interface, vpn.ipsec phase2, \
+         vpn.ipsec phase2-interface, vpn.ssl.web host-check-software, \
+         vpn.ssl.web portal, vpn.ssl.web realm, vpn.ssl.web user-bookmark, \
+         vpn.ssl.web user-group-bookmark, vpn.ssl.web virtual-desktop-app-list, \
+         vpn.ssl settings, vpn l2tp, vpn pptp, waf main-class, waf profile, \
+         waf signature, waf sub-class, wanopt auth-group, wanopt peer, \
+         wanopt profile, wanopt settings, wanopt storage, wanopt webcache, \
+         web-proxy debug-url, web-proxy explicit, web-proxy forward-server, \
+         web-proxy forward-server-group, web-proxy global, web-proxy profile, \
+         web-proxy url-match, web-proxy wisp, webfilter content, \
+         webfilter content-header, webfilter cookie-ovrd, webfilter fortiguard, \
+         webfilter ftgd-local-cat, webfilter ftgd-local-rating, \
+         webfilter ftgd-warning, webfilter ips-urlfilter-cache-setting, \
+         webfilter ips-urlfilter-setting, webfilter override, \
+         webfilter override-user, webfilter profile, webfilter search-engine, \
+         webfilter urlfilter, wireless-controller ap-status, \
+         wireless-controller global, wireless-controller setting, \
+         wireless-controller timers, wireless-controller vap, \
+         wireless-controller vap-group, wireless-controller wids-profile, \
+         wireless-controller wtp, wireless-controller wtp-group, \
+         wireless-controller wtp-profile]
+
+    mkey:
+        description:
+            - Master key of the resource for those endpoints \
+            representing a table
+
+    config_parameters:
+        description:
+            - Any of the additional parameters that are required by some \
+            endpoints to complete the request
+        required: true
+'''
+
+EXAMPLES = '''
+- hosts: localhost
+  vars:
+   host: "192.168.40.8"
+   username: "admin"
+   password: ""
+   vdom: "root"
+  tasks:
+  - name: Set static route on the fortigate
+    fortios_cmdb_set:
+     host:  "{{  host }}"
+     username: "{{  username}}"
+     password: "{{ password }}"
+     vdom:  "{{  vdom }}"
+     endpoint: "router static"
+     config_parameters:
+       seq-num: "8"
+       dst: "10.10.32.0 255.255.255.0"
+       device: "port2"
+       gateway: "192.168.40.252"
+  - name:   firewall policy
+    fortios_cmdb_set:
+     endpoint: "firewall policy"
+     host: "{{ host }}"
+     username: "{{ username }}"
+     password: "{{ password }}"
+     vdom:  "{{  vdom }}"
+     config_parameters:
+        policyid: "66"
+        name: "ansible"
+        json:
+          policyid: "66"
+          name: "ansible"
+          action: "accept"
+          srcintf: [ {"name": "port1"} ]
+          dstintf: [{"name":"port2"} ]
+          srcaddr: [{"name":"all"} ]
+          dstaddr: [{"name":"all"}]
+          schedule: "always"
+          service:  [{"name":"HTTPS"}]
+          logtraffic: "all"
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import logging
+try:
+    from fortiosapi import FortiOSAPI
+    HAS_FORTIOSAPI = True
+except ImportError:
+    HAS_FORTIOSAPI = False
+
+if HAS_FORTIOSAPI:
+    fos = FortiOSAPI()
+else:
+    raise ImportError("fortiosapi module is required")
+
+formatter = logging.Formatter('%(asctime)s %(name)-12s '
+                              '%(levelname)-8s %(message)s')
+logger = logging.getLogger('fortiosapi')
+hdlr = logging.FileHandler('/var/tmp/ansible-fortiosconfig.log')
+hdlr.setFormatter(formatter)
+logger.addHandler(hdlr)
+logger.setLevel(logging.DEBUG)
+
+AVAILABLE_ENDPOINTS = [
+    'system resource',
+    'system vdom-resource',
+    'alertemail setting',
+    'antivirus heuristic',
+    'antivirus profile',
+    'antivirus quarantine',
+    'antivirus settings',
+    'application.casi profile',
+    'application custom',
+    'application internet-service',
+    'application internet-service-custom',
+    'application list',
+    'application name',
+    'application rule-settings',
+    'certificate ca',
+    'certificate crl',
+    'certificate local',
+    'dlp filepattern',
+    'dlp fp-doc-source',
+    'dlp fp-sensitivity',
+    'dlp sensor',
+    'dlp settings',
+    'dnsfilter profile',
+    'dnsfilter urlfilter',
+    'endpoint-control client',
+    'endpoint-control forticlient-registration-syn',
+    'endpoint-control profile',
+    'endpoint-control registered-forticlient',
+    'endpoint-control settings',
+    'extender-controller extender',
+    'firewall.ipmacbinding setting',
+    'firewall.ipmacbinding table',
+    'firewall.schedule group',
+    'firewall.schedule onetime',
+    'firewall.schedule recurring',
+    'firewall.service category',
+    'firewall.service custom',
+    'firewall.service group',
+    'firewall.shaper per-ip-shaper',
+    'firewall.shaper traffic-shaper',
+    'firewall.ssl setting',
+    'firewall DoS-policy',
+    'firewall DoS-policy6',
+    'firewall address',
+    'firewall address6',
+    'firewall addrgrp',
+    'firewall addrgrp6',
+    'firewall auth-portal',
+    'firewall central-snat-map',
+    'firewall dnstranslation',
+    'firewall explicit-proxy-address',
+    'firewall explicit-proxy-addrgrp',
+    'firewall explicit-proxy-policy',
+    'firewall identity-based-route',
+    'firewall interface-policy',
+    'firewall interface-policy6',
+    'firewall ip-translation',
+    'firewall ippool',
+    'firewall ippool6',
+    'firewall ipv6-eh-filter',
+    'firewall ldb-monitor',
+    'firewall local-in-policy',
+    'firewall local-in-policy6',
+    'firewall multicast-address',
+    'firewall multicast-address6',
+    'firewall multicast-policy',
+    'firewall multicast-policy6',
+    'firewall policy',
+    'firewall policy46',
+    'firewall policy6',
+    'firewall policy64',
+    'firewall profile-group',
+    'firewall profile-protocol-options',
+    'firewall shaping-policy',
+    'firewall sniffer',
+    'firewall ssl-server',
+    'firewall ssl-ssh-profile',
+    'firewall ttl-policy',
+    'firewall vip',
+    'firewall vip46',
+    'firewall vip6',
+    'firewall vip64',
+    'firewall vipgrp',
+    'firewall vipgrp46',
+    'firewall vipgrp6',
+    'firewall vipgrp64',
+    'ftp-proxy explicit',
+    'gui console',
+    'icap profile',
+    'icap server',
+    'ips custom',
+    'ips dbinfo',
+    'ips decoder',
+    'ips global',
+    'ips rule',
+    'ips rule-settings',
+    'ips sensor',
+    'ips settings',
+    'log.disk filter',
+    'log.disk setting',
+    'log.fortianalyzer filter',
+    'log.fortianalyzer override-filter',
+    'log.fortianalyzer override-setting',
+    'log.fortianalyzer setting',
+    'log.fortianalyzer2 filter',
+    'log.fortianalyzer2 setting',
+    'log.fortianalyzer3 filter',
+    'log.fortianalyzer3 setting',
+    'log.fortiguard filter',
+    'log.fortiguard override-filter',
+    'log.fortiguard override-setting',
+    'log.fortiguard setting',
+    'log.memory filter',
+    'log.memory global-setting',
+    'log.memory setting',
+    'log.null-device filter',
+    'log.null-device setting',
+    'log.syslogd filter',
+    'log.syslogd override-filter',
+    'log.syslogd override-setting',
+    'log.syslogd setting',
+    'log.syslogd2 filter',
+    'log.syslogd2 setting',
+    'log.syslogd3 filter',
+    'log.syslogd3 setting',
+    'log.syslogd4 filter',
+    'log.syslogd4 setting',
+    'log.webtrends filter',
+    'log.webtrends setting',
+    'log custom-field',
+    'log eventfilter',
+    'log gui-display',
+    'log setting',
+    'log threat-weight',
+    'netscan assets',
+    'netscan settings',
+    'report chart',
+    'report dataset',
+    'report layout',
+    'report setting',
+    'report style',
+    'report theme',
+    'router access-list',
+    'router access-list6',
+    'router aspath-list',
+    'router auth-path',
+    'router bfd',
+    'router bgp',
+    'router community-list',
+    'router isis',
+    'router key-chain',
+    'router multicast',
+    'router multicast-flow',
+    'router multicast6',
+    'router ospf',
+    'router ospf6',
+    'router policy',
+    'router policy6',
+    'router prefix-list',
+    'router prefix-list6',
+    'router rip',
+    'router ripng',
+    'router route-map',
+    'router setting',
+    'router static',
+    'router static6',
+    'spamfilter bwl',
+    'spamfilter bword',
+    'spamfilter dnsbl',
+    'spamfilter fortishield',
+    'spamfilter iptrust',
+    'spamfilter mheader',
+    'spamfilter options',
+    'spamfilter profile',
+    'switch-controller managed-switch',
+    'system.autoupdate push-update',
+    'system.autoupdate schedule',
+    'system.autoupdate tunneling',
+    'system.dhcp server',
+    'system.dhcp6 server',
+    'system.replacemsg admin',
+    'system.replacemsg alertmail',
+    'system.replacemsg auth',
+    'system.replacemsg device-detection-portal',
+    'system.replacemsg ec',
+    'system.replacemsg fortiguard-wf',
+    'system.replacemsg ftp',
+    'system.replacemsg http',
+    'system.replacemsg mail',
+    'system.replacemsg nac-quar',
+    'system.replacemsg nntp',
+    'system.replacemsg spam',
+    'system.replacemsg sslvpn',
+    'system.replacemsg traffic-quota',
+    'system.replacemsg utm',
+    'system.replacemsg webproxy',
+    'system.snmp community',
+    'system.snmp sysinfo',
+    'system.snmp user',
+    'system accprofile',
+    'system admin',
+    'system alarm',
+    'system arp-table',
+    'system auto-install',
+    'system auto-script',
+    'system central-management',
+    'system cluster-sync',
+    'system config backup',
+    'system config restore',
+    'system console',
+    'system custom-language',
+    'system ddns',
+    'system dedicated-mgmt',
+    'system dns',
+    'system dns-database',
+    'system dns-server',
+    'system dscp-based-priority',
+    'system email-server',
+    'system fips-cc',
+    'system fm',
+    'system fortiguard',
+    'system fortimanager',
+    'system fortisandbox',
+    'system fsso-polling',
+    'system geoip-override',
+    'system global',
+    'system gre-tunnel',
+    'system ha',
+    'system ha-monitor',
+    'system interface',
+    'system ipip-tunnel',
+    'system ips-urlfilter-dns',
+    'system ipv6-neighbor-cache',
+    'system ipv6-tunnel',
+    'system link-monitor',
+    'system mac-address-table',
+    'system management-tunnel',
+    'system mobile-tunnel',
+    'system nat64',
+    'system netflow',
+    'system network-visibility',
+    'system nst',
+    'system ntp',
+    'system object-tag',
+    'system password-policy',
+    'system password-policy-guest-admin',
+    'system probe-response',
+    'system proxy-arp',
+    'system replacemsg-group',
+    'system replacemsg-image',
+    'system resource-limits',
+    'system session-helper',
+    'system session-ttl',
+    'system settings',
+    'system sflow',
+    'system sit-tunnel',
+    'system sms-server',
+    'system storage',
+    'system switch-interface',
+    'system tos-based-priority',
+    'system vdom',
+    'system vdom-dns',
+    'system vdom-link',
+    'system vdom-netflow',
+    'system vdom-property',
+    'system vdom-radius-server',
+    'system vdom-sflow',
+    'system virtual-wan-link',
+    'system virtual-wire-pair',
+    'system wccp',
+    'system zone',
+    'user adgrp',
+    'user device',
+    'user device-access-list',
+    'user device-category',
+    'user device-group',
+    'user fortitoken',
+    'user fsso',
+    'user fsso-polling',
+    'user group',
+    'user ldap',
+    'user local',
+    'user password-policy',
+    'user peer',
+    'user peergrp',
+    'user pop3',
+    'user radius',
+    'user security-exempt-list',
+    'user setting',
+    'user tacacs+',
+    'voip profile',
+    'vpn.certificate ca',
+    'vpn.certificate crl',
+    'vpn.certificate local',
+    'vpn.certificate ocsp-server',
+    'vpn.certificate remote',
+    'vpn.certificate setting',
+    'vpn.ipsec concentrator',
+    'vpn.ipsec forticlient',
+    'vpn.ipsec manualkey',
+    'vpn.ipsec manualkey-interface',
+    'vpn.ipsec phase1',
+    'vpn.ipsec phase1-interface',
+    'vpn.ipsec phase2',
+    'vpn.ipsec phase2-interface',
+    'vpn.ssl.web host-check-software',
+    'vpn.ssl.web portal',
+    'vpn.ssl.web realm',
+    'vpn.ssl.web user-bookmark',
+    'vpn.ssl.web user-group-bookmark',
+    'vpn.ssl.web virtual-desktop-app-list',
+    'vpn.ssl settings',
+    'vpn l2tp',
+    'vpn pptp',
+    'waf main-class',
+    'waf profile',
+    'waf signature',
+    'waf sub-class',
+    'wanopt auth-group',
+    'wanopt peer',
+    'wanopt profile',
+    'wanopt settings',
+    'wanopt storage',
+    'wanopt webcache',
+    'web-proxy debug-url',
+    'web-proxy explicit',
+    'web-proxy forward-server',
+    'web-proxy forward-server-group',
+    'web-proxy global',
+    'web-proxy profile',
+    'web-proxy url-match',
+    'web-proxy wisp',
+    'webfilter content',
+    'webfilter content-header',
+    'webfilter cookie-ovrd',
+    'webfilter fortiguard',
+    'webfilter ftgd-local-cat',
+    'webfilter ftgd-local-rating',
+    'webfilter ftgd-warning',
+    'webfilter ips-urlfilter-cache-setting',
+    'webfilter ips-urlfilter-setting',
+    'webfilter override',
+    'webfilter override-user',
+    'webfilter profile',
+    'webfilter search-engine',
+    'webfilter urlfilter',
+    'wireless-controller ap-status',
+    'wireless-controller global',
+    'wireless-controller setting',
+    'wireless-controller timers',
+    'wireless-controller vap',
+    'wireless-controller vap-group',
+    'wireless-controller wids-profile',
+    'wireless-controller wtp',
+    'wireless-controller wtp-group',
+    'wireless-controller wtp-profile']
+
+
+def login(data):
+    host = data['host']
+    username = data['username']
+    fos.debug('on')
+    fos.login(host, username, '')
+
+
+def logout():
+    fos.logout()
+
+
+def fortios_cmdb_set(data):
+    host = data['host']
+    username = data['username']
+    password = data['password']
+    fos.login(host, username, password)
+
+    functions = data['endpoint'].split()
+
+    resp = fos.set(functions[0],
+                   functions[1],
+                   vdom=data['vdom'],
+                   mkey=data['mkey'] if 'mkey' in data else None,
+                   data=data['config_parameters'])
+    fos.logout()
+
+    meta = {"status": resp['status'], 'version': resp['version'], }
+    if resp['status'] == "success":
+        return False, True, meta
+    else:
+        return True, False, meta
+
+
+def main():
+    if not HAS_FORTIOSAPI:
+        module.fail_json(msg="Need FortiOSApi library installed")
+
+    fields = {
+        "host": {"required": True, "type": "str"},
+        "password": {"required": False, "type": "str"},
+        "username": {"required": True, "type": "str"},
+        "vdom": {"required": False, "type": "str", "default": "root"},
+        "endpoint": {"required": True,
+                     "choices": AVAILABLE_ENDPOINTS,
+                     "type": "str"},
+        "mkey": {"required": False, "type": "str"},
+        "config_parameters": {"required": True, "type": "dict"},
+    }
+
+    module = AnsibleModule(argument_spec=fields,
+                           supports_check_mode=False)
+    is_error, has_changed, result = fortios_cmdb_set(module.params)
+
+    if not is_error:
+        module.exit_json(changed=has_changed, meta=result)
+    else:
+        module.fail_json(msg="Error in repo", meta=result)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
+++ b/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
@@ -26,7 +26,6 @@ ANSIBLE_METADATA = {'status': ['preview'],
                     'supported_by': 'community',
                     'metadata_version': '1.1'}
 
-
 DOCUMENTATION = '''
 ---
 module: fortios_cmdb_set
@@ -257,8 +256,10 @@ EXAMPLES = '''
 
 from ansible.module_utils.basic import AnsibleModule
 import logging
+
 try:
     from fortiosapi import FortiOSAPI
+
     HAS_FORTIOSAPI = True
 except ImportError:
     HAS_FORTIOSAPI = False
@@ -669,9 +670,6 @@ def fortios_cmdb_set(data):
 
 
 def main():
-    if not HAS_FORTIOSAPI:
-        module.fail_json(msg="Need FortiOSApi library installed")
-
     fields = {
         "host": {"required": True, "type": "str"},
         "password": {"required": False, "type": "str"},

--- a/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
+++ b/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
@@ -37,8 +37,9 @@ description:
     the needed REST API calls.
 
 version_added: "2.5"
-author: "Nicolas Thomas / thomnico / (nthomas at fortinet.com) and \
- Miguel Angel Munoz / mamunozgonzalez / (magonzalez at fortinet.com)"
+author:
+    - Nicolas Thomas (@thomnico)
+    - Miguel Angel Munoz (@mamunozgonzalez)
 notes:
     - "Requires fortiosapi library developed by Fortinet"
     - "Run as a local_action in your playbook"
@@ -259,25 +260,13 @@ results:
   description: Data returned by the endpoint operation
   returned: on sucess
   type: string
-  sample: {
-            "apply-to": "admin-password ipsec-preshared-key",
-            "change-4-characters": "disable",
-            "expire-day": 90,
-            "expire-status": "enable",
-            "min-lower-case-letter": 2,
-            "min-non-alphanumeric": 1,
-            "min-number": 2,
-            "min-upper-case-letter": 2,
-            "minimum-length": 8,
-            "reuse-password": "disable",
-            "status": "enable
-          }
+  sample: 'apply-to: admin-password ipsec-preshared-key'
 
 status:
   description: Indication of the operation's result
   returned: always
   type: string
-  sample: "success"
+  sample: success
 
 version:
   description: Version of the FortiGate
@@ -290,16 +279,7 @@ version:
 from ansible.module_utils.basic import AnsibleModule
 import logging
 
-try:
-    from fortiosapi import FortiOSAPI
-    HAS_FORTIOSAPI = True
-except ImportError:
-    HAS_FORTIOSAPI = False
-
-if HAS_FORTIOSAPI:
-    fos = FortiOSAPI()
-else:
-    raise ImportError("fortiosapi module is required")
+fos = None
 
 formatter = logging.Formatter('%(asctime)s %(name)-12s '
                               '%(levelname)-8s %(message)s')
@@ -702,6 +682,7 @@ def fortios_cmdb_set(data):
 
 
 def main():
+
     fields = {
         "host": {"required": True, "type": "str"},
         "password": {"required": False, "type": "str"},
@@ -716,6 +697,14 @@ def main():
 
     module = AnsibleModule(argument_spec=fields,
                            supports_check_mode=False)
+    try:
+        from fortiosapi import FortiOSAPI
+    except ImportError:
+        raise ImportError("fortiosapi module is required")
+
+    global fos
+    fos = FortiOSAPI()
+
     is_error, has_changed, result = fortios_cmdb_set(module.params)
 
     if not is_error:

--- a/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
+++ b/lib/ansible/modules/network/fortios/fortios_cmdb_set.py
@@ -36,7 +36,7 @@ description:
     or fortigate device. The module transforms the playbook into \
     the needed REST API calls.
 
-version_added: "1.2"
+version_added: "2.5"
 author: "Nicolas Thomas / thomnico / (nthomas at fortinet.com) and \
  Miguel Angel Munoz / mamunozgonzalez / (magonzalez at fortinet.com)"
 notes:
@@ -254,12 +254,44 @@ EXAMPLES = '''
           logtraffic: "all"
 '''
 
+RETURN = '''
+results:
+  description: Data returned by the endpoint operation
+  returned: on sucess
+  type: string
+  sample: {
+            "apply-to": "admin-password ipsec-preshared-key",
+            "change-4-characters": "disable",
+            "expire-day": 90,
+            "expire-status": "enable",
+            "min-lower-case-letter": 2,
+            "min-non-alphanumeric": 1,
+            "min-number": 2,
+            "min-upper-case-letter": 2,
+            "minimum-length": 8,
+            "reuse-password": "disable",
+            "status": "enable
+          }
+
+status:
+  description: Indication of the operation's result
+  returned: always
+  type: string
+  sample: "success"
+
+version:
+  description: Version of the FortiGate
+  returned: always
+  type: string
+  sample: v5.6.2
+
+'''
+
 from ansible.module_utils.basic import AnsibleModule
 import logging
 
 try:
     from fortiosapi import FortiOSAPI
-
     HAS_FORTIOSAPI = True
 except ImportError:
     HAS_FORTIOSAPI = False

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -1,4 +1,5 @@
 cryptography
+fortiosapi
 jinja2
 mock
 paramiko

--- a/test/runner/requirements/sanity.txt
+++ b/test/runner/requirements/sanity.txt
@@ -1,5 +1,4 @@
 cryptography
-fortiosapi
 jinja2
 mock
 paramiko

--- a/test/runner/requirements/units.txt
+++ b/test/runner/requirements/units.txt
@@ -28,3 +28,7 @@ ncclient
 
 # requirement for aci_rest module
 xmljson
+
+# requirement for fortios
+fortiosapi
+

--- a/test/units/modules/network/fortios/test_fortios_cmdb_set.py
+++ b/test/units/modules/network/fortios/test_fortios_cmdb_set.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright 2017 Fortinet, Inc.
+#
+# Author: Miguel Angel Munoz (magonzalez at fortinet.com) and 
+#         Nicolas Thomas (nthomas at fortinet.com)
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import sys
+from nose.plugins.skip import SkipTest
+if sys.version_info < (2, 7):
+    raise SkipTest("Python >= 2.7 is required for running unit tests")
+
+try:
+	import library.fortios_cmdb_set as sut
+except ImportError:
+	try:
+		import ansible.modules.network.fortios.fortios_cmdb_set as sut
+	except ImportError:
+		raise SkipTest("FortiOS Ansible module not found")
+
+try:
+	from fortiosapi import FortiOSAPI
+except ImportError:
+	raise SkipTest("FortiOS Ansible module requires FortiOSapi")
+
+import ansible.module_utils.basic
+import requests
+
+
+def test_cmdb_set(monkeypatch):
+    def set(self, path, name, vdom=None,
+            mkey=None, parameters=None, data=None):
+        return {'status': 'success', 'version': '5.6.2'}
+
+    monkeypatch.setattr(FortiOSAPI,
+                        'login',
+                        lambda self, host, username, password: True)
+    monkeypatch.setattr(FortiOSAPI, 'set', set)
+    monkeypatch.setattr(FortiOSAPI, 'logout', lambda _: True)
+
+    is_error, is_changed, result = sut.fortios_cmdb_set(
+        {"host": "192.168.122.40",
+         "username": "admin",
+         "password": "",
+         "endpoint": "router static",
+         "vdom": "global",
+         "config_parameters": {"seq-num": 8,
+                               "dst": "10.10.32.0 255.255.255.0",
+                               "device": "port2",
+                               "gateway": "192.168.40.252"}
+         })
+    assert not is_error
+    assert is_changed
+    assert result is not None
+
+
+def test_cmdb_set_failed(monkeypatch):
+    def set(self, path, name, vdom=None,
+            mkey=None, parameters=None, data=None):
+        return {'status': 'error', 'version': '5.6.2'}
+
+    monkeypatch.setattr(FortiOSAPI,
+                        'login',
+                        lambda self, host, username, password: True)
+    monkeypatch.setattr(FortiOSAPI, 'set', set)
+    monkeypatch.setattr(FortiOSAPI, 'logout', lambda _: True)
+
+    is_error, is_changed, result = sut.fortios_cmdb_set(
+        {"host": "192.168.122.40",
+         "username": "admin",
+         "password": "",
+         "endpoint": "router static",
+         "vdom": "global",
+         "config_parameters": {"seq-num": 8,
+                               "dst": "10.10.32.0 255.255.255.0",
+                               "device": "port2",
+                               "gateway": "192.168.40.252"}
+         })
+    assert is_error
+    assert not is_changed
+    assert result is not None
+
+
+def test_required_params(monkeypatch):
+    def ansible_constructor(self, argument_spec, bypass_checks=False,
+                            no_log=False, check_invalid_arguments=True,
+                            mutually_exclusive=None, required_together=None,
+                            required_one_of=None, add_file_common_args=False,
+                            supports_check_mode=False, required_if=None):
+        self.params = ""
+        self.cleanup_files = ""
+        self._warnings = ""
+        self._deprecations = ""
+        self.no_log_values = ""
+
+        assert 'host' in argument_spec
+        assert argument_spec['host']['required']
+        assert 'username' in argument_spec
+        assert argument_spec['username']['required']
+        assert 'endpoint' in argument_spec
+        assert argument_spec['endpoint']['required']
+        assert 'config_parameters' in argument_spec
+        assert argument_spec['config_parameters']['required']
+
+    monkeypatch.setattr(ansible.module_utils.basic.AnsibleModule,
+                        '__init__',
+                        ansible_constructor)
+    monkeypatch.setattr(sut,
+                        'fortios_cmdb_set',
+                        lambda _: (False,
+                                   True,
+                                   {'status': 'error', 'version': '5.6.2'}))
+    monkeypatch.setattr(sys, 'exit', lambda x: True)
+
+    sut.main()
+
+
+def test_optional_params(monkeypatch):
+    def ansible_constructor(self, argument_spec, bypass_checks=False,
+                            no_log=False, check_invalid_arguments=True,
+                            mutually_exclusive=None, required_together=None,
+                            required_one_of=None, add_file_common_args=False,
+                            supports_check_mode=False, required_if=None):
+        self.params = ""
+        self.cleanup_files = ""
+        self._warnings = ""
+        self._deprecations = ""
+        self.no_log_values = ""
+
+        assert 'password' in argument_spec
+        assert not argument_spec['password']['required']
+        assert 'vdom' in argument_spec
+        assert not argument_spec['vdom']['required']
+        assert 'mkey' in argument_spec
+        assert not argument_spec['mkey']['required']
+
+        return
+
+    monkeypatch.setattr(ansible.module_utils.basic.AnsibleModule,
+                        '__init__',
+                        ansible_constructor)
+    monkeypatch.setattr(sut,
+                        'fortios_cmdb_set',
+                        lambda _: (False,
+                                   True,
+                                   {'status': 'error', 'version': '5.6.2'}))
+    monkeypatch.setattr(sys, 'exit', lambda x: True)
+
+    sut.main()
+
+
+def test_endpoint_properly_built(monkeypatch):
+    class Result():
+
+        content = ""
+        x = 0
+
+        def calculate_result(self):
+            if Result.x == 0:
+                self.content = b'1document.location="/ng/prompt?viewOnly&redir'
+                Result.x += 1
+            else:
+                self.content = b'[{ "result":"200", ' \
+                               b'"http_status":200, ' \
+                               b'"status":"success", ' \
+                               b'"version":"5.6.2"}]'
+
+    def get(self, path, name, vdom=None, mkey=None, parameters=None):
+        return {'version': '5.6.2.'}
+
+    def post(self, url, data=None, json=None, **kwargs):
+        if url != 'https://192.168.122.40/logincheck' and \
+                        url != 'https://192.168.122.40/api/v2/cmdb/' \
+                               'firewall/policy?global=1':
+            assert False, "Url not properly built: %s" % url
+        result = Result()
+        result.calculate_result()
+        return result
+
+    monkeypatch.setattr(requests.Session, 'post', post)
+    monkeypatch.setattr(FortiOSAPI, 'get', get)
+    monkeypatch.setattr(FortiOSAPI, 'logout', lambda _: True)
+
+    is_error, is_changed, result = sut.fortios_cmdb_set(
+        {"host": "192.168.122.40",
+         "username": "admin",
+         "password": "",
+         "endpoint": "firewall policy",
+         "vdom": "global",
+         "config_parameters": {"seq-num": 8,
+                               "dst": "10.10.32.0 255.255.255.0",
+                               "device": "port2",
+                               "gateway": "192.168.40.252"}
+         })
+    assert not is_error
+    assert is_changed
+    assert result is not None
+
+
+def test_failed_login(monkeypatch):
+    def login(self, host, username, password):
+        raise Exception("Failed Login")
+
+    def set(self, path, name, vdom=None,
+            mkey=None, parameters=None, data=None):
+        return {'status': 'error', 'version': '5.6.2'}
+
+    monkeypatch.setattr(FortiOSAPI, 'login', login)
+    monkeypatch.setattr(FortiOSAPI, 'set', set)
+    monkeypatch.setattr(FortiOSAPI, 'logout', lambda _: True)
+
+    try:
+        sut.fortios_cmdb_set(
+            {"host": "192.168.122.40",
+             "username": "admin",
+             "password": "",
+             "endpoint": "router static",
+             "vdom": "global",
+             "config_parameters": {"seq-num": 8,
+                                   "dst": "10.10.32.0 255.255.255.0",
+                                   "device": "port2",
+                                   "gateway": "192.168.40.252"}
+             })
+        assert False, "Error: No exception raised when failed login"
+    except Exception:
+        pass

--- a/test/units/modules/network/fortios/test_fortios_cmdb_set.py
+++ b/test/units/modules/network/fortios/test_fortios_cmdb_set.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Fortinet, Inc.
 #
-# Author: Miguel Angel Munoz (magonzalez at fortinet.com) and 
+# Author: Miguel Angel Munoz (magonzalez at fortinet.com) and
 #         Nicolas Thomas (nthomas at fortinet.com)
 #
 # This program is free software: you can redistribute it and/or modify

--- a/test/units/modules/network/fortios/test_fortios_cmdb_set.py
+++ b/test/units/modules/network/fortios/test_fortios_cmdb_set.py
@@ -20,21 +20,22 @@
 
 import sys
 from nose.plugins.skip import SkipTest
+
 if sys.version_info < (2, 7):
     raise SkipTest("Python >= 2.7 is required for running unit tests")
 
 try:
-	import library.fortios_cmdb_set as sut
+    import library.fortios_cmdb_set as sut
 except ImportError:
-	try:
-		import ansible.modules.network.fortios.fortios_cmdb_set as sut
-	except ImportError:
-		raise SkipTest("FortiOS Ansible module not found")
+    try:
+        import ansible.modules.network.fortios.fortios_cmdb_set as sut
+    except ImportError:
+        raise SkipTest("FortiOS Ansible module not found")
 
 try:
-	from fortiosapi import FortiOSAPI
+    from fortiosapi import FortiOSAPI
 except ImportError:
-	raise SkipTest("FortiOS Ansible module requires FortiOSapi")
+    raise SkipTest("FortiOS Ansible module requires FortiOSapi")
 
 import ansible.module_utils.basic
 import requests
@@ -183,8 +184,8 @@ def test_endpoint_properly_built(monkeypatch):
 
     def post(self, url, data=None, json=None, **kwargs):
         if url != 'https://192.168.122.40/logincheck' and \
-                        url != 'https://192.168.122.40/api/v2/cmdb/' \
-                               'firewall/policy?global=1':
+                url != 'https://192.168.122.40/api/v2/cmdb/' \
+                       'firewall/policy?global=1':
             assert False, "Url not properly built: %s" % url
         result = Result()
         result.calculate_result()


### PR DESCRIPTION
##### SUMMARY
FortiOS and FortiGate products need to be supported by Ansible, also for cmdb operations. This module aims to support that.

The module let the user configure different endpoints of the Fortigate, by allowing to set configuration values.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
fortios_cmdb_set

##### ANSIBLE VERSION
```
ansible 2.5.0 (fortios_cmdb 7782b9106e) last updated 2017/12/05 19:46:41 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/magonzalez/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/magonzalez/ansible/lib/ansible
  executable location = /home/magonzalez/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```
