### PR TITLE
file module, follow symlink when doing hardlink

### DIFF
--- a/changelogs/fragments/file_hardlink.yml
+++ b/changelogs/fragments/file_hardlink.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - file - retrieve the link's full path when hard linking a soft link with follow (https://github.com/ansible/ansible/issues/33911).

--- a/lib/ansible/modules/file.py
+++ b/lib/ansible/modules/file.py
@@ -872,6 +872,8 @@ def ensure_hardlink(path, src, follow, force, timestamps):
                                                   'path': path})
         else:
             try:
+                if follow and os.path.islink(b_src):
+                    b_src = os.readlink(b_src)
                 os.link(b_src, b_path)
             except OSError as e:
                 raise AnsibleModuleError(results={'msg': 'Error while linking: %s'

--- a/test/integration/targets/file/tasks/link_follow.yml
+++ b/test/integration/targets/file/tasks/link_follow.yml
@@ -1,0 +1,45 @@
+- name: Ensure output_dir
+  file:
+    path: "{{output_dir}}"
+    state: directory
+
+- name: Touch a file in it
+  file:
+    path: "{{output_dir}}/original.txt"
+    state: touch
+
+- name: Create a symlink
+  file:
+    src: "{{output_dir}}/original.txt"
+    dest: "{{output_dir}}/soft.txt"
+    state: link
+
+- name: Create an hard link with follow to the sym link
+  file:
+    src: "{{output_dir}}/soft.txt"
+    dest: "{{output_dir}}/hard.txt"
+    state: hard
+    follow: yes
+
+- name: Create a symlink from another symlink
+  file:
+    src: "{{output_dir}}/soft.txt"
+    dest: "{{output_dir}}/soft2.txt"
+    follow: yes
+    state: link
+
+- name: Hard link stat
+  stat:
+    path: "{{output_dir}}/hard.txt"
+  register: hard_stat
+
+- name: Soft link stat
+  stat:
+    path: "{{output_dir}}/soft2.txt"
+  register: soft_stat
+
+- name: Check link status
+  assert:
+    that:
+      - "hard_stat.stat.exists == true"
+      - "soft_stat.stat.exists == true"


### PR DESCRIPTION
##### SUMMARY

Uses `os.readlink` to retrieve the link's full path when hard linking a soft link (using `follow: true`).

Fixes #33911 

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
File

##### ANSIBLE VERSION

```
ansible 2.5.0
  config file = None
  configured module search path = [u'/home/lrossetti/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/lrossetti/Work/ansible/venv/lib/python2.7/site-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /home/lrossetti/Work/ansible/venv/bin/ansible
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

I created an additional task in the module's integration test, sample usage:

```
-
  hosts: localhost
  tasks:
    - 
      name: Run hard link test
      include_role:
        name: file_test
        tasks_from: hard_link_follow.yml
  vars:
    output_dir: ~/tmp

```

Note: not sure if this is the best approach to test this, I tried to use the file role test (main.yml) but it failed a couple of times to me + this test felt like it should be an isolated test case on its own.