### PR TITLE
Fix plugin_docs to merge document fragments correctly

### DIFF
--- a/lib/ansible/utils/plugin_docs.py
+++ b/lib/ansible/utils/plugin_docs.py
@@ -56,7 +56,7 @@ def merge_fragment(target, source):
                 value = sorted(frozenset(value + target[key]))
             else:
                 raise Exception("Attempt to extend a documentation fragement, invalid type for %s" % key)
-            target[key] = value
+        target[key] = value
 
 
 def add_fragments(doc, filename):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
This PR fixes the `plugin_docs.merge_fragment` method to correctly add keys that are not existent to the target data structure.

The noticeable erroneous behavior for me was not including the document fragments documentation for the module documentation it generated.

To reproduce the error run 

``` cd $ANSIBLE/docs/docsite && make modules```

Then grep any output file in `docs/docsite/rst` for a documentation fragment.

For example in `docs/docsite/rst/netscaler_cs_action_module.rst` will be missing documentation for the `nsip`, `nitro_user`, `nitro_pass`, `validate_certs` options which are defined in its document fragments class.

The same effect happens for any module that has documentation fragments defined.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/utils/plugin_docs.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix_document_fragments 5bf9c856c8) last updated 2017/12/08 13:06:10 (GMT +300)
  config file = /home/georgen/.ansible.cfg
  configured module search path = [u'/home/georgen/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/georgen/repos/ansible_fork/lib/ansible
  executable location = /home/georgen/repos/ansible_fork/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
