### PR TITLE
Python 3 doesn't have exception.message

### DIFF
--- a/lib/ansible/template/vars.py
+++ b/lib/ansible/template/vars.py
@@ -105,7 +105,10 @@ class AnsibleJ2Vars(Mapping):
             try:
                 value = self._templar.template(variable)
             except Exception as e:
-                raise type(e)(to_native(variable) + ': ' + e.message)
+                try:
+                    raise type(e)(to_native(variable) + ': ' + e.message)
+                except AttributeError:
+                    raise type(e)(to_native(variable) + ': ' + to_native(e))
             return value
 
     def add_locals(self, locals):


### PR DESCRIPTION
##### SUMMARY
Catch the AttributeError and use to_native(e) rather than e.message.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/template/vars.py

##### ANSIBLE VERSION
```
2.5.0
```