### PR TITLE
nmcli: Check dns4 param for None

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -556,7 +556,7 @@ class Nmcli(object):
         self.type = module.params['type']
         self.ip4 = module.params['ip4']
         self.gw4 = module.params['gw4']
-        self.dns4 = ' '.join(module.params['dns4'])
+        self.dns4 = ' '.join(module.params['dns4']) if module.params.get('dns4') else None
         self.ip6 = module.params['ip6']
         self.gw6 = module.params['gw6']
         self.dns6 = module.params['dns6']

--- a/test/units/modules/net_tools/test_nmcli.py
+++ b/test/units/modules/net_tools/test_nmcli.py
@@ -1,0 +1,25 @@
+# Copyright: (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+import json
+
+from ansible.modules.net_tools import nmcli
+
+pytestmark = pytest.mark.usefixtures('patch_ansible_module')
+
+TESTCASE = [
+    {'type': 'ethernet',
+     'conn_name': 'non_existent_nw_device',
+     'state': 'absent'}
+]
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE, indirect=['patch_ansible_module'])
+def test_failure(mocker, capfd):
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    out, err = capfd.readouterr()
+    results = json.loads(out)
+    assert not results['changed']


### PR DESCRIPTION
##### SUMMARY
This fix check dns4 parameter in nmcli module for None value.

Fixes: #34012

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/net_tools/nmcli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```