### PR TITLE
Test for fix using loop_control with delegate_to

### DIFF
--- a/test/integration/targets/delegate_to/runme.sh
+++ b/test/integration/targets/delegate_to/runme.sh
@@ -4,3 +4,5 @@ set -eux
 
 ANSIBLE_SSH_ARGS='-C -o ControlMaster=auto -o ControlPersist=60s -o UserKnownHostsFile=/dev/null' \
     ANSIBLE_HOST_KEY_CHECKING=false ansible-playbook test_delegate_to.yml -i ../../inventory -v "$@"
+
+ansible-playbook test_loop_control.yml -v "$@"

--- a/test/integration/targets/delegate_to/test_loop_control.yml
+++ b/test/integration/targets/delegate_to/test_loop_control.yml
@@ -1,0 +1,16 @@
+- hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Test delegate_to with loop_control
+      ping:
+      delegate_to: "{{ item }}"
+      with_items:
+        - localhost
+      loop_control:
+        label: "{{ item }}"
+      register: out
+
+    - name: Check if delegated_host was templated properly
+      assert:
+        that:
+          - out.results[0]['_ansible_delegated_vars']['ansible_delegated_host'] == 'localhost'


### PR DESCRIPTION
##### SUMMARY
Update: The previous fix pushed in #34008, so at least adding tests here.

The value of `task.loop_control.loop_var` may be `None`, so we need to default it to `"item"`.

Fixes https://github.com/ansible/ansible/issues/33398 https://github.com/ansible/ansible/issues/33981

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
vars/manager.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION