### PR TITLE
remove unused import and unused variable disk_size

### DIFF
--- a/lib/ansible/modules/cloud/linode/linode.py
+++ b/lib/ansible/modules/cloud/linode/linode.py
@@ -144,7 +144,6 @@ options:
 requirements:
     - python >= 2.6
     - linode-python
-    - pycurl
 author:
 - Vincent Viallet (@zbal)
 notes:
@@ -249,12 +248,6 @@ import os
 import time
 
 try:
-    import pycurl
-    HAS_PYCURL = True
-except ImportError:
-    HAS_PYCURL = False
-
-try:
     from linode import api as linode_api
     HAS_LINODE = True
 except ImportError:
@@ -319,7 +312,6 @@ def linodeServers(module, api, state, name,
     disks = []
     configs = []
     jobs = []
-    disk_size = 0
 
     # See if we can match an existing server details with the provided linode_id
     if linode_id:
@@ -597,8 +589,6 @@ def main():
         ),
     )
 
-    if not HAS_PYCURL:
-        module.fail_json(msg='pycurl required for this module')
     if not HAS_LINODE:
         module.fail_json(msg='linode-python required for this module')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Removes the pycurl import and import check, no longer used
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
linode

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
Also removes unused variable `disk_size`.

