### PR TITLE
Add doc fragment for files

### DIFF
--- a/lib/ansible/modules/web_infrastructure/htpasswd.py
+++ b/lib/ansible/modules/web_infrastructure/htpasswd.py
@@ -65,6 +65,7 @@ notes:
   - "On RHEL or CentOS: Enable EPEL, then install I(python-passlib)."
 requirements: [ passlib>=1.6 ]
 author: "Ansible Core Team"
+extends_documentation_fragment: files
 """
 
 EXAMPLES = """


### PR DESCRIPTION

##### SUMMARY
The doc do not list the various arguments used for file (such as owner, etc), despites being supported.

Found by @Pilou- and @spredzy during co-debugging #32676

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
htpasswd
