### PR TITLE
Encode xml data to utf8 standard

### DIFF
--- a/lib/ansible/modules/network/dellos10/dellos10_facts.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_facts.py
@@ -160,7 +160,7 @@ class Default(FactsBase):
     def populate(self):
         super(Default, self).populate()
         data = self.responses[0]
-        xml_data = ET.fromstring(data)
+        xml_data = ET.fromstring(data.encode('utf8'))
 
         self.facts['name'] = self.parse_name(xml_data)
         self.facts['version'] = self.parse_version(xml_data)
@@ -168,7 +168,7 @@ class Default(FactsBase):
         self.facts['hostname'] = self.parse_hostname(xml_data)
 
         data = self.responses[1]
-        xml_data = ET.fromstring(data)
+        xml_data = ET.fromstring(data.encode('utf8'))
 
         self.facts['servicetag'] = self.parse_servicetag(xml_data)
 
@@ -220,7 +220,7 @@ class Hardware(FactsBase):
         super(Hardware, self).populate()
         data = self.responses[0]
 
-        xml_data = ET.fromstring(data)
+        xml_data = ET.fromstring(data.encode('utf8'))
 
         self.facts['cpu_arch'] = self.parse_cpu_arch(xml_data)
 
@@ -277,7 +277,7 @@ class Interfaces(FactsBase):
         for line in int_show_data:
             if pattern in line:
                 if skip is False:
-                    xml_data = ET.fromstring(data)
+                    xml_data = ET.fromstring(data.encode('utf8'))
                     self.populate_interfaces(xml_data)
                     data = ''
                 else:
@@ -286,7 +286,7 @@ class Interfaces(FactsBase):
             data += line
 
         if skip is False:
-            xml_data = ET.fromstring(data)
+            xml_data = ET.fromstring(data.encode('utf8'))
             self.populate_interfaces(xml_data)
 
         self.facts['interfaces'] = self.intf_facts
@@ -299,7 +299,7 @@ class Interfaces(FactsBase):
         for line in lldp_data:
             if pattern in line:
                 if skip is False:
-                    xml_data = ET.fromstring(data)
+                    xml_data = ET.fromstring(data.encode('utf8'))
                     self.populate_neighbors(xml_data)
                     data = ''
                 else:
@@ -308,7 +308,7 @@ class Interfaces(FactsBase):
             data += line
 
         if skip is False:
-            xml_data = ET.fromstring(data)
+            xml_data = ET.fromstring(data.encode('utf8'))
             self.populate_neighbors(xml_data)
 
         self.facts['neighbors'] = self.lldp_facts


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
In dellos10, response of few CLI commands are in XML format. Parsing that XML data throws below error.

Error snippet:
"ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration."

Fix for the above error is to encode XML string data

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
 - modules/network/dellos10/dellos10_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
root:~/ansible/ansible-xml/ansible# ansible --version
ansible 2.5.0 (fix_encode_xml_string_devel c71b80e698) last updated 2017/12/20 04:18:59 (GMT -500)
  config file = /etc/ansible/ansible.cfg
  configured module search path =
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

This PR needs to be backported to older versions

Before change:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
TASK [dellos10_facts] *********************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.
fatal: [VLT-C-1]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_hb6LzP/ansible_module_dellos10_facts.py\", line 505, in <module>\n    main()\n  File \"/tmp/ansible_hb6LzP/ansible_module_dellos10_facts.py\", line 490, in main\n    inst.populate()\n  File \"/tmp/ansible_hb6LzP/ansible_module_dellos10_facts.py\", line 223, in populate\n    xml_data = ET.fromstring(data)\n  File \"src/lxml/lxml.etree.pyx\", line 3213, in lxml.etree.fromstring (src/lxml/lxml.etree.c:79010)\n  File \"src/lxml/parser.pxi\", line 1843, in lxml.etree._parseMemoryDocument (src/lxml/lxml.etree.c:118282)\nValueError: Unicode strings with encoding declaration are not supported. Please use bytes input or XML fragments without declaration.\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
        to retry, use: --limit @/root/ansible/vxlan/lothlorien/ansible-dellos-examples/getfacts_os10.retry

PLAY RECAP ********************************************************************************************
VLT-C-1                    : ok=0    changed=0    unreachable=0    failed=1
```
After Change:
```
PLAY RECAP ********************************************************************************************
VLT-C-1                    : ok=2    changed=0    unreachable=0    failed=0
```