### PR TITLE
accept variants of returned json mime type

### DIFF
--- a/lib/ansible/modules/net_tools/basics/uri.py
+++ b/lib/ansible/modules/net_tools/basics/uri.py
@@ -236,6 +236,8 @@ import ansible.module_utils.six as six
 from ansible.module_utils._text import to_native, to_text
 from ansible.module_utils.urls import fetch_url, url_argument_spec
 
+JSON_CANDIDATES = ('text', 'json', 'javascript')
+
 
 def write_file(module, url, dest, content):
     # create a tempfile with some test content
@@ -475,7 +477,7 @@ def main():
         if 'charset' in params:
             content_encoding = params['charset']
         u_content = to_text(content, encoding=content_encoding)
-        if 'application/json' in content_type or 'text/json' in content_type:
+        if any(candidate in content_type for candidate in JSON_CANDIDATES):
             try:
                 js = json.loads(u_content)
                 uresp['json'] = js


### PR DESCRIPTION
##### SUMMARY
I have a server that is returning application/vnd.blahblah+json, which [is a valid json mime type](https://tools.ietf.org/html/rfc6838#section-4.2.8).

Alternatives:

- replace the whole conditional with a regex. The current conditions are a little lax- in other words, "application/json" would be accepted even if it was "xapplication/jsonhelloworld", I'd rather make the regex more strict.
- add a param to only accept +json if the param bit was flipped. Yet another param isn't worth the cognitive overhead, it seems.
- add a 'force parsing of json' param, perhaps as a third boolean to `return_content`. Again, doesn't seem worth the cognitive overhead.

Kinda curious about the accepted indentation for the conditional too.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
uri.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

##### ADDITIONAL INFORMATION

I'm using it in my local installation, patching it into the library, it works.
