### PR TITLE
ios_logging: Configure logging trap changes.

### DIFF
--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -55,6 +55,11 @@ options:
   level:
     description:
       - Set logging severity levels.
+  trap:
+    description:
+      - Set logging trap levels.
+    default: informational
+    choices: ['emergencies', 'alerts', 'critical', 'errors', 'warnings', 'notifications', 'informational', 'debugging']
   aggregate:
     description: List of logging definitions.
   state:
@@ -106,14 +111,15 @@ EXAMPLES = """
       - { dest: console, level: notifications }
       - { dest: buffered, size: 9000 }
     state: absent
+
 - name : Configure logging with trap
   ios_logging:
-  dest: host
-  name: 172.16.0.1
-  facility: local6
-  level: warnings
-  trap: warnings
-  state: present
+    dest: host
+    name: 172.16.0.1
+    facility: local6
+    level: warnings
+    trap: warnings
+    state: present
 """
 
 RETURN = """

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: ios_logging
-version_added: "2.5"
+version_added: "2.4"
 author: "Trishna Guha (@trishnaguha)"
 short_description: Manage logging on network devices
 description:
@@ -56,6 +56,7 @@ options:
     description:
       - Set logging severity levels.
   trap:
+    version_added: "2.5"
     description:
       - Set logging trap levels.
     default: informational

--- a/lib/ansible/modules/network/ios/ios_logging.py
+++ b/lib/ansible/modules/network/ios/ios_logging.py
@@ -26,7 +26,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = """
 ---
 module: ios_logging
-version_added: "2.4"
+version_added: "2.5"
 author: "Trishna Guha (@trishnaguha)"
 short_description: Manage logging on network devices
 description:

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -127,3 +127,20 @@
       - 'result.changed == true'
       - '"no logging console" in result.commands'
       - '"no logging buffered" in result.commands'
+
+- name: Configure logging trap
+  ios_logging:
+    dest: host
+    name: 172.16.0.1
+    facility: local6
+    level: warnings
+    trap: warnings
+    state: present
+  register: result
+
+- assert:
+    that:
+      - 'result.changed == true'
+      - '"logging host 172.16.0.1" in result.commands'
+      - '"logging facility local6" in result.commands'
+      - '"logging trap warnings" in result.commands'

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -155,6 +155,6 @@
     state: present
   register: result
 
-  - assert:
-      that:
-        - 'result.changed == false'
+- assert:
+    that:
+      - 'result.changed == false'

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -144,3 +144,17 @@
       - '"logging host 172.16.0.1" in result.commands'
       - '"logging facility local6" in result.commands'
       - '"logging trap warnings" in result.commands'
+
+- name: Configure logging trap (idempotent)
+  ios_logging:
+    dest: host
+    name: 172.16.0.1
+    facility: local6
+    level: warnings
+    trap: warnings
+    state: present
+  register: result
+
+  - assert:
+      that:
+        - 'result.changed == false'

--- a/test/integration/targets/ios_logging/tests/cli/basic.yaml
+++ b/test/integration/targets/ios_logging/tests/cli/basic.yaml
@@ -136,6 +136,7 @@
     level: warnings
     trap: warnings
     state: present
+    authorize: yes
   register: result
 
 - assert:
@@ -153,6 +154,7 @@
     level: warnings
     trap: warnings
     state: present
+    authorize: yes
   register: result
 
 - assert:

--- a/test/sanity/validate-modules/ignore.txt
+++ b/test/sanity/validate-modules/ignore.txt
@@ -535,7 +535,6 @@ lib/ansible/modules/network/ios/ios_interface.py E322
 lib/ansible/modules/network/ios/ios_l3_interface.py E322
 lib/ansible/modules/network/ios/ios_linkagg.py E322
 lib/ansible/modules/network/ios/ios_lldp.py E322
-lib/ansible/modules/network/ios/ios_logging.py E322
 lib/ansible/modules/network/ios/ios_static_route.py E322
 lib/ansible/modules/network/ios/ios_user.py E322
 lib/ansible/modules/network/ios/ios_vlan.py E322


### PR DESCRIPTION
##### SUMMARY
Added support to configure logging trap with module ios_logging.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ios_logging

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/asand3r/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```

##### ADDITIONAL INFORMATION
The module ios_logging hasn't opportunity to configure logging trap on network devices, so I've add some code to add this functionality.
![config_screen](https://user-images.githubusercontent.com/13959303/33757502-83e847b2-dc0b-11e7-846e-9b7c2e8ceb2b.png)
![screen_dry_run](https://user-images.githubusercontent.com/13959303/33757505-878169c6-dc0b-11e7-82cd-066265c86c5e.png)
