### PR TITLE
Fix ios_l3_interface configure ipv4 address issue

### DIFF
--- a/lib/ansible/modules/network/ios/ios_l3_interface.py
+++ b/lib/ansible/modules/network/ios/ios_l3_interface.py
@@ -185,14 +185,14 @@ def map_obj_to_commands(updates, module):
 
         elif state == 'present':
             if ipv4:
-                if obj_in_have is None or ipv4 != obj_in_have['ipv4']:
+                if obj_in_have is None or obj_in_have.get('ipv4') is None or ipv4 != obj_in_have['ipv4']:
                     address = ipv4.split('/')
                     if len(address) == 2:
                         ipv4 = '{0} {1}'.format(address[0], to_netmask(address[1]))
                     commands.append('ip address {}'.format(ipv4))
 
             if ipv6:
-                if obj_in_have is None or obj_in_have['ipv6'] is None or ipv6.lower() != obj_in_have['ipv6'].lower():
+                if obj_in_have is None or obj_in_have.get('ipv6') is None or ipv6.lower() != obj_in_have['ipv6'].lower():
                     commands.append('ipv6 address {}'.format(ipv6))
 
         if commands[-1] == interface:


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a new interface and it's ipv4/ipv6 address results
in failure. Add a check to validate if interface address is
already configured or not.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_l3_interface

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
