### PR TITLE
Fail when model not found

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -134,7 +134,7 @@ class KubernetesAnsibleModule(AnsibleModule):
             helper.get_model(api_version, kind)
             return helper
         except KubernetesException as exc:
-            self.fail_json(msg="Error initializing module helper {0}".format(exc.message))
+            self.fail_json(msg="Error initializing module helper: {0}".format(exc.message))
 
     def execute_module(self):
         if self.resource_definition:
@@ -355,7 +355,7 @@ class OpenShiftAnsibleModule(KubernetesAnsibleModule):
             helper.get_model(api_version, kind)
             return helper
         except KubernetesException as exc:
-            self.exit_json(msg="Error initializing module helper {}".format(exc.message))
+            self.fail_json(msg="Error initializing module helper: {0}".format(exc.message))
 
     def _create(self, namespace):
         if self.kind.lower() == 'project':


### PR DESCRIPTION
##### SUMMARY
Make get_model() methods consistent, and always fail when the model cannot be found.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/k8s/common.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 34699cd1f1) last updated 2017/12/25 16:26:31 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/.pyenv/versions/venv27/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```
