### PR TITLE
Revert "YAML inventory unit test: fix test inventory format (#33828)"

### DIFF
--- a/lib/ansible/plugins/inventory/yaml.py
+++ b/lib/ansible/plugins/inventory/yaml.py
@@ -140,9 +140,6 @@ class InventoryModule(BaseFileInventoryPlugin):
                     for host_pattern in group_data['hosts']:
                         hosts, port = self._parse_host(host_pattern)
                         self._populate_host_vars(hosts, group_data['hosts'][host_pattern] or {}, group, port)
-                        if group == 'all':
-                            for host in hosts:
-                                self.inventory.add_host(host, group='ungrouped', port=port)
                 else:
                     self.display.warning('Skipping unexpected key (%s) in group (%s), only "vars", "children" and "hosts" are valid' % (key, group))
 

--- a/test/units/plugins/inventory/test_inventory.py
+++ b/test/units/plugins/inventory/test_inventory.py
@@ -113,7 +113,7 @@ class TestInventory(unittest.TestCase):
             )
 
 
-class TestInventoryPlugins(unittest.TestCase):
+class IniInventory(unittest.TestCase):
 
     def test_empty_inventory(self):
         inventory = self._get_inventory('')
@@ -168,21 +168,13 @@ class TestInventoryPlugins(unittest.TestCase):
         ---
         all:
             hosts:
-                test1:
-                test2:
+                test1
+                test2
         """)}
         C.INVENTORY_ENABLED = ['yaml']
         fake_loader = DictDataLoader(inventory_content)
         im = InventoryManager(loader=fake_loader, sources=filename)
         self.assertTrue(im._inventory.hosts)
-        self.assertIn('test1', im._inventory.hosts)
-        self.assertIn('test2', im._inventory.hosts)
-        self.assertIn(im._inventory.get_host('test1'), im._inventory.groups['all'].hosts)
-        self.assertIn(im._inventory.get_host('test2'), im._inventory.groups['all'].hosts)
-        self.assertEqual(len(im._inventory.groups['all'].hosts), 2)
-        self.assertIn(im._inventory.get_host('test1'), im._inventory.groups['ungrouped'].hosts)
-        self.assertIn(im._inventory.get_host('test2'), im._inventory.groups['ungrouped'].hosts)
-        self.assertEqual(len(im._inventory.groups['ungrouped'].hosts), 2)
 
     def _get_inventory(self, inventory_content):
 


### PR DESCRIPTION
##### SUMMARY
This reverts commit dfb2f346d8141028ba8d4efd705671babc90ed3c.

As yaml plugin should not be responsible for ungrouped

Original PR https://github.com/ansible/ansible/pull/33828


##### ISSUE TYPE
 - Bugfix Pull Request
