### PR TITLE
Adds parents to mutually_exclusive with src for *_config modules

### DIFF
--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -48,7 +48,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -287,7 +287,8 @@ def main():
 
     argument_spec.update(aruba_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -277,7 +277,7 @@ def main():
 
     argument_spec.update(asa_argument_spec)
 
-    mutually_exclusive = [('lines', 'src'), 
+    mutually_exclusive = [('lines', 'src'),
                           ('parents', 'src'),
                           ('defaults', 'passwords')]
 

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -49,7 +49,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -277,7 +277,9 @@ def main():
 
     argument_spec.update(asa_argument_spec)
 
-    mutually_exclusive = [('lines', 'src'), ('defaults', 'passwords')]
+    mutually_exclusive = [('lines', 'src'), 
+                          ('parents', 'src'),
+                          ('defaults', 'passwords')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -291,7 +291,8 @@ def main():
 
     argument_spec.update(ce_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -49,7 +49,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -229,7 +229,8 @@ def main():
 
     argument_spec.update(dellos10_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -48,7 +48,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -228,7 +228,8 @@ def main():
 
     argument_spec.update(dellos6_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -48,7 +48,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -234,7 +234,8 @@ def main():
 
     argument_spec.update(dellos9_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/lib/ansible/modules/network/enos/enos_config.py
+++ b/lib/ansible/modules/network/enos/enos_config.py
@@ -52,7 +52,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is
-        mutually exclusive with I(lines).
+        mutually exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -253,7 +253,8 @@ def main():
 
     argument_spec.update(enos_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -336,6 +336,7 @@ def main():
     argument_spec.update(eos_argument_spec)
 
     mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src'),
                           ('save', 'save_when')]
 
     required_if = [('match', 'strict', ['lines']),

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -60,7 +60,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
     version_added: "2.2"
@@ -415,6 +415,7 @@ def main():
     argument_spec.update(ios_argument_spec)
 
     mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src'),
                           ('save', 'save_when')]
 
     required_if = [('match', 'strict', ['lines']),

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -51,7 +51,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
     version_added: "2.2"
@@ -281,7 +281,8 @@ def main():
 
     argument_spec.update(iosxr_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/ironware/ironware_config.py
+++ b/lib/ansible/modules/network/ironware/ironware_config.py
@@ -49,7 +49,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -256,7 +256,8 @@ def main():
 
     argument_spec.update(ironware_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/mlnxos/mlnxos_config.py
+++ b/lib/ansible/modules/network/mlnxos/mlnxos_config.py
@@ -47,7 +47,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -230,7 +230,8 @@ def main():
         save=dict(type='bool', default=False),
     )
 
-    mutually_exclusive = [('lines', 'src'), ]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -344,6 +344,7 @@ def main():
     argument_spec.update(nxos_argument_spec)
 
     mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src'),
                           ('save', 'save_when')]
 
     required_if = [('match', 'strict', ['lines']),

--- a/lib/ansible/modules/network/ordnance/ordnance_config.py
+++ b/lib/ansible/modules/network/ordnance/ordnance_config.py
@@ -48,7 +48,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
   before:
@@ -342,7 +342,8 @@ def main():
         save=dict(default=False, type='bool'),
     )
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     required_if = [('match', 'strict', ['lines']),
                    ('match', 'exact', ['lines']),

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -50,7 +50,7 @@ options:
         or configuration template to load.  The path to the source file can
         either be the full path on the Ansible control host or a relative
         path from the playbook or role root directory.  This argument is mutually
-        exclusive with I(lines).
+        exclusive with I(lines), I(parents).
     required: false
     default: null
     version_added: "2.2"
@@ -296,7 +296,8 @@ def main():
 
     argument_spec.update(sros_argument_spec)
 
-    mutually_exclusive = [('lines', 'src')]
+    mutually_exclusive = [('lines', 'src'),
+                          ('parents', 'src')]
 
     module = AnsibleModule(argument_spec=argument_spec,
                            mutually_exclusive=mutually_exclusive,

--- a/test/units/modules/network/ios/test_ios_config.py
+++ b/test/units/modules/network/ios/test_ios_config.py
@@ -174,3 +174,33 @@ class TestIosConfigModule(TestIosModule):
         set_module_args(dict(lines=lines, parents=parents, match='exact'))
         commands = parents + lines
         self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_ios_config_src_and_lines_fails(self):
+        args = dict(src='foo', lines='foo')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_ios_config_src_and_parents_fails(self):
+        args = dict(src='foo', parents='foo')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_ios_config_match_exact_requires_lines(self):
+        args = dict(match='exact')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_ios_config_match_strict_requires_lines(self):
+        args = dict(match='strict')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_ios_config_replace_block_requires_lines(self):
+        args = dict(replace='block')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_ios_config_replace_config_requires_src(self):
+        args = dict(replace='config')
+        set_module_args(args)
+        result = self.execute_module(failed=True)

--- a/test/units/modules/network/iosxr/test_iosxr_config.py
+++ b/test/units/modules/network/iosxr/test_iosxr_config.py
@@ -137,3 +137,33 @@ class TestIosxrConfigModule(TestIosxrModule):
         set_module_args(dict(lines=lines, parents=parents, match='exact'))
         commands = parents + lines
         self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_iosxr_config_src_and_lines_fails(self):
+        args = dict(src='foo', lines='foo')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_iosxr_config_src_and_parents_fails(self):
+        args = dict(src='foo', parents='foo')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_iosxr_config_match_exact_requires_lines(self):
+        args = dict(match='exact')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_iosxr_config_match_strict_requires_lines(self):
+        args = dict(match='strict')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_iosxr_config_replace_block_requires_lines(self):
+        args = dict(replace='block')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
+    def test_iosxr_config_replace_config_requires_src(self):
+        args = dict(replace='config')
+        set_module_args(args)
+        result = self.execute_module(failed=True)

--- a/test/units/modules/network/nxos/test_nxos_config.py
+++ b/test/units/modules/network/nxos/test_nxos_config.py
@@ -110,6 +110,11 @@ class TestNxosConfigModule(TestNxosModule):
         set_module_args(args)
         result = self.execute_module(failed=True)
 
+    def test_nxos_config_src_and_parents_fails(self):
+        args = dict(src='foo', parents='foo')
+        set_module_args(args)
+        result = self.execute_module(failed=True)
+
     def test_nxos_config_match_exact_requires_lines(self):
         args = dict(match='exact')
         set_module_args(args)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

It was noticed on the slack that ios_config allowed src and parents, which are actually mutually exclusive (parents becomes a NOOP).  I added it to mutually exclusive, updated the docs.

Also (somewhat tediously!) added this to all the other network modules.  I did not personally test those, but the change is simple an straightforward enough I just insured the syntax looked good.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
all relevant network *_config modules
