### PR TITLE
Fix Command module documentation

### DIFF
--- a/lib/ansible/modules/commands/command.py
+++ b/lib/ansible/modules/commands/command.py
@@ -57,7 +57,8 @@ options:
     default: null
 notes:
     -  If you want to run a command through the shell (say you are using C(<), C(>), C(|), etc), you actually want the M(shell) module instead.
-       The C(command) module is much more secure as it's not affected by the user's environment.
+       Parsing shell metacharacters can lead to unexpected commands being executed if quoting is not done correctly so it is more secure to
+       use the C(command) module when possible.
     -  " C(creates), C(removes), and C(chdir) can be specified after the command.
        For instance, if you only want to run a command if a certain file does not exist, use this."
     -  The C(executable) parameter is removed since version 2.4. If you have a need for this parameter, use the M(shell) module instead.


### PR DESCRIPTION
The command module docs were unclear.  They talked about ignoring the user's environment which lead people to believe the user's environment variables were not used.  In actual fact, the user's environment variables are used.  They just are not expanded in the command.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
lib/ansible/modules/commands/command.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel, stable-2.4
```
