### PR TITLE
Aruba indenting

### DIFF
--- a/lib/ansible/module_utils/network/aruba/aruba.py
+++ b/lib/ansible/module_utils/network/aruba/aruba.py
@@ -25,6 +25,9 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
+
+import re
+
 from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import env_fallback, return_values
 from ansible.module_utils.network.common.utils import to_list, ComplexList
@@ -77,9 +80,17 @@ def get_config(module, flags=None):
         rc, out, err = exec_command(module, cmd)
         if rc != 0:
             module.fail_json(msg='unable to retrieve current config', stderr=to_text(err, errors='surrogate_then_replace'))
-        cfg = to_text(out, errors='surrogate_then_replace').strip()
+        cfg = sanitize(to_text(out, errors='surrogate_then_replace').strip())
         _DEVICE_CONFIGS[cmd] = cfg
         return cfg
+
+
+def sanitize(resp):
+    # Takes response from device and adjusts leading whitespace to just 1 space
+    cleaned = []
+    for line in resp.splitlines():
+        cleaned.append(re.sub("^\s+", " ", line))
+    return '\n'.join(cleaned).strip()
 
 
 def to_commands(module, commands):

--- a/lib/ansible/module_utils/network/aruba/aruba.py
+++ b/lib/ansible/module_utils/network/aruba/aruba.py
@@ -89,7 +89,7 @@ def sanitize(resp):
     # Takes response from device and adjusts leading whitespace to just 1 space
     cleaned = []
     for line in resp.splitlines():
-        cleaned.append(re.sub("^\s+", " ", line))
+        cleaned.append(re.sub(r"^\s+", " ", line))
     return '\n'.join(cleaned).strip()
 
 

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -233,11 +233,11 @@ def get_running_config(module, config=None):
             contents = config
         else:
             contents = get_config(module)
-    return NetworkConfig(indent=1, contents=contents)
+    return NetworkConfig(contents=contents)
 
 
 def get_candidate(module):
-    candidate = NetworkConfig(indent=1)
+    candidate = NetworkConfig()
 
     if module.params['src']:
         candidate.load(module.params['src'])
@@ -307,7 +307,7 @@ def main():
 
     if module.params['backup'] or (module._diff and module.params['diff_against'] == 'running'):
         contents = get_config(module)
-        config = NetworkConfig(indent=1, contents=contents)
+        config = NetworkConfig(contents=contents)
         if module.params['backup']:
             result['__backup__'] = contents
 
@@ -354,8 +354,8 @@ def main():
     elif module.params['save_when'] == 'modified':
         output = run_commands(module, ['show running-config', 'show startup-config'])
 
-        running_config = NetworkConfig(indent=1, contents=output[0], ignore_lines=diff_ignore_lines)
-        startup_config = NetworkConfig(indent=1, contents=output[1], ignore_lines=diff_ignore_lines)
+        running_config = NetworkConfig(contents=output[0], ignore_lines=diff_ignore_lines)
+        startup_config = NetworkConfig(contents=output[1], ignore_lines=diff_ignore_lines)
 
         if running_config.sha1 != startup_config.sha1:
             save_config(module, result)
@@ -371,7 +371,7 @@ def main():
             contents = running_config.config_text
 
         # recreate the object in order to process diff_ignore_lines
-        running_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+        running_config = NetworkConfig(contents=contents, ignore_lines=diff_ignore_lines)
 
         if module.params['diff_against'] == 'running':
             if module.check_mode:
@@ -391,7 +391,7 @@ def main():
             contents = module.params['intended_config']
 
         if contents is not None:
-            base_config = NetworkConfig(indent=1, contents=contents, ignore_lines=diff_ignore_lines)
+            base_config = NetworkConfig(contents=contents, ignore_lines=diff_ignore_lines)
 
             if running_config.sha1 != base_config.sha1:
                 result.update({

--- a/test/units/modules/network/aruba/fixtures/aruba_config_config.cfg
+++ b/test/units/modules/network/aruba/fixtures/aruba_config_config.cfg
@@ -2,11 +2,16 @@
 hostname router
 !
 interface GigabitEthernet0/0
- ip address 1.2.3.4 255.255.255.0
- description test string
+	ip address 1.2.3.4 255.255.255.0
+	description test string
 !
 interface GigabitEthernet0/1
  ip address 6.7.8.9 255.255.255.0
  description test string
  shutdown
 !
+wlan ssid-profile "blah"
+   essid "blah"
+!
+ip access-list session blah
+  any any any permit

--- a/test/units/modules/network/aruba/test_aruba_config.py
+++ b/test/units/modules/network/aruba/test_aruba_config.py
@@ -59,6 +59,14 @@ class TestArubaConfigModule(TestArubaModule):
         set_module_args(dict(src=src))
         self.execute_module()
 
+    def test_aruba_config_unchanged_different_spacing(self):
+        # Tab indented
+        set_module_args(dict(lines=['description test string'], parents=['interface GigabitEthernet0/0']))
+        self.execute_module(changed=False)
+        # 3 spaces indented
+        set_module_args(dict(lines=['essid "blah"'], parents=['wlan ssid-profile "blah"']))
+        self.execute_module(changed=False)
+
     def test_aruba_config_src(self):
         src = load_fixture('aruba_config_src.cfg')
         set_module_args(dict(src=src))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Originally I had aruba_config indenting set to 1 space, but found out that the configs have arbitrary spacing. A child config can be indented by 1, 2, or 3 spaces or 1 tab. That broke the idempotency because the parser would think that the children are at a different level and keep reapplying configs when it shouldn't. This sanitizes the aruba config to all children have uniformly spaced indentation.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
aruba_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (aruba_indenting 32b8c85cda) last updated 2017/12/13 08:52:31 (GMT -700)
  config file = None
  configured module search path = [u'/Users/james/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/james/Documents/git/ansible/lib/ansible
  executable location = /Users/james/Documents/git/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```



