### PR TITLE
icinga2_host: Don't set template attribute on modification, it's not permitted

### DIFF
--- a/lib/ansible/modules/monitoring/icinga2_host.py
+++ b/lib/ansible/modules/monitoring/icinga2_host.py
@@ -81,6 +81,7 @@ options:
   template:
     description:
       - The template used to define the host.
+      - Template cannot be modified after object creation.
     required: false
     default: None
   check_command:
@@ -294,7 +295,12 @@ def main():
         elif icinga.diff(name, data):
             if module.check_mode:
                 module.exit_json(changed=False, name=name, data=data)
+
+            # Template attribute is not allowed in modification
+            del data['attrs']['templates']
+
             ret = icinga.modify(name, data)
+
             if ret['code'] == 200:
                 changed = True
             else:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Icinga2 API doesn't permit to modify template attribute.
Added a notice about it in docs and drop template attribute in object dictionnary when modification happens.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
icinga2_host

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2.0
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

Here is the icinga2 error:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
failed: [PRVLINF8004 -> 172.23.15.82] (item=prvlinf8406) => {
    "changed": false,
    "item": "server02",
    "msg": {
        "code": 200,
        "data": {
            "results": [
                {
                    "code": 500.0,
                    "name": "server02",
                    "status": "Attribute 'templates' could not be set: Error: Attribute cannot be modified.

    \t(0) libbase.so.2.8.0: <unknown function> (+0xf8f37) [0x2b5f7d9b2f37]
    \t(1) libbase.so.2.8.0: <unknown function> (+0xf8ff7) [0x2b5f7d9b2ff7]
    \t(2) libbase.so.2.8.0: ********::ConfigObject::ModifyAttribute(********::String const&, ********::Value const&, bool) (+0xe54) [0x2b5f7d97a5a4]
    \t(3) libremote.so.2.8.0: ********::ModifyObjectHandler::HandleRequest(boost::intrusive_ptr<********::ApiUser> const&, ********::HttpRequest&, ********::HttpResponse&, boost::intrusive_ptr<********::Dictio
nary> const&) (+0x871) [0x2b5f7e25c991]
    \t(4) libremote.so.2.8.0: ********::HttpHandler::ProcessRequest(boost::intrusive_ptr<********::ApiUser> const&, ********::HttpRequest&, ********::HttpResponse&) (+0x5c2) [0x2b5f7e256082]
    \t(5) libremote.so.2.8.0: ********::HttpServerConnection::ProcessMessageAsync(********::HttpRequest&) (+0x577) [0x2b5f7e259057]
    \t(6) libbase.so.2.8.0: ********::WorkQueue::WorkerThreadProc() (+0x4f3) [0x2b5f7d93c163]
    \t(7) libboost_thread.so.1.55.0: <unknown function> (+0xdaea) [0x2b5f7ccffaea]
    \t(8) libpthread.so.0: <unknown function> (+0x8064) [0x2b5f7d6a5064]
    \t(9) libc.so.6: clone (+0x6d) [0x2b5f8011d62d]

    ",
                    "type": "Host"
                }
            ]

```
