### PR TITLE
Add module mlnxos_lldp for supporting configuration of LLDP protocol on Mellanox switches

### DIFF
--- a/lib/ansible/modules/network/mlnxos/mlnxos_lldp.py
+++ b/lib/ansible/modules/network/mlnxos/mlnxos_lldp.py
@@ -1,7 +1,6 @@
 #!/usr/bin/python
-# -*- coding: utf-8 -*-
 
-# (c) 2017, Ansible by Red Hat, inc
+# Copyright: Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -9,7 +8,7 @@ __metaclass__ = type
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
-                    'supported_by': 'network'}
+                    'supported_by': 'community'}
 
 DOCUMENTATION = """
 ---

--- a/lib/ansible/modules/network/mlnxos/mlnxos_lldp.py
+++ b/lib/ansible/modules/network/mlnxos/mlnxos_lldp.py
@@ -48,8 +48,8 @@ commands:
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ansible.module_utils.network.mlnxos.mlnxos import BaseMlnxosModule, \
-    show_cmd
+from ansible.module_utils.network.mlnxos.mlnxos import BaseMlnxosModule
+from ansible.module_utils.network.mlnxos.mlnxos import show_cmd
 
 
 class MlnxosLldpModule(BaseMlnxosModule):

--- a/lib/ansible/modules/network/mlnxos/mlnxos_lldp.py
+++ b/lib/ansible/modules/network/mlnxos/mlnxos_lldp.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2017, Ansible by Red Hat, inc
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'network'}
+
+DOCUMENTATION = """
+---
+module: mlnxos_lldp
+version_added: "2.5"
+author: "Samer Deeb (@samerd)"
+short_description: Manage LLDP configuration on Mellanox MLNX-OS network devices
+description:
+  - This module provides declarative management of LLDP service configuration
+    on Mellanox MLNX-OS network devices.
+options:
+  state:
+    description:
+      - State of the LLDP protocol configuration.
+    default: present
+    choices: ['present', 'absent']
+"""
+
+EXAMPLES = """
+- name: Enable LLDP protocol
+  mlnxos_lldp:
+    state: present
+
+- name: Disable LLDP protocol
+  mlnxos_lldp:
+    state: lldp
+"""
+
+RETURN = """
+commands:
+  description: The list of configuration mode commands to send to the device
+  returned: always.
+  type: list
+  sample:
+    - lldp
+"""
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible.module_utils.network.mlnxos.mlnxos import BaseMlnxosModule, \
+    show_cmd
+
+
+class MlnxosLldpModule(BaseMlnxosModule):
+    LLDP_ENTRY = 'LLDP'
+    SHOW_LLDP_CMD = 'show lldp local'
+
+    @classmethod
+    def _get_element_spec(cls):
+        return dict(
+            state=dict(default='present', choices=['present', 'absent']),
+        )
+
+    def init_module(self):
+        """ main entry point for module execution
+        """
+        element_spec = self._get_element_spec()
+        argument_spec = dict()
+        argument_spec.update(element_spec)
+        self._module = AnsibleModule(
+            argument_spec=argument_spec,
+            supports_check_mode=True)
+
+    def get_required_config(self):
+        self._required_config = dict()
+        module_params = self._module.params
+        params = {
+            'state': module_params['state'],
+        }
+
+        self.validate_param_values(params)
+        self._required_config.update(params)
+
+    def _get_lldp_config(self):
+        return show_cmd(self._module, self.SHOW_LLDP_CMD)
+
+    def load_current_config(self):
+        self._current_config = dict()
+        state = 'absent'
+        config = self._get_lldp_config() or dict()
+        for item in config:
+            lldp_state = item.get(self.LLDP_ENTRY)
+            if lldp_state is not None:
+                if lldp_state == 'enabled':
+                    state = 'present'
+                break
+        self._current_config['state'] = state
+
+    def generate_commands(self):
+        req_state = self._required_config['state']
+        curr_state = self._current_config['state']
+        if curr_state != req_state:
+            cmd = 'lldp'
+            if req_state == 'absent':
+                cmd = 'no %s' % cmd
+            self._commands.append(cmd)
+
+
+def main():
+    """ main entry point for module execution
+    """
+    MlnxosLldpModule.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/mlnxos/fixtures/mlnxos_lldp_show.cfg
+++ b/test/units/modules/network/mlnxos/fixtures/mlnxos_lldp_show.cfg
@@ -1,0 +1,14 @@
+[
+    {
+        "LLDP": "enabled"
+    },
+    {
+        "Supported capabilities": "B,R",
+        "Chassis sub type": "Mac Address",
+        "header": "Local global configuration",
+        "System Name": "ufm-switch16",
+        "Supported capabilities enabled": "B",
+        "Chassis id": "7c:fe:90:e5:ca:00",
+        "System Description": "Mellanox MSN2700,MLNX-OS,SWv3.6.5000-04"
+    }
+]

--- a/test/units/modules/network/mlnxos/test_mlnxos_lldp.py
+++ b/test/units/modules/network/mlnxos/test_mlnxos_lldp.py
@@ -1,0 +1,71 @@
+#
+# (c) 2016 Red Hat Inc.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import json
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.mlnxos import mlnxos_lldp
+from ansible.module_utils.network.mlnxos import mlnxos as mlnxos_utils
+from units.modules.utils import set_module_args
+from .mlnxos_module import TestMlnxosModule, load_fixture
+
+
+class TestMlnxosInterfaceModule(TestMlnxosModule):
+
+    module = mlnxos_lldp
+
+    def setUp(self):
+        super(TestMlnxosInterfaceModule, self).setUp()
+        self.mock_get_config = patch.object(
+            mlnxos_lldp.MlnxosLldpModule, "_get_lldp_config")
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch(
+            'ansible.module_utils.network.mlnxos.mlnxos.load_config')
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestMlnxosInterfaceModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        if commands == ['lldp']:
+            self.get_config.return_value = None
+        else:
+            config_file = 'mlnxos_lldp_show.cfg'
+            self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_lldp_no_change(self):
+        set_module_args(dict())
+        self.execute_module(changed=False)
+
+    def test_lldp_disable(self):
+        set_module_args(dict(state='absent'))
+        commands = ['no lldp']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_lldp_enable(self):
+        set_module_args(dict(state='present'))
+        commands = ['lldp']
+        self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
Signed-off-by: Samer Deeb <samerd@mellanox.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add module mlnxos_lldp for supporting enabling/disabling LLDP protocol on Mellanox switches.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request
##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/mlnxos/mlnxos_lldp

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (feature/net-lldp 6fce9d2133) last updated 2017/12/21 18:23:58 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
