### PR TITLE
Add scan_new_hosts feature in ansible foreman inventory

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -155,3 +155,6 @@ rich_params = False
 [cache]
 path = .
 max_age = 60
+
+# Whether to scan foreman to add recently created hosts in inventory cache
+scan_new_hosts = True

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -139,6 +139,10 @@ class ForemanInventory(object):
             self.cache_max_age = config.getint('cache', 'max_age')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             self.cache_max_age = 60
+        try:
+            self.scan_new_hosts = config.getboolean('cache', 'scan_new_hosts')
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            self.scan_new_hosts = False
 
         return True
 
@@ -267,13 +271,15 @@ class ForemanInventory(object):
         regex = "[^A-Za-z0-9\_]"
         return re.sub(regex, "_", word.replace(" ", ""))
 
-    def update_cache(self):
+    def update_cache(self, scan_only_new_hosts=False):
         """Make calls to foreman and save the output in a cache"""
 
         self.groups = dict()
         self.hosts = dict()
 
         for host in self._get_hosts():
+            if host['name'] in self.cache.keys() and scan_only_new_hosts:
+                continue
             dns_name = host['name']
 
             host_data = self._get_host_data_by_id(host['id'])
@@ -387,6 +393,8 @@ class ForemanInventory(object):
             self.load_facts_from_cache()
             self.load_hostcollections_from_cache()
             self.load_cache_from_cache()
+            if self.scan_new_hosts:
+                self.update_cache(True)
 
     def get_host_info(self):
         """Get variables about a specific host"""


### PR DESCRIPTION
##### SUMMARY
Fixes #33736 

A new boolean option scan_new_hosts has been added in foreman.ini. 
When scan_new_hosts is equal to true foreman.py always calls foreman api to check if new hosts have been added to foreman. If a new hosts is added to foreman and the cache is still valid only the information related to the new hosts are collected calling the foreman inventory.

The advantage of enable the option scan_new_hosts is to obtain data of recently created hosts when ansible foreman cache is enabled.
The disadvantage of enable the option scan_new_hosts is that a call to foreman api to retrieve the list of hosts is always executed . 
Because there are advantages and disadvantages of this new feature I have added the option scan_new_hosts in foreman.ini to disable it if required.

This feature is really useful when an ansible playbook is executed using the feature provisioning callbacks of AWX(or Ansible Tower) ( http://docs.ansible.com/ansible-tower/latest/html/userguide/job_templates.html#provisioning-callbacks ). 

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
foreman.py

##### ANSIBLE VERSION
```
$ ./bin/ansible --version
ansible 2.5.0 (pull-issue-foreman 604a2132d4) last updated 2017/12/07 00:55:40 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/gsciorti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/gsciorti/PycharmProjects/ansible/lib/ansible
  executable location = ./bin/ansible
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
```
1) First execution of foreman.py to fill the cache
2) Create a new host on foreman called "ansibletest.example.com"
3) Re-run foreman.py before the cache is expired

$ ansible -i ./contrib/inventory/foreman.py all --list-hosts
  hosts (8):
    gs-sat61.localdomain
    rhel6a
    rhel7a
    ansibletest.example.com
```
