### PR TITLE
Added hostgroup child-parent relationship mapping

### DIFF
--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -317,13 +317,13 @@ class ForemanInventory(object):
                         parent = self.hostgroups[parentid]
                         safe_key = self.to_safe('%s' % (parent['name'].lower()))
                         if safe_key not in self.inventory.keys():
-                            self.inventory[safe_key]={}
+                            self.inventory[safe_key] = {}
                         safe_hgname = self.to_safe('%s' % hgname.lower())
                         try:
                             if safe_hgname not in self.inventory[safe_key]['children']:
                                 self.inventory[safe_key]['children'].append(safe_hgname)
                         except KeyError:
-                            self.inventory[safe_key]['children']=[safe_hgname]
+                            self.inventory[safe_key]['children'] = [safe_hgname]
 
             else:
                 # Create ansible groups for hostgroup

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -59,7 +59,7 @@ def json_format_dict(data, pretty=False):
 class ForemanInventory(object):
 
     def __init__(self):
-        self.inventory = defaultdict(list)  # A list of groups and the hosts in that group
+        self.inventory = defaultdict(dict)  # A dictionary of groups and the hosts in that group
         self.cache = dict()   # Details about hosts in the inventory
         self.params = dict()  # Params of each host
         self.facts = dict()   # Facts of each host
@@ -307,7 +307,10 @@ class ForemanInventory(object):
                 # First, put the relation with the hostgroup - no prefix is applied whatsoever
                 if hgname:
                     safe_key = self.to_safe('%s' % (hgname.lower()))
-                    self.inventory[safe_key].append(dns_name)
+                    if 'hosts' in self.inventory[safe_key].keys():
+                        self.inventory[safe_key]['hosts'].append(dns_name)
+                    else:
+                        self.inventory[safe_key]['hosts'] = [dns_name]
                 if hgid:
                     parentid = self.hostgroups[hgid].get('parent_id')
                     if parentid:
@@ -328,7 +331,10 @@ class ForemanInventory(object):
                 val = host.get('%s_title' % group) or host.get('%s_name' % group)
                 if val:
                     safe_key = self.to_safe('%s%s_%s' % (self.group_prefix, group, val.lower()))
-                    self.inventory[safe_key].append(dns_name)
+                    if 'hosts' in self.inventory[safe_key].keys():
+                        self.inventory[safe_key]['hosts'].append(dns_name)
+                    else:
+                        self.inventory[safe_key] = {'hosts': []}
 
                 # Create ansible groups for environment, location and organization
                 for group in ['environment', 'location', 'organization']:
@@ -371,7 +377,11 @@ class ForemanInventory(object):
             self.cache[dns_name] = host
             self.params[dns_name] = params
             self.facts[dns_name] = self._get_facts(host)
-            self.inventory['all'].append(dns_name)
+            if 'hosts' in self.inventory['all'].keys():
+                self.inventory['all']['hosts'].append(dns_name)
+            else:
+                self.inventory['all']['hosts'] = [dns_name]
+
         self._write_cache()
 
     def is_cache_valid(self):

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -314,7 +314,7 @@ class ForemanInventory(object):
                         parent = self.hostgroups[parentid]
                         safe_key = self.to_safe('%s' % (parent['name'].lower()))
                         if safe_key not in self.inventory.keys():
-                            self.inventory[safe_key]={}
+                            self.inventory[safe_key] = {}
                         safe_hgname = self.to_safe('%s' % hgname.lower())
                         try:
                             if safe_hgname not in self.inventory[safe_key]['children']:

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -92,6 +92,12 @@ class ForemanInventory(object):
 
         # Ansible related
         try:
+            group_direct_mappings = config.get('ansible', 'group_direct_mappings')
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            group_direct_mappings = False
+        self.group_direct_mappings = group_direct_mappings
+
+        try:
             group_patterns = config.get('ansible', 'group_patterns')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             group_patterns = "[]"
@@ -135,6 +141,7 @@ class ForemanInventory(object):
         self.cache_path_params = cache_path + "/%s.params" % script
         self.cache_path_facts = cache_path + "/%s.facts" % script
         self.cache_path_hostcollections = cache_path + "/%s.hostcollections" % script
+        self.cache_path_hostgroups = cache_path + "/%s.hostgroups" % script
         try:
             self.cache_max_age = config.getint('cache', 'max_age')
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
@@ -205,6 +212,12 @@ class ForemanInventory(object):
         url = "%s/api/v2/hosts/%s" % (self.foreman_url, hid)
         return self._get_json(url)
 
+    def _get_hostgroup_by_id(self, hid):
+        return self._get_json("%s/api/v2/hostgroups/%s" % (self.foreman_url, hid))
+
+    def _get_hostgroups(self):
+        return self._get_json("%s/api/v2/hostgroups" % self.foreman_url)
+
     def _get_facts_by_id(self, hid):
         url = "%s/api/v2/hosts/%s/facts" % (self.foreman_url, hid)
         return self._get_json(url)
@@ -256,6 +269,7 @@ class ForemanInventory(object):
         self.write_to_cache(self.params, self.cache_path_params)
         self.write_to_cache(self.facts, self.cache_path_facts)
         self.write_to_cache(self.hostcollections, self.cache_path_hostcollections)
+        self.write_to_cache(self.hostgroups, self.cache_path_hostgroups)
 
     def to_safe(self, word):
         '''Converts 'bad' characters in a string to underscores
@@ -264,7 +278,7 @@ class ForemanInventory(object):
         >>> ForemanInventory.to_safe("foo-bar baz")
         'foo_barbaz'
         '''
-        regex = r"[^A-Za-z0-9\_]"
+        regex = r"[^A-Za-z0-9\_\:]"
         return re.sub(regex, "_", word.replace(" ", ""))
 
     def update_cache(self):
@@ -273,11 +287,38 @@ class ForemanInventory(object):
         self.groups = dict()
         self.hosts = dict()
 
+        # Populate inventory with hostgroups info
+        for hostgroup in self._get_hostgroups():
+            id = hostgroup.get('id')
+            if id:
+                self.hostgroups.update({id: self._get_hostgroup_by_id(id)})
+
+
         for host in self._get_hosts():
             dns_name = host['name']
 
             host_data = self._get_host_data_by_id(host['id'])
             host_params = host_data.get('all_parameters', {})
+
+            if self.group_direct_mappings:
+                # Create ansible groups based on hostgroups taking into account hostgroup parent-child relationship in Foreman
+                hgid = host.get('hostgroup_id')
+                hgname = host.get('hostgroup_name')
+                # First, put the relation with the hostgroup - no prefix is applied whatsoever
+                if hgname:
+                    safe_key = self.to_safe('%s' % (hgname.lower()))
+                    self.inventory[safe_key].append(dns_name)
+                if hgid:
+                    parentid = self.hostgroups[hgid].get('parent_id')
+                    if parentid:
+                        parent = self.hostgroups[parentid]
+                        safe_key = self.to_safe('%s:children' % (parent['name'].lower()))
+                        try:
+                            if hgname not in self.inventory[safe_key]:
+                                self.inventory[safe_key].append(hgname)
+                        except KeyError:
+                            self.inventory[safe_key]=hgname
+
 
             # Create ansible groups for hostgroup
             group = 'hostgroup'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Foreman hostgroup nesting matches very well Ansible groups child-parent relationship.
The patch is adding the possibility to define Ansible groups relations based on Foreman nested groups.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
contrib/inventory/foreman.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.2.0
  config file = /work/staging/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.11+ (default, Apr 17 2016, 14:00:29) [GCC 5.3.1 20160413]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
