### PR TITLE
Add module_stdout/stderr fields to list in 'debug' callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/debug.py
+++ b/lib/ansible/plugins/callback/debug.py
@@ -38,13 +38,13 @@ class CallbackModule(CallbackModule_default):  # pylint: disable=too-few-public-
         result['_ansible_verbose_always'] = True
 
         save = {}
-        for key in ['stdout', 'stdout_lines', 'stderr', 'stderr_lines', 'msg']:
+        for key in ['stdout', 'stdout_lines', 'stderr', 'stderr_lines', 'msg', 'module_stdout', 'module_stderr']:
             if key in result:
                 save[key] = result.pop(key)
 
         output = CallbackModule_default._dump_results(self, result)
 
-        for key in ['stdout', 'stderr', 'msg']:
+        for key in ['stdout', 'stderr', 'msg', 'module_stdout', 'module_stderr']:
             if key in save and save[key]:
                 output += '\n\n%s:\n\n%s\n' % (key.upper(), save[key])
 


### PR DESCRIPTION
##### SUMMARY
This PR adds `module_stderr` and `module_stdout` to the list of fields that are handled specially by the `debug` callback plugin. This allows for prettier output of module tracebacks and such.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
`debug` callback plugin

##### ANSIBLE VERSION
```
ansible 2.5.0 (debug_callback_fields f69d1a216b) last updated 2017/12/05 23:39:59 (GMT -600)
```

##### ADDITIONAL INFORMATION
Before:

```
$ ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook debug_callback.yml 

PLAY [localhost] **************************************************************************************************************************************************************************************************************************************************************

TASK [test_module] ************************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "failed": true, 
    "module_stderr": "stderr line 1\nstderr line 2\n", 
    "module_stdout": "stdout line 1\nstdout line 2\n", 
    "rc": 0
}

MSG:

MODULE FAILURE
```

After:

```
$ ANSIBLE_STDOUT_CALLBACK=debug ansible-playbook debug_callback.yml 

PLAY [localhost] **************************************************************************************************************************************************************************************************************************************************************

TASK [test_module] ************************************************************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {
    "changed": false, 
    "rc": 0
}

MSG:

MODULE FAILURE


MODULE_STDOUT:

stdout line 1
stdout line 2



MODULE_STDERR:

stderr line 1
stderr line 2

```