### PR TITLE
Adds token cleanup to some f5 modules

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_https.py
@@ -566,6 +566,16 @@ class ArgumentSpec(object):
         self.f5_product_name = 'bigip'
 
 
+def cleanup_tokens(client):
+    try:
+        resource = client.api.shared.authz.tokens_s.token.load(
+            name=client.api.icrs.token
+        )
+        resource.delete()
+    except Exception:
+        pass
+
+
 def main():
     spec = ArgumentSpec()
 
@@ -574,6 +584,7 @@ def main():
         supports_check_mode=spec.supports_check_mode,
         f5_product_name=spec.f5_product_name
     )
+
     try:
         if not HAS_F5SDK:
             raise F5ModuleError("The python f5-sdk module is required")
@@ -583,8 +594,10 @@ def main():
 
         mm = ModuleManager(client)
         results = mm.exec_module()
+        cleanup_tokens(client)
         client.module.exit_json(**results)
     except F5ModuleError as e:
+        cleanup_tokens(client)
         client.module.fail_json(msg=str(e))
 
 

--- a/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
@@ -642,23 +642,35 @@ class ArgumentSpec(object):
         self.f5_product_name = 'bigip'
 
 
-def main():
+def cleanup_tokens(client):
     try:
-        spec = ArgumentSpec()
-
-        client = AnsibleF5Client(
-            argument_spec=spec.argument_spec,
-            supports_check_mode=spec.supports_check_mode,
-            f5_product_name=spec.f5_product_name
+        resource = client.api.shared.authz.tokens_s.token.load(
+            name=client.api.icrs.token
         )
+        resource.delete()
+    except Exception:
+        pass
 
+
+def main():
+    spec = ArgumentSpec()
+
+    client = AnsibleF5Client(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+        f5_product_name=spec.f5_product_name
+    )
+
+    try:
         if not HAS_F5SDK:
             raise F5ModuleError("The python f5-sdk module is required")
 
         mm = ModuleManager(client)
         results = mm.exec_module()
+        cleanup_tokens(client)
         client.module.exit_json(**results)
     except F5ModuleError as e:
+        cleanup_tokens(client)
         client.module.fail_json(msg=str(e))
 
 

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp.py
@@ -945,17 +945,27 @@ class ArgumentSpec(object):
         ]
 
 
-def main():
+def cleanup_tokens(client):
     try:
-        spec = ArgumentSpec()
-
-        client = AnsibleF5Client(
-            argument_spec=spec.argument_spec,
-            supports_check_mode=spec.supports_check_mode,
-            f5_product_name=spec.f5_product_name,
-            mutually_exclusive=spec.mutually_exclusive
+        resource = client.api.shared.authz.tokens_s.token.load(
+            name=client.api.icrs.token
         )
+        resource.delete()
+    except Exception:
+        pass
 
+
+def main():
+    spec = ArgumentSpec()
+
+    client = AnsibleF5Client(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+        f5_product_name=spec.f5_product_name,
+        mutually_exclusive=spec.mutually_exclusive
+    )
+
+    try:
         if not HAS_F5SDK:
             raise F5ModuleError("The python f5-sdk module is required")
 
@@ -964,8 +974,10 @@ def main():
 
         mm = ModuleManager(client)
         results = mm.exec_module()
+        cleanup_tokens(client)
         client.module.exit_json(**results)
     except F5ModuleError as e:
+        cleanup_tokens(client)
         client.module.fail_json(msg=str(e))
 
 

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
@@ -495,16 +495,26 @@ class ArgumentSpec(object):
         self.f5_product_name = 'bigip'
 
 
-def main():
+def cleanup_tokens(client):
     try:
-        spec = ArgumentSpec()
-
-        client = AnsibleF5Client(
-            argument_spec=spec.argument_spec,
-            supports_check_mode=spec.supports_check_mode,
-            f5_product_name=spec.f5_product_name
+        resource = client.api.shared.authz.tokens_s.token.load(
+            name=client.api.icrs.token
         )
+        resource.delete()
+    except Exception:
+        pass
 
+
+def main():
+    spec = ArgumentSpec()
+
+    client = AnsibleF5Client(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+        f5_product_name=spec.f5_product_name
+    )
+
+    try:
         if not HAS_F5SDK:
             raise F5ModuleError("The python f5-sdk module is required")
 
@@ -513,8 +523,10 @@ def main():
 
         mm = ModuleManager(client)
         results = mm.exec_module()
+        cleanup_tokens(client)
         client.module.exit_json(**results)
     except F5ModuleError as e:
+        cleanup_tokens(client)
         client.module.fail_json(msg=str(e))
 
 

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
@@ -543,16 +543,26 @@ class ArgumentSpec(object):
         self.f5_product_name = 'bigip'
 
 
-def main():
+def cleanup_tokens(client):
     try:
-        spec = ArgumentSpec()
-
-        client = AnsibleF5Client(
-            argument_spec=spec.argument_spec,
-            supports_check_mode=spec.supports_check_mode,
-            f5_product_name=spec.f5_product_name
+        resource = client.api.shared.authz.tokens_s.token.load(
+            name=client.api.icrs.token
         )
+        resource.delete()
+    except Exception:
+        pass
 
+
+def main():
+    spec = ArgumentSpec()
+
+    client = AnsibleF5Client(
+        argument_spec=spec.argument_spec,
+        supports_check_mode=spec.supports_check_mode,
+        f5_product_name=spec.f5_product_name
+    )
+
+    try:
         if not HAS_F5SDK:
             raise F5ModuleError("The python f5-sdk module is required")
 
@@ -561,8 +571,10 @@ def main():
 
         mm = ModuleManager(client)
         results = mm.exec_module()
+        cleanup_tokens(client)
         client.module.exit_json(**results)
     except F5ModuleError as e:
+        cleanup_tokens(client)
         client.module.fail_json(msg=str(e))
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
The tokens can build up over time and if too many accumulate, it
prevents you from logging in. This adds cleanup

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
bigip monitor modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (bugfix.cleanup-tokens-in-f5 2afb54cd8f) last updated 2017/12/08 23:31:50 (GMT +000)
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /here/local/ansible/lib/ansible
  executable location = /here/local/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  4 2017, 22:29:35) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
