### PR TITLE
YAML inventory unit test: fix test inventory format

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -140,6 +140,9 @@ class InventoryModule(BaseFileInventoryPlugin):
                     for host_pattern in group_data['hosts']:
                         hosts, port = self._parse_host(host_pattern)
                         self._populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
+                        if group == 'all':
+                            for host in hosts:
+                                self.inventory.add_host(host, group='ungrouped', port=port)
                 else:
                     self.display.warning('Skipping unexpected key (%s) in group (%s), only "vars", "children" and "hosts" are valid' % (key, group))
 

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -168,8 +168,8 @@ class IniInventory(unittest.TestCase):
         ---
         all:
             hosts:
-                test1
-                test2
+                test1:
+                test2:
         """)}
         C.INVENTORY_ENABLED = ['yaml']
         fake_loader = DictDataLoader(inventory_content)

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -113,7 +113,7 @@ class TestInventory(unittest.TestCase):
             )
 
 
-class IniInventory(unittest.TestCase):
+class TestInventoryPlugins(unittest.TestCase):
 
     def test_empty_inventory(self):
         inventory = self._get_inventory('')
@@ -175,6 +175,14 @@ class IniInventory(unittest.TestCase):
         fake_loader = DictDataLoader(inventory_content)
         im = InventoryManager(loader=fake_loader, sources=filename)
         self.assertTrue(im._inventory.hosts)
+        self.assertIn('test1', im._inventory.hosts)
+        self.assertIn('test2', im._inventory.hosts)
+        self.assertIn(im._inventory.get_host('test1'), im._inventory.groups['all'].hosts)
+        self.assertIn(im._inventory.get_host('test2'), im._inventory.groups['all'].hosts)
+        self.assertEqual(len(im._inventory.groups['all'].hosts), 2)
+        self.assertIn(im._inventory.get_host('test1'), im._inventory.groups['ungrouped'].hosts)
+        self.assertIn(im._inventory.get_host('test2'), im._inventory.groups['ungrouped'].hosts)
+        self.assertEqual(len(im._inventory.groups['ungrouped'].hosts), 2)
 
     def _get_inventory(self, inventory_content):
 


### PR DESCRIPTION
##### SUMMARY
- YAML inventory: populate `ungrouped` group allowing to list these hosts using `ansible-inventory`
- Fix YAML inventory unit test: test inventory isn't using a valid format (missing colons).
- Add some asserts in the existing unit test

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
YAML inventory unit test

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 1bb974a917) last updated 2017/12/12 18:03:28 (GMT +200)
```

##### ADDITIONAL INFORMATION
Test inventory:
```
$ cat hosts.yml
all:
  hosts:
    testhost:
```

Current behavior:
```
$ ansible-inventory -i hosts.yml  --list
{ 
    "_meta": {
        "hostvars": {
            "testhost": {}
        }   
    },  
    "all": {
        "children": [
            "ungrouped"
        ]   
    },  
    "ungrouped": {}
}
```

Expected behavior:
```
{
    "_meta": {
        "hostvars": {
            "testhost": {}
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "testhost"
        ]
    }
}
```

Behavior using INI inventory:
```
$ cat hosts.ini 
localhost

$ ansible-inventory -i hosts.ini  --list
{
    "_meta": {
        "hostvars": {
            "localhost": {}
        }
    },
    "all": {
        "children": [
            "ungrouped"
        ]
    },
    "ungrouped": {
        "hosts": [
            "localhost"
        ]
    }
}
```