### PR TITLE
Fixes get_prompt() issue for network platforms using cliconf plugins

### DIFF
--- a/lib/ansible/plugins/cliconf/__init__.py
+++ b/lib/ansible/plugins/cliconf/__init__.py
@@ -25,7 +25,7 @@ from abc import ABCMeta, abstractmethod
 from functools import wraps
 
 from ansible.errors import AnsibleError, AnsibleConnectionFailure
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_bytes, to_text
 from ansible.module_utils.six import with_metaclass
 
 try:
@@ -45,8 +45,8 @@ except ImportError:
 def enable_mode(func):
     @wraps(func)
     def wrapped(self, *args, **kwargs):
-        prompt = self.get_prompt()
-        if not str(prompt).strip().endswith('#'):
+        prompt = self._connection.get_prompt()
+        if not to_text(prompt, errors='surrogate_or_strict').strip().endswith('#'):
             raise AnsibleError('operation requires privilege escalation')
         return func(self, *args, **kwargs)
     return wrapped


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #34220
Ensure get_prompt() method is invoked on network_cli Connection class object. 
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
cliconf/__init__.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
