### PR TITLE
Added icinga service module

### DIFF
--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -48,6 +48,10 @@ options:
   display_name:
     description:
       - The name used to display the service. If not set, then Icinga will use the value of I(name).
+  http_agent:
+    description:
+      - The http agent used
+    default: ansible-httpget
   force_basic_auth:
     description:
       - Httplib2, the library used by the uri module only sends authentication information when a webservice

--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -19,114 +19,180 @@ module: icinga2_service
 short_description: Manage a service for a host in Icinga2
 description:
    - "Add or remove a services to Icinga2 through the API"
-   - "( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )"
-version_added: "2.5"
+   - "See U(https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/)"
+   - "Many option defaults are controlled by the Icinga2 configuration."
+version_added: "2.6"
 author: "Jurgen Brand (@t794104)"
 options:
+  cascade:
+    description:
+      - This option controls behaviour when I(state) is C(absent) and the object is present. When set to C(true)
+        the object and all objects that depend on it are removed. When set to C(false), the icinga API will let
+        you know that the object cannot be removed, while there are dependent objects.
+    default: true
+    type: bool
+  check_command:
+    description:
+      - The command used to execute the service check
+    required: true
+  client_cert:
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, I(client_key) is not required.
+  client_key:
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If I(client_cert) contains both the certificate
+        and key, this option is not required.
+  display_name:
+    description:
+      - The name used to display the service. If not set, then Icinga will use the value of I(name).
+  force_basic_auth:
+    description:
+      - Httplib2, the library used by the uri module only sends authentication information when a webservice
+        responds to an initial request with a C(401) status. Since some basic auth services do not properly
+        send a C(401), logins will fail. This option forces the sending of the Basic authentication header
+        upon initial request.
+    default: no
+    type: bool
+  force_check:
+    description:
+      - Force a check when a service is created or modified
+    type: bool
+    default: yes
+  host:
+    description:
+      - The name of the host the service is associated to.
+      - If used, must be paired with I(service).
+      - Mutually exclusive with I(name).
+  name:
+    description:
+      - Name of the service in Icinga2 style; C(host!service). Where C(host) is
+        an existing host.
+      - Mutually exclusive with I(host) + I(service).
+  service:
+    description:
+      - The name of the service.
+      - If used, must be paired with I(host).
+      - Mutually exclusive with I(name).
+  state:
+    description:
+      - Apply feature state.
+    choices: [ "present", "absent" ]
+    default: present
+  template:
+    description:
+      - The template used to define the host
   url:
     description:
       - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
     required: true
+  url_password:
+    description:
+        - The password for use in HTTP basic authentication.
+        - If the I(url_username) option is not specified, the I(url_password) option will not be used.
+  url_username:
+    description:
+      - The username for use in HTTP basic authentication.
+      - This parameter can be used without I(url_password) for sites that allow empty passwords.
   use_proxy:
     description:
       - If C(no), it will not use a proxy, even if one is defined in
         an environment variable on the target hosts.
-    default: 'yes'
+    default: yes
     type: bool
   validate_certs:
     description:
       - If C(no), SSL certificates will not be validated. This should only be used
         on personally controlled sites using self-signed certificates.
-    default: 'yes'
+    default: yes
     type: bool
-  url_username:
+  max_check_attempts:
     description:
-      - The username for use in HTTP basic authentication.
-      - This parameter can be used without C(url_password) for sites that allow empty passwords.
-  url_password:
+      - The number of times a service is checked before changing into a hard state.
+    type: int
+  check_period:
     description:
-        - The password for use in HTTP basic authentication.
-        - If the C(url_username) parameter is not specified, the C(url_password) parameter will not be used.
-  force_basic_auth:
+      - The name of a time period which determines when this service should be checked.
+  check_timeout:
     description:
