### PR TITLE
WinRM: fix format_exc call

### DIFF
--- a/lib/ansible/plugins/connection/winrm.py
+++ b/lib/ansible/plugins/connection/winrm.py
@@ -375,7 +375,7 @@ class Connection(ConnectionBase):
 
             except Exception as ex:
                 from traceback import format_exc
-                display.warning("FATAL ERROR DURING FILE TRANSFER: %s" % format_exc(ex))
+                display.warning("FATAL ERROR DURING FILE TRANSFER: %s" % format_exc())
                 stdin_push_failed = True
 
             if stdin_push_failed:


### PR DESCRIPTION
##### SUMMARY
This fix adds correct call for format_exc in winrm plugin.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/plugins/connection/winrm.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```
