### PR TITLE
Added sorting to ec2_vpc_subnet_facts module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_subnet_facts.py
@@ -44,6 +44,7 @@ options:
       - Optional attribute for sorting the results by specified key
     choices: ['subnet_id', 'cidr_block', 'availability_zone']
     required: false
+    version_added: "2.5"
 extends_documentation_fragment:
     - aws
     - ec2


### PR DESCRIPTION
… to sort results by cidr_block, subnet_id and availability_zone

##### SUMMARY
Allow sorting of ec2_vpc_subnet_facts results to make return values more predictable.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_subnet_facts module

##### ANSIBLE VERSION
2.4.2

##### ADDITIONAL INFORMATION
See summary.
