### PR TITLE
zabbix_host ipmi_*-tests

### DIFF
--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_doc.yml
@@ -7,7 +7,7 @@
     server_url: "{{ zabbix_server_url }}"
     login_user: "{{ zabbix_login_user }}"
     login_password: "{{ zabbix_login_password }}"
-    host_name: ExampleHost
+    host_name: ExampleHost1
     visible_name: ExampleName
     description: My ExampleHost Description
     host_groups:
@@ -27,6 +27,10 @@
       site_rack: test-rack
       os: test-os
       hardware: test-hw
+    ipmi_authtype: 2
+    ipmi_privilege: 4
+    ipmi_username: username
+    ipmi_password: password
     interfaces:
       - type: 1
         main: 1

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
@@ -667,11 +667,6 @@
       that:
           - "zabbix_host1 is not changed"
 
-- name: expect to succeed and that things have not changed
-  assert:
-      that:
-          - "zabbix_host1 is not changed"
-
 - name: "test: verify that an empty change is idempotent"
   local_action:
     module: zabbix_host

--- a/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
+++ b/test/integration/targets/zabbix_host/tasks/zabbix_host_tests.yml
@@ -631,6 +631,97 @@
       that:
           - "not zabbix_host1 is changed"
 
+- name: "test: add IPMI settings"
+  local_action:
+    module: zabbix_host
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    ipmi_authtype: 2
+    ipmi_privilege: 4
+    ipmi_username: username
+    ipmi_password: password
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: add IPMI settings again"
+  local_action:
+    module: zabbix_host
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    ipmi_authtype: 2
+    ipmi_privilege: 4
+    ipmi_username: username
+    ipmi_password: password
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: verify that an empty change is idempotent"
+  local_action:
+    module: zabbix_host
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
+- name: "test: IPMI set default values"
+  local_action:
+    module: zabbix_host
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    ipmi_authtype: -1
+    ipmi_privilege: 2
+    ipmi_username: ""
+    ipmi_password: ""
+  register: zabbix_host1
+
+- name: expect to succeed and that things have changed
+  assert:
+      that:
+          - "zabbix_host1 is changed"
+
+- name: "test: IPMI set default values (again)"
+  local_action:
+    module: zabbix_host
+    server_url: "{{ zabbix_server_url }}"
+    login_user: "{{ zabbix_login_user }}"
+    login_password: "{{ zabbix_login_password }}"
+    host_name: ExampleHost
+    ipmi_authtype: -1
+    ipmi_privilege: 2
+    ipmi_username: ""
+    ipmi_password: ""
+  register: zabbix_host1
+
+- name: expect to succeed and that things have not changed
+  assert:
+      that:
+          - "zabbix_host1 is not changed"
+
 - name: "test: attempt to delete host created earlier"
   local_action:
     module: zabbix_host


### PR DESCRIPTION
##### SUMMARY

This adds a couple of integration tests for the newly added ipmi_*-options introduced in #33435.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
zabbix_host

##### ANSIBLE VERSION
2.5.0

