### PR TITLE
ovirt_storage_domains.py: Raise Exception in case no host is up for SD removal

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_domains.py
@@ -531,7 +531,12 @@ def main():
             host_param = module.params['host']
             if not host_param:
                 host = search_by_attributes(connection.system_service().hosts_service(), status='up')
-                host_param = host.name if host is not None else None
+                if host is None:
+                    raise Exception(
+                        "Not possible to remove storage domain '%s' "
+                        "because no host found with status `up`." % module.params['name']
+                    )
+                host_param = host.name
             ret = storage_domains_module.remove(
                 destroy=module.params['destroy'],
                 format=module.params['format'],


### PR DESCRIPTION
##### SUMMARY
When trying to remove a storage domain, in case we don't supply the host parameter and in case no host has up state, we should fail with appropriate Exception.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ovirt_storage_domains.py

##### ANSIBLE VERSION
```
ansible 2.5.0
```
