### PR TITLE
Use an appropriate regex to sanitize hostname.

### DIFF
--- a/contrib/inventory/ec2.ini
+++ b/contrib/inventory/ec2.ini
@@ -34,6 +34,7 @@ destination_variable = public_dns_name
 # This allows you to override the inventory_name with an ec2 variable, instead
 # of using the destination_variable above. Addressing (aka ansible_ssh_host)
 # will still use destination_variable. Tags should be written as 'tag_TAGNAME'.
+# Invalid characters in the tag or instance variable will be stripped.
 #hostname_variable = tag_Name
 
 # For server inside a VPC, using DNS names may not make sense. When an instance

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -927,14 +927,12 @@ class Ec2Inventory(object):
                 if name.endswith(self.route53_hostnames):
                     hostname = name
 
-        # If we can't get a nice hostname, use the destination address
-        if not hostname:
-            hostname = dest
-        # to_safe strips hostname characters like dots, so don't strip route53 hostnames
-        elif self.route53_enabled and self.route53_hostnames and hostname.endswith(self.route53_hostnames):
-            hostname = hostname.lower()
+        # If we have a hostname, sanitize it. If we can't
+        # get a nice hostname, use the destination address
+        if hostname:
+            hostname = re.sub('[^a-z0-9\-\.]+', '', hostname.lower())
         else:
-            hostname = self.to_safe(hostname).lower()
+            hostname = dest
 
         # if we only want to include hosts that match a pattern, skip those that don't
         if self.pattern_include and not self.pattern_include.match(hostname):

--- a/contrib/inventory/ec2.py
+++ b/contrib/inventory/ec2.py
@@ -930,7 +930,7 @@ class Ec2Inventory(object):
         # If we have a hostname, sanitize it. If we can't
         # get a nice hostname, use the destination address
         if hostname:
-            hostname = re.sub('[^a-z0-9\-\.]+', '', hostname.lower())
+            hostname = re.sub(r'[^a-z0-9\-\.]+', '', hostname.lower())
         else:
             hostname = dest
 


### PR DESCRIPTION
##### SUMMARY
Fixes #21167

When I tried to use an instance tag in ec2 containing the FQDN of my hosts as a custom hostname field in awx by setting the `hostname_variable = tag_Name` variable, my hostnames were mangled. I dug into the problem and found this block. 

Valid characters for FQDNs are `[a-z0-9\.\-]`. The `to_safe()` method replaces the valid characters `.` and `-` with the invalid character `_` which causes breakage.

My solution uses a corrected regex to sanitize hostname.


##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
contrib/inventory/ec2.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
N/A