### PR TITLE
Add --vault-id support to ansible-pull

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -239,6 +239,9 @@ class PullCLI(CLI):
         if self.options.vault_password_files:
             for vault_password_file in self.options.vault_password_files:
                 cmd += " --vault-password-file=%s" % vault_password_file
+        if self.options.vault_ids:
+            for vault_id in self.options.vault_ids:
+                cmd += " --vault-id=%s" % vault_id
 
         for ev in self.options.extra_vars:
             cmd += ' -e "%s"' % ev


### PR DESCRIPTION
##### SUMMARY
Without this additional code snippet `ansible-pull` will still accept
the `--vault-id` option. It just won't pass the option along when
invoking `ansible-pull`.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-pull

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 425537861a) last updated 2017/12/06 13:57:34 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/labs/ansible/devel/lib/ansible
  executable location = /home/andreas/labs/ansible/devel/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```