### PR TITLE
Added support for Cisco stacks in ios_facts.py

### DIFF
--- a/lib/ansible/modules/network/ios/ios_facts.py
+++ b/lib/ansible/modules/network/ios/ios_facts.py
@@ -194,9 +194,13 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_model(self, data):
-        match = re.search(r'^Cisco (.+) \(revision', data, re.M)
+        match = re.findall(r'^Model number\s+: (\S+)', data, re.M)
         if match:
-            return match.group(1)
+            return match
+        else:
+            match = re.search(r'^[Cc]isco (\S+).+bytes of memory', data, re.M)
+            if match:
+                return [match.group(1)]
 
     def parse_image(self, data):
         match = re.search(r'image file is "(.+)"', data)
@@ -204,9 +208,13 @@ class Default(FactsBase):
             return match.group(1)
 
     def parse_serialnum(self, data):
-        match = re.search(r'board ID (\S+)', data)
+        match = re.findall(r'^System serial number\s+: (\S+)', data, re.M)
         if match:
-            return match.group(1)
+            return match
+        else:
+            match = re.search(r'board ID (\S+)', data)
+            if match:
+                return [match.group(1)]
 
 
 class Hardware(FactsBase):


### PR DESCRIPTION
##### SUMMARY
Added support for Cisco logical devices made of multiple physical devices (stacks).
Changed the model regex as well to pick only the model name without the processor type and be consistent.  
/!\ Warning /!\ : this changed the type of ansible_net_model and ansible_net_serialnum to lists of strings instead of strings.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_facts in modules/network/ios/

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 882065b9b4) last updated 2017/12/08 11:30:36 (GMT +200)
  config file = None
  configured module search path = [u'/home/cba/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/cba/Documents/Code/Python/ansible-dev/ansible/lib/ansible
  executable location = /home/cba/Documents/Code/Python/ansible-dev/ansible/bin/ansible
  python version = 2.7.13 (default, Nov 23 2017, 15:37:09) [GCC 6.3.0 20170406]
```

##### ADDITIONAL INFORMATION
Cisco offers to "stack" physical devices of specific models to create a larger logical device with a shared configuration.
As it is made of multiple physical devices, a stack has multiple models and serial numbers. This pull request adds the possibility to see the multiple models and serial numbers in a Cisco stack. So the ansible_net_model and ansible_net_serialnum facts are changed to list of strings instead of strings.

Tested on stacks of Catalyst 3750 with IOS 12.2 and stacks of Catalyst 2960X with IOS 15.2.

Here is an example on a stack of 3 x 3750. Some fields (hostname, user, serial numbers) are redacted and between chevrons, due to privacy issues.

Before
```
$ ansible <hostname.domain.tld> -i hosts -m ios_facts -u <user> -k -c local -a 'gather_subset=!all'
SSH password:
<hostname.domain.tld> | SUCCESS => {
    "ansible_facts": {
        "ansible_net_gather_subset": [
            "default"
        ], 
        "ansible_net_hostname": "<hostname>", 
        "ansible_net_image": "flash:c3750-ipservicesk9-mz.122-55.SE10.bin", 
        "ansible_net_model": null, 
        "ansible_net_serialnum": "<device1_serialnum>", 
        "ansible_net_version": "12.2(55)SE10"
    }, 
    "changed": false
}

```

After
```
$ ansible <hostname.domain.tld> -i hosts -m ios_facts -u <user> -k -c local -a 'gather_subset=!all'
SSH password: 
<hostname.domain.tld> | SUCCESS => {
    "ansible_facts": {
        "ansible_net_gather_subset": [
            "default"
        ], 
        "ansible_net_hostname": "<hostname>", 
        "ansible_net_image": "flash:c3750-ipservicesk9-mz.122-55.SE10.bin", 
        "ansible_net_model": [
            "WS-C3750G-12S-E", 
            "WS-C3750G-12S-E", 
            "WS-C3750X-12S-S"
        ], 
        "ansible_net_serialnum": [
            "<device1_serialnum>", 
            "<device2_serialnum>", 
            "<device3_serialnum>"
        ], 
        "ansible_net_version": "12.2(55)SE10"
    }, 
    "changed": false
}


```