### PR TITLE
Split lsattr output on any amount of whitespece, not single spaces only

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -1291,7 +1291,7 @@ class AnsibleModule(object):
             try:
                 rc, out, err = self.run_command(attrcmd)
                 if rc == 0:
-                    res = out.split(' ')[0:2]
+                    res = out.split()[0:2]
                     output['attr_flags'] = res[1].replace('-', '').strip()
                     output['version'] = res[0].strip()
                     output['attributes'] = format_attributes(output['attr_flags'])


### PR DESCRIPTION
Fixes #33745

##### SUMMARY
lsattr output could have more than one space separating elements.  We need to account for that otherwise we'll find the wrong field when looking for attributes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
lib/ansi ble/module_utils/basic.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel 2.4
```


##### ADDITIONAL INFORMATION
@bcoca, looks like you wrote this code originally.  Just CC'ing you in case there's some corner case which the previous code was intended to specifically work for.