### PR TITLE
tower_job_template: Fixing ask_credential and ask_inventory support

### DIFF
--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -172,6 +172,8 @@ def update_fields(p):
     '''
     params = p.copy()
     field_map = {
+        'ask_credential' : 'ask_credential_on_launch',
+        'ask_inventory' : 'ask_inventory_on_launch',
         'ask_extra_vars': 'ask_variables_on_launch',
         'ask_limit': 'ask_limit_on_launch',
         'ask_tags': 'ask_tags_on_launch',

--- a/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
+++ b/lib/ansible/modules/web_infrastructure/ansible_tower/tower_job_template.py
@@ -172,8 +172,8 @@ def update_fields(p):
     '''
     params = p.copy()
     field_map = {
-        'ask_credential' : 'ask_credential_on_launch',
-        'ask_inventory' : 'ask_inventory_on_launch',
+        'ask_credential': 'ask_credential_on_launch',
+        'ask_inventory': 'ask_inventory_on_launch',
         'ask_extra_vars': 'ask_variables_on_launch',
         'ask_limit': 'ask_limit_on_launch',
         'ask_tags': 'ask_tags_on_launch',


### PR DESCRIPTION
##### SUMMARY
ask_credential and ask_inventory need to mapped to the correct tower api attributes.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
tower_job_template

##### ANSIBLE VERSION
```
ansible --version
ansible 2.5.0
  config file = /Users/sidelig/.ansible.cfg
  configured module search path = [u'/Users/sidelig/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/sidelig/.virtualenvs/ansible-dev/lib/python2.7/site-packages/ansible
  executable location = /Users/sidelig/.virtualenvs/ansible-dev/bin/ansible
  python version = 2.7.10 (default, Feb  7 2017, 00:08:15) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
```


##### ADDITIONAL INFORMATION
ask_credential and ask_inventory where not being saved to Tower 3.1.3.  The Tower API docs show these as the correct attributes to set.
```
ask_inventory_on_launch: (boolean, default=False)
ask_credential_on_launch: (boolean, default=False)
```