### PR TITLE
Use ec2_url in a few places it was missing in AWS modules

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_placement_group.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_placement_group.py
@@ -182,7 +182,7 @@ def main():
 
     connection = boto3_conn(module,
                             resource='ec2', conn_type='client',
-                            region=region, **aws_connect_params)
+                            region=region, endpoint=ec2_url, **aws_connect_params)
 
     state = module.params.get("state")
 

--- a/lib/ansible/modules/cloud/amazon/ec2_placement_group_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_placement_group_facts.py
@@ -123,7 +123,7 @@ def main():
 
     connection = boto3_conn(module,
                             resource='ec2', conn_type='client',
-                            region=region, **aws_connect_params)
+                            region=region, endpoint=ec2_url, **aws_connect_params)
 
     placement_groups = get_placement_groups_details(connection, module)
     module.exit_json(changed=False, placement_groups=placement_groups)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -273,7 +273,7 @@ def main():
     changed = False
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, **aws_connect_params)
+    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
 
     if dns_hostnames and not dns_support:
         module.fail_json(msg='In order to enable DNS Hostnames you must also enable DNS support')


### PR DESCRIPTION
##### SUMMARY
There are a few places in the ec2 AWS modules where the ec2_url is not being used and should be.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
modules/cloud/amazon/ec2_placement_group
modules/cloud/amazon/ec2_placement_gorup_facts
modules/cloud/amazon/ec2_vpc_net

##### ANSIBLE VERSION
```
ansible 2.5.0 (ec2_url_usage 1ed9181ce9) last updated 2017/12/15 10:50:06 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/staebler/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/staebler/go/src/github.com/ansible/ansible/lib/ansible
  executable location = /home/staebler/go/src/github.com/ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
1. Run https://github.com/spulec/moto as a standalone server serving the ec2 service locally on port 5000.
2. Set the EC2_URL environment variable to https://localhost:5000.
3. Run the https://github.com/openshift/openshift-ansible/playbooks/aws/openshift-cluster/prerequisites.yml playbook.

The ansible/modules/cloud/amazon/ec2_vpc_net.py module attempts to connect to the real AWS ec2 service instead of the local fake service.