### PR TITLE
enable Windows Server 2016 in CI

### DIFF
--- a/examples/scripts/ConfigureRemotingForAnsible.ps1
+++ b/examples/scripts/ConfigureRemotingForAnsible.ps1
@@ -74,7 +74,7 @@ Function Write-VerboseLog
 Function Write-HostLog
 {
     $Message = $args[0]
-    Write-Host $Message
+    Write-Output $Message
     Write-Log $Message
 }
 
@@ -196,8 +196,8 @@ $adminRole=[System.Security.Principal.WindowsBuiltInRole]::Administrator
 # Check to see if we are currently running "as Administrator"
 if (-Not $myWindowsPrincipal.IsInRole($adminRole))
 {
-    Write-Host "ERROR: You need elevated Administrator privileges in order to run this script."
-    Write-Host "       Start Windows PowerShell by using the Run as Administrator option."
+    Write-Output "ERROR: You need elevated Administrator privileges in order to run this script."
+    Write-Output "       Start Windows PowerShell by using the Run as Administrator option."
     Exit 2
 }
 

--- a/test/integration/host_vars/windows-2016-English-Full-Base
+++ b/test/integration/host_vars/windows-2016-English-Full-Base
@@ -1,0 +1,4 @@
+# force 2016 to use NTLM + HTTP message encryption
+ansible_winrm_transport: ntlm
+ansible_winrm_scheme: http
+ansible_port: 5985

--- a/test/runner/requirements/constraints.txt
+++ b/test/runner/requirements/constraints.txt
@@ -1,5 +1,5 @@
 coverage >= 4.2, != 4.3.2 # features in 4.2+ required, avoid known bug in 4.3.2 on python 2.6
-pywinrm >= 0.2.1 # 0.1.1 required, but 0.2.1 provides better performance
+pywinrm >= 0.3.0 # message encryption support
 pylint == 1.7.4 ; python_version >= '3.5' # versions before 1.7.1 hang or fail to install on python 3.x
 pylint == 1.6.5 ; python_version <= '2.7' # versions after 1.6.5 hang or fail during test on python 2.x
 sphinx < 1.6 ; python_version < '2.7' # sphinx 1.6 and later require python 2.7 or later
@@ -11,3 +11,6 @@ ncclient >= 0.5.2 # Need features added in 0.5.2 and greater
 idna < 2.6 # requests requires idna < 2.6, but cryptography will cause the latest version to be installed instead
 paramiko < 2.4.0 ; python_version < '2.7' # paramiko 2.4.0 drops support for python 2.6
 pytest < 3.3.0 ; python_version < '2.7' # pytest 3.3.0 drops support for python 2.6
+ntlm-auth >= 1.0.6 # message encryption support
+requests-ntlm >= 1.1.0 # message encryption support
+requests-credssp >= 0.1.0 # message encryption support

--- a/test/runner/requirements/windows-integration.txt
+++ b/test/runner/requirements/windows-integration.txt
@@ -2,5 +2,8 @@ cryptography
 jinja2
 junit-xml
 paramiko
-pywinrm
+ntlm-auth
+requests-ntlm
+requests-credssp
+pywinrm[credssp]
 pyyaml

--- a/test/utils/shippable/windows.sh
+++ b/test/utils/shippable/windows.sh
@@ -33,6 +33,7 @@ if [ -s /tmp/windows.txt ] || [ "${CHANGED:+$CHANGED}" == "" ]; then
         --windows 2008-R2_SP1
         --windows 2012-RTM
         --windows 2012-R2_RTM
+        --windows 2016-English-Full-Base
     )
 else
     echo "No changes requiring integration tests specific to Windows were detected."


### PR DESCRIPTION
##### SUMMARY
With new pywinrm (et al) released, now we should be able to test Server 2016 using HTTP message encryption (conveniently sidestepping the occasional HTTPS wedging issue we're hitting on AWS). 

* Updated `ansible-test` requirements to require minimum versions of pywinrm and deps that support message encryption.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ansible-test

##### ANSIBLE VERSION
