### PR TITLE
Replace exit() with sys.exit()

### DIFF
--- a/contrib/inventory/nagios_livestatus.py
+++ b/contrib/inventory/nagios_livestatus.py
@@ -34,6 +34,8 @@ Livestatus API: http://www.naemon.org/documentation/usersguide/livestatus.html
 import os
 import re
 import argparse
+import sys
+
 try:
     import configparser
 except ImportError:
@@ -44,8 +46,7 @@ import json
 try:
     from mk_livestatus import Socket
 except ImportError:
-    print("Error: mk_livestatus is needed. Try something like: pip install python-mk-livestatus")
-    exit(1)
+    sys.exit("Error: mk_livestatus is needed. Try something like: pip install python-mk-livestatus")
 
 
 class NagiosLivestatusInventory(object):
@@ -160,8 +161,7 @@ class NagiosLivestatusInventory(object):
             self.json_indent = 2
 
         if len(self.backends) == 0:
-            print("Error: Livestatus configuration is missing. See nagios_livestatus.ini.")
-            exit(1)
+            sys.exit("Error: Livestatus configuration is missing. See nagios_livestatus.ini.")
 
         for backend in self.backends:
             self.query_backend(backend, self.options.host)
@@ -171,7 +171,6 @@ class NagiosLivestatusInventory(object):
         elif self.options.list:
             print(json.dumps(self.result, indent=self.json_indent))
         else:
-            print("usage: --list or --host HOSTNAME [--pretty]")
-            exit(1)
+            sys.exit("usage: --list or --host HOSTNAME [--pretty]")
 
 NagiosLivestatusInventory()

--- a/contrib/inventory/nagios_ndo.py
+++ b/contrib/inventory/nagios_ndo.py
@@ -28,6 +28,7 @@ Configuration is read from `nagios_ndo.ini`.
 
 import os
 import argparse
+import sys
 try:
     import configparser
 except ImportError:
@@ -39,8 +40,7 @@ try:
     from sqlalchemy import text
     from sqlalchemy.engine import create_engine
 except ImportError:
-    print("Error: SQLAlchemy is needed. Try something like: pip install sqlalchemy")
-    exit(1)
+    sys.exit("Error: SQLAlchemy is needed. Try something like: pip install sqlalchemy")
 
 
 class NagiosNDOInventory(object):
@@ -101,10 +101,8 @@ class NagiosNDOInventory(object):
             elif self.options.list:
                 print(json.dumps(self.result))
             else:
-                print("usage: --list or --host HOSTNAME")
-                exit(1)
+                sys.exit("usage: --list or --host HOSTNAME")
         else:
-            print("Error: Database configuration is missing. See nagios_ndo.ini.")
-            exit(1)
+            sys.exit("Error: Database configuration is missing. See nagios_ndo.ini.")
 
 NagiosNDOInventory()

--- a/hacking/report.py
+++ b/hacking/report.py
@@ -63,7 +63,7 @@ def parse_args():
 
 def query_database():
     if not os.path.exists(DATABASE_PATH):
-        exit('error: Database not found. Did you run `report.py populate` first?')
+        sys.exit('error: Database not found. Did you run `report.py populate` first?')
 
     os.execvp('sqlite3', ('sqlite3', DATABASE_PATH))
 


### PR DESCRIPTION
##### SUMMARY
This fix adds replacement for exit() to sys.exit(), as
exit() is not recommended way to exit from the program.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/nagios_livestatus.py
contrib/inventory/nagios_ndo.py
hacking/report.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```