### PR TITLE
ios_static_route: fix broken import

### DIFF
--- a/lib/ansible/modules/network/ios/ios_static_route.py
+++ b/lib/ansible/modules/network/ios/ios_static_route.py
@@ -35,6 +35,8 @@ description:
     IP routes on Cisco IOS network devices.
 notes:
   - Tested against IOS 15.6
+requirements:
+  - Python >= 3.3 or C(ipaddress) python package
 options:
   prefix:
     description:

--- a/lib/ansible/modules/network/ios/ios_static_route.py
+++ b/lib/ansible/modules/network/ios/ios_static_route.py
@@ -102,8 +102,13 @@ from ansible.module_utils.connection import exec_command
 from ansible.module_utils.network.common.utils import remove_default_spec
 from ansible.module_utils.network.ios.ios import load_config, run_commands
 from ansible.module_utils.network.ios.ios import ios_argument_spec, check_args
-from ipaddress import ip_network
 import re
+
+try:
+    from ipaddress import ip_network
+    HAS_IPADDRESS = True
+except ImportError:
+    HAS_IPADDRESS = False
 
 
 def map_obj_to_commands(updates, module):
@@ -215,6 +220,9 @@ def main():
                            required_together=required_together,
                            mutually_exclusive=mutually_exclusive,
                            supports_check_mode=True)
+
+    if not HAS_IPADDRESS:
+        module.fail_json(msg="ipaddress python package is required")
 
     warnings = list()
     check_args(module, warnings)

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -10,7 +10,6 @@ lib/ansible/modules/cloud/webfaction/webfaction_db.py
 lib/ansible/modules/cloud/webfaction/webfaction_domain.py
 lib/ansible/modules/cloud/webfaction/webfaction_mailbox.py
 lib/ansible/modules/cloud/webfaction/webfaction_site.py
-lib/ansible/modules/network/ios/ios_static_route.py
 lib/ansible/modules/network/lenovo/cnos_backup.py
 lib/ansible/modules/network/lenovo/cnos_bgp.py
 lib/ansible/modules/network/lenovo/cnos_command.py


### PR DESCRIPTION
##### SUMMARY
- [fix broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#fixing-broken-imports):
```
$ ansible-test sanity --test import --python 2.7 lib/ansible/modules/network/ios/ios_static_route.py
ERROR: lib/ansible/modules/network/ios/ios_static_route.py:105:0: ImportError: No module named ipaddress
```
- doc: add `ipaddress` Python package in requirements

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ios_static_route

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 853fa8223a) last updated 2017/12/21 09:18:28 (GMT +200)
```