### PR TITLE
fix Azure test case failure for function apps module

### DIFF
--- a/test/integration/targets/azure_rm_functionapp/tasks/main.yml
+++ b/test/integration/targets/azure_rm_functionapp/tasks/main.yml
@@ -19,10 +19,13 @@
   azure_rm_functionapp_facts:
     resource_group: '{{ resource_group }}'
     name: azfuncci
+  register: results
 
 - name: assert the facts were retrieved
   assert:
-    that: '{{ ansible_facts.azure_functionapps|length == 1 }}'
+    that:
+    - results.ansible_facts.azure_functionapps|length == 1
+    - results.ansible_facts.azure_functionapps[0].name == 'azfuncci'
 
 - name: delete basic function app
   azure_rm_functionapp:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This commit below below task failure when running test for Azure function apps module.

```
TASK [assert the facts were retrieved] *****************************************
fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'ansible_facts' is undefined\n\nThe error appears to have been in '/home/travis/build/Azure/preview-modules/tests/integration/targets/azure_rm_functionapp/tasks/main.yml': line 23, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: assert the facts were retrieved\n  ^ here\n\nexception type: <class 'ansible.errors.AnsibleUndefinedVariable'>\nexception: 'ansible_facts' is undefined"}
```
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
azure_rm_functionapp

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/Users/zhijzhao/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
@yuwzho @zikalino @yaweiw 