### PR TITLE
locahost -> localhost typo in inventory/data.py

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -66,7 +66,7 @@ class InventoryData(object):
         data = {
             'groups': self.groups,
             'hosts': self.hosts,
-            'local': self.locahost,
+            'local': self.localhost,
             'source': self.current_source,
         }
         return data


### PR DESCRIPTION
Signed-off-by: Adam Miller <maxamillion@fedoraproject.org>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Currently there is a typo in `lib/ansible/inventory/data.py` which leads to a reference of a variable that doesn't exist if someone calls the `serialize()` method.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
inventory

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (fix-inventory-data 39efb6a6e8) last updated 2017/12/11 16:11:28 (GMT -500)                              
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = ['/home/admiller/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']    
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible                                          
  executable location = /home/admiller/src/dev/ansible/bin/ansible                                                     
  python version = 3.6.3 (default, Oct  9 2017, 12:07:10) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]   
```


