### PR TITLE
Create lookup plugin `aws_sg_transform`

### DIFF
--- a/lib/ansible/module_utils/ec2.py
+++ b/lib/ansible/module_utils/ec2.py
@@ -615,7 +615,6 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
 
     sec_group_id_list = []
 
-
     # Get all security groups
     all_sec_groups = ec2_connection.get_all_security_groups(vpc_id=vpc_id)
     unmatched = set(sec_group_list).difference(str(get_sg_name(all_sg, boto3)) for all_sg in all_sec_groups)

--- a/lib/ansible/plugins/lookup/aws_sg_transform.py
+++ b/lib/ansible/plugins/lookup/aws_sg_transform.py
@@ -3,6 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.ec2 import HAS_BOTO3
@@ -58,6 +59,7 @@ EXAMPLES = '''
   #=> ['MyGroupA']
 '''
 
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
@@ -83,20 +85,24 @@ class LookupModule(LookupBase):
 
         for group_list in terms:
             if boolean(kwargs.get('id_to_name')):
-                #sg-... => MyName
+                # sg-... => MyName
                 names = get_ec2_names_from_security_group_ids(group_list, ec2, vpc_id=kwargs.get('vpc_id'))
                 results.append(names)
             else:
-                #MyName => sg-...
+                # MyName => sg-...
                 ids = get_ec2_security_group_ids_from_names(group_list, ec2, vpc_id=kwargs.get('vpc_id'))
                 results.append(ids)
 
         return results
 
-    #This is not a module, so construct something that has the same interfaceish
+
+    # This is not a module, so construct something that has the same interfaceish
     class ModuleFacade(object):
+
+
         def __init__(self, kwargs):
             self.params = self.ParamMock(kwargs)
+
 
         class ParamMock(object):
             def __init__(self, incoming_dict):
@@ -105,5 +111,5 @@ class LookupModule(LookupBase):
             def get(self, key):
                 if key in self.my_dict:
                     return self.my_dict[key]
-                else:
-                    return None
+
+                return None

--- a/lib/ansible/plugins/lookup/aws_sg_transform.py
+++ b/lib/ansible/plugins/lookup/aws_sg_transform.py
@@ -1,0 +1,109 @@
+# (c) 2017, Aaron Haaf <aabonh(at)gmail.com>
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.errors import AnsibleError
+from ansible.module_utils.ec2 import HAS_BOTO3
+from ansible.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils.ec2 import get_ec2_names_from_security_group_ids
+from ansible.module_utils.ec2 import get_ec2_security_group_ids_from_names
+from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.plugins.lookup import LookupBase
+
+try:
+    import boto3
+except ImportError:
+    pass  # will be captured by imported HAS_BOTO3
+
+DOCUMENTATION = '''
+lookup: aws_ssm
+author: Aaron Haaf <aabonh(at)gmail.com>
+version_added: 2.5
+short_description: Convert between name and id for AWS EC2 Security Groups
+description: Changes names like "My-Group-A" to an identifier like sg-2hg21da
+options:
+    aws_profile:
+    description: The boto profile to use. You may use environment variables or the default profile as an alternative.
+    region:
+    description: The region to use. You may use environment variables or the default profile's region as an alternative.
+    id_to_name:
+    description: Go backwards and convert identifiers to names
+    default: False
+'''
+
+EXAMPLES = '''
+# lookup sample:
+- name: Lookup a single group
+  debug: msg="{{lookup('aws_sg_transform', "MyGroupA")}}"
+  #=> ['sg-A']
+
+- name: Lookup a few groups in a different region
+  debug: msg="{{lookup('aws_sg_transform', "MyGroupA", "MyGroupB", region="eu-west-1")}}"
+  #=> [ ['sg-A'], ['sg-B'] ]
+
+# Multiple groups:
+- name: Get a few groups going
+  set_fact:
+    my_groups_a: ['MyGroupA', 'MyGroupB'] #=> ['sg-A', 'sg-B']
+    my_groups_b: ['MyGroupC', 'MyGroupD'] #=> ['sg-C', 'sg-D']
+
+- name: Look up a few groups in a different region
+  debug: msg="{{lookup('aws_sg_transform', my_groups_a, 'MyGroupC', region="eu-west-1")}}"
+  #=> [ ['sg-A', 'sg-B'], ['sg-C'] ]
+
+- name: Go backwards you crazy diamond
+  debug: msg="{{ lookup('aws_sg_transform', 'sg-A', id_to_name=True)}}"
+  #=> ['MyGroupA']
+'''
+
+class LookupModule(LookupBase):
+
+    def run(self, terms, variables, **kwargs):
+        '''
+            :param terms: a list of plugin options
+                          e.g. [ [sg-A, sg-B], sg-C ]
+            :param variables: variables for the current host
+            :return An array of strings
+        '''
+
+        if not HAS_BOTO3:
+            raise AnsibleError('botocore and boto3 are required.')
+
+        fauxdule = self.ModuleFacade(kwargs)
+        region = get_aws_connection_info(fauxdule)[0]
+
+        if not region:
+            raise AnsibleError('please specify region somehow')
+
+        ec2 = boto3.client('ec2', region_name=region)
+
+        results = []
+
+        for group_list in terms:
+            if boolean(kwargs.get('id_to_name')):
+                #sg-... => MyName
+                names = get_ec2_names_from_security_group_ids(group_list, ec2, vpc_id=kwargs.get('vpc_id'))
+                results.append(names)
+            else:
+                #MyName => sg-...
+                ids = get_ec2_security_group_ids_from_names(group_list, ec2, vpc_id=kwargs.get('vpc_id'))
+                results.append(ids)
+
+        return results
+
+    #This is not a module, so construct something that has the same interfaceish
+    class ModuleFacade(object):
+        def __init__(self, kwargs):
+            self.params = self.ParamMock(kwargs)
+
+        class ParamMock(object):
+            def __init__(self, incoming_dict):
+                self.my_dict = incoming_dict
+
+            def get(self, key):
+                if key in self.my_dict:
+                    return self.my_dict[key]
+                else:
+                    return None

--- a/lib/ansible/plugins/lookup/aws_sg_transform.py
+++ b/lib/ansible/plugins/lookup/aws_sg_transform.py
@@ -95,14 +95,11 @@ class LookupModule(LookupBase):
 
         return results
 
-
     # This is not a module, so construct something that has the same interfaceish
     class ModuleFacade(object):
 
-
         def __init__(self, kwargs):
             self.params = self.ParamMock(kwargs)
-
 
         class ParamMock(object):
             def __init__(self, incoming_dict):


### PR DESCRIPTION
##### SUMMARY

* Create lookup 'aws_sg_transform'
* Refactor `module_utils.ec2.get_ec2_names_from_security_group_ids` to use Boto3 filters for finding groups
* Write inverse `module_utils.ec2get_ec2_names_from_security_group_ids`

Implements a lookup to transform AWS EC2 Security Group Names back and forth between name and id.

This is mainly a solution to work around and through the inconsistencies between the different AWS modules being unable to take group-names.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
aws_sg_transform

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /mnt/c/git/ansible/ansible.cfg
  configured module search path = [u'/mnt/c/git/ansible/library', u'/usr/share/ansible']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Nov 23 2017, 15:49:48) [GCC 4.8.4]
```

##### ADDITIONAL INFORMATION

```
- debug: msg="{{lookup('aws_sg_transform', 'MyGroup', region='us-west-2', id_to_name=True)}}"
  #=> [ 'sg-abc123' ]
```
