### PR TITLE
Fix (#33816): cloudflare module doesn't respect CNAME change

### DIFF
--- a/lib/ansible/modules/net_tools/cloudflare_dns.py
+++ b/lib/ansible/modules/net_tools/cloudflare_dns.py
@@ -575,7 +575,7 @@ class CloudflareAPI(object):
             if ('data' in new_record) and ('data' in cur_record):
                 if (cur_record['data'] > new_record['data']) - (cur_record['data'] < new_record['data']):
                     do_update = True
-            if (type == 'CNAME') and (cur_record['content'] != new_record['content']):
+            if (params['type'] == 'CNAME') and (cur_record['content'] != new_record['content']):
                 do_update = True
             if do_update:
                 if self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Fixes #33816

Variable named _type_ was undefined so _if_ statement was always false.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloudflare_dns module
##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/home/marko/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/marko/.virtualenvs/ansible/lib/python2.7/site-packages/ansible
  executable location = /home/marko/.virtualenvs/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```


##### ADDITIONAL INFORMATION
None