### PR TITLE
tower_group: add update_cache_timeout option

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -92,7 +92,7 @@ options:
         - Refresh inventory data from its source each time a job is run.
       required: False
       default: False
-    update_cache_timeout
+    update_cache_timeout:
       description:
         - Time in seconds to consider an inventory sync to be current when update_on_launch is True.
       required: False

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -92,6 +92,11 @@ options:
         - Refresh inventory data from its source each time a job is run.
       required: False
       default: False
+    update_cache_timeout
+      description:
+        - Time in seconds to consider an inventory sync to be current when update_on_launch is True.
+      required: False
+      default: null
     state:
       description:
         - Desired state of the resource.
@@ -144,6 +149,7 @@ def main():
         overwrite=dict(type='bool', default=False),
         overwrite_vars=dict(),
         update_on_launch=dict(type='bool', default=False),
+        update_cache_timeout = dict(type="int"),
         state=dict(choices=['present', 'absent'], default='present'),
     ))
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -149,7 +149,7 @@ def main():
         overwrite=dict(type='bool', default=False),
         overwrite_vars=dict(),
         update_on_launch=dict(type='bool', default=False),
-        update_cache_timeout = dict(type="int"),
+        update_cache_timeout=dict(type="int"),
         state=dict(choices=['present', 'absent'], default='present'),
     ))
 

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_group.py
@@ -97,6 +97,7 @@ options:
         - Time in seconds to consider an inventory sync to be current when update_on_launch is True.
       required: False
       default: null
+      version_added: "2.5"
     state:
       description:
         - Desired state of the resource.


### PR DESCRIPTION
The tower_cli supports update_cache_timeout so I'm not sure why it was left out.  I've created 50 groups in tower 3.1.3 to test the patch with and without a update_cache_timeout set.

##### SUMMARY
Add update_cache_timeout support to the tower_group module.



##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
tower_group

##### ANSIBLE VERSION
```
ansible 2.3.1.0
  configured module search path = Default w/o overrides
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
The tower_cli has support for the update_cache_timeout option and by adding the option the tower_group module passes it on.
