### PR TITLE
Fixes #24864 installing plugin dependencies when "state=latest" or none

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -406,7 +406,7 @@ class JenkinsPlugin(object):
                 self.params['jenkins_home'],
                 self.params['name']))
 
-        if not self.is_installed and self.params['version'] is None:
+        if not self.is_installed and self.params['version'] in [None, 'latest']:
             if not self.module.check_mode:
                 # Install the plugin (with dependencies)
                 install_script = (


### PR DESCRIPTION
##### SUMMARY

The check for the `version=latest` was missing. The `state=latest` leads to an impossibility to have something, except the `version=latest`.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
jenkins_plugin

##### ANSIBLE VERSION
```
(venv) BR0kEN@Macintosh:~/ansible (issue-24864) $ ansible --version
ansible 2.5.0 (issue-24864 afcd305e9e) last updated 2017/12/18 23:40:33 (GMT +400)
  config file = None
  configured module search path = [u'/Users/BR0kEN/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/BR0kEN/ansible/lib/ansible
  executable location = /Users/BR0kEN/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
https://github.com/ansible/ansible/issues/24864