### PR TITLE
Remove diff and request data

### DIFF
--- a/lib/ansible/module_utils/k8s/common.py
+++ b/lib/ansible/module_utils/k8s/common.py
@@ -167,9 +167,6 @@ class KubernetesAnsibleModule(AnsibleModule):
 
         return_attributes = dict(changed=False, result=dict())
 
-        if self._diff:
-            return_attributes['request'] = self.helper.request_body_from_params(self.params)
-
         if self.helper.base_model_name_snake.endswith('list'):
             k8s_obj = self._read(name, namespace)
             return_attributes['result'] = k8s_obj.to_dict()
@@ -225,8 +222,6 @@ class KubernetesAnsibleModule(AnsibleModule):
             if match:
                 return_attributes['result'] = existing.to_dict()
                 self.exit_json(**return_attributes)
-            elif self._diff:
-                return_attributes['differences'] = diff
             # Differences exist between the existing obj and requested params
             if not self.check_mode:
                 try:

--- a/lib/ansible/modules/clustering/k8s/k8s_raw.py
+++ b/lib/ansible/modules/clustering/k8s/k8s_raw.py
@@ -29,7 +29,7 @@ description:
     files and using Jinja templates.
   - Access to the full range of K8s APIs.
   - Authenticate using either a config file, certificates, password or token.
-  - Supports check mode, and the diff option.
+  - Supports check mode.
 
 extends_documentation_fragment:
   - k8s_state_options
@@ -124,19 +124,32 @@ result:
   description:
   - The created, patched, or otherwise present object. Will be empty in the case of a deletion.
   returned: success
-  type: dict
-request:
-  description:
-  - The object sent to the API. Useful for troubleshooting unexpected differences and 404 errors.
-  returned: when diff is true
-  type: dict
-diff:
-  description:
-  - List of differences found when determining if an existing object will be patched. A copy of the existing object
-    is updated with the requested options, and the updated object is then compared to the original. If there are
-    differences, they will appear here.
-  returned: when diff is true
-  type: list
+  type: complex
+  contains:
+     api_version:
+       description: The versioned schema of this representation of an object.
+       returned: success
+       type: str
+     kind:
+       description: Represents the REST resource this object represents.
+       returned: success
+       type: str
+     metadata:
+       description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
+       returned: success
+       type: complex
+     spec:
+       description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
+       returned: success
+       type: complex
+     status:
+       description: Current status details for the object.
+       returned: success
+       type: complex
+     items:
+       description: Returned only when the I(kind) is a List type resource. Contains a set of objects.
+       returned: when resource is a List
+       type: list
 '''
 
 from ansible.module_utils.k8s.common import KubernetesAnsibleModule

--- a/lib/ansible/modules/clustering/openshift/openshift_raw.py
+++ b/lib/ansible/modules/clustering/openshift/openshift_raw.py
@@ -29,7 +29,7 @@ description:
     files and using Jinja templates.
   - Access to the full range of K8s and OpenShift APIs.
   - Authenticate using either a config file, certificates, password or token.
-  - Supports check mode, and the diff option.
+  - Supports check mode.
 
 extends_documentation_fragment:
   - k8s_state_options
@@ -165,19 +165,32 @@ result:
   description:
   - The created, patched, or otherwise present object. Will be empty in the case of a deletion.
   returned: success
-  type: dict
-request:
-  description:
-  - The object sent to the API. Useful for troubleshooting unexpected differences and 404 errors.
-  returned: when diff is true
-  type: dict
-diff:
-  description:
-  - List of differences found when determining if an existing object will be patched. A copy of the existing object
-    is updated with the requested options, and the updated object is then compared to the original. If there are
-    differences, they will appear here.
-  returned: when diff is true
-  type: list
+  type: complex
+  contains:
+     api_version:
+       description: The versioned schema of this representation of an object.
+       returned: success
+       type: str
+     kind:
+       description: Represents the REST resource this object represents.
+       returned: success
+       type: str
+     metadata:
+       description: Standard object metadata. Includes name, namespace, annotations, labels, etc.
+       returned: success
+       type: complex
+     spec:
+       description: Specific attributes of the object. Will vary based on the I(api_version) and I(kind).
+       returned: success
+       type: complex
+     status:
+       description: Current status details for the object.
+       returned: success
+       type: complex
+     items:
+       description: Returned only when the I(kind) is a List type resource. Contains a set of objects.
+       returned: when resource is a List
+       type: list
 '''
 
 from ansible.module_utils.k8s.common import OpenShiftAnsibleModule


### PR DESCRIPTION
##### SUMMARY
- Remove request and diff data from module output in an attempt to fully address security concerns raised by [openshift-restclient-python #107](https://github.com/openshift/openshift-restclient-python/issues/107)
- Add more RETURN docs detail 

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/k8s/common.py
lib/ansible/modules/clustering/k8s/k8s_raw.py 
lib/ansible/modules/clustering/openshift/openshift_raw.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 2d13167f1c) last updated 2017/12/25 21:34:22 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/chouseknecht/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/chouseknecht/projects/ansible/lib/ansible
  executable location = /Users/chouseknecht/.pyenv/versions/venv27/bin/ansible
  python version = 2.7.14 (default, Nov 14 2017, 23:24:24) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.38)]
```