### PR TITLE
VMware: Allow users to specify port for ESXi

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/vmware.py
+++ b/lib/ansible/utils/module_docs_fragments/vmware.py
@@ -41,4 +41,10 @@ options:
         required: False
         default: 'True'
         choices: ['True', 'False']
+    port:
+        description:
+            - The port number of the vSphere vCenter or ESXi server.
+        required: False
+        default: 443
+        version_added: 2.5
 '''


### PR DESCRIPTION
##### SUMMARY
This fix adds 'port' as module parameter in VMware modules,
which allows user to specify vCenter or ESXi server port number for
admin connection.

Fixes: #34070

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/module_utils/vmware.py
lib/ansible/utils/module_docs_fragments/vmware.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```