### PR TITLE
fix options output for bool type

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -119,7 +119,7 @@ Options
                 {# choices #}
                 <td>
                     <div class="cell-border">
-                        {% if value.type == 'boolean' %}
+                        {% if value.type == 'bool' %}
                             <ul>
                                 <li>yes</li>
                                 <li>no</li>


### PR DESCRIPTION
##### SUMMARY
Fix for the html output to show `yes` and `no` for the choices when `type: bool` is set on an option.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
docs

##### ANSIBLE VERSION
```
2.5
```