### PR TITLE
win_domain_group: added ability to specify AD server to interact with

### DIFF
--- a/lib/ansible/modules/windows/win_domain_group.ps1
+++ b/lib/ansible/modules/windows/win_domain_group.ps1
@@ -1,25 +1,10 @@
 #!powershell
 # This file is part of Ansible
-#
-# (c) 2017, Jordan Borean <jborean93@gmail.com>, and others
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# WANT_JSON
-# POWERSHELL_COMMON
+# (c) 2017, Jordan Borean <jborean93@gmail.com>, and others
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
 
 $ErrorActionPreference = "Stop"
 
@@ -40,6 +25,7 @@ $organizational_unit = Get-AnsibleParam -obj $params -name "organizational_unit"
 $state = Get-AnsibleParam -obj $params -name "state" -type "str" -default "present" -validateset "present","absent"
 $protect = Get-AnsibleParam -obj $params -name "protect" -type "bool"
 $ignore_protection = Get-AnsibleParam -obj $params -name "ignore_protection" -type "bool" -default $false
+$server = Get-AnsibleParam -obj $params -name "server" -type "str"
 
 $result = @{
     changed = $false
@@ -59,6 +45,9 @@ if ($domain_username -ne $null) {
     $domain_password = ConvertTo-SecureString $domain_password -AsPlainText -Force
     $credential = New-Object -TypeName System.Management.Automation.PSCredential -ArgumentList $domain_username, $domain_password
     $extra_args.Credential = $credential
+}
+if ($server -ne $null) {
+    $extra_args.Server = $server
 }
 
 try {

--- a/lib/ansible/modules/windows/win_domain_group.py
+++ b/lib/ansible/modules/windows/win_domain_group.py
@@ -1,21 +1,9 @@
 #!/usr/bin/python
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-# this is a windows documentation stub, actual code lives in the .ps1
-# file of the same name
+# This file is part of Ansible
+
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -101,6 +89,13 @@ options:
     - If C(state=absent) this module will delete the group if it exists
     default: present
     choices: [ absent, present ]
+  server:
+    description:
+    - Specifies the Active Directory Domain Services instance to connect to.
+    - Can be in the form of an FQDN or NetBIOS name.
+    - If not specified then the value is based on the domain of the computer
+      running PowerShell.
+    version_added: '2.5'
 notes:
 - This must be run on a host that has the ActiveDirectory powershell module
   installed.
@@ -147,6 +142,14 @@ EXAMPLES = r'''
   win_domain_group:
     name: Group Name Here
     managed_by: Domain Admins
+
+- name: add group and specify the AD domain services to use for the create
+  win_domain_group:
+    name: Test Group
+    domain_admin_user: user@CORP.ANSIBLE.COM
+    domain_admin_password: Password01!
+    scope: domainlocal
+    server: corp-DC12.corp.ansible.com
 '''
 
 RETURN = r'''


### PR DESCRIPTION
##### SUMMARY
Added the ability to select the AD server to use when managing domain groups.

Fixes https://github.com/ansible/ansible/issues/33467

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_domain_group

##### ANSIBLE VERSION
```
2.5
```