### PR TITLE
Bugfix for #17492: Do not prepend PWD when path is in form user@server:path or server:path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ rpm-build
 # Eclipse/PyDev stuff...
 .project
 .pydevproject
+.settings
 # PyCharm stuff...
 .idea
 #IntelliJ IDEA stuff..

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -32,8 +32,14 @@ class ActionModule(ActionBase):
 
     def _get_absolute_path(self, path):
         original_path = path
-
-        if path.startswith('rsync://'):
+        
+        #
+        # Check if we have a local relative path and do not process
+        # * remote paths (some.server.domain:/some/remote/path/...)
+        # * URLs (rsync://...)
+        # * local absolute paths (/some/local/path/...)
+        #
+        if ':' in path or path.startswith('/'):
             return path
 
         if self._task._role is not None:
@@ -73,8 +79,7 @@ class ActionModule(ActionBase):
         if host not in C.LOCALHOST:
             return self._format_rsync_rsh_target(host, path, user)
 
-        if ':' not in path and not path.startswith('/'):
-            path = self._get_absolute_path(path=path)
+        path = self._get_absolute_path(path=path)
         return path
 
     def _process_remote(self, task_args, host, path, user, port_matches_localhost_port):
@@ -103,8 +108,7 @@ class ActionModule(ActionBase):
                 task_args['_substitute_controller'] = True
             return self._format_rsync_rsh_target(host, path, user)
 
-        if ':' not in path and not path.startswith('/'):
-            path = self._get_absolute_path(path=path)
+        path = self._get_absolute_path(path=path)
         return path
 
     def _override_module_replaced_vars(self, task_vars):
@@ -349,10 +353,8 @@ class ActionModule(ActionBase):
         else:
             # Still need to munge paths (to account for roles) even if we aren't
             # copying files between hosts
-            if ':' not in src and not src.startswith('/'):
-                src = self._get_absolute_path(path=src)
-            if ':' not in dest and not dest.startswith('/'):
-                dest = self._get_absolute_path(path=dest)
+            src = self._get_absolute_path(path=src)
+            dest = self._get_absolute_path(path=dest)
 
         _tmp_args['src'] = src
         _tmp_args['dest'] = dest

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -32,7 +32,7 @@ class ActionModule(ActionBase):
 
     def _get_absolute_path(self, path):
         original_path = path
-        
+
         #
         # Check if we have a local relative path and do not process
         # * remote paths (some.server.domain:/some/remote/path/...)

--- a/lib/ansible/plugins/action/synchronize.py
+++ b/lib/ansible/plugins/action/synchronize.py
@@ -349,9 +349,9 @@ class ActionModule(ActionBase):
         else:
             # Still need to munge paths (to account for roles) even if we aren't
             # copying files between hosts
-            if not src.startswith('/'):
+            if ':' not in src and not src.startswith('/'):
                 src = self._get_absolute_path(path=src)
-            if not dest.startswith('/'):
+            if ':' not in dest and not dest.startswith('/'):
                 dest = self._get_absolute_path(path=dest)
 
         _tmp_args['src'] = src


### PR DESCRIPTION
##### SUMMARY
This fixes #17492. There are several instances where the _get_absolute_path function is called. This should only happen for relative paths on a local file system and hence
 * not for paths on a remote server
 * nor for absolute paths.
In some cases the code in the synchronize.py plugin would check for presence of a colon (path on remote server) and if the path starts with a slash forward (absolute path). In two cases the code would only check for absolute paths, but failed to check for remote paths. This results in ${PWD} getting prepended to the remote path leading to something like /path/to/PWD/user@server:/path/to/what/needs/to/be/synced. 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
synchronize plugin

##### ANSIBLE VERSION
```
ansible 2.4.2.0
```
##### ADDITIONAL INFORMATION
