### PR TITLE
influxdb: default hostname to localhost

### DIFF
--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -40,7 +40,7 @@ class InfluxDb():
     @staticmethod
     def influxdb_argument_spec():
         return dict(
-            hostname=dict(required=True, type='str'),
+            hostname=dict(default='localhost', type='str'),
             port=dict(default=8086, type='int'),
             username=dict(default='root', type='str'),
             password=dict(default='root', type='str', no_log=True),

--- a/lib/ansible/utils/module_docs_fragments/influxdb.py
+++ b/lib/ansible/utils/module_docs_fragments/influxdb.py
@@ -10,7 +10,8 @@ options:
   hostname:
     description:
     - The hostname or IP address on which InfluxDB server is listening
-    required: true
+    - Since version 2.5, defaulted to localhost.
+    default: localhost
   username:
     description:
     - Username that will be used to authenticate against InfluxDB server


### PR DESCRIPTION
##### SUMMARY
default hostname to localhost similar as in other modules

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
influxdb

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
