### PR TITLE
win_script: work when argument exceeds stdin buffer size

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -391,8 +391,6 @@ class Connection(ConnectionBase):
             stdin_push_failed = False
             command_id = self.protocol.run_command(self.shell_id, to_bytes(command), map(to_bytes, args), console_mode_stdin=(stdin_iterator is None))
 
-            # TODO: try/except around this, so we can get/return the command result on a broken pipe or other failure (probably more useful than the 500 that
-            # comes from this)
             try:
                 if stdin_iterator:
                     for (data, is_last) in stdin_iterator:
@@ -400,11 +398,8 @@ class Connection(ConnectionBase):
 
             except Exception as ex:
                 from traceback import format_exc
-                display.warning("FATAL ERROR DURING FILE TRANSFER: %s" % format_exc())
+                display.warning("FATAL ERROR DURING FILE TRANSFER: %s" % to_text(ex))
                 stdin_push_failed = True
-
-            if stdin_push_failed:
-                raise AnsibleError('winrm send_input failed')
 
             # NB: this can hang if the receiver is still running (eg, network failed a Send request but the server's still happy).
             # FUTURE: Consider adding pywinrm status check/abort operations to see if the target is still running after a failure.
@@ -423,7 +418,11 @@ class Connection(ConnectionBase):
             display.vvvvvv('WINRM STDERR %s' % to_text(response.std_err), host=self._winrm_host)
 
             if stdin_push_failed:
-                raise AnsibleError('winrm send_input failed; \nstdout: %s\nstderr %s' % (response.std_out, response.std_err))
+                stderr = to_bytes(response.std_err, encoding='utf-8')
+                if self.is_clixml(stderr):
+                    stderr = self.parse_clixml_stream(stderr)
+
+                raise AnsibleError('winrm send_input failed; \nstdout: %s\nstderr %s' % (response.std_out, stderr))
 
             return response
         finally:
@@ -456,7 +455,9 @@ class Connection(ConnectionBase):
             'powershell_modules': {},
             'actions': ['exec'],
             'exec': to_text(base64.b64encode(to_bytes(leaf_exec))),
-            'environment': environment
+            'environment': environment,
+            'min_ps_version': None,
+            'min_os_version': None
         }
 
         return json.dumps(payload)

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -54,6 +54,24 @@
       - "test_script_with_args_result is not failed"
       - "test_script_with_args_result is changed"
 
+# Bug: https://github.com/ansible/ansible/issues/32850
+- name: set fact of long string
+  set_fact:
+    long_string: "{{ lookup('pipe', 'printf \"a%.0s\" {1..1000}') }}"
+
+- name: run test script with args that exceed the stdin buffer
+  script: test_script_with_args.ps1 {{ long_string }}
+  register: test_script_with_large_args_result
+
+- name: check that script ran and received arguments correctly
+  assert:
+    that:
+    - test_script_with_large_args_result.rc == 0
+    - test_script_with_large_args_result.stdout == long_string + "\r\n"
+    - not test_script_with_large_args_result.stderr
+    - test_script_with_large_args_result is not failed
+    - test_script_with_large_args_result is changed
+
 - name: run test script that takes parameters passed via splatting
   script: test_script_with_splatting.ps1 @{ This = 'this'; That = '{{ test_win_script_value }}'; Other = 'other'}
   register: test_script_with_splatting_result

--- a/test/integration/targets/win_script/tasks/main.yml
+++ b/test/integration/targets/win_script/tasks/main.yml
@@ -201,20 +201,17 @@
       - "test_script_bool_result.stdout_lines[0] == 'System.Boolean'"
       - "test_script_bool_result.stdout_lines[1] == 'True'"
 
-# FIXME: re-enable this test once script can run under the wrapper with powershell
-#- name: run test script that uses envvars
-#  script: test_script_with_env.ps1
-#  environment:
-#    taskenv: task
-#  register: test_script_env_result
-#
-#- name: ensure that script ran and that environment var was passed
-#  assert:
-#    that:
-#    - test_script_env_result is successful
-#    - test_script_env_result.stdout_lines[0] == 'task'
-#
+- name: run test script that uses envvars
+  script: test_script_with_env.ps1
+  environment:
+    taskenv: task
+  register: test_script_env_result
 
+- name: ensure that script ran and that environment var was passed
+  assert:
+    that:
+    - test_script_env_result is successful
+    - test_script_env_result.stdout_lines[0] == 'task'
 
 # check mode
 - name: Run test script that creates a file in check mode


### PR DESCRIPTION
##### SUMMARY
When running script over WinRM, it would work fine in most situations except when the arguments passed with script exceeded the stdin iterator buffer size. Due to an error in the script plugin both the raw command and an empty PS exec wrapper with the command was sent through. What happens is that the Windows host will execute the the script passed through once the initial stdin data was sent through and then finish the task. When sending multiple stdin payloads, the 2nd payload will fail as the script would have finished and there is no pipe open anymore.

