### PR TITLE
Update FreeBSD versions used in CI.

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -17,8 +17,8 @@ matrix:
 
     - env: TEST=osx/10.11
 
-    - env: TEST=freebsd/10.3-STABLE
-    - env: TEST=freebsd/11.0-STABLE
+    - env: TEST=freebsd/10.4
+    - env: TEST=freebsd/11.1
 
     - env: TEST=windows/1
     - env: TEST=windows/2


### PR DESCRIPTION
##### SUMMARY

Update FreeBSD versions used in CI.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

shippable.yml

##### ANSIBLE VERSION

```
ansible 2.3.3.0 (freebsd-2.3 45445d1806) last updated 2017/12/05 20:49:46 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
