### PR TITLE
route53_zone: fix the private zone creation example

### DIFF
--- a/lib/ansible/modules/cloud/amazon/route53_zone.py
+++ b/lib/ansible/modules/cloud/amazon/route53_zone.py
@@ -81,6 +81,7 @@ EXAMPLES = '''
     zone: devel.example.com
     state: present
     vpc_id: '{{ myvpc_id }}'
+    vpc_region: us-west-2
     comment: developer domain
 
 # more complex example


### PR DESCRIPTION
##### SUMMARY
Creating a private hosted zone requires both `vpc_id` as well as `vpc_region`

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`route53_zone`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```

