### PR TITLE
add new fact "goarch"

### DIFF
--- a/lib/ansible/module_utils/facts/system/platform.py
+++ b/lib/ansible/module_utils/facts/system/platform.py
@@ -14,6 +14,7 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 import re
@@ -90,5 +91,16 @@ class PlatformFactCollector(BaseFactCollector):
         if machine_id:
             machine_id = machine_id.splitlines()[0]
             platform_facts["machine_id"] = machine_id
+
+        GOARCH_DICT = {
+            'x86_64': 'amd64',
+            'aarch64': 'arm64',
+            'i386': '386'
+        }
+
+        if platform_facts['architecture'] in GOARCH_DICT:
+            platform_facts['goarch'] = GOARCH_DICT[platform_facts['architecture']]
+        else:
+            platform_facts['goarch'] = platform_facts['architecture']
 
         return platform_facts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

`Golang` is widely used. The value of `GOARCH` is different from `ansible_architecture`. Currently `ansible` does not provide a way to get `GOARCH`, which is quite useful when deploying/downloading golang-related applications.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
Add new fact `ansible_goarch`

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->


