### PR TITLE
zabbix_template: add Logan2211 to maintainers in BOTMETA

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -427,6 +427,7 @@ files:
   $modules/monitoring/zabbix/zabbix_hostmacro.py: cave
   $modules/monitoring/zabbix/zabbix_maintenance.py: abulimov
   $modules/monitoring/zabbix/zabbix_screen.py: cove harrisongu
+  $modules/monitoring/zabbix/zabbix_template.py: eikef Logan2211 sookido
   $modules/net_tools/basics/get_url.py: jpmens
   $modules/net_tools/basics/slurp.py: $team_ansible
   $modules/net_tools/basics/uri.py: $team_ansible


### PR DESCRIPTION
##### SUMMARY
This PR adds @Logan2211 to the maintainers for the zabbix_template module. They have revamped the module recently, and are helping with reviews of PRs (for instance in #33462); as such, the bot should probably honor their shipits.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_template

##### ANSIBLE VERSION
2.5.0