-      - httplib2, the library used by the uri module only sends authentication information when a webservice
-        responds to an initial request with a 401 status. Since some basic auth services do not properly
-        send a 401, logins will fail. This option forces the sending of the Basic authentication header
-        upon initial request.
-    default: 'no'
+      - Check command timeout in seconds. Overrides the CheckCommand’s timeout attribute.
+    type: int
+  check_interval:
+    description: 
+      - The check interval (in seconds). This interval is used for checks when the service is in a HARD state. 
+    type: int
+  retry_interval:
+    description:
+      - The retry interval (in seconds). This interval is used for checks when the service is in a SOFT state.
+    type: int
+  enable_notifications:
+    description:
+      - Whether notifications are enabled.
     type: bool
-  client_cert:
+  enable_active_checks:
     description:
-      - PEM formatted certificate chain file to be used for SSL client
-        authentication. This file can also include the key as well, and if
-        the key is included, C(client_key) is not required.
-  client_key:
+      - Whether active checks are enabled.
+    type: bool
+  enable_passive_checks:
     description:
-      - PEM formatted file that contains your private key to be used for SSL
-        client authentication. If C(client_cert) contains both the certificate
-        and key, this option is not required.
-  state:
+      - Whether passive checks are enabled.
+    type: bool
+  enable_event_handler:
     description:
-      - Apply feature state.
-    required: false
-    choices: [ "present", "absent" ]
-    default: present
-  name:
+       - Enables event handlers for this host.
+    type: bool
+  enable_flapping:
     description:
-      - Name of the service in Icinga2 style; <host>!<service>. Where <host> is
-        a existing host.
-      - Mutually exclusive with host / service.
-    required: true
-  host:
+      - Enables Whether flap detection is enabled.
+    type: bool
+  enable_perfdata:
     description:
-      - The name of the host the service will be create for.
-      - If used, must be paired with service.
-      - Mutually exclusive with name.
-  service:
+      - Enables event handlers for this host.
+    type: bool
+  event_command:
     description:
-      - The name of the service.
-      - If used, must be paired with host.
-      - Mutually exclusive with name.
-  zone:
+      - The name of an event command that should be executed every time the service’s state changes or the service is in a SOFT state.
+  volatile:
     description:
-      - The zone from where this host should be polled.
-  template:
+      - The volatile setting enables always HARD state types if NOT-OK state changes occur. 
+    default: False
+    type: bool
+  command_endpoint:
     description:
-      - the template used to define the host
-    required: false
-    default: None
-  check_command:
+      - The endpoint where commands are executed on.
+  notes:
     description:
-      - the command used to check if the host is alive
-    required: false
-    default: "hostalive"
-  display_name:
+      - Notes for the host.
+  notes_url:
     description:
-      - the name used to display the service
-    required: false
-    default: if none is give it is the value of the <name> parameter
-  ip:
+      - URL for notes for the host (for example, in notification commands).
+  action_url:
     description:
-      - The IP address of the host.
-    required: true
-  force_check:
+      - URL for actions for the host (for example, an external graphing tool).
+  image_icon:
     description:
-      - Force a (re)check when a service is created or modified
-    required: false
-    default: Yes
+      -  Icon image for the host. Used by external interfaces only.
+  image_icon_alt:
+    description:
+      - Icon image description for the host. Used by external interface only.
   variables:
     description:
       - List of variables.
     required: false
-    default: None
+  zone:
+    description:
+      - The zone from where this host should be polled. If I(zone) is omitted, during creation of the object,
+        then the zone will be inherited from the engine that processes the API call.
 '''
 
 EXAMPLES = '''
 - name: Add a service to a host to icinga
-  icinga_host:
-    icinga_server: "icinga.example.com"
-    icinga_user: "anisble"
-    icinga_pass: "mypassword"
+  icinga2_service:
+    url: "https://icinga2.example.com"
+    url_username: "ansible"
+    url_password: "a_secret"
     state: present
     name: "{{ ansible_fqdn }}!nrpe"
     display_name: "NRPE"
@@ -135,10 +201,10 @@ EXAMPLES = '''
         nrpe_port: "5667"
 
 - name: Same service but with host/service
-  icinga_host:
-    icinga_server: "icinga.example.com"
-    icinga_user: "anisble"
-    icinga_pass: "mypassword"
+  icinga2_service:
+    url: "https://icinga2.example.com"
+    url_username: "ansible"
+    url_password: "a_secret"
     state: present
     host: "{{ ansible_fqdn }}"
     service: "nrpe"
@@ -161,9 +227,28 @@ data:
 
 import json
 import os
+import types
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url, url_argument_spec
+
+
+# ===========================================
+# Return a dict that is flat (no dict as values)
+#
+def flat_dict (aDict):
+  if type(aDict) is types.DictType:
+    flat = {}
+    for key, value in aDict.iteritems():
+       if type (value) is types.DictType:
+         ret = flat_dict (value)
+         for k, v in ret.iteritems():
+           flat[key+'.'+k] = v
+       else:
+         flat[key] = value
+    return flat
+  else:
+    return aDict
 
 
 # ===========================================
@@ -179,12 +264,16 @@ class icinga2_api:
         }
         url = self.module.params.get("url") + "/" + path
         rsp, info = fetch_url(module=self.module, url=url, data=data, headers=headers, method=method)
-        body = ''
-        if rsp:
+        # catching transport level code and body first
+        body = info['msg']
+        code = info['status']
+        if info['status'] <= 400:
+            # approved of transport level responses
             body = json.loads(rsp.read())
-        if info['status'] >= 400:
-            body = info['body']
-        return {'code': info['status'], 'data': body}
+            if method != 'GET':
+                # for POST and PUT there is a json code available for usage
+                code = body['results'][0]['code']
+        return {'code': int(code), 'data': body}
 
     def check_connection(self):
         ret = self.call_url('v1/status')
@@ -209,8 +298,11 @@ class icinga2_api:
         )
         return ret
 
-    def delete(self, service):
-        data = {"cascade": 1}
+    def delete(self, service, cascade):
+        if cascade:
+            data = {"cascade": 1}
+        else:
+            data = {"cascade": 0}
         ret = self.call_url(
             path="v1/objects/services/" + service,
             data=self.module.jsonify(data),
@@ -245,13 +337,19 @@ class icinga2_api:
             method="GET"
         )
         changed = False
-        ic_data = ret['data']['results'][0]
-        for key in data['attrs']:
-            if key not in ic_data['attrs'].keys():
+        ch_data={
+            'attrs': {}
+        }
+        ic_attr = flat_dict(ret['data']['results'][0]['attrs'])
+        an_attr = flat_dict(data['attrs'])
+        for key in an_attr:
+            if key not in ic_attr.keys():
                 changed = True
-            elif data['attrs'][key] != ic_data['attrs'][key]:
+                ch_data['attrs'][key] = an_attr[key]
+            elif an_attr[key] != ic_attr[key]:
                 changed = True
-        return changed
+                ch_data['attrs'][key] = an_attr[key]
+        return (changed, ch_data)
 
 
 # ===========================================
@@ -268,13 +366,33 @@ def main():
         name=dict(),
         host=dict(),
         service=dict(),
-        zone=dict(),
+        zone=dict(default=None),
         template=dict(default=None),
-        check_command=dict(default="hostalive"),
+        check_command=dict(required=True,default=None),
+        cascade=dict(default=True, type='bool'),
         display_name=dict(default=None),
-        command_endpoint=dict(default=""),
         force_check=dict(default=True, type='bool'),
         variables=dict(type='dict', default=None),
+        max_check_attempts=dict(default=None, type='int'),
+        check_period=dict(default=None),
+        check_timeout=dict(default=None, type='int'),
+        check_interval=dict(default=None, type='int'),
+        retry_interval=dict(default=None, type='int'),
+        enable_notifications=dict(default=None, type='bool'),
+        enable_active_checks=dict(default=None, type='bool'),
+        enable_passive_checks=dict(default=None, type='bool'),
+        enable_event_handler=dict(default=None, type='bool'),
+        enable_flapping=dict(default=None, type='bool'),
+        enable_perfdata=dict(default=None, type='bool'),
+        event_command=dict(default=None),
+        flapping_threshold=dict(default=None),
+        volatile=dict(default=False, type='bool'),
+        command_endpoint=dict(default=None),
+        notes=dict(default=None),
+        notes_url=dict(default=None),
+        action_url=dict(default=None),
+        image_icon=dict(default=None),
+        image_icon_alt=dict(default=None),
     )
 
     # Define the main module
@@ -293,15 +411,14 @@ def main():
         name = module.params["host"] + "!" + module.params["service"]
     else:
         name = module.params["name"]
-    zone = module.params["zone"]
     template = []
-    template.append(name)
     if module.params["template"]:
         template.append(module.params["template"])
     check_command = module.params["check_command"]
+    cascade=module.params["cascade"]
     command_endpoint = module.params["command_endpoint"]
-    display_name = module.params["display_name"]
     force_check = module.params["force_check"]
+    display_name = module.params["display_name"]
     if not display_name:
         display_name = name
     variables = module.params["variables"]
@@ -313,52 +430,61 @@ def main():
     except Exception as e:
         module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % (e))
 
+# Add attributes
     data = {
+        'templates': template,
         'attrs': {
             'check_command': check_command,
-            'command_endpoint': command_endpoint,
             'display_name': display_name,
-            'zone': zone,
             'vars': {
-                'made_by': "ansible",
-            },
-            'templates': template,
+                'made_by': 'Ansible'
+            }
         }
     }
-
+    #Loop through list of setable objects. 
+    obj_attrs = ['max_check_attempts', 'check_period', 'check_timeout', 'check_interval', 'retry_interval', 'enable_notifications', 'enable_active_checks', 
+              'enable_passive_checks', 'enable_event_handler', 'enable_flapping', 'enable_perfdata', 'event_command', 'flapping_threshold', 'volatile', 
+              'command_endpoint', 'notes', 'notes_url', 'action_url', 'image_icon', 'image_icon_alt' ]
+    for x in obj_attrs:
+        if module.params[x]:
+            data['attrs'][x]=module.params[x]
+        
     if variables:
         data['attrs']['vars'].update(variables)
 
+    data['attrs'] = flat_dict (data['attrs'])
     changed = False
     if icinga.exists(name):
+        diff, ch_data = icinga.diff(name, data)
         if state == "absent":
             if module.check_mode:
                 module.exit_json(changed=True, name=name, data=data)
             else:
                 try:
-                    ret = icinga.delete(name)
+                    ret = icinga.delete(name, cascade)
                     if ret['code'] == 200:
                         changed = True
                     else:
-                        module.fail_json(msg="bad return code deleting service: %s" % (ret['data']))
+                        module.fail_json(msg="Caught return code [%i] deleting service: %s" % (ret['code'],ret['data']))
                 except Exception as e:
                     module.fail_json(msg="exception deleting service: " + str(e))
-
-        elif icinga.diff(name, data):
+        elif diff:
             if module.check_mode:
-                module.exit_json(changed=False, name=name, data=data)
-            # ret = icinga.modify(name,data)
-            ret = icinga.delete(name)
-            ret = icinga.create(name, data)
-            if ret['code'] == 200:
-                changed = True
-                if force_check:
-                    ret = icinga.check(name)
-                    if ret['code'] != 200:
-                        module.fail_json(msg="bad return code checking service: %s" % (ret['data']))
+                module.exit_json(changed=False, name=name, data=ch_data)
             else:
-                module.fail_json(msg="bad return code modifying service: %s" % (ret['data']))
-
+                try:
+                    ret = icinga.modify(name, ch_data)
+                    if ret['code'] == 200:
+                        changed = True
+                        data = ch_data
+                        if force_check:
+                            ret = icinga.check(name)
+                            if ret['code'] != 200:
+                                module.fail_json(msg="Caught return code [%i] forcing service check: %s" % (ret['code'],ret['data']))
+                    else:
+                        module.fail_json(msg="Caught return code [%i] modifying service: %s" % (ret['code'],ret['data']))
+                except Exception as e:
+                    module.fail_json(msg="exception modifying service: " + str(e))
     else:
         if state == "present":
             if module.check_mode:
@@ -371,9 +497,9 @@ def main():
                         if force_check:
                             ret = icinga.check(name)
                             if ret['code'] != 200:
-                                module.fail_json(msg="bad return code checking service: %s" % (ret['data']))
+                                module.fail_json(msg="Caught return code [%i] forcing service check: %s" % (ret['code'],ret['data']))
                     else:
-                        module.fail_json(msg="bad return code creating service: %s" % (ret['data']))
+                        module.fail_json(msg="Caught return code [%i] creating service: %s" % (ret['code'],ret['data']))
                 except Exception as e:
                     module.fail_json(msg="exception creating service: " + str(e))
 

--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -111,22 +111,18 @@ options:
   max_check_attempts:
     description:
       - The number of times a service is checked before changing into a hard state.
-    type: integer
   check_period:
     description:
       - The name of a time period which determines when this service should be checked.
   check_timeout:
     description:
       - Check command timeout in seconds. Overrides the CheckCommand's timeout attribute.
-    type: integer
   check_interval:
     description:
       - The check interval (in seconds). This interval is used for checks when the service is in a HARD state.
-    type: integer
   retry_interval:
     description:
       - The retry interval (in seconds). This interval is used for checks when the service is in a SOFT state.
-    type: integer
   enable_notifications:
     description:
       - Whether notifications are enabled.
@@ -245,9 +241,9 @@ def flat_dict(aDict):
             if isinstance(value, dict):
                 ret = flat_dict(value)
                 for k, v in ret.items():
-                    flat[key+'.'+k]=v
+                    flat[key + '.' + k] = v
             else:
-                flat[key]=value
+                flat[key] = value
         return flat
     else:
         return aDict
@@ -445,8 +441,8 @@ def main():
     }
     # Loop through list of setable objects.
     obj_attrs = ['max_check_attempts', 'check_period', 'check_timeout', 'check_interval', 'retry_interval', 'enable_notifications', 'enable_active_checks',
-        'enable_passive_checks', 'enable_event_handler', 'enable_flapping', 'enable_perfdata', 'event_command', 'flapping_threshold', 'volatile',
-        'command_endpoint', 'notes', 'notes_url', 'action_url', 'image_icon', 'image_icon_alt']
+                 'enable_passive_checks', 'enable_event_handler', 'enable_flapping', 'enable_perfdata', 'event_command', 'flapping_threshold', 'volatile',
+                 'command_endpoint', 'notes', 'notes_url', 'action_url', 'image_icon', 'image_icon_alt']
     for x in obj_attrs:
         if module.params[x]:
             data['attrs'][x] = module.params[x]

--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -270,9 +270,9 @@ def main():
     )
 
     state = module.params["state"]
-    if module.params["host"]
+    if module.params["host"]:
       name = module.params["host"] + "!" + module.params["service"]
-    else
+    else:
       name = module.params["name"]
     zone = module.params["zone"]
     template = []

--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -79,11 +79,11 @@ options:
     required: true
   host:
     description:
-      - The name of the host the service will be create for. 
+      - The name of the host the service will be create for.
       - If used, must be paired with service.
       - Mutually exclusive with name.
   service:
-    descritpopn:
+    description:
       - The name of the service.
       - If used, must be paired with host.
       - Mutually exclusive with name.
@@ -194,7 +194,7 @@ class icinga2_api:
 
     def exists(self, service):
         ret = self.call_url(
-            path="v1/objects/services?service="+service,
+            path="v1/objects/services?service=" + service,
         )
         if ret['code'] == 200:
             if len(ret['data']['results']) == 1:
@@ -203,16 +203,16 @@ class icinga2_api:
 
     def create(self, service, data):
         ret = self.call_url(
-            path="v1/objects/services/"+ service,
+            path="v1/objects/services/" + service,
             data=self.module.jsonify(data),
             method="PUT"
         )
         return ret
 
     def delete(self, service):
-        data = { "cascade": 1 }
+        data = {"cascade": 1}
         ret = self.call_url(
-            path="v1/objects/services/"+ service,
+            path="v1/objects/services/" + service,
             data=self.module.jsonify(data),
             method="DELETE"
         )
@@ -220,18 +220,18 @@ class icinga2_api:
 
     def modify(self, service, data):
         ret = self.call_url(
-            path="v1/objects/services/"+ service,
+            path="v1/objects/services/" + service,
             data=self.module.jsonify(data),
             method="POST"
         )
         return ret
 
     def check(self, service):
-        data={
+        data = {
             "type": "Service",
             "filter": "service.__name==\"" + service + "\"",
             "force_check": True,
-        };
+        }
         ret = self.call_url(
             path="v1/actions/reschedule-check",
             data=self.module.jsonify(data),
@@ -290,9 +290,9 @@ def main():
 
     state = module.params["state"]
     if module.params["host"]:
-      name = module.params["host"] + "!" + module.params["service"]
+        name = module.params["host"] + "!" + module.params["service"]
     else:
-      name = module.params["name"]
+        name = module.params["name"]
     zone = module.params["zone"]
     template = []
     template.append(name)
@@ -347,7 +347,7 @@ def main():
         elif icinga.diff(name, data):
             if module.check_mode:
                 module.exit_json(changed=False, name=name, data=data)
-            #ret = icinga.modify(name,data)
+            # ret = icinga.modify(name,data)
             ret = icinga.delete(name)
             ret = icinga.create(name, data)
             if ret['code'] == 200:
@@ -357,7 +357,7 @@ def main():
                     if ret['code'] != 200:
                         module.fail_json(msg="bad return code checking service: %s" % (ret['data']))
             else:
-                module.fail_json(msg="bad return code modifying service: %s" % (ret['data']))        
+                module.fail_json(msg="bad return code modifying service: %s" % (ret['data']))
 
     else:
         if state == "present":

--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -241,7 +241,7 @@ class icinga2_api:
 
     def diff(self, service, data):
         ret = self.call_url(
-            path="v1/objects/services/"+ service,
+            path="v1/objects/services/" + service,
             method="GET"
         )
         changed = False

--- a/lib/ansible/modules/monitoring/icinga2_service.py
+++ b/lib/ansible/modules/monitoring/icinga2_service.py
@@ -1,0 +1,344 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: icinga2_service
+short_description: Manage a service fot a host in Icinga2
+description:
+   - "Add or remove a services to Icinga2 through the API"
+   - "( see https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/ )"
+version_added: "2.5"
+author: "Jurgen Brand"
+options:
+  url:
+    description:
+      - HTTP, HTTPS, or FTP URL in the form (http|https|ftp)://[user[:pass]]@host.domain[:port]/path
+    required: true
+  force:
+    description:
+      - If C(yes) and C(dest) is not a directory, will download the file every
+        time and replace the file if the contents change. If C(no), the file
+        will only be downloaded if the destination does not exist. Generally
+        should be C(yes) only for small local files.
+      - Prior to 0.6, this module behaved as if C(yes) was the default.
+    version_added: '0.7'
+    default: 'no'
+    type: bool
+    aliases: [ thirsty ]
+  use_proxy:
+    description:
+      - if C(no), it will not use a proxy, even if one is defined in
+        an environment variable on the target hosts.
+    default: 'yes'
+    type: bool
+  validate_certs:
+    description:
+      - If C(no), SSL certificates will not be validated. This should only be used
+        on personally controlled sites using self-signed certificates.
+    default: 'yes'
+    type: bool
+  url_username:
+    description:
+      - The username for use in HTTP basic authentication.
+      - This parameter can be used without C(url_password) for sites that allow empty passwords.
+    version_added: '1.6'
+  url_password:
+    description:
+        - The password for use in HTTP basic authentication.
+        - If the C(url_username) parameter is not specified, the C(url_password) parameter will not be used.
+    version_added: '1.6'
+  force_basic_auth:
+    version_added: '2.0'
+    description:
+      - httplib2, the library used by the uri module only sends authentication information when a webservice
+        responds to an initial request with a 401 status. Since some basic auth services do not properly
+        send a 401, logins will fail. This option forces the sending of the Basic authentication header
+        upon initial request.
+    default: 'no'
+    type: bool
+  client_cert:
+    description:
+      - PEM formatted certificate chain file to be used for SSL client
+        authentication. This file can also include the key as well, and if
+        the key is included, C(client_key) is not required.
+    version_added: '2.4'
+  client_key:
+    description:
+      - PEM formatted file that contains your private key to be used for SSL
+        client authentication. If C(client_cert) contains both the certificate
+        and key, this option is not required.
+    version_added: '2.4'
+  state:
+    description:
+      - Apply feature state.
+    required: false
+    choices: [ "present", "absent" ]
+    default: present
+  name:
+    description:
+      - name used to create / delete the host
+      - this does not need to be the FQDN, but does needs to be uniuqe
+    required: true
+    default: null
+  zone:
+    description:
+      - ??
+    required: false
+    default: None
+  template:
+    description:
+      - the template used to define the host
+    required: false
+    default: None
+  check_command:
+    description:
+      - the command used to check if the host is alive
+    required: false
+    default: "hostalive"
+  display_name:
+    description:
+      - the name used to display the host
+    required: false
+    default: <name>
+  ip:
+    description:
+      - the ip-addres of the host
+    required: true
+  variables:
+    description:
+      - list of variables
+    required: false
+    default: None
+'''
+
+EXAMPLES = '''
+- name: Add host to icinga
+  icinga_host:
+    icinga_server: "icinga.example.com"
+    icinga_user: "anisble"
+    icinga_pass: "mypassword"
+    state: present
+    name: "{{ ansible_fqdn }}!nrpe"
+    display_name: "NRPE"
+    check_command: "nrpe"
+    variables:
+        nrpe_port: "5667"
+'''
+
+RETURN = '''
+#
+'''
+
+import json
+import os
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.urls import fetch_url, url_argument_spec
+
+
+# ===========================================
+# Icinga2 API class
+#
+class icinga2_api:
+    module = None
+
+    def call_url(self, path, data='', method='GET'):
+        headers = {
+            'Accept': 'application/json',
+            'X-HTTP-Method-Override': method,
+        }
+        url = self.module.params.get("url") + "/" + path
+        rsp, info = fetch_url(module=self.module, url=url, data=data, headers=headers, method=method)
+        body = ''
+        if rsp:
+            body = json.loads(rsp.read())
+        if info['status'] >= 400:
+            body = info['body']
+        return {'code': info['status'], 'data': body}
+
+    def check_connection(self):
+        ret = self.call_url('v1/status')
+        if ret['code'] == 200:
+            return True
+        return False
+
+    def exists(self, service):
+        ret = self.call_url(
+            path="v1/objects/services?service="+service,
+        )
+        if ret['code'] == 200:
+            if len(ret['data']['results']) == 1:
+                return True
+        return False
+
+    def create(self, service, data):
+        ret = self.call_url(
+            path="v1/objects/services/"+ service,
+            data=self.module.jsonify(data),
+            method="PUT"
+        )
+        return ret
+
+    def delete(self, service):
+        data = { "cascade": 1 }
+        ret = self.call_url(
+            path="v1/objects/services/"+ service,
+            data=self.module.jsonify(data),
+            method="DELETE"
+        )
+        return ret
+
+    def modify(self, service, data):
+        ret = self.call_url(
+            path="v1/objects/services/"+ service,
+            data=self.module.jsonify(data),
+            method="POST"
+        )
+        return ret
+
+    def diff(self, service, data):
+        ret = self.call_url(
+            path="v1/objects/services/"+ service,
+            method="GET"
+        )
+        changed = False
+        ic_data = ret['data']['results'][0]
+        for key in data['attrs']:
+            if key not in ic_data['attrs'].keys():
+                changed = True
+            elif data['attrs'][key] != ic_data['attrs'][key]:
+                changed = True
+        return changed
+
+
+# ===========================================
+# Module execution.
+#
+def main():
+    # use the predefined argument spec for url
+    argument_spec = url_argument_spec()
+    # add our own arguments
+    argument_spec.update(
+        state=dict(default="present", choices=["absent", "present"]),
+        name=dict(required=True, aliases=['host']),
+        zone=dict(default=None),
+        template=dict(default=None),
+        check_command=dict(default="hostalive"),
+        display_name=dict(default=None),
+        command_endpoint=dict(default=""),
+        variables=dict(type='dict', default=None),
+    )
+
+    # Define the main module
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    state = module.params["state"]
+    name = module.params["name"]
+    zone = module.params["zone"]
+    template = []
+    template.append(name)
+    if module.params["template"]:
+        template.append(module.params["template"])
+    check_command = module.params["check_command"]
+    command_endpoint = module.params["command_endpoint"]
+    display_name = module.params["display_name"]
+    if not display_name:
+        display_name = name
+    variables = module.params["variables"]
+
+    try:
+        icinga = icinga2_api()
+        icinga.module = module
+        icinga.check_connection()
+    except Exception as e:
+        module.fail_json(msg="unable to connect to Icinga. Exception message: %s" % (e))
+
+    data = {
+        'attrs': {
+            'check_command': check_command,
+            'command_endpoint': command_endpoint,
+            'display_name': display_name,
+            'zone': zone,
+            'vars': {
+                'made_by': "ansible",
+            },
+            'templates': template,
+        }
+    }
+
+    if variables:
+        data['attrs']['vars'].update(variables)
+
+    changed = False
+    if icinga.exists(name):
+        if state == "absent":
+            if module.check_mode:
+                module.exit_json(changed=True, name=name, data=data)
+            else:
+                try:
+                    ret = icinga.delete(name)
+                    if ret['code'] == 200:
+                        changed = True
+                    else:
+                        module.fail_json(msg="bad return code deleting service: %s" % (ret['data']))
+                except Exception as e:
+                    module.fail_json(msg="exception deleting service: " + str(e))
+                module.exit_json(changed=changed, name=name, data=data)
+
+        elif icinga.diff(name, data):
+            if module.check_mode:
+                module.exit_json(changed=False, name=name, data=data)
+            #ret = icinga.modify(name,data)
+            ret = icinga.delete(name)
+            ret = icinga.create(name, data)
+            if ret['code'] == 200:
+                changed = True
+            else:
+                module.fail_json(msg="bad return code modifying service: %s" % (ret['data']))        
+
+        module.exit_json(changed=changed, name=name, data=data)
+
+    else:
+        if state == "present":
+            if module.check_mode:
+                changed = True
+            else:
+                try:
+                    ret = icinga.create(name, data)
+                    if ret['code'] == 200:
+                        changed = True
+                    else:
+                        module.fail_json(msg="bad return code creating service: %s" % (ret['data']))
+                except Exception as e:
+                    module.fail_json(msg="exception creating service: " + str(e))
+        elif icinga.diff(name, data):
+            if module.check_mode:
+                module.exit_json(changed=False, name=name, data=data)
+            #ret = icinga.modify(name,data)
+            ret = icinga.delete(name)
+            ret = icinga.create(name, data)
+            if ret['code'] == 200:
+                changed = True
+            else:
+                module.fail_json(msg="bad return code modifying service: %s" % (ret['data']))        
+
+        module.exit_json(changed=changed, name=name, data=data)
+
+
+# import module snippets
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
SUMMARY

This module (icinga2_service) allows the use of the Icinga2 REST API (https://www.icinga.com/docs/icinga2/latest/doc/12-icinga2-api/) to manage the services of a host in Icinga2.

ISSUE TYPE

    New Module Pull Request

COMPONENT NAME

    icinga2_service

ANSIBLE VERSION

    2.6.0

ADDITIONAL INFORMATION

modules done
 - icinga2_host (manage host to monitor)

modules to follow are
 - icinga2_service (manage services to monitor)

All 3 modules together will make it possible for a playbook to make sure the host(s) are monitored, they are down while running the playbook (no alarms are send) and manage the services that need to be monitored.

Please let me know if I can improve / help this along in any way.