### PR TITLE
add VMware provider to ManageIQ module

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -37,7 +37,7 @@ options:
   type:
     description: The provider's type.
     required: true
-    choices: ['Openshift', 'Amazon', 'oVirt']
+    choices: ['Openshift', 'Amazon', 'oVirt', 'VMware']
   zone:
     description: The ManageIQ zone name that will manage the provider.
     required: false
@@ -46,6 +46,16 @@ options:
     description: The provider region name to connect to (e.g. AWS region for Amazon).
     required: false
     default: null
+  host_default_vnc_port_start:
+    required: false
+    default: null
+    description: The first port in the host VNC range. defaults to None.
+    version_added: "2.5"
+  host_default_vnc_port_end:
+    required: false
+    default: null
+    description: The last port in the host VNC range. defaults to None.
+    version_added: "2.5"
 
   provider:
     required: false
@@ -326,6 +336,22 @@ EXAMPLES = '''
       username: 'admin'
       password: 'password'
       verify_ssl: true
+
+- name: Create a new VMware provider in ManageIQ
+  manageiq_provider:
+    name: 'EngVMware'
+    type: 'VMware'
+    state: 'present'
+    provider:
+      hostname: 'vcenter.example.com'
+      host_default_vnc_port_start: 5800
+      host_default_vnc_port_end: 5801
+      userid: 'root'
+      password: 'password'
+    manageiq_connection:
+      url: 'https://127.0.0.1'
+      token: 'VeryLongToken'
+      verify_ssl: true
 '''
 
 RETURN = '''
@@ -349,6 +375,9 @@ def supported_providers():
         ),
         oVirt=dict(
             class_name='ManageIQ::Providers::Redhat::InfraManager',
+        ),
+        VMware=dict(
+            class_name='ManageIQ::Providers::Vmware::InfraManager',
         ),
     )
 
@@ -500,7 +529,8 @@ class ManageIQProvider(object):
 
         return dict(changed=True, msg=result['message'])
 
-    def edit_provider(self, provider, name, provider_type, endpoints, zone_id, provider_region):
+    def edit_provider(self, provider, name, provider_type, endpoints, zone_id, provider_region,
+                      host_default_vnc_port_start, host_default_vnc_port_end):
         """ Edit a user from manageiq.
 
         Returns:
@@ -513,6 +543,8 @@ class ManageIQProvider(object):
             zone={'id': zone_id},
             provider_region=provider_region,
             connection_configurations=endpoints,
+            host_default_vnc_port_start=host_default_vnc_port_start,
+            host_default_vnc_port_end=host_default_vnc_port_end,
         )
 
         # NOTE: we do not check for diff's between requested and current
@@ -534,7 +566,8 @@ class ManageIQProvider(object):
             changed=True,
             msg="successfully updated the provider %s: %s" % (provider['name'], result))
 
-    def create_provider(self, name, provider_type, endpoints, zone_id, provider_region):
+    def create_provider(self, name, provider_type, endpoints, zone_id, provider_region,
+                        host_default_vnc_port_start, host_default_vnc_port_end):
         """ Creates the user in manageiq.
 
         Returns:
@@ -553,6 +586,8 @@ class ManageIQProvider(object):
                 type=supported_providers()[provider_type]['class_name'],
                 zone={'id': zone_id},
                 provider_region=provider_region,
+                host_default_vnc_port_start=host_default_vnc_port_start,
+                host_default_vnc_port_end=host_default_vnc_port_end,
                 connection_configurations=endpoints,
             )
         except Exception as e:
@@ -571,6 +606,8 @@ def main():
         name=dict(required=True),
         zone=dict(default='default'),
         provider_region=dict(),
+        host_default_vnc_port_start=dict(),
+        host_default_vnc_port_end=dict(),
         type=dict(choices=supported_providers().keys()),
     )
     # add the manageiq connection arguments to the arguments
@@ -589,6 +626,8 @@ def main():
     provider_type = module.params['type']
     raw_endpoints = module.params
     provider_region = module.params['provider_region']
+    host_default_vnc_port_start = module.params['host_default_vnc_port_start']
+    host_default_vnc_port_end = module.params['host_default_vnc_port_end']
     state = module.params['state']
 
     manageiq = ManageIQ(module)
@@ -634,10 +673,12 @@ def main():
 
         # if we have a provider, edit it
         if provider:
-            res_args = manageiq_provider.edit_provider(provider, name, provider_type, endpoints, zone_id, provider_region)
+            res_args = manageiq_provider.edit_provider(provider, name, provider_type, endpoints, zone_id, provider_region,
+                                                       host_default_vnc_port_start, host_default_vnc_port_end)
         # if we do not have a provider, create it
         else:
-            res_args = manageiq_provider.create_provider(name, provider_type, endpoints, zone_id, provider_region)
+            res_args = manageiq_provider.create_provider(name, provider_type, endpoints, zone_id, provider_region,
+                                                         host_default_vnc_port_start, host_default_vnc_port_end)
 
     module.exit_json(**res_args)
 


### PR DESCRIPTION
##### SUMMARY
Currently the manageiq remote management module only supports
OpenShift, AWS and oVirt. This adds the ability to create VMware
providers by adding two additional parameters for configuring a
host VNC range.


##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
remote_management/manageiq

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel aa50487ed7) last updated 2017/12/20 21:08:51 (GMT +100)
```


##### ADDITIONAL INFORMATION
This has been tested using Red Hat OpenTLC LE