### PR TITLE
cloud:ovirt:ovirt_vms.py:  Added 'quota_id','sso', 'boot_menu', 'usb_support', 'serial_console' fields to ovirt_vms module

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -835,7 +835,9 @@ class VmsModule(BaseModule):
             stateless=self.param('stateless') or self.param('use_latest_template_version'),
             delete_protected=self.param('delete_protected'),
             bios=(
-                otypes.Bios(boot_menu=otypes.BootMenu(enabled=True)) if self.param('boot_menu') is True else otypes.Bios(boot_menu=otypes.BootMenu(enabled=False))
+                otypes.Bios(boot_menu=otypes.BootMenu(enabled=True))
+                if self.param('boot_menu') is True
+                else otypes.Bios(boot_menu=otypes.BootMenu(enabled=False))
             ) if self.param('boot_menu') is not None else None,
             console=(
                 otypes.Console(enabled=True) if self.param('serial_console') is True else otypes.Console(enabled=False)

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -171,6 +171,10 @@ options:
             - Type of the Virtual Machine.
             - Default value is set by oVirt/RHV engine.
         choices: [ desktop, server ]
+    quota_id:
+        description:
+            - "Disk quota ID to be used for disk. By default quota is chosen by oVirt/RHV engine."
+        version_added: "2.5"
     operating_system:
         description:
             - Operating system of the Virtual Machine.
@@ -221,6 +225,22 @@ options:
             - List of boot devices which should be used to boot. For example C([ cdrom, hd ]).
             - Default value is set by oVirt/RHV engine.
         choices: [ cdrom, hd, network ]
+    boot_menu:
+        description:
+            - "I(True) enable menu to select boot device, I(False) to disable it. By default is chosen by oVirt/RHV engine."
+        version_added: "2.5"
+    usb_support:
+        description:
+            - "I(True) enable USB support, I(False) to disable it. By default is chosen by oVirt/RHV engine."
+        version_added: "2.5"
+    serial_console:
+        description:
+            - "I(True) enable VirtIO serial console, I(False) to disable it. By default is chosen by oVirt/RHV engine."
+        version_added: "2.5"
+    sso:
+        description:
+            - "I(True) enable Single Sign On by Guest Agent, I(False) to disable it. By default is chosen by oVirt/RHV engine."
+        version_added: "2.5"
     host:
         description:
             - Specify host where Virtual Machine should be running. By default the host is chosen by engine scheduler.
@@ -686,6 +706,18 @@ EXAMPLES = '''
   ovirt_vms:
     state: absent
     name: myvm
+    
+# Defining a specific quota for a VM:
+# Since Ansible 2.5
+- ovirt_quotas_facts:
+    data_center: Default
+    name: myquota
+- ovirt_vms:
+    sso: False
+    boot_menu: True
+    usb_support: True
+    serial_console: True
+    quota_id: "{{ ovirt_quotas[0]['id'] }}"
 '''
 
 
@@ -802,6 +834,19 @@ class VmsModule(BaseModule):
             use_latest_template_version=self.param('use_latest_template_version'),
             stateless=self.param('stateless') or self.param('use_latest_template_version'),
             delete_protected=self.param('delete_protected'),
+            bios=(
+                  otypes.Bios(boot_menu=otypes.BootMenu(enabled=True)) if self.param('boot_menu') is True else otypes.Bios(boot_menu=otypes.BootMenu(enabled=False))
+                  ) if self.param('boot_menu') is not None else None,
+            console=(
+                 otypes.Console(enabled=True) if self.param('serial_console') is True else otypes.Console(enabled=False)
+                 ) if self.param('serial_console') is not None else None,
+            usb=(
+                 otypes.Usb(enabled=True) if self.param('usb_support') is True else otypes.Usb(enabled=False)
+                 ) if self.param('usb_support') is not None else None,
+            sso=(
+                 otypes.Sso() if self.param('sso') is True else otypes.Sso(methods=[])
+                 ) if self.param('sso') is not None else None,
+            quota=otypes.Quota(id=self._module.params.get('quota_id')) if self.param('quota_id') is not None else None,            
             high_availability=otypes.HighAvailability(
                 enabled=self.param('high_availability')
             ) if self.param('high_availability') is not None else None,
@@ -871,6 +916,11 @@ class VmsModule(BaseModule):
             equal(self.param('cpu_threads'), entity.cpu.topology.threads) and
             equal(self.param('type'), str(entity.type)) and
             equal(self.param('operating_system'), str(entity.os.type)) and
+            equal(self.param('boot_menu'), entity.boot.boot_menu.enabled) and
+            equal(self.param('serial_console'), entity.console.enabled) and
+            equal(self.param('usb_support'), entity.usb.enabled) and
+            equal(self.param('sso'), True if entity.sso.methods else False) and
+            equal(self.param('quota_id'), getattr(entity.quota, 'id')) and
             equal(self.param('high_availability'), entity.high_availability.enabled) and
             equal(self.param('lease'), get_link_name(self._connection, getattr(entity.lease, 'storage_domain', None))) and
             equal(self.param('stateless'), entity.stateless) and
@@ -1457,6 +1507,11 @@ def main():
         lun_mappings=dict(default=[], type='list'),
         domain_mappings=dict(default=[], type='list'),
         reassign_bad_macs=dict(default=None, type='bool'),
+        boot_menu=dict(type='bool'),
+        serial_console=dict(type='bool'),
+        usb_support=dict(type='bool'),
+        sso=dict(type='bool'),
+        quota_id=dict(type='str'),
         high_availability=dict(type='bool'),
         lease=dict(type='str'),
         stateless=dict(type='bool'),

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -173,7 +173,7 @@ options:
         choices: [ desktop, server ]
     quota_id:
         description:
-            - "Disk quota ID to be used for disk. By default quota is chosen by oVirt/RHV engine."
+            - "Virtual Machine quota ID to be used for disk. By default quota is chosen by oVirt/RHV engine."
         version_added: "2.5"
     operating_system:
         description:
@@ -713,6 +713,7 @@ EXAMPLES = '''
     data_center: Default
     name: myquota
 - ovirt_vms:
+    name: myvm
     sso: False
     boot_menu: True
     usb_support: True
@@ -835,19 +836,19 @@ class VmsModule(BaseModule):
             stateless=self.param('stateless') or self.param('use_latest_template_version'),
             delete_protected=self.param('delete_protected'),
             bios=(
-                otypes.Bios(boot_menu=otypes.BootMenu(enabled=True))
-                if self.param('boot_menu') is True
-                else otypes.Bios(boot_menu=otypes.BootMenu(enabled=False))
+                otypes.Bios(boot_menu=otypes.BootMenu(enabled=self.param('boot_menu')))
             ) if self.param('boot_menu') is not None else None,
             console=(
-                otypes.Console(enabled=True) if self.param('serial_console') is True else otypes.Console(enabled=False)
+                otypes.Console(enabled=self.param('serial_console'))
             ) if self.param('serial_console') is not None else None,
             usb=(
-                otypes.Usb(enabled=True) if self.param('usb_support') is True else otypes.Usb(enabled=False)
+                otypes.Usb(enabled=self.param('usb_support'))
             ) if self.param('usb_support') is not None else None,
             sso=(
-                otypes.Sso() if self.param('sso') is True else otypes.Sso(methods=[])
-            ) if self.param('sso') is not None else None,
+                otypes.Sso(
+                    methods=[otypes.Method(id=otypes.SsoMethod.GUEST_AGENT)] if self.param('sso') else []
+                )
+            ),
             quota=otypes.Quota(id=self._module.params.get('quota_id')) if self.param('quota_id') is not None else None,
             high_availability=otypes.HighAvailability(
                 enabled=self.param('high_availability')

--- a/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_vms.py
@@ -706,7 +706,7 @@ EXAMPLES = '''
   ovirt_vms:
     state: absent
     name: myvm
-    
+
 # Defining a specific quota for a VM:
 # Since Ansible 2.5
 - ovirt_quotas_facts:
@@ -835,18 +835,18 @@ class VmsModule(BaseModule):
             stateless=self.param('stateless') or self.param('use_latest_template_version'),
             delete_protected=self.param('delete_protected'),
             bios=(
-                  otypes.Bios(boot_menu=otypes.BootMenu(enabled=True)) if self.param('boot_menu') is True else otypes.Bios(boot_menu=otypes.BootMenu(enabled=False))
-                  ) if self.param('boot_menu') is not None else None,
+                otypes.Bios(boot_menu=otypes.BootMenu(enabled=True)) if self.param('boot_menu') is True else otypes.Bios(boot_menu=otypes.BootMenu(enabled=False))
+            ) if self.param('boot_menu') is not None else None,
             console=(
-                 otypes.Console(enabled=True) if self.param('serial_console') is True else otypes.Console(enabled=False)
-                 ) if self.param('serial_console') is not None else None,
+                otypes.Console(enabled=True) if self.param('serial_console') is True else otypes.Console(enabled=False)
+            ) if self.param('serial_console') is not None else None,
             usb=(
-                 otypes.Usb(enabled=True) if self.param('usb_support') is True else otypes.Usb(enabled=False)
-                 ) if self.param('usb_support') is not None else None,
+                otypes.Usb(enabled=True) if self.param('usb_support') is True else otypes.Usb(enabled=False)
+            ) if self.param('usb_support') is not None else None,
             sso=(
-                 otypes.Sso() if self.param('sso') is True else otypes.Sso(methods=[])
-                 ) if self.param('sso') is not None else None,
-            quota=otypes.Quota(id=self._module.params.get('quota_id')) if self.param('quota_id') is not None else None,            
+                otypes.Sso() if self.param('sso') is True else otypes.Sso(methods=[])
+            ) if self.param('sso') is not None else None,
+            quota=otypes.Quota(id=self._module.params.get('quota_id')) if self.param('quota_id') is not None else None,
             high_availability=otypes.HighAvailability(
                 enabled=self.param('high_availability')
             ) if self.param('high_availability') is not None else None,


