### PR TITLE
openssl_certificate: Return self.cert.get_VALUES()

### DIFF
--- a/test/integration/targets/openssl_certificate/tasks/main.yml
+++ b/test/integration/targets/openssl_certificate/tasks/main.yml
@@ -17,6 +17,16 @@
         privatekey_path: '{{ output_dir }}/privatekey.pem'
         provider: selfsigned
         selfsigned_digest: sha256
+      register: selfsigned_certificate
+
+    - name: Generate selfsigned certificate
+      openssl_certificate:
+        path: '{{ output_dir }}/cert.pem'
+        csr_path: '{{ output_dir }}/csr.csr'
+        privatekey_path: '{{ output_dir }}/privatekey.pem'
+        provider: selfsigned
+        selfsigned_digest: sha256
+      register: selfsigned_certificate_idempotence
 
     - name: Check selfsigned certificate
       openssl_certificate:

--- a/test/integration/targets/openssl_certificate/tests/validate.yml
+++ b/test/integration/targets/openssl_certificate/tests/validate.yml
@@ -16,6 +16,13 @@
       - cert_modulus.stdout == privatekey_modulus.stdout
       - cert_version.stdout == '3'
 
+- name: Validate certificate idempotence
+  assert:
+    that:
+      - selfsigned_certificate.serial_number == selfsigned_certificate_idempotence.serial_number
+      - selfsigned_certificate.notBefore == selfsigned_certificate_idempotence.notBefore
+      - selfsigned_certificate.notAfter == selfsigned_certificate_idempotence.notAfter
+
 - name: Validate certificate v2 (test - certificate version == 2)
   shell: 'openssl x509 -noout  -in {{ output_dir}}/cert_v2.pem -text | grep "Version" | sed "s/.*: \(.*\) .*/\1/g"'
   register: cert_v2_version


### PR DESCRIPTION
##### SUMMARY

Currently when we make up the return value, we take values based of the
parameters rather than the generated openssl_certificate itself.

This commits returns the actual certificate values making it all time
accurate.

##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME

- crypto/openssl_privatekey

##### ANSIBLE VERSION

- N/A

##### ADDITIONAL INFORMATION

Fixes #33934 
