### PR TITLE
influxdb: make param database_name uncommon

### DIFF
--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -44,7 +44,6 @@ class InfluxDb():
             port=dict(default=8086, type='int'),
             username=dict(default='root', type='str'),
             password=dict(default='root', type='str', no_log=True),
-            database_name=dict(required=True, type='str'),
             ssl=dict(default=False, type='bool'),
             validate_certs=dict(default=True, type='bool'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/database/influxdb/influxdb_database.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_database.py
@@ -25,6 +25,10 @@ requirements:
     - "influxdb >= 0.9"
     - requests
 options:
+    database_name:
+        description:
+            - Name of the database.
+        required: true
     state:
         description:
             - Determines if the database should be created or destroyed.
@@ -107,6 +111,7 @@ def drop_database(module, client, database_name):
 def main():
     argument_spec = InfluxDb.influxdb_argument_spec()
     argument_spec.update(
+        database_name=dict(required=True, type='str'),
         state=dict(default='present', type='str', choices=['present', 'absent'])
     )
     module = AnsibleModule(

--- a/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_retention_policy.py
@@ -25,6 +25,10 @@ requirements:
     - "influxdb >= 0.9"
     - requests
 options:
+    database_name:
+        description:
+            - Name of the database.
+        required: true
     policy_name:
         description:
             - Name of the retention policy
@@ -165,6 +169,7 @@ def alter_retention_policy(module, client, retention_policy):
 def main():
     argument_spec = InfluxDb.influxdb_argument_spec()
     argument_spec.update(
+        database_name=dict(required=True, type='str'),
         policy_name=dict(required=True, type='str'),
         duration=dict(required=True, type='str'),
         replication=dict(required=True, type='int'),

--- a/lib/ansible/utils/module_docs_fragments/influxdb.py
+++ b/lib/ansible/utils/module_docs_fragments/influxdb.py
@@ -23,10 +23,6 @@ options:
     description:
     - The port on which InfluxDB server is listening
     default: 8086
-  database_name:
-    description:
-    - Name of the database.
-    required: true
   validate_certs:
     description:
     - If set to C(no), the SSL certificates will not be validated.


### PR DESCRIPTION
##### SUMMARY
remove param database_name from the common params because influxdb_user #31566 don't have this requirement.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
influxdb

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

/cc @Akasurde 