### PR TITLE
win_firewall options added

### DIFF
--- a/lib/ansible/modules/windows/win_firewall.ps1
+++ b/lib/ansible/modules/windows/win_firewall.ps1
@@ -1,6 +1,7 @@
 #!powershell
 # This file is part of Ansible
 
+# Copyright 2017, Jamie Thompson <jamiet@datacom.co.nz>
 # Copyright 2017, Michael Eaton <meaton@iforium.com>
 #
 # Ansible is free software: you can redistribute it and/or modify
@@ -28,6 +29,70 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 $profiles = Get-AnsibleParam -obj $params -name "profiles" -type "list" -default @("Domain", "Private", "Public")
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -failifempty $true -validateset 'disabled','enabled'
 
+$DefaultInboundAction = Get-AnsibleParam -obj $params -name "defaultinboundaction" -validateset 'block','allow','notconfigured' -failifempty $false
+$DefaultOutboundAction = Get-AnsibleParam -obj $params -name "defaultoutboundaction" -validateset 'block','allow','notconfigured' -failifempty $false
+$AllowInboundRules = Get-AnsibleParam -obj $params -name "allowinboundrules" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowLocalFirewallRules = Get-AnsibleParam -obj $params -name "allowlocalfirewallrules" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowLocalIPsecRules = Get-AnsibleParam -obj $params -name "allowlocalipsecrules" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowUserApps = Get-AnsibleParam -obj $params -name "allowuserapps" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowUserPorts = Get-AnsibleParam -obj $params -name "allowuserports" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowUnicastResponseToMulticast = Get-AnsibleParam -obj $params -name "allowunicastresponsetomulticast" -validateset 'true','false','notconfigured' -failifempty $false
+$NotifyOnListen = Get-AnsibleParam -obj $params -name "notifyonlisten" -validateset 'true','false','notconfigured' -failifempty $false
+$EnableStealthModeForIPsec = Get-AnsibleParam -obj $params -name "enablestealthmodeforipsec" -validateset 'true','false','notconfigured' -failifempty $false
+$LogFileName = Get-AnsibleParam -obj $params -name "logfilename" -failifempty $false -type "str"
+$LogMaxSizeKilobytes = Get-AnsibleParam -obj $params -name "logmaxsizekilobytes" -failifempty $false
+$LogAllowed = Get-AnsibleParam -obj $params -name "logallowed" -validateset 'true','false','notconfigured' -failifempty $false
+$LogBlocked = Get-AnsibleParam -obj $params -name "logblocked" -validateset 'true','false','notconfigured' -failifempty $false
+$LogIgnored = Get-AnsibleParam -obj $params -name "logignored" -validateset 'true','false','notconfigured' -failifempty $false
+#$DisabledInterfaceAliases = $null
+#$PolicyStore = $null
+
+# Firewall Options hashtable
+$NetFirewallProfile =
+@([pscustomobject]@{option="DefaultInboundAction";value=$DefaultInboundAction;DataType="GpoBoolean"},
+[pscustomobject]@{option="DefaultOutboundAction";value=$DefaultOutboundAction;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowInboundRules";value=$AllowInboundRules;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowLocalFirewallRules";value=$AllowLocalFirewallRules;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowLocalIPsecRules";value=$AllowLocalIPsecRules;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowUserApps";value=$AllowUserApps;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowUserPorts";value=$AllowUserPorts;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowUnicastResponseToMulticast";value=$AllowUnicastResponseToMulticast;DataType="GpoBoolean"},
+[pscustomobject]@{option="NotifyOnListen";value=$NotifyOnListen;DataType="GpoBoolean"},
+[pscustomobject]@{option="EnableStealthModeForIPsec";value=$EnableStealthModeForIPsec;DataType="GpoBoolean"},
+[pscustomobject]@{option="LogFileName";value=$LogFileName;DataType="String"},
+[pscustomobject]@{option="LogMaxSizeKilobytes";value=$LogMaxSizeKilobytes;DataType="UInt64"},
+[pscustomobject]@{option="LogAllowed";value=$LogAllowed;DataType="GpoBoolean"},
+[pscustomobject]@{option="LogBlocked";value=$LogBlocked;DataType="GpoBoolean"},
+[pscustomobject]@{option="LogIgnored";value=$LogIgnored;DataType="String"},
+[pscustomobject]@{option="DisabledInterfaceAliases";value=$DisabledInterfaceAliases;DataType="String"},
+[pscustomobject]@{option="Enabled";value=$state;DataType="GpoBoolean"},
+[pscustomobject]@{option="PolicyStore";value=$PolicyStore;DataType="String"}
+)
+
+# Create hash table of required settings
+ $settings = $null
+ $settings = @{}
+
+ # Add String values to the settings hashtable
+  foreach ($option in $NetFirewallProfile | where {$_.value -ne $null -and $_.DataType -eq "String"}) {
+   $settings.Add("$($option.option)", "$($option.value)")
+    }
+
+# Add GPOBoolean values to the settings hashtable (really just strings in this case) should use [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetSecurity.GpoBoolean]
+  foreach ($option in $NetFirewallProfile | where {$_.value -ne $null -and $_.DataType -eq "GpoBoolean"}) {
+       if($option.value -eq 'enabled') {
+             $settings.Add("$($option.option)", "true")
+    } elseif($option.value -eq 'disabled') {
+             $settings.Add("$($option.option)", "false")
+    } else{
+              $settings.Add("$($option.option)", "$($option.value)")
+              }
+          }
+# Add uint64 values to the settings hashtable
+  foreach ($option in $NetFirewallProfile | where {$_.value -ne $null -and $_.DataType -eq "UInt64"}) {
+   $settings.Add("$($option.option)", ([uint64]::Parse($option.value)))
+    }
+
 $result = @{
     changed = $false
     profiles = $profiles
@@ -35,44 +100,55 @@ $result = @{
 }
 
 if ($PSVersionTable.PSVersion -lt [Version]"5.0") {
-    Fail-Json $result "win_firewall requires Windows Management Framework 5 or higher."
+     "win_firewall requires Windows Management Framework 5 or higher."
 }
 
 Try {
 
     ForEach ($profile in $firewall_profiles) {
+        # build hashtable to store only the settings that actually need changing based on Firewall Profile
+         $splat += @{
+              $profile = @{}
+                 }
 
-        $currentstate = (Get-NetFirewallProfile -Name $profile).Enabled
+        # Get current firewall profile state
+        $currentstate = (Get-NetFirewallProfile -Name $profile)
+        $changerequired = 0
+
         $result.$profile = @{
-            enabled = ($currentstate -eq 1)
             considered = ($profiles -contains $profile)
-            currentstate = $currentstate
+            currentstate = $currentstate.Enabled
+            changerequired = $changerequired
         }
 
-        if ($profiles -notcontains $profile) {
-            continue
-        }
+         ForEach ($name in $settings.Keys) {
+                  $result.$profile.add( "$($name)",(Get-Variable -name currentstate).value.$($name))
+                  if( (Get-Variable -name currentstate).value.$($name) -eq $settings.$name){
+                     "Already set"}
+                else{
+                     # Accumulate the settings that require changing
+                     $splat.$profile.add("$($name)",$settings.$name)
+                     # Flag a change is required
+                     $result.$profile.changerequired++ }
+           }
 
-        if ($state -eq 'enabled') {
+          # only action the firewall profiles requested
+          if ($profiles -notcontains $profile) {
+              continue
+              }
 
-            if ($currentstate -eq $false) {
-                Set-NetFirewallProfile -name $profile -Enabled true -WhatIf:$check_mode
-                $result.changed = $true
-                $result.$profile.enabled = $true
-            }
-
-        } else {
-
-            if ($currentstate -eq $true) {
-                Set-NetFirewallProfile -name $profile -Enabled false -WhatIf:$check_mode
-                $result.changed = $true
-                $result.$profile.enabled = $false
-            }
-
-        }
+                  if ($result.$profile.changerequired -ge '1'){
+                  $splat = $splat.$profile
+                      Set-NetFirewallProfile -name $profile @splat -WhatIf:$check_mode
+                      $result.changed = $true
+                      "Changed"
+                  } else {
+                  "No Change"
+                  }
     }
-} Catch {
-    Fail-Json $result "an error occurred when attempting to change firewall status for profile $profile $($_.Exception.Message)"
+
+      } Catch {
+                "an error occurred when attempting to change firewall status for profile $profile $($_.Exception.Message)"
 }
 
 Exit-Json $result

--- a/lib/ansible/modules/windows/win_firewall.ps1
+++ b/lib/ansible/modules/windows/win_firewall.ps1
@@ -44,8 +44,12 @@ $LogMaxSizeKilobytes = Get-AnsibleParam -obj $params -name "logmaxsizekilobytes"
 $LogAllowed = Get-AnsibleParam -obj $params -name "logallowed" -validateset 'true','false','notconfigured' -failifempty $false
 $LogBlocked = Get-AnsibleParam -obj $params -name "logblocked" -validateset 'true','false','notconfigured' -failifempty $false
 $LogIgnored = Get-AnsibleParam -obj $params -name "logignored" -validateset 'true','false','notconfigured' -failifempty $false
-#$DisabledInterfaceAliases = $null
-#$PolicyStore = $null
+
+# Check Windows Management Framework 5 or higher is installed
+if ($PSVersionTable.PSVersion -lt [Version]"5.0") {
+    Fail-Json $result "win_firewall requires Windows Management Framework 5 or higher."
+}
+
 
 # Firewall Options hashtable
 $NetFirewallProfile =
@@ -97,10 +101,6 @@ $result = @{
     changed = $false
     profiles = $profiles
     state = $state
-}
-
-if ($PSVersionTable.PSVersion -lt [Version]"5.0") {
-     "win_firewall requires Windows Management Framework 5 or higher."
 }
 
 Try {

--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# Copyright 2017, Jamie Thompson <jamiet@datacom.co.nz>
 # (c) 2017, Michael Eaton <meaton@iforium.com>
 #
 # This file is part of Ansible
@@ -21,7 +22,7 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
+ANSIBLE_METADATA = {'metadata_version': '1.2',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
@@ -47,6 +48,104 @@ options:
     choices:
     - enabled
     - disabled
+  defaultinboundaction:
+    description:
+    - Specifies how to filter inbound traffic.
+    choices:
+    - block
+    - allow
+    - notconfigured
+  defaultoutboundaction:
+    description:
+    - Specifies how to filter outbound traffic.
+    choices:
+    - block
+    - allow
+    - notconfigured
+  allowinboundrules:
+    description:
+    - Specifies that the firewall blocks inbound traffic.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowlocalfirewallrules:
+    description:
+    - Specifies that the local firewall rules should be merged into the effective policy along with Group Policy settings.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowlocalipsecrules:
+    description:
+    - Specifies that the local IPsec rules should be merged into the effective policy along with Group Policy settings.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowuserapps:
+    description:
+    - Specifies that the local IPsec rules should be merged into the effective policy along with Group Policy settings.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowuserports:
+    description:
+    - Determines how the Windows XP policy is applied to the newer Windows Firewall. Defines how to use the policy merge field for older operating systems.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowunicastresponsetomulticast:
+    description:
+    - Allows unicast responses to multi-cast traffic.
+    choices:
+    - true
+    - false
+    - notconfigured
+  notifyonlisten:
+    description:
+    - Allows the notification of listening for inbound connections by a service.
+    choices:
+    - true
+    - false
+    - notconfigured
+  enablestealthmodeforipsec:
+    description:
+    - Enables stealth mode for IPsec traffic.
+    choices:
+    - true
+    - false
+    - notconfigured
+  logfilename:
+    description:
+    - Specifies the path and filename of the file to which Windows Server writes log entries.
+    - '%windir%\system32\logfiles\firewall\pfirewall.log'
+  logmaxsizekilobytes:
+    description:
+    - Specifies the maximum file size of the log, in kilobytes. The acceptable values for this parameter are: 1 through 32767
+  logallowed:
+    description:
+    - Specifies how to log the allowed packets in the location specified by the LogFileName parameter.
+    choices:
+    - true
+    - false
+    - notconfigured
+  logblocked:
+    description:
+    - Specifies how to log the dropped packets in the location specified by the LogFileName parameter.
+    choices:
+    - true
+    - false
+    - notconfigured
+  logignored:
+    description:
+    - Specifies how to log the ignored packets in the location specified by the LogFileName parameter.
+    choices:
+    - true
+    - false
+    - notconfigured
 requirements:
   - This module requires Windows Management Framework 5 or later.
 author: Michael Eaton (@if-meaton)
@@ -68,6 +167,20 @@ EXAMPLES = r'''
     profiles:
     - Domain
   tags: disable_firewall
+
+- name: Apply Domain Firewall settings
+  win_firewall:
+    profiles: Domain
+    state: enabled
+    defaultinboundaction: block
+    defaultoutboundaction: allow
+    notifyonlisten: true
+    allowlocalfirewallrules: true
+    allowlocalipsecrules: true
+    logblocked: true
+    logallowed: true
+    logmaxsizekilobytes: 16364
+    logfilename: "%systemroot%\\system32\\logfiles\\firewall\\domainfw.log"
 '''
 
 RETURN = r'''
@@ -86,4 +199,9 @@ state:
     returned: always
     type: list
     sample: enabled
+msg:
+    description: Possible error message on failure
+    returned: failed
+    type: string
+    sample: "an error occurred when attempting to change firewall status for profile <profilename>"
 '''

--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -22,15 +22,15 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
-ANSIBLE_METADATA = {'metadata_version': '1.2',
+ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = r'''
 ---
 module: win_firewall
-version_added: '2.5'
 short_description: Enable or disable the Windows Firewall
+version_added: '2.4'
 description:
 - Enable or Disable Windows Firewall profiles.
 options:
@@ -55,6 +55,7 @@ options:
     - block
     - allow
     - notconfigured
+    version_added: '2.5'
   defaultoutboundaction:
     description:
     - Specifies how to filter outbound traffic.
@@ -62,6 +63,7 @@ options:
     - block
     - allow
     - notconfigured
+    version_added: '2.5'
   allowinboundrules:
     description:
     - Specifies that the firewall blocks inbound traffic.
@@ -69,6 +71,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   allowlocalfirewallrules:
     description:
     - Specifies that the local firewall rules should be merged into the effective policy along with Group Policy settings.
@@ -76,6 +79,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   allowlocalipsecrules:
     description:
     - Specifies that the local IPsec rules should be merged into the effective policy along with Group Policy settings.
@@ -83,6 +87,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   allowuserapps:
     description:
     - Specifies that the local IPsec rules should be merged into the effective policy along with Group Policy settings.
@@ -90,6 +95,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   allowuserports:
     description:
     - Determines how the Windows XP policy is applied to the newer Windows Firewall. Defines how to use the policy merge field for older operating systems.
@@ -97,6 +103,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   allowunicastresponsetomulticast:
     description:
     - Allows unicast responses to multi-cast traffic.
@@ -104,6 +111,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   notifyonlisten:
     description:
     - Allows the notification of listening for inbound connections by a service.
@@ -111,6 +119,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   enablestealthmodeforipsec:
     description:
     - Enables stealth mode for IPsec traffic.
@@ -118,13 +127,16 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   logfilename:
     description:
     - Specifies the path and filename of the file to which Windows Server writes log entries.
     - '%windir%\system32\logfiles\firewall\pfirewall.log'
+    version_added: '2.5'
   logmaxsizekilobytes:
     description:
     - Specifies the maximum file size of the log, in kilobytes. The acceptable values for this parameter are: 1 through 32767
+    version_added: '2.5'
   logallowed:
     description:
     - Specifies how to log the allowed packets in the location specified by the LogFileName parameter.
@@ -132,6 +144,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   logblocked:
     description:
     - Specifies how to log the dropped packets in the location specified by the LogFileName parameter.
@@ -139,6 +152,7 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
   logignored:
     description:
     - Specifies how to log the ignored packets in the location specified by the LogFileName parameter.
@@ -146,9 +160,10 @@ options:
     - true
     - false
     - notconfigured
+    version_added: '2.5'
 requirements:
   - This module requires Windows Management Framework 5 or later.
-author: Michael Eaton (@if-meaton)
+author: Michael Eaton (@if-meaton), Jamie Thompson
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -135,7 +135,8 @@ options:
     version_added: '2.5'
   logmaxsizekilobytes:
     description:
-    - Specifies the maximum file size of the log, in kilobytes. The acceptable values for this parameter are: 1 through 32767
+    - 'Specifies the maximum file size of the log, in kilobytes. The acceptable values for this parameter are: 1 through 32767.'
+    type: bool
     version_added: '2.5'
   logallowed:
     description:
@@ -163,7 +164,9 @@ options:
     version_added: '2.5'
 requirements:
   - This module requires Windows Management Framework 5 or later.
-author: Michael Eaton (@if-meaton), Jamie Thompson
+author:
+  - Michael Eaton (@if-meaton)
+  - Jamie Thompson
 '''
 
 EXAMPLES = r'''

--- a/lib/ansible/modules/windows/win_firewall.py
+++ b/lib/ansible/modules/windows/win_firewall.py
@@ -29,7 +29,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.2',
 DOCUMENTATION = r'''
 ---
 module: win_firewall
-version_added: '2.4'
+version_added: '2.5'
 short_description: Enable or disable the Windows Firewall
 description:
 - Enable or Disable Windows Firewall profiles.


### PR DESCRIPTION
##### SUMMARY
Added additional functionality to the win_firewall module:
Updated the module to use more of the PowerShell Set-NetFirewallProfile Parameters rather than just enable or disable by firewall profile. 

Extra parameters added:

- defaultinboundaction 
- defaultoutboundaction
-  allowinboundrules
- allowlocalfirewallrules
- allowlocalipsecrules
- allowuserapps
- allowuserports
- allowunicastresponsetomulticast
- notifyonlisten
- enablestealthmodeforipsec
- logfilename
- logmaxsizekilobytes
- logallowed
- logblocked
- logignored


<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
 win_firewall 

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.1.0
```


##### ADDITIONAL INFORMATION

Added extra functionally to the module to behave like the powershell Set-NetFirewallProfile cmdlet 


<!--- Paste verbatim command output below, e.g. before and after your change -->
```
#!powershell		 #!powershell
 # This file is part of Ansible		 # This file is part of Ansible
 		 
+# Copyright 2017, Jamie Thompson <jamiet@datacom.co.nz>
 # Copyright 2017, Michael Eaton <meaton@iforium.com>		 # Copyright 2017, Michael Eaton <meaton@iforium.com>
 #		 #
 # Ansible is free software: you can redistribute it and/or modify		 # Ansible is free software: you can redistribute it and/or modify
 @@ -28,51 +29,126 @@ $check_mode = Get-AnsibleParam -obj $params -name "_ansible_check_mode" -type "b
 $profiles = Get-AnsibleParam -obj $params -name "profiles" -type "list" -default @("Domain", "Private", "Public")		 $profiles = Get-AnsibleParam -obj $params -name "profiles" -type "list" -default @("Domain", "Private", "Public")
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -failifempty $true -validateset 'disabled','enabled'		 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -failifempty $true -validateset 'disabled','enabled'
 		 
+$DefaultInboundAction = Get-AnsibleParam -obj $params -name "defaultinboundaction" -validateset 'block','allow','notconfigured' -failifempty $false
+$DefaultOutboundAction = Get-AnsibleParam -obj $params -name "defaultoutboundaction" -validateset 'block','allow','notconfigured' -failifempty $false
+$AllowInboundRules = Get-AnsibleParam -obj $params -name "allowinboundrules" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowLocalFirewallRules = Get-AnsibleParam -obj $params -name "allowlocalfirewallrules" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowLocalIPsecRules = Get-AnsibleParam -obj $params -name "allowlocalipsecrules" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowUserApps = Get-AnsibleParam -obj $params -name "allowuserapps" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowUserPorts = Get-AnsibleParam -obj $params -name "allowuserports" -validateset 'true','false','notconfigured' -failifempty $false
+$AllowUnicastResponseToMulticast = Get-AnsibleParam -obj $params -name "allowunicastresponsetomulticast" -validateset 'true','false','notconfigured' -failifempty $false
+$NotifyOnListen = Get-AnsibleParam -obj $params -name "notifyonlisten" -validateset 'true','false','notconfigured' -failifempty $false
+$EnableStealthModeForIPsec = Get-AnsibleParam -obj $params -name "enablestealthmodeforipsec" -validateset 'true','false','notconfigured' -failifempty $false
+$LogFileName = Get-AnsibleParam -obj $params -name "logfilename" -failifempty $false -type "str"
+$LogMaxSizeKilobytes = Get-AnsibleParam -obj $params -name "logmaxsizekilobytes" -failifempty $false
+$LogAllowed = Get-AnsibleParam -obj $params -name "logallowed" -validateset 'true','false','notconfigured' -failifempty $false
+$LogBlocked = Get-AnsibleParam -obj $params -name "logblocked" -validateset 'true','false','notconfigured' -failifempty $false
+$LogIgnored = Get-AnsibleParam -obj $params -name "logignored" -validateset 'true','false','notconfigured' -failifempty $false
+#$DisabledInterfaceAliases = $null
+#$PolicyStore = $null
+
+# Firewall Options hashtable
+$NetFirewallProfile =
+@([pscustomobject]@{option="DefaultInboundAction";value=$DefaultInboundAction;DataType="GpoBoolean"},
+[pscustomobject]@{option="DefaultOutboundAction";value=$DefaultOutboundAction;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowInboundRules";value=$AllowInboundRules;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowLocalFirewallRules";value=$AllowLocalFirewallRules;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowLocalIPsecRules";value=$AllowLocalIPsecRules;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowUserApps";value=$AllowUserApps;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowUserPorts";value=$AllowUserPorts;DataType="GpoBoolean"},
+[pscustomobject]@{option="AllowUnicastResponseToMulticast";value=$AllowUnicastResponseToMulticast;DataType="GpoBoolean"},
+[pscustomobject]@{option="NotifyOnListen";value=$NotifyOnListen;DataType="GpoBoolean"},
+[pscustomobject]@{option="EnableStealthModeForIPsec";value=$EnableStealthModeForIPsec;DataType="GpoBoolean"},
+[pscustomobject]@{option="LogFileName";value=$LogFileName;DataType="String"},
+[pscustomobject]@{option="LogMaxSizeKilobytes";value=$LogMaxSizeKilobytes;DataType="UInt64"},
+[pscustomobject]@{option="LogAllowed";value=$LogAllowed;DataType="GpoBoolean"},
+[pscustomobject]@{option="LogBlocked";value=$LogBlocked;DataType="GpoBoolean"},
+[pscustomobject]@{option="LogIgnored";value=$LogIgnored;DataType="String"},
+[pscustomobject]@{option="DisabledInterfaceAliases";value=$DisabledInterfaceAliases;DataType="String"},
+[pscustomobject]@{option="Enabled";value=$state;DataType="GpoBoolean"},
+[pscustomobject]@{option="PolicyStore";value=$PolicyStore;DataType="String"}
+)
+
+# Create hash table of required settings
+ $settings = $null
+ $settings = @{}
+
+ # Add String values to the settings hashtable
+  foreach ($option in $NetFirewallProfile | where {$_.value -ne $null -and $_.DataType -eq "String"}) {
+   $settings.Add("$($option.option)", "$($option.value)")
+    }
+
+# Add GPOBoolean values to the settings hashtable (really just strings in this case) should use [Microsoft.PowerShell.Cmdletization.GeneratedTypes.NetSecurity.GpoBoolean]
+  foreach ($option in $NetFirewallProfile | where {$_.value -ne $null -and $_.DataType -eq "GpoBoolean"}) {
+       if($option.value -eq 'enabled') {
+             $settings.Add("$($option.option)", "true")
+    } elseif($option.value -eq 'disabled') {
+             $settings.Add("$($option.option)", "false")
+    } else{
+              $settings.Add("$($option.option)", "$($option.value)")
+              }
+          }
+# Add uint64 values to the settings hashtable
+  foreach ($option in $NetFirewallProfile | where {$_.value -ne $null -and $_.DataType -eq "UInt64"}) {
+   $settings.Add("$($option.option)", ([uint64]::Parse($option.value)))
+    }
+
 $result = @{		 $result = @{
     changed = $false		     changed = $false
     profiles = $profiles		     profiles = $profiles
     state = $state		     state = $state
 }		 }
 		 
 if ($PSVersionTable.PSVersion -lt [Version]"5.0") {		 if ($PSVersionTable.PSVersion -lt [Version]"5.0") {
-    Fail-Json $result "win_firewall requires Windows Management Framework 5 or higher."		+     "win_firewall requires Windows Management Framework 5 or higher."
 }		 }
 		 
 Try {		 Try {
 		 
     ForEach ($profile in $firewall_profiles) {		     ForEach ($profile in $firewall_profiles) {
+        # build hashtable to store only the settings that actually need changing based on Firewall Profile
+         $splat += @{
+              $profile = @{}
+                 }
+
+        # Get current firewall profile state
+        $currentstate = (Get-NetFirewallProfile -Name $profile)
+        $changerequired = 0
 		 
-        $currentstate = (Get-NetFirewallProfile -Name $profile).Enabled		
         $result.$profile = @{		         $result.$profile = @{
-            enabled = ($currentstate -eq 1)		
             considered = ($profiles -contains $profile)		             considered = ($profiles -contains $profile)
-            currentstate = $currentstate		+            currentstate = $currentstate.Enabled
-        }		+            changerequired = $changerequired
-		
-        if ($profiles -notcontains $profile) {		
-            continue		
         }		         }
 		 
-        if ($state -eq 'enabled') {		+         ForEach ($name in $settings.Keys) {
-		+                  $result.$profile.add( "$($name)",(Get-Variable -name currentstate).value.$($name))
-            if ($currentstate -eq $false) {		+                  if( (Get-Variable -name currentstate).value.$($name) -eq $settings.$name){
-                Set-NetFirewallProfile -name $profile -Enabled true -WhatIf:$check_mode		+                     "Already set"}
-                $result.changed = $true		+                else{
-                $result.$profile.enabled = $true		+                     # Accumulate the settings that require changing
-            }		+                     $splat.$profile.add("$($name)",$settings.$name)
-		+                     # Flag a change is required
-        } else {		+                     $result.$profile.changerequired++ }
-		+           }
-            if ($currentstate -eq $true) {		+
-                Set-NetFirewallProfile -name $profile -Enabled false -WhatIf:$check_mode		+          # only action the firewall profiles requested
-                $result.changed = $true		+          if ($profiles -notcontains $profile) {
-                $result.$profile.enabled = $false		+              continue
-            }		+              }
-		+
-        }		+                  if ($result.$profile.changerequired -ge '1'){
+                  $splat = $splat.$profile
+                      Set-NetFirewallProfile -name $profile @splat -WhatIf:$check_mode
+                      $result.changed = $true
+                      "Changed"
+                  } else {
+                  "No Change"
+                  }
     }		     }
-} Catch {		+
-    Fail-Json $result "an error occurred when attempting to change firewall status for profile $profile $($_.Exception.Message)"		+      } Catch {
+                "an error occurred when attempting to change firewall status for profile $profile $($_.Exception.Message)"
 }		 }
 		 
 Exit-Json $result		 Exit-Json $result
View   
120  lib/ansible/modules/windows/win_firewall.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python		 #!/usr/bin/python
 # -*- coding: utf-8 -*-		 # -*- coding: utf-8 -*-
 		 
+# Copyright 2017, Jamie Thompson <jamiet@datacom.co.nz>
 # (c) 2017, Michael Eaton <meaton@iforium.com>		 # (c) 2017, Michael Eaton <meaton@iforium.com>
 #		 #
 # This file is part of Ansible		 # This file is part of Ansible
 @@ -21,7 +22,7 @@
 # this is a windows documentation stub.  actual code lives in the .ps1		 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name		 # file of the same name
 		 
-ANSIBLE_METADATA = {'metadata_version': '1.1',		+ANSIBLE_METADATA = {'metadata_version': '1.2',
                     'status': ['preview'],		                     'status': ['preview'],
                     'supported_by': 'community'}		                     'supported_by': 'community'}
 		 
 @@ -47,6 +48,104 @@
     choices:		     choices:
     - enabled		     - enabled
     - disabled		     - disabled
+  defaultinboundaction:
+    description:
+    - Specifies how to filter inbound traffic.
+    choices:
+    - block
+    - allow
+    - notconfigured
+  defaultoutboundaction:
+    description:
+    - Specifies how to filter outbound traffic.
+    choices:
+    - block
+    - allow
+    - notconfigured
+  allowinboundrules:
+    description:
+    - Specifies that the firewall blocks inbound traffic.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowlocalfirewallrules:
+    description:
+    - Specifies that the local firewall rules should be merged into the effective policy along with Group Policy settings.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowlocalipsecrules:
+    description:
+    - Specifies that the local IPsec rules should be merged into the effective policy along with Group Policy settings.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowuserapps:
+    description:
+    - Specifies that the local IPsec rules should be merged into the effective policy along with Group Policy settings.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowuserports:
+    description:
+    - Determines how the Windows XP policy is applied to the newer Windows Firewall. Defines how to use the policy merge field for older operating systems.
+    choices:
+    - true
+    - false
+    - notconfigured
+  allowunicastresponsetomulticast:
+    description:
+    - Allows unicast responses to multi-cast traffic.
+    choices:
+    - true
+    - false
+    - notconfigured
+  notifyonlisten:
+    description:
+    - Allows the notification of listening for inbound connections by a service.
+    choices:
+    - true
+    - false
+    - notconfigured
+  enablestealthmodeforipsec:
+    description:
+    - Enables stealth mode for IPsec traffic.
+    choices:
+    - true
+    - false
+    - notconfigured
+  logfilename:
+    description:
+    - Specifies the path and filename of the file to which Windows Server writes log entries.
+    - '%windir%\system32\logfiles\firewall\pfirewall.log'
+  logmaxsizekilobytes:
+    description:
+    - Specifies the maximum file size of the log, in kilobytes. The acceptable values for this parameter are: 1 through 32767
+  logallowed:
+    description:
+    - Specifies how to log the allowed packets in the location specified by the LogFileName parameter.
+    choices:
+    - true
+    - false
+    - notconfigured
+  logblocked:
+    description:
+    - Specifies how to log the dropped packets in the location specified by the LogFileName parameter.
+    choices:
+    - true
+    - false
+    - notconfigured
+  logignored:
+    description:
+    - Specifies how to log the ignored packets in the location specified by the LogFileName parameter.
+    choices:
+    - true
+    - false
+    - notconfigured
 requirements:		 requirements:
   - This module requires Windows Management Framework 5 or later.		   - This module requires Windows Management Framework 5 or later.
 author: Michael Eaton (@if-meaton)		 author: Michael Eaton (@if-meaton)
 @@ -68,6 +167,20 @@
     profiles:		     profiles:
     - Domain		     - Domain
   tags: disable_firewall		   tags: disable_firewall
+
+- name: Apply Domain Firewall settings
+  win_firewall:
+    profiles: Domain
+    state: enabled
+    defaultinboundaction: block
+    defaultoutboundaction: allow
+    notifyonlisten: true
+    allowlocalfirewallrules: true
+    allowlocalipsecrules: true
+    logblocked: true
+    logallowed: true
+    logmaxsizekilobytes: 16364
+    logfilename: "%systemroot%\\system32\\logfiles\\firewall\\domainfw.log"
 '''		 '''
 		 
 RETURN = r'''		 RETURN = r'''
 @@ -86,4 +199,9 @@
     returned: always		     returned: always
     type: list		     type: list
     sample: enabled		     sample: enabled
+msg:
+    description: Possible error message on failure
+    returned: failed
+    type: string
+    sample: "an error occurred when attempting to change firewall status for profile <profilename>"
```
