### PR TITLE
gcdns_zone: fix broken import

### DIFF
--- a/lib/ansible/modules/cloud/google/gcdns_zone.py
+++ b/lib/ansible/modules/cloud/google/gcdns_zone.py
@@ -26,7 +26,6 @@ description:
 version_added: "2.2"
 author: "William Albert (@walbert947)"
 requirements:
-    - "python >= 2.6"
     - "apache-libcloud >= 0.19.0"
 options:
     state:

--- a/lib/ansible/modules/cloud/google/gcdns_zone.py
+++ b/lib/ansible/modules/cloud/google/gcdns_zone.py
@@ -124,9 +124,12 @@ try:
     from libcloud.common.google import ResourceExistsError
     from libcloud.common.google import ResourceNotFoundError
     from libcloud.dns.types import Provider
+    # The libcloud Google Cloud DNS provider.
+    PROVIDER = Provider.GOOGLE
     HAS_LIBCLOUD = True
 except ImportError:
     HAS_LIBCLOUD = False
+    PROVIDER = None
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.gcdns import gcdns_connect
@@ -140,9 +143,6 @@ from ansible.module_utils.gcdns import gcdns_connect
 # v1 API. Earlier versions contained the beta v1 API, which has since been
 # deprecated and decommissioned.
 MINIMUM_LIBCLOUD_VERSION = '0.19.0'
-
-# The libcloud Google Cloud DNS provider.
-PROVIDER = Provider.GOOGLE
 
 # The URL used to verify ownership of a zone in Google Cloud DNS.
 ZONE_VERIFICATION_URL = 'https://www.google.com/webmasters/verification/'

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -4,7 +4,6 @@ lib/ansible/modules/cloud/azure/azure.py
 lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
 lib/ansible/modules/cloud/centurylink/clc_firewall_policy.py
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
-lib/ansible/modules/cloud/google/gcdns_zone.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py
 lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py


### PR DESCRIPTION
##### SUMMARY
- [fix broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports):
    ```
    $ ansible-test sanity --test import --python 3.6
    ERROR: lib/ansible/modules/cloud/google/gcdns_zone.py:145:0: NameError: name 'Provider' is not defined
    ```
- since Python `>= 2.6` is required on managed nodes, update requirements.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
gcdns_zone

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 78a14d7966) last updated 2017/12/20 09:09:08 (GMT +200)
```


##### ADDITIONAL INFORMATION
Same as #34024