### PR TITLE
Change cow path selection variable from COWPATH to COW_PATH

### DIFF
--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -56,11 +56,11 @@ ANSIBLE_NOCOWS:
   - {key: nocows, section: defaults}
   type: boolean
   yaml: {key: display.i_am_no_fun}
-ANSIBLE_COWPATH:
+ANSIBLE_COW_PATH:
   name: Set path to cowsay command
   default: null
   description: Specify a custom cowsay path or swap in your cowsay implementation of choice
-  env: [{name: ANSIBLE_COWPATH}]
+  env: [{name: ANSIBLE_COW_PATH}]
   ini:
   - {key: cowpath, section: defaults}
   type: string

--- a/lib/ansible/utils/display.py
+++ b/lib/ansible/utils/display.py
@@ -101,8 +101,8 @@ class Display:
         if C.ANSIBLE_NOCOWS:
             return
 
-        if C.ANSIBLE_COWPATH:
-            self.b_cowsay = C.ANSIBLE_COWPATH
+        if C.ANSIBLE_COW_PATH:
+            self.b_cowsay = C.ANSIBLE_COW_PATH
         else:
             for b_cow_path in b_COW_PATHS:
                 if os.path.exists(b_cow_path):


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

For consistency with other cow-related options, such as
`ANSIBLE_COW_SELECTION`, add an underscore to the new `ANSIBLE_COWPATH`
option.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cowsay

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (cowpath-to-cow_path e6aa7e9c72) last updated 2017/12/19 15:49:01 (GMT -400)
  config file = None
  configured module search path = [u'/home/ryansb/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  executable location = /home/ryansb/.pyenv/versions/tmpenv-n0MYm5X6IDVqMB4/bin/ansible
  python version = 2.7.12 (default, Sep 27 2016, 18:08:33) [GCC 6.2.1 20160916 (Red Hat 6.2.1-2)]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
