### PR TITLE
Address recent changes to tests to fix jinja tests as filters

### DIFF
--- a/test/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/test/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -11,7 +11,7 @@
     - name: assert failure
       assert:
         that:
-          - 'result | failed'
+          - 'result is failed'
           - 'result.msg.startswith("missing required arguments")'
 
     # ============================================================
@@ -28,7 +28,7 @@
     - name: assert connection failure
       assert:
         that:
-          - 'result | failed'
+          - 'result is failed'
           - 'result.msg.startswith("No handler was ready to authenticate")'
 
     # ============================================================
@@ -71,7 +71,7 @@
     - name: assert the VPC was created successfully
       assert:
         that:
-          - 'result | success'
+          - 'result is successful'
           - 'result.changed'
 
     - name: assert the output
@@ -126,7 +126,7 @@
     - name: assert a new VPC was created
       assert:
         that:
-          - 'result | success'
+          - 'result is successful'
           - 'result.changed'
           - 'result.vpc.instance_tenancy == "dedicated"'
           - result.vpc.id != vpc_1
@@ -146,7 +146,7 @@
     - name: assert failure
       assert:
         that:
-          - 'result | failed'
+          - 'result is failed'
           - '"If you would like to create the VPC anyway please pass True to the multi_ok param" in result.msg'
 
     # ============================================================
@@ -243,7 +243,7 @@
     - name: assert a change was made
       assert:
         that:
-          - 'result | success'
+          - 'result is successful'
           # FIXME The module currently doesn't note changed for VPC attributes.
           # Once this is fixed a test should be added for check mode as well.
           # - 'result.changed'

--- a/test/integration/targets/win_audit_policy_system/tasks/add.yml
+++ b/test/integration/targets/win_audit_policy_system/tasks/add.yml
@@ -18,8 +18,8 @@
 - name: check mode assert that changed is true
   assert:
     that:
-      - category | changed
-      - subcategory | changed
+      - category is changed
+      - subcategory is changed
 
 - name: check mode assert that audit_type is "no auditing"
   assert:
@@ -54,8 +54,8 @@
 - name: enable assert that changed is true
   assert:
     that:
-      - category | changed
-      - subcategory | changed
+      - category is changed
+      - subcategory is changed
 
 - name: enable assert that audit_type is "success" for category
   assert:
@@ -90,8 +90,8 @@
 - name: idem assert that changed is false
   assert:
     that:
-      - not category | changed
-      - not subcategory | changed
+      - category is not changed
+      - subcategory is not changed
 
 - name: idem assert that audit_type is "success" for category
   assert:

--- a/test/integration/targets/win_audit_policy_system/tasks/remove.yml
+++ b/test/integration/targets/win_audit_policy_system/tasks/remove.yml
@@ -18,8 +18,8 @@
 - name: check mode assert that changed is true
   assert:
     that:
-      - category | changed
-      - subcategory | changed
+      - category is changed
+      - subcategory is changed
 
 - name: check mode assert that audit_type is still "success" (old value) for category
   assert:
@@ -54,8 +54,8 @@
 - name: assert that changed is true
   assert:
     that:
-      - category | changed
-      - subcategory | changed
+      - category is changed
+      - subcategory is changed
 
 - name: assert that audit_type is "no auditing"
   assert:
@@ -84,8 +84,8 @@
 - name: idem assert that changed is false
   assert:
     that:
-      - not category | changed
-      - not subcategory | changed
+      - category is not changed
+      - subcategory is not changed
 
 - name: assert that audit_type is "no auditing"
   assert:


### PR DESCRIPTION
##### SUMMARY
Address recent changes to tests to fix jinja tests as filters

Following on #32361 this PR fixes tests as filters syntax to use proper is test syntax in newly modified files.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tests

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```