### PR TITLE
Add support for using IP addresses in target groups

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -105,6 +105,12 @@ options:
     description:
       - A dictionary of one or more tags to assign to the target group.
     required: false
+  target_type:
+    description:
+      - Indicate whether the target group consists of instances IDS 'instance' or IP addresses 'ip'. Default is 'instance'.
+    choices: ['instance', 'ip']
+    required: false
+    version_added: "2.5"
   targets:
     description:
       - A list of targets to assign to the target group. This parameter defaults to an empty list. Unless you set the 'modify_targets' parameter then
@@ -380,6 +386,10 @@ def create_or_update_target_group(connection, module):
             params['Matcher'] = {}
             params['Matcher']['HttpCode'] = module.params.get("successful_response_codes")
 
+    # Get target type
+    if module.params.get("target_type") is not None:
+        params['TargetType'] = module.params.get("target_type")
+
     # Get target group
     tg = get_target_group(connection, module)
 
@@ -645,6 +655,7 @@ def main():
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             successful_response_codes=dict(type='str'),
             tags=dict(default={}, type='dict'),
+            target_type=dict(default='instance', choices=['instance', 'ip'], type='str'),
             targets=dict(type='list'),
             unhealthy_threshold_count=dict(type='int'),
             vpc_id=dict(type='str'),

--- a/lib/ansible/modules/cloud/amazon/elb_target_group.py
+++ b/lib/ansible/modules/cloud/amazon/elb_target_group.py
@@ -13,10 +13,11 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: elb_target_group
-short_description: Manage a target group for an Application load balancer
+short_description: Manage a target group for an Application or Network load balancer
 description:
-    - Manage an AWS Application Elastic Load Balancer target group. See
-      U(http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) for details.
+    - Manage an AWS Elastic Load Balancer target group. See
+      U(http://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) or
+      U(http://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-target-groups.html) for details.
 version_added: "2.4"
 requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
@@ -97,8 +98,7 @@ options:
     default: lb_cookie
   successful_response_codes:
     description:
-      - >
-        The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of
+      - The HTTP codes to use when checking for a successful response from a target. You can specify multiple values (for example, "200,202") or a range of
         values (for example, "200-299").
     required: false
   tags:
@@ -107,10 +107,16 @@ options:
     required: false
   target_type:
     description:
-      - Indicate whether the target group consists of instances IDS 'instance' or IP addresses 'ip'. Default is 'instance'.
-    choices: ['instance', 'ip']
+      - The type of target that you must specify when registering targets with this target group. The possible values are
+        C(instance) (targets are specified by instance ID) or C(ip) (targets are specified by IP address).
+        Note that you can't specify targets for a target group using both instance IDs and IP addresses.
+        If the target type is ip, specify IP addresses from the subnets of the virtual private cloud (VPC) for the target
+        group, the RFC 1918 range (10.0.0.0/8, 172.16.0.0/12, and 192.168.0.0/16), and the RFC 6598 range (100.64.0.0/10).
+        You can't specify publicly routable IP addresses.
     required: false
-    version_added: "2.5"
+    default: instance
+    choices: ['instance', 'ip']
+    version_added: 2.5
   targets:
     description:
       - A list of targets to assign to the target group. This parameter defaults to an empty list. Unless you set the 'modify_targets' parameter then
@@ -157,22 +163,42 @@ EXAMPLES = '''
     name: mytargetgroup
     state: absent
 
-# Create a target group with targets
+# Create a target group with instance targets
 - elb_target_group:
-  name: mytargetgroup
-  protocol: http
-  port: 81
-  vpc_id: vpc-01234567
-  health_check_path: /
-  successful_response_codes: "200,250-260"
-  targets:
-    - Id: i-01234567
-      Port: 80
-    - Id: i-98765432
-      Port: 80
-  state: present
-  wait_timeout: 200
-  wait: True
+    name: mytargetgroup
+    protocol: http
+    port: 81
+    vpc_id: vpc-01234567
+    health_check_path: /
+    successful_response_codes: "200,250-260"
+    targets:
+      - Id: i-01234567
+        Port: 80
+      - Id: i-98765432
+        Port: 80
+    state: present
+    wait_timeout: 200
+    wait: True
+
+# Create a target group with IP address targets
+- elb_target_group:
+    name: mytargetgroup
+    protocol: http
+    port: 81
+    vpc_id: vpc-01234567
+    health_check_path: /
+    successful_response_codes: "200,250-260"
+    target_type: ip
+    targets:
+      - Id: 10.0.0.10
+        Port: 80
+        AvailabilityZone: all
+      - Id: 10.0.0.20
+        Port: 80
+    state: present
+    wait_timeout: 200
+    wait: True
+
 '''
 
 RETURN = '''
@@ -655,7 +681,7 @@ def main():
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             successful_response_codes=dict(type='str'),
             tags=dict(default={}, type='dict'),
-            target_type=dict(default='instance', choices=['instance', 'ip'], type='str'),
+            target_type=dict(type='str', default='instance', choices=['instance', 'ip']),
             targets=dict(type='list'),
             unhealthy_threshold_count=dict(type='int'),
             vpc_id=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
Add support for using IP addresses in target groups. (functionality added by Network LBs)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
elb_target_group

##### ANSIBLE VERSION
```
2.5
```


##### ADDITIONAL INFORMATION
@s-hertel @willthames 