### PR TITLE
setup: facts: linux: respect partitions if device is nvme, cciss or loop.

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -615,7 +615,10 @@ class LinuxHardware(Hardware):
 
             d['partitions'] = {}
             for folder in os.listdir(sysdir):
-                m = re.search("(" + diskname + r"\d+)", folder)
+                if diskname.startswith(('nvme', 'cciss', 'loop')):
+                    m = re.search("(" + diskname + r"p\d+)", folder)
+                else:
+                    m = re.search("(" + diskname + r"\d+)", folder)
                 if m:
                     part = {}
                     partname = m.group(1)

--- a/test/units/module_utils/facts/hardware/linux_data.py
+++ b/test/units/module_utils/facts/hardware/linux_data.py
@@ -20,6 +20,9 @@ LSBLK_OUTPUT = b"""
 /dev/sda
 /dev/sda1                             32caaec3-ef40-4691-a3b6-438c3f9bc1c0
 /dev/sda2                             66Ojcd-ULtu-1cZa-Tywo-mx0d-RF4O-ysA9jK
+/dev/nvme0n1
+/dev/nvme0n1p1                        d7689555-a803-431b-ad28-f4ce64b62dbb
+/dev/nvme0n1p2                        ca780054-f7fd-436a-b1c7-efe179279e41
 /dev/mapper/fedora_dhcp129--186-swap  eae6059d-2fbe-4d1c-920d-a80bbeb1ac6d
 /dev/mapper/fedora_dhcp129--186-root  d34cf5e3-3449-4a6c-8179-a1feb2bca6ce
 /dev/mapper/fedora_dhcp129--186-home  2d3e4853-fa69-4ccf-8a6a-77b05ab0a42d
@@ -37,6 +40,9 @@ LSBLK_OUTPUT_2 = b"""
 /dev/sda
 /dev/sda1                            32caaec3-ef40-4691-a3b6-438c3f9bc1c0
 /dev/sda2                            66Ojcd-ULtu-1cZa-Tywo-mx0d-RF4O-ysA9jK
+/dev/nvme0n1
+/dev/nvme0n1p1                       d7689555-a803-431b-ad28-f4ce64b62dbb
+/dev/nvme0n1p2                       ca780054-f7fd-436a-b1c7-efe179279e41
 /dev/mapper/fedora_dhcp129--186-swap eae6059d-2fbe-4d1c-920d-a80bbeb1ac6d
 /dev/mapper/fedora_dhcp129--186-root d34cf5e3-3449-4a6c-8179-a1feb2bca6ce
 /dev/mapper/fedora_dhcp129--186-home 2d3e4853-fa69-4ccf-8a6a-77b05ab0a42d
@@ -100,6 +106,7 @@ tmpfs /tmp tmpfs rw,seclabel 0 0
 mqueue /dev/mqueue mqueue rw,seclabel,relatime 0 0
 /dev/loop0 /var/lib/machines btrfs rw,seclabel,relatime,space_cache,subvolid=5,subvol=/ 0 0
 /dev/sda1 /boot ext4 rw,seclabel,relatime,data=ordered 0 0
+/dev/nvme0n1p1 /var/lib/ceph/osd/ceph-24 xfs rw,noatime,attr2,inode64,noquota 0 0
 /dev/mapper/fedora_dhcp129--186-home /home ext4 rw,seclabel,relatime,data=ordered 0 0
 tmpfs /run/user/1000 tmpfs rw,seclabel,nosuid,nodev,relatime,size=1611044k,mode=700,uid=1000,gid=1000 0 0
 gvfsd-fuse /run/user/1000/gvfs fuse.gvfsd-fuse rw,nosuid,nodev,relatime,user_id=1000,group_id=1000 0 0
