### PR TITLE
Add module for interacting with AWS-hosted Elasticsearch

### DIFF
--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -103,7 +103,7 @@ endpoint:
     description: When cluster is finished being created, endpoint to submit requests to.
     returned: always
     type: string
-    sample: "https://testing-asdfqwerty.us-west-1.es.amazonaws.com"
+    sample: "search-testing-asdfqwerty.us-west-1.es.amazonaws.com"
 processing:
     description: Is the cluster processing config changes.
     returned: always

--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -78,6 +78,9 @@ options:
     description:
       - JSON string describing the access policy of the cluster.
     required: true
+  wait:
+    description:
+      - Wait for cluster creation to finish
 
 extends_documentation_fragment:
     - aws
@@ -170,7 +173,10 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils.ec2 import boto3_conn, compare_policies, ec2_argument_spec, get_aws_connection_info
 
-from botocore.exceptions import BotoCoreError, ClientError
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass # boto3_conn will handle missing dependencies
 
 
 def _create_elasticsearch_domain(connection, module):

--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -176,7 +176,7 @@ from ansible.module_utils.ec2 import boto3_conn, compare_policies, ec2_argument_
 try:
     from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
-    pass # boto3_conn will handle missing dependencies
+    pass  # boto3_conn will handle missing dependencies
 
 
 def _create_elasticsearch_domain(connection, module):

--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -335,7 +335,7 @@ def main():
             instance_type={'required': True},
             zone_awareness={'type': 'bool', 'default': True},
             dedicated_master_enabled={
-                'type': 'bool', 'default': False, 'choices': [True, False]
+                'type': 'bool', 'default': False
             },
             dedicated_master_type={},
             dedicated_master_count={'type': 'int'},

