### PR TITLE
win_unzip: clarified documentation

### DIFF
--- a/lib/ansible/modules/windows/win_unzip.py
+++ b/lib/ansible/modules/windows/win_unzip.py
@@ -55,6 +55,7 @@ options:
   recurse:
     description:
       - Recursively expand zipped files within the src file.
+      - Setting to a value of C(yes) requires the PSCX module to be installed.
     type: bool
     default: 'no'
   creates:


### PR DESCRIPTION
##### SUMMARY
Added more clarification for win_unzip when using the recurse option and how PSCX is required.

Fixes https://github.com/ansible/ansible/issues/33197

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_unzip

##### ANSIBLE VERSION
```
2.5
```
