### PR TITLE
fixes guess_os for netconf connections

### DIFF
--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -164,6 +164,7 @@ class Connection(ConnectionBase):
         allow_agent = True
         if self._play_context.password is not None:
             allow_agent = False
+        setattr(self._play_context, 'allow_agent', allow_agent)
 
         key_filename = None
         if self._play_context.private_key_file:
@@ -195,7 +196,7 @@ class Connection(ConnectionBase):
                 key_filename=str(key_filename),
                 hostkey_verify=C.HOST_KEY_CHECKING,
                 look_for_keys=C.PARAMIKO_LOOK_FOR_KEYS,
-                allow_agent=allow_agent,
+                allow_agent=self._play_context.allow_agent,
                 timeout=self._play_context.timeout,
                 device_params={'name': network_os},
                 ssh_config=ssh_config
@@ -234,3 +235,4 @@ class Connection(ConnectionBase):
             self._manager.close_session()
             self._connected = False
         super(Connection, self).close()
+

--- a/lib/ansible/plugins/connection/netconf.py
+++ b/lib/ansible/plugins/connection/netconf.py
@@ -235,4 +235,3 @@ class Connection(ConnectionBase):
             self._manager.close_session()
             self._connected = False
         super(Connection, self).close()
-

--- a/lib/ansible/plugins/netconf/iosxr.py
+++ b/lib/ansible/plugins/netconf/iosxr.py
@@ -141,10 +141,10 @@ class Netconf(NetconfBase):
                 port=obj._play_context.port or 830,
                 username=obj._play_context.remote_user,
                 password=obj._play_context.password,
-                key_filename=str(obj.key_filename),
+                key_filename=obj._play_context.private_key_file,
                 hostkey_verify=C.HOST_KEY_CHECKING,
                 look_for_keys=C.PARAMIKO_LOOK_FOR_KEYS,
-                allow_agent=obj.allow_agent,
+                allow_agent=obj._play_context.allow_agent,
                 timeout=obj._play_context.timeout
             )
         except SSHUnknownHostError as exc:

--- a/lib/ansible/plugins/netconf/junos.py
+++ b/lib/ansible/plugins/netconf/junos.py
@@ -107,10 +107,10 @@ class Netconf(NetconfBase):
                 port=obj._play_context.port or 830,
                 username=obj._play_context.remote_user,
                 password=obj._play_context.password,
-                key_filename=str(obj.key_filename),
+                key_filename=obj._play_context.private_key_file,
                 hostkey_verify=C.HOST_KEY_CHECKING,
                 look_for_keys=C.PARAMIKO_LOOK_FOR_KEYS,
-                allow_agent=obj.allow_agent,
+                allow_agent=obj._play_context.allow_agent,
                 timeout=obj._play_context.timeout
             )
         except SSHUnknownHostError as exc:


### PR DESCRIPTION
This change fixes invalid calls to play_context when the network_os is
not set and the connection attempts to guess the network_os.  The method
will now check the correct values for ssh key file and allow agent
instead of returning errors.

