### PR TITLE
Added 'quota' parameter and 'description' parameter to ovirt_disk module

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -216,14 +216,15 @@ EXAMPLES = '''
 
 # Defining a specific quota while creating a disk image:
 # Since Ansible 2.5
-        - ovirt_quotas_facts:
-            data_center: Default
-            name: myquota
-        - ovirt_disk:
-            name: mydisk
-            size: 10GiB
-            storage_domain: data
-            quota: "{{ ovirt_quotas[0]['id'] }}"
+- ovirt_quotas_facts:
+    data_center: Default
+    name: myquota
+- ovirt_disk:
+    name: mydisk
+    size: 10GiB
+    storage_domain: data
+    description: somedescriptionhere
+    quota: "{{ ovirt_quotas[0]['id'] }}"
 '''
 
 

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -112,7 +112,7 @@ options:
     profile:
         description:
             - "Disk profile name to be attached to disk. By default profile is chosen by oVirt/RHV engine."
-    quota:
+    quota_id:
         description:
             - "Disk quota ID to be used for disk. By default quota is chosen by oVirt/RHV engine."
         version_added: "2.5"
@@ -224,7 +224,7 @@ EXAMPLES = '''
     size: 10GiB
     storage_domain: data
     description: somedescriptionhere
-    quota: "{{ ovirt_quotas[0]['id'] }}"
+    quota_id: "{{ ovirt_quotas[0]['id'] }}"
 '''
 
 
@@ -450,7 +450,7 @@ class DisksModule(BaseModule):
                     name=self._module.params.get('storage_domain'),
                 ),
             ],
-            quota=otypes.Quota(id=self._module.params.get('quota')),
+            quota=otypes.Quota(id=self._module.params.get('quota_id')) if self.param('quota_id') else None,
             shareable=self._module.params.get('shareable'),
             lun_storage=otypes.HostStorage(
                 type=otypes.StorageType(
@@ -519,6 +519,7 @@ class DisksModule(BaseModule):
     def _update_check(self, entity):
         return (
             equal(self._module.params.get('description'), entity.description) and
+            equal(self.param('quota_id'), getattr(entity.quota, 'id')) and
             equal(convert_to_bytes(self._module.params.get('size')), entity.provisioned_size) and
             equal(self._module.params.get('shareable'), entity.shareable)
         )
@@ -560,7 +561,7 @@ def main():
         storage_domain=dict(default=None),
         storage_domains=dict(default=None, type='list'),
         profile=dict(default=None),
-        quota=dict(default=None),
+        quota_id=dict(default=None),
         format=dict(default='cow', choices=['raw', 'cow']),
         bootable=dict(default=None, type='bool'),
         shareable=dict(default=None, type='bool'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk.py
@@ -40,6 +40,10 @@ options:
         description:
             - "Name of the disk to manage. Either C(id) or C(name)/C(alias) is required."
         aliases: ['alias']
+    description:
+        description:
+            - "Description of the disk image to manage."
+        version_added: "2.5"
     vm_name:
         description:
             - "Name of the Virtual Machine to manage. Either C(vm_id) or C(vm_name) is required if C(state) is I(attached) or I(detached)."
@@ -108,6 +112,10 @@ options:
     profile:
         description:
             - "Disk profile name to be attached to disk. By default profile is chosen by oVirt/RHV engine."
+    quota:
+        description:
+            - "Disk quota ID to be used for disk. By default quota is chosen by oVirt/RHV engine."
+        version_added: "2.5"
     bootable:
         description:
             - "I(True) if the disk should be bootable. By default when disk is created it isn't bootable."
@@ -205,6 +213,17 @@ EXAMPLES = '''
     id: 7de90f31-222c-436c-a1ca-7e655bd5b60c
     image_provider: myglance
     state: exported
+
+# Defining a specific quota while creating a disk image:
+# Since Ansible 2.5
+        - ovirt_quotas_facts:
+            data_center: Default
+            name: myquota
+        - ovirt_disk:
+            name: mydisk
+            size: 10GiB
+            storage_domain: data
+            quota: "{{ ovirt_quotas[0]['id'] }}"
 '''
 
 
@@ -430,6 +449,7 @@ class DisksModule(BaseModule):
                     name=self._module.params.get('storage_domain'),
                 ),
             ],
+            quota=otypes.Quota(id=self._module.params.get('quota')),
             shareable=self._module.params.get('shareable'),
             lun_storage=otypes.HostStorage(
                 type=otypes.StorageType(
@@ -531,6 +551,7 @@ def main():
         ),
         id=dict(default=None),
         name=dict(default=None, aliases=['alias']),
+        description=dict(default=None),
         vm_name=dict(default=None),
         vm_id=dict(default=None),
         size=dict(default=None),
@@ -538,6 +559,7 @@ def main():
         storage_domain=dict(default=None),
         storage_domains=dict(default=None, type='list'),
         profile=dict(default=None),
+        quota=dict(default=None),
         format=dict(default='cow', choices=['raw', 'cow']),
         bootable=dict(default=None, type='bool'),
         shareable=dict(default=None, type='bool'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_disk_facts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_disk_facts.py
@@ -39,7 +39,7 @@ options:
     pattern:
       description:
         - "Search term which is accepted by oVirt/RHV search backend."
-        - "For example to search Disk X from storafe Y use following pattern:
+        - "For example to search Disk X from storage Y use following pattern:
            name=X and storage.name=Y"
 extends_documentation_fragment: ovirt_facts
 '''


### PR DESCRIPTION
##### SUMMARY
By adding a 'quota' parameter in the ovirt_disk module the administrator could now create VMs disks by assigning them to a specific quota instead of on the default one, this is very useful when the quota mode of ovirt cluster is set to enforced and every users (or group of) have a specific quota to use.

By adding a 'description' parameter in the ovirt_disk module the administrator could now specify a description field for the newly created disk.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- lib/ansible/modules/cloud/ovirt/ovirt_disk.py
- lib/ansible/modules/cloud/ovirt/ovirt_disk_facts.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel c743e4d4da) last updated 2017/12/13 10:53:30 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/paolomargara/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/paolomargara/workspace-neon/ansible-mrg/lib/ansible
  executable location = /home/paolomargara/workspace-neon/ansible-mrg/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
Example: defining a specific quota while creating a disk image :

```
        - ovirt_quotas_facts:
            data_center: Default
            name: myquota
        - ovirt_disk:
            name: mydisk
            size: 10GiB
            storage_domain: data
            description: somedescriptionhere
            quota: "{{ ovirt_quotas[0]['id'] }}"
```
