### PR TITLE
[new module] add/retrieve secrets from Thycotic secret server - database/misc/thycotic_secret

### DIFF
--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -4,9 +4,6 @@
 # Copyright: (c) 2017, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# TODO: Write quick & dirty test playbook
-# TODO: Review & Submit PR
-
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -21,9 +21,6 @@ short_description: "Enforce state upon secrets stored in Thycotic Secret Server"
 
 version_added: "2.5"
 
-requirements:
-    - zeep
-
 description:
     - "NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance."
     - "Webservices must be enabled for this work correctly."

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -19,7 +19,7 @@ module: "thycotic_secret"
 
 short_description: "Add or retrieve secrets from of Thycotic Secret Server"
 
-version_added: "2.4"
+version_added: "2.5"
 
 description:
     - "NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance."

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -1,11 +1,6 @@
 #!/usr/bin/python
 
-# TODO: Allow for putting secret files
-# TODO: Allow for putting secret files w/ check mode
 # TODO: Update to pass all sanity checks
-# TODO: Beef up the return documentation
-# TODO: Add example for getting a file
-# TODO: Add example for putting a file
 # TODO: Review & Submit PR
 
 
@@ -24,29 +19,15 @@ short_description: Allows the retrieval or addition of secrets from a instance o
 version_added: "2.4"
 
 description:
-    - "NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance. Webservices must be enabled for this work correctly"
+    - NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance.
+    - Webservices must be enabled for this work correctly
+    - This module works by editing a single field value of a secret at a time
+    - The field value can be a file or text value
 
 options:
     endpoint:
         description:
             - The endpoint of your secret server instance
-        required: true
-    name:
-        description:
-            - Name of the secret you wish to interact with
-        required: true
-    is_file:
-        description:
-            - Boolean designating if the secret is a file
-        default: false
-        required: false
-    dest:
-        description:
-            - Absolute path on the host machine that you wish to download the secret file to
-        required: false
-    folder:
-        description:
-            - The folder you wish to store/retrieve the secret in/from
         required: true
     username:
         description:
@@ -54,159 +35,194 @@ options:
         required: true
     password:
         description:
-            - Password of the user you wish to authenticate into the instance with; it is recomended to store your password in a file and use a lookup plugin to inject it into your playbook
+            - Password of the user you wish to authenticate into the instance with
+            - It is recomended to store your password in a file and use a lookup plugin to inject it into your playbook
         required: true
+    folder:
+        description:
+            - The folder you wish to store/retrieve the secret in/from
+        required: true
+    secret_name:
+        description:
+            - Name of the secret you wish to interact with
+        required: true
+    field_name:
+        description:
+            - Name of the field you wish to edit
+        required: true
+    type:
+        description:
+            - Type of secret template you wish to use
+            - Required for putting secrets (file or text)
+        required: false
+    src:
+        description:
+            - Absolute path on the host machine to the file that you wish to upload and attach to the secret
+            - Required for putting files
+        required: false
+    dest:
+        description:
+            - Absolute path on the host machine to the folder that you wish to download the secret file to
+            - Required for getting files
+        required: false
+    field_value:
+        description:
+            - Text value that you wish to place in the secret field
+            - Required for putting text
+        required: false
     mode:
         description:
             - Mode of operation of the module
         choices:
             - get
             - put
-        required: false
-        default: get
-    type:
-        description:
-            - Type of secret template you wish to use
-        required: false
-    secret_args:
-        description:
-            - Dictionary of the secrets you wish to store. Keys should be the field name as it is shown in the template and the value should be the coresponding secret
-        required: false
-    overwrite:
-        description:
-            - If set, if a secrets value's are different than the secret_args, the secret will be updated
-        required: false
-        default: false
+        required: true
 
 author:
     - Patrick Thomison (@pthomison)
 '''
 
 EXAMPLES = '''
-# Retrieve a SSH Key
-- name: Retrieve an SSH Key
+# Retrieve Text From A Field
+- name: get text
   thycotic_secret:
-    name: 'example_ssh_key'
-    folder: 'example_folder'
+    username: 'admin'
+    password: 'adm-password'
+    endpoint: 'http://endpoint/SecretServer/webservices/sswebservice.asmx'
+    secret_name: 'example_ssh_key'
+    field_name: 'Private Key'
+    folder: 'demo'
     mode: 'get'
-    username: 'admin'
-    password: 'r3dh4t1!'
-    endpoint: 'http://127.0.0.1/SecretServer/webservices/sswebservice.asmx'
-    register: results
+  register: priv_key
 
-# Add a SSH key
-- name: add secret into secret server
+# Retrieve File Attachement From A Field
+- name: get file
   thycotic_secret:
