### PR TITLE
Adding param "rule_num" for insert action to iptables module

### DIFF
--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -52,6 +52,11 @@ options:
     choices: [ append, insert ]
     default: append
     version_added: "2.2"
+  rule_num:
+    description:
+      - Insert the rule as the given rule number. This works only with
+        action = 'insert'.
+    version_added: "2.5"
   ip_version:
     description:
       - Which version of the IP protocol this rule should apply to.
@@ -440,6 +445,8 @@ def push_arguments(iptables_path, action, params, make_rule=True):
     cmd = [iptables_path]
     cmd.extend(['-t', params['table']])
     cmd.extend([action, params['chain']])
+    if action == '-I':
+        cmd.extend([params['rule_num']])
     if make_rule:
         cmd.extend(construct_rule(params))
     return cmd
@@ -496,6 +503,7 @@ def main():
             action=dict(type='str', default='append', choices=['append', 'insert']),
             ip_version=dict(type='str', default='ipv4', choices=['ipv4', 'ipv6']),
             chain=dict(type='str'),
+            rule_num=dict(type='str'),
             protocol=dict(type='str'),
             source=dict(type='str'),
             to_source=dict(type='str'),

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -321,7 +321,7 @@ EXAMPLES = '''
     set_dscp_mark_class: CS1
     protocol: tcp
 
-# Insert a rule on line 5 
+# Insert a rule on line 5
 - iptables:
     chain: INPUT
     protocol: tcp

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -453,7 +453,7 @@ def push_arguments(iptables_path, action, params, make_rule=True):
     cmd = [iptables_path]
     cmd.extend(['-t', params['table']])
     cmd.extend([action, params['chain']])
-    if action == '-I':
+    if action == '-I' and params['rule_num']:
         cmd.extend([params['rule_num']])
     if make_rule:
         cmd.extend(construct_rule(params))

--- a/lib/ansible/modules/system/iptables.py
+++ b/lib/ansible/modules/system/iptables.py
@@ -321,6 +321,14 @@ EXAMPLES = '''
     set_dscp_mark_class: CS1
     protocol: tcp
 
+# Insert a rule on line 5 
+- iptables:
+    chain: INPUT
+    protocol: tcp
+    destination_port: 8080
+    jump: ACCEPT
+    rule_num: 5
+
 # Set the policy for the INPUT chain to DROP
 - iptables:
     chain: INPUT


### PR DESCRIPTION
##### SUMMARY
This adds the parameter "rule_num" for insert actions to the iptables module.
Sometimes it is neccessary to place a rule before other rules. This can be solved with the rule_num. 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Module: iptables

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 8e937f9579) last updated 2017/12/08 14:51:16 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ana/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ana/devel/upstream/ansible/lib/ansible
  executable location = /home/ana/devel/upstream/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION