### PR TITLE
Link to the Galaxy platforms list from the meta file template

### DIFF
--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -30,8 +30,10 @@ galaxy_info:
   #github_branch:
 
   #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  # See the full list at https://galaxy.ansible.com/api/v1/platforms/.
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
   #
   # platforms:
   # - name: Fedora

--- a/lib/ansible/galaxy/data/container/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/container/meta/main.yml.j2
@@ -31,6 +31,7 @@ galaxy_info:
 
   #
   # platforms is a list of platforms, and each platform has a name and a list of versions.
+  # See the full list at https://galaxy.ansible.com/api/v1/platforms/.
   #
   # platforms:
   # - name: Fedora

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -30,8 +30,10 @@ galaxy_info:
   #github_branch:
 
   #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  # See the full list at https://galaxy.ansible.com/api/v1/platforms/.
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
   #
   # platforms:
   # - name: Fedora

--- a/lib/ansible/galaxy/data/default/meta/main.yml.j2
+++ b/lib/ansible/galaxy/data/default/meta/main.yml.j2
@@ -31,6 +31,7 @@ galaxy_info:
 
   #
   # platforms is a list of platforms, and each platform has a name and a list of versions.
+  # See the full list at https://galaxy.ansible.com/api/v1/platforms/.
   #
   # platforms:
   # - name: Fedora

--- a/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
+++ b/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
@@ -28,6 +28,7 @@ galaxy_info:
 
   #
   # platforms is a list of platforms, and each platform has a name and a list of versions.
+  # See the full list at https://galaxy.ansible.com/api/v1/platforms/.
   #
   # platforms:
   # - name: Fedora

--- a/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
+++ b/test/units/cli/test_data/role_skeleton/meta/main.yml.j2
@@ -27,8 +27,10 @@ galaxy_info:
   #github_branch:
 
   #
-  # platforms is a list of platforms, and each platform has a name and a list of versions.
-  # See the full list at https://galaxy.ansible.com/api/v1/platforms/.
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
   #
   # platforms:
   # - name: Fedora


### PR DESCRIPTION
##### SUMMARY

It's unclear what the supported values are from looking at the meta file or the documentation. This gives users a way to understand the different values, even if reading it from JSON output isn't ideal.

Fixes https://github.com/ansible/galaxy/issues/52.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
`ansible-galaxy init`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/aidanfeldman/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/var/pyenv/versions/2.7.11/lib/python2.7/site-packages/ansible
  executable location = /usr/local/var/pyenv/versions/2.7.11/bin/ansible
  python version = 2.7.11 (default, Feb  8 2016, 15:08:06) [GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)]
```


##### ADDITIONAL INFORMATION

Wouldn't be a bad idea to add this sentence to https://galaxy.ansible.com/intro#meta, but I couldn't figure out where to submit a pull request.
