### PR TITLE
imc_rest: fail when requirement is missing

### DIFF
--- a/lib/ansible/modules/remote_management/imc/imc_rest.py
+++ b/lib/ansible/modules/remote_management/imc/imc_rest.py
@@ -333,6 +333,12 @@ def main():
         mutually_exclusive=[['content', 'path']],
     )
 
+    if not HAS_LXML_ETREE:
+        module.fail_json(msg='module requires the lxml Python library installed on the managed host')
+
+    if not HAS_XMLJSON_COBRA:
+        module.fail_json(msg='module requires the xmljson (>= 0.1.8) Python library installed on the managed host')
+
     hostname = module.params['hostname']
     username = module.params['username']
     password = module.params['password']


### PR DESCRIPTION
##### SUMMARY
`imc_rest`: fail when a requirement is missing

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
imc_rest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 326b208b19) last updated 2017/12/10 01:54:05 (GMT +200)
```