### PR TITLE
add oVirt provider to ManageIQ module

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -37,7 +37,7 @@ options:
   type:
     description: The provider's type.
     required: true
-    choices: ['Openshift', 'Amazon']
+    choices: ['Openshift', 'Amazon', 'oVirt']
   zone:
     description: The ManageIQ zone name that will manage the provider.
     required: false
@@ -310,6 +310,22 @@ EXAMPLES = '''
       url: 'https://127.0.0.1'
       token: 'VeryLongToken'
       verify_ssl: true
+
+
+- name: Create a new oVirt provider in ManageIQ
+  manageiq_provider:
+    name: 'RHEV'
+    type: 'oVirt'
+    state: 'present'
+    provider:
+      hostname: 'rhev01.example.com'
+      userid: 'admin@internal'
+      password: 'password'
+    manageiq_connection:
+      url: 'https://127.0.0.1'
+      username: 'admin'
+      password: 'password'
+      verify_ssl: true
 '''
 
 RETURN = '''
@@ -330,6 +346,9 @@ def supported_providers():
         ),
         Amazon=dict(
             class_name='ManageIQ::Providers::Amazon::CloudManager',
+        ),
+        oVirt=dict(
+            class_name='ManageIQ::Providers::Redhat::InfraManager',
         ),
     )
 


### PR DESCRIPTION
##### SUMMARY
This commit adds oVirt/RHEV capability to the ManageIQ remote
management module.

Currently the manageiq remote management module only supports OpenShift and AWS. This adds oVirt/RHEV capability. Aside from required parameters like the provider type, name and type of connection, only API hostname, userid and password are required and therefore this should be a trivial commit. ie. Functionality already exists within the module to support oVirt/RHEV.

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
modules/remote_management/manageiq

##### ADDITIONAL INFORMATION
An example of the current calls using the uri module:

```
- name: Create RHEV Provider
  uri:
    url: "{{ miq_endpoint }}"
    method: POST
    user: "{{ vault_cfme_user }}"
    password: "{{ vault_cfme_password }}"
    body: 
      type: "ManageIQ::Providers::Redhat::InfraManager"
      name: "{{ rhev_provider_name }}"
      hostname: "{{ rhev_provider_endpoint }}"
      credentials:
        userid: "{{ vault_rhev_user }}"
        password: "{{ vault_rhev_password }}"
    status_code: 200
    body_format: json
    validate_certs: no
```