### PR TITLE
nmcli: Add missing 'primary' option

### DIFF
--- a/lib/ansible/modules/net_tools/nmcli.py
+++ b/lib/ansible/modules/net_tools/nmcli.py
@@ -565,6 +565,7 @@ class Nmcli(object):
         self.priority = module.params['priority']
         self.mode = module.params['mode']
         self.miimon = module.params['miimon']
+        self.primary = module.params['primary']
         self.downdelay = module.params['downdelay']
         self.updelay = module.params['updelay']
         self.arp_interval = module.params['arp_interval']
@@ -814,6 +815,9 @@ class Nmcli(object):
         if self.downdelay is not None:
             cmd.append('arp-ip-target')
             cmd.append(self.arp_ip_target)
+        if self.primary is not None:
+            cmd.append('primary')
+            cmd.append(self.primary)
         return cmd
 
     def modify_connection_bond(self):
@@ -1052,6 +1056,7 @@ def main():
             updelay=dict(required=False, default=None, type='str'),
             arp_interval=dict(required=False, default=None, type='str'),
             arp_ip_target=dict(required=False, default=None, type='str'),
+            primary=dict(required=False, default=None, type='str'),
             # general usage
             mtu=dict(required=False, default=None, type='str'),
             mac=dict(required=False, default=None, type='str'),

--- a/test/units/modules/net_tools/test_nmcli.py
+++ b/test/units/modules/net_tools/test_nmcli.py
@@ -17,6 +17,72 @@ TESTCASE = [
     }
 ]
 
+TESTCASE_BOND = [
+    {
+        'type': 'bond',
+        'conn_name': 'non_existent_nw_device',
+        'ifname': 'bond_non_existant',
+        'mode': 'active-backup',
+        'ip4': '10.10.10.10',
+        'gw4': '10.10.10.1',
+        'state': 'present',
+        'primary': 'non_existent_primary',
+        '_ansible_check_mode': False,
+    }
+]
+
+
+def mocker_set(mocker, connection_exists=False):
+    """
+    Common mocker object
+    """
+    mocker.patch('ansible.modules.net_tools.nmcli.HAVE_DBUS', True)
+    mocker.patch('ansible.modules.net_tools.nmcli.HAVE_NM_CLIENT', True)
+    get_bin_path = mocker.patch('ansible.module_utils.basic.AnsibleModule.get_bin_path')
+    get_bin_path.return_value = '/usr/bin/nmcli'
+    connection = mocker.patch.object(nmcli.Nmcli, 'connection_exists')
+    connection.return_value = connection_exists
+    return connection
+
+
+@pytest.fixture
+def mocked_generic_connection_create(mocker):
+    mocker_set(mocker)
+    command_result = mocker.patch.object(nmcli.Nmcli, 'execute_command')
+    command_result.return_value = {"rc": 100, "out": "aaa", "err": "none"}
+    return command_result
+
+
+@pytest.mark.parametrize('patch_ansible_module', TESTCASE_BOND, indirect=['patch_ansible_module'])
+def test_bond_connection_create(mocked_generic_connection_create):
+    """
+    Test : Bond connection created
+    """
+    with pytest.raises(SystemExit):
+        nmcli.main()
+
+    assert nmcli.Nmcli.execute_command.call_count == 1
+    arg_list = nmcli.Nmcli.execute_command.call_args_list
+    args, kwargs = arg_list[0]
+
+    assert args[0][0] == '/usr/bin/nmcli'
+    assert args[0][1] == 'con'
+    assert args[0][2] == 'add'
+    assert args[0][3] == 'type'
+    assert args[0][4] == 'bond'
+    assert args[0][5] == 'con-name'
+    assert args[0][6] == 'non_existent_nw_device'
+    assert args[0][7] == 'ifname'
+    assert args[0][8] == 'bond_non_existant'
+    assert args[0][9] == 'mode'
+    assert args[0][10] == 'active-backup'
+    assert args[0][11] == 'ip4'
+    assert args[0][12] == '10.10.10.10'
+    assert args[0][13] == 'gw4'
+    assert args[0][14] == '10.10.10.1'
+    assert args[0][15] == 'primary'
+    assert args[0][16] == 'non_existent_primary'
+
 
 @pytest.fixture
 def mocked_connection_exists(mocker):


### PR DESCRIPTION
##### SUMMARY
This fix adds missing 'primary' option in nmcli module.

Fixes: #30405

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
lib/ansible/modules/net_tools/nmcli.py
test/units/modules/net_tools/test_nmcli.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```