--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -1,0 +1,299 @@
+#!/usr/bin/python
+#
+# Copyright (c) 2017 Ansible Project
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: elasticsearch
+short_description: Manage hosted Elasticsearch in Amazon Web Services.
+description:
+  - Manage hosted Elasticsearch in Amazon Web Services.
+  - Returns information about the hosted Elasticsearch.
+version_added: "2.5"
+requirements: [ boto3 ]
+author: "Zach Steindler (@steiza)"
+options:
+  domain:
+    description:
+      - Domain name for cluster.
+    required: true
+  version:
+    description:
+      - Version of Elasticsearch to use.
+    required: false
+    default: 5.1
+  instance_count:
+    description:
+      - Number of non-master nodes in the cluster.
+    required: false
+    default: 1
+  instance_type:
+    description:
+      - Instance type of non-master nodes in the cluster.
+    required: false
+    default: t2.medium.elasticsearch
+  zone_awareness:
+    description:
+      - Should cluster be aware of AWS availability zones.
+    required: false
+    default: true
+  dedicated_master_enabled:
+    description:
+      - If cluster have dedicated master node(s).
+    choices: [true, false]
+    required: false
+    default: false
+  dedicated_master_type:
+    description:
+      - Instance type of dedicated master nodes. Ignored if dedicated_master_enabled is False.
+    required: false
+    default: m3.medium.elasticsearch
+  dedicated_master_count:
+    description:
+      - Number of dedicated master node(s). Ignored if dedicated_master_enabled is False.
+    required: false
+  ebs_volume_type:
+    description:
+      - What type of EBS volume should nodes have.
+    choices: [ "standard", "gp2", "io1" ]
+    required: false
+    default: gp2
+  ebs_volume_size:
+    description:
+      - What size EBS volume each node should have.
+    required: true
+  access_policies:
+    description:
+      - JSON string describing the access policy of the cluster.
+    required: true
+
+extends_documentation_fragment:
+    - aws
+    - ec2
+"""
+
+EXAMPLES = """
+# Note: None of these examples set aws_access_key, aws_secret_key, or region.
+# It is assumed that their matching environment variables are set.
+
+# Basic example
+- aws_elasticsearch:
+    domain: testing
+    instance_count: 1
+    zone_awareness: false
+    instance_type: "t2.medium.elasticsearch"
+    ebs_volume_size: 10
+    access_policies: '{"Statement": [{"Action": "*", "Resource": "arn:aws:iam::XXXXXXXXXXXXX:user/you", "Effect": "Allow"}]}'
+    region: us-east-1
+"""
+
+RETURN = """
+domain:
+    description: details about Elasticsearch cluster from describe_elasticsearch_domain()
+    returned: always
+    type: complex
+"""
+
+import collections
+import json
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils import ec2
+
+try:
+    import botocore.exceptions
+except ImportError:
+    pass # will be detected by ec2.HAS_BOTO3
+
+
+def _create_elasticsearch_domain(connection, module):
+    elasticsearch_cluster_config = {
+        'InstanceCount': module.params['instance_count'],
+        'InstanceType': module.params['instance_type'],
+        'ZoneAwarenessEnabled': module.params['zone_awareness'],
+        'DedicatedMasterEnabled': module.params['dedicated_master_enabled'],
+    }
+
+    if module.params['dedicated_master_enabled']:
+        elasticsearch_cluster_config['DedicatedMasterType'] = module.params['dedicated_master_type']
+        elasticsearch_cluster_config['DedicatedMasterCount'] = module.params['dedicated_master_count']
+
+    connection.create_elasticsearch_domain(
+        DomainName=module.params['domain'],
+        ElasticsearchVersion=module.params['version'],
+        ElasticsearchClusterConfig=elasticsearch_cluster_config,
+        EBSOptions={
+            'EBSEnabled': True,
+            'VolumeType': module.params['ebs_volume_type'],
+            'VolumeSize': module.params['ebs_volume_size'],
+            },
+        AccessPolicies=module.params['access_policies'],
+        )
+
+    return True
+
+
+def ensure_present(connection, module):
+    domain = module.params['domain']
+    elasticserach_domain = is_present(connection, domain)
+    if elasticserach_domain:
+        changed = False
+    else:
+        changed = True
+        _create_elasticsearch_domain(connection, module)
+        elasticserach_domain = is_present(connection, domain)
+    return changed, elasticserach_domain
+
+
+def is_present(connection, name):
+    """Get the current status of Elasticsearch domain"""
+    try:
+        response = connection.describe_elasticsearch_domain(
+            DomainName=name
+            )
+
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return None
+        else:
+            raise
+
+    return response
+
+
+def check_existing_config(module, domain):
+    modifications_needed = collections.defaultdict(dict)
+
+    existing_config = domain['DomainStatus']
+    desired_config = module.params
+
+    config_to_check = [
+        (('ElasticsearchVersion',), desired_config['version']),
+        (('ElasticsearchClusterConfig', 'InstanceCount'),
+            desired_config['instance_count']),
+        (('ElasticsearchClusterConfig', 'InstanceType'),
+            desired_config['instance_type']),
+        (('ElasticsearchClusterConfig', 'ZoneAwarenessEnabled'),
+            desired_config['zone_awareness']),
+        (('ElasticsearchClusterConfig', 'DedicatedMasterEnabled'),
+            desired_config['dedicated_master_enabled']),
+        (('EBSOptions', 'VolumeType'), desired_config['ebs_volume_type']),
+        (('EBSOptions', 'VolumeSize'), desired_config['ebs_volume_size']),
+        ]
+
+    if desired_config['dedicated_master_enabled']:
+        config_to_check.extend([
+            (('ElasticsearchClusterConfig', 'DedicatedMasterType'),
+                desired_config['dedicated_master_type']),
+            (('ElasticsearchClusterConfig', 'DedicatedMasterCount'),
+                desired_config['dedicated_master_count']),
+            ])
+
+    try:
+        for key_path, desired_value in config_to_check:
+            # Traverse key path to get existing value
+            existing_value = existing_config
+            for key in key_path:
+                existing_value = existing_value.get(key)
+
+            if existing_value != desired_value:
+                # Traverse key path in modifications dictionary to submit to AWS
+                modification = modifications_needed
+                for key in key_path[:-1]:
+                    if key not in modification:
+                        modification[key] = {}
+
+                    modification = modification[key]
+
+                modification[key_path[-1]] = desired_value
+
+    except Exception as e:
+        module.fail_json(
+            msg=str(e), key_path=key_path, desired_value=desired_value,
+            existing_config=existing_config,
+            modifications_needed=modifications_needed)
+
+    # Config is JSON, so compare JSON dictionaries instead of strings
+    existing_access_json = json.loads(domain['DomainStatus']['AccessPolicies'])
+    supplied_access_json = json.loads(module.params['access_policies'])
+
+    if existing_access_json != supplied_access_json:
+        modifications_needed['AccessPolicies'] = module.params['access_policies']
+
+    return modifications_needed
+
+
+def main():
+    argument_spec = ec2.ec2_argument_spec()
+    argument_spec.update(
+        dict(
+            domain={'required': True},
+            version={'required': False, 'default': '5.1'},
+            instance_count={'required': False, 'type': 'int', 'default': 1},
+            instance_type=
+                {'required': False, 'default': 't2.medium.elasticsearch'},
+            zone_awareness=
+                {'required': False, 'type': 'bool', 'default': True},
+            dedicated_master_enabled=
+                {'required': False, 'type': 'bool', 'default': False,
+                    'choices': [True, False]},
+            dedicated_master_type={'required': False},
+            dedicated_master_count={'required': False, 'type': 'int'},
+            ebs_volume_type=
+                {'required': False, 'default': 'gp2',
+                    'choices': ['standard', 'gp2', 'io1']},
+            ebs_volume_size={'required': True, 'type': 'int'},
+            access_policies={'required': True},
+            wait={'required': False, 'type': 'bool'},
+            )
+        )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        )
+
+    if not ec2.HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    region, _, aws_connect_kwargs = ec2.get_aws_connection_info(module)
+
+    if region:
+        try:
+            client = ec2.boto3_conn(
+                module, 'client', 'es', region,
+                profile_name=aws_connect_kwargs['profile_name'])
+        except Exception as e:
+            module.fail_json(msg=str(e))
+    else:
+        module.fail_json(msg='region must be specified')
+
+    changed, domain = ensure_present(client, module)
+    modifications_needed = check_existing_config(module, domain)
+
+    if modifications_needed:
+        changed = True
+        modifications_needed['DomainName'] = module.params['domain']
+        client.update_elasticsearch_domain_config(**modifications_needed)
+
+        # Reload after modifying
+        domain = is_present(client, module.params['domain'])
+
+    if module.params['wait']:
+        while not domain['DomainStatus'].get('Endpoint'):
+            time.sleep(10)
+            domain = is_present(client, module.params['domain'])
+
+    module.exit_json(
+        changed=changed,
+        domain=domain)
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -15,7 +15,7 @@ short_description: Manage hosted Elasticsearch in Amazon Web Services.
 description:
   - Manage hosted Elasticsearch in Amazon Web Services.
   - Returns information about the hosted Elasticsearch.
-version_added: "2.5"
+version_added: "2.6"
 requirements: [ boto3 ]
 author: "Zach Steindler (@steiza)"
 options:
@@ -45,19 +45,19 @@ options:
   zone_awareness:
     description:
       - Should cluster be aware of AWS availability zones.
+    type: bool
     required: false
     default: true
   dedicated_master_enabled:
     description:
       - If cluster have dedicated master nodes.
-    choices: [true, false]
+    type: bool
     required: false
     default: false
   dedicated_master_type:
     description:
       - Instance type of dedicated master nodes. Ignored if dedicated_master_enabled is False.
     required: false
-    default: t2.medium.elasticsearch
   dedicated_master_count:
     description:
       - Number of dedicated master nodes. Ignored if dedicated_master_enabled is False.
@@ -79,6 +79,7 @@ options:
   wait:
     description:
       - Wait for cluster creation to finish
+    type: bool
   tags:
     description:
       - Dictionary of tags to ensure are present on resource. Will not remove other tags.
@@ -384,7 +385,7 @@ def main():
             arn = domain['DomainStatus']['ARN']
 
             tag_list = []
-            for each_key, each_value in module.params['tags'].iteritems():
+            for each_key, each_value in module.params['tags'].items():
                 tag_list.append({'Key': each_key, 'Value': each_value})
 
             client.add_tags(ARN=arn, TagList=tag_list)

--- a/lib/ansible/modules/cloud/amazon/elasticsearch.py
+++ b/lib/ansible/modules/cloud/amazon/elasticsearch.py
@@ -110,7 +110,7 @@ from ansible.module_utils import ec2
 try:
     import botocore.exceptions
 except ImportError:
-    pass # will be detected by ec2.HAS_BOTO3
+    pass  # will be detected by ec2.HAS_BOTO3
 
 
 def _create_elasticsearch_domain(connection, module):
@@ -133,9 +133,9 @@ def _create_elasticsearch_domain(connection, module):
             'EBSEnabled': True,
             'VolumeType': module.params['ebs_volume_type'],
             'VolumeSize': module.params['ebs_volume_size'],
-            },
+        },
         AccessPolicies=module.params['access_policies'],
-        )
+    )
 
     return True
 
@@ -157,7 +157,7 @@ def is_present(connection, name):
     try:
         response = connection.describe_elasticsearch_domain(
             DomainName=name
-            )
+        )
 
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == 'ResourceNotFoundException':
@@ -186,15 +186,17 @@ def check_existing_config(module, domain):
             desired_config['dedicated_master_enabled']),
         (('EBSOptions', 'VolumeType'), desired_config['ebs_volume_type']),
         (('EBSOptions', 'VolumeSize'), desired_config['ebs_volume_size']),
-        ]
+    ]
 
     if desired_config['dedicated_master_enabled']:
-        config_to_check.extend([
-            (('ElasticsearchClusterConfig', 'DedicatedMasterType'),
-                desired_config['dedicated_master_type']),
-            (('ElasticsearchClusterConfig', 'DedicatedMasterCount'),
-                desired_config['dedicated_master_count']),
-            ])
+        config_to_check.extend(
+            [
+                (('ElasticsearchClusterConfig', 'DedicatedMasterType'),
+                    desired_config['dedicated_master_type']),
+                (('ElasticsearchClusterConfig', 'DedicatedMasterCount'),
+                    desired_config['dedicated_master_count']),
+            ]
+        )
 
     try:
         for key_path, desired_value in config_to_check:
@@ -237,32 +239,36 @@ def main():
             domain={'required': True},
             version={'required': False, 'default': '5.1'},
             instance_count={'required': False, 'type': 'int', 'default': 1},
-            instance_type=
-                {'required': False, 'default': 't2.medium.elasticsearch'},
-            zone_awareness=
-                {'required': False, 'type': 'bool', 'default': True},
-            dedicated_master_enabled=
-                {'required': False, 'type': 'bool', 'default': False,
-                    'choices': [True, False]},
+            instance_type={
+                'required': False, 'default': 't2.medium.elasticsearch'
+            },
+            zone_awareness={
+                'required': False, 'type': 'bool', 'default': True
+            },
+            dedicated_master_enabled={
+                'required': False, 'type': 'bool', 'default': False,
+                'choices': [True, False]
+            },
             dedicated_master_type={'required': False},
             dedicated_master_count={'required': False, 'type': 'int'},
-            ebs_volume_type=
-                {'required': False, 'default': 'gp2',
-                    'choices': ['standard', 'gp2', 'io1']},
+            ebs_volume_type={
+                'required': False, 'default': 'gp2',
+                'choices': ['standard', 'gp2', 'io1']
+            },
             ebs_volume_size={'required': True, 'type': 'int'},
             access_policies={'required': True},
             wait={'required': False, 'type': 'bool'},
-            )
         )
+    )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        )
+    )
 
     if not ec2.HAS_BOTO3:
         module.fail_json(msg='boto3 required for this module')
 
-    region, _, aws_connect_kwargs = ec2.get_aws_connection_info(module)
+    region, ec2_url, aws_connect_kwargs = ec2.get_aws_connection_info(module)
 
     if region:
         try:
@@ -292,7 +298,8 @@ def main():
 
     module.exit_json(
         changed=changed,
-        domain=domain)
+        domain=domain
+    )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
##### SUMMARY
I've been using this to manage AWS-hosted Elasticsearch and thought I would post it to see if it would be useful to others.

I haven't submitted a PR for ansible before, but I did read over the Contributing pages - feedback welcome!

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
cloud/amazon/elasticsearch.py

##### ANSIBLE VERSION
```
[14:30:31] ~$ ansible --version
ansible 2.4.2.0
  config file = /Users/zachsteindler/.ansible.cfg
  configured module search path = [u'/Users/zachsteindler/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/ansible
  executable location = /Library/Frameworks/Python.framework/Versions/2.7/bin/ansible
  python version = 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 12:39:47) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
```

##### ADDITIONAL INFORMATION
N/A