### PR TITLE
github_release: Fix state returned from module

### DIFF
--- a/docs/docsite/rst/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guide_2.5.rst
@@ -64,7 +64,12 @@ Modules
 
 Major changes in popular modules are detailed here
 
-No notable changes.
+github_release
+--------------
+
+In the version 2.4 and older, after creating GitHub release using ``create_release`` state, module ``github_release`` used to report state as ``skipped``.
+In the version 2.5 and onwards, this behavior is now changed. After creating GitHub release using ``create_release`` state, module now reports state as ``changed``.
+
 
 Modules removed
 ---------------

--- a/docs/docsite/rst/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guide_2.5.rst
@@ -67,8 +67,8 @@ Major changes in popular modules are detailed here
 github_release
 --------------
 
-In the version 2.4 and older, after creating GitHub release using ``create_release`` state, module ``github_release`` used to report state as ``skipped``.
-In the version 2.5 and onwards, this behavior is now changed. After creating GitHub release using ``create_release`` state, module now reports state as ``changed``.
+In Ansible versions 2.4 and older, after creating a GitHub release using the ``create_release`` state, the ``github_release`` module reported state as ``skipped``.
+In Ansible version 2.5 and later, after creating a GitHub release using the ``create_release`` state, the ``github_release`` module now reports state as ``changed``.
 
 
 Modules removed

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -119,8 +119,8 @@ RETURN = '''
 create_release:
     description:
     - Version of the created release
-    - "If specified release version already exists, then State is unchanged, version added 2.5"
-    - "If specified release version already exists, then State is skipped, version previous to 2.5"
+    - "For Ansible version 2.5 and later, if specified release version already exists, then State is unchanged"
+    - "For Ansible versions prior to 2.5, if specified release version already exists, then State is skipped"
     type: string
     returned: success
     sample: 1.1.0

--- a/lib/ansible/modules/source_control/github_release.py
+++ b/lib/ansible/modules/source_control/github_release.py
@@ -116,6 +116,15 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
+create_release:
+    description:
+    - Version of the created release
+    - "If specified release version already exists, then State is unchanged, version added 2.5"
+    - "If specified release version already exists, then State is skipped, version previous to 2.5"
+    type: string
+    returned: success
+    sample: 1.1.0
+
 latest_release:
     description: Version of the latest release
     type: string
@@ -201,15 +210,14 @@ def main():
     if action == 'create_release':
         release_exists = repository.release_from_tag(tag)
         if release_exists:
-            module.exit_json(
-                skipped=True, msg="Release for tag %s already exists." % tag)
+            module.exit_json(changed=False, msg="Release for tag %s already exists." % tag)
 
         release = repository.create_release(
             tag, target, name, body, draft, prerelease)
         if release:
-            module.exit_json(tag=release.tag_name)
+            module.exit_json(changed=True, tag=release.tag_name)
         else:
-            module.exit_json(tag=None)
+            module.exit_json(changed=False, tag=None)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
This fix corrects the module state returned by github_module.
Now,
* When the release already exists, state is "ok"
* When the release is created, state is "changed"

Fixes: #33687

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/modules/source_control/github_release.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```