### PR TITLE
Fix elasticdog removal as an author in the module docs

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -548,7 +548,9 @@ files:
   $modules/packaging/os/openbsd_pkg.py: eest
   $modules/packaging/os/opkg.py: skinp
   $modules/packaging/os/package.py: $team_ansible
-  $modules/packaging/os/pacman.py: indrajitr
+  $modules/packaging/os/pacman.py:
+    ignored: elasticdog
+    maintainers: indrajitr
   $modules/packaging/os/pkg5.py: mavit
   $modules/packaging/os/pkg5_publisher.py: mavit
   $modules/packaging/os/pkgin.py: L2G jasperla szinck troy2914


### PR DESCRIPTION
##### SUMMARY
Need to specify `ignored: elasticdog` because they are listed as an author. Re: https://github.com/ansible/ansible/pull/33644#issuecomment-349752842. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
BOTMETA

##### ANSIBLE VERSION
```
2.5.0
```
