### PR TITLE
basic: Add check for None in command argument

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -2176,6 +2176,9 @@ class AnsibleModule(object):
            - opt_dirs:  optional list of directories to search in addition to PATH
         if found return full path; otherwise return None
         '''
+        if arg is None:
+            self.fail_json(msg='Name of required executable can not be None')
+
         opt_dirs = [] if opt_dirs is None else opt_dirs
 
         sbin_paths = ['/sbin', '/usr/sbin', '/usr/local/sbin']


### PR DESCRIPTION
##### SUMMARY
This fix adds a check for None, when command argument send to
get_bin_path API is None.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py

##### ANSIBLE VERSION
```
2.5devel
```