### PR TITLE
Add autodetection of atomic as a package manager

### DIFF
--- a/lib/ansible/module_utils/facts/system/pkg_mgr.py
+++ b/lib/ansible/module_utils/facts/system/pkg_mgr.py
@@ -47,6 +47,7 @@ PKG_MGRS = [{'path': '/usr/bin/yum', 'name': 'yum'},
             {'path': '/usr/local/sbin/pkg', 'name': 'pkgng'},
             {'path': '/usr/bin/swupd', 'name': 'swupd'},
             {'path': '/usr/sbin/sorcery', 'name': 'sorcery'},
+            {'path': '/usr/bin/rpm-ostree', 'name': 'atomic_container'},
             ]
 
 


### PR DESCRIPTION
##### SUMMARY

On Fedora Atomic Host, there is no yum or dnf, but the module ot use to
install package should be atomic_container. We verify that this is
a Fedora Atomic Host with rpm-ostree, not atomic since atomic
can be used on a regular non ostree distribution.

Related to #25897 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
setup

