### PR TITLE
nxos_facts: add check for ipv6 support

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_facts.py
+++ b/lib/ansible/modules/network/nxos/nxos_facts.py
@@ -281,6 +281,15 @@ class Interfaces(FactsBase):
         ('prefix', 'subnet')
     ])
 
+    def ipv6_structure_op_supported(self):
+        data = self.run('show version', 'json')
+        if data:
+            unsupported_versions = ['I2', 'F1', 'A8']
+            for ver in unsupported_versions:
+                if ver in data.get('kickstart_ver_str'):
+                    return False
+            return True
+
     def populate(self):
         self.facts['all_ipv4_addresses'] = list()
         self.facts['all_ipv6_addresses'] = list()
@@ -289,7 +298,7 @@ class Interfaces(FactsBase):
         if data:
             self.facts['interfaces'] = self.populate_interfaces(data)
 
-        data = self.run('show ipv6 interface', 'json')
+        data = self.run('show ipv6 interface', 'json') if self.ipv6_structure_op_supported() else None
         if data and not isinstance(data, string_types):
             self.parse_ipv6_interfaces(data)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
After the recent change to module_utils where a non json object returned fails the module, we need to update nxos_facts to handle a few platforms that don't support structured output for 'sh ipv6 interface'.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
- nxos_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (nxos_facts 0abe10f220) last updated 2017/12/05 14:23:10 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /root/agents-ci/ansible/lib/ansible
  executable location = /root/agents-ci/ansible/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```