### PR TITLE
Accept other ios_banner types

### DIFF
--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -37,8 +37,8 @@ notes:
 options:
   banner:
     description:
-      - Specifies which banner that should be
-        configured on the remote device.
+      - Specifies which banner should be configured on the remote device.
+        In Ansible 2.4 and earlier only I(login) and I(motd) were supported.
     required: true
     default: null
     choices: ['login', 'motd', 'exec', 'incoming', 'slip-ppp']

--- a/lib/ansible/modules/network/ios/ios_banner.py
+++ b/lib/ansible/modules/network/ios/ios_banner.py
@@ -41,7 +41,7 @@ options:
         configured on the remote device.
     required: true
     default: null
-    choices: ['login', 'motd']
+    choices: ['login', 'motd', 'exec', 'incoming', 'slip-ppp']
   text:
     description:
       - The banner text that should be
@@ -151,7 +151,7 @@ def main():
     """ main entry point for module execution
     """
     argument_spec = dict(
-        banner=dict(required=True, choices=['login', 'motd']),
+        banner=dict(required=True, choices=['login', 'motd', 'exec', 'incoming', 'slip-ppp']),
         text=dict(),
         state=dict(default='present', choices=['present', 'absent'])
     )

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -48,7 +48,7 @@ class TestIosBannerModule(TestIosModule):
     def test_ios_banner_create(self):
         for banner_type in ('login', 'motd', 'exec', 'incoming', 'slip-ppp'):
             set_module_args(dict(banner=banner_type, text='test\nbanner\nstring'))
-            commands = ['banner {} @\ntest\nbanner\nstring\n@'.format(banner_type)]
+            commands = ['banner {0} @\ntest\nbanner\nstring\n@'.format(banner_type)]
             self.execute_module(changed=True, commands=commands)
 
     def test_ios_banner_remove(self):

--- a/test/units/modules/network/ios/test_ios_banner.py
+++ b/test/units/modules/network/ios/test_ios_banner.py
@@ -46,9 +46,10 @@ class TestIosBannerModule(TestIosModule):
         self.load_config.return_value = dict(diff=None, session='session')
 
     def test_ios_banner_create(self):
-        set_module_args(dict(banner='login', text='test\nbanner\nstring'))
-        commands = ['banner login @\ntest\nbanner\nstring\n@']
-        self.execute_module(changed=True, commands=commands)
+        for banner_type in ('login', 'motd', 'exec', 'incoming', 'slip-ppp'):
+            set_module_args(dict(banner=banner_type, text='test\nbanner\nstring'))
+            commands = ['banner {} @\ntest\nbanner\nstring\n@'.format(banner_type)]
+            self.execute_module(changed=True, commands=commands)
 
     def test_ios_banner_remove(self):
         set_module_args(dict(banner='login', state='absent'))


### PR DESCRIPTION
##### SUMMARY
Update `ios_banner` to accept all banner types in Cisco IOS 15M. Specifically, this change adds `exec`, `incoming`, and `slip-ppp` to the list of accepted banner types.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_banner

##### ANSIBLE VERSION
```
ansible 2.5.0 (add_ios_banner_choices 5839342daf) last updated 2017/12/15 14:17:48 (GMT -700)
  config file = /Users/pflegge/.ansible.cfg
  configured module search path = [u'/Users/pflegge/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pflegge/Projects/ansible/ansible/lib/ansible
  executable location = /Users/pflegge/Projects/ansible/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 14:47:14) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```


##### ADDITIONAL INFORMATION
[Banner command in *Configuration Fundamentals Configuration Guide, Cisco IOS Release 15M&T*](https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/fundamentals/configuration/15mt/fundamentals-15-mt-book/cf-connections.html#GUID-D176A70A-EA99-4BF9-BBA6-AED5383D5729)
