### PR TITLE
Add a new option firstmatch to lineinfile module.

### DIFF
--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -105,11 +105,11 @@ options:
      type: bool
      default: 'no'
   firstmatch:
-     description:
-       - Used with C(insertafter) or C(insertbefore). If set, C(insertafter) and C(inserbefore) find
-         a first line has regular expression matches.
-     type: bool
-     default: 'no'
+    description:
+      - Used with C(insertafter) or C(insertbefore). If set, C(insertafter) and C(inserbefore) find
+        a first line has regular expression matches.
+    type: bool
+    default: 'no'
   others:
      description:
        - All arguments accepted by the M(file) module also work here.

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -110,6 +110,7 @@ options:
         a first line has regular expression matches.
     type: bool
     default: 'no'
+    version_added: "2.5"
   others:
      description:
        - All arguments accepted by the M(file) module also work here.

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -72,8 +72,10 @@ options:
   insertafter:
     description:
       - Used with C(state=present). If specified, the line will be inserted
-        after the last match of specified regular expression. A special value is
-        available; C(EOF) for inserting the line at the end of the file.
+        after the last match of specified regular expression.
+        If the first match is required, use(firstmatch=yes).
+        A special value is available; C(EOF) for inserting the line at the
+        end of the file.
         If specified regular expression has no matches, EOF will be used instead.
         May not be used with C(backrefs).
     choices: [ EOF, '*regex*' ]
@@ -81,8 +83,10 @@ options:
   insertbefore:
     description:
       - Used with C(state=present). If specified, the line will be inserted
-        before the last match of specified regular expression. A value is
-        available; C(BOF) for inserting the line at the beginning of the file.
+        before the last match of specified regular expression.
+        If the first match is required, use(firstmatch=yes).
+        A value is available; C(BOF) for inserting the line at
+        the beginning of the file.
         If specified regular expression has no matches, the line will be
         inserted at the end of the file.  May not be used with C(backrefs).
     choices: [ BOF, '*regex*' ]
@@ -214,7 +218,7 @@ def check_file_attrs(module, changed, message, diff):
 
 
 def present(module, dest, regexp, line, insertafter, insertbefore, create,
-            backup, backrefs):
+            backup, backrefs, firstmatch):
 
     diff = {'before': '',
             'after': '',
@@ -264,9 +268,13 @@ def present(module, dest, regexp, line, insertafter, insertbefore, create,
             if insertafter:
                 # + 1 for the next line
                 index[1] = lineno + 1
+                if firstmatch:
+                    break
             if insertbefore:
                 # + 1 for the previous line
                 index[1] = lineno
+                if firstmatch:
+                    break
 
     msg = ''
     changed = False
@@ -407,6 +415,7 @@ def main():
             backrefs=dict(type='bool', default=False),
             create=dict(type='bool', default=False),
             backup=dict(type='bool', default=False),
+            firstmatch=dict(default=False, type='bool'),
             validate=dict(type='str'),
         ),
         mutually_exclusive=[['insertbefore', 'insertafter']],
@@ -419,6 +428,7 @@ def main():
     backup = params['backup']
     backrefs = params['backrefs']
     path = params['path']
+    firstmatch = params['firstmatch']
 
     b_path = to_bytes(path, errors='surrogate_or_strict')
     if os.path.isdir(b_path):
@@ -440,7 +450,7 @@ def main():
         line = params['line']
 
         present(module, path, params['regexp'], line,
-                ins_aft, ins_bef, create, backup, backrefs)
+                ins_aft, ins_bef, create, backup, backrefs, firstmatch)
     else:
         if params['regexp'] is None and params.get('line', None) is None:
             module.fail_json(msg='one of line= or regexp= is required with state=absent')

--- a/lib/ansible/modules/files/lineinfile.py
+++ b/lib/ansible/modules/files/lineinfile.py
@@ -104,6 +104,12 @@ options:
          get the original file back if you somehow clobbered it incorrectly.
      type: bool
      default: 'no'
+  firstmatch:
+     description:
+       - Used with C(insertafter) or C(insertbefore). If set, C(insertafter) and C(inserbefore) find
+         a first line has regular expression matches.
+     type: bool
+     default: 'no'
   others:
      description:
        - All arguments accepted by the M(file) module also work here.


### PR DESCRIPTION
##### SUMMARY

Currently, lineinfile module with insertbefore or insertafter options will insert the line where the last match of specified regular expression.

Some case, the first match of regexp is more useful, then add `firstmatch` options for `insertbefore` and `insertafter`.
It breaks the loop after found first regexp matched line when `firstmatch=yes`.

The `firstmatch` option is `no` by default for backward compatible.

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lineinfile module

##### ANSIBLE VERSION

```
ansible 2.3.0.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Apr  4 2017, 08:46:44) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

/etc/resolv.conf
```
nameserver 192.168.0.1
nameserver 192.168.0.2
```

```
- lineinfile:
    path: /etc/resolv.conf
    insertbefore: '^nameserver '
    line: 'nameserver 127.0.0.1'
    firstmatch: yes
```

When firstmatch is no (by default)

```
nameserver 192.168.0.1
nameserver 127.0.0.1
nameserver 192.168.0.2
```

firstmatch = yes

```
nameserver 127.0.0.1
nameserver 192.168.0.1
nameserver 192.168.0.2
```
