### PR TITLE
K8s raw modules

### DIFF
--- a/lib/ansible/modules/clustering/k8s/_kubernetes.py
+++ b/lib/ansible/modules/clustering/k8s/_kubernetes.py
@@ -7,13 +7,14 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
+                    'status': ['deprecated'],
                     'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---
 module: kubernetes
 version_added: "2.1"
+deprecated: In 2.5 use M(k8s_raw) instead.
 short_description: Manage Kubernetes resources
 description:
     - This module can manage Kubernetes resources on an existing cluster using

--- a/lib/ansible/modules/clustering/k8s/k8s_raw.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_raw.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 
-module: k8s
+module: k8s_raw
 
 short_description: Manage Kubernetes (K8s) objects
 
@@ -38,14 +38,14 @@ requirements:
 
 EXAMPLES = '''
 - name: Create a k8s namespace
-  k8s:
+  k8s_raw:
     name: testing
     api_version: v1
     kind: Namespace
     state: present
 
 - name: Create a Service object from an inline definition
-  k8s:
+  k8s_raw:
     state: present
     definition:
       apiVersion: v1
@@ -67,12 +67,12 @@ EXAMPLES = '''
           port: 8000
 
 - name: Create a Service object by reading the definition from a file
-  k8s:
+  k8s_raw:
     state: present
     src: /testing/service.yml
 
 - name: Get an existing Service object
-  k8s:
+  k8s_raw:
     api_version: v1
     kind: Service
     name: web
@@ -80,14 +80,14 @@ EXAMPLES = '''
   register: web_service
 
 - name: Get a list of all service objects
-  k8s:
+  k8s_raw:
     api_version: v1
     kind: ServiceList
     namespace: testing
   register: service_list
 
 - name: Remove an existing Service object
-  k8s:
+  k8s_raw:
     state: absent
     api_version: v1
     kind: Service

--- a/lib/ansible/modules/clustering/openshift/_oc.py
+++ b/lib/ansible/modules/clustering/openshift/_oc.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {
     'metadata_version': '1.1',
-    'status': ['preview'],
+    'status': ['deprecated'],
     'supported_by': 'community'
 }
 
@@ -17,6 +17,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 author:
   - "Kenneth D. Evensen (@kevensen)"
+deprecated: In 2.5 use M(oc_raw) instead.
 description:
   - This module allows management of resources in an OpenShift cluster. The
     inventory host can be any host with network connectivity to the OpenShift

--- a/lib/ansible/modules/clustering/openshift/_oc.py
+++ b/lib/ansible/modules/clustering/openshift/_oc.py
@@ -17,7 +17,7 @@ ANSIBLE_METADATA = {
 DOCUMENTATION = """
 author:
   - "Kenneth D. Evensen (@kevensen)"
-deprecated: In 2.5 use M(oc_raw) instead.
+deprecated: In 2.5 use M(openshift_raw) instead.
 description:
   - This module allows management of resources in an OpenShift cluster. The
     inventory host can be any host with network connectivity to the OpenShift
@@ -246,7 +246,7 @@ class OC(object):
         return response, changed
 
     def exists(self, named_resource):
-        _, code = self.connect(named_resource.url(), 'get')
+        x, code = self.connect(named_resource.url(), 'get')
         if code == 200:
             return True
         return False
@@ -286,7 +286,7 @@ class OC(object):
     def replace(self, named_resource, check_mode):
         changed = False
 
-        existing_definition, _ = self.get(named_resource)
+        existing_definition, x = self.get(named_resource)
 
         new_definition, changed = self.merge(named_resource.definition,
                                              existing_definition,
@@ -345,7 +345,7 @@ class OC(object):
                 except AttributeError:
                     node = {}
                 finally:
-                    _, changed = self.merge(value, node, changed)
+                    x, changed = self.merge(value, node, changed)
 
             elif isinstance(value, list) and key in destination.keys():
                 if destination[key] != source[key]:

--- a/lib/ansible/modules/clustering/openshift/oc_raw.py
+++ b/lib/ansible/modules/clustering/openshift/oc_raw.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 
-module: openshift
+module: oc_raw.py 
 
 short_description: Manage OpenShift objects
 
@@ -37,7 +37,7 @@ requirements:
 
 EXAMPLES = '''
 - name: Create a project
