### PR TITLE
ovirt: host_pm: Add missing order parameter

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_host_pm.py
@@ -75,6 +75,7 @@ options:
     order:
         description:
             - "Integer value specifying, by default it's added at the end."
+        version_added: "2.5"
 extends_documentation_fragment: ovirt
 '''
 
@@ -171,7 +172,8 @@ class HostPmModule(BaseModule):
             equal(self._module.params.get('password'), entity.password) and
             equal(self._module.params.get('username'), entity.username) and
             equal(self._module.params.get('port'), entity.port) and
-            equal(self._module.params.get('type'), entity.type)
+            equal(self._module.params.get('type'), entity.type) and
+            equal(self._module.params.get('order'), entity.order)
         )
 
 
@@ -187,6 +189,7 @@ def main():
         password=dict(default=None, no_log=True),
         type=dict(default=None),
         port=dict(default=None, type='int'),
+        order=dict(default=None, type='int'),
         slot=dict(default=None),
         options=dict(default=None, type='dict'),
         encrypt_options=dict(default=None, type='bool', aliases=['encrypt']),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes: https://github.com/ansible/ansible/issues/34134

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_host_pm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4.2
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
