### PR TITLE
Feature/Added support for China and US Gov To Lambda Module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/lambda.py
+++ b/lib/ansible/modules/cloud/amazon/lambda.py
@@ -295,7 +295,8 @@ def main():
     except (botocore.exceptions.ClientError, botocore.exceptions.ValidationError) as e:
         module.fail_json(msg=str(e))
 
-    if role.startswith('arn:aws:iam'):
+    partition_match_pattern = 'arn:(aws[a-zA-Z-]*)?:iam'
+    if re.match(partition_match_pattern, role):
         role_arn = role
     else:
         # get account ID and assemble ARN


### PR DESCRIPTION
##### SUMMARY
This update enables the Ansible 'Lambda' Module in Ansible 2.3 to support the creation of Lambda resources in the China and US Gov AWS Regions by catering for AWS ARN Partitions other than 'arn:aws'.

In summary, it adds support for the following

- aws - Public AWS partition
- aws-cn - AWS China
- aws-us-gov - AWS GovCloud


##### ADDITIONAL INFORMATION
Without this update, it is not possible to create Lambda Functions in AWS China Regions or AWS GovCloud Regions