-  openshift:
+  oc_raw:
     api_version: v1
     kind: Project
     name: testing
@@ -46,7 +46,7 @@ EXAMPLES = '''
     state: present
 
 - name: Create a Persistent Volume Claim from an inline definition
-  openshift:
+  oc_raw:
     state: present
     definition:
       apiVersion: v1
@@ -62,7 +62,7 @@ EXAMPLES = '''
         - ReadWriteOnce
 
 - name: Create a Deployment from an inline definition
-  openshift:
+  oc_raw:
     state: present
     definition:
       apiVersion: v1
@@ -96,19 +96,19 @@ EXAMPLES = '''
             type: Rolling
 
 - name: Create a Deployment by reading the definition from a file
-  openshift:
+  oc_raw:
     state: present
     src: /testing/deployment.yml
 
 - name: Get the list of all Deployments
-  openshift:
+  oc_raw:
     api_version: v1
     kind: DeploymentConfigList
     namespace: testing
   register: deployment_list
 
 - name: Remove an existing Deployment
-  openshift:
+  oc_raw:
     api_version: v1
     kind: DeploymentConfig
     name: elastic
@@ -116,7 +116,7 @@ EXAMPLES = '''
     state: absent
 
 - name: Create a Secret
-  openshift:
+  oc_raw:
     inline:
       apiVersion: v1
       kind: Secret
@@ -129,7 +129,7 @@ EXAMPLES = '''
         password: "{{ 'foobard' | b64encode }}"
 
 - name: Retrieve the Secret
-  openshift:
+  oc_raw:
     api: v1
     kind: Secret
     name: mysecret

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 
-module: oc_raw.py 
+module: openshift_raw.py 
 
 short_description: Manage OpenShift objects
 
@@ -37,7 +37,7 @@ requirements:
 
 EXAMPLES = '''
 - name: Create a project
-  oc_raw:
+  openshift_raw:
     api_version: v1
     kind: Project
     name: testing
@@ -46,7 +46,7 @@ EXAMPLES = '''
     state: present
 
 - name: Create a Persistent Volume Claim from an inline definition
-  oc_raw:
+  openshift_raw:
     state: present
     definition:
       apiVersion: v1
@@ -62,7 +62,7 @@ EXAMPLES = '''
         - ReadWriteOnce
 
 - name: Create a Deployment from an inline definition
-  oc_raw:
+  openshift_raw:
     state: present
     definition:
       apiVersion: v1
@@ -96,19 +96,19 @@ EXAMPLES = '''
             type: Rolling
 
 - name: Create a Deployment by reading the definition from a file
-  oc_raw:
+  openshift_raw:
     state: present
     src: /testing/deployment.yml
 
 - name: Get the list of all Deployments
-  oc_raw:
+  openshift_raw:
     api_version: v1
     kind: DeploymentConfigList
     namespace: testing
   register: deployment_list
 
 - name: Remove an existing Deployment
-  oc_raw:
+  openshift_raw:
     api_version: v1
     kind: DeploymentConfig
     name: elastic
@@ -116,7 +116,7 @@ EXAMPLES = '''
     state: absent
 
 - name: Create a Secret
-  oc_raw:
+  openshift_raw:
     inline:
       apiVersion: v1
       kind: Secret
@@ -129,7 +129,7 @@ EXAMPLES = '''
         password: "{{ 'foobard' | b64encode }}"
 
 - name: Retrieve the Secret
-  oc_raw:
+  openshift_raw:
     api: v1
     kind: Secret
     name: mysecret

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 
-module: openshift_raw.py
+module: openshift_raw
 
 short_description: Manage OpenShift objects
 

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 
 DOCUMENTATION = '''
 
-module: openshift_raw.py 
+module: openshift_raw.py
 
 short_description: Manage OpenShift objects
 


### PR DESCRIPTION
##### SUMMARY
Per core team discussion:

- Adds `clustering/openshift` modules directory
- Adds `clustering/k8s` modules directory 
- Deprecates existing `kubernetes` module
- Deprecates existing `oc` module
- Renames new `openshift` module to `openshift_raw`
- Renames new `k8s` module to `k8s_raw`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
See list above.

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/move_k8s_modules 4e56428dc8) last updated 2017/12/19 12:34:56 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/.pyenv/versions/venv27/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```