### PR TITLE
maven_artifact: fix broken import

### DIFF
--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -28,7 +28,6 @@ description:
       version if one is not available.
 author: "Chris Schmidt (@chrisisbeef)"
 requirements:
-    - "python >= 2.6"
     - lxml
     - boto if using a S3 repository (s3://...)
 options:

--- a/lib/ansible/modules/packaging/language/maven_artifact.py
+++ b/lib/ansible/modules/packaging/language/maven_artifact.py
@@ -155,7 +155,11 @@ import os
 import posixpath
 import sys
 
-from lxml import etree
+try:
+    from lxml import etree
+    HAS_LXML_ETREE = True
+except ImportError:
+    HAS_LXML_ETREE = False
 
 try:
     import boto3
@@ -418,6 +422,9 @@ def main():
         ),
         add_file_common_args=True
     )
+
+    if not HAS_LXML_ETREE:
+        module.fail_json(msg='module requires the lxml python library installed on the managed machine')
 
     repository_url = module.params["repository_url"]
     if not repository_url:

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -33,6 +33,5 @@ lib/ansible/modules/network/lenovo/cnos_template.py
 lib/ansible/modules/network/lenovo/cnos_vlag.py
 lib/ansible/modules/network/lenovo/cnos_vlan.py
 lib/ansible/modules/network/nxos/nxos_file_copy.py
-lib/ansible/modules/packaging/language/maven_artifact.py
 lib/ansible/modules/packaging/os/yum_repository.py
 lib/ansible/modules/system/hostname.py


### PR DESCRIPTION
##### SUMMARY
maven_artifact: detect when `lxml` is missing ([fix broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports))

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
maven_artifact

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 326b208b19) last updated 2017/12/10 01:54:05 (GMT +200)
```