### PR TITLE
Pass in '**results' to exit_json only if results is a dict

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_zone.py
+++ b/lib/ansible/modules/cloud/amazon/route53_zone.py
@@ -350,7 +350,10 @@ def main():
     elif state == 'absent':
         changed, result = delete(conn, module, matching_zones=zones)
 
-    module.exit_json(changed=changed, result=result, **result)
+    if isinstance(result, dict):
+        module.exit_json(changed=changed, result=result, **result)
+    else:
+        module.exit_json(changed=changed, result=result)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
Currently, the exit_json line looks like -
`module.exit_json(changed=changed, result=result, **result)`

When `route53_zone` is used to delete a hosted zone, `result` is just a string containing a short message. In this case, `**results` errors out because for it to work, results has to be mappable.
This PR takes care of fixing that.

This bug was introduced by #33403

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
`route53_zone`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
