### PR TITLE
Add some bot ignores on some namespaces for a few users

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -268,6 +268,8 @@ files:
   $modules/cloud/packet/:
   $modules/cloud/profitbricks/: baldwinSPC
   $modules/cloud/pubnub/pubnub_blocks.py: parfeon pubnub
+  $modules/cloud/rackspace/:
+    ignored: sivel angstwad
   $modules/cloud/rackspace/rax_cdb.py: jails
   $modules/cloud/rackspace/rax_cdb_database.py: jails
   $modules/cloud/rackspace/rax_cdb_user.py: jails
@@ -695,7 +697,9 @@ files:
   $modules/web_infrastructure/rundeck_project.py: nerzhul
   $modules/web_infrastructure/supervisorctl.py: inetfuture mattupstate
   $modules/web_infrastructure/taiga_issue.py: lekum
-  $modules/windows/: $team_windows
+  $modules/windows/:
+    maintainers: $team_windows
+    ignored: angstwad
   $modules/windows/async_status.ps1: $team_windows
   $modules/windows/async_wrapper.ps1: $team_windows
   $modules/windows/setup.ps1: $team_ansible


### PR DESCRIPTION
##### SUMMARY

Extends https://github.com/ansible/ansible/pull/32865 to make sure myself and @angstwad  are ignored on some modules and namespaces that we no longer maintain.

##### ISSUE TYPE

 - Docs Pull Request

##### COMPONENT NAME
botmeta

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```