### PR TITLE
rhn_register: Fix for "cannot marshal None unless.."

### DIFF
--- a/lib/ansible/modules/packaging/os/rhn_register.py
+++ b/lib/ansible/modules/packaging/os/rhn_register.py
@@ -292,6 +292,8 @@ class Rhn(redhat.RegistrationBase):
         os.unlink(self.config['systemIdPath'])
 
     def subscribe(self, channels):
+        if not channels:
+            return
         if self._is_hosted():
             current_channels = self.api('channel.software.listSystemChannels', self.systemid)
             new_channels = [item['channel_label'] for item in current_channels]

--- a/test/units/modules/packaging/os/test_rhn_register.py
+++ b/test/units/modules/packaging/os/test_rhn_register.py
@@ -110,9 +110,9 @@ def test_without_required_parameters(capfd, patch_rhn):
 TESTED_MODULE = rhn_register.__name__
 TEST_CASES = [
     [
-        # Registering an unregistered host
+        # Registering an unregistered host and subscribing to one channel
         {
-            'activationkey': 'key',
+            'channels': 'rhel-x86_64-server-6',
             'username': 'user',
             'password': 'pass',
         },
@@ -133,6 +133,26 @@ TEST_CASES = [
             'run_command.call_count': 1,
             'run_command.call_args': '/usr/sbin/rhnreg_ks',
             'request_called': True,
+            'unlink.call_count': 0,
+        }
+    ],
+    [
+        # Registering an unregistered host with only an activationkey and without subscribing any channels
+        {
+            'activationkey': 'key',
+        },
+        {
+            'calls': [
+            ],
+            'is_registered': False,
+            'is_registered.call_count': 1,
+            'enable.call_count': 1,
+            'systemid.call_count': 0,
+            'changed': True,
+            'msg': "System successfully registered to 'rhn.redhat.com'.",
+            'run_command.call_count': 1,
+            'run_command.call_args': '/usr/sbin/rhnreg_ks',
+            'request_called': False,
             'unlink.call_count': 0,
         }
     ],


### PR DESCRIPTION
when using only an activation key without any channels.
As already suggested by @mattclay in
https://github.com/ansible/ansible/pull/25079

##### SUMMARY
rhn_register still throws an error with ansible-2.4.2.0 when using only an activationkey:
```
fatal: [MYHOST]: FAILED! => {"changed": false, "msg": "Failed to
register with 'MY_SPACEWALKSERVER': cannot marshal None unless allow_none is
enabled"}
```
This is Bug was reported in #24997

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
rhn_register

##### ANSIBLE VERSION

```
ansible 2.5.0 (fix_rhn_register 9fd7da88a1) last updated 2017/12/07 10:28:59 (GMT +200)
```