### PR TITLE
Allow apt downgrades

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -70,6 +70,13 @@ options:
     type: bool
     default: 'no'
     version_added: "2.1"
+  allow_downgrades:
+    description:
+      - Allow packages to be downgraded to an earlier version. This can be used as a more granular
+        "force".
+    type: bool
+    default: 'no'
+    version_added: "2.5"
   upgrade:
     description:
       - If yes or safe, performs an aptitude safe-upgrade.
@@ -154,6 +161,12 @@ EXAMPLES = '''
   apt:
     name: foo=1.00
     state: present
+
+- name: Install the version '1.00' of package "foo" and allow potential downgrades
+  apt:
+    name: foo=1.00
+    state: present
+    allow_downgrades: yes
 
 - name: Update the repository cache and update package "nginx" to latest version using default release squeeze-backport
   apt:

--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -483,7 +483,7 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
             install_recommends=None, force=False,
             dpkg_options=expand_dpkg_options(DPKG_OPTIONS),
             build_dep=False, autoremove=False, only_upgrade=False,
-            allow_unauthenticated=False):
+            allow_unauthenticated=False, allow_downgrades=False):
     pkg_list = []
     packages = ""
     pkgspec = expand_pkgspec_from_fnmatches(m, pkgspec, cache)
@@ -545,6 +545,9 @@ def install(m, pkgspec, cache, upgrade=False, default_release=None,
         if allow_unauthenticated:
             cmd += " --allow-unauthenticated"
 
+        if allow_downgrades:
+            cmd += " --allow-downgrades"
+
         rc, out, err = m.run_command(cmd)
         if m._diff:
             diff = parse_diff(out)
@@ -569,7 +572,8 @@ def get_field_of_deb(m, deb_file, field="Version"):
     return to_native(stdout).strip('\n')
 
 
-def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated, dpkg_options):
+def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated, dpkg_options,
+                allow_downgrades):
     changed = False
     deps_to_install = []
     pkgs_to_install = []
@@ -623,6 +627,9 @@ def install_deb(m, debs, cache, force, install_recommends, allow_unauthenticated
             options += " --simulate"
         if force:
             options += " --force-all"
+
+        if allow_downgrades:
+            options += " --force-downgrade"
 
         cmd = "dpkg %s -i %s" % (options, " ".join(pkgs_to_install))
         rc, out, err = m.run_command(cmd)
@@ -887,6 +894,7 @@ def main():
             only_upgrade=dict(type='bool', default=False),
             force_apt_get=dict(type='bool', default=False),
             allow_unauthenticated=dict(type='bool', default=False, aliases=['allow-unauthenticated']),
+            allow_downgrades=dict(type='bool', default=False, aliases=['allow-downgrades']),
         ),
         mutually_exclusive=[['deb', 'package', 'upgrade']],
         required_one_of=[['autoremove', 'deb', 'package', 'update_cache', 'upgrade']],
@@ -930,6 +938,7 @@ def main():
     updated_cache_time = 0
     install_recommends = p['install_recommends']
     allow_unauthenticated = p['allow_unauthenticated']
+    allow_downgrades = p['allow_downgrades']
     dpkg_options = expand_dpkg_options(p['dpkg_options'])
     autoremove = p['autoremove']
     autoclean = p['autoclean']
@@ -997,6 +1006,7 @@ def main():
             install_deb(module, p['deb'], cache,
                         install_recommends=install_recommends,
                         allow_unauthenticated=allow_unauthenticated,
+                        allow_downgrades=allow_downgrades,
                         force=force_yes, dpkg_options=p['dpkg_options'])
 
         unfiltered_packages = p['package'] or ()
@@ -1042,7 +1052,8 @@ def main():
                 build_dep=state_builddep,
                 autoremove=autoremove,
                 only_upgrade=p['only_upgrade'],
-                allow_unauthenticated=allow_unauthenticated
+                allow_unauthenticated=allow_unauthenticated,
+                allow_downgrades=allow_downgrades
             )
 
             # Store if the cache has been updated


### PR DESCRIPTION
##### SUMMARY

This introduces an `allow_downgrades` option to the apt module. The reason we want this internally is because we feel `force` is too broad, but ocasionally want to use rollbacks.

Fixes https://github.com/ansible/ansible/issues/29451

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

Ansible apt module.

##### ANSIBLE VERSION
```
ansible 2.5.0 (allow-apt-downgrades e4d648a02d) last updated 2017/12/07 15:58:00 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/laurens/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/laurens/repos/ansible/ansible/lib/ansible
  executable location = /home/laurens/repos/ansible/ansible/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION

After this change, we can write the following task for a playbook:

```
- name: downgrade package
  apt
    package: foo=1.2
    state: present
    allow_downgrades: yes
```