### PR TITLE
Fixes #33771 - win_iis_webapppool bugfix 

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -255,11 +255,13 @@ if ($state -eq "absent") {
         }
     }
 
+    $stateChanged=$false # tracks if a status happened
     # Set the state of the pool
     if (($state -eq "stopped") -and ($pool.State -eq "Started")) {
         if (-not $check_mode) {
             try {
                 Stop-WebAppPool -Name $name
+                $stateChanged=$true                
             } catch {
                 Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
             }
@@ -267,37 +269,40 @@ if ($state -eq "absent") {
         $result.changed = $true
     }
 
-    
-    if ($pool.State -eq "Stopped") {
-        if ($state -eq "started" -or $state -eq "restarted") {
-            if (-not $check_mode) {
-                try {
-                    Start-WebAppPool -Name $name
-                } catch {
-                    Fail-Json $result "Failed to start Web App Pool $($name): $($_.Exception.Message)"
+    if (-not $stateChanged){        
+        if ($pool.State -eq "Stopped") {
+            if ($state -eq "started" -or $state -eq "restarted") {
+                if (-not $check_mode) {
+                    try {
+                        Start-WebAppPool -Name $name
+                        $stateChanged=$true
+                    } catch {
+                        Fail-Json $result "Failed to start Web App Pool $($name): $($_.Exception.Message)"
+                    }
                 }
+                $result.changed = $true
             }
-            $result.changed = $true
-        }
-    } else {
-        if ($state -eq "stopped") {
-            if (-not $check_mode) {
-                try {
-                    Stop-WebAppPool -Name $name
-                } catch {
-                    Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
+        } else {
+            if ($state -eq "stopped") {
+                if (-not $check_mode) {
+                    try {
+                        Stop-WebAppPool -Name $name
+                        $stateChanged=$true
+                    } catch {
+                        Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
+                    }
                 }
-            }
-            $result.changed = $true
-        } elseif ($state -eq "restarted") {
-            if (-not $check_mode) {
-                try {
-                    Restart-WebAppPool -Name $name
-                } catch {
-                    Fail-Json $result "Failed to restart Web App Pool $($name): $($_.Exception.Message)"
+                $result.changed = $true
+            } elseif ($state -eq "restarted") {
+                if (-not $check_mode) {
+                    try {
+                        Restart-WebAppPool -Name $name
+                    } catch {
+                        Fail-Json $result "Failed to restart Web App Pool $($name): $($_.Exception.Message)"
+                    }
                 }
+                $result.changed = $true
             }
-            $result.changed = $true
         }
     }
 }

--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -254,57 +254,40 @@ if ($state -eq "absent") {
             $result.changed = $true
         }
     }
-
-    $stateChanged=$false # tracks if a status happened
+   
     # Set the state of the pool
-    if (($state -eq "stopped") -and ($pool.State -eq "Started")) {
-        if (-not $check_mode) {
-            try {
-                Stop-WebAppPool -Name $name
-                $stateChanged=$true                
-            } catch {
-                Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
+    if ($pool.State -eq "Stopped") {
+        if ($state -eq "started" -or $state -eq "restarted") {
+            if (-not $check_mode) {
+                try {
+                    Start-WebAppPool -Name $name
+                } catch {
+                    Fail-Json $result "Failed to start Web App Pool $($name): $($_.Exception.Message)"
+                }
             }
+            $result.changed = $true
         }
-        $result.changed = $true
-    }
-
-    if (-not $stateChanged){        
-        if ($pool.State -eq "Stopped") {
-            if ($state -eq "started" -or $state -eq "restarted") {
-                if (-not $check_mode) {
-                    try {
-                        Start-WebAppPool -Name $name
-                        $stateChanged=$true
-                    } catch {
-                        Fail-Json $result "Failed to start Web App Pool $($name): $($_.Exception.Message)"
-                    }
+    } else {
+        if ($state -eq "stopped") {
+            if (-not $check_mode) {
+                try {
+                    Stop-WebAppPool -Name $name
+                } catch {
+                    Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
                 }
-                $result.changed = $true
             }
-        } else {
-            if ($state -eq "stopped") {
-                if (-not $check_mode) {
-                    try {
-                        Stop-WebAppPool -Name $name
-                        $stateChanged=$true
-                    } catch {
-                        Fail-Json $result "Failed to stop Web App Pool $($name): $($_.Exception.Message)"
-                    }
+            $result.changed = $true
+        } elseif ($state -eq "restarted") {
+            if (-not $check_mode) {
+                try {
+                    Restart-WebAppPool -Name $name
+                } catch {
+                    Fail-Json $result "Failed to restart Web App Pool $($name): $($_.Exception.Message)"
                 }
-                $result.changed = $true
-            } elseif ($state -eq "restarted") {
-                if (-not $check_mode) {
-                    try {
-                        Restart-WebAppPool -Name $name
-                    } catch {
-                        Fail-Json $result "Failed to restart Web App Pool $($name): $($_.Exception.Message)"
-                    }
-                }
-                $result.changed = $true
             }
+            $result.changed = $true
         }
-    }
+    }  
 }
 
 # Get all the current attributes for the pool

--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -254,7 +254,7 @@ if ($state -eq "absent") {
             $result.changed = $true
         }
     }
-   
+
     # Set the state of the pool
     if ($pool.State -eq "Stopped") {
         if ($state -eq "started" -or $state -eq "restarted") {
@@ -287,7 +287,7 @@ if ($state -eq "absent") {
             }
             $result.changed = $true
         }
-    }  
+    }
 }
 
 # Get all the current attributes for the pool


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Bugfix in win_iis_webapppool module (#33771). The module throws an exception in stopping IIS Web Application Pool. I added a variable that tracks if a change in application pool happened.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
win_iis_webapppool

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.9 (default, Jun 29 2016, 13:08:31) [GCC 4.9.2]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before 
```
fatal: [webserver01]: FAILED! => {"attributes": {}, "changed": true, "info": {"attributes": {}, "cpu": {}, "failure": {}, "name": "apppool", "processModel": {}, "recycling": {"periodicRestart": {}}, "state": "stopped"}, "msg": "Failed to stop Web App Pool apppool: The service cannot accept control messages at this time. (Exception from HRESULT: 0x80070425)"}
```
after
```
changed: [webserver01]
```
