### PR TITLE
add new regex_split filter

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -203,6 +203,16 @@ def regex_search(value, regex, *args, **kwargs):
             return items
 
 
+def regex_split(value, pattern, maxsplit=0, ignorecase=False, multiline=False):
+    ''' Splits a provided string using a regex pattern. '''
+    flags = 0
+    if ignorecase:
+        flags |= re.I
+    if multiline:
+        flags |= re.M
+    return re.split(pattern, value, maxsplit, flags)
+
+
 def ternary(value, true_val, false_val):
     '''  value ? true_val : false_val '''
     if bool(value):
@@ -532,6 +542,7 @@ class FilterModule(object):
             'regex_escape': regex_escape,
             'regex_search': regex_search,
             'regex_findall': regex_findall,
+            'regex_split': regex_split,
 
             # ? : ;
             'ternary': ternary,


### PR DESCRIPTION
##### SUMMARY
Adds new split filter to allow splitting on regular expressions, in comparison to the built-in string split method, which only allows splitting on fixed strings.  Notably, this allows for splitting on an arbitrary number of separator characters using the regular expression pipe ('|').

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
filters

##### ANSIBLE VERSION
ansible 2.5.0
