### PR TITLE
Clarify docs to explain that max_fail_percentage uses batch size

### DIFF
--- a/docs/docsite/rst/playbooks_delegation.rst
+++ b/docs/docsite/rst/playbooks_delegation.rst
@@ -80,9 +80,9 @@ You can also mix and match the values::
 Maximum Failure Percentage
 ``````````````````````````
 
-By default, Ansible will continue executing actions as long as there are hosts in the group that have not yet failed.
-In some situations, such as with the rolling updates described above, it may be desirable to abort the play when a 
-certain threshold of failures have been reached. To achieve this, as of version 1.3 you can set a maximum failure 
+By default, Ansible will continue executing actions as long as there are hosts in the batch that have not yet failed. The batch size for a play is all the hosts specified in the ``hosts:`` field.
+In some situations, such as with the rolling updates described above, it may be desirable to abort the play when a
+certain threshold of failures have been reached. To achieve this, you can set a maximum failure
 percentage on a play as follows::
 
     - hosts: webservers


### PR DESCRIPTION
##### SUMMARY

Explain that `max_fail_percentage` uses batch size not group size.

Fixes #33672 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
