### PR TITLE
Adds a tmsh command fallback

### DIFF
--- a/lib/ansible/plugins/terminal/bigip.py
+++ b/lib/ansible/plugins/terminal/bigip.py
@@ -58,4 +58,3 @@ class TerminalModule(TerminalBase):
                     self._exec_cli_command(b'tmsh modify cli preference display-threshold 0 pager disabled')
                 except AnsibleConnectionFailure as ex:
                     raise AnsibleConnectionFailure('unable to set terminal parameters')
-

--- a/lib/ansible/plugins/terminal/bigip.py
+++ b/lib/ansible/plugins/terminal/bigip.py
@@ -51,5 +51,11 @@ class TerminalModule(TerminalBase):
     def on_open_shell(self):
         try:
             self._exec_cli_command(b'modify cli preference display-threshold 0 pager disabled')
-        except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure('unable to set terminal parameters')
+        except AnsibleConnectionFailure as ex:
+            output = str(ex)
+            if 'modify: command not found' in output:
+                try:
+                    self._exec_cli_command(b'tmsh modify cli preference display-threshold 0 pager disabled')
+                except AnsibleConnectionFailure as ex:
+                    raise AnsibleConnectionFailure('unable to set terminal parameters')
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The bigip terminal plugin assumes that the remote shell is tmsh.
This is not always true. The remote shell may be bash sometimes.

This adds a different shell command in the case that bash is the
remote shell

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
plugins/terminal/bigip.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Nov  4 2017, 22:29:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
