### PR TITLE
HipChat API v2 support for ansible callback plugin

### DIFF
--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -7,45 +7,63 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
     callback: hipchat
-    type: notification
+    callback_type: notification
+    requirements:
+      - whitelist in configuration.
+      - prettytable (python lib)
     short_description: post task events to hipchat
     description:
-      - The chatty part of ChatOps with a Hipchat server as a target
       - This callback plugin sends status updates to a HipChat channel during playbook execution.
+      - Before 2.4 only environment variables were available for configuring this plugin.
     version_added: "1.6"
-    requirements:
-      - prettytable (python lib)
     options:
       token:
         description: HipChat API token for v1 or v2 API.
         required: True
         env:
           - name: HIPCHAT_TOKEN
+        ini:
+          - section: callback_hipchat
+          - key: token
       api_version:
-        description: HipChat API version.
+        description: HipChat API version, v1 or v2.
         required: False
         default: v1
         env:
           - name: HIPCHAT_API_VERSION
+        ini:
+          - section: callback_hipchat
+          - key: api_version
       room:
         description: HipChat room to post in.
         default: ansible
         env:
           - name: HIPCHAT_ROOM
+        ini:
+          - section: callback_hipchat
+          - key: room
       from:
         description:  Name to post as
         default: ansible
         env:
           - name: HIPCHAT_FROM
+        ini:
+          - section: callback_hipchat
+          - key: from
       notify:
         description: Add notify flag to important messages
         type: bool
         default: True
         env:
           - name: HIPCHAT_NOTIFY
+        ini:
+          - section: callback_hipchat
+          - key: notify
+
 '''
 
 import os
+import json
 
 try:
     import prettytable
@@ -61,18 +79,8 @@ from ansible.module_utils.urls import open_url
 class CallbackModule(CallbackBase):
     """This is an example ansible callback plugin that sends status
     updates to a HipChat channel during playbook execution.
-
-    This plugin makes use of the following environment variables:
-        HIPCHAT_TOKEN (required): HipChat API token
-        HIPCHAT_ROOM  (optional): HipChat room to post in. Default: ansible
-        HIPCHAT_FROM  (optional): Name to post as. Default: ansible
-        HIPCHAT_NOTIFY (optional): Add notify flag to important messages ("true" or "false"). Default: true
-        HIPCHAT_API_VERSION (optional): v1 is default.
-
-    Requires:
-        prettytable
-
     """
+
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'notification'
     CALLBACK_NAME = 'hipchat'
@@ -89,18 +97,18 @@ class CallbackModule(CallbackBase):
             self.disabled = True
             self._display.warning('The `prettytable` python module is not installed. '
                                   'Disabling the HipChat callback plugin.')
+        self.printed_playbook = False
+        self.playbook_name = None
+        self.play = None
 
-        self.token = os.getenv('HIPCHAT_TOKEN')
-        self.room = os.getenv('HIPCHAT_ROOM', 'ansible')
-        self.from_name = os.getenv('HIPCHAT_FROM', 'ansible')
-        self.allow_notify = (os.getenv('HIPCHAT_NOTIFY') != 'false')
-        self.hipchat_api_version = os.getenv('HIPCHAT_API_VERSION', 'v1')
+    def set_options(self, task_keys=None, var_options=None, direct=None):
+        super(CallbackModule, self).set_options(task_keys=task_keys, var_options=var_options, direct=direct)
 
-        # Pick the request handler.
-        if self.hipchat_api_version == 'v2':
-            self.send_msg = self.send_msg_v2
-        else:
-            self.send_msg = self.send_msg_v1
+        self.token = self.get_option('token')
+        self.api_version = self.get_option('api_version')
+        self.from_name = self.get_option('from')
+        self.allow_notify = self.get_option('notify')
+        self.room = self.get_option('room')
 
         if self.token is None:
             self.disabled = True
@@ -108,9 +116,11 @@ class CallbackModule(CallbackBase):
                                   'token can be provided using the `HIPCHAT_TOKEN` '
                                   'environment variable.')
 
-        self.printed_playbook = False
-        self.playbook_name = None
-        self.play = None
+        # Pick the request handler.
+        if self.api_version == 'v2':
+            self.send_msg = self.send_msg_v2
+        else:
+            self.send_msg = self.send_msg_v1
 
     def send_msg_v2(self, msg, msg_format='text', color='yellow', notify=False):
         """Method for sending a message to HipChat"""

--- a/lib/ansible/plugins/callback/hipchat.py
+++ b/lib/ansible/plugins/callback/hipchat.py
@@ -114,7 +114,6 @@ class CallbackModule(CallbackBase):
 
     def send_msg_v2(self, msg, msg_format='text', color='yellow', notify=False):
         """Method for sending a message to HipChat"""
-        #print ("msg: {}, msg_format: {}, color: {}, notify: {}".format(msg, msg_format, color, notify))
 
         headers = {'Authorization': 'Bearer %s' % self.token, 'Content-Type': 'application/json'}
 
@@ -124,7 +123,7 @@ class CallbackModule(CallbackBase):
         body['message'] = msg
         body['message_format'] = msg_format
         body['color'] = color
-        body['notify'] = self.allow_notify or notify
+        body['notify'] = self.allow_notify and notify
 
         data = json.dumps(body)
         url = self.API_V2_URL + "room/{room_id}/notification".format(room_id=self.room)
@@ -149,8 +148,8 @@ class CallbackModule(CallbackBase):
         try:
             response = open_url(url, data=urlencode(params))
             return response.read()
-        except:
-            self._display.warning('Could not submit message to hipchat')
+        except Exception as ex:
+            self._display.warning('Could not submit message to hipchat: {}'.format(ex))
 
     def v2_playbook_on_play_start(self, play):
         """Display Playbook and play start messages"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
HipChat API v2 support for ansible callback plugin
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
callback_plugin/hipchat

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.1.0  and above
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This ansible `callback`  plugin work as it's before, ie; it will still use the Hipchat
`API v1` as default, but user can switch it by passing the API version string via Environment
variable `HIPCHAT_API_VERSION=v2`.

