### PR TITLE
Remove deprecated restart: parameter from win_feature examples

### DIFF
--- a/lib/ansible/modules/windows/win_feature.py
+++ b/lib/ansible/modules/windows/win_feature.py
@@ -99,9 +99,13 @@ EXAMPLES = r'''
   win_feature:
     name: Web-Server
     state: present
-    restart: True
     include_sub_features: True
     include_management_tools: True
+  register: win_feature
+
+- name: reboot if installing Web-Server feature requires it
+  win_reboot:
+  when: win_feature.reboot_required
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
`restart` is a deprecated parameter. Show how to use `reboot_required`
in examples instead

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_feature

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 1d10a2867c) last updated 2017/12/13 16:39:26 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

##### ADDITIONAL INFORMATION
The `win_reboot` example might not be needed, but might just help demonstrate good practice
