### PR TITLE
aws_s3 - Change S3 MD5 checksum for multipart support

### DIFF
--- a/lib/ansible/modules/cloud/amazon/aws_s3.py
+++ b/lib/ansible/modules/cloud/amazon/aws_s3.py
@@ -271,8 +271,9 @@ s3_keys:
   - prefix1/key2
 '''
 
-import os
+import hashlib
 import mimetypes
+import os
 import traceback
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ssl import SSLError
@@ -306,7 +307,34 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
     return exists
 
 
-def keysum(module, s3, bucket, obj, version=None):
+def keysum_compare(module, local_file, s3, bucket, obj, version=None):
+    s3_keysum = keysum(s3, bucket, obj, version=version)
+    if '-' in s3_keysum:  # Check for multipart, ETag is not a proper MD5 sum
+        parts = int(s3_keysum.split('-')[1])
+        md5s = []
+
+        with open(local_file, 'rb') as f:
+            for part_num in range(1, parts + 1):
+                # Get the part size for every part of the multipart uploaded object
+                if version:
+                    key_head = s3.head_object(Bucket=bucket, Key=obj, VersionId=version, PartNumber=part_num)
+                else:
+                    key_head = s3.head_object(Bucket=bucket, Key=obj, PartNumber=part_num)
+                part_size = int(key_head['ContentLength'])
+                data = f.read(part_size)
+                hash = hashlib.md5(data)
+                md5s.append(hash)
+
+        digests = b''.join(m.digest() for m in md5s)
+        digests_md5 = hashlib.md5(digests)
+        local_keysum = '{0}-{1}'.format(digests_md5.hexdigest(), len(md5s))
+    else:  # Compute the MD5 sum normally
+        local_keysum = module.md5(local_file)
+
+    return s3_keysum == local_keysum
+
+
+def keysum(s3, bucket, obj, version=None):
     if version:
         key_check = s3.head_object(Bucket=bucket, Key=obj, VersionId=version)
     else:
@@ -314,8 +342,6 @@ def keysum(module, s3, bucket, obj, version=None):
     if not key_check:
         return None
     md5_remote = key_check['ETag'][1:-1]
-    if '-' in md5_remote:  # Check for multipart, etag is not md5
-        return None
     return md5_remote
 
 
@@ -706,11 +732,11 @@ def main():
             else:
                 module.fail_json(msg="Key %s does not exist." % obj)
 
-        # If the destination path doesn't exist or overwrite is True, no need to do the md5um etag check, so just download.
+        # If the destination path doesn't exist or overwrite is True, no need to do the md5sum ETag check, so just download.
         # Compare the remote MD5 sum of the object with the local dest md5sum, if it already exists.
         if path_check(dest):
             # Determine if the remote and local object are identical
-            if keysum(module, s3, bucket, obj, version=version) == module.md5(dest):
+            if keysum_compare(module, dest, s3, bucket, obj, version=version):
                 sum_matches = True
                 if overwrite == 'always':
                     download_s3file(module, s3, bucket, obj, dest, retries, version=version)
@@ -740,10 +766,10 @@ def main():
         if bucketrtn:
             keyrtn = key_check(module, s3, bucket, obj, version=version, validate=validate)
 
-        # Lets check key state. Does it exist and if it does, compute the etag md5sum.
+        # Lets check key state. Does it exist and if it does, compute the ETag md5sum.
         if bucketrtn and keyrtn:
             # Compare the local and remote object
-            if module.md5(src) == keysum(module, s3, bucket, obj):
+            if keysum_compare(module, src, s3, bucket, obj):
                 sum_matches = True
                 if overwrite == 'always':
                     # only use valid object acls for the upload_s3file function


### PR DESCRIPTION
##### SUMMARY
Fixes #23547
Currently, the aws_s3 module ignores the ETag for a multipart upload because the ETag is not a valid MD5 sum. This does not allow proper overwrite behavior for multipart uploaded files. This change would compute the multipart object ETag for the local file for comparison against the S3 ETag (digest of digests appended with the number of parts).

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
aws_s3

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel bf04e8a8ea) last updated 2017/12/24 10:57:26 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/vinay.dandekar/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/vinay.dandekar/ansible/lib/ansible
  executable location = /home/vinay.dandekar/ansible/bin/ansible
  python version = 2.7.5 (default, Aug  4 2017, 00:39:18) [GCC 4.8.5 20150623 (Red Hat 4.8.5-16)]
```


##### ADDITIONAL INFORMATION
Wanted to avoid the approach in #31371 since custom metadata tagging is not always achievable (no permissions on bucket, public bucket, lack of access to PUT metadata, uploads performed by the AWS S3 CLI, etc.).

Since the part size can be variable for each part, a HEAD request must be made for each part to get each part size.

```yaml
- name: Download file
  aws_s3:
    region: '<region>'
    bucket: '<bucket_name>'
    object: '<object_name>'
    dest: '<location>'
    mode: get
    overwrite: different
```

Before:
```
TASK [Download file] **********************************************************************************************************************************************************
changed: [localhost] => {"changed": true, "msg": "GET operation complete"}
```

After:
```
TASK [Download file] **********************************************************************************************************************************************************
ok: [localhost] => {"changed": false, "msg": "Local and remote object are identical, ignoring. Use overwrite=always parameter to force."}
```