### PR TITLE
task_executor.py: Raise 'conditional exception' in case of 'include_*'

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -456,7 +456,7 @@ class TaskExecutor:
             if self._loop_eval_error is not None:
                 raise self._loop_eval_error  # pylint: disable=raising-bad-type
             # skip conditional exception in the case of includes as the vars needed might not be available except in the included tasks or due to tags
-            if self._task.action not in ['include', 'include_tasks', 'include_role']:
+            if self._task.action not in ['include']:
                 raise
 
         # Not skipping, if we had loop error raised earlier we need to raise it now to halt the execution of this task

--- a/test/integration/targets/include_role/aliases
+++ b/test/integration/targets/include_role/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/include_role/tasks/main.yml
+++ b/test/integration/targets/include_role/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- command: "echo ok"
+  changed_when: False
+  register: "_command_result"
+
+- include_role:
+    name: "no_log"
+  ignore_errors: True
+  register: "_include_role_result"
+  when:
+    - "_undefined == 'yes'"
+
+- assert:
+    that:
+      - "_include_role_result is failed"
+    msg: "'include_role' did not evaluate it's attached condition and failed"

--- a/test/integration/targets/include_tasks/aliases
+++ b/test/integration/targets/include_tasks/aliases
@@ -1,0 +1,1 @@
+posix/ci/group3

--- a/test/integration/targets/include_tasks/tasks/include_tasks.yml
+++ b/test/integration/targets/include_tasks/tasks/include_tasks.yml
@@ -1,0 +1,5 @@
+---
+
+- debug:
+    msg: "This message comes from an 'include_tasks'-task! :-)"
+  register: "_include_tasks_task_result"

--- a/test/integration/targets/include_tasks/tasks/main.yml
+++ b/test/integration/targets/include_tasks/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+
+- command: "echo ok"
+  changed_when: False
+  register: "_command_result"
+
+- include_tasks: "include_tasks.yml"
+  ignore_errors: True
+  register: "_include_tasks_result"
+  when:
+    - "_undefined == 'yes'"
+
+- assert:
+    that:
+      - "_include_tasks_result is failed"
+      - "_include_tasks_task_result is not defined"
+    msg: "'include_tasks' did not evaluate it's attached condition and failed"


### PR DESCRIPTION
##### SUMMARY
This protection was initially added as a solution to #12843 at a time
when there only was 'include'.

After final integration of 483df9c5f83befbef85796090c0f61de6436b130, the protection is not feasible anymore - since
we've introduced 'import_*' for explicit, "dynamic including".

While this PR does not touch the meanwhile deprecated 'include'-behaviour,
it does change the behavior of 'include_task' and 'include_role', since these
(according to documentation) are supposed to apply i.e. conditions to the
statement itself, and not to the set of included objectives (which implies
raising an exception when failing to properly evaluate conditions, instead
of silently catching it).

Fixes #33632

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
executor/task_executor.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (fix_33632 e4d3715d36) last updated 2017/12/27 13:37:35 (GMT +200)
  config file = /Users/pringl/development/cm-infra/ansible.cfg
  configured module search path = [u'/usr/share/ansible']
  ansible python module location = /Users/pringl/development/ansible/lib/ansible
  executable location = /Users/pringl/development/ansible/bin/ansible
  python version = 2.7.13 (default, Jun 15 2017, 10:33:06) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```