### PR TITLE
Fix storage endpoint for Azure Stack

### DIFF
--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -799,8 +799,8 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                 properties = self.get_storage_account(self.storage_account_name)
 
                 requested_vhd_uri = '{0}{1}/{2}'.format(properties.primary_endpoints.blob,
-                                                       self.storage_container_name,
-                                                       self.storage_blob_name)
+                                                        self.storage_container_name,
+                                                        self.storage_blob_name)
 
             disable_ssh_password = not self.ssh_password_enabled
 

--- a/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
+++ b/lib/ansible/modules/cloud/azure/azure_rm_virtualmachine.py
@@ -796,12 +796,11 @@ class AzureRMVirtualMachine(AzureRMModuleBase):
                 self.storage_blob_name = self.name
 
             if self.storage_account_name and not self.managed_disk_type:
-                self.get_storage_account(self.storage_account_name)
+                properties = self.get_storage_account(self.storage_account_name)
 
-                requested_vhd_uri = 'https://{0}.blob.{1}/{2}/{3}'.format(self.storage_account_name,
-                                                                          self._cloud_environment.suffixes.storage_endpoint,
-                                                                          self.storage_container_name,
-                                                                          self.storage_blob_name)
+                requested_vhd_uri = '{0}{1}/{2}'.format(properties.primary_endpoints.blob,
+                                                       self.storage_container_name,
+                                                       self.storage_blob_name)
 
             disable_ssh_password = not self.ssh_password_enabled
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The change removes the requirement for a storage endpoint which isn't required if managed disks aren't being used. Currently Azure Stack does not support support managed disks and does not have an endpoint available so this changes removes the requirement so it works.

The issue is described here https://github.com/Azure/msrestazure-for-python/issues/64
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->
cloud/azure/azure_rm_virtualmachine

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
