### PR TITLE
order agnostic child group definition in inventory

### DIFF
--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -180,7 +180,17 @@ class InventoryModule(BaseFileInventoryPlugin):
                     # but [groupname:vars] is allowed only if the # group is declared elsewhere.
                     # We add the group anyway, but make a note in pending_declarations to check at the end.
                     if state == 'vars':
-                        pending_declarations[groupname] = dict(line=self.lineno, state=state, name=groupname)
+
+                        # It's possible that a group is previously pending due to being
+                        # defined as a child group, in that case we simply pass so that
+                        # the logic below to process pending declarations will take the
+                        # appropriate action for a pending child group instead of
+                        # incorrectly handling it as a var state pending declaration
+                        if groupname in pending_declarations:
+                            if pending_declarations[groupname]['state'] == 'children':
+                                pass
+                        else:
+                            pending_declarations[groupname] = dict(line=self.lineno, state=state, name=groupname)
 
                     self.inventory.add_group(groupname)
 

--- a/lib/ansible/plugins/inventory/ini.py
+++ b/lib/ansible/plugins/inventory/ini.py
@@ -179,18 +179,13 @@ class InventoryModule(BaseFileInventoryPlugin):
                     # Either [groupname] or [groupname:children] is sufficient to declare a group,
                     # but [groupname:vars] is allowed only if the # group is declared elsewhere.
                     # We add the group anyway, but make a note in pending_declarations to check at the end.
-                    if state == 'vars':
-
-                        # It's possible that a group is previously pending due to being
-                        # defined as a child group, in that case we simply pass so that
-                        # the logic below to process pending declarations will take the
-                        # appropriate action for a pending child group instead of
-                        # incorrectly handling it as a var state pending declaration
-                        if groupname in pending_declarations:
-                            if pending_declarations[groupname]['state'] == 'children':
-                                pass
-                        else:
-                            pending_declarations[groupname] = dict(line=self.lineno, state=state, name=groupname)
+                    #
+                    # It's possible that a group is previously pending due to being defined as a child
+                    # group, in that case we simply pass so that the logic below to process pending
+                    # declarations will take the appropriate action for a pending child group instead of
+                    # incorrectly handling it as a var state pending declaration
+                    if state == 'vars' and groupname not in pending_declarations:
+                        pending_declarations[groupname] = dict(line=self.lineno, state=state, name=groupname)
 
                     self.inventory.add_group(groupname)
 


### PR DESCRIPTION
##### SUMMARY
Previously if a child's group vars section was defined before the
child group itself, an edge case would be hit where the state of the
pending declaration would process as var and therefore drop the
child pending declaration context. This would result in the group
vars defined for the parent group being out of scope for the child
group.

Example:

    [web:children]
    appnodes
    proxies

    [web:vars]
    deployment_type=prod

    [appnodes:vars]
    foo_var=true

    [appnodes]
    appnodes[1:3].example.com

    [proxies:vars]
    bar_var=true

    [proxies]
    proxies[1:3].example.com

Previously the deployment_type variable would be out of scope for
both the appnodes and proxies groups. This patch fixes that.

Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

Fixes #33584 

##### ISSUE TYPE
 - Bugfix Pull Request


##### COMPONENT NAME
inventory

##### ANSIBLE VERSION
```
ansible 2.5.0 (fix-inventory b660dad54b) last updated 2017/12/11 12:53:03 (GMT -500)                                   
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']    
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible                                          
  executable location = /home/admiller/src/dev/ansible/bin/ansible                                                     
  python version = 3.6.3 (default, Oct  9 2017, 12:07:10) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]  
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
$  cat invtest.inventory 
[OSEv3:children]
masters
nodes

[OSEv3:vars]
deployment_type=openshift-enterprise

[masters:vars]
foo_var=true

[masters]
localhost              ansible_connection=local ansible_python_interpreter=/usr/bin/python3

[nodes:vars]
foo_var=true

[nodes]
localhost2              ansible_connection=local ansible_python_interpreter=/usr/bin/python3

###### BEFORE FIX
$ ansible nodes -m debug -a 'var=deployment_type' -i invtest.inventory 
localhost2 | SUCCESS => {
    "changed": false,
    "deployment_type": "VARIABLE IS NOT DEFINED!"
}

###### AFTER FIX
$ ansible nodes -m debug -a 'var=deployment_type' -i invtest.inventory 
localhost2 | SUCCESS => {
    "changed": false,
    "deployment_type": "openshift-enterprise"
}

```
