### PR TITLE
freeipa: Refactor ipa_dnszone

### DIFF
--- a/lib/ansible/modules/identity/ipa/ipa_dnszone.py
+++ b/lib/ansible/modules/identity/ipa/ipa_dnszone.py
@@ -29,33 +29,7 @@ options:
     required: false
     default: present
     choices: ["present", "absent"]
-  ipa_port:
-    description: Port of IPA server
-    required: false
-    default: 443
-  ipa_host:
-    description: IP or hostname of IPA server
-    required: false
-    default: localhost
-  ipa_user:
-    description: Administrative account used on IPA server
-    required: false
-    default: admin
-  ipa_pass:
-    description: Password of administrative user
-    required: true
-  ipa_prot:
-    description: Protocol used by IPA server
-    required: false
-    default: https
-    choices: ["http", "https"]
-  validate_certs:
-    description:
-    - This only applies if C(ipa_prot) is I(https).
-    - If set to C(no), the SSL certificates will not be validated.
-    - This should only set to C(no) used on personally controlled sites using self-signed certificates.
-    required: false
-    default: true
+extends_documentation_fragment: ipa.documentation
 version_added: "2.5"
 '''
 
@@ -84,7 +58,7 @@ zone:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ipa import IPAClient
+from ansible.module_utils.ipa import IPAClient, ipa_argument_spec
 from ansible.module_utils._text import to_native
 
 
@@ -135,30 +109,14 @@ def ensure(module, client):
 
 
 def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            zone_name=dict(type='str', required=True),
-            ipa_prot=dict(
-                type='str',
-                default='https',
-                choices=['http', 'https']
-            ),
-            ipa_host=dict(
-                type='str',
-                default='localhost'
-            ),
-            state=dict(
-                type='str',
-                default='present',
-                choices=['present', 'absent']
-            ),
-            ipa_port=dict(type='int', default=443),
-            ipa_user=dict(type='str', default='admin'),
-            ipa_pass=dict(type='str', required=True, no_log=True),
-            validate_certs=dict(type='bool', default=True),
-        ),
-        supports_check_mode=True,
-    )
+    argument_spec = ipa_argument_spec()
+    argument_spec.update(zone_name=dict(type='str', required=True),
+                         state=dict(type='str', default='present', choices=['present', 'absent']),
+                         )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True,
+                           )
 
     client = DNSZoneIPAClient(
         module=module,


### PR DESCRIPTION

##### SUMMARY
Code refactoring of ipa_dnszone module
- use ipa_argument_spec
- use common documentation fragment

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/modules/identity/ipa/ipa_dnszone.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```