### PR TITLE
Fixes url to no longer redirect

### DIFF
--- a/lib/ansible/utils/module_docs_fragments/f5.py
+++ b/lib/ansible/utils/module_docs_fragments/f5.py
@@ -55,5 +55,5 @@ options:
       - no
     version_added: 2.0
 notes:
-  - For more information on using Ansible to manage F5 Networks devices see U(https://www.ansible.com/ansible-f5).
+  - For more information on using Ansible to manage F5 Networks devices see U(https://www.ansible.com/integrations/networks/f5).
 '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixes the Ansible F5 link to point to the real page, instead of a redirect

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
f5 documentation stubs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
