### PR TITLE
Added new return status fields for mongodb_user module

### DIFF
--- a/lib/ansible/modules/database/mongodb/mongodb_user.py
+++ b/lib/ansible/modules/database/mongodb/mongodb_user.py
@@ -269,14 +269,15 @@ def user_find(client, user, db_name):
 
 
 def user_add(module, client, db_name, user, password, roles):
-    #pymongo's user_add is a _create_or_update_user so we won't know if it was changed or updated
-    #without reproducing a lot of the logic in database.py of pymongo
+    # pymongo's user_add is a _create_or_update_user so we won't know if it was changed or updated
+    # without reproducing a lot of the logic in database.py of pymongo
     db = client[db_name]
 
     if roles is None:
         db.add_user(user, password, False)
     else:
         db.add_user(user, password, None, roles=roles)
+
 
 def user_remove(module, client, db_name, user):
     exists = user_find(client, user, db_name)
@@ -287,6 +288,7 @@ def user_remove(module, client, db_name, user):
         db.remove_user(user)
     else:
         module.exit_json(changed=False, user=user)
+
 
 def load_mongocnf():
     config = configparser.RawConfigParser()
@@ -302,7 +304,6 @@ def load_mongocnf():
         return False
 
     return creds
-
 
 
 def check_if_roles_changed(uinfo, roles, db_name):
@@ -326,7 +327,7 @@ def check_if_roles_changed(uinfo, roles, db_name):
         output = list()
         for role in roles:
             if isinstance(role, (binary_type, text_type)):
-                new_role = { "role": role, "db": db_name }
+                new_role = {"role": role, "db": db_name}
                 output.append(new_role)
             else:
                 output.append(role)
@@ -340,14 +341,13 @@ def check_if_roles_changed(uinfo, roles, db_name):
     return True
 
 
-
 # =========================================
 # Module execution.
 #
 
 def main():
     module = AnsibleModule(
-        argument_spec = dict(
+        argument_spec=dict(
             login_user=dict(default=None),
             login_password=dict(default=None, no_log=True),
             login_host=dict(default='localhost'),
@@ -416,12 +416,11 @@ def main():
         elif LooseVersion(PyMongoVersion) >= LooseVersion('3.0'):
             if db_name != "admin":
                 module.fail_json(msg='The localhost login exception only allows the first admin account to be created')
-            #else: this has to be the first admin user added
+            # else: this has to be the first admin user added
 
     except Exception as e:
         module.fail_json(msg='unable to connect to database: %s' % to_native(e), exception=traceback.format_exc())
- 
-    ## CHANGE
+
     uinfo = user_find(client, user, db_name)
     if uinfo:
         roles_changed = check_if_roles_changed(uinfo, roles, db_name)
@@ -429,8 +428,6 @@ def main():
     else:
         roles_changed = True
         new_user = True
-    ##
-
 
     if state == 'present':
         if password is None and update_password == 'always':
@@ -450,8 +447,8 @@ def main():
             module.fail_json(msg='Unable to add or update user: %s' % to_native(e), exception=traceback.format_exc())
 
             # Here we can  check password change if mongo provide a query for that : https://jira.mongodb.org/browse/SERVER-22848
-            #newuinfo = user_find(client, user, db_name)
-            #if uinfo['role'] == newuinfo['role'] and CheckPasswordHere:
+            # newuinfo = user_find(client, user, db_name)
+            # if uinfo['role'] == newuinfo['role'] and CheckPasswordHere:
             #    module.exit_json(changed=False, user=user)
 
     elif state == 'absent':
@@ -460,12 +457,7 @@ def main():
         except Exception as e:
             module.fail_json(msg='Unable to remove user: %s' % to_native(e), exception=traceback.format_exc())
 
-        ##ADDED
         module.exit_json(changed=True, user=user, roles_changed=True, new_user=False)
-
-
-
-    #module.exit_json(changed=True, user=user)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
As it is right now, mongodb_user module has the same status when I add new user or when I just change roles for existing user. In both cases, `changed` is set to `true`, which is fine, but in some cases, there may be need to find out if we changed roles for existing user or if we created new user. New status fields (booleans) `roles_changed` and `new_user` allow such thing.

```
ok: [localhost] => {
    "msg": {
        "changed": true,
        "failed": false,
        "new_user": false,
        "roles_changed": true,
        "user": "bob3"
    }
}
```

It's important to say that this change is compatible to previous version. All existing status fields are there, the same as before.


##### ISSUE TYPE
 - Feature Pull Request


##### COMPONENT NAME
mongodb_user module

##### ANSIBLE VERSION
```
ansible 2.4.1.0
  config file = /Users/boban/.ansible.cfg
  configured module search path = [u'/Users/boban/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Python/2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```


##### ADDITIONAL INFORMATION
It's important to say that this change is compatible to previous version. All existing status fields are there, the same as before.

New return status:  
```
ok: [localhost] => {
    "msg": {
        "changed": true,
        "failed": false,
        "new_user": false,
        "roles_changed": true,
        "user": "bob3"
    }
}
```
Old return status:  
```
ok: [localhost] => {
    "msg": {
        "changed": true,
        "failed": false,
        "user": "bob3"
    }
}
```