### PR TITLE
Fix issues with net_user tests on eos

### DIFF
--- a/test/integration/targets/net_user/tests/eos/userprivilege.yaml
+++ b/test/integration/targets/net_user/tests/eos/userprivilege.yaml
@@ -1,4 +1,11 @@
 ---
+- name: Setup
+  net_user: &clear_netop
+    name: netop
+    state: absent
+    authorize: yes
+    provider: "{{ cli }}"
+
 - name: Set user to privilege level 15
   net_user:
     name: netop
@@ -12,9 +19,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["username netop privilege 15"]'
+      - 'result.commands == ["username netop privilege 15", "username netop nopassword"]'
 
 - name: tearDown
-  net_user:
-    purge: yes
-    provider: "{{ cli }}"
+  net_user: *clear_netop

--- a/test/integration/targets/net_user/tests/eos/userrole.yaml
+++ b/test/integration/targets/net_user/tests/eos/userrole.yaml
@@ -1,9 +1,19 @@
 ---
+- name: Setup
+  net_user: &clear_users
+    aggregate:
+      - name: netop
+      - name: netend
+    state: absent
+    authorize: yes
+    provider: "{{ cli }}"
+
 - name: Set multiple users role
   net_user:
     aggregate:
       - name: netop
       - name: netend
+    nopassword: yes
     role: network-operator
     state: present
     authorize: yes
@@ -13,10 +23,7 @@
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["username netop role network-operator", "username netend role network-operator"]'
+      - 'result.commands == ["username netop role network-operator", "username netop nopassword", "username netend role network-operator", "username netend nopassword"]'
 
 - name: tearDown
-  net_user:
-    purge: yes
-    authorize: yes
-    provider: "{{ cli }}"
+  net_user: *clear_users

--- a/test/integration/targets/net_user/tests/eos/users.yaml
+++ b/test/integration/targets/net_user/tests/eos/users.yaml
@@ -1,20 +1,27 @@
 ---
+- name: Setup
+  net_user: &clear_netop
+    name: netop
+    state: absent
+    authorize: yes
+    provider: "{{ cli }}"
+
 - name: Create user
   net_user:
     name: netop
+    nopassword: yes
     state: present
+    authorize: yes
     provider: "{{ cli }}"
   register: result
 
 - assert:
     that:
       - 'result.changed == true'
-      - 'result.commands == ["username netop"]'
+      - 'result.commands == ["username netop nopassword"]'
 
-- name: Purge users
-  net_user:
-    purge: yes
-    provider: "{{ cli }}"
+- name: tearDown
+  net_user: *clear_netop
   register: result
 
 - assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
These tests are a little problematic and do not work correctly. I added a setup to clear the users in question, replaced the later `purge: yes` with the same check, and set `nopassword` to mollify eos_user.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
net_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```