### PR TITLE
allow ansilbe_x_interpreter to be templated

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -164,7 +164,7 @@ class ActionBase(with_metaclass(ABCMeta, object)):
                                                                     become_password=self._play_context.become_pass,
                                                                     environment=final_environment)
 
-        return (module_style, module_shebang, module_data, module_path)
+        return (module_style, self._templar.template(module_shebang), module_data, module_path)
 
     def _compute_environment_string(self, raw_environment_out=None):
         '''


### PR DESCRIPTION
##### SUMMARY
hardcoded interpreter paths worked, but templated values did not

fixes #18665


##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
core
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4/2.5
```

