### PR TITLE
Temporary workaround for network integration tests

### DIFF
--- a/test/integration/targets/prepare_eos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_eos_tests/tasks/main.yml
@@ -4,8 +4,7 @@
       - no shutdown
       - no switchport
     parents: int Ethernet1
-  become: yes
-  connection: network_cli
+    provider: "{{ cli }}"
 
 - name: Enable Ethernet2 interface and disable switchport
   eos_config:
@@ -13,8 +12,7 @@
       - no shutdown
       - no switchport
     parents: int Ethernet2
-  become: yes
-  connection: network_cli
+    provider: "{{ cli }}"
 
 - name: enable eapi
   eos_eapi:
@@ -22,6 +20,5 @@
     https: yes
     local_http: no
     enable_socket: yes
-  become: yes
-  connection: network_cli
+    provider: "{{ cli }}"
   tags: eapi

--- a/test/integration/targets/prepare_ios_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_ios_tests/tasks/main.yml
@@ -3,8 +3,7 @@
 - name: Ensure we have loopback 888 for testing
   ios_config:
     src: config.j2
-  connection: network_cli
-  become: yes
+    provider: "{{ cli }}"
 
 # Some AWS hostnames can be longer than those allowed by the system we are testing
 # Truncate the hostname


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
`ansible_connection=local` gets pushed to `prepare_*`, which overrides `connection`

This can be reverted when versioned integration tests come in. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```