### PR TITLE
Handle duplicate headers in the uri module

### DIFF
--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1066,10 +1066,12 @@ def fetch_url(module, url, data=None, headers=None, method=None,
             pass
 
         # parse the cookies into a nice dictionary
+        cookie_list = []
         cookie_dict = dict()
         for cookie in cookies:
             cookie_dict[cookie.name] = cookie.value
-        info['cookie_string'] = '; '.join('%s=%s' % c for c in cookie_dict.items())
+            cookie_list.append((cookie.name, cookie.value))
+        info['cookies_string'] = '; '.join('%s=%s' % c for c in cookie_list)
 
         info['cookies'] = cookie_dict
         # finally update the result with a message about the fetch

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1050,10 +1050,27 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      follow_redirects=follow_redirects, client_cert=client_cert,
                      client_key=client_key, cookies=cookies)
         info.update(r.info())
+
+        # Don't be lossy, append header values for duplciate headers
+        try:
+            # Py3
+            _h = {}
+            for k, v in r.headers.items():
+                if k in _h:
+                    _h[k] = ', '.join((_h[k], v))
+                else:
+                    _h[k] = v
+            info.update(_h)
+        except AttributeError:
+            # In Py2 there is nothing that needs done, py2 does this for us
+            pass
+
         # parse the cookies into a nice dictionary
         cookie_dict = dict()
         for cookie in cookies:
             cookie_dict[cookie.name] = cookie.value
+        info['cookie_string'] = '; '.join('%s=%s' % c for c in cookie_dict.items())
+
         info['cookies'] = cookie_dict
         # finally update the result with a message about the fetch
         info.update(dict(msg="OK (%s bytes)" % r.headers.get('Content-Length', 'unknown'), url=r.geturl(), status=r.code))

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1049,17 +1049,20 @@ def fetch_url(module, url, data=None, headers=None, method=None,
                      url_password=password, http_agent=http_agent, force_basic_auth=force_basic_auth,
                      follow_redirects=follow_redirects, client_cert=client_cert,
                      client_key=client_key, cookies=cookies)
-        info.update(r.info())
+        # Lowercase keys, to conform to py2 behavior, so that py3 and py2 are predictable
+        info.update(dict((k.lower(), v) for k, v in r.info().items()))
 
         # Don't be lossy, append header values for duplciate headers
         try:
             # Py3
             _h = {}
             for k, v in r.headers.items():
-                if k in _h:
-                    _h[k] = ', '.join((_h[k], v))
+                # The same as above, lower case keys to match py2 behavior, and create more consistent results
+                _k = k.lower()
+                if _k in _h:
+                    _h[_k] = ', '.join((_h[_k], v))
                 else:
-                    _h[k] = v
+                    _h[_k] = v
             info.update(_h)
         except AttributeError:
             # In Py2 there is nothing that needs done, py2 does this for us

--- a/lib/ansible/module_utils/urls.py
+++ b/lib/ansible/module_utils/urls.py
@@ -1068,6 +1068,9 @@ def fetch_url(module, url, data=None, headers=None, method=None,
         # parse the cookies into a nice dictionary
         cookie_list = []
         cookie_dict = dict()
+        # Python sorts cookies in order of most specific (ie. longest) path first. See ``CookieJar._cookie_attrs``
+        # Cookies with the same path are reversed from response order.
+        # This code makes no assumptions about that, and accepts the order given by python
         for cookie in cookies:
             cookie_dict[cookie.name] = cookie.value
             cookie_list.append((cookie.name, cookie.value))

--- a/test/integration/targets/uri/tasks/main.yml
+++ b/test/integration/targets/uri/tasks/main.yml
@@ -375,6 +375,17 @@
   failed_when: result is not failed
   when: has_httptester
 
+- uri:
+    url: https://{{ httpbin_host }}/response-headers?Set-Cookie=Foo%3Dbar&Set-Cookie=Baz%3Dqux
+  register: result
+
+- assert:
+    that:
+      - result['set_cookie'] == 'Foo=bar, Baz=qux'
+      # Python sorts cookies in order of most specific (ie. longest) path first
+      # items with the same path are reversed from response order
+      - result['cookies_string'] == 'Baz=qux; Foo=bar'
+
 - name: Write out netrc template
   template:
     src: netrc.j2

--- a/test/units/module_utils/urls/test_fetch_url.py
+++ b/test/units/module_utils/urls/test_fetch_url.py
@@ -133,8 +133,11 @@ def test_fetch_url_cookies(mocker, fake_ansible_module):
     r, info = fetch_url(fake_ansible_module, 'http://ansible.com/')
 
     assert info['cookies'] == {'Baz': 'qux', 'Foo': 'bar'}
+    # Python sorts cookies in order of most specific (ie. longest) path first
+    # items with the same path are reversed from response order
     assert info['cookies_string'] == 'Baz=qux; Foo=bar'
     # The key here has a `-` as opposed to what we see in the `uri` module that converts to `_`
+    # Note: this is response order, which differs from cookies_string
     assert info['set-cookie'] == 'Foo=bar, Baz=qux'
 
 


### PR DESCRIPTION
##### SUMMARY
...and make it easier for users to use cookies by providing a pre-built string

FIxes #33325 
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
uri

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```