### PR TITLE
Accept interfaces without address family or method

### DIFF
--- a/lib/ansible/modules/system/interfaces_file.py
+++ b/lib/ansible/modules/system/interfaces_file.py
@@ -208,14 +208,15 @@ def read_interfaces_lines(module, line_strings):
                 "down": [],
                 "post-up": []
             }
-            iface_name, address_family_name, method_name = words[1:4]
-            if len(words) != 4:
-                module.fail_json(msg="Incorrect number of parameters (%d) in line %d, must be exectly 3" % (len(words), i))
-                # TODO: put line and count parameters
-                return None, None
-
-            currif['address_family'] = address_family_name
-            currif['method'] = method_name
+            iface_name = words[1]
+            try:
+                currif['address_family'] = words[2]
+            except IndexError:
+                currif['address_family'] = None
+            try:
+                currif['method'] = words[3]
+            except IndexError:
+                currif['method'] = None
 
             ifaces[iface_name] = currif
             lines.append({'line': line, 'iface': iface_name, 'line_type': 'iface', 'params': currif})


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Interfaces do not require address family or method to be set. Without this patch, this module cannot parse inventory files that don't have the address family or method set.
fixes #30768 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
interfaces_file

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.13 (default, Dec 22 2016, 09:22:15) [GCC 6.2.1 20160822]
```


##### ADDITIONAL INFORMATION

Example interfaces file that triggers bug:
```
auto lo
iface lo inet loopback

auto eth0
iface eth0 inet dhcp

auto br0
iface br0
```

Error seen before change
```
TASK [Add interface option] ************************************************************************
fatal: [172.x.x.x]: FAILED! => {"changed": false, "module_stderr": "Shared connection to 172.x.x.x closed.\r\n", "module_stdout": "\r\nTraceback (most recent call last):\r\n  File \"/tmp/ansible_vhT1bm/ansible_module_interfaces_file.py\", line 385, in <module>\r\n    main()\r\n  File \"/tmp/ansible_vhT1bm/ansible_module_interfaces_file.py\", line 366, in main\r\n    lines, ifaces = read_interfaces_file(module, dest)\r\n  File \"/tmp/ansible_vhT1bm/ansible_module_interfaces_file.py\", line 177, in read_interfaces_file\r\n    return read_interfaces_lines(module, f)\r\n  File \"/tmp/ansible_vhT1bm/ansible_module_interfaces_file.py\", line 211, in read_interfaces_lines\r\n    iface_name, address_family_name, method_name = words[1:4]\r\nValueError: need more than 1 value to unpack\r\n", "msg": "MODULE FAILURE", "rc": 0}
```
After change:
```
TASK [Add interface option] ************************************************************************
ok: [172.x.x.x]
```
