### PR TITLE
gcdns_record: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/google/gcdns_record.py
+++ b/lib/ansible/modules/cloud/google/gcdns_record.py
@@ -319,8 +319,11 @@ try:
     from libcloud.dns.types import RecordDoesNotExistError
     from libcloud.dns.types import ZoneDoesNotExistError
     HAS_LIBCLOUD = True
+    # The libcloud Google Cloud DNS provider.
+    PROVIDER = Provider.GOOGLE
 except ImportError:
     HAS_LIBCLOUD = False
+    PROVIDER = None
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.gcdns import gcdns_connect
@@ -334,9 +337,6 @@ from ansible.module_utils.gcdns import gcdns_connect
 # v1 API. Earlier versions contained the beta v1 API, which has since been
 # deprecated and decommissioned.
 MINIMUM_LIBCLOUD_VERSION = '0.19.0'
-
-# The libcloud Google Cloud DNS provider.
-PROVIDER = Provider.GOOGLE
 
 # The records that libcloud's Google Cloud DNS provider supports.
 #

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -4,7 +4,6 @@ lib/ansible/modules/cloud/azure/azure.py
 lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
 lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
-lib/ansible/modules/cloud/google/gcdns_record.py
 lib/ansible/modules/cloud/google/gcdns_zone.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py
 lib/ansible/modules/cloud/webfaction/webfaction_db.py


### PR DESCRIPTION
##### SUMMARY
gcdns_record: [fix broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports):
```
$ ansible-test sanity --python 3.6 --test import
ERROR: lib/ansible/modules/cloud/google/gcdns_record.py:339:0: NameError: name 'Provider' is not defined
```

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gcdns_record

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 370a7ace4b) last updated 2017/12/18 19:43:24 (GMT +200)
```