### PR TITLE
Only expose rekey options to ansible-vault command

### DIFF
--- a/lib/ansible/cli/__init__.py
+++ b/lib/ansible/cli/__init__.py
@@ -413,7 +413,7 @@ class CLI(with_metaclass(ABCMeta, object)):
     @staticmethod
     def base_parser(usage="", output_opts=False, runas_opts=False, meta_opts=False, runtask_opts=False, vault_opts=False, module_opts=False,
                     async_opts=False, connect_opts=False, subset_opts=False, check_opts=False, inventory_opts=False, epilog=None, fork_opts=False,
-                    runas_prompt_opts=False, desc=None, basedir_opts=False):
+                    runas_prompt_opts=False, desc=None, basedir_opts=False, vault_rekey_opts=False):
         ''' create an options parser for most ansible scripts '''
 
         # base opts
@@ -446,10 +446,12 @@ class CLI(with_metaclass(ABCMeta, object)):
                               help='ask for vault password')
             parser.add_option('--vault-password-file', default=[], dest='vault_password_files',
                               help="vault password file", action="callback", callback=CLI.unfrack_paths, type='string')
-            parser.add_option('--new-vault-password-file', default=[], dest='new_vault_password_files',
-                              help="new vault password file for rekey", action="callback", callback=CLI.unfrack_paths, type='string')
             parser.add_option('--vault-id', default=[], dest='vault_ids', action='append', type='string',
                               help='the vault identity to use')
+
+        if vault_rekey_opts:
+            parser.add_option('--new-vault-password-file', default=[], dest='new_vault_password_files',
+                              help="new vault password file for rekey", action="callback", callback=CLI.unfrack_paths, type='string')
             parser.add_option('--new-vault-id', default=None, dest='new_vault_id', type='string',
                               help='the new vault identity to use for rekey')
 

--- a/lib/ansible/cli/vault.py
+++ b/lib/ansible/cli/vault.py
@@ -110,6 +110,7 @@ class VaultCLI(CLI):
 
         self.parser = CLI.base_parser(
             vault_opts=True,
+            vault_rekey_opts=True,
             usage="usage: %%prog [%s] [options] [vaultfile.yml]" % "|".join(self.VALID_ACTIONS),
             desc="encryption/decryption utility for Ansible data files",
             epilog="\nSee '%s <command> --help' for more information on a specific command.\n\n" % os.path.basename(sys.argv[0])


### PR DESCRIPTION
##### SUMMARY
`ansible-vault` is the only cli command which knows how to handle the
rekey options `--new-vault-id` and `--new-vault-password-file`. No
point in exposing those rekey options to any of the other ansible
commands.

On a practical level I think this matters most in ensuring that
`--help` doesn't produce any false/unhelpful output.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-vault

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel b91117dac8) last updated 2017/12/07 05:32:01 (GMT +200)
  config file = None
  configured module search path = [u'/home/andreas/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/andreas/labs/ansible/devel/lib/ansible
  executable location = /home/andreas/labs/ansible/devel/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```