### PR TITLE
Updated documentation description

### DIFF
--- a/lib/ansible/plugins/callback/logstash.py
+++ b/lib/ansible/plugins/callback/logstash.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
     type: notification
     short_description: Sends events to Logstash
     description:
-      - This callback will report facts and task events to Foreman https://theforeman.org/
+      - This callback will report facts and task events to Logstash https://www.elastic.co/products/logstash
     version_added: "2.3"
     requirements:
       - whitelisting in configuration


### PR DESCRIPTION
The description for this plugin was referencing Foreman rather than Logstash.

##### SUMMARY
This will update the documentation description to properly reference Logstash rather than Foreman. I believe this will also update https://docs.ansible.com/ansible/devel/plugins/callback/logstash.html.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
https://docs.ansible.com/ansible/devel/plugins/callback/logstash.html
