### PR TITLE
add state parameter to patch module

### DIFF
--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -188,10 +188,10 @@ def main():
     p.src = os.path.abspath(p.src)
 
     changed = False
-    if not is_already_applied(patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip):
+    if not is_already_applied(patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip, state=p.state):
         try:
             apply_patch(patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip,
-                        dry_run=module.check_mode, backup=p.backup)
+                        dry_run=module.check_mode, backup=p.backup, state=p.state)
             changed = True
         except PatchError as e:
             module.fail_json(msg=to_native(e), exception=format_exc())

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -43,7 +43,7 @@ options:
     required: true
     aliases: [ patchfile ]
   state:
-    version_added: "2.5"
+    version_added: "2.6"
     description:
       - Whether the patch should be applied or reverted.
     choices: [ absent, present ]

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -42,6 +42,11 @@ options:
         module's I(files) directory.
     required: true
     aliases: [ patchfile ]
+  state:
+    description:
+      - Whether the patch should be applied or reverted.
+    choices: [ absent, present ]
+    default: present
   remote_src:
     description:
       - If C(no), it will search for src at originating/master machine, if C(yes) it will
@@ -84,6 +89,12 @@ EXAMPLES = r'''
     src: /tmp/customize.patch
     basedir: /var/www
     strip: 1
+
+- name: Revert patch to one file
+  patch:
+    src: /tmp/index.html.patch
+    dest: /var/www/index.html
+    state: absent
 '''
 
 import os
@@ -96,20 +107,22 @@ class PatchError(Exception):
     pass
 
 
-def is_already_applied(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0):
-    opts = ['--quiet', '--reverse', '--forward', '--dry-run',
+def is_already_applied(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0, state='present'):
+    opts = ['--quiet', '--forward', '--dry-run',
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
     if binary:
         opts.append('--binary')
     if dest_file:
         opts.append("'%s'" % dest_file)
+    if state == 'present':
+        opts.append('--reverse')
 
     (rc, _, _) = patch_func(opts)
     return rc == 0
 
 
-def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0, dry_run=False, backup=False):
+def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0, dry_run=False, backup=False, state='present'):
     opts = ['--quiet', '--forward', '--batch', '--reject-file=-',
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
@@ -121,6 +134,8 @@ def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, s
         opts.append("'%s'" % dest_file)
     if backup:
         opts.append('--backup --version-control=numbered')
+    if state == 'absent':
+        opts.append('--reverse')
 
     (rc, out, err) = patch_func(opts)
     if rc != 0:
@@ -140,6 +155,7 @@ def main():
             #     since patch will create numbered copies, not strftime("%Y-%m-%d@%H:%M:%S~")
             backup=dict(type='bool', default=False),
             binary=dict(type='bool', default=False),
+            state=dict(type='str', default='present', choices=['absent', 'present']),
         ),
         required_one_of=[['dest', 'basedir']],
         supports_check_mode=True,

--- a/lib/ansible/modules/files/patch.py
+++ b/lib/ansible/modules/files/patch.py
@@ -43,6 +43,7 @@ options:
     required: true
     aliases: [ patchfile ]
   state:
+    version_added: "2.5"
     description:
       - Whether the patch should be applied or reverted.
     choices: [ absent, present ]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add a state parameter to patch module. We sometimes need to apply and revert patches on many machines and therefore need a possibility to apply and (later on) revert patch files. So I added a state parameter (present/absent) to also revert a patch.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
patch
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 60e6396c2a) last updated 2017/12/07 21:51:16 (GMT +200)
  config file = None
  configured module search path = [u'/home/markus/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/markus/ansible/lib/ansible
  executable location = /home/markus/ansible/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]
```

