### PR TITLE
Compact module descriptions

### DIFF
--- a/docs/templates/plugin.rst.j2
+++ b/docs/templates/plugin.rst.j2
@@ -166,7 +166,7 @@ Options
                             <div>@{ value.description | replace('\n', '\n    ') | html_ify }@</div>
                         {% else %}
                             {% for desc in value.description %}
-                                <p>@{ desc | replace('\n', '\n    ') | html_ify }@</p>
+                                <div>@{ desc | replace('\n', '\n    ') | html_ify }@</div>
                             {% endfor %}
                         {% endif %}
                         {% if 'aliases' in value and value.aliases %}


### PR DESCRIPTION
##### SUMMARY
Before this fix lists of `documentation:` were in individual <p> tags
causing a lot of whitespace on the rendered _module.html pages.

##### ISSUE TYPE
 - Docs Pull Request
