### PR TITLE
Use pop in cb clean results

### DIFF
--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -236,7 +236,7 @@ class CallbackBase(AnsiblePlugin):
     def _clean_results(self, result, task_name):
         ''' removes data from results for display '''
         if task_name in ['debug']:
-            for remove_key in ('invocation'):
+            for remove_key in ('invocation',):
                 if remove_key in result:
                     del result[remove_key]
 

--- a/lib/ansible/plugins/callback/__init__.py
+++ b/lib/ansible/plugins/callback/__init__.py
@@ -236,9 +236,7 @@ class CallbackBase(AnsiblePlugin):
     def _clean_results(self, result, task_name):
         ''' removes data from results for display '''
         if task_name in ['debug']:
-            for remove_key in ('invocation',):
-                if remove_key in result:
-                    del result[remove_key]
+            result.pop('invocation', None)
 
     def set_play_context(self, play_context):
         pass

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -67,12 +67,12 @@ class TestCallbackResults(unittest.TestCase):
         res = cb._get_item(results)
         self.assertEquals(res, "some_item")
 
-    def test_clean_results(self):
+    def test_clean_results_debug_task(self):
         cb = CallbackBase()
         result = {'item': 'some_item',
                   'invocation': 'foo --bar whatever [some_json]',
-                  'a': 'a single a in result',
-                  'b': 'a single b in result',
+                  'a': 'a single a in result note letter a is in invocation',
+                  'b': 'a single b in result note letter b is not in invocation',
                   'changed': True}
 
         cb._clean_results(result, 'debug')
@@ -82,6 +82,38 @@ class TestCallbackResults(unittest.TestCase):
         self.assertTrue('b' in result)
         self.assertFalse('invocation' in result)
         self.assertTrue('changed' in result)
+
+    def test_clean_results_debug_task_no_invocation(self):
+        cb = CallbackBase()
+        result = {'item': 'some_item',
+                  'a': 'a single a in result note letter a is in invocation',
+                  'b': 'a single b in result note letter b is not in invocation',
+                  'changed': True}
+
+        cb._clean_results(result, 'debug')
+        self.assertTrue('a' in result)
+        self.assertTrue('b' in result)
+        self.assertTrue('changed' in result)
+        self.assertFalse('invocation' in result)
+
+    def test_clean_results_debug_task_empty_results(self):
+        cb = CallbackBase()
+        result = {}
+        cb._clean_results(result, 'debug')
+        self.assertFalse('invocation' in result)
+        self.assertEqual(len(result), 0)
+
+    def test_clean_results(self):
+        cb = CallbackBase()
+        result = {'item': 'some_item',
+                  'invocation': 'foo --bar whatever [some_json]',
+                  'a': 'a single a in result note letter a is in invocation',
+                  'b': 'a single b in result note letter b is not in invocation',
+                  'changed': True}
+
+        expected_result = result.copy()
+        cb._clean_results(result, 'ebug')
+        self.assertEqual(result, expected_result)
 
 
 class TestCallbackDumpResults(unittest.TestCase):

--- a/test/units/plugins/callback/test_callback.py
+++ b/test/units/plugins/callback/test_callback.py
@@ -71,11 +71,17 @@ class TestCallbackResults(unittest.TestCase):
         cb = CallbackBase()
         result = {'item': 'some_item',
                   'invocation': 'foo --bar whatever [some_json]',
+                  'a': 'a single a in result',
+                  'b': 'a single b in result',
                   'changed': True}
 
-        self.assertTrue('changed' in result)
-        self.assertTrue('invocation' in result)
         cb._clean_results(result, 'debug')
+
+        # See https://github.com/ansible/ansible/issues/33723
+        self.assertTrue('a' in result)
+        self.assertTrue('b' in result)
+        self.assertFalse('invocation' in result)
+        self.assertTrue('changed' in result)
 
 
 class TestCallbackDumpResults(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY
Further fixes/tests for #33723 in addition to https://github.com/ansible/ansible/pull/33778

Use .pop() to remove invocation from results dict
    
In base callback _clean_results, simplify the way the 'invocation' item is removed.
    
Add some more unit tests.

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->

 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansible/plugins/callback/__init__.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (use_pop_in_cb_clean_results cbc45ac140) last updated 2017/12/11 12:19:27 (GMT -400)
  config file = /home/adrian/src/ansible/ansible.cfg
  configured module search path = [u'/home/adrian/ansible/my-modules']
  ansible python module location = /home/adrian/src/ansible/lib/ansible
  executable location = /home/adrian/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]


```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
