### PR TITLE
Allow propagation policy as a param to DELETE requests

### DIFF
--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -218,7 +218,7 @@ KIND_URL = {
     "deployment": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments",
     "horizontalpodautoscaler": "/apis/extensions/v1beta1/namespaces/{namespace}/horizontalpodautoscalers",  # NOQA
     "ingress": "/apis/extensions/v1beta1/namespaces/{namespace}/ingresses",
-    "job": "/apis/extensions/v1beta1/namespaces/{namespace}/jobs",
+    "job": "/apis/batch/v1/namespaces/{namespace}/jobs",
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 

--- a/lib/ansible/modules/clustering/kubernetes.py
+++ b/lib/ansible/modules/clustering/kubernetes.py
@@ -66,7 +66,7 @@ options:
     required: false
     default: null
     choices: ["Orphan", "Foreground", "Background"]
-    version_added: 2.4
+    version_added: 2.5
   url_password:
     description:
       - The HTTP Basic Auth password for the API I(endpoint). This should be set
@@ -284,16 +284,16 @@ def k8s_delete_resource(module, url, data, delete_propagation_policy):
 
     url = url + '/' + name
     info, body = api_request(
-                             module,
-                             url,
-                             method="DELETE",
-                             headers={"Content-Type": "application/json"},
-                             data={
-                                   "kind":"DeleteOptions",
-                                   "apiVersion":"v1",
-                                   "propagationPolicy": delete_propagation_policy
-                                  }
-                            )
+        module,
+        url,
+        method="DELETE",
+        headers={"Content-Type": "application/json"},
+        data={
+            "kind": "DeleteOptions",
+            "apiVersion": "v1",
+            "propagationPolicy": delete_propagation_policy
+        }
+    )
     if info['status'] == 404:
         return False, "Resource name '%s' already absent" % name
     elif info['status'] >= 400:


### PR DESCRIPTION
##### SUMMARY

The kubernetes.py module doesn't not currently support a parameter for propagation policy on DELETE requests.
The Kuberenetes API has different default policies for different objects.

This change adds a parameter for a propagation policy on delete requests. Namely, deployments default policy as of Kubernetes version 1.7 is to leave orphan replicasets and pods. This change will permit passing a policy parameter to cascade the delete request onto child objects.
 
##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME

lib/ansible/modules/clustering/kubernetes.py

##### ANSIBLE VERSION
```
2.4
```


##### ADDITIONAL INFORMATION

Please refer to https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/ for more information

```
Before this change, object deletion tasks uses the default K8S propagation delete policy.

After this change, an optional parameter can be passed to the API to allow the overriding of the default propagation policy. Refer to the updated module document for additional details.

```