### PR TITLE
Enable redshift enhanced vpc routing, dc2.8xlarge type

### DIFF
--- a/lib/ansible/modules/cloud/amazon/redshift.py
+++ b/lib/ansible/modules/cloud/amazon/redshift.py
@@ -34,8 +34,8 @@ options:
   node_type:
     description:
       - The node type of the cluster. Must be specified when command=create.
-    choices: ['ds1.xlarge', 'ds1.8xlarge', 'ds2.xlarge', 'ds2.8xlarge', 'dc1.large', 'dc2.large', 'dc1.8xlarge', 'dw1.xlarge',
-              'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge']
+    choices: ['ds1.xlarge', 'ds1.8xlarge', 'ds2.xlarge', 'ds2.8xlarge', 'dc1.large', 'dc1.8xlarge', 'dc2.large', 'dc2.8xlarge',
+              'dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge']
   username:
     description:
       - Master database username. Used only when command=create.
@@ -284,7 +284,7 @@ def create_cluster(module, redshift):
               'automated_snapshot_retention_period', 'port',
               'cluster_version', 'allow_version_upgrade',
               'number_of_nodes', 'publicly_accessible',
-              'encrypted', 'elastic_ip'):
+              'encrypted', 'elastic_ip', 'enhanced_vpc_routing'):
         if p in module.params:
             params[p] = module.params.get(p)
 
@@ -397,7 +397,8 @@ def modify_cluster(module, redshift):
               'availability_zone', 'preferred_maintenance_window',
               'cluster_parameter_group_name',
               'automated_snapshot_retention_period', 'port', 'cluster_version',
-              'allow_version_upgrade', 'number_of_nodes', 'new_cluster_identifier'):
+              'allow_version_upgrade', 'number_of_nodes', 'new_cluster_identifier',
+              'enhanced_vpc_routing'):
         if p in module.params:
             params[p] = module.params.get(p)
 
@@ -462,6 +463,7 @@ def main():
         encrypted=dict(type='bool', default=False),
         elastic_ip=dict(required=False),
         new_cluster_identifier=dict(aliases=['new_identifier']),
+        enhanced_vpc_routing=dict(type='bool', default=False),
         wait=dict(type='bool', default=False),
         wait_timeout=dict(type='int', default=300),
     ))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
- Adds Enhanced VPC Routing as a configurable option when creating a
  new cluster.  Defaults to 'false'
- Adds the new dc2.8xlarge node type

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
redshift

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/mattdoller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/opt/pyenv/versions/2.7.13/lib/python2.7/site-packages/ansible
  executable location = /usr/local/opt/pyenv/versions/2.7.13/bin/ansible
  python version = 2.7.13 (default, Oct 23 2017, 22:12:17) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
<no output / empty>

