### PR TITLE
win_iis_webapppool: stop any passwords from being returned

### DIFF
--- a/lib/ansible/modules/windows/win_iis_webapppool.ps1
+++ b/lib/ansible/modules/windows/win_iis_webapppool.ps1
@@ -305,9 +305,11 @@ foreach ($element in $elements)  {
 
     foreach ($attribute in $attribute_collection) {
         $attribute_name = $attribute.Name
-        $attribute_value = $attribute_parent.$attribute_name
+        if ($attribute_name -notlike "*password*") {
+            $attribute_value = $attribute_parent.$attribute_name
 
-        $result.info.$element.Add($attribute_name, $attribute_value)
+            $result.info.$element.Add($attribute_name, $attribute_value)
+        }
     }
 }
 

--- a/test/integration/targets/win_iis_webapppool/tasks/tests.yml
+++ b/test/integration/targets/win_iis_webapppool/tasks/tests.yml
@@ -416,7 +416,7 @@
       state: present
       attributes:
         startMode: AlwaysRunning
-        processModel.identityType: 3
+        processModel.identityType: SpecificUser
         processModel.userName: '{{ansible_user}}'
         processModel.password: '{{ansible_password}}'
     register: iis_attributes_new_check
@@ -434,7 +434,7 @@
       state: present
       attributes:
         startMode: AlwaysRunning
-        processModel.identityType: 3
+        processModel.identityType: SpecificUser
         processModel.userName: '{{ansible_user}}'
         processModel.password: '{{ansible_password}}'
     register: iis_attributes_new
@@ -446,7 +446,6 @@
       - iis_attributes_new.info.attributes.startMode == 'AlwaysRunning'
       - iis_attributes_new.info.processModel.identityType == 'SpecificUser'
       - iis_attributes_new.info.processModel.userName == ansible_user
-      - iis_attributes_new.info.processModel.password == ansible_password
 
   - name: change attributes for newer IIS version again
     win_iis_webapppool:


### PR DESCRIPTION
##### SUMMARY
Any password attribute set for a pool was being set to the return object which means that Ansible logs these passwords. This PR stops the module from that anymore.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_iis_webapppool

##### ANSIBLE VERSION
```
2.5
```