This change does 2 things
* Instead of running the script as a raw command, run it over the exec wrapper so that environment variables are re-enabled and the script will be executed once all the stdin payloads are sent through
* Fix up some error handling for Python 3 to make the error output easier to understand and read (no more plain send_input failures!!!!).

Fixes https://github.com/ansible/ansible/issues/32850

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
script

##### ANSIBLE VERSION
```
2.5
```

##### ADDITIONAL INFORMATION
This change also includes a fix in the winrm connection plugin to better handle failures when send_input fails. Current without this fix the following error will occur

```
The full traceback is:
Traceback (most recent call last):
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/winrm/transport.py", line 262, in _send_message_request
    response.raise_for_status()
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/requests/models.py", line 935, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 500 Server Error:  for url: https://server2016.domain.local:5986/wsman

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/winrm/protocol.py", line 234, in send_message
    resp = self.transport.send_message(message)
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/winrm/transport.py", line 256, in send_message
    response = self._send_message_request(prepared_request, message)
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/winrm/transport.py", line 273, in _send_message_request
    raise WinRMTransportError('http', ex.response.status_code, response_text)
winrm.exceptions.WinRMTransportError: Bad HTTP response returned from server. Code 500

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 340, in _winrm_exec
    self._winrm_send_input(self.protocol, self.shell_id, command_id, data, eof=is_last)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 320, in _winrm_send_input
    protocol.send_message(xmltodict.unparse(rq))
  File "/Users/jborean/venvs/ansible-py36/lib/python3.6/site-packages/winrm/protocol.py", line 272, in send_message
    raise WinRMError('{0} (extended fault data: {1})'.format(error_message, fault_data))
winrm.exceptions.WinRMError: The pipe has been ended.  (extended fault data: {'transport_message': 'Bad HTTP response returned from server. Code 500', 'http_status_code': 500, 'wsmanfault_code': '109', 'fault_code': 's:Receiver', 'fault_subcode': 'w:InternalError'})

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 119, in run
    res = self._execute()
  File "/Users/jborean/dev/ansible/lib/ansible/executor/task_executor.py", line 523, in _execute
    result = self._handler.run(task_vars=variables)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/script.py", line 123, in run
    result.update(self._low_level_execute_command(cmd=script_cmd, in_data=exec_data, sudoable=True, chdir=chdir))
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/action/__init__.py", line 859, in _low_level_execute_command
    rc, stdout, stderr = self._connection.exec_command(cmd, in_data=in_data, sudoable=sudoable)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 423, in exec_command
    result = self._winrm_exec(cmd_parts[0], cmd_parts[1:], from_exec=True, stdin_iterator=stdin_iterator)
  File "/Users/jborean/dev/ansible/lib/ansible/plugins/connection/winrm.py", line 344, in _winrm_exec
    display.warning("FATAL ERROR DURING FILE TRANSFER: %s" % format_exc(ex))
  File "/usr/local/lib/python3.6/traceback.py", line 163, in format_exc
    return "".join(format_exception(*sys.exc_info(), limit=limit, chain=chain))
  File "/usr/local/lib/python3.6/traceback.py", line 117, in format_exception
    type(value), value, tb, limit=limit).format(chain=chain))
  File "/usr/local/lib/python3.6/traceback.py", line 486, in __init__
    _seen=_seen)
  File "/usr/local/lib/python3.6/traceback.py", line 486, in __init__
    _seen=_seen)
  File "/usr/local/lib/python3.6/traceback.py", line 497, in __init__
    capture_locals=capture_locals)
  File "/usr/local/lib/python3.6/traceback.py", line 332, in extract
    if limit >= 0:
TypeError: '>=' not supported between instances of 'WinRMError' and 'int'

fatal: [SERVER2016.domain.local]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```

This swallows the 500 error message returned from the server and prints an ugly stacktrace which makes it hard to understand what is going on.

This changed coupled with the latest pywinrm beta we would now see
```
 [WARNING]: FATAL ERROR DURING FILE TRANSFER: The pipe has been ended.
(extended fault data: {'transport_message': 'Bad HTTP response returned from
server. Code 500', 'http_status_code': 500, 'wsmanfault_code': '109',
'fault_code': 's:Receiver', 'fault_subcode': 'w:InternalError'})
fatal: [SERVER2016.domain.local]: FAILED! => {
    "msg": "winrm send_input failed; \nstdout: hi\n\nstderr "
}
```

Now we can see the error from the server `The pipe has been ended` plus any stdout/stderr from the server that was received before the stdin failure.