### PR TITLE
Add the possibility to assign a default value to env lookup

### DIFF
--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -3,9 +3,10 @@
 # GNU General Public License v3.0+ (see COPYING or
 # https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import (absolute_import, division, print_function)
 import os
 from ansible.plugins.lookup import LookupBase
-from __future__ import (absolute_import, division, print_function)
+
 __metaclass__ = type
 
 DOCUMENTATION = """

--- a/lib/ansible/plugins/lookup/env.py
+++ b/lib/ansible/plugins/lookup/env.py
@@ -1,6 +1,10 @@
 # (c) 2012, Jan-Piet Mens <jpmens(at)gmail.com>
 # (c) 2017 Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# GNU General Public License v3.0+ (see COPYING or
+# https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import os
+from ansible.plugins.lookup import LookupBase
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
@@ -10,37 +14,40 @@ DOCUMENTATION = """
     version_added: "0.9"
     short_description: read the value of environment variables
     requirements:
-      - dns/dns.resolver (python library)
+      - none
     description:
-        - Allows you to query the environment variables available on the controller when you invoked Ansible.
+        - Allows you to query the environment variables available on the
+          controller when you invoked Ansible.
     options:
       _terms:
-        description: Environment variable or list of them to lookup the values for
+        description: Environment variable or list of them to lookup the values
+          for. To provide a default value, add it after the variable name and a
+          comma.
         required: True
 """
 
 EXAMPLES = """
 - debug: msg="{{ lookup('env','HOME') }} is an environment variable"
+- debug:
+    msg: "{{ lookup('env','LANG, fr_FR.UTF-8') }} is an environment variable"
 """
 
 RETURN = """
   _list:
     description:
-      - values returned by the DNS TXT record.
+      - the environment variable values.
     type: list
 """
-import os
-
-from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
-
         ret = []
         for term in terms:
-            var = term.split()[0]
-            ret.append(os.getenv(var, ''))
+            terms_elem = term.split(',')
+            var = terms_elem[0].strip()
+            default = terms_elem[1].strip() if len(terms_elem) > 1 else ''
+            ret.append(os.getenv(var, default))
 
         return ret


### PR DESCRIPTION
##### SUMMARY
By default lookup('env', ) returns an empty string if the variable does not
exists, and force the user to add boolean=True to the default() jinja filter
(see #15575)

This is a proposition to assign a default value to a environment
variable, directly in the lookup plugin, in the same way of os.getenv()
python function.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
plugins/lookup/env

##### ANSIBLE VERSION
ansible 2.4.2.0

##### ADDITIONAL INFORMATION

```
{{ lookup('env', 'OTHER_HOME')|default('playbook_dir/../other', true) }}
```

Can now also be written:
```
{{ lookup('env', 'OTHER_HOME, playbook_dir/../other') }}

```