### PR TITLE
locale_gen: Use /usr/share/i18n/SUPPORTED if exists

### DIFF
--- a/lib/ansible/modules/system/locale_gen.py
+++ b/lib/ansible/modules/system/locale_gen.py
@@ -124,7 +124,15 @@ def set_locale(name, enabled=True):
         new_string = r'# %s \g<charset>' % (name)
     try:
         f = open("/etc/locale.gen", "r")
-        lines = [re.sub(search_string, new_string, line) for line in f]
+        lines = f.readlines()
+        if next((line for line in lines if re.match(search_string, line)), None) != None:
+            lines = [re.sub(search_string, new_string, line) for line in lines]
+        else:
+            if os.path.exists('/usr/share/i18n/SUPPORTED'):
+                f_supported = open("/usr/share/i18n/SUPPORTED", "r")
+                line_found = next((line for line in f_supported if re.match(search_string, line)), None)
+                if line_found != None: 
+                    lines.append(line_found)
     finally:
         f.close()
     try:

--- a/lib/ansible/modules/system/locale_gen.py
+++ b/lib/ansible/modules/system/locale_gen.py
@@ -125,13 +125,13 @@ def set_locale(name, enabled=True):
     try:
         f = open("/etc/locale.gen", "r")
         lines = f.readlines()
-        if next((line for line in lines if re.match(search_string, line)), None) != None:
+        if next((line for line in lines if re.match(search_string, line)), None) is not None:
             lines = [re.sub(search_string, new_string, line) for line in lines]
         else:
             if os.path.exists('/usr/share/i18n/SUPPORTED'):
                 f_supported = open("/usr/share/i18n/SUPPORTED", "r")
                 line_found = next((line for line in f_supported if re.match(search_string, line)), None)
-                if line_found != None: 
+                if line_found is not None:
                     lines.append(line_found)
     finally:
         f.close()

--- a/lib/ansible/modules/system/locale_gen.py
+++ b/lib/ansible/modules/system/locale_gen.py
@@ -69,7 +69,7 @@ def is_available(name, ubuntuMode):
     checking either :
     * if the locale is present in /etc/locales.gen
     * or if the locale is present in /usr/share/i18n/SUPPORTED"""
-    if ubuntuMode:
+    if os.path.exists('/usr/share/i18n/SUPPORTED'):
         __regexp = r'^(?P<locale>\S+_\S+) (?P<charset>\S+)\s*$'
         __locales_available = '/usr/share/i18n/SUPPORTED'
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Use /usr/share/i18n/SUPPORTED if exists.
Many distributions or distribution images (scaleway hosting provider by exemple) do not have a /etc/locale.gen file filled with all the available locales. It is preferable to use the /usr/share/i18n/SUPPORTED file when it is available.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request
 
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
locale_gen

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.3.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
  python version = 2.7.3 (default, Mar 13 2014, 11:03:55) [GCC 4.7.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
