### PR TITLE
Fixes  prompt doubling issue that impacted missing ios enable password prompts.

### DIFF
--- a/lib/ansible/plugins/terminal/__init__.py
+++ b/lib/ansible/plugins/terminal/__init__.py
@@ -69,7 +69,9 @@ class TerminalBase(with_metaclass(ABCMeta, object)):
 
         :returns: A byte string of the prompt
         """
-        self._exec_cli_command(b'\n')
+        self._exec_cli_command(b'')  # do not send '\n',
+                                     # exec_cli_command sends '\r' already,
+                                     # doing so causes double prompts.
         return self._connection._matched_prompt
 
     def on_open_shell(self):

--- a/lib/ansible/plugins/terminal/__init__.py
+++ b/lib/ansible/plugins/terminal/__init__.py
@@ -69,9 +69,10 @@ class TerminalBase(with_metaclass(ABCMeta, object)):
 
         :returns: A byte string of the prompt
         """
-        self._exec_cli_command(b'')  # do not send '\n',
-                                     # exec_cli_command sends '\r' already,
-                                     # doing so causes double prompts.
+        # do not send '\n' here, exec_cli_command sends '\r' already,
+        # doing so causes double prompts.
+        self._exec_cli_command(b'')
+
         return self._connection._matched_prompt
 
     def on_open_shell(self):

--- a/lib/ansible/plugins/terminal/ios.py
+++ b/lib/ansible/plugins/terminal/ios.py
@@ -65,8 +65,12 @@ class TerminalModule(TerminalBase):
 
         try:
             self._exec_cli_command(to_bytes(json.dumps(cmd), errors='surrogate_or_strict'))
+            prompt = self._get_prompt()
+            if not prompt.endswith(b'#'):
+                raise AnsibleConnectionFailure('failed to elevate privilege to enable mode still at prompt [%s]' % prompt)
         except AnsibleConnectionFailure:
-            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode')
+            prompt = self._get_prompt()
+            raise AnsibleConnectionFailure('unable to elevate privilege to enable mode, at prompt [%s]' % prompt)
 
     def on_unbecome(self):
         prompt = self._get_prompt()


### PR DESCRIPTION

Due to get_prompt sending a '\n' the prompts became doubled and out-of-sync with what
was expected.  This caused the enable command prompts to be missed.
Also added verification that on_become succeeded to reach enable prompt.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

I was unable to get my IOS device to reliably enter enable mode with devel 2.5.  I ran a test in a loop and found that it succeeded about 30% of the time.

It was challenging to dig into this because of the lack of availability of the device interaction output that happens under the covers, but after wrangling that issue, I was able to see that prompts were getting out of sync with what the code was expecting.

One clear culprit of this was that TerminalBase._get_prompt was sending an '\n' to trigger a new prompt.  Which resulted in '\n\r' being sent because Connection.send() already appends a '\r'.

This caused doubling of prompts, and depending on timing/io issues sometimes the become 'prompt/answer' Password prompts would be missed.

Note: one side-effect I noticed of my prompt verification change is also that the '% Bad Secrets' is seen in the IO buffer when checking for the next prompt.  So if you leave the extra '\n' you will actually see the Bad Secrets error verses the failed to enable messages, which is actually helpful in this case.


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ios.py
terminal/__init__.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Addresses issues in #33029 

##### FUTURE FIXES

Previously this code had sent the string 'prompt()' which may have helped because it was not just \n even though it caused error messages to be printed.  While removing the '\n' fixes this particular issue, I think this is perhaps an incomplete fix.  Shell interaction should have a bit more precision than it currently has. Out-of-sync prompting is a common issue when things go awry.   As a future proposal I would suggest something like have the vendor classes defining a NOOP cmd that could have a uniq string appended to or formatted into it.  The network_cli interaction could then use this to INSURE that it is in sync with the command sent and the response that came back.  An example of this would be sending a command 'echo [UUID]' or '! SYNC [UUID]' to the device and insuring that is the last thing seen before the prompt regex.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
