### PR TITLE
[WIP] Environment is built prepended, and no longer needs to be reversed

### DIFF
--- a/lib/ansible/plugins/action/__init__.py
+++ b/lib/ansible/plugins/action/__init__.py
@@ -177,10 +177,6 @@ class ActionBase(with_metaclass(ABCMeta, object)):
             if not isinstance(environments, list):
                 environments = [environments]
 
-            # the environments as inherited need to be reversed, to make
-            # sure we merge in the parent's values first so those in the
-            # block then task 'win' in precedence
-            environments.reverse()
             for environment in environments:
                 if environment is None or len(environment) == 0:
                     continue


### PR DESCRIPTION
##### SUMMARY

As of https://github.com/ansible/ansible/commit/df5895e585e18bfbf84af993c152801124332bf0 the environment is built by prepending values. Due to this we no longer need to reverse environment later.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
```
plugins/action/__init__.py
```
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```