-    name: 'example_ssh_key'
-    folder: 'example_folder'
-    mode: 'put'
     username: 'admin'
-    password: 'r3dh4t1!'
-    endpoint: 'http://127.0.0.1/SecretServer/webservices/sswebservice.asmx'
-    type: 'SSH Key'
-    secret_args:
-      Public Key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
-      Private Key: "{{ lookup('file', '~/.ssh/id_rsa') }}"
-      Private Key Passphrase: password
+    password: 'adm-password'
+    endpoint: 'http://endpoint/SecretServer/webservices/sswebservice.asmx'
+    secret_name: 'test_image'
+    field_name: 'file'
+    dest: '/tmp/'
+    folder: 'demo'
+    mode: 'get'
+
+# Place Text In A Field
+- name: put text
+  thycotic_secret:
+    username: 'admin'
+    password: 'adm-password'
+    endpoint: 'http://endpoint/SecretServer/webservices/sswebservice.asmx'
+    secret_name: 'test_password'
+    type: 'Password'
+    field_name: 'Password'
+    field_value: 'pa44w0rd'
+    folder: 'demo'
+    mode: 'put'
+
+# Attach A File To A Field
+- name: put file
+  thycotic_secret:
+    username: 'admin'
+    password: 'adm-password'
+    endpoint: 'http://endpoint/SecretServer/webservices/sswebservice.asmx'
+    secret_name: 'test_file'
+    type: 'generic_file'
+    field_name: 'file'
+    src: '/tmp/test_file.jpg'
+    folder: 'demo'
+    mode: 'put'
+
 '''
 
 RETURN = '''
