### PR TITLE
Add test for clean_copy preservation of keys

### DIFF
--- a/test/units/executor/test_task_result.py
+++ b/test/units/executor/test_task_result.py
@@ -147,3 +147,25 @@ class TestTaskResult(unittest.TestCase):
         tr = TaskResult(mock_host, mock_task, dict(_ansible_no_log=True, secret='DONTSHOWME'))
         clean = tr.clean_copy()
         self.assertTrue('secret' not in clean._result)
+
+    def test_task_result_no_log_preserve(self):
+        mock_host = MagicMock()
+        mock_task = MagicMock()
+
+        # no_log should not remove presrved keys
+        tr = TaskResult(
+            mock_host,
+            mock_task,
+            dict(
+                _ansible_no_log=True,
+                retries=5,
+                attempts=5,
+                changed=False,
+                foo='bar',
+            )
+        )
+        clean = tr.clean_copy()
+        self.assertTrue('retries' in clean._result)
+        self.assertTrue('attempts' in clean._result)
+        self.assertTrue('changed' in clean._result)
+        self.assertTrue('foo' not in clean._result)


### PR DESCRIPTION
##### SUMMARY

Test for #33637

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tests/results

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before #33637
```
test/units/executor/test_task_result.py::TestTaskResult::test_task_result_no_log_preserve FAILED

--- generated xml file: /root/ansible/test/results/junit/python2.6-units.xml ---
=========================== short test summary info ============================
FAIL test/units/executor/test_task_result.py::TestTaskResult::test_task_result_no_log_preserve
=================================== FAILURES ===================================
_______________ TestTaskResult.test_task_result_no_log_preserve ________________
self = <units.executor.test_task_result.TestTaskResult testMethod=test_task_result_no_log_preserve>

    def test_task_result_no_log_preserve(self):
        mock_host = MagicMock()
        mock_task = MagicMock()

        # no_log should not remove presrved keys
        tr = TaskResult(
            mock_host,
            mock_task,
            dict(
                _ansible_no_log=True,
                retries=5,
                attempts=5,
                changed=False,
                foo='bar',
            )
        )
        clean = tr.clean_copy()
>       self.assertTrue('retries' in clean._result)
E       AssertionError: False is not true
```