### PR TITLE
Remove params option from examples

### DIFF
--- a/lib/ansible/modules/packaging/os/yum_repository.py
+++ b/lib/ansible/modules/packaging/os/yum_repository.py
@@ -431,25 +431,6 @@ EXAMPLES = '''
     name: epel
     file: external_repos
     state: absent
-
-#
-# Allow to overwrite the yum_repository parameters by defining the parameters
-# as a variable in the defaults or vars file:
-#
-# my_role_somerepo_params:
-#   # Disable GPG checking
-#   gpgcheck: no
-#   # Remove the gpgkey option
-#   gpgkey: null
-#
-- name: Add Some repo
-  yum_repository:
-    name: somerepo
-    description: Some YUM repo
-    baseurl: http://server.com/path/to/the/repo
-    gpgkey: http://server.com/keys/somerepo.pub
-    gpgcheck: yes
-    params: "{{ my_role_somerepo_params }}"
 '''
 
 RETURN = '''

--- a/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_plugin.py
@@ -164,16 +164,12 @@ EXAMPLES = '''
 #
 # Example of how to authenticate
 #
-# my_jenkins_params:
-#   url_username: admin
-#
 - name: Install plugin
   jenkins_plugin:
     name: build-pipeline-plugin
-    params: "{{ my_jenkins_params }}"
+    url_username: admin
     url_password: p4ssw0rd
     url: http://localhost:8888
-# Note that url_password **can not** be placed in params as params could end up in a log file
 
 #
 # Example of a Play which handles Jenkins restarts during the state changes


### PR DESCRIPTION
##### SUMMARY
We removed params for 2.5 from yum_repository and jenkins_plugin but there were still two places in documentation that referenced the option: in examples in each of the plugins.  This PR removes or modifies those to not use params.

##### ISSUE TYPE
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
yum_repository.py
jenkins_plugin.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```