### PR TITLE
zabbix_host: fix integration tests only working individually

### DIFF
--- a/test/integration/targets/apache2_module/tasks/cleanup.yml
+++ b/test/integration/targets/apache2_module/tasks/cleanup.yml
@@ -1,0 +1,20 @@
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: uninstall libapache2-mod-evasive via apt
+  apt:
+    name: libapache2-mod-evasive
+    state: absent
+  when: "ansible_os_family == 'Debian'"

--- a/test/integration/targets/apache2_module/tasks/main.yml
+++ b/test/integration/targets/apache2_module/tasks/main.yml
@@ -1,6 +1,12 @@
 ---
 
-- name: include only on supported systems
-  include: actualtest.yml
+- name:
+  block:
+    - name: include only on supported systems
+      include: actualtest.yml
+  always:
+     - name: cleanup installed modules
+       include: cleanup.yml
   when: ansible_os_family in ['Debian', 'Suse']
   # centos/RHEL does not have a2enmod/a2dismod
+

--- a/test/integration/targets/apache2_module/tasks/main.yml
+++ b/test/integration/targets/apache2_module/tasks/main.yml
@@ -9,4 +9,3 @@
        include: cleanup.yml
   when: ansible_os_family in ['Debian', 'Suse']
   # centos/RHEL does not have a2enmod/a2dismod
-

--- a/test/integration/targets/zabbix_host/aliases
+++ b/test/integration/targets/zabbix_host/aliases
@@ -1,4 +1,5 @@
 destructive
+posix/ci/group1
 skip/osx
 skip/freebsd
 skip/rhel


### PR DESCRIPTION
##### SUMMARY
zabbix_host integration tests would run when executed individually, but fail to execute properly when run in conjunction with all other CI tests.
The apache2_module integration test installs mod_evasive, which blocks the default configuration of zabbix_web. This PR removes the mod_evasive installation after the tests on apache2_module have run through.

This PR also re-enables the CI tests for zabbix_host.

@mattclay disabled this with a comment in #33184; this should now be resolved.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
2.5.0