### PR TITLE
make jira authentication Python3 compatible

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -227,6 +227,7 @@ EXAMPLES = """
 import base64
 import json
 import sys
+import six
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -243,7 +244,10 @@ def request(url, user, passwd, timeout, data=None, method=None):
     # resulting in unexpected results. To work around this we manually
     # inject the basic-auth header up-front to ensure that JIRA treats
     # the requests as authorized for this user.
-    auth = base64.encodestring('%s:%s' % (user, passwd)).replace('\n', '')
+    auth = base64.b64encode('{}:{}'.format(user, passwd).encode())
+    if six.PY3:
+        auth = auth.decode()
+
     response, info = fetch_url(module, url, data=data, method=method, timeout=timeout,
                                headers={'Content-Type': 'application/json',
                                         'Authorization': "Basic %s" % auth})

--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -227,7 +227,7 @@ EXAMPLES = """
 import base64
 import json
 import sys
-import six
+import ansible.module_utils.six as six
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url

--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -227,7 +227,7 @@ EXAMPLES = """
 import base64
 import json
 import sys
-import ansible.module_utils.six as six
+from ansible.module_utils._text import to_text
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -244,9 +244,7 @@ def request(url, user, passwd, timeout, data=None, method=None):
     # resulting in unexpected results. To work around this we manually
     # inject the basic-auth header up-front to ensure that JIRA treats
     # the requests as authorized for this user.
-    auth = base64.b64encode('{}:{}'.format(user, passwd).encode())
-    if six.PY3:
-        auth = auth.decode()
+    auth = to_text(base64.b64encode('{0}:{1}'.format(user, passwd).encode()))
 
     response, info = fetch_url(module, url, data=data, method=method, timeout=timeout,
                                headers={'Content-Type': 'application/json',

--- a/lib/ansible/modules/web_infrastructure/jira.py
+++ b/lib/ansible/modules/web_infrastructure/jira.py
@@ -227,7 +227,7 @@ EXAMPLES = """
 import base64
 import json
 import sys
-from ansible.module_utils._text import to_text
+from ansible.module_utils._text import to_text, to_bytes
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
@@ -244,7 +244,7 @@ def request(url, user, passwd, timeout, data=None, method=None):
     # resulting in unexpected results. To work around this we manually
     # inject the basic-auth header up-front to ensure that JIRA treats
     # the requests as authorized for this user.
-    auth = to_text(base64.b64encode('{0}:{1}'.format(user, passwd).encode()))
+    auth = to_text(base64.b64encode(to_bytes('{0}:{1}'.format(user, passwd), errors='surrogate_or_strict')))
 
     response, info = fetch_url(module, url, data=data, method=method, timeout=timeout,
                                headers={'Content-Type': 'application/json',


### PR DESCRIPTION
##### SUMMARY

Fixes problem with jira module and Python3

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/web_infrastructure/jira.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.0.0
python version = 3.6.3 (default, Oct  6 2017, 11:37:43) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION


<!--- Paste verbatim command output below, e.g. before and after your change -->
Full traceback before change
```
The full traceback is:
Traceback (most recent call last):
  File "/home/twerner/ansible_venv/lib/python3.6/base64.py", line 517, in _input_type_check
    m = memoryview(s)
TypeError: memoryview: a bytes-like object is required, not 'str'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/tmp/ansible_zjezlbg5/ansible_module_jira.py", line 431, in main
    ret = method(restbase, user, passwd, module.params)
  File "/tmp/ansible_zjezlbg5/ansible_module_jira.py", line 324, in fetch
    ret = get(url, user, passwd, params['timeout'])
  File "/tmp/ansible_zjezlbg5/ansible_module_jira.py", line 275, in get
    return request(url, user, passwd, timeout)
  File "/tmp/ansible_zjezlbg5/ansible_module_jira.py", line 247, in request
    auth = base64.encodestring('%s:%s' % (user, passwd)).replace('\n', '')
  File "/home/twerner/ansible_venv/lib/python3.6/base64.py", line 547, in encodestring
    return encodebytes(s)
  File "/home/twerner/ansible_venv/lib/python3.6/base64.py", line 534, in encodebytes
    _input_type_check(s)
  File "/home/twerner/ansible_venv/lib/python3.6/base64.py", line 520, in _input_type_check
    raise TypeError(msg) from err
TypeError: expected bytes-like object, not str
```
