### PR TITLE
Fixes some verbiage in the f5 docs

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -23,34 +23,32 @@ options:
   password:
     description:
       - The password for the user account used to connect to the BIG-IP.
-        This option can be omitted if the environment variable C(F5_PASSWORD)
+        You can omit this option if the environment variable C(F5_PASSWORD)
         is set.
     required: true
   server:
     description:
-      - The BIG-IP host. This option can be omitted if the environment
+      - The BIG-IP host. You can omit this option if the environment
         variable C(F5_SERVER) is set.
     required: true
   server_port:
     description:
-      - The BIG-IP server port. This option can be omitted if the environment
+      - The BIG-IP server port. You can omit this option if the environment
         variable C(F5_SERVER_PORT) is set.
-    required: false
     default: 443
     version_added: 2.2
   user:
     description:
       - The username to connect to the BIG-IP with. This user must have
-        administrative privileges on the device. This option can be omitted
+        administrative privileges on the device. You can omit this option
         if the environment variable C(F5_USER) is set.
     required: true
   validate_certs:
     description:
-      - If C(no), SSL certificates will not be validated. This should only be
-        used on personally controlled sites using self-signed certificates.
-        This option can be omitted if the environment variable
+      - If C(no), SSL certificates will not be validated. Use this only
+        on personally controlled sites using self-signed certificates.
+        You can omit this option if the environment variable
         C(F5_VALIDATE_CERTS) is set.
-    required: false
     default: yes
     choices:
       - yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
the doc writer on the f5 team is having a pep8-like tantrum.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
module doc fragment for f5 modules

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /here/test/integration/ansible.cfg
  configured module search path = [u'/here/library']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
