### PR TITLE
helpers: Typo fixed. Checking for import_tasks allowed for using loops on 'import_role' statements

### DIFF
--- a/lib/ansible/playbook/helpers.py
+++ b/lib/ansible/playbook/helpers.py
@@ -311,7 +311,7 @@ def load_list_of_tasks(ds, play, block=None, role=None, task_include=None, use_h
 
                 if is_static:
                     if ir.loop is not None:
-                        if 'import_tasks' in task_ds:
+                        if 'import_role' in task_ds:
                             raise AnsibleParserError("You cannot use loops on 'import_role' statements. You should use 'include_role' instead.", obj=task_ds)
                         else:
                             raise AnsibleParserError("You cannot use 'static' on an include_role with a loop", obj=task_ds)


### PR DESCRIPTION
##### SUMMARY
Condition wasn't checking what it should have.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
