### PR TITLE
tower_job_template: Add ask_inventory and ask_credential parameters to cli mapping.

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -177,6 +177,8 @@ def update_fields(p):
         'ask_tags': 'ask_tags_on_launch',
         'ask_job_type': 'ask_job_type_on_launch',
         'machine_credential': 'credential',
+        'ask_inventory': 'ask_inventory_on_launch',
+        'ask_credential': 'ask_credential_on_launch',
     }
 
     params_update = {}


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower_job_template

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /home/europa/IdeaProjects/vagrant_test_harness/ansible.cfg
  configured module search path = [u'/home/europa/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]

```


##### ADDITIONAL INFORMATION
The "ask_inventory" and "ask_credential" parameters are not mapped to their Ansible cli equivalents of "ask_inventory_on_launch" and "ask_credential_on_launch".

There is no change to the Ansible command following this change.
