### PR TITLE
Add want_ssh_ansible_host flag to foreman dynamic inventory

### DIFF
--- a/contrib/inventory/foreman.ini
+++ b/contrib/inventory/foreman.ini
@@ -152,6 +152,12 @@ want_hostcollections = False
 # Disabled by default as the change would else not be backward compatible.
 rich_params = False
 
+# Whether to populate the ansible_ssh_host variable to explicitly specify the
+# connection target.  Only tested with Katello (Red Hat Satellite).
+# If the foreman 'ip' fact exists then the ansible_ssh_host varibale is populated
+# to permit connections where DNS resolution fails.
+want_ansible_ssh_host = False
+
 [cache]
 path = .
 max_age = 60

--- a/contrib/inventory/foreman.py
+++ b/contrib/inventory/foreman.py
@@ -113,6 +113,11 @@ class ForemanInventory(object):
         except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
             self.want_hostcollections = False
 
+        try:
+            self.want_ansible_ssh_host = config.getboolean('ansible', 'want_ansible_ssh_host')
+        except (ConfigParser.NoOptionError, ConfigParser.NoSectionError):
+            self.want_ansible_ssh_host = False
+
         # Do we want parameters to be interpreted if possible as JSON? (no by default)
         try:
             self.rich_params = config.getboolean('ansible', 'rich_params')
@@ -424,6 +429,8 @@ class ForemanInventory(object):
                     'foreman': self.cache[hostname],
                     'foreman_params': self.params[hostname],
                 }
+                if self.want_ansible_ssh_host and 'ip' in self.cache[hostname]:
+                    self.inventory['_meta']['hostvars'][hostname]['ansible_ssh_host'] = self.cache[hostname]['ip']
                 if self.want_facts:
                     self.inventory['_meta']['hostvars'][hostname]['foreman_facts'] = self.facts[hostname]
 


### PR DESCRIPTION
##### SUMMARY
Add flag to the foreman inventory script to optionally populate the `ansible_ssh_host` data field.

This permits connectivity via foreman defined IP address rather than requiring valid hostname resolution.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
inventory / foreman.py

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/resark/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.5 (default, May  3 2017, 07:55:04) [GCC 4.8.5 20150623 (Red Hat 4.8.5-14)]
```

##### ADDITIONAL INFORMATION
Enabling the flag in `foreman.ini` (default is False which disables this behaviour):
```
want_ansible_ssh_host = True
```
Populates the `ansible_ssh_host` field in inventory output, like:
```
{
  "_meta": {
    "hostvars": {
      "my-hostname": {
        "ansible_ssh_host": "192.168.0.101",
        ...
      }
  }
 ...
}
```
