### PR TITLE
ce_file_copy: fix broken import

### DIFF
--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -38,26 +38,26 @@ options:
     local_file:
         description:
             - Path to local file. Local directory must exist.
-              The maximum length of local_file is 4096.
+              The maximum length of I(local_file) is C(4096).
         required: true
     remote_file:
         description:
             - Remote file path of the copy. Remote directories must exist.
               If omitted, the name of the local file will be used.
-              The maximum length of remote_file is 4096.
+              The maximum length of I(remote_file) is C(4096).
         required: false
         default: null
     file_system:
         description:
             - The remote file system of the device. If omitted,
-              devices that support a file_system parameter will use
+              devices that support a I(file_system) parameter will use
               their default values.
               File system indicates the storage medium and can be set to as follows,
-              1) 'flash:' is root directory of the flash memory on the master MPU.
-              2) 'slave#flash:' is root directory of the flash memory on the slave MPU.
+              1) C(flash) is root directory of the flash memory on the master MPU.
+              2) C(slave#flash) is root directory of the flash memory on the slave MPU.
                  If no slave MPU exists, this drive is unavailable.
-              3) 'chassis ID/slot number#flash:' is root directory of the flash memory on
-                 a device in a stack. For example, 1/5#flash indicates the flash memory
+              3) C(chassis ID/slot number#flash) is root directory of the flash memory on
+                 a device in a stack. For example, C(1/5#flash) indicates the flash memory
                  whose chassis ID is 1 and slot number is 5.
         required: false
         default: 'flash:'

--- a/lib/ansible/modules/network/cloudengine/ce_file_copy.py
+++ b/lib/ansible/modules/network/cloudengine/ce_file_copy.py
@@ -32,6 +32,8 @@ author:
 notes:
     - The feature must be enabled with feature scp-server.
     - If the file is already present, no transfer will take place.
+requirements:
+    - paramiko
 options:
     local_file:
         description:
@@ -111,9 +113,14 @@ import re
 import os
 import time
 from xml.etree import ElementTree
-import paramiko
 from ansible.module_utils.basic import get_exception, AnsibleModule
 from ansible.module_utils.network.cloudengine.ce import ce_argument_spec, run_commands, get_nc_config
+
+try:
+    import paramiko
+    HAS_PARAMIKO = True
+except ImportError:
+    HAS_PARAMIKO = False
 
 try:
     from scp import SCPClient
@@ -326,6 +333,10 @@ class FileCopy(object):
         if not HAS_SCP:
             self.module.fail_json(
                 msg="'Error: No scp package, please install it.'")
+
+        if not HAS_PARAMIKO:
+            self.module.fail_json(
+                msg="'Error: No paramiko package, please install it.'")
 
         if self.local_file and len(self.local_file) > 4096:
             self.module.fail_json(

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -11,7 +11,6 @@ lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py
 lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
-lib/ansible/modules/network/cloudengine/ce_file_copy.py
 lib/ansible/modules/network/ios/ios_static_route.py
 lib/ansible/modules/network/lenovo/cnos_backup.py
 lib/ansible/modules/network/lenovo/cnos_bgp.py


### PR DESCRIPTION
##### SUMMARY
`ce_file_copy` module:
- detect when `paramiko` is missing ([fix broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports))
- doc:
  - add `paramiko` in `requirements`
  - use [formatting functions](http://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#formatting-options)

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ce_file_copy

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 370a7ace4b) last updated 2017/12/18 19:43:24 (GMT +200)
```