### PR TITLE
typo fix

### DIFF
--- a/lib/ansible/plugins/connection/zone.py
+++ b/lib/ansible/plugins/connection/zone.py
@@ -19,7 +19,7 @@ DOCUMENTATION = """
     options:
       remote_addr:
         description:
-            - Zone identifire
+            - Zone identifier
         default: inventory_hostname
         vars:
             - name: ansible_host


### PR DESCRIPTION
typo fix in description

##### SUMMARY
fixes a small typo which complicated reference keyword searches

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
plugin/connection/zone

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/username/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/Cellar/ansible/2.4.2.0_1/libexec/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Sep 26 2017, 17:32:28) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```

##### ADDITIONAL INFORMATION
none