### PR TITLE
mysql_user module not idempotent for MySQL 5.7.6 with special privilege REQUIRESSL

### DIFF
--- a/lib/ansible/modules/database/mysql/mysql_user.py
+++ b/lib/ansible/modules/database/mysql/mysql_user.py
@@ -38,10 +38,10 @@ options:
       - replaces the old special privilege REQUIRESSL.
       - introduced to allow compatibility with MySQL > 5.7.6
       - introduced to allow compatibility with MariaDB > 10.2.0
+    type: bool
     required: false
     default: "no"
-    choices: [ "yes", "no" ]
-    version_added: "2.5"
+    version_added: "2.6"
   encrypted:
     description:
       - Indicate that the 'password' field is a `mysql_native_password` hash.

--- a/test/integration/targets/mysql_user/tasks/assert_user.yml
+++ b/test/integration/targets/mysql_user/tasks/assert_user.yml
@@ -32,3 +32,12 @@
 - name: assert user has giving privileges
   assert: { that: "'GRANT {{priv}} ON *.*' in result.stdout" }
   when: priv is defined
+
+- name: run command to query for mysql user with require ssl
+  command: mysql "-e SELECT User FROM mysql.user where user='{{ user_name }}' and ssl_type='ANY';"
+  register: result
+  when: require_ssl is defined
+
+- name: assert mysql user with require ssl is present
+  assert: { that: "'{{ user_name }}' in result.stdout" }
+  when: require_ssl is defined

--- a/test/integration/targets/mysql_user/tasks/create_user_with_ssl.yml
+++ b/test/integration/targets/mysql_user/tasks/create_user_with_ssl.yml
@@ -18,7 +18,12 @@
 
 # ============================================================
 - name: create mysql user {{user_name}}
-  mysql_user: name={{user_name}} password={{user_password}} state=present require_ssl=true
+  mysql_user:
+    name: '{{user_name}}'
+    password: '{{user_password}}'
+    state: present
+    login_unix_socket: '{{ mysql_socket }}'
+    require_ssl: true
   register: result
 
 - name: assert output message mysql user was created

--- a/test/integration/targets/mysql_user/tasks/create_user_with_ssl.yml
+++ b/test/integration/targets/mysql_user/tasks/create_user_with_ssl.yml
@@ -1,0 +1,25 @@
+# test code to create mysql user
+# (c) 2017,  Jasper van Wanrooy <jasper@vanwanrooy.net>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# ============================================================
+- name: create mysql user {{user_name}}
+  mysql_user: name={{user_name}} password={{user_password}} state=present require_ssl=true
+  register: result
+
+- name: assert output message mysql user was created
+  assert: { that: "result.changed == true" }

--- a/test/integration/targets/mysql_user/tasks/main.yml
+++ b/test/integration/targets/mysql_user/tasks/main.yml
@@ -28,6 +28,15 @@
 - include: assert_no_user.yml user_name={{user_name_1}}
 
 # ============================================================
+# create mysql user which requires ssl to login
+#
+- include: create_user_with_ssl.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
+
+- include: assert_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }} require_ssl=true
+
+- include: remove_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}
+
+# ============================================================
 # Create mysql user that already exist on mysql database
 #
 - include: create_user.yml user_name={{user_name_1}} user_password={{ user_password_1 }}


### PR DESCRIPTION
##### SUMMARY
MySQL 5.7.6 and higher changed the way non privileges can be configured for a user. The `REQUIRE SSL` specification is not included any longer in the `SHOW GRANTS FOR ...` query.

In order to keep this module idempotent, I propose a few changes:
- Changed special privilege `REQUIRESSL` to become a dedicated option `require_ssl` as it can't be treated as a privilege any longer.
- Changed the version checking to become better readable.
- Changed the implementation to verify whether SSL is required for a user.
- Deprecated the `REQUIRESSL` special privilege, but remain backwards compatible.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
mysql_user

##### ANSIBLE VERSION
```
ansible 2.5.0 (feature/mysql_user_require_ssl_compatibility d54f9fcaa4) last updated 2017/12/20 22:22:19 (GMT +200)
  config file = None
  configured module search path = [u'/Users/jaspervanwanrooy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/jaspervanwanrooy/development/ansible/lib/ansible
  executable location = /Users/jaspervanwanrooy/development/ansible/bin/ansible
  python version = 2.7.14 (default, Sep 25 2017, 09:53:22) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.37)]
```


##### ADDITIONAL INFORMATION
Steps to reproduce the issue where the REQUIRESSL privilege is not idempotent:
- Start the docker compose stack as shown below. It starts 7 MySQL/MariaDB database servers.
- Run the playbook for the first time: `ansible-playbook -vv --inventory=ssl-test-inventory.yml ssl-test-playbook.yml`. It should give `changed=1` for all database servers. The first debug message shows the output of `SHOW GRANTS ...` which is currently used to validate whether the user requires ssl. The second one shows my proposed way to validate whether the user requires ssl.
- Run the playbook again. All hosts have `changed=0`, except for host `mysql57`, which has `changed=1`. That's due to the way the require ssl state is validated.

`docker-compose.yml` for quite a few different databases.
```yaml
version: '3'
services:
  mysql55:
    image: mysql:5.5.58
    ports:
      - "3305:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
  mysql56:
    image: mysql:5.6.38
    ports:
      - "3306:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
  mysql57:
    image: mysql:5.7.20
    ports:
      - "3307:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
  mariadb55:
    image: mariadb:5.5.58
    ports:
      - "3309:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
  mariadb100:
    image: mariadb:10.0.33
    ports:
      - "3310:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
  mariadb101:
    image: mariadb:10.1.29
    ports:
      - "3311:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
  mariadb102:
    image: mariadb:10.2.11
    ports:
      - "3312:3306"
    environment:
      MYSQL_ROOT_PASSWORD: "root"
```

`ssl-test-inventory.yml`
```yaml
all:
  hosts:
    mysql55:
      mysql_port: 3305
    mysql56:
      mysql_port: 3306
    mysql57:
      mysql_port: 3307
    mariadb55:
      mysql_port: 3309
    mariadb100:
      mysql_port: 3310
    mariadb101:
      mysql_port: 3311
    mariadb102:
      mysql_port: 3312
```

`ssl-test-playbook.yml`
```yaml
- hosts: all
  connection: local
  tasks:
    - mysql_user:
        name: testuser
        password: testpassword
        host: "%"
        priv: "*.*:SELECT,REQUIRESSL"
        login_host: "127.0.0.1"
        login_user: "root"
        login_password: "root"
        login_port: "{{ mysql_port }}"
        state: present
    - command: "mysql --host=127.0.0.1 --user=root --password=root --port={{ mysql_port }} -e \"SHOW GRANTS FOR 'testuser'@'%'\""
      changed_when: False
      register: users
    - debug: var=users.stdout_lines
    - command: "mysql --host=127.0.0.1 --user=root --password=root --port={{ mysql_port }} -e \"SELECT Ssl_Type FROM mysql.user WHERE User='testuser' and Host='%'\""
      changed_when: False
      register: users
    - debug: var=users.stdout_lines
```
