### PR TITLE
Fixing wrong parameter name in documentation example

### DIFF
--- a/lib/ansible/modules/network/radware/vdirect_commit.py
+++ b/lib/ansible/modules/network/radware/vdirect_commit.py
@@ -129,7 +129,7 @@ requirements:
 EXAMPLES = '''
 - name: vdirect_commit
   vdirect_commit:
-      vdirect_primary_ip: 10.10.10.10
+      vdirect_ip: 10.10.10.10
       vdirect_user: vDirect
       vdirect_password: radware
       devices: ['dev1', 'dev2']

--- a/lib/ansible/modules/network/radware/vdirect_file.py
+++ b/lib/ansible/modules/network/radware/vdirect_file.py
@@ -106,7 +106,7 @@ requirements:
 EXAMPLES = '''
 - name: vdirect_file
   vdirect_file:
-      vdirect_primary_ip: 10.10.10.10
+      vdirect_ip: 10.10.10.10
       vdirect_user: vDirect
       vdirect_password: radware
       file_name: /tmp/get_vlans.vm

--- a/lib/ansible/modules/network/radware/vdirect_runnable.py
+++ b/lib/ansible/modules/network/radware/vdirect_runnable.py
@@ -121,7 +121,7 @@ requirements:
 EXAMPLES = '''
 - name: vdirect_runnable
   vdirect_runnable:
-      vdirect_primary_ip: 10.10.10.10
+      vdirect_ip: 10.10.10.10
       vdirect_user: vDirect
       vdirect_password: radware
       runnable_type: ConfigurationTemplate


### PR DESCRIPTION
Fixes #33529

##### SUMMARY
Fixing wrong parameter name in documentation example

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
module network/radware/vdirect_file
module network/radware/vdirect_runnable
module network/radware/vdirect_commit

##### ANSIBLE VERSION
ansible 2.4

