### PR TITLE
docker_image: Fix up 'changed' event in force mode

### DIFF
--- a/changelogs/fragments/33754-docker_image_fix_changed_in_force_mode.yaml
+++ b/changelogs/fragments/33754-docker_image_fix_changed_in_force_mode.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- "docker_image - set ``changed`` to ``false`` when using ``force: yes`` to load or build an image that ends up being identical to one already present on the Docker host."

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -348,9 +348,9 @@ class ImageManager(DockerBaseClass):
                 self.results['actions'].append('Pulled image %s:%s' % (self.name, self.tag))
                 self.results['changed'] = True
                 if not self.check_mode:
-                    self.results['image'], already_latest = self.client.pull_image(self.name, tag=self.tag)
-                    if already_latest:
-                        self.results['changed'] = False
+                    self.results['image'], _ = self.client.pull_image(self.name, tag=self.tag)
+            if not self.check_mode and image and image['Id'] == self.results['image']['Id']:
+                self.results['changed'] = False
 
         if self.archive_path:
             self.archive_image(self.name, self.tag)

--- a/lib/ansible/modules/cloud/docker/docker_image.py
+++ b/lib/ansible/modules/cloud/docker/docker_image.py
@@ -348,7 +348,7 @@ class ImageManager(DockerBaseClass):
                 self.results['actions'].append('Pulled image %s:%s' % (self.name, self.tag))
                 self.results['changed'] = True
                 if not self.check_mode:
-                    self.results['image'], _ = self.client.pull_image(self.name, tag=self.tag)
+                    self.results['image'], dummy = self.client.pull_image(self.name, tag=self.tag)
             if not self.check_mode and image and image['Id'] == self.results['image']['Id']:
                 self.results['changed'] = False
 


### PR DESCRIPTION
##### SUMMARY

This makes the `docker_image` module have `changed=False` when force-rebuilding an image that ends up being identical to the one that was already built in the Docker build cache.

This is the same change as https://github.com/ansible/ansible/pull/19235 except it works for all image-building modes that the `docker_image` module supports (building the image locally, loading the image from an archive, or pulling the image from a repo), rather than only when pulling the image from a repo.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`docker_image.py`

##### ANSIBLE VERSION

`devel`