### PR TITLE
implemented installroot option

### DIFF
--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -63,7 +63,7 @@ options:
         default: "package"
         version_added: "2.0"
     extra_args_precommand:
-       version_added: "2.5"
+       version_added: "2.6"
        required: false
        description:
          - Add additional global target options to C(zypper).

--- a/lib/ansible/modules/packaging/os/zypper.py
+++ b/lib/ansible/modules/packaging/os/zypper.py
@@ -62,6 +62,12 @@ options:
         choices: [ package, patch, pattern, product, srcpackage, application ]
         default: "package"
         version_added: "2.0"
+    extra_args_precommand:
+       version_added: "2.5"
+       required: false
+       description:
+         - Add additional global target options to C(zypper).
+         - Options should be supplied in a single line as if given in the command line.
     disable_gpg_check:
         description:
           - Whether to disable to GPG signature checking of the package
@@ -308,7 +314,9 @@ def get_cmd(m, subcommand):
     is_install = subcommand in ['install', 'update', 'patch', 'dist-upgrade']
     is_refresh = subcommand == 'refresh'
     cmd = ['/usr/bin/zypper', '--quiet', '--non-interactive', '--xmlout']
-
+    if m.params['extra_args_precommand']:
+        args_list = m.params['extra_args_precommand'].split()
+        cmd.extend(args_list)
     # add global options before zypper command
     if (is_install or is_refresh) and m.params['disable_gpg_check']:
         cmd.append('--no-gpg-checks')
@@ -464,6 +472,7 @@ def main():
             name=dict(required=True, aliases=['pkg'], type='list'),
             state=dict(required=False, default='present', choices=['absent', 'installed', 'latest', 'present', 'removed', 'dist-upgrade']),
             type=dict(required=False, default='package', choices=['package', 'patch', 'pattern', 'product', 'srcpackage', 'application']),
+            extra_args_precommand=dict(required=False, default=None),
             disable_gpg_check=dict(required=False, default='no', type='bool'),
             disable_recommends=dict(required=False, default='yes', type='bool'),
             force=dict(required=False, default='no', type='bool'),

--- a/test/integration/targets/zypper/tasks/zypper.yml
+++ b/test/integration/targets/zypper/tasks/zypper.yml
@@ -229,6 +229,23 @@
     name: empty
     state: removed
 
+- name: extract from rpm
+  zypper:
+    name: "{{ output_dir | expanduser }}/zypper2/rpm-build/noarch/empty-1-0.noarch.rpm"
+    state: installed
+    disable_gpg_check: yes
+    extra_args_precommand: --root {{ output_dir | expanduser }}/testdir/
+
+- name: check that dir var is exist
+  stat: path={{ output_dir | expanduser }}/testdir/var
+  register: stat_result
+
+- name: check that we extract rpm package in testdir folder and folder var is exist
+  assert:
+    that:
+     - "stat_result.stat.exists == true"
+
+
 # test simultaneous remove and install using +- prefixes
 
 - name: install hello to prep next task


### PR DESCRIPTION
SUMMARY

added installroot option to zypper module
ISSUE TYPE

    Feature Pull Request

COMPONENT NAME

module
ANSIBLE VERSION

ansible 2.4.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.9 (default, Dec 21 2014, 11:02:59) [GCC

ADDITIONAL INFORMATION

This is fix for  https://github.com/ansible/ansible/pull/28651 (See this tread)
