### PR TITLE
Fail hard when tests pass that are expected to fail

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ passenv =
     # variable error. See issue: #20424
     HOME
 
+[pytest]
+xfail_strict = true
 
 [flake8]
 # These are things that the devs don't agree make the code more readable


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION

`@pytest.mark.xfail()` can be used to decorate tests that don't yet
pass. By default, if I wrote a test like this:

```
@pytest.mark.xfail()
def test_naughty():
    assert 1 == 1
```

Then Pytest would allow this test to pass without notifying that an
expected-fail *didn't* fail. To make that happen, you have to set
xfail_strict=True so that the above test would cause the tests to fail.