### PR TITLE
Add support for intra-region VPC peering

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -320,7 +320,6 @@ def remove_peer_connection(client, module):
 
     try:
         params = dict()
-        params['DryRun'] = module.check_mode
         params['VpcPeeringConnectionId'] = pcx_id
         client.delete_vpc_peering_connection(**params)
         module.exit_json(changed=True)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -217,6 +217,8 @@ try:
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
+import distutils.version
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import boto3_conn, ec2_argument_spec, get_aws_connection_info, HAS_BOTO3
 
@@ -273,7 +275,12 @@ def create_peer_connection(client, module):
     params = dict()
     params['VpcId'] = module.params.get('vpc_id')
     params['PeerVpcId'] = module.params.get('peer_vpc_id')
-    params['PeerRegion'] = module.params.get('peer_region')
+    if module.params.get('peer_region'):
+        if distutils.version.StrictVersion(botocore.__version__) < distutils.version.StrictVersion('1.8.6'):
+            module.fail_json(msg="specifying peer_region parameter requires botocore >= 1.8.6")
+        params['PeerRegion'] = module.params.get('peer_region')
+
+
     if module.params.get('peer_owner_id'):
         params['PeerOwnerId'] = str(module.params.get('peer_owner_id'))
     params['DryRun'] = module.check_mode

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -279,8 +279,6 @@ def create_peer_connection(client, module):
         if distutils.version.StrictVersion(botocore.__version__) < distutils.version.StrictVersion('1.8.6'):
             module.fail_json(msg="specifying peer_region parameter requires botocore >= 1.8.6")
         params['PeerRegion'] = module.params.get('peer_region')
-
-
     if module.params.get('peer_owner_id'):
         params['PeerOwnerId'] = str(module.params.get('peer_owner_id'))
     params['DryRun'] = module.check_mode

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -299,8 +299,8 @@ def create_peer_connection(client, module):
 
 def remove_peer_connection(client, module):
     pcx_id = module.params.get('peering_id')
-    params = dict()
     if not pcx_id:
+        params = dict()
         params['VpcId'] = module.params.get('vpc_id')
         params['PeerVpcId'] = module.params.get('peer_vpc_id')
         params['PeerRegion'] = module.params.get('peer_region')
@@ -312,7 +312,10 @@ def remove_peer_connection(client, module):
             module.exit_json(changed=False)
         else:
             pcx_id = peering_conns['VpcPeeringConnections'][0]['VpcPeeringConnectionId']
+
     try:
+        params = dict()
+        params['DryRun'] = module.check_mode
         params['VpcPeeringConnectionId'] = pcx_id
         client.delete_vpc_peering_connection(**params)
         module.exit_json(changed=True)

--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_peer.py
@@ -31,6 +31,7 @@ options:
     description:
       - Region of the accepting VPC.
     required: false
+    version_added: '2.5'
   peer_vpc_id:
     description:
       - VPC id of the accepting VPC.


### PR DESCRIPTION
##### SUMMARY
AWS recently announced the ability to peer VPCs in different regions: https://aws.amazon.com/about-aws/whats-new/2017/11/announcing-support-for-inter-region-vpc-peering/

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ec2_vpc_peer

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = None
  configured module search path = [u'/Users/blamar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/blamar/Projects/om/automation/env/lib/python2.7/site-packages/ansible
  executable location = env/bin/ansible
  python version = 2.7.14 (default, Nov  5 2017, 10:57:53) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```


##### ADDITIONAL INFORMATION
This PR adds the ability to peer across regions -- however only a subset of regions are able to be paired currently.  If you attempt to peer regions which are not supported you will get a message similar to:

```
An error occurred (InvalidParameterValue) when calling the CreateVpcPeeringConnection operation: You cannot create a VPC peering connection between the sa-east-1 and us-west-2 regions.
```
