### PR TITLE
Change incorrect `items:` to `loop:` in tests.

### DIFF
--- a/test/integration/targets/win_regedit/tasks/main.yml
+++ b/test/integration/targets/win_regedit/tasks/main.yml
@@ -13,7 +13,7 @@
       test_win_regedit_key_expected_value_null: '{{item.value_null}}'
       test_win_regedit_key_expected_value1: '{{item.value1}}'
       test_win_regedit_key_expected_value2: '{{item.value2}}'
-    items:
+    loop:
     - type: dword
       reg_type: REG_DWORD
       data1: 1337 # decimal format

--- a/test/integration/targets/win_regedit/tasks/tests.yml
+++ b/test/integration/targets/win_regedit/tasks/tests.yml
@@ -311,7 +311,7 @@
   win_regedit:
     path: '{{test_win_regedit_local_key}}\{{item}}'
     state: present
-  items:
+  loop:
   - nest1
   - nest2
   - nest1\nested


### PR DESCRIPTION
##### SUMMARY

Change incorrect `items:` to `loop:` in tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

win_regedit integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (loop-fix 22bae01464) last updated 2017/12/21 00:14:37 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
