### PR TITLE
Fix bug in `consul_acl` to allow an ACL's token to be changed

### DIFF
--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -251,7 +251,8 @@ def set_acl(consul_client, configuration):
         # Token given but no ACL with token exists, however an ACL with the same name exists. Remove ACL with outdated
         # token
         remove_old_result = remove_acl(consul_client, existing_acls_mapped_by_name[configuration.name].token)
-        assert remove_old_result.changed
+        if not remove_old_result.changed:
+            raise AssertionError()
         del existing_acls_mapped_by_name[configuration.name]
 
     if configuration.token and configuration.token in existing_acls_mapped_by_token:

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 #
 # (c) 2015, Steve Gargan <steve.gargan@gmail.com>
+# Copyright (c) 2017 Genome Research Ltd.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -245,6 +245,14 @@ def set_acl(consul_client, configuration):
         # Name used as identifier instead of token - get token of ACL with identifying name
         configuration.token = existing_acls_mapped_by_name[configuration.name].token
 
+    if configuration.token not in existing_acls_mapped_by_token \
+            and configuration.name in existing_acls_mapped_by_name:
+        # Token given but no ACL with token exists, however an ACL with the same name exists. Remove ACL with outdated
+        # token
+        remove_old_result = remove_acl(consul_client, existing_acls_mapped_by_name[configuration.name].token)
+        assert remove_old_result.changed
+        del existing_acls_mapped_by_name[configuration.name]
+
     if configuration.token and configuration.token in existing_acls_mapped_by_token:
         # Token given and ACL with token exists - update the existing ACL
         return update_acl(

--- a/lib/ansible/modules/clustering/consul_acl.py
+++ b/lib/ansible/modules/clustering/consul_acl.py
@@ -238,8 +238,8 @@ def set_acl(consul_client, configuration):
     existing_acls_mapped_by_name = dict((acl.name, acl) for acl in acls_as_json if acl.name is not None)
     existing_acls_mapped_by_token = dict((acl.token, acl) for acl in acls_as_json)
     if None in existing_acls_mapped_by_token:
-        raise AssertionError("expecting ACL list to be associated to a token: %s" %
-                             existing_acls_mapped_by_token[None])
+        raise AssertionError("Expecting ACL list to be associated to a token: %s"
+                             % existing_acls_mapped_by_token[None])
 
     if configuration.token is None and configuration.name is not None \
             and configuration.name in existing_acls_mapped_by_name:
@@ -252,7 +252,8 @@ def set_acl(consul_client, configuration):
         # token
         remove_old_result = remove_acl(consul_client, existing_acls_mapped_by_name[configuration.name].token)
         if not remove_old_result.changed:
-            raise AssertionError()
+            raise AssertionError("Expecting the old ACL with the token \"%s\" to have been removed"
+                                 % (existing_acls_mapped_by_name[configuration.name].token, ))
         del existing_acls_mapped_by_name[configuration.name]
 
     if configuration.token and configuration.token in existing_acls_mapped_by_token:
@@ -261,9 +262,9 @@ def set_acl(consul_client, configuration):
             consul_client, configuration.token, configuration.name, configuration.token_type, configuration.rules)
     else:
         if configuration.token in existing_acls_mapped_by_token:
-            raise AssertionError()
+            raise AssertionError("Expecting ACL with token \"%s\" not to exist" % (configuration.token, ))
         if configuration.name in existing_acls_mapped_by_name:
-            raise AssertionError()
+            raise AssertionError("Expecting ACL with name \"%s\" not to exist" % (configuration.name, ))
         return create_acl(
             consul_client, configuration.token, configuration.name, configuration.token_type, configuration.rules)
 
@@ -286,7 +287,7 @@ def update_acl(consul_client, token, name, token_type, rules):
         rules_as_hcl = encode_rules_as_hcl_string(rules)
         updated_token = consul_client.acl.update(token, name=name, type=token_type, rules=rules_as_hcl)
         if updated_token != token:
-            raise AssertionError()
+            raise AssertionError("Unexpected ACL token returned by Consul client")
 
     return Output(changed=changed, token=token, rules=rules, operation=UPDATE_OPERATION)
 
@@ -401,13 +402,13 @@ def encode_rules_as_json(rules):
     for rule in rules:
         if rule.pattern is not None:
             if rule.pattern in rules_as_json[rule.scope]:
-                raise AssertionError()
+                raise AssertionError("Duplicate pattern for \"%s\" scope in the rule: %s" % (rule.scope, rule))
             rules_as_json[rule.scope][rule.pattern] = {
                 _POLICY_JSON_PROPERTY: rule.policy
             }
         else:
             if rule.scope in rules_as_json:
-                raise AssertionError()
+                raise AssertionError("Duplicate \"%s\" scope in the rule: %s" % (rule.scope, rule))
             rules_as_json[rule.scope] = rule.policy
     return rules_as_json
 

--- a/test/legacy/roles/test_consul_acl/tasks/main.yml
+++ b/test/legacy/roles/test_consul_acl/tasks/main.yml
@@ -8,4 +8,6 @@
 
 - import_tasks: update-acl.yml
 
+- import_tasks: update-acl-token.yml
+
 - import_tasks: remove-acl.yml

--- a/test/legacy/roles/test_consul_acl/tasks/update-acl-token.yml
+++ b/test/legacy/roles/test_consul_acl/tasks/update-acl-token.yml
@@ -1,0 +1,30 @@
+---
+
+- name: create an ACL
+  consul_acl:
+    host: "{{ acl_host }}"
+    mgmt_token: "{{ mgmt_token }}"
+    name: "{{ test_consul_acl_token_name }}"
+    token: "{{ test_consul_acl_token_id }}"
+  register: created_acl
+
+- name: change ACL token
+  consul_acl:
+    host: "{{ acl_host }}"
+    mgmt_token: "{{ mgmt_token }}"
+    name: "{{ test_consul_acl_token_name }}"
+    token: "{{ test_consul_acl_token_id_2 }}"
+  register: updated_acl
+
+- name: verify updated ACL
+  assert:
+    that:
+      - updated_acl.changed
+      - updated_acl.token == test_consul_acl_token_id_2
+
+- name: clean up
+  consul_acl:
+    host: "{{ acl_host }}"
+    mgmt_token: "{{ mgmt_token }}"
+    token: "{{ created_acl.token }}"
+    state: absent

--- a/test/legacy/roles/test_consul_acl/vars/main.yml
+++ b/test/legacy/roles/test_consul_acl/vars/main.yml
@@ -1,4 +1,5 @@
 ---
 
-test_consul_acl_token_name: example-token
+test_consul_acl_token_name: example-acl-name
 test_consul_acl_token_id: 60DEC4BC-DD47-4F4E-A95A-19D639407D2C
+test_consul_acl_token_id_2: 41EE7010-A4F7-4F4C-A379-B7B34DC44255


### PR DESCRIPTION
##### SUMMARY
Fixes a bug in `consul_acl`, where if an ACL with the same name had a different token, an assertion failed (i.e. the module was unable to handle an ACL's token changing).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
consul_acl

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.6/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.6.2 (default, Sep 13 2017, 14:26:54) [GCC 4.9.2]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Regression tests added (although they're not currently ran as part of the CI - see #26229).