### PR TITLE
file integration tests: control machine and managed host can be distinct

### DIFF
--- a/test/integration/targets/file/tasks/main.yml
+++ b/test/integration/targets/file/tasks/main.yml
@@ -18,6 +18,13 @@
 
 - set_fact: output_file={{output_dir}}/foo.txt
 
+# same as expanduser & expandvars called on managed host
+- command: 'echo {{ output_file }}'
+  register: echo
+
+- set_fact:
+    remote_file_expanded: '{{ echo.stdout }}'
+
 - name: prep with a basic copy
   copy: src=foo.txt dest={{output_file}}
 
@@ -121,8 +128,8 @@
   assert:
     that:
       - "file5a_result.changed == true"
-      - "file5a_result.diff.before.src == output_file|expanduser"
-      - "file5a_result.diff.after.src == output_file|basename"
+      - "file5a_result.diff.before.src == remote_file_expanded"
+      - "file5a_result.diff.after.src == remote_file_expanded|basename"
 
 - name: soft link idempotency check
   file: src={{output_file|basename}} dest={{output_dir}}/soft.txt state=link


### PR DESCRIPTION
##### SUMMARY
When control machine and managed host are distinct, `file` integration tests fail:
```
TASK [file : verify that the file was marked as changed] *****************************************************************************************************
fatal: [testhost]: FAILED! => {
    "assertion": "file5a_result.diff.before.src == output_file|expanduser",
    "changed": false,
    "evaluated_to": false
}
```

In the CI  control machine and managed host are the same.

This pull request allows control machine to be distinct from managed host.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/integration/targets/file

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel a130549ead) last updated 2017/12/16 12:03:23 (GMT +200)
```