### PR DESCRIPTION
##### SUMMARY
- By adding a 'quota_id' parameter in the ovirt_vms module the administrator could now create VMs by assigning them to a specific quota instead of on the default one, this is very useful when the quota mode of ovirt cluster is set to enforced and every users (or group of) have a specific quota to use.

- By adding a 'sso' parameter in the ovirt_vms module the administrator could now specify if SSO should be enabled or disabled.

- By adding a 'boot_menu' parameter in the ovirt_vms module the administrator could now specify if the boot menu should be enabled or disabled.

- By adding a 'usb_support' parameter in the ovirt_vms module the administrator could now specify if the USB support should be enabled or disabled.

- By adding a 'serial_console' parameter in the ovirt_vms module the administrator could now specify if VirtIO serial console should be enabled or disabled.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
- lib/ansible/modules/cloud/ovirt/ovirt_vms.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel d859fdb3a6) last updated 2017/12/19 17:59:51 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/paolomargara/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/paolomargara/workspace-neon/ansible-mrg/lib/ansible
  executable location = /home/paolomargara/workspace-neon/ansible-mrg/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
Example: defining a specific quota for a VM
```
- ovirt_quotas_facts:
    data_center: Default
    name: myquota
- ovirt_vms:
    sso: False
    boot_menu: True
    usb_support: True
    serial_console: True
    quota_id: "{{ ovirt_quotas[0]['id'] }}"
```