### PR TITLE
lib/ansible/plugins/action/copy.py: Attend to potentially failing module calls

### DIFF
--- a/lib/ansible/plugins/action/copy.py
+++ b/lib/ansible/plugins/action/copy.py
@@ -190,7 +190,7 @@ class ActionModule(ActionBase):
 
     def _create_remote_file_args(self, module_args):
         # remove action plugin only keys
-        return dict((k, v) for k, v in module_args.items() if k not in ('content', 'decrypt'))
+        return dict((k, v) for k, v in module_args.items() if k not in ('content', 'decrypt', 'local_follow'))
 
     def _copy_file(self, source_full, source_rel, content, content_tempfile, dest, task_vars, tmp):
         decrypt = boolean(self._task.args.get('decrypt', True), strict=False)
@@ -504,6 +504,11 @@ class ActionModule(ActionBase):
             if 'diff' in result and not result['diff']:
                 del result['diff']
             module_executed = True
+
+            if module_return.get('failed'):
+                result.update(module_return)
+                return result
+
             changed = changed or module_return.get('changed', False)
 
         for src, dest_path in source_files['directories']:
@@ -520,6 +525,11 @@ class ActionModule(ActionBase):
 
             module_return = self._execute_module(module_name='file', module_args=new_module_args, task_vars=task_vars, tmp=tmp)
             module_executed = True
+
+            if module_return.get('failed'):
+                result.update(module_return)
+                return result
+
             changed = changed or module_return.get('changed', False)
 
         for target_path, dest_path in source_files['symlinks']:

--- a/test/integration/targets/copy/tasks/tests.yml
+++ b/test/integration/targets/copy/tasks/tests.yml
@@ -876,6 +876,27 @@
     state: absent
 
 #
+# recursive copy with invalid directory_mode (#33785)
+#
+- name: Test recursive copy with invalid directory_mode
+  copy:
+    src: subdir
+    dest: "{{ remote_subdir }}"
+    directory_mode: bogus
+  ignore_errors: True
+  register: recursive_copy_invalid_directory_mode_result
+
+- name: Assert that the recursive copy with invalid directory_mode fails
+  assert:
+    that:
+      - "recursive_copy_invalid_directory_mode_result.failed"
+
+- name: Cleanup the recursive copy subdir
+  file:
+    name: "{{ remote_subdir }}"
+    state: absent
+
+#
 # Recursive copy of tricky symlinks
 #
 - block:


### PR DESCRIPTION
##### SUMMARY
As stated in (#33785) when trying use a bogus `directory_mode`, the runtime behaviour is anything but what one would expect.
While #33785 is only the symptom, the actual cause are exceptions which are raised, but not handled properly and therefor become masked. 

The same kind of issue was already handled for the 'Copy symlinks over'-snippet, which is also why I aligned my changes to the very same way.

Fixes #33785

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
plugins/action/copy.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (fix_33785 ccae57bf86) last updated 2017/12/19 12:34:27 (GMT +200)
  config file = /Users/pringl/development/cm-infra/ansible.cfg
  configured module search path = [u'/Users/pringl/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/pringl/development/ansible/lib/ansible
  executable location = /Users/pringl/development/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 15 2017, 10:33:06) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
