### PR TITLE
ovirt: Fix check for upgrade when no updates

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_hosts.py
@@ -476,8 +476,11 @@ def main():
                             event
                             for event in events_service.list(
                                 from_=int(last_event.id),
-                                search='type=885 and host.name=%s' % host.name,
-                            )
+                                search='type=885',
+                                # Uncomment when 4.1 is EOL, and remove the cond:
+                                # if host.name in event.description
+                                # search='type=885 and host.name=%s' % host.name,
+                            ) if host.name in event.description
                         ]) > 0
                     ),
                     fail_condition=lambda host: len([


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In version 4.1.8 of the oVirt we don't return host element in events for event type 885.

But in 4.2 version this is returned OK:
```xml
<event href="/ovirt-engine/api/events/2879" id="2879">
<description>Check for available updates on host host1 was completed successfully with message 'no updates found.'.</description>
<code>885</code>
<custom_id>-1</custom_id>
<flood_rate>0</flood_rate>
<index>2879</index>
<origin>oVirt</origin>
<severity>normal</severity>
<time>2017-12-15T10:10:28.847+01:00</time>
<host href="/ovirt-engine/api/hosts/14b23813-6c7c-4c92-8dc6-442d060c52d7" id="14b23813-6c7c-4c92-8dc6-442d060c52d7">
  <name>host1</name>
</host>
</event>
```

So to be able the module to work in version <= 4.1.8 of the oVirt this patch adds the workaround to  check the hostname in description, instead of the host element.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
ovirt_hosts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
