### PR TITLE
Fixes #30599 Ini_file module: Options within no section managed

### DIFF
--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -182,7 +182,7 @@ def do_ini(module, filename, section=None, option=None, value=None,
     ini_lines.append('[')
 
     # If no section is defined, fake section is used
-    if section == '' or not section:
+    if not section:
         section = fake_section_name
 
     within_section = not section

--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -162,18 +162,9 @@ def do_ini(module, filename, section=None, option=None, value=None,
 
     # append fake section lines to simplify the logic
     # At top:
-    # Generate fake section name to manage options without section.
-    # The idea is to generate a section name strange enough to do not match any other in the file
-    # Name is created using a uniq of every letter in option and value (Max 8)
-    # and wrapped between the sequence '_-_'. Example:
-    # For drink = water, the fake section name will be: _-_aediknrt_-_
-    fake_section_template = '_-_%s_-_'
-
-    # As option and value are not mandatory, we have to control how it's used
-    fake_section_pseudo_rand_name = ''.join((set(option or "NO_OPTION").union(set(value or "NO_VALUE"))))
-
-    # Generate fake section name, using first 8 chars of fake_section_pseudo_rand_name
-    fake_section_name = fake_section_template % fake_section_pseudo_rand_name[:8]
+    # Fake random section to do not match any other in the file
+    # Using commit hash as fake section name
+    fake_section_name = "ad01e11446efb704fcdbdb21f2c43757423d91c5"
 
     # Insert it at the beginning
     ini_lines.insert(0, '[%s]' % fake_section_name)

--- a/lib/ansible/modules/files/ini_file.py
+++ b/lib/ansible/modules/files/ini_file.py
@@ -164,10 +164,18 @@ def do_ini(module, filename, section=None, option=None, value=None,
     # At top:
     # Generate fake section name to manage options without section.
     # The idea is to generate a section name strange enough to do not match any other in the file
-    # Name is created using a uniq of every letter in option and value (Max 8), wrapped between the sequence '_-_'
+    # Name is created using a uniq of every letter in option and value (Max 8)
+    # and wrapped between the sequence '_-_'. Example:
     # For drink = water, the fake section name will be: _-_aediknrt_-_
-    fake_section_name = '_-_%s_-_'
-    fake_section_name = fake_section_name % ''.join((set(option).union(set(value))))[:8]
+    fake_section_template = '_-_%s_-_'
+
+    # As option and value are not mandatory, we have to control how it's used
+    fake_section_pseudo_rand_name = ''.join((set(option or "NO_OPTION").union(set(value or "NO_VALUE"))))
+
+    # Generate fake section name, using first 8 chars of fake_section_pseudo_rand_name
+    fake_section_name = fake_section_template % fake_section_pseudo_rand_name[:8]
+
+    # Insert it at the beginning
     ini_lines.insert(0, '[%s]' % fake_section_name)
 
     # At botton:

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -195,12 +195,12 @@
         path: "{{ output_file }}"
         section:
         option: like
-        value: beer
+        value: tea
 
 - name: set expected content and get current ini file content
   set_fact:
     expected9: |-
-      like = beer
+      like = tea
 
       [drinks]
       hate = water

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -121,3 +121,93 @@
       - result5.changed == True
       - result5.msg == 'section removed'
       - content5 == ""
+
+- name: Ensure "hate=coke" is created within no section
+  ini_file:
+    section:
+    path: "{{ output_file }}"
+    option: hate
+    value: coke
+  register: result6
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected6: "hate = coke"
+    content6: "{{ lookup('file', output_file) }}"
+
+- name: assert 'changed' is true and content is OK (no section)
+  assert:
+    that:
+      - result6|changed
+      - result6.msg == 'option added'
+      - content6 == expected6
+
+- name: Ensure "hate=coke" is modified as "hate=water" within no section
+  ini_file:
+    path: "{{ output_file }}"
+    option: hate
+    value: water
+    section:
+  register: result7
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected7: "hate = water"
+
+    content7: "{{ lookup('file', output_file) }}"
+
+- name: assert 'changed' is true and content is OK (no section)
+  assert:
+    that:
+      - result7.changed == True
+      - result7.msg == 'option changed'
+      - content7 == expected7
+
+- name: remove option 'hate' within no section
+  ini_file:
+    section:
+    path: "{{ output_file }}"
+    option: hate
+    state: absent
+  register: result8
+
+- name: get current ini file content
+  set_fact:
+    content8: "{{ lookup('file', output_file) }}"
+
+- name: assert changed (no section)
+  assert:
+    that:
+      - result8.changed == True
+      - result8.msg == 'option changed'
+      - content8 == ""
+
+- name: Check add option without section before existing section
+  block:
+    - name: Add option with section
+      ini_file:
+        path: "{{ output_file }}"
+        section: drinks
+        option: hate
+        value: water
+    - name: Add option without section
+      ini_file:
+        path: "{{ output_file }}"
+        section:
+        option: like
+        value: beer
+
+- name: set expected content and get current ini file content
+  set_fact:
+    expected9: |-
+      like = beer
+
+      [drinks]
+      hate = water
+    content9: "{{ lookup('file', output_file) }}"
+
+- name: Verify content of ini file is as expected
+  assert:
+    that:
+      - content9 == expected9
+

--- a/test/integration/targets/ini_file/tasks/main.yml
+++ b/test/integration/targets/ini_file/tasks/main.yml
@@ -210,4 +210,3 @@
   assert:
     that:
       - content9 == expected9
-


### PR DESCRIPTION
##### SUMMARY
Fixes #30599
Options within no sections aren't included, deleted or modified. These are just unmanged. This pull request solves this.

The fix consists in creating a fake section at the beginning of the execution and remove it just before the file is written. This way options with or without sections are treated in the same way, heving a consisten behaviour. Furthermore, creating fake sections is something that was already being done in the module.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ini_file


##### ANSIBLE VERSION
```
ansible 2.5.0 (30599_no_sect_options 6e4c36a4ad) last updated 2017/12/13 21:41:21 (GMT +200)
  config file = None
  configured module search path = [u'/home/jdani/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/jdani/freak/devel/ansible/lib/ansible
  executable location = /home/jdani/freak/devel/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 23 2017, 22:06:14) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
