### PR TITLE
Network cli interaction logging

### DIFF
--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -393,12 +393,9 @@ class Connection(ConnectionBase):
             recv.seek(offset)
 
             window = self._strip(recv.read())
+            display.debug("CLI-PROMPT: looking for prompts in | %s" % self._escape_crnl(window))
+
             if prompts and not handled:
-                # This is useful to see, but because our reads are essentially char by char it is not
-                # all that clean to show.  The CLI-PROMPT response comes before the CLI-RECV
-                # is printed, which appears out-of-order
-                #
-                # display.debug("CLI-PROMPT-WINDOW: %s" % self._escape_crnl(window))
                 handled = self._handle_prompt(window, prompts, answer, newline)
 
             # XXX Should it be a warning here if recv.getvalue()[:len(command)] != command

--- a/lib/ansible/plugins/connection/network_cli.py
+++ b/lib/ansible/plugins/connection/network_cli.py
@@ -394,8 +394,14 @@ class Connection(ConnectionBase):
 
             window = self._strip(recv.read())
             if prompts and not handled:
+                # This is useful to see, but because our reads are essentially char by char it is not
+                # all that clean to show.  The CLI-PROMPT response comes before the CLI-RECV
+                # is printed, which appears out-of-order
+                #
+                # display.debug("CLI-PROMPT-WINDOW: %s" % self._escape_crnl(window))
                 handled = self._handle_prompt(window, prompts, answer, newline)
 
+            # XXX Should it be a warning here if recv.getvalue()[:len(command)] != command
             if self._find_prompt(window):
                 self._last_response = recv.getvalue()
                 resp = self._strip(self._last_response)
@@ -407,10 +413,12 @@ class Connection(ConnectionBase):
         '''
         try:
             self._history.append(command)
+            display.debug("CLI-SEND: %s\\r" % self._escape_crnl(command))
             self._ssh_shell.sendall(b'%s\r' % command)
             if sendonly:
                 return
             response = self.receive(command, prompt, answer, newline)
+            display.debug("CLI-RECV: %s" % self._escape_crnl(self._last_response))
             return to_text(response, errors='surrogate_or_strict')
         except (socket.timeout, AttributeError):
             display.vvvv(traceback.format_exc(), host=self._play_context.remote_addr)
@@ -422,6 +430,13 @@ class Connection(ConnectionBase):
         '''
         for regex in self._terminal.ansi_re:
             data = regex.sub(b'', data)
+        return data
+
+    def _escape_crnl(self, data):
+        '''
+        Replace carriage-return and newline with escaped versions
+        '''
+        data = data.replace(b'\r', b'\\r').replace(b'\n', b'\\n')
         return data
 
     def _handle_prompt(self, resp, prompts, answer, newline):
@@ -443,6 +458,9 @@ class Connection(ConnectionBase):
                 self._ssh_shell.sendall(b'%s' % answer)
                 if newline:
                     self._ssh_shell.sendall(b'\r')
+                    display.debug("CLI-SUBPROMPT: Matched %s, sent '<answer>\\r'" % regex.pattern)
+                else:
+                    display.debug("CLI-SUBPROMPT: Matched %s, sent '<answer>'" % regex.pattern)
                 return True
         return False
 
@@ -471,6 +489,7 @@ class Connection(ConnectionBase):
                 for regex in self._terminal.terminal_stdout_re:
                     match = regex.search(response)
                     if match:
+                        display.debug("CLI-PROMPT: Matched Error Prompt %s" % regex.pattern)
                         errored_response = response
                         self._matched_prompt = match.group()
                         break
@@ -479,6 +498,7 @@ class Connection(ConnectionBase):
             for regex in self._terminal.terminal_stdout_re:
                 match = regex.search(response)
                 if match:
+                    display.debug("CLI-PROMPT: Matched Standard Prompt %s" % regex.pattern)
                     self._matched_pattern = regex.pattern
                     self._matched_prompt = match.group()
                     if not errored_response:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adds the interaction with the device to the debug output.

This is not quite what I desired in #29548 over a year ago, but it does help to debug some of the 'behind the scenes' cli chat with the device and when things go awry (#33794)

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (network_cli_interaction_logging 5cd847b998) last updated 2017/12/14 21:50:30 (GMT +000)
```

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
2017-12-14 21:45:35,725 p=19870 u=bdowling |   19877 1513287935.71843: CLI-SEND: terminal length 0\r
2017-12-14 21:45:35,864 p=19870 u=bdowling |   19877 1513287935.86334: CLI-RECV: terminal length 0\r\nbd-csr1000v-00>
2017-12-14 21:45:35,865 p=19870 u=bdowling |   19877 1513287935.86452: CLI-SEND: terminal width 512\r
2017-12-14 21:45:36,022 p=19870 u=bdowling |   19877 1513287936.02179: CLI-RECV: terminal width 512\r\nbd-csr1000v-00>
2017-12-14 21:45:36,023 p=19870 u=bdowling |   19877 1513287936.02305: CLI-SEND: \r
2017-12-14 21:45:36,057 p=19870 u=bdowling |   19877 1513287936.05630: CLI-RECV: \r\nbd-csr1000v-00>
2017-12-14 21:45:36,058 p=19870 u=bdowling |   19877 1513287936.05765: CLI-SEND: enable\r
2017-12-14 21:45:36,103 p=19870 u=bdowling |   19877 1513287936.10237: CLI-PROMPT: Matched [\r\n]?password: $, sent '<answer>\r'
2017-12-14 21:45:36,168 p=19870 u=bdowling |   19877 1513287936.16800: CLI-RECV: enable\r\nPassword: \r\nbd-csr1000v-00#
2017-12-14 21:45:36,170 p=19870 u=bdowling |   19877 1513287936.16923: CLI-SEND: \r
2017-12-14 21:45:36,187 p=19870 u=bdowling |   19877 1513287936.18633: CLI-RECV: \r\nbd-csr1000v-00#
2017-12-14 21:45:36,633 p=19870 u=bdowling |   19877 1513287936.63297: CLI-SEND: show version\r
```
