### PR TITLE
files/file.py: Raise an IOError when trying to touch a file with missing intermediate directories within it's path

### DIFF
--- a/lib/ansible/modules/files/file.py
+++ b/lib/ansible/modules/files/file.py
@@ -440,7 +440,7 @@ def main():
             if prev_state == 'absent':
                 try:
                     open(b_path, 'wb').close()
-                except OSError as e:
+                except (OSError, IOError) as e:
                     module.fail_json(path=path, msg='Error, could not touch target: %s' % to_native(e, nonstring='simplerepr'))
             elif prev_state in ('file', 'directory', 'hard'):
                 try:


### PR DESCRIPTION
##### SUMMARY

As stated in (#33744) when trying to touch a file with missing intermediate directories, all the user gets is a stacktrack, since IOError is not properly caught.

Fixes #33744 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
file

##### ANSIBLE VERSION
```
ansible 2.5.0 (bugfix_33744 52698499a6) last updated 2017/12/11 12:18:22 (GMT +200)
  config file = None
  configured module search path = [u'/Users/pringl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pringl/development/ansible/lib/ansible
  executable location = /Users/pringl/development/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 15 2017, 10:33:06) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```