### PR TITLE
Fix playbook cli unit test

### DIFF
--- a/test/units/cli/test_playbook.py
+++ b/test/units/cli/test_playbook.py
@@ -38,5 +38,8 @@ class TestPlaybookCLI(unittest.TestCase):
         fake_loader = DictDataLoader({'foobar.yml': ""})
         inventory = InventoryManager(loader=fake_loader, sources='testhost,')
 
+        variable_manager.set_host_facts(inventory.get_host('testhost'), {'canary': True})
+        self.assertTrue('testhost' in variable_manager._fact_cache)
+
         cli._flush_cache(inventory, variable_manager)
         self.assertFalse('testhost' in variable_manager._fact_cache)

--- a/test/units/cli/test_playbook.py
+++ b/test/units/cli/test_playbook.py
@@ -30,7 +30,9 @@ from ansible.cli.playbook import PlaybookCLI
 
 class TestPlaybookCLI(unittest.TestCase):
     def test_flush_cache(self):
-        cli = PlaybookCLI(args=["--flush-cache", "foobar.yml"])
+        cli = PlaybookCLI(args=["ansible-playbook", "--flush-cache", "foobar.yml"])
+        cli.parse()
+        self.assertTrue(cli.options.flush_cache)
 
         variable_manager = VariableManager()
         fake_loader = DictDataLoader({'foobar.yml': ""})


### PR DESCRIPTION
##### SUMMARY
Playbook cli unit test doesn't really test anything.

This PR checks that:
- `--flush-cache` switch is doing something
- call to `_flush_cache` method is doing something

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
TestPlaybookCLI unit test

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 145c6f953d) last updated 2017/12/11 11:22:10 (GMT +200)
```