### PR TITLE
Promote get_prompt to live in network_cli instead of cliconf

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -106,10 +106,6 @@ class CliconfBase(with_metaclass(ABCMeta, object)):
         signal.alarm(0)
         return resp
 
-    def get_prompt(self):
-        """Returns the current prompt from the device"""
-        return self._connection._matched_prompt
-
     def get_base_rpc(self):
         """Returns list of base rpc method supported by remote device"""
         return ['get_config', 'edit_config', 'get_capabilities', 'get']

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -106,6 +106,10 @@ class Connection(ConnectionBase):
                 raise AttributeError("'%s' object has no attribute '%s'" % (self.__class__.__name__, name))
             return getattr(self._cliconf, name)
 
+    def get_prompt(self):
+        """Returns the current prompt from the device"""
+        return self._matched_prompt
+
     def exec_command(self, cmd, in_data=None, sudoable=True):
         # this try..except block is just to handle the transition to supporting
         # network_cli as a toplevel connection.  Once connection=local is gone,


### PR DESCRIPTION
##### SUMMARY
This removes the immediate need for a cliconf plugin to use network_cli

This change _should_ be transparent, as the only path to get_prompt is already through network_cli

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
network_cli

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```