### PR TITLE
ec2: only warn for pre-existing instances trying to modify non-modifiable attribute

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2.py
+++ b/lib/ansible/modules/cloud/amazon/ec2.py
@@ -992,9 +992,9 @@ def enforce_count(module, ec2, vpc):
     # ensure all instances are dictionaries
     all_instances = []
     for inst in instances:
-        warn_if_public_ip_assignment_changed(module, inst)
 
         if not isinstance(inst, dict):
+            warn_if_public_ip_assignment_changed(module, inst)
             inst = get_instance_info(inst)
         all_instances.append(inst)
 


### PR DESCRIPTION
##### SUMMARY
This fixes a bug that only happens when creating new instances with count tag; existing instances are returned via a boto call and have a .id attribute, but new instances are formatted in an instance dict (and have an 'id' key) leading to failure when warning if the public ip assignment changed. But since the public ip assignment is correct for instances that have just been created, there is no need to try to warn. Just moved the warning into the if statement to ignore newly created instances.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2.py

##### ANSIBLE VERSION
```
2.5.0
```
