### PR TITLE
Added new merged module win_disk_facts to release 2.5 in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -214,6 +214,7 @@ Ansible Changes By Release
   * win_audit_rule
   * win_scheduled_task_stat
   * win_whoami
+  * win_disk_facts
 
 <a id="2.4.1"></a>
 


### PR DESCRIPTION
##### SUMMARY
New module win_disk_facts was merged in pull request #32935
This change here adds the new module to the ansible/CHANGELOG.md as a new module for ansible release 2.5 in section Windows.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_disk_facts and CHANGELOG.md

##### ANSIBLE VERSION
```
ansible 2.4.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
Not needed
