### PR TITLE
Update Azure module test infrastructure.

### DIFF
--- a/test/runner/lib/cloud/azure.py
+++ b/test/runner/lib/cloud/azure.py
@@ -30,6 +30,14 @@ class AzureCloudProvider(CloudProvider):
     """Azure cloud provider plugin. Sets up cloud resources before delegation."""
     SHERLOCK_CONFIG_PATH = os.path.expanduser('~/.ansible-sherlock-ci.cfg')
 
+    def __init__(self, args):
+        """
+        :type args: TestConfig
+        """
+        super(AzureCloudProvider, self).__init__(args)
+
+        self.aci = None
+
     def filter(self, targets, exclude):
         """Filter out the cloud tests when the necessary config and resources are not available.
         :type targets: tuple[TestTarget]
@@ -59,6 +67,13 @@ class AzureCloudProvider(CloudProvider):
             self._setup_dynamic()
 
         get_config(self.config_path)  # check required variables
+
+    def cleanup(self):
+        """Clean up the cloud resource and any temporary configuration files after tests complete."""
+        if self.aci:
+            self.aci.stop()
+
+        super(AzureCloudProvider, self).cleanup()
 
     def _setup_dynamic(self):
         """Request Azure credentials through Sherlock."""
@@ -95,6 +110,7 @@ class AzureCloudProvider(CloudProvider):
 
             if not self.args.explain:
                 response = aci_result['azure']
+                self.aci = aci
 
         if not self.args.explain:
             values = dict(
@@ -114,7 +130,7 @@ class AzureCloudProvider(CloudProvider):
         """
         :rtype: AnsibleCoreCI
         """
-        return AnsibleCoreCI(self.args, 'azure', 'sherlock', persist=False, stage=self.args.remote_stage, provider=self.args.remote_provider)
+        return AnsibleCoreCI(self.args, 'azure', 'azure', persist=False, stage=self.args.remote_stage, provider=self.args.remote_provider)
 
 
 class AzureCloudEnvironment(CloudEnvironment):

--- a/test/runner/lib/core_ci.py
+++ b/test/runner/lib/core_ci.py
@@ -64,7 +64,6 @@ class AnsibleCoreCI(object):
         providers = dict(
             aws=(
                 'aws',
-                'azure',
                 'windows',
                 'freebsd',
                 'rhel',
@@ -73,6 +72,7 @@ class AnsibleCoreCI(object):
                 'ios',
             ),
             azure=(
+                'azure',
             ),
             parallels=(
                 'osx',


### PR DESCRIPTION
##### SUMMARY

Update Azure module test infrastructure.

- Use new Azure direct API implementation.
- Enable Azure tests to clean up on exit.

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

ansible-test

##### ANSIBLE VERSION

```
ansible 2.5.0 (at-azure-cleanup 8d02b9d14f) last updated 2017/12/07 17:09:46 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
