### PR TITLE
Set 'changed' to False if the installed jenkins plugin isn't changed

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -526,13 +526,8 @@ class JenkinsPlugin(object):
             params.update(self.params)
             file_args = self.module.load_file_common_arguments(params)
 
-            if not self.module.check_mode:
-                # Not sure how to run this in the check mode
-                changed = self.module.set_fs_attributes_if_different(
-                    file_args, changed)
-            else:
-                # See the comment above
-                changed = True
+            changed = self.module.set_fs_attributes_if_different(
+                file_args, changed)
 
         return changed
 


### PR DESCRIPTION
##### SUMMARY

`changed` is always `True` when we run the playbook with check mode even if the specified version of jenkins plugin is already installed.

After this PR is merged, `changed` will be `False` if the specified version of jenkins plugin is already installed and the attributes of existing `jpi` file is not different from the attributes in the task options.
I deleted some codes because `set_fs_attributes_if_different` supports to check mode.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

jenkins_plugin

##### ANSIBLE VERSION

```
ansible 2.4.2.0
```
