### PR TITLE
Fix a typo in the readme of the skeleton used by ansible-galaxy.

### DIFF
--- a/lib/ansible/galaxy/data/container_enabled/README.md
+++ b/lib/ansible/galaxy/data/container_enabled/README.md
@@ -23,7 +23,7 @@ $ ansible-container install <USERNAME.ROLE_NAME>
     $ cd myproject
 
     # Initialize the project
-    $ ansible-contiainer init
+    $ ansible-container init
     ```
 
 - Continue listing any prerequisites here...


### PR DESCRIPTION
`ansible-container init` instead of `ansible-contiainer init`

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fix a typo in the readme of the skeleton used by ansible-galaxy.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
  config file = None
  configured module search path = ['/usr/local/lib/python3.5/dist-packages/ara/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```