### PR TITLE
archive: Add support for xz

### DIFF
--- a/test/integration/targets/archive/tasks/main.yml
+++ b/test/integration/targets/archive/tasks/main.yml
@@ -25,6 +25,44 @@
   apt: name=zip state=latest
   when: ansible_pkg_mgr == 'apt'
 
+- name: Install prerequisites for backports.lzma when using python2 (non OSX)
+  block:
+    - name: Set liblzma package name depending on the OS
+      set_fact:
+        liblzma_dev_package:
+          Debian: liblzma-dev
+          RedHat: xz-devel
+          Suse: xz-devel
+    - name: Ensure liblzma-dev is present to install backports-lzma
+      package: name={{ liblzma_dev_package[ansible_os_family] }} state=latest
+      when: ansible_os_family in liblzma_dev_package.keys()
+  when:
+    - ansible_python_version.split('.')[0] == '2'
+    - ansible_os_family != 'Darwin'
+
+- name: Install prerequisites for backports.lzma when using python2 (OSX)
+  block:
+    - name: Find brew binary
+      command: which brew
+      register: brew_which
+    - name: Get owner of brew binary
+      stat: path="{{ brew_which.stdout }}"
+      register: brew_stat
+    - name: "Install package"
+      homebrew:
+        name: xz
+        state: present
+        update_homebrew: no
+      become: yes
+      become_user: "{{ brew_stat.stat.pw_name }}"
+  when:
+    - ansible_python_version.split('.')[0] == '2'
+    - ansible_os_family == 'Darwin'
+
+- name: Ensure backports.lzma is present to create test archive (pip)
+  pip: name=backports.lzma state=latest
+  when: ansible_python_version.split('.')[0] == '2'
+
 - name: prep our file
   copy: src={{ item }} dest={{output_dir}}/{{ item }}
   with_items:
@@ -81,12 +119,31 @@
 - name: verify that the files archived
   file: path={{output_dir}}/archive_01.bz2 state=file
 
-- name: check if zip file exists
+- name: check if bzip file exists
   assert:
     that:
       - "{{ archive_bz2_result_01.changed }}"
       - "{{ 'archived' in archive_bz2_result_01 }}"
       - "{{ archive_bz2_result_01['archived'] | length }} == 2"
+
+- name: archive using xz
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/archive_01.xz"
+    format: xz
+  register: archive_xz_result_01
+
+- debug: msg="{{ archive_xz_result_01 }}"
+
+- name: verify that the files archived
+  file: path={{output_dir}}/archive_01.xz state=file
+
+- name: check if xz file exists
+  assert:
+    that:
+      - "{{ archive_xz_result_01.changed }}"
+      - "{{ 'archived' in archive_xz_result_01 }}"
+      - "{{ archive_xz_result_01['archived'] | length }} == 2"
 
 - name: archive and set mode to 0600
   archive:
@@ -164,6 +221,30 @@
 - name: remove our bz2
   file: path="{{ output_dir }}/archive_02.bz2" state=absent
 
+- name: archive and set mode to 0600
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/archive_02.xz"
+    format: xz
+    mode: "u+rwX,g-rwx,o-rwx"
+  register: archive_xz_result_02
+
+- name: Test that the file modes were changed
+  stat:
+    path: "{{ output_dir }}/archive_02.xz"
+  register: archive_02_xz_stat
+
+- name: Test that the file modes were changed
+  assert:
+    that:
+      - "archive_02_xz_stat.changed == False"
+      - "archive_02_xz_stat.stat.mode == '0600'"
+      - "'archived' in archive_xz_result_02"
+      - "{{ archive_xz_result_02['archived']| length}} == 2"
+
+- name: remove our xz
+  file: path="{{ output_dir }}/archive_02.xz" state=absent
+
 - name: test that gz archive that contains non-ascii filenames
   archive:
     path: "{{ output_dir }}/*.txt"
@@ -205,6 +286,27 @@
 
 - name: remove nonascii test
   file: path="{{ output_dir }}/test-archive-nonascii-くらとみ.bz2" state=absent
+
+- name: test that xz archive that contains non-ascii filenames
+  archive:
+    path: "{{ output_dir }}/*.txt"
+    dest: "{{ output_dir }}/test-archive-nonascii-くらとみ.xz"
+    format: xz
+  register: nonascii_result_1
+
+- name: Check that file is really there
+  stat:
+    path: "{{ output_dir }}/test-archive-nonascii-くらとみ.xz"
+  register: nonascii_stat_1
+
+- name: Assert that nonascii tests succeeded
+  assert:
+    that:
+      - "nonascii_result_1.changed == true"
+      - "nonascii_stat_1.stat.exists == true"
+
+- name: remove nonascii test
+  file: path="{{ output_dir }}/test-archive-nonascii-くらとみ.xz" state=absent
 
 - name: test that zip archive that contains non-ascii filenames
   archive:


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Implement support for xz format on archive module

Fixes #34037

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/files/archive.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (archive 526a4418dc) last updated 2017/12/20 14:02:50 (GMT -500)
  config file = None
  configured module search path = [u'/Users/albertom/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/albertom/github/ansible/lib/ansible
  executable location = /Users/albertom/github/ansible/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
