### PR TITLE
Updated Documentation and examples for clarity

### DIFF
--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -55,7 +55,7 @@ EXAMPLES = '''
 
 - name: lookup ssm parameter store with all options.
   debug: msg="{{ lookup('aws_ssm', 'Hello', 'decrypt=false', 'region=us-east-2', 'aws_profile=myprofile') }}"
-  
+
 - name: lookup a single ssm parameter at the end of a path.
   debug: msg="{{ lookup('aws_ssm', '/PATH/to/params/Hello', 'aws_profile=myprofile') }}"
 

--- a/lib/ansible/plugins/lookup/aws_ssm.py
+++ b/lib/ansible/plugins/lookup/aws_ssm.py
@@ -24,7 +24,7 @@ DOCUMENTATION = '''
         description: The region to use. You may use environment variables ar the default profile's region as an alternative.
       decrypt:
         description: A boolean to indicate whether to decrypt the parameter.
-        default: false
+        default: true
       bypath:
         description: A boolean to indicate whether the parameter is provided as a hierarchy.
         default: false
@@ -55,6 +55,9 @@ EXAMPLES = '''
 
 - name: lookup ssm parameter store with all options.
   debug: msg="{{ lookup('aws_ssm', 'Hello', 'decrypt=false', 'region=us-east-2', 'aws_profile=myprofile') }}"
+  
+- name: lookup a single ssm parameter at the end of a path.
+  debug: msg="{{ lookup('aws_ssm', '/PATH/to/params/Hello', 'aws_profile=myprofile') }}"
 
 - name: return a dictionary of ssm parameters from a hierarchy path
   debug: msg="{{ lookup('aws_ssm', '/PATH/to/params', 'region=ap-southeast-2', 'bypath', 'recursive=true' ) }}"


### PR DESCRIPTION
##### SUMMARY
The documentation declared "decrypt" to default to False, the code actually defaults it to True, additional to this I've added an example for a single parameter at the end of a path as the bypath documentation could lead to confusion without this (at least, I got confused by this for longer than I care to admit)


##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lookup plugin - aws_ssm

##### ANSIBLE VERSION

```
ansible 2.4.2.0
  config file = /root/.ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
There is no before or after command for my documentation change but following the documentation before my change I thought I needed to specify "decrypt=True" to decrypt a value and was surprised when it wasn't. 

I also was surprised to receive and empty response when passing a full path up to and including my parameter with the "bypath" option.