### PR TITLE
ec2_asg: fix desired_capacity not optional

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_asg.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_asg.py
@@ -1145,6 +1145,9 @@ def replace(connection):
     replace_instances = module.params.get('replace_instances')
 
     as_group = describe_autoscaling_groups(connection, group_name)[0]
+    if desired_capacity is None:
+        desired_capacity = as_group['DesiredCapacity']
+
     wait_for_new_inst(connection, group_name, wait_timeout, as_group['MinSize'], 'viable_instances')
     props = get_properties(as_group)
     instances = props['instances']
@@ -1178,8 +1181,7 @@ def replace(connection):
         min_size = as_group['MinSize']
     if max_size is None:
         max_size = as_group['MaxSize']
-    if desired_capacity is None:
-        desired_capacity = as_group['DesiredCapacity']
+
     # set temporary settings and wait for them to be reached
     # This should get overwritten if the number of instances left is less than the batch size.
 
@@ -1265,6 +1267,9 @@ def terminate_batch(connection, replace_instances, initial_instances, leftovers=
     break_loop = False
 
     as_group = describe_autoscaling_groups(connection, group_name)[0]
+    if desired_capacity is None:
+        desired_capacity = as_group['DesiredCapacity']
+
     props = get_properties(as_group)
     desired_size = as_group['MinSize']
 
@@ -1433,6 +1438,7 @@ def main():
     if create_changed or replace_changed:
         changed = True
     module.exit_json(changed=changed, **asg_properties)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### SUMMARY
the desired_capacity has `required=False`. When not provided, it has default None which causes a traceback on lines having:
~~~python
num_new_inst_needed = desired_capacity - len(new_instances)
~~~

~~~
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_BimUFr/ansible_module_ec2_asg.py\", line 1438, in <module>\n    main()\n  File \"/tmp/ansible_BimUFr/ansible_module_ec2_asg.py\", line 1432, in main\n    replace_changed, asg_properties = replace(connection)\n  File \"/tmp/ansible_BimUFr/ansible_module_ec2_asg.py\", line 1156, in replace\n    num_new_inst_needed = desired_capacity - len(new_instances)\nTypeError: unsupported operand type(s) for -: 'NoneType' and 'int'\n", "module_stdout": "", "msg": "MODULE FAILURE", "rc": 0}
~~~

This PR fixes the issue by defaulting the desired_capacity from the asg when value is not passed by args.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ec2_asg

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4, devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
