### PR TITLE
apt_get: add warning for force_apt_get

### DIFF
--- a/lib/ansible/modules/packaging/os/apt.py
+++ b/lib/ansible/modules/packaging/os/apt.py
@@ -753,6 +753,12 @@ def upgrade(m, mode="yes", force=False, default_release=None,
     else:
         force_yes = ''
 
+    if apt_cmd is None:
+        if use_apt_get:
+            apt_cmd = APT_GET_CMD
+        else:
+            m.fail_json(msg="Unable to find APTITUDE in path. Please make sure "
+                            "to have APTITUDE in path or use 'force_apt_get=True'")
     apt_cmd_path = m.get_bin_path(apt_cmd, required=True)
 
     cmd = '%s -y %s %s %s %s' % (apt_cmd_path, dpkg_options,


### PR DESCRIPTION
##### SUMMARY
This fix adds strict check for package manager binary checking in given
path.

Fixes: #32940

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/packaging/os/apt.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```