### PR TITLE
osx_say callback plugin: add espeak support, rename to say

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -955,7 +955,7 @@ files:
     support: core
   $plugins/callback/oneline:
     support: core
-  $plugins/callback/osx_say.py: *macos
+  $plugins/callback/say.py: *macos
   $plugins/callback/profile:
     support: core
   $plugins/callback/stderr.py:

--- a/changelogs/fragments/33740-osx_say_callback_renamed_say.yml
+++ b/changelogs/fragments/33740-osx_say_callback_renamed_say.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "``osx_say`` callback plugin was renamed into ``say``."

--- a/docs/docsite/rst/plugins/callback.rst
+++ b/docs/docsite/rst/plugins/callback.rst
@@ -19,7 +19,7 @@ Example callback plugins
 The :ref:`log_plays <log_plays_callback>` callback is an example of how to record playbook events to a log file,
 and the :ref:`mail <mail_callback>` callback sends email on playbook failures.
 
-The :ref:`osx_say <osx_say_callback>` callback responds with computer synthesized speech on macOS in relation to playbook events.
+The :ref:`say <say_callback>` callback responds with computer synthesized speech in relation to playbook events.
 
 .. _enabling_callbacks:
 

--- a/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
+++ b/docs/docsite/rst/porting_guides/porting_guide_2.8.rst
@@ -242,6 +242,8 @@ Plugins
 
 * Play recap now counts ``ignored`` and ``rescued`` tasks as well as ``ok``, ``changed``, ``unreachable``, ``failed`` and ``skipped`` tasks, thanks to two additional stat counters in the ``default`` callback plugin. Tasks that fail and have ``ignore_errors: yes`` set are listed as ``ignored``. Tasks that fail and then execute a rescue section are listed as ``rescued``. Note that ``rescued`` tasks are no longer counted as ``failed`` as in Ansible 2.7 (and earlier).
 
+* ``osx_say`` callback plugin was renamed into :ref:`say <say_callback>`.
+
 Porting custom scripts
 ======================
 

--- a/lib/ansible/plugins/callback/osx_say.py
+++ b/lib/ansible/plugins/callback/osx_say.py
@@ -1,0 +1,1 @@
+../../lib/ansible/plugins/callback/say.py

--- a/lib/ansible/plugins/callback/osx_say.py
+++ b/lib/ansible/plugins/callback/osx_say.py
@@ -1,1 +1,1 @@
-lib/ansible/plugins/callback/say.py
+say.py

--- a/lib/ansible/plugins/callback/osx_say.py
+++ b/lib/ansible/plugins/callback/osx_say.py
@@ -1,1 +1,1 @@
-../../lib/ansible/plugins/callback/say.py
+lib/ansible/plugins/callback/say.py

--- a/lib/ansible/plugins/callback/say.py
+++ b/lib/ansible/plugins/callback/say.py
@@ -7,15 +7,17 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    callback: osx_say
+    callback: say
     type: notification
     requirements:
       - whitelisting in configuration
-      - the '/usr/bin/say' command line program (standard on macOS)
-    short_description: oneline Ansible screen output
+      - the '/usr/bin/say' command line program (standard on macOS) or 'espeak' command line program
+    short_description: notify using software speech synthesizer
     version_added: historical
     description:
-      - This plugin will use the 'say' program to "speak" about play events.
+      - This plugin will use the 'say' or 'espeak' program to "speak" about play events.
+    notes:
+      - In 2.5, this callback has been renamed from M(osx_say) into M(say).
 '''
 
 import subprocess
@@ -32,11 +34,11 @@ SAY_CMD = "/usr/bin/say"
 
 class CallbackModule(CallbackBase):
     """
-    makes Ansible much more exciting on macOS.
+    makes Ansible much more exciting.
     """
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'notification'
-    CALLBACK_NAME = 'osx_say'
+    CALLBACK_NAME = 'say'
     CALLBACK_NEEDS_WHITELIST = True
 
     def __init__(self):

--- a/lib/ansible/plugins/callback/say.py
+++ b/lib/ansible/plugins/callback/say.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
     description:
       - This plugin will use the 'say' or 'espeak' program to "speak" about play events.
     notes:
-      - In 2.5, this callback has been renamed from C(osx_say) into M(say).
+      - In 2.8, this callback has been renamed from C(osx_say) into M(say).
 '''
 
 import distutils.spawn

--- a/lib/ansible/plugins/callback/say.py
+++ b/lib/ansible/plugins/callback/say.py
@@ -17,7 +17,7 @@ DOCUMENTATION = '''
     description:
       - This plugin will use the 'say' or 'espeak' program to "speak" about play events.
     notes:
-      - In 2.5, this callback has been renamed from M(osx_say) into M(say).
+      - In 2.5, this callback has been renamed from C(osx_say) into M(say).
 '''
 
 import distutils.spawn


### PR DESCRIPTION
##### SUMMARY
- Add support for `espeak` (and `say` GNUstep tool)
- Rename plugin

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
say callback plugin

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 326b208b19) last updated 2017/12/10 01:54:05 (GMT +200)
```

##### ADDITIONAL INFORMATION
Tested with Python 2.7 and Python 3.6 using: `ANSIBLE_CALLBACK_WHITELIST=say ansible-playbook testplay.yml`.

Related: #33071