### PR TITLE
ovirt: Set no_log for storage connections

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_storage_connections.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_storage_connections.py
@@ -232,7 +232,7 @@ def main():
         nfs_timeout=dict(default=None, type='int'),
         nfs_retrans=dict(default=None, type='int'),
         mount_options=dict(default=None),
-        password=dict(default=None),
+        password=dict(default=None, no_log=True),
         username=dict(default=None),
         port=dict(default=None, type='int'),
         target=dict(default=None),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Set `no_log=true` for password in `ovirt_storage_connections` module.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_storage_connections
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