-secret:
-    description: The secret object stored in thycotic secret server
-    type: dict
+secret_value:
+    description: The secret field value that you requested; Only populated when getting text
+    type: str
 '''
 
 try:
     from ansible.module_utils.basic import AnsibleModule
     from zeep import Client, helpers
-    import pdb
     import os
-    import tempfile
-    import filecmp
 except:
     module.fail_json(msg="Zeep is a required library", **result)
 
 def run_module():
     module_args = dict(
         endpoint=dict(type='str', required=True),
-        name=dict(type='str', required=True),
-        is_file=dict(type='bool', required=False, default=False),
-        dest=dict(type='str', required=False),
-        src=dict(type='str', required=False),
         username=dict(type='str', required=True),
         password=dict(type='str', required=True),
         folder=dict(type='str', required=True),
-        mode=dict(type='str', required=False, choices=['get', 'put', 'debug'], default='get'),
+        secret_name=dict(type='str', required=True),
+        field_name=dict(type='str', required=True),
+        mode=dict(type='str', required=True, choices=['get', 'put', 'debug']),
+        src=dict(type='str', required=False),
+        dest=dict(type='str', required=False),
         type=dict(type='str', required=False),
-        secret_args=dict(type='dict', required=False),
-        overwrite=dict(type='bool', required=False, default=False)
+        field_value=dict(type='str', required=False),
     )
 
     result = dict(
         changed=False,
-        secret=dict(),
+        secret_value=dict(),
         debug=dict()
     )
 
-    # TODO: Update the arg to arg requirements
     module = AnsibleModule(
         argument_spec=module_args,
         supports_check_mode=True,
-        # required_if=[
-        #     ["mode", "put", ["type", "secret_args"]],
-        #     ["is_file", True, ["dest"]]
-        # ]
+        required_if=[
+            ["mode", "put", ["type"]]
+        ]
     )
+
+    # authenticates & retrieves token
+    token_args = {'username': module.params['username'], 'password': module.params['password']}
+    token_result = make_soap_request(module.params['endpoint'], 'Authenticate', token_args)
+    token = token_result['Token']
+
+    # if errors when encountered during authentication
+    if token_result['Errors']:
+        module.fail_json(msg=str(token_result['Errors']), **result)
+
+    # searches for specified folder
+    # should fail if folder does not exist
+    folder_result = make_soap_request(module.params['endpoint'], 'SearchFolders', {'token': token, 'folderName': module.params['folder']})
+
+    # if errors when encountered during authentication
+    if not folder_result['Folders']:
+        module.fail_json(msg="folder does not exist", **result)
+
+    folderId = folder_result['Folders']['Folder'][0]['Id']
+
+    secret = find_secret(module.params['endpoint'], token, module.params['secret_name'], folderId)
 
     # non production, testing mode
     if module.params['mode'] == 'debug':
         result['debug'] = 'test'
         result['changed'] = False
 
-    else:
-        # authenticates & retrieves token
-        token_args = {'username': module.params['username'], 'password': module.params['password']}
-        token_result = make_soap_request(module.params['endpoint'], 'Authenticate', token_args)
-        token = token_result['Token']
-
-        # if errors when encountered during authentication
-        if token_result['Errors']:
-            module.fail_json(msg=str(token_result['Errors']), **result)
-
-        # searches for specified folder
-        # should fail if folder does not exist
-        folder_result = make_soap_request(module.params['endpoint'], 'SearchFolders', {'token': token, 'folderName': module.params['folder']})
-
-        # if errors when encountered during authentication
-        if not folder_result['Folders']:
-            module.fail_json(msg="folder does not exist", **result)
-
-        folderId = folder_result['Folders']['Folder'][0]['Id']
-
-        # determining if secret exists
-        search_args = {'token': token, 'searchTerm': module.params['name'], 'folderId': folderId, 'includeSubFolders': False, 'includeDeleted': False, 'includeRestricted': False}
-        search_result = make_soap_request(module.params['endpoint'], 'SearchSecretsByFolder', search_args)
-
-        # Secret exists, request it
-        if search_result['SecretSummaries']:
-            secret_id = int(search_result['SecretSummaries']['SecretSummary'][0]['SecretId'])
-            secret_args = {'token': token, 'secretId': secret_id, 'loadSettingsAndPermissions': False, 'codeResponses': []}
-            secret_result = make_soap_request(module.params['endpoint'], 'GetSecret', secret_args)
-            secret = secret_result['Secret']
-        else:
-            secret = None
-
-        # retrieves a secret and returns it
-        if module.params['mode'] == 'get':
-            # error checking
+    # retrieves a secret and returns it
+    elif module.params['mode'] == 'get':
+            # secret must exist
             if secret is None:
                 module.fail_json(msg='Secret Does Not Exist', **result)
 
-            if module.params['is_file']:
-                get_file_args = {'token': token, 'secretId': secret_id}
-                get_file_result = make_soap_request(module.params['endpoint'], 'DownloadFileAttachment', get_file_args)
+            # field name must be present on the secret
+            field = field_name_filter(secret, module.params['field_name'])
+            if field is None:
+                module.fail_json(msg='Field Is Not Present On The Secret', **result)
+
+            if field['IsFile']:
+                # Download destination must be present if it is a file
+                if not module.params['dest']:
+                    module.fail_json(msg="Field is a file and no destination was given", **result)
+
+                # Downloading file
+                get_file_args = {'token': token, 'secretId': secret_id, 'secretItemId': field['Id']}
+                get_file_result = make_soap_request(module.params['endpoint'], 'DownloadFileAttachmentByItemId', get_file_args)
                 file_bytes = get_file_result["FileAttachment"]
-                pdb.set_trace()
                 download_location = os.path.join(module.params['dest'], get_file_result["FileName"])
 
                 # assume nothing changes
@@ -230,95 +246,158 @@ def run_module():
                     else:
                         result['changed'] = True
 
+                # Downloading the file to the correct location
                 if result['changed'] and not module.check_mode:
                     with open(download_location, 'wb') as fp:
                         fp.write(file_bytes)
 
             else:
                 # returning secret
-                result['secret'] = secret
+                result['secret_value'] = field['Value']
                 result['changed'] = False
 
-        # ensures the secret is added into the secret server
-        elif module.params['mode'] == 'put':
+    # ensures the secret is added into the secret server
+    elif module.params['mode'] == 'put':
+            # Get the correct template
+            get_templates_result = make_soap_request(module.params['endpoint'], 'GetSecretTemplates', {'token': token})
+            template_list = get_templates_result["SecretTemplates"]["SecretTemplate"]
+            template_test = [tpl for tpl in template_list if (module.params['type'] == tpl["Name"])]
+            # Ensuring template is Present
+            if len(template_test) == 0:
+                module.fail_json(msg='Secret Type Is Not Present On This Server', **result)
+            template = template_test[0]
+
+            template_fields = template['Fields']['SecretField']
+            template_field_name_test = [x for x in template_fields if x['DisplayName'] == module.params['field_name']]
+            # Ensuring the field name is on the template
+            if len(template_field_name_test) == 0:
+                module.fail_json(msg='Field Is Not Present On The Secret Type', **result)
+            template_field = template_field_name_test[0]
+
+            # CHANGE VALIDATION
 
             # assume nothing changes
             result['changed'] = False
 
+            # Secret is present
             if secret is not None:
-                if module.params['is_file']:
-                    get_file_args = {'token': token, 'secretId': secret_id}
-                    get_file_result = make_soap_request(module.params['endpoint'], 'DownloadFileAttachment', get_file_args)
+                field = field_name_filter(secret, module.params['field_name'])
+
+                if template_field['IsFile']:
+                    #error check for 'src'
+                    if not module.params['src']:
+                        module.fail_json(msg="Field is a file and no src was given", **result)
+
+                    get_file_args = {'token': token, 'secretId': secret['Id'], 'secretItemId': field['Id']}
+                    get_file_result = make_soap_request(module.params['endpoint'], 'DownloadFileAttachmentByItemId', get_file_args)
                     file_bytes = get_file_result["FileAttachment"]
 
                     with open(module.params['src'], "rb") as fp:
                         src_bytes = fp.read()
-
                     equality_test = file_bytes == src_bytes
 
                 else:
-                    equality_test = check_secret_equality(local_secret=secret, args=module.params['secret_args'])
+                    equality_test = field['Value'] == module.params['field_value']
 
                 # if arguments & secret match, change nothing
                 if equality_test:
                     result['changed'] = False
-                # if arguments & secret don't match & overwrite is true, the secret will be updated
-                elif module.params['overwrite']:
-                    result['changed'] = True
-                # if arguments & secret don't match & overwrite is false,
-                # nothing will change and the module will fail
+                # if arguments & secret don't match, the secret will be updated
                 else:
-                    result['changed'] = False
-                    module.fail_json(msg="Secret is present & changed, and overwrite is not set", **result)
-            # if secret is not present, it will be uploaded
+                    result['changed'] = True
+
+            # if secret is not present
+            # it will be uploaded
             else:
                 result['changed'] = True
+
+            # CHANGE IMPLEMENTATION
 
             # if the secret is not present or doesn't match the argmuments,
             if result['changed'] and not module.check_mode:
 
-                if module.params['is_file']:
-                    pass
-                # if secret is present, update it
-                elif secret is not None:
-                    updated_secret = inject_args(secret, module.params['secret_args'])
-                    make_soap_request(module.params['endpoint'], 'UpdateSecret', {'token': token, 'secret': updated_secret})
-
-                # if secret is not present, it should be created
-                else:
-                    # Get the correct type id
-                    get_templates_result = make_soap_request(module.params['endpoint'], 'GetSecretTemplates', {'token': token})
-                    templates = get_templates_result["SecretTemplates"]["SecretTemplate"]
-                    requested_template = [tpl for tpl in templates if (module.params['type'] == tpl["Name"])][0]
-                    template_id = requested_template['Id']
-
+                # Secret does not exist, must be created
+                if secret is None:
                     # Creating a new secret from the template
-                    get_new_secret_args = {'token': token, 'secretTypeId': template_id, 'folderId': folderId}
+                    get_new_secret_args = {'token': token, 'secretTypeId': template['Id'], 'folderId': folderId}
                     get_new_secret_result = make_soap_request(module.params['endpoint'], 'GetNewSecret', get_new_secret_args)
 
-                    # Adding in the actual secrets
                     new_secret = get_new_secret_result['Secret']
-                    new_secret["Name"] = module.params['name']
-                    new_secret = inject_args(new_secret, module.params['secret_args'])
+                    new_secret["Name"] = module.params['secret_name']
 
+                    if not template_field['IsFile']:
+                        new_secret = inject_arg(new_secret, module.params['field_name'], module.params['field_value'])
+
+                    # Tell the server to add the new secret
                     make_soap_request(module.params['endpoint'], 'AddNewSecret', {'token': token, 'secret': new_secret})
 
-        module.exit_json(**result)
+                    if template_field['IsFile']:
+                        # re-requesting secret to get updated ID
+                        new_secret = find_secret(module.params['endpoint'], token, module.params['secret_name'], folderId)
+                        new_secret_field = field_name_filter(new_secret, module.params['field_name'])
+                        upload_file(module.params['endpoint'], token, new_secret['Id'], new_secret_field['Id'], module.params['src'])
+
+                # if secret is present, update it
+                else:
+                    if template_field['IsFile']:
+                        field = field_name_filter(secret, module.params['field_name'])
+                        upload_file(module.params['endpoint'], token, secret['Id'], field['Id'], module.params['src'])
+
+                    else:
+                        updated_secret = inject_arg(secret, module.params['field_name'], module.params['field_value'])
+                        make_soap_request(module.params['endpoint'], 'UpdateSecret', {'token': token, 'secret': updated_secret})
+
+    module.exit_json(**result)
 
 
-def check_secret_equality(local_secret, args):
-    for item in local_secret["Items"]["SecretItem"]:
-        if item['FieldName'] in args.keys():
-            if str(args[item['FieldName']]) != str(item['Value']):
-                return False
-    return True
+def upload_file(endpoint, token, secretId, secretItemId, src):
+    filename = os.path.basename(src)
+    with open(src, 'rb') as fp:
+        data = fp.read()
+        upload_file_args = {'token': str(token),
+                            'secretId': int(secretId),
+                            'secretItemId': int(secretItemId),
+                            'fileData': bytes(data),
+                            'fileName': str(filename)}
+    # Tell the server to upload file
+    make_soap_request(endpoint, 'UploadFileAttachmentByItemId', upload_file_args)
+
+
+def find_secret(endpoint, token, secret_name, folder_id):
+    # determining if secret exists
+    search_args = {'token': token,
+                   'searchTerm': secret_name,
+                   'folderId': folder_id,
+                   'includeSubFolders': False,
+                   'includeDeleted': False,
+                   'includeRestricted': False}
+    search_result = make_soap_request(endpoint, 'SearchSecretsByFolder', search_args)
+
+    # Secret exists, request it
+    if search_result['SecretSummaries']:
+        secret_id = int(search_result['SecretSummaries']['SecretSummary'][0]['SecretId'])
+        secret_args = {'token': token,
+                       'secretId': secret_id,
+                       'loadSettingsAndPermissions': False,
+                       'codeResponses': []}
+        secret_result = make_soap_request(endpoint, 'GetSecret', secret_args)
+        secret = secret_result['Secret']
+    else:
+        secret = None
+    return secret
+
+
+def field_name_filter(secret, field_name):
+    arr = [x for x in secret['Items']['SecretItem'] if x['FieldDisplayName'] == field_name]
+    if len(arr) != 0:
+        return arr[0]
 
 
 # takes in a secret and a dictionary of argument and applies them to the secret
-def inject_args(local_secret, args):
+def inject_arg(local_secret, field, val):
     for item in local_secret["Items"]["SecretItem"]:
-        if item['FieldName'] in args.keys():
-            item["Value"] = args[item['FieldName']]
+        if item['FieldDisplayName'] == field:
+            item["Value"] = val
     return local_secret
 
 

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -1,0 +1,274 @@
+#!/usr/bin/python
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: thycotic_secret
+
+short_description: Allows the retrieval or addition of secrets from a instance of Thycotic Secret Server
+
+version_added: "2.4"
+
+description:
+    - "NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance. Webservices must be enabled for this work correctly"
+
+options:
+    endpoint:
+        description:
+            - The endpoint of your secret server instance
+        required: true
+    name:
+        description:
+            - Name of the secret you wish to interact with
+        required: true
+    folder:
+        description:
+            - The folder you wish to store/retrieve the secret in/from
+        required: true
+    username:
+        description:
+            - Name of the user you wish to authenticate into the instance with
+        required: true
+    password:
+        description:
+            - Password of the user you wish to authenticate into the instance with; it is recomended to store your password in a file and use a lookup plugin to inject it into your playbook
+        required: true
+    mode:
+        description:
+            - Mode of operation of the module
+        choices:
+            - get
+            - put
+        required: false
+        default: get
+    type:
+        description:
+            - Type of secret template you wish to use
+        required: false
+    secret_args:
+        description:
+            - Dictionary of the secrets you wish to store. Keys should be the field name as it is shown in the template and the value should be the coresponding secret
+        required: false
+    overwrite:
+        description:
+            - If set, if a secrets value's are different than the secret_args, the secret will be updated
+        required: false
+        default: false
+
+author:
+    - Patrick Thomison (@pthomison)
+'''
+
+EXAMPLES = '''
+# Retrieve a SSH Key
+- name: Retrieve an SSH Key
+  thycotic_secret:
+    name: 'example_ssh_key'
+    folder: 'example_folder'
+    mode: 'get'
+    username: 'admin'
+    password: 'r3dh4t1!'
+    endpoint: 'http://127.0.0.1/SecretServer/webservices/sswebservice.asmx'
+    register: results
+
+# Add a SSH key
+- name: add secret into secret server
+  thycotic_secret:
+    name: 'example_ssh_key'
+    folder: 'example_folder'
+    mode: 'put'
+    username: 'admin'
+    password: 'r3dh4t1!'
+    endpoint: 'http://127.0.0.1/SecretServer/webservices/sswebservice.asmx'
+    type: 'SSH Key'
+    secret_args:
+      Public Key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+      Private Key: "{{ lookup('file', '~/.ssh/id_rsa') }}"
+      Private Key Passphrase: password
+'''
+
+RETURN = '''
+secret:
+    description: The secret object stored in thycotic secret server
+    type: dict
+'''
+
+try:
+    from ansible.module_utils.basic import AnsibleModule
+    from zeep import Client, helpers
+except:
+    module.fail_json(msg="Zeep is a required library", **result)
+
+def run_module():
+    module_args = dict(
+        endpoint=dict(type='str', required=True),
+        name=dict(type='str', required=True),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True),
+        folder=dict(type='str', required=True),
+        mode=dict(type='str', required=False, choices=['get', 'put', 'debug'], default='get'),
+        type=dict(type='str', required=False),
+        secret_args=dict(type='dict', required=False),
+        overwrite=dict(type='bool', required=False, default=False)
+    )
+
+    result = dict(
+        changed=False,
+        secret=dict(),
+        debug=dict()
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False,
+        required_if=[
+            ["mode", "put", ["type", "secret_args"]]
+        ]
+    )
+
+    # non production, testing mode
+    if module.params['mode'] == 'debug':
+        result['debug'] = 'test'
+        result['changed'] = False
+
+    else:
+        # authenticates & retrieves token
+        token_args = {'username': module.params['username'], 'password': module.params['password']}
+        token_result = make_soap_request(module.params['endpoint'], 'Authenticate', token_args)
+        token = token_result['Token']
+
+        # if errors when encountered during authentication
+        if token_result['Errors']:
+            module.fail_json(msg=str(token_result['Errors']), **result)
+
+        # searches for specified folder
+        # should fail if folder does not exist
+        folder_result = make_soap_request(module.params['endpoint'], 'SearchFolders', {'token': token, 'folderName': module.params['folder']})
+
+        # if errors when encountered during authentication
+        if not folder_result['Folders']:
+            module.fail_json(msg="folder does not exist", **result)
+
+        folderId = folder_result['Folders']['Folder'][0]['Id']
+
+        # determining if secret exists
+        search_args = {'token': token, 'searchTerm': module.params['name'], 'folderId': folderId, 'includeSubFolders': False, 'includeDeleted': False, 'includeRestricted': False}
+        search_result = make_soap_request(module.params['endpoint'], 'SearchSecretsByFolder', search_args)
+
+        # Secret exists, request it
+        if search_result['SecretSummaries']:
+            secret_id = int(search_result['SecretSummaries']['SecretSummary'][0]['SecretId'])
+            secret_args = {'token': token, 'secretId': secret_id, 'loadSettingsAndPermissions': False, 'codeResponses': []}
+            secret_result = make_soap_request(module.params['endpoint'], 'GetSecret', secret_args)
+            secret = secret_result['Secret']
+        else:
+            secret = None
+
+        # retrieves a secret and returns it
+        if module.params['mode'] == 'get':
+
+            # error checking
+            if secret is None:
+                module.fail_json(msg='Secret Does Not Exist', **result)
+
+            # returning secret
+            result['secret'] = secret
+            result['changed'] = False
+
+        # ensures the secret is added into the secret server
+        elif module.params['mode'] == 'put':
+
+            # assume nothing changes
+            changed = False
+
+            if secret is not None:
+                equality_test = check_secret_equality(local_secret=secret, args=module.params['secret_args'])
+                # if arguments & secret match, change nothing
+                if equality_test:
+                    changed = False
+                # if arguments & secret don't match & overwrite is true, the secret will be updated
+                elif module.params['overwrite']:
+                    changed = True
+                # if arguments & secret don't match & overwrite is false,
+                # nothing will change and the module will fail
+                else:
+                    changed = False
+                    module.fail_json(msg="Secret is present & changed, and overwrite is not set", **result)
+            # if secret is not present, it will be uploaded
+            else:
+                changed = True
+
+
+            # if secret is present & matches the inputted args, nothing should change
+            if not changed:
+                result['changed'] = False
+
+            # if the secret is not present or doesn't match the argmuments,
+            else:
+                result['changed'] = True
+
+                # if secret is present, update it
+                if secret is not None:
+                    updated_secret = inject_args(secret, module.params['secret_args'])
+                    make_soap_request(module.params['endpoint'], 'UpdateSecret', {'token': token, 'secret': updated_secret})
+                    result['changed'] = True
+
+                # if secret is not present, it should be created
+                else:
+                    # Get the correct type id
+                    get_templates_result = make_soap_request(module.params['endpoint'], 'GetSecretTemplates', {'token': token})
+                    templates = get_templates_result["SecretTemplates"]["SecretTemplate"]
+                    requested_template = [tpl for tpl in templates if (module.params['type'] == tpl["Name"])][0]
+                    template_id = requested_template['Id']
+
+                    # Creating a new secret from the template
+                    get_new_secret_args = {'token': token, 'secretTypeId': template_id, 'folderId': folderId}
+                    get_new_secret_result = make_soap_request(module.params['endpoint'], 'GetNewSecret', get_new_secret_args)
+
+                    # Adding in the actual secrets
+                    new_secret = get_new_secret_result['Secret']
+                    new_secret["Name"] = module.params['name']
+                    new_secret = inject_args(new_secret, module.params['secret_args'])
+
+                    make_soap_request(module.params['endpoint'], 'AddNewSecret', {'token': token, 'secret': new_secret})
+                    result['changed'] = True
+
+        module.exit_json(**result)
+
+
+def check_secret_equality(local_secret, args):
+    for item in local_secret["Items"]["SecretItem"]:
+        if item['FieldName'] in args.keys():
+            if str(args[item['FieldName']]) != str(item['Value']):
+                return False
+    return True
+
+
+# takes in a secret and a dictionary of argument and applies them to the secret
+def inject_args(local_secret, args):
+    for item in local_secret["Items"]["SecretItem"]:
+        if item['FieldName'] in args.keys():
+            item["Value"] = args[item['FieldName']]
+    return local_secret
+
+
+# makes request against the specified service at the endpoint with the given argument_list
+# return dictionary of results
+def make_soap_request(endpoint, serviceName, argument_list):
+    client = Client(endpoint + '?WSDL')
+    response = getattr(client.service, serviceName)(**argument_list)
+    if response:
+        return dict(helpers.serialize_object(response))
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -158,7 +158,7 @@ def run_module():
     module_args = dict(
         endpoint=dict(type='str', required=True),
         username=dict(type='str', required=True),
-        password=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
         folder=dict(type='str', required=True),
         secret_name=dict(type='str', required=True),
         field_name=dict(type='str', required=True),
@@ -166,7 +166,7 @@ def run_module():
         src=dict(type='str', required=False),
         dest=dict(type='str', required=False),
         type=dict(type='str', required=False),
-        field_value=dict(type='str', required=False),
+        field_value=dict(type='str', required=False, no_log=True),
     )
 
     result = dict(

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -278,6 +278,9 @@ def run_module():
                 module.fail_json(msg='Secret Type Is Not Present On This Server', **result)
             template = template_test[0]
 
+            if template['Fields'] is None:
+                module.fail_json(msg='Secret Has No Fields', **result)
+
             template_fields = template['Fields']['SecretField']
             template_field_name_test = [x for x in template_fields if x['DisplayName'] == module.params['field_name']]
             # Ensuring the field name is on the template

--- a/lib/ansible/modules/database/misc/thycotic_secret.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret.py
@@ -21,6 +21,9 @@ short_description: "Add or retrieve secrets from of Thycotic Secret Server"
 
 version_added: "2.5"
 
+requirements:
+    - zeep
+
 description:
     - "NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance."
     - "Webservices must be enabled for this work correctly."

--- a/lib/ansible/modules/database/misc/thycotic_secret_retrieval.py
+++ b/lib/ansible/modules/database/misc/thycotic_secret_retrieval.py
@@ -1,0 +1,208 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2017, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: "thycotic_secret_retrieval"
+
+short_description: "Retrieve secrets stored in Thycotic Secret Server"
+
+version_added: "2.5"
+
+requirements:
+    - zeep
+
+description:
+    - "NOTE: Requires Zeep library. The module interacts with the SOAP API of the instance."
+    - "Webservices must be enabled for this work correctly."
+    - "This module works by editing a single field value of a secret at a time."
+    - "The field value can be a file or text value."
+
+options:
+    endpoint:
+        description:
+            - The endpoint of your secret server instance
+        required: true
+    username:
+        description:
+            - Name of the user you wish to authenticate into the instance with
+        required: true
+    password:
+        description:
+            - Password of the user you wish to authenticate into the instance with
+            - It is recomended to store your password in a file and use a lookup plugin to inject it into your playbook
+        required: true
+    folder:
+        description:
+            - The folder you wish to store/retrieve the secret in/from
+        required: true
+    secret_name:
+        description:
+            - Name of the secret you wish to interact with
+        required: true
+    field_name:
+        description:
+            - Name of the field you wish to edit
+        required: true
+    dest:
+        description:
+            - Absolute path on the host machine to the folder that you wish to download the secret file to
+            - Required for getting files
+        required: false
+
+author:
+    - Patrick Thomison (@pthomison)
+'''
+
+
+EXAMPLES = '''
+# Retrieve Text From A Field
+- name: get text
+  thycotic_secret:
+    username: 'admin'
+    password: 'adm-password'
+    endpoint: 'http://endpoint/SecretServer/webservices/sswebservice.asmx'
+    secret_name: 'example_ssh_key'
+    field_name: 'Private Key'
+    folder: 'demo'
+  register: priv_key
+
+# Retrieve File Attachement From A Field
+- name: get file
+  thycotic_secret:
+    username: 'admin'
+    password: 'adm-password'
+    endpoint: 'http://endpoint/SecretServer/webservices/sswebservice.asmx'
+    secret_name: 'test_image'
+    field_name: 'file'
+    dest: '/tmp/'
+    folder: 'demo'
+'''
+
+RETURN = '''
+secret_value:
+    description: The secret field value that you requested; Only populated when getting text
+    type: str
+    returned: success
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+import_failed = False
+try:
+    from zeep import Client, helpers
+except:
+    import_failed = True
+
+
+def run_module():
+    module_args = dict(
+        endpoint=dict(type='str', required=True),
+        username=dict(type='str', required=True),
+        password=dict(type='str', required=True, no_log=True),
+        folder=dict(type='str', required=True),
+        secret_name=dict(type='str', required=True),
+        field_name=dict(type='str', required=True),
+        dest=dict(type='str', required=False)
+    )
+
+    result = dict(
+        changed=False,
+        secret_value="test"
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    # Error checking for imports
+    if import_failed:
+        module.fail_json(msg="Zeep is a required library", **result)
+
+    # authenticates & retrieves token
+    token_args = {'username': module.params['username'], 'password': module.params['password']}
+    token_result = make_soap_request(module.params['endpoint'], 'Authenticate', token_args)
+    token = token_result['Token']
+
+    # if errors when encountered during authentication
+    if token_result['Errors']:
+        module.fail_json(msg=str(token_result['Errors']), **result)
+
+    # searches for specified folder
+    # should fail if folder does not exist
+    folder_result = make_soap_request(module.params['endpoint'], 'SearchFolders', {'token': token, 'folderName': module.params['folder']})
+
+    # if errors when encountered during authentication
+    if not folder_result['Folders']:
+        module.fail_json(msg="folder does not exist", **result)
+
+    folderId = folder_result['Folders']['Folder'][0]['Id']
+
+    secret = find_secret(module.params['endpoint'], token, module.params['secret_name'], folderId)
+
+    # secret must exist
+    if secret is None:
+        module.fail_json(msg='Secret Does Not Exist', **result)
+
+    # field name must be present on the secret
+    field = field_name_filter(secret, module.params['field_name'])
+    if field is None:
+        module.fail_json(msg='Field Is Not Present On The Secret', **result)
+
+    if field['IsFile']:
+        # Download destination must be present if it is a file
+        if not module.params['dest']:
+            module.fail_json(msg="Field is a file and no destination was given", **result)
+
+        # Downloading file
+        get_file_args = {'token': token, 'secretId': secret['Id'], 'secretItemId': field['Id']}
+        get_file_result = make_soap_request(module.params['endpoint'], 'DownloadFileAttachmentByItemId', get_file_args)
+        file_bytes = get_file_result["FileAttachment"]
+        download_location = os.path.join(module.params['dest'], get_file_result["FileName"])
+
+        # assume nothing changes
+        result['changed'] = False
+
+        # if getting a file and the dest does not exist
+        if not os.path.exists(download_location):
+            result['changed'] = True
+
+        # if getting a file, and the dest already exists, download a temp copy, check to see if the files match
+        else:
+            with open(download_location, 'rb') as fp:
+                curr_file = fp.read()
+
+            # if they do, return nothing changed
+            if curr_file == file_bytes:
+                result['changed'] = False
+
+            # if they don't & check mode is not enabled, return changed & update the file
+            # if they don't & check mode is enabled, return changed, but do not update the file
+            else:
+                result['changed'] = True
+
+        # Downloading the file to the correct location
+        if result['changed'] and not module.check_mode:
+            with open(download_location, 'wb') as fp:
+                fp.write(file_bytes)
+
+    else:
+        # returning secret
+        result['secret_value'] = field['Value']
+        result['changed'] = False
+
+    module.exit_json(**result)


### PR DESCRIPTION
##### SUMMARY
Adding a module which allows for the addition or retrieval of "secrets" from an instance of thycotic secret server

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
thycotic_secret

##### ANSIBLE VERSION
ansible 2.5.0 (thycotic_module_dev df6e6887de) last updated 2017/12/11 10:07:49 (GMT -700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/pthomison/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/pthomison/Projects/thycotic_integration/ansible-with-thycotic-integration/lib/ansible
  executable location = /home/pthomison/Projects/thycotic_integration/ansible-with-thycotic-integration/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]


##### ADDITIONAL INFORMATION
N/A