### PR TITLE
add documentation around commonly-used Facts for Conditionals

### DIFF
--- a/docs/docsite/rst/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbooks_conditionals.rst
@@ -6,7 +6,7 @@ Conditionals
 
 Often the result of a play may depend on the value of a variable, fact (something learned about the remote system), or previous task result.
 In some cases, the values of variables may depend on other variables.
-Further, additional groups can be created to manage hosts based on whether the hosts match other criteria. This topic covers how conditionals are used in playbooks. 
+Further, additional groups can be created to manage hosts based on whether the hosts match other criteria. This topic covers how conditionals are used in playbooks.
 
 .. note:: There are many options to control execution flow in Ansible. More examples of supported conditionals can be located here: http://jinja.pocoo.org/docs/dev/templates/#comparisons.
 
@@ -319,6 +319,69 @@ You may check the registered variable's string contents for emptiness::
             debug: msg="Directory is empty"
             when: contents.stdout == ""
 
+Commonly Used Facts
+```````````````````
+
+The following Facts (see :ref:`_vars_and_facts`) are frequently used in Conditionals - see above for examples.
+
+.. _ansible_distribution:
+
+ansible_distribution
+--------------------
+
+Possible values::
+
+    Alpine
+    Altlinux
+    Amazon
+    Archlinux
+    ClearLinux
+    Coreos
+    Debian
+    Gentoo
+    Mandriva
+    NA
+    OpenWrt
+    OracleLinux
+    RedHat
+    Slackware
+    SMGL
+    SUSE
+    VMwareESX
+
+.. See `OSDIST_LIST`
+
+.. _ansible_distribution_major_version:
+
+ansible_distribution_major_version
+----------------------------------
+
+This will be the major version of the operating system. For example, the value will be `16` for Ubuntu 16.04.
+
+.. _ansible_os_family:
+
+ansible_os_family
+-----------------
+
+Possible values::
+
+    AIX
+    Alpine
+    Altlinux
+    Archlinux
+    Darwin
+    Debian
+    FreeBSD
+    Gentoo
+    HP-UX
+    Mandrake
+    RedHat
+    SGML
+    Slackware
+    Solaris
+    Suse
+
+.. See `OS_FAMILY_MAP`
 
 .. seealso::
 

--- a/docs/docsite/rst/playbooks_conditionals.rst
+++ b/docs/docsite/rst/playbooks_conditionals.rst
@@ -6,7 +6,7 @@ Conditionals
 
 Often the result of a play may depend on the value of a variable, fact (something learned about the remote system), or previous task result.
 In some cases, the values of variables may depend on other variables.
-Further, additional groups can be created to manage hosts based on whether the hosts match other criteria. This topic covers how conditionals are used in playbooks.
+Additional groups can be created to manage hosts based on whether the hosts match other criteria. This topic covers how conditionals are used in playbooks.
 
 .. note:: There are many options to control execution flow in Ansible. More examples of supported conditionals can be located here: http://jinja.pocoo.org/docs/dev/templates/#comparisons.
 

--- a/lib/ansible/module_utils/facts/system/distribution.py
+++ b/lib/ansible/module_utils/facts/system/distribution.py
@@ -55,6 +55,7 @@ class DistributionFiles:
     #  - allowempty == True
     #  - be listed in SEARCH_STRING
     #  - have a function get_distribution_DISTNAME implemented
+    # keep names in sync with Conditionals page of docs
     OSDIST_LIST = (
         {'path': '/etc/oracle-release', 'name': 'OracleLinux'},
         {'path': '/etc/slackware-version', 'name': 'Slackware'},
@@ -403,6 +404,7 @@ class Distribution(object):
         'SMGL': 'Source Mage GNU/Linux',
     }
 
+    # keep keys in sync with Conditionals page of docs
     OS_FAMILY_MAP = {'RedHat': ['RedHat', 'Fedora', 'CentOS', 'Scientific', 'SLC',
                                 'Ascendos', 'CloudLinux', 'PSBM', 'OracleLinux', 'OVS',
                                 'OEL', 'Amazon', 'Virtuozzo', 'XenServer'],


### PR DESCRIPTION
##### SUMMARY

There are a few Facts that are often used for Conditionals, so documenting them on the Conditionals page with their possible values. The question originally came up in [this mailing list thread](https://groups.google.com/forum/#!msg/Ansible-project/OZPu-b17n_w/b1SF4LIzwRQJ).

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
System facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/aidanfeldman/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/var/pyenv/versions/2.7.14/lib/python2.7/site-packages/ansible
  executable location = /usr/local/var/pyenv/versions/2.7.14/bin/ansible
  python version = 2.7.14 (default, Dec 27 2017, 12:36:43) [GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)]
```


##### ADDITIONAL INFORMATION
I'm new to reStructuredText, so let me know if the formatting could have been done better.