@@ -292,6 +299,7 @@ MTAB_ENTRIES = [
     ['/dev/sdz3', '/not/a/real/device', 'none', 'rw,seclabel,relatime,data=ordered', '0', '0'],
     # lets assume this is a bindmount
     ['/dev/sdz4', '/not/a/real/bind_mount', 'ext4', 'rw,seclabel,relatime,data=ordered', '0', '0'],
+    ['/dev/nvme0n1p1', '/var/lib/ceph/osd/ceph-24', 'xfs', 'rw,noatime,attr2,inode64,noquota', '0', '0'],
     [
         '/dev/mapper/fedora_dhcp129--186-home',
         '/home',
@@ -327,6 +335,15 @@ STATVFS_INFO = {'/': {'block_available': 10192323,
                       'inode_used': 215101,
                       'size_available': 41747755008,
                       'size_total': 52710309888},
+                '/var/lib/ceph/osd/ceph-24': {'block_available': 376068204,
+                                              'block_size': 512,
+                                              'block_total': 978753928,
+                                              'block_used': 602685724,
+                                              'inode_available': 122253327,
+                                              'inode_total': 122403968,
+                                              'inode_used': 150641,
+                                              'size_available': 385093844992,
+                                              'size_total': 1002244022272},
                 '/not/a/real/bind_mount': {},
                 '/home': {'block_available': 1001578731,
                           'block_size': 4096,

--- a/test/units/module_utils/facts/hardware/test_linux.py
+++ b/test/units/module_utils/facts/hardware/test_linux.py
@@ -94,7 +94,7 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         mtab_entries = lh._mtab_entries()
         self.assertIsInstance(mtab_entries, list)
         self.assertIsInstance(mtab_entries[0], list)
-        self.assertEqual(len(mtab_entries), 38)
+        self.assertEqual(len(mtab_entries), 39)
 
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._run_findmnt', return_value=(0, FINDMNT_OUTPUT, ''))
     def test_find_bind_mounts(self, mock_run_findmnt):
@@ -134,6 +134,7 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         self.assertIsInstance(lsblk_uuids, dict)
         self.assertIn(b'/dev/loop9', lsblk_uuids)
         self.assertIn(b'/dev/sda1', lsblk_uuids)
+        self.assertIn(b'/dev/nvme0n1p1', lsblk_uuids)
         self.assertEqual(lsblk_uuids[b'/dev/sda1'], b'32caaec3-ef40-4691-a3b6-438c3f9bc1c0')
 
     @patch('ansible.module_utils.facts.hardware.linux.LinuxHardware._run_lsblk', return_value=(37, LSBLK_OUTPUT, ''))
@@ -162,6 +163,7 @@ class TestFactsLinuxHardwareGetMountFacts(unittest.TestCase):
         self.assertIsInstance(lsblk_uuids, dict)
         self.assertIn(b'/dev/loop0', lsblk_uuids)
         self.assertIn(b'/dev/sda1', lsblk_uuids)
+        self.assertIn(b'/dev/nvme0n1p1', lsblk_uuids)
         self.assertEqual(lsblk_uuids[b'/dev/mapper/an-example-mapper with a space in the name'], b'84639acb-013f-4d2f-9392-526a572b4373')
         self.assertEqual(lsblk_uuids[b'/dev/sda1'], b'32caaec3-ef40-4691-a3b6-438c3f9bc1c0')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Current match don't work with "non-standard" devices like NVMe.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

setup

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.2.0
  config file = /home/k0ste/.ansible.cfg
  configured module search path = [u'/home/k0ste/ansible/my_modules', u'/home/k0ste/ceph-ansible/library']
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:

```json
        "ansible_devices": {
            "nvme0n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Lite-On Technology Corporation M8Pe Series NVMe SSD (rev 01)", 
                "model": "PLEXTOR PX-128M8PeY", 
                "partitions": {}, 
                "removable": "0", 
                "rotational": "0", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "", 
                "sectors": "250069680", 
                "sectorsize": "512", 
                "size": "119.24 GB", 
                "support_discard": "512", 
                "vendor": null
            }, 
            "nvme1n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                "model": "INTEL SSDPEDMD400G4", 
                "partitions": {}, 
                "removable": "0", 
                "rotational": "0", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "", 
                "sectors": "781422768", 
                "sectorsize": "512", 
                "size": "372.61 GB", 
                "support_discard": "512", 
                "vendor": null
            }, 
            "nvme2n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Lite-On Technology Corporation M8Pe Series NVMe SSD (rev 01)", 
                "model": "PLEXTOR PX-1TM8PeY", 
                "partitions": {}, 
                "removable": "0", 
                "rotational": "0", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "", 
                "sectors": "2000409264", 
                "sectorsize": "512", 
                "size": "953.87 GB", 
                "support_discard": "512", 
                "vendor": null
            }, 
```

After:

```json
        "ansible_devices": {
            "nvme0n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Lite-On Technology Corporation M8Pe Series NVMe SSD (rev 01)", 
                "model": "PLEXTOR PX-128M8PeY", 
                "partitions": {
                    "nvme0n1p1": {
                        "holders": [], 
                        "sectors": "58720256", 
                        "sectorsize": 512, 
                        "size": "28.00 GB", 
                        "start": "2048", 
                        "uuid": null
                    }, 
                    "nvme0n1p2": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "58722304", 
                        "uuid": null
                    }, 
                    "nvme0n1p3": {
                        "holders": [], 
                        "sectors": "58720256", 
                        "sectorsize": 512, 
                        "size": "28.00 GB", 
                        "start": "60819456", 
                        "uuid": null
                    }, 
                    "nvme0n1p4": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "119539712", 
                        "uuid": null
                    }, 
                    "nvme0n1p5": {
                        "holders": [], 
                        "sectors": "58720256", 
                        "sectorsize": 512, 
                        "size": "28.00 GB", 
                        "start": "121636864", 
                        "uuid": null
                    }, 
                    "nvme0n1p6": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "180357120", 
                        "uuid": null
                    }, 
                    "nvme0n1p7": {
                        "holders": [], 
                        "sectors": "58720256", 
                        "sectorsize": 512, 
                        "size": "28.00 GB", 
                        "start": "182454272", 
                        "uuid": null
                    }, 
                    "nvme0n1p8": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "241174528", 
                        "uuid": null
                    }
                }, 
                "removable": "0", 
                "rotational": "0", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "", 
                "sectors": "250069680", 
                "sectorsize": "512", 
                "size": "119.24 GB", 
                "support_discard": "512", 
                "vendor": null
            }, 
            "nvme1n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                "model": "INTEL SSDPEDMD400G4", 
                "partitions": {
                    "nvme1n1p1": {
                        "holders": [], 
                        "sectors": "62914560", 
                        "sectorsize": 512, 
                        "size": "30.00 GB", 
                        "start": "2048", 
                        "uuid": null
                    }, 
                    "nvme1n1p2": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "62916608", 
                        "uuid": null
                    }, 
                    "nvme1n1p3": {
                        "holders": [], 
                        "sectors": "62914560", 
                        "sectorsize": 512, 
                        "size": "30.00 GB", 
                        "start": "65013760", 
                        "uuid": null
                    }, 
                    "nvme1n1p4": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "127928320", 
                        "uuid": null
                    }, 
                    "nvme1n1p5": {
                        "holders": [], 
                        "sectors": "62914560", 
                        "sectorsize": 512, 
                        "size": "30.00 GB", 
                        "start": "130025472", 
                        "uuid": null
                    }, 
                    "nvme1n1p6": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "192940032", 
                        "uuid": null
                    }, 
                    "nvme1n1p7": {
                        "holders": [], 
                        "sectors": "62914560", 
                        "sectorsize": 512, 
                        "size": "30.00 GB", 
                        "start": "195037184", 
                        "uuid": null
                    }, 
                    "nvme1n1p8": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "257951744", 
                        "uuid": null
                    }
                }, 
                "removable": "0", 
                "rotational": "0", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "", 
                "sectors": "781422768", 
                "sectorsize": "512", 
                "size": "372.61 GB", 
                "support_discard": "512", 
                "vendor": null
            }, 
            "nvme2n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Lite-On Technology Corporation M8Pe Series NVMe SSD (rev 01)", 
                "model": "PLEXTOR PX-1TM8PeY", 
                "partitions": {
                    "nvme2n1p1": {
                        "holders": [], 
                        "sectors": "204800", 
                        "sectorsize": 512, 
                        "size": "100.00 MB", 
                        "start": "2048", 
                        "uuid": "aaaf3aa9-feab-4a6d-ada1-466f15e53494"
                    }, 
                    "nvme2n1p2": {
                        "holders": [], 
                        "sectors": "1935190671", 
                        "sectorsize": 512, 
                        "size": "922.77 GB", 
                        "start": "65218560", 
                        "uuid": null
                    }, 
                    "nvme2n1p3": {
                        "holders": [], 
                        "sectors": "62914560", 
                        "sectorsize": 512, 
                        "size": "30.00 GB", 
                        "start": "206848", 
                        "uuid": null
                    }, 
                    "nvme2n1p4": {
                        "holders": [], 
                        "sectors": "2097152", 
                        "sectorsize": 512, 
                        "size": "1.00 GB", 
                        "start": "63121408", 
                        "uuid": null
                    }
                }, 
                "removable": "0", 
                "rotational": "0", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "", 
                "sectors": "2000409264", 
                "sectorsize": "512", 
                "size": "953.87 GB", 
                "support_discard": "512", 
                "vendor": null
            }, 
```