### PR TITLE
Update FreeBSD completion for ansible-test.

### DIFF
--- a/test/runner/completion/remote.txt
+++ b/test/runner/completion/remote.txt
@@ -1,4 +1,4 @@
-freebsd/10.3-STABLE
-freebsd/11.0-STABLE
+freebsd/10.4
+freebsd/11.1
 osx/10.11
 rhel/7.4


### PR DESCRIPTION
##### SUMMARY

Update FreeBSD completion for ansible-test.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-completion 4a4ba930d2) last updated 2017/12/05 20:58:52 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
