### PR TITLE
DigitalOcean Inventory: Removed sort from json dump

### DIFF
--- a/contrib/inventory/digital_ocean.py
+++ b/contrib/inventory/digital_ocean.py
@@ -312,7 +312,7 @@ class DigitalOceanInventory(object):
             self.write_to_cache()
 
         if self.args.pretty:
-            print(json.dumps(json_data, sort_keys=True, indent=2))
+            print(json.dumps(json_data, indent=2))
         else:
             print(json.dumps(json_data))
 
@@ -515,7 +515,7 @@ class DigitalOceanInventory(object):
     def write_to_cache(self):
         """ Writes data in JSON format to a file """
         data = {'data': self.data, 'inventory': self.inventory}
-        json_data = json.dumps(data, sort_keys=True, indent=2)
+        json_data = json.dumps(data, indent=2)
 
         with open(self.cache_filename, 'w') as cache:
             cache.write(json_data)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Remove sort_keys from json.dumps since the resulting keys are strings and integers. Currently this works without an issues when using python 2. When running the same code under python3 the inventory script is unable to complete successfully because key sorting is attempting to sort a string against an integer.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
contrib/inventory/digital_ocean.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (test/block-storage ee4235019f) last updated 2017/12/22 17:09:40 (GMT -400)
  config file = /Users/abond/Dev/github/ansible.cfg
  configured module search path = ['/Users/abond/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/abond/Dev/github/ansible/lib/ansible
  executable location = /Users/abond/Dev/github/ansible/bin/ansible
  python version = 3.6.4 (default, Dec 19 2017, 15:24:51) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
/usr/local/bin/python3 /Users/abond/Dev/github/ansible/contrib/inventory/digital_ocean.py --pretty
Traceback (most recent call last):
  File "/Users/abond/Dev/github/ansible/contrib/inventory/digital_ocean.py", line 543, in <module>
    DigitalOceanInventory()
  File "/Users/abond/Dev/github/ansible/contrib/inventory/digital_ocean.py", line 313, in __init__
    self.write_to_cache()
  File "/Users/abond/Dev/github/ansible/contrib/inventory/digital_ocean.py", line 519, in write_to_cache
    json_data = json.dumps(data, sort_keys=True, indent=2)
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 201, in encode
    chunks = list(chunks)
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 430, in _iterencode
    yield from _iterencode_dict(o, _current_indent_level)
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 404, in _iterencode_dict
    yield from chunks
  File "/usr/local/Cellar/python3/3.6.4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/json/encoder.py", line 353, in _iterencode_dict
    items = sorted(dct.items(), key=lambda kv: kv[0])
TypeError: '<' not supported between instances of 'int' and 'str'
```

After removing `sort_keys=True` the inventory script will respond accordingly.