### PR TITLE
galaxy unit tests: add missing arg

### DIFF
--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -43,7 +43,7 @@ class TestGalaxy(unittest.TestCase):
             shutil.rmtree("./delete_me")
 
         # creating framework for a role
-        gc = GalaxyCLI(args=["init", "--offline", "delete_me"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "init", "--offline", "delete_me"])
         gc.parse()
         gc.run()
         cls.role_dir = "./delete_me"
@@ -90,7 +90,7 @@ class TestGalaxy(unittest.TestCase):
             shutil.rmtree(cls.role_path)
 
     def setUp(self):
-        self.default_args = []
+        self.default_args = ['ansible-galaxy']
 
     def test_init(self):
         galaxy_cli = GalaxyCLI(args=self.default_args)
@@ -113,7 +113,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_run(self):
         ''' verifies that the GalaxyCLI object's api is created and that execute() is called. '''
-        gc = GalaxyCLI(args=["install", "--ignore-errors", "imaginary_role"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--ignore-errors", "imaginary_role"])
         gc.parse()
         with patch.object(ansible.cli.CLI, "execute", return_value=None) as mock_ex:
             with patch.object(ansible.cli.CLI, "run", return_value=None) as mock_run:
@@ -126,7 +126,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_execute_remove(self):
         # installing role
-        gc = GalaxyCLI(args=["install", "--offline", "-p", self.role_path, "-r", self.role_req, '--force'])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--offline", "-p", self.role_path, "-r", self.role_req, '--force'])
         gc.parse()
         gc.run()
 
@@ -134,7 +134,7 @@ class TestGalaxy(unittest.TestCase):
         role_file = os.path.join(self.role_path, self.role_name)
 
         # removing role
-        gc = GalaxyCLI(args=["remove", "--init-path", role_file, self.role_name])
+        gc = GalaxyCLI(args=["ansible-galaxy", "remove", "--init-path", role_file, self.role_name])
         gc.parse()
         gc.run()
 
@@ -144,7 +144,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_exit_without_ignore_without_flag(self):
         ''' tests that GalaxyCLI exits with the error specified if the --ignore-errors flag is not used '''
-        gc = GalaxyCLI(args=["install", "--server=None", "fake_role_name"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--server=None", "fake_role_name"])
         gc.parse()
         with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
             # testing that error expected is raised
@@ -154,7 +154,7 @@ class TestGalaxy(unittest.TestCase):
     def test_exit_without_ignore_with_flag(self):
         ''' tests that GalaxyCLI exits without the error specified if the --ignore-errors flag is used  '''
         # testing with --ignore-errors flag
-        gc = GalaxyCLI(args=["install", "--server=None", "fake_role_name", "--ignore-errors"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--server=None", "fake_role_name", "--ignore-errors"])
         gc.parse()
         with patch.object(ansible.utils.display.Display, "display", return_value=None) as mocked_display:
             gc.run()
@@ -188,23 +188,23 @@ class TestGalaxy(unittest.TestCase):
 
     def test_parse_no_action(self):
         ''' testing the options parser when no action is given '''
-        gc = GalaxyCLI(args=[""])
+        gc = GalaxyCLI(args=["ansible-galaxy", ""])
         self.assertRaises(AnsibleOptionsError, gc.parse)
 
     def test_parse_invalid_action(self):
         ''' testing the options parser when an invalid action is given '''
-        gc = GalaxyCLI(args=["NOT_ACTION"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "NOT_ACTION"])
         self.assertRaises(AnsibleOptionsError, gc.parse)
 
     def test_parse_delete(self):
         ''' testing the options parser when the action 'delete' is given '''
-        gc = GalaxyCLI(args=["delete"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "delete"])
         self.run_parse_common(gc, "delete")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_import(self):
         ''' testing the options parser when the action 'import' is given '''
-        gc = GalaxyCLI(args=["import"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "import"])
         self.run_parse_common(gc, "import")
         self.assertEqual(gc.options.wait, True)
         self.assertEqual(gc.options.reference, None)
@@ -213,20 +213,20 @@ class TestGalaxy(unittest.TestCase):
 
     def test_parse_info(self):
         ''' testing the options parser when the action 'info' is given '''
-        gc = GalaxyCLI(args=["info"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "info"])
         self.run_parse_common(gc, "info")
         self.assertEqual(gc.options.offline, False)
 
     def test_parse_init(self):
         ''' testing the options parser when the action 'init' is given '''
-        gc = GalaxyCLI(args=["init"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "init"])
         self.run_parse_common(gc, "init")
         self.assertEqual(gc.options.offline, False)
         self.assertEqual(gc.options.force, False)
 
     def test_parse_install(self):
         ''' testing the options parser when the action 'install' is given '''
-        gc = GalaxyCLI(args=["install"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install"])
         self.run_parse_common(gc, "install")
         self.assertEqual(gc.options.ignore_errors, False)
         self.assertEqual(gc.options.no_deps, False)
@@ -235,26 +235,26 @@ class TestGalaxy(unittest.TestCase):
 
     def test_parse_list(self):
         ''' testing the options parser when the action 'list' is given '''
-        gc = GalaxyCLI(args=["list"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "list"])
         self.run_parse_common(gc, "list")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_login(self):
         ''' testing the options parser when the action 'login' is given '''
-        gc = GalaxyCLI(args=["login"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "login"])
         self.run_parse_common(gc, "login")
         self.assertEqual(gc.options.verbosity, 0)
         self.assertEqual(gc.options.token, None)
 
     def test_parse_remove(self):
         ''' testing the options parser when the action 'remove' is given '''
-        gc = GalaxyCLI(args=["remove"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "remove"])
         self.run_parse_common(gc, "remove")
         self.assertEqual(gc.options.verbosity, 0)
 
     def test_parse_search(self):
         ''' testing the options parswer when the action 'search' is given '''
-        gc = GalaxyCLI(args=["search"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "search"])
         self.run_parse_common(gc, "search")
         self.assertEqual(gc.options.platforms, None)
         self.assertEqual(gc.options.galaxy_tags, None)
@@ -262,7 +262,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_parse_setup(self):
         ''' testing the options parser when the action 'setup' is given '''
-        gc = GalaxyCLI(args=["setup"])
+        gc = GalaxyCLI(args=["ansible-galaxy", "setup"])
         self.run_parse_common(gc, "setup")
 
         self.assertEqual(gc.options.verbosity, 0)
@@ -292,7 +292,7 @@ class ValidRoleTests(object):
         cls.role_name = role_name
 
         # create role using default skeleton
-        gc = GalaxyCLI(args=['init', '-c', '--offline'] + galaxy_args + ['--init-path', cls.test_dir, cls.role_name])
+        gc = GalaxyCLI(args=['ansible-galaxy', 'init', '-c', '--offline'] + galaxy_args + ['--init-path', cls.test_dir, cls.role_name])
         gc.parse()
         gc.run()
         cls.gc = gc

--- a/test/units/cli/test_galaxy.py
+++ b/test/units/cli/test_galaxy.py
@@ -126,7 +126,7 @@ class TestGalaxy(unittest.TestCase):
 
     def test_execute_remove(self):
         # installing role
-        gc = GalaxyCLI(args=["ansible-galaxy", "install", "--offline", "-p", self.role_path, "-r", self.role_req, '--force'])
+        gc = GalaxyCLI(args=["ansible-galaxy", "install", "-p", self.role_path, "-r", self.role_req, '--force'])
         gc.parse()
         gc.run()
 
@@ -134,7 +134,7 @@ class TestGalaxy(unittest.TestCase):
         role_file = os.path.join(self.role_path, self.role_name)
 
         # removing role
-        gc = GalaxyCLI(args=["ansible-galaxy", "remove", "--init-path", role_file, self.role_name])
+        gc = GalaxyCLI(args=["ansible-galaxy", "remove", role_file, self.role_name])
         gc.parse()
         gc.run()
 


### PR DESCRIPTION
##### SUMMARY
First element of `args` parameter of `GalaxyCLI` should be a program name.

For some tests (for example: [`test_execute_remove`](https://github.com/ansible/ansible/blob/145c6f953dfcc1d89543875a4c2841c26dec041d/test/units/cli/test_galaxy.py#L129), `install` doesn't support `--offline` switch), an incorrect switch was used instead of program name. Tests were successful because this incorrect switch [was ignored](https://github.com/ansible/ansible/blob/145c6f953dfcc1d89543875a4c2841c26dec041d/lib/ansible/cli/__init__.py#L577).

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 145c6f953d) last updated 2017/12/11 11:22:10 (GMT +200)
```