### PR TITLE
fixed: win_copy: typo "file file" (double "file")

### DIFF
--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -291,7 +291,7 @@ if ($mode -eq "query") {
     # expanded this will always result in a change as the calculation is done
     # on the win_copy action plugin and is only run if a change needs to occur
     if (-not (Test-Path -Path $src -PathType Leaf)) {
-        Fail-Json -obj $result -message "Cannot expand src zip file file: $src as it does not exist"
+        Fail-Json -obj $result -message "Cannot expand src zip file: $src as it does not exist"
     }
 
     # Detect if the PS zip assemblies are available or whether to use Shell

--- a/lib/ansible/modules/windows/win_copy.ps1
+++ b/lib/ansible/modules/windows/win_copy.ps1
@@ -1,8 +1,8 @@
 #!powershell
 # This file is part of Ansible
 
-# (c) 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
-# Copyright (c) 2017 Ansible Project
+# Copyright: (c) 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+# Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 #Requires -Module Ansible.ModuleUtils.Legacy
@@ -52,7 +52,7 @@ Function Copy-File($source, $dest) {
     }
 
     if (Test-Path -Path $dest -PathType Container) {
-        Fail-Json -obj $result -message "cannot copy file from $source to $($dest): dest is already a folder"
+        Fail-Json -obj $result -message "cannot copy file from '$source' to '$dest': dest is already a folder"
     } elseif (Test-Path -Path $dest -PathType Leaf) {
         if ($force) {
             $target_checksum = Get-FileChecksum -path $dest
@@ -68,7 +68,7 @@ Function Copy-File($source, $dest) {
         $file_dir = [System.IO.Path]::GetDirectoryName($dest)
         # validate the parent dir is not a file and that it exists
         if (Test-Path -Path $file_dir -PathType Leaf) {
-            Fail-Json -obj $result -message "cannot copy file from $source to $($dest): object at dest parent dir is not a folder"
+            Fail-Json -obj $result -message "cannot copy file from '$source' to '$dest': object at dest parent dir is not a folder"
         } elseif (-not (Test-Path -Path $file_dir)) {
             # directory doesn't exist, need to create
             New-Item -Path $file_dir -ItemType Directory -WhatIf:$check_mode | Out-Null
@@ -110,10 +110,10 @@ Function Copy-Folder($source, $dest) {
     if (-not (Test-Path -Path $dest -PathType Container)) {
         $parent_dir = [System.IO.Path]::GetDirectoryName($dest)
         if (Test-Path -Path $parent_dir -PathType Leaf) {
-            Fail-Json -obj $result -message "cannot copy file from $source to $($dest): object at dest parent dir is not a folder"
+            Fail-Json -obj $result -message "cannot copy file from '$source' to '$dest': object at dest parent dir is not a folder"
         }
         if (Test-Path -Path $dest -PathType Leaf) {
-            Fail-Json -obj $result -message "cannot copy folder from $source to $($dest): dest is already a file"
+            Fail-Json -obj $result -message "cannot copy folder from '$source' to '$dest': dest is already a file"
         }
 
         New-Item -Path $dest -ItemType Container -WhatIf:$check_mode | Out-Null
@@ -173,10 +173,10 @@ Function Extract-Zip($src, $dest) {
             if ($archive_name.EndsWith("/") -or $archive_name.EndsWith("`\")) {
                 $base64_name = $archive_name.Substring(0, $archive_name.Length - 1)
             } else {
-                throw "invalid base64 archive name $archive_name"
+                throw "invalid base64 archive name '$archive_name'"
             }
         } else {
-            throw "invalid base64 length $archive_name"
+            throw "invalid base64 length '$archive_name'"
         }
 
         # to handle unicode character, win_copy action plugin has encoded the filename
@@ -260,7 +260,7 @@ if ($mode -eq "query") {
                 }
             }
         } elseif (Test-Path -Path $filepath -PathType Container) {
-            Fail-Json -obj $result -message "cannot copy file to dest $($filepath): object at path is already a directory"
+            Fail-Json -obj $result -message "cannot copy file to dest '$filepath': object at path is already a directory"
         } else {
             $changed_files += $file
         }
@@ -272,10 +272,10 @@ if ($mode -eq "query") {
         $dirpath = Join-Path -Path $dest -ChildPath $dirname
         $parent_dir = [System.IO.Path]::GetDirectoryName($dirpath)
         if (Test-Path -Path $parent_dir -PathType Leaf) {
-            Fail-Json -obj $result -message "cannot copy folder to dest $($dirpath): object at parent directory path is already a file"
+            Fail-Json -obj $result -message "cannot copy folder to dest '$dirpath': object at parent directory path is already a file"
         }
         if (Test-Path -Path $dirpath -PathType Leaf) {
-            Fail-Json -obj $result -message "cannot copy folder to dest $($dirpath): object at path is already a file"
+            Fail-Json -obj $result -message "cannot copy folder to dest '$dirpath': object at path is already a file"
         } elseif (-not (Test-Path -Path $dirpath -PathType Container)) {
             $changed_directories += $directory
         }
@@ -291,7 +291,7 @@ if ($mode -eq "query") {
     # expanded this will always result in a change as the calculation is done
     # on the win_copy action plugin and is only run if a change needs to occur
     if (-not (Test-Path -Path $src -PathType Leaf)) {
-        Fail-Json -obj $result -message "Cannot expand src zip file: $src as it does not exist"
+        Fail-Json -obj $result -message "Cannot expand src zip file: '$src' as it does not exist"
     }
 
     # Detect if the PS zip assemblies are available or whether to use Shell
@@ -316,7 +316,7 @@ if ($mode -eq "query") {
     $result.dest = $dest
 
     if (-not (Test-Path -Path $src)) {
-        Fail-Json -obj $result -message "Cannot copy src file: $src as it does not exist"
+        Fail-Json -obj $result -message "Cannot copy src file: '$src' as it does not exist"
     }
 
     if (Test-Path -Path $src -PathType Container) {
@@ -355,9 +355,9 @@ if ($mode -eq "query") {
             # file and dest if the path to a file (doesn't end with \ or /)
             $parent_dir = Split-Path -Path $dest
             if (Test-Path -Path $parent_dir -PathType Leaf) {
-                Fail-Json -obj $result -message "object at destination parent dir $parent_dir is currently a file"
+                Fail-Json -obj $result -message "object at destination parent dir '$parent_dir' is currently a file"
             } elseif (-not (Test-Path -Path $parent_dir -PathType Container)) {
-                Fail-Json -obj $result -message "Destination directory $parent_dir does not exist"
+                Fail-Json -obj $result -message "Destination directory '$parent_dir' does not exist"
             }
         }
         $copy_result = Copy-File -source $src -dest $dest
@@ -379,7 +379,7 @@ if ($mode -eq "query") {
     # always result in a change as the calculation is done on the Ansible side
     # before this is run. This should also never run in check mode
     if (-not (Test-Path -Path $src -PathType Leaf)) {
-        Fail-Json -obj $result -message "Cannot copy src file: $src as it does not exist"
+        Fail-Json -obj $result -message "Cannot copy src file: '$src' as it does not exist"
     }
 
     # the dest parameter is a directory, we need to append original_basename
@@ -389,7 +389,7 @@ if ($mode -eq "query") {
 
         # when dest ends with /, we need to create the destination directories
         if (Test-Path -Path $parent_dir -PathType Leaf) {
-            Fail-Json -obj $result -message "object at destination parent dir $parent_dir is currently a file"
+            Fail-Json -obj $result -message "object at destination parent dir '$parent_dir' is currently a file"
         } elseif (-not (Test-Path -Path $parent_dir -PathType Container)) {
             New-Item -Path $parent_dir -ItemType Directory | Out-Null
         }
@@ -399,9 +399,9 @@ if ($mode -eq "query") {
 
         # check if the dest parent dirs exist, need to fail if they don't
         if (Test-Path -Path $parent_dir -PathType Leaf) {
-            Fail-Json -obj $result -message "object at destination parent dir $parent_dir is currently a file"
+            Fail-Json -obj $result -message "object at destination parent dir '$parent_dir' is currently a file"
         } elseif (-not (Test-Path -Path $parent_dir -PathType Container)) {
-            Fail-Json -obj $result -message "Destination directory $parent_dir does not exist"
+            Fail-Json -obj $result -message "Destination directory '$parent_dir' does not exist"
         }
     }
 

--- a/test/integration/targets/win_copy/tasks/remote_tests.yml
+++ b/test/integration/targets/win_copy/tasks/remote_tests.yml
@@ -5,7 +5,7 @@
     dest: fakedest
     remote_src: yes
   register: fail_remote_invalid_source
-  failed_when: "fail_remote_invalid_source.msg != 'Cannot copy src file: fakesource as it does not exist'"
+  failed_when: "'it does not exist' not in fail_remote_invalid_source.msg"
 
 - name: setup source folder for remote tests
   win_copy:
@@ -43,7 +43,7 @@
     dest: '{{test_win_copy_path}}\target\file\foo.txt'
     remote_src: yes
   register: fail_remote_file_parent_dir_file
-  failed_when: fail_remote_file_parent_dir_file.msg != 'object at destination parent dir ' + test_win_copy_path + '\\target\\file is currently a file'
+  failed_when: "'is currently a file' not in fail_remote_file_parent_dir_file.msg"
 
 - name: fail source is a folder dest parent dir is also a file
   win_copy:
@@ -59,7 +59,7 @@
     dest: '{{test_win_copy_path}}\missing-dir\foo.txt'
     remote_src: yes
   register: fail_remote_missing_parent_dir
-  failed_when: "'Destination directory ' + test_win_copy_path + '\\missing-dir does not exist' not in fail_remote_missing_parent_dir.msg"
+  failed_when: "'missing-dir does not exist' not in fail_remote_missing_parent_dir.msg"
 
 - name: remove target after remote failure tests
   win_file:

--- a/test/integration/targets/win_copy/tasks/remote_tests.yml
+++ b/test/integration/targets/win_copy/tasks/remote_tests.yml
@@ -59,7 +59,7 @@
     dest: '{{test_win_copy_path}}\missing-dir\foo.txt'
     remote_src: yes
   register: fail_remote_missing_parent_dir
-  failed_when: "'missing-dir does not exist' not in fail_remote_missing_parent_dir.msg"
+  failed_when: "'does not exist' not in fail_remote_missing_parent_dir.msg"
 
 - name: remove target after remote failure tests
   win_file:

--- a/test/integration/targets/win_copy/tasks/tests.yml
+++ b/test/integration/targets/win_copy/tasks/tests.yml
@@ -24,7 +24,7 @@
     src: foo.txt
     dest: '{{test_win_copy_path}}\missing-dir\foo.txt'
   register: fail_missing_parent_dir
-  failed_when: "'missing-dir does not exist' not in fail_missing_parent_dir.msg"
+  failed_when: "'does not exist' not in fail_missing_parent_dir.msg"
 
 - name: fail to copy an encrypted file without the password set
   win_copy:

--- a/test/integration/targets/win_copy/tasks/tests.yml
+++ b/test/integration/targets/win_copy/tasks/tests.yml
@@ -24,7 +24,7 @@
     src: foo.txt
     dest: '{{test_win_copy_path}}\missing-dir\foo.txt'
   register: fail_missing_parent_dir
-  failed_when: "'Destination directory ' + test_win_copy_path + '\\missing-dir does not exist' not in fail_missing_parent_dir.msg"
+  failed_when: "'missing-dir does not exist' not in fail_missing_parent_dir.msg"
 
 - name: fail to copy an encrypted file without the password set
   win_copy:


### PR DESCRIPTION
##### SUMMARY
Fixes a typo in an error message `Cannot expand src zip file file: $src as it does not exist`

`file` is typed twice.

Should be  `Cannot expand src zip file: $src as it does not exist`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`lib/ansible/modules/windows/win_copy.ps1`

##### ANSIBLE VERSION
`devel` branch
