### PR TITLE
Conjur Lookup Plugin

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1135,6 +1135,8 @@ files:
   lib/ansible/plugins/lookup/dig:
     maintainers: jpmens
     labels: community
+  lib/ansible/plugins/lookup/conjur_variable.py:
+    maintainers: $team_cyberark_conjur
   lib/ansible/plugins/netconf/:
     maintainers: $team_networking
     labels: networking
@@ -1221,6 +1223,7 @@ macros:
   team_avi: ericsysmin grastogi23 khaltore
   team_azure: haroldwongms nitzmahone tstringer yuwzho xscript zikalino
   team_cumulus: isharacomix jrrivers privateip
+  team_cyberark_conjur: jvanderhoof ryanprior
   team_manageiq: gtanzillo abellotti zgalor yaacov cben
   team_netapp: hulquest lmprice broncofan gouthampacha
   team_netscaler: chiradeep giorgos-nikolopoulos

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -9,9 +9,9 @@ DOCUMENTATION = """
     version_added: "2.5"
     short_description: Fetch credentials from CyberArk Conjur.
     description:
-      - Retrieves credentials from Conjur using the server's Conjur identity. More information about Conjur can be found at https://www.conjur.org/.
+      - Retrieves credentials from Conjur using the server's Conjur identity. More information about Conjur can be found at U(https://www.conjur.org/).
     requirements:
-      - The machine running Ansible has been given a Conjur identity.
+      - The machine running Ansible has been given a Conjur identity. (More: U(https://developer.conjur.net/key_concepts/machine_identity.html))
     options:
       _term:
         description: Variable path

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -9,9 +9,9 @@ DOCUMENTATION = """
     version_added: "2.5"
     short_description: Fetch credentials from CyberArk Conjur.
     description:
-      - Retrieves credentials from Conjur using the server's Conjur identity. More information about Conjur can be found at U(https://www.conjur.org/).
+      - Retrieves credentials from Conjur using the controlling host's Conjur identity. Conjur info: U(https://www.conjur.org/).
     requirements:
-      - The machine running Ansible has been given a Conjur identity. (More: U(https://developer.conjur.net/key_concepts/machine_identity.html))
+      - The controlling host running Ansible has a Conjur identity. (More: U(https://developer.conjur.net/key_concepts/machine_identity.html))
     options:
       _term:
         description: Variable path

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -74,13 +74,15 @@ def _load_conf_from_file(conf_path):
     display.vvv('conf file: {0}'.format(conf_path))
 
     if not os.path.exists(conf_path):
-        raise AnsibleError('Conjur configuration file `{0}` was not found'.format(conf_path))
+        raise AnsibleError('Conjur configuration file `{0}` was not found on the controlling host'
+                           .format(conf_path))
 
     display.vvvv('Loading configuration from: {0}'.format(conf_path))
     with open(conf_path) as f:
         config = yaml.safe_load(f.read())
         if 'account' not in config or 'appliance_url' not in config:
-            raise AnsibleError('{0} must contain an `account` and `appliance_url` entry'.format(conf_path))
+            raise AnsibleError('{0} on the controlling host must contain an `account` and `appliance_url` entry'
+                               .format(conf_path))
         return config
 
 
@@ -89,7 +91,8 @@ def _load_identity_from_file(identity_path, appliance_url):
     display.vvvv('identity file: {0}'.format(identity_path))
 
     if not os.path.exists(identity_path):
-        raise AnsibleError('Conjur identity file `{0}` was not found'.format(identity_path))
+        raise AnsibleError('Conjur identity file `{0}` was not found on the controlling host'
+                           .format(identity_path))
 
     display.vvvv('Loading identity from: {0} for {1}'.format(identity_path, appliance_url))
 
@@ -97,11 +100,13 @@ def _load_identity_from_file(identity_path, appliance_url):
     identity = netrc(identity_path)
 
     if identity.authenticators(conjur_authn_url) is None:
-        raise AnsibleError('The netrc file does not contain an entry for: {0}'.format(conjur_authn_url))
+        raise AnsibleError('The netrc file on the controlling host does not contain an entry for: {0}'
+                           .format(conjur_authn_url))
 
     id, account, api_key = identity.authenticators(conjur_authn_url)
     if not id or not api_key:
-        raise AnsibleError('{0} must contain a `login` and `password` entry for {1}'.format(identity_path, appliance_url))
+        raise AnsibleError('{0} on the controlling host must contain a `login` and `password` entry for {1}'
+                           .format(identity_path, appliance_url))
 
     return {'id': id, 'api_key': api_key}
 
@@ -137,7 +142,8 @@ def _fetch_conjur_variable(conjur_variable, token, conjur_url, account):
     if response.getcode() == 401:
         raise AnsibleError('Conjur request has invalid authorization credentials')
     if response.getcode() == 403:
-        raise AnsibleError('Conjur host does not have authorization to retrieve {0}'.format(conjur_variable))
+        raise AnsibleError('The controlling host\'s Conjur identity does not have authorization to retrieve {0}'
+                           .format(conjur_variable))
     if response.getcode() == 404:
         raise AnsibleError('The variable {0} does not exist'.format(conjur_variable))
 

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -36,7 +36,7 @@ from base64 import b64encode
 from netrc import netrc
 from os import environ
 from time import time
-from urllib import quote_plus
+from ansible.module_utils.six.moves.urllib.parse import quote_plus
 import yaml
 
 import requests

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -30,7 +30,7 @@ RETURN = """
 """
 
 import os.path
-from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from base64 import b64encode
 from netrc import netrc
@@ -48,87 +48,95 @@ except ImportError:
     display = Display()
 
 
+# Load Conjur configuration from either `/etc/conjur.conf` or `~/.conjurrc`
+def _load_configuration():
+    for location in ['~/.conjurrc', '/etc/conjur.conf']:
+        conf = _load_conf_from_file(location)
+        if conf:
+            display.vvvv('configuration: {0}'.format(conf))
+            return conf
+
+    raise AnsibleError('Conjur configuration should be in one of the following files: \'~/.conjurrc\', \'/etc/conjur.conf\'')
+
+# Load Conjur identity from either `/etc/conjur.identity`, or `~/.netrc`
+def _load_identity(appliance_url):
+    for location in ['~/.netrc', '/etc/conjur.identity']:
+        identity = _load_identity_from_file(location, appliance_url)
+        if identity:
+            display.vvvv('configuration: {0}'.format(identity))
+            return identity
+
+    raise AnsibleError('Conjur identity should be in environment variables or in one of the following paths: \'~/.netrc\', \'/etc/conjur.identity\'')
+
+# Load configuration and return as dictionary if file is present on file system
+def _load_conf_from_file(conf_path):
+    conf_path = os.path.expanduser(conf_path)
+
+    if os.path.exists(conf_path):
+        display.vvvv('Loading configuration from: {0}'.format(conf_path))
+        with open(conf_path) as f:
+            return yaml.safe_load(f.read())
+    return {}
+
+# Load identity and return as dictionary if file is present on file system
+def _load_identity_from_file(identity_path, appliance_url):
+    identity_path = os.path.expanduser(identity_path)
+
+    if os.path.exists(identity_path):
+        display.vvvv('Loading identity from: {0} for {1}'.format(identity_path, appliance_url))
+
+        conjur_authn_url = '{0}/authn'.format(appliance_url)
+        identity = netrc(identity_path)
+        if identity.authenticators(conjur_authn_url) is None:
+            raise AnsibleError('The netrc file does not contain an entry for: {0}'.format(conjur_authn_url))
+
+        id, account, api_key = identity.authenticators(conjur_authn_url)
+        if not id or not api_key:
+            return {}
+
+        return {'id': id, 'api_key': api_key}
+
+    return {}
+
+# Use credentials to retrieve temporary authorization token
+def _fetch_conjur_token(conjur_url, account, username, api_key):
+    conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, username)
+    display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, username))
+
+    response = open_url(conjur_url, data=api_key, method='POST')
+
+    if response.getcode() != 200:
+        raise AnsibleError('Failed to authenticate as \'{0}\''.format(identity['id']))
+
+    return response.read()
+
+# Retrieve Conjur variable using the temporary token
+def _fetch_conjur_variable(conjur_variable, token, conjur_url, account):
+    token = b64encode(token)
+    headers = {'Authorization': 'Token token="{0}"'.format(token)}
+    display.vvvv('Header: {0}'.format(headers))
+
+    url = '{0}/secrets/{1}/variable/{2}'.format(conjur_url, account, quote_plus(conjur_variable))
+    display.vvvv('Conjur Variable URL: {0}'.format(url))
+
+    response = open_url(url, headers=headers, method='GET')
+
+    if response.getcode() == 200:
+        display.vvvv('Conjur variable {0} was successfully retrieved'.format(conjur_variable))
+        return [response.read()]
+    if response.getcode() == 401:
+        raise AnsibleError('Conjur request has invalid authorization credentials')
+    if response.getcode() == 403:
+        raise AnsibleError('Conjur host does not have authorization to retrieve {0}'.format(conjur_variable))
+    if response.getcode() == 404:
+        raise AnsibleError('The variable {0} does not exist'.format(conjur_variable))
+
+
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
-        conf = self.load_configuration()
-        identity = self.load_identity(conf['appliance_url'])
+        conf = _load_configuration()
+        identity = _load_identity(conf['appliance_url'])
 
-        # Use credentials to retrieve temporary authorization token
-        conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conf['appliance_url'], conf['account'], identity['id'])
-        display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, identity['id']))
-
-        response = open_url(conjur_url, data=identity['api_key'], method='POST')
-
-        if response.getcode() != 200:
-            raise AnsibleError('Failed to authenticate as \'{0}\''.format(identity['id']))
-
-        # Retrieve Conjur variable using the temporary token
-        token = b64encode(response.read())
-        headers = {'Authorization': 'Token token="{0}"'.format(token)}
-        display.vvvv('Header: {0}'.format(headers))
-
-        url = '{0}/secrets/{1}/variable/{2}'.format(conf['appliance_url'], conf['account'], quote_plus(terms[0]))
-        display.vvvv('Conjur Variable URL: {0}'.format(url))
-
-        response = open_url(url, headers=headers, method='GET')
-
-        if response.getcode() == 200:
-            display.vvvv('Conjur variable {0} was successfully retrieved'.format(terms[0]))
-            return [response.read()]
-        if response.getcode() == 401:
-            raise AnsibleError('Conjur request has invalid authorization credentials')
-        if response.getcode() == 403:
-            raise AnsibleError('Conjur host does not have authorization to retrieve {0}'.format(terms[0]))
-        if response.getcode() == 404:
-            raise AnsibleError('The variable {0} does not exist'.format(terms[0]))
-
-    # Load Conjur configuration from either `/etc/conjur.conf` or `~/.conjurrc`
-    def load_configuration(self):
-        for location in ['~/.conjurrc', '/etc/conjur.conf']:
-            conf = self.load_conf_from_file(location)
-            if conf:
-                display.vvvv('configuration: {0}'.format(conf))
-                return conf
-
-        raise AnsibleError('Conjur configuration should be in one of the following files: \'~/.conjurrc\', \'/etc/conjur.conf\'')
-
-    # Load Conjur identity from either `/etc/conjur.identity`, or `~/.netrc`
-    def load_identity(self, appliance_url):
-        for location in ['~/.netrc', '/etc/conjur.identity']:
-            identity = self.load_identity_from_file(location, appliance_url)
-            if identity:
-                display.vvvv('configuration: {0}'.format(identity))
-                return identity
-
-        raise AnsibleError('Conjur identity should be in environment variables or in one of the following paths: \'~/.netrc\', \'/etc/conjur.identity\'')
-
-    # Load configuration and return as dictionary if file is present on file system
-    def load_conf_from_file(self, conf_path):
-        conf_path = os.path.expanduser(conf_path)
-
-        if os.path.exists(conf_path):
-            display.vvvv('Loading configuration from: {0}'.format(conf_path))
-            with open(conf_path) as f:
-                return yaml.safe_load(f.read())
-        return {}
-
-    # Load identity and return as dictionary if file is present on file system
-    def load_identity_from_file(self, identity_path, appliance_url):
-        identity_path = os.path.expanduser(identity_path)
-
-        if os.path.exists(identity_path):
-            display.vvvv('Loading identity from: {0} for {1}'.format(identity_path, appliance_url))
-
-            conjur_authn_url = '{0}/authn'.format(appliance_url)
-            identity = netrc(identity_path)
-            if identity.authenticators(conjur_authn_url) is None:
-                raise AnsibleError('The netrc file does not contain an entry for: {0}'.format(conjur_authn_url))
-
-            id, account, api_key = identity.authenticators(conjur_authn_url)
-            if not id or not api_key:
-                return {}
-
-            return {'id': id, 'api_key': api_key}
-
-        return {}
+        token = _fetch_conjur_token(conf['appliance_url'], conf['account'], identity['id'], identity['api_key'])
+        return _fetch_conjur_variable(terms[0], token, conf['appliance_url'], conf['account'])

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -28,7 +28,7 @@ DOCUMENTATION = """
       config_file:
         description: Path to the Conjur configuration file. The configuration file is a YAML file.
         default: /etc/conjur.conf
-        require: False
+        required: False
         ini:
           - section: conjur,
             key: config_file_path

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -59,6 +59,7 @@ def _load_configuration():
 
     raise AnsibleError('Conjur configuration should be in one of the following files: \'~/.conjurrc\', \'/etc/conjur.conf\'')
 
+
 # Load Conjur identity from either `/etc/conjur.identity`, or `~/.netrc`
 def _load_identity(appliance_url):
     for location in ['~/.netrc', '/etc/conjur.identity']:
@@ -69,6 +70,7 @@ def _load_identity(appliance_url):
 
     raise AnsibleError('Conjur identity should be in environment variables or in one of the following paths: \'~/.netrc\', \'/etc/conjur.identity\'')
 
+
 # Load configuration and return as dictionary if file is present on file system
 def _load_conf_from_file(conf_path):
     conf_path = os.path.expanduser(conf_path)
@@ -78,6 +80,7 @@ def _load_conf_from_file(conf_path):
         with open(conf_path) as f:
             return yaml.safe_load(f.read())
     return {}
+
 
 # Load identity and return as dictionary if file is present on file system
 def _load_identity_from_file(identity_path, appliance_url):
@@ -99,6 +102,7 @@ def _load_identity_from_file(identity_path, appliance_url):
 
     return {}
 
+
 # Use credentials to retrieve temporary authorization token
 def _fetch_conjur_token(conjur_url, account, username, api_key):
     conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, username)
@@ -110,6 +114,7 @@ def _fetch_conjur_token(conjur_url, account, username, api_key):
         raise AnsibleError('Failed to authenticate as \'{0}\''.format(username))
 
     return response.read()
+
 
 # Retrieve Conjur variable using the temporary token
 def _fetch_conjur_variable(conjur_variable, token, conjur_url, account):

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -9,7 +9,7 @@ DOCUMENTATION = """
     version_added: "2.5"
     short_description: Fetch credentials from CyberArk Conjur.
     description:
-      - Retrieves credentials from Conjur using the server's Conjur identity.
+      - Retrieves credentials from Conjur using the server's Conjur identity. More information about Conjur can be found at https://www.conjur.org/.
     requirements:
       - The machine running Ansible has been given a Conjur identity.
     options:

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -18,6 +18,7 @@ DOCUMENTATION = """
         required: True
       identity_file:
         description: Path to the Conjur identity file. The identity file follows the netrc file format convention.
+        type: path
         default: /etc/conjur.identity
         required: False
         ini:
@@ -27,6 +28,7 @@ DOCUMENTATION = """
           - name: CONJUR_IDENTITY_FILE
       config_file:
         description: Path to the Conjur configuration file. The configuration file is a YAML file.
+        type: path
         default: /etc/conjur.conf
         required: False
         ini:
@@ -69,7 +71,6 @@ except ImportError:
 
 # Load configuration and return as dictionary if file is present on file system
 def _load_conf_from_file(conf_path):
-    conf_path = os.path.expanduser(conf_path)
     display.vvv('conf file: {0}'.format(conf_path))
 
     if not os.path.exists(conf_path):
@@ -85,7 +86,6 @@ def _load_conf_from_file(conf_path):
 
 # Load identity and return as dictionary if file is present on file system
 def _load_identity_from_file(identity_path, appliance_url):
-    identity_path = os.path.expanduser(identity_path)
     display.vvvv('identity file: {0}'.format(identity_path))
 
     if not os.path.exists(identity_path):

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -59,7 +59,7 @@ class LookupModule(LookupBase):
             self.load_conf('~/.conjurrc')
         )
         if not conf:
-            raise AnsibleError('Conjur configuration should be in environment variables or in one of the following paths: \'~/.conjurrc\', \'/etc/conjur.conf\'')
+            raise AnsibleError('Conjur configuration should be in one of the following files: \'~/.conjurrc\', \'/etc/conjur.conf\'')
         display.vvvv("configuration: {}".format(conf))
 
         # Load Conjur identity
@@ -71,15 +71,14 @@ class LookupModule(LookupBase):
             raise AnsibleError('Conjur identity should be in environment variables or in one of the following paths: \'~/.netrc\', \'/etc/conjur.identity\'')
         display.vvvv("configuration: {}".format(identity))
 
-
         # Use credentials to retrieve temporary authorization token
         conjur_url = "{}/authn/{}/{}/authenticate".format(conf['appliance_url'], conf['account'], identity['id'])
         display.vvvv("Authentication request to Conjur at: {}, with user: {}".format(conjur_url, identity['id']))
 
         if 'cert_file' in conf:
-            response = requests.post(conjur_url, data = identity['api_key'], verify = conf['cert_file'])
+            response = requests.post(conjur_url, data=identity['api_key'], verify=conf['cert_file'])
         else:
-            response = requests.post(conjur_url, data = identity['api_key'])
+            response = requests.post(conjur_url, data=identity['api_key'])
         display.vvvv("response: {}".format(response.text))
 
         if response.status_code != 200:
@@ -94,7 +93,7 @@ class LookupModule(LookupBase):
         display.vvvv("Conjur Variable URL: {}".format(url))
 
         if 'cert_file' in conf:
-            response = requests.get(url, headers=headers, verify = conf['cert_file'])
+            response = requests.get(url, headers=headers, verify=conf['cert_file'])
         else:
             response = requests.get(url, headers=headers)
 
@@ -119,7 +118,7 @@ class LookupModule(LookupBase):
                     return yaml.safe_load(f.read())
                 except Exception as exception:
                     display.info("Error: parsing %s - %s" % (conf_path, str(exception)))
-                    self.fail("Error: parsing %s - %s" % (conf_path, str(exception)))
+                    AnsibleError("Error: parsing %s - %s" % (conf_path, str(exception)))
         return {}
 
     # Load identity and return as dictionary if file is present on file system
@@ -130,13 +129,13 @@ class LookupModule(LookupBase):
             display.vvvv("Loading identity from: %s" % identity_path)
             try:
                 identity = netrc(identity_path)
-                id, _, api_key = identity.authenticators('{}/authn'.format(appliance_url))
+                id, account, api_key = identity.authenticators('{}/authn'.format(appliance_url))
                 if not id or not api_key:
                     return {}
 
                 return {"id": id, "api_key": api_key}
             except Exception as exception:
-                self.fail("Error: parsing %s - %s" % (conf_path, str(exception)))
+                AnsibleError("Error: parsing %s - %s" % (identity_path, str(exception)))
 
         return {}
 

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -1,0 +1,191 @@
+# (c) 2017, Oren Ben Meir <oren.benmeir@cyberark.com>, Jason Vanderhoof <jason.vanderhoof@cyberark.com>
+# (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = """
+    lookup: conjur_variable
+    version_added: "2.5"
+    short_description: Fetch credentials from CyberArk Conjur.
+    description:
+      - Retrieves credentials from Conjur using the server's Conjur identity.
+    requirements:
+      - The machine running Ansible has been given a Conjur identity.
+    options:
+      _term:
+        description: Variable path
+        required: True
+"""
+
+EXAMPLES = """
+  - debug
+    msg: {{ lookup('conjur_variable', '/path/to/secret') }}
+"""
+
+RETURN = """
+  _raw:
+    description:
+      - Value stored in Conjur.
+"""
+
+import os.path
+import ssl
+from ansible.errors import AnsibleError, AnsibleParserError
+from ansible.plugins.lookup import LookupBase
+from base64 import b64encode
+from httplib import HTTPSConnection
+from httplib import HTTPConnection
+from netrc import netrc
+from os import environ
+from time import time
+from urllib import quote_plus
+from urlparse import urlparse
+
+
+class Token:
+    def __init__(self, http_connection, id, api_key, account):
+        self.http_connection = http_connection
+        self.id = id
+        self.api_key = api_key
+        self.token = None
+        self.refresh_time = 0
+        self.account = account
+
+    # refresh
+    # Exchanges API key for an auth token, storing it base64 encoded within the
+    # 'token' member variable. If it fails to obtain a token, the process exits.
+    def refresh(self):
+
+        authn_url = '/authn/{}/{}/authenticate'.format(quote_plus(self.account), quote_plus(self.id))
+        self.http_connection.request('POST', authn_url, self.api_key)
+
+        response = self.http_connection.getresponse()
+
+        if response.status != 200:
+            raise Exception('Failed to authenticate as \'{}\''.format(self.id))
+
+        self.token = b64encode(response.read())
+        self.refresh_time = time() + 5 * 60
+
+    # get_header_value
+    # Returns the value for the Authorization header. Refreshes the auth token
+    # before returning if necessary.
+    def get_header_value(self):
+        if time() >= self.refresh_time:
+            self.refresh()
+
+        return 'Token token="{}"'.format(self.token)
+
+class LookupModule(LookupBase):
+    def retrieve_secrets(self, conf, conjur_https, token, terms):
+
+        secrets = []
+        for term in terms:
+            variable_name = term.split()[0]
+            headers = {'Authorization': token.get_header_value()}
+            url = '/secrets/{}/variable/{}'.format(conf['account'], quote_plus(variable_name))
+
+            conjur_https.request('GET', url, headers=headers)
+            response = conjur_https.getresponse()
+            if response.status != 200:
+                raise Exception('Failed to retrieve variable \'{}\' with response status: {} {}'.format(variable_name,
+                                                                                                        response.status,
+                                                                                                        response.reason))
+
+            secrets.append(response.read())
+
+        return secrets
+
+    def run(self, terms, variables=None, **kwargs):
+        # Load Conjur configuration
+        conf = self.merge_dictionaries(
+            self.load_conf('/etc/conjur.conf'),
+            self.load_conf('~/.conjurrc'),
+            {
+                "account": environ.get('CONJUR_ACCOUNT'),
+                "appliance_url": environ.get("CONJUR_APPLIANCE_URL"),
+                "cert_file": environ.get('CONJUR_CERT_FILE')
+            } if (environ.get('CONJUR_ACCOUNT') is not None and environ.get('CONJUR_APPLIANCE_URL')
+                  is not None and (environ.get('CONJUR_APPLIANCE_URL').startswith('https') is not True or environ.get('CONJUR_CERT_FILE') is not None))
+            else {}
+        )
+        if not conf:
+            raise Exception('Conjur configuration should be in environment variables or in one of the following paths: \'~/.conjurrc\', \'/etc/conjur.conf\'')
+
+        # Load Conjur identity
+        identity = self.merge_dictionaries(
+            self.load_identity('/etc/conjur.identity', conf['appliance_url']),
+            self.load_identity('~/.netrc', conf['appliance_url']),
+            {
+                "id": environ.get('CONJUR_AUTHN_LOGIN'),
+                "api_key": environ.get('CONJUR_AUTHN_API_KEY')
+            } if (environ.get('CONJUR_AUTHN_LOGIN') is not None and environ.get('CONJUR_AUTHN_API_KEY') is not None)
+            else {}
+        )
+        if not identity:
+            raise Exception('Conjur identity should be in environment variables or in one of the following paths: \'~/.netrc\', \'/etc/conjur.identity\'')
+
+        if conf['appliance_url'].startswith('https'):
+            # Load our certificate for validation
+            ssl_context = ssl.create_default_context()
+            ssl_context.load_verify_locations(conf['cert_file'])
+            conjur_connection = HTTPSConnection(urlparse(conf['appliance_url']).netloc,
+                                       context = ssl_context)
+        else:
+            conjur_connection = HTTPConnection(urlparse(conf['appliance_url']).netloc)
+
+        token = Token(conjur_connection, identity['id'], identity['api_key'], conf['account'])
+
+        # retrieve secrets of the given variables from Conjur
+        return self.retrieve_secrets(conf, conjur_connection, token, terms)
+
+    # if the conf is not in the path specified, or if an exception is thrown while reading the conf file
+    # we don't exit as the conf might be in another path
+    def load_conf(self, conf_path):
+        conf_path = os.path.expanduser(conf_path)
+
+        if not os.path.isfile(conf_path):
+            return {}
+
+        try:
+            config_map = {}
+            lines = open(conf_path).read().splitlines()
+            for line in lines:
+                if line == '---':
+                    continue
+                parts = line.split(': ')
+                config_map[parts[0]] = parts[1]
+            return config_map
+        except:
+            pass
+
+        return {}
+
+
+    # if the identity is not in the path specified, or if an exception is thrown while reading the identity file
+    # we don't exit as the identity might be in another path
+    def load_identity(self, identity_path, appliance_url):
+        identity_path = os.path.expanduser(identity_path)
+
+        if not os.path.isfile(identity_path):
+            return {}
+
+        try:
+            identity = netrc(identity_path)
+            id, _, api_key = identity.authenticators('{}/authn'.format(appliance_url))
+            if not id or not api_key:
+                return {}
+
+            return {"id": id, "api_key": api_key}
+        except:
+            pass
+
+        return {}
+
+
+    def merge_dictionaries(self, *arg):
+        ret = {}
+        for a in arg:
+            ret.update(a)
+        return ret

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -60,7 +60,7 @@ class LookupModule(LookupBase):
         )
         if not conf:
             raise AnsibleError('Conjur configuration should be in one of the following files: \'~/.conjurrc\', \'/etc/conjur.conf\'')
-        display.vvvv("configuration: {}".format(conf))
+        display.vvvv('configuration: {0}'.format(conf))
 
         # Load Conjur identity
         identity = self.merge_dictionaries(
@@ -69,28 +69,28 @@ class LookupModule(LookupBase):
         )
         if not identity:
             raise AnsibleError('Conjur identity should be in environment variables or in one of the following paths: \'~/.netrc\', \'/etc/conjur.identity\'')
-        display.vvvv("configuration: {}".format(identity))
+        display.vvvv('configuration: {0}'.format(identity))
 
         # Use credentials to retrieve temporary authorization token
-        conjur_url = "{}/authn/{}/{}/authenticate".format(conf['appliance_url'], conf['account'], identity['id'])
-        display.vvvv("Authentication request to Conjur at: {}, with user: {}".format(conjur_url, identity['id']))
+        conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conf['appliance_url'], conf['account'], identity['id'])
+        display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, identity['id']))
 
         if 'cert_file' in conf:
             response = requests.post(conjur_url, data=identity['api_key'], verify=conf['cert_file'])
         else:
             response = requests.post(conjur_url, data=identity['api_key'])
-        display.vvvv("response: {}".format(response.text))
+        display.vvvv('response: {0}'.format(response.text))
 
         if response.status_code != 200:
-            raise AnsibleError('Failed to authenticate as \'{}\''.format(identity['id']))
+            raise AnsibleError('Failed to authenticate as \'{0}\''.format(identity['id']))
 
         # Retrieve Conjur variable using the temporary token
         token = b64encode(response.text)
-        headers = {'Authorization': "Token token=\"{}\"".format(token)}
-        display.vvvv("Header: {}".format(headers))
+        headers = {'Authorization': 'Token token="{0}"'.format(token)}
+        display.vvvv('Header: {0}'.format(headers))
 
-        url = "{}/secrets/{}/variable/{}".format(conf['appliance_url'], conf['account'], quote_plus(terms[0]))
-        display.vvvv("Conjur Variable URL: {}".format(url))
+        url = '{0}/secrets/{1}/variable/{2}'.format(conf['appliance_url'], conf['account'], quote_plus(terms[0]))
+        display.vvvv('Conjur Variable URL: {0}'.format(url))
 
         if 'cert_file' in conf:
             response = requests.get(url, headers=headers, verify=conf['cert_file'])
@@ -98,27 +98,26 @@ class LookupModule(LookupBase):
             response = requests.get(url, headers=headers)
 
         if response.status_code == 200:
-            display.vvvv("Conjur variable {} was successfully retrieved".format(terms[0]))
+            display.vvvv('Conjur variable {0} was successfully retrieved'.format(terms[0]))
             return [response.text]
         if response.status_code == 401:
             raise AnsibleError('Conjur request has invalid authorization credentials')
         if response.status_code == 403:
-            raise AnsibleError('Conjur host does not have authorization to retrieve {}'.format(terms[0]))
+            raise AnsibleError('Conjur host does not have authorization to retrieve {0}'.format(terms[0]))
         if response.status_code == 404:
-            raise AnsibleError('The variable {} does not exist'.format(terms[0]))
+            raise AnsibleError('The variable {0} does not exist'.format(terms[0]))
 
     # Load configuration and return as dictionary if file is present on file system
     def load_conf(self, conf_path):
         conf_path = os.path.expanduser(conf_path)
 
         if conf_path and os.path.exists(conf_path):
-            display.vvvv("Loading configuration from: %s" % conf_path)
+            display.vvvv('Loading configuration from: {0}'.format(conf_path))
             with open(conf_path) as f:
                 try:
                     return yaml.safe_load(f.read())
                 except Exception as exception:
-                    display.info("Error: parsing %s - %s" % (conf_path, str(exception)))
-                    AnsibleError("Error: parsing %s - %s" % (conf_path, str(exception)))
+                    AnsibleError('Error: parsing {0} - {1}'.format(conf_path, str(exception)))
         return {}
 
     # Load identity and return as dictionary if file is present on file system
@@ -126,16 +125,16 @@ class LookupModule(LookupBase):
         identity_path = os.path.expanduser(identity_path)
 
         if identity_path and os.path.exists(identity_path):
-            display.vvvv("Loading identity from: %s" % identity_path)
+            display.vvvv('Loading identity from: {0}'.format(identity_path))
             try:
                 identity = netrc(identity_path)
-                id, account, api_key = identity.authenticators('{}/authn'.format(appliance_url))
+                id, account, api_key = identity.authenticators('{0}/authn'.format(appliance_url))
                 if not id or not api_key:
                     return {}
 
-                return {"id": id, "api_key": api_key}
+                return {'id': id, 'api_key': api_key}
             except Exception as exception:
-                AnsibleError("Error: parsing %s - %s" % (identity_path, str(exception)))
+                AnsibleError('Error: parsing {0} - {1}'.format(identity_path, str(exception)))
 
         return {}
 

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -82,7 +82,6 @@ def _load_conf_from_file(conf_path):
             raise AnsibleError('{0} must contain an `account` and `appliance_url` entry'.format(conf_path))
         return config
 
-
 # Load identity and return as dictionary if file is present on file system
 def _load_identity_from_file(identity_path, appliance_url):
     identity_path = os.path.expanduser(identity_path)
@@ -105,19 +104,22 @@ def _load_identity_from_file(identity_path, appliance_url):
 
     return {'id': id, 'api_key': api_key}
 
+def _open_url_token_retrival(url, api_key):
+    return open_url(url, data=api_key, method='POST')
+
 
 # Use credentials to retrieve temporary authorization token
 def _fetch_conjur_token(conjur_url, account, username, api_key):
     conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, username)
     display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, username))
 
-    response = open_url(conjur_url, data=api_key, method='POST')
-
+    response = _open_url_token_retrival(conjur_url, api_key)
+    # print('response: {0}'.format(response))
+    # print('response code: {0}'.format(response))
     if response.getcode() != 200:
         raise AnsibleError('Failed to authenticate as \'{0}\''.format(username))
 
     return response.read()
-
 
 # Retrieve Conjur variable using the temporary token
 def _fetch_conjur_variable(conjur_variable, token, conjur_url, account):

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -82,6 +82,7 @@ def _load_conf_from_file(conf_path):
             raise AnsibleError('{0} must contain an `account` and `appliance_url` entry'.format(conf_path))
         return config
 
+
 # Load identity and return as dictionary if file is present on file system
 def _load_identity_from_file(identity_path, appliance_url):
     identity_path = os.path.expanduser(identity_path)
@@ -104,6 +105,7 @@ def _load_identity_from_file(identity_path, appliance_url):
 
     return {'id': id, 'api_key': api_key}
 
+
 # Use credentials to retrieve temporary authorization token
 def _fetch_conjur_token(conjur_url, account, username, api_key):
     conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, username)
@@ -114,6 +116,7 @@ def _fetch_conjur_token(conjur_url, account, username, api_key):
         raise AnsibleError('Failed to authenticate as \'{0}\''.format(username))
 
     return response.read()
+
 
 # Retrieve Conjur variable using the temporary token
 def _fetch_conjur_variable(conjur_variable, token, conjur_url, account):

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -106,7 +106,6 @@ def _load_identity_from_file(identity_path, appliance_url):
     return {'id': id, 'api_key': api_key}
 
 
-
 # Use credentials to retrieve temporary authorization token
 def _fetch_conjur_token(conjur_url, account, username, api_key):
     conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, username)

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -4,6 +4,10 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = """
     lookup: conjur_variable
     version_added: "2.5"

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -112,8 +112,10 @@ def _fetch_conjur_token(conjur_url, account, username, api_key):
     display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, username))
 
     response = open_url(conjur_url, data=api_key, method='POST')
-    if response.getcode() != 200:
-        raise AnsibleError('Failed to authenticate as \'{0}\''.format(username))
+    code = response.getcode()
+    if code != 200:
+        raise AnsibleError('Failed to authenticate as \'{0}\' (got {1} response)'
+                           .format(username, code))
 
     return response.read()
 

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -41,6 +41,7 @@ import yaml
 
 from ansible.module_utils.urls import open_url
 
+
 try:
     from __main__ import display
 except ImportError:
@@ -106,7 +107,7 @@ def _fetch_conjur_token(conjur_url, account, username, api_key):
     response = open_url(conjur_url, data=api_key, method='POST')
 
     if response.getcode() != 200:
-        raise AnsibleError('Failed to authenticate as \'{0}\''.format(identity['id']))
+        raise AnsibleError('Failed to authenticate as \'{0}\''.format(username))
 
     return response.read()
 

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -30,17 +30,13 @@ RETURN = """
 """
 
 import os.path
-import ssl
 from ansible.errors import AnsibleError, AnsibleParserError
 from ansible.plugins.lookup import LookupBase
 from base64 import b64encode
-from httplib import HTTPSConnection
-from httplib import HTTPConnection
 from netrc import netrc
 from os import environ
 from time import time
 from urllib import quote_plus
-from urlparse import urlparse
 import yaml
 
 import requests

--- a/lib/ansible/plugins/lookup/conjur_variable.py
+++ b/lib/ansible/plugins/lookup/conjur_variable.py
@@ -104,18 +104,12 @@ def _load_identity_from_file(identity_path, appliance_url):
 
     return {'id': id, 'api_key': api_key}
 
-def _open_url_token_retrival(url, api_key):
-    return open_url(url, data=api_key, method='POST')
-
-
 # Use credentials to retrieve temporary authorization token
 def _fetch_conjur_token(conjur_url, account, username, api_key):
     conjur_url = '{0}/authn/{1}/{2}/authenticate'.format(conjur_url, account, username)
     display.vvvv('Authentication request to Conjur at: {0}, with user: {1}'.format(conjur_url, username))
 
-    response = _open_url_token_retrival(conjur_url, api_key)
-    # print('response: {0}'.format(response))
-    # print('response code: {0}'.format(response))
+    response = open_url(conjur_url, data=api_key, method='POST')
     if response.getcode() != 200:
         raise AnsibleError('Failed to authenticate as \'{0}\''.format(username))
 

--- a/test/units/plugins/lookup/test_conjur_variable.py
+++ b/test/units/plugins/lookup/test_conjur_variable.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+# (c) 2018, Jason Vanderhoof <jason.vanderhoof@cyberark.com>
 #
 # This file is part of Ansible
 #
@@ -53,7 +53,6 @@ class TestLookupModule(unittest.TestCase):
 
             with self.assertRaises(AnsibleError):
                 conjur_variable._load_identity_from_file(temp_netrc.name, 'http://foo')
-
 
     def test_valid_configuration(self):
         with tempfile.NamedTemporaryFile() as configuration_file:

--- a/test/units/plugins/lookup/test_conjur_variable.py
+++ b/test/units/plugins/lookup/test_conjur_variable.py
@@ -31,7 +31,6 @@ from ansible.plugins.lookup import conjur_variable
 import tempfile
 
 
-
 class TestLookupModule(unittest.TestCase):
     def test_valid_netrc_file(self):
         temp_netrc = tempfile.NamedTemporaryFile()

--- a/test/units/plugins/lookup/test_conjur_variable.py
+++ b/test/units/plugins/lookup/test_conjur_variable.py
@@ -21,16 +21,16 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-from ansible.module_utils.basic import AnsibleModule
+# from ansible.module_utils.basic import AnsibleModule
 import pytest
 from ansible.compat.tests.mock import patch, Mock
 from ansible.errors import AnsibleError
-from ansible.plugins.loader import PluginLoader
+# from ansible.plugins.loader import PluginLoader
 from ansible.plugins.lookup import conjur_variable
 import tempfile
 
 
-class TestLookupModule(object):
+class TestLookupModule:
     def test_valid_netrc_file(self):
         with tempfile.NamedTemporaryFile() as temp_netrc:
             temp_netrc.write(b"machine http://localhost/authn\n")
@@ -65,32 +65,54 @@ class TestLookupModule(object):
             assert results['account'] == 'demo-policy'
             assert results['appliance_url'] == 'http://localhost:8080'
 
-    @patch('ansible.plugins.lookup.conjur_variable.open_url')
-    def test_valid_token_retrieval(self, mock_open_url):
+    # @pytest.fixture
+    # def valid_token_request(self):
+    #     a = Mock()
+    #     a.read.return_value = 'foo-bar-token'
+    #     a.getcode.return_value = 200
+    #     return a
+
+        # print('Fixture request: {}'.format(response))
+        # response.getcode.return_value=200
+
+        # return mock.MagicMock(getcode=200, read='foo-bar-token')
+        # response = Mock()
+        # response.read.return_value
+        # a = Mock()
+        # response.read.return_value = 'foo-bar-token'
+        # response.getcode.return_value = 200
+        # mock_open_url.return_value = a
+        # response.return_value = a
+        # return response
+
+    @patch('ansible.plugins.lookup.conjur_variable._open_url_token_retrival')
+    def test_valid_token_retrieval(self, valid_token_response):
         a = Mock()
         a.read.return_value = 'foo-bar-token'
         a.getcode.return_value = 200
-        mock_open_url.return_value = a
+        valid_token_response.return_value = a
 
         response = conjur_variable._fetch_conjur_token('http://conjur', 'account', 'username', 'api_key')
         assert response == 'foo-bar-token'
 
-    @patch('ansible.plugins.lookup.conjur_variable.open_url')
-    def test_valid_fetch_conjur_variable(self, mock_open_url):
-        a = Mock()
-        a.read.return_value = 'foo-bar-token'
-        a.getcode.return_value = 200
-        mock_open_url.return_value = a
+    # @pytest.fixture
+    # def valid_variable_request():
+    #     a = Mock()
+    #     a.read.return_value = 'foo-bar'
+    #     a.getcode.return_value = 200
+    #     return a
+    #
+    # @patch('ansible.plugins.lookup.conjur_variable.open_url')
+    # def test_valid_fetch_conjur_variable(self, valid_variable_request):
+    #     response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')
+    #     assert response == 'foo-bar-token'
 
-        response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')
-        assert response == 'foo-bar-token'
-
-    @patch('ansible.plugins.lookup.conjur_variable.open_url')
-    def test_invalid_fetch_conjur_variable(self, mock_open_url):
-        for code in [401, 403, 404]:
-            a = Mock()
-            a.getcode.return_value = code
-            mock_open_url.return_value = a
-
-            with pytest.raises(AnsibleError):
-                response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')
+    # @patch('ansible.plugins.lookup.conjur_variable.open_url')
+    # def test_invalid_fetch_conjur_variable(self, mock_open_url):
+    #     for code in [401, 403, 404]:
+    #         a = Mock()
+    #         a.getcode.return_value = code
+    #         mock_open_url.return_value = a
+    #
+    #         with pytest.raises(AnsibleError):
+    #             response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')

--- a/test/units/plugins/lookup/test_conjur_variable.py
+++ b/test/units/plugins/lookup/test_conjur_variable.py
@@ -64,16 +64,16 @@ class TestLookupModule:
             assert results['account'] == 'demo-policy'
             assert results['appliance_url'] == 'http://localhost:8080'
 
-    # def mock_open_url_response(self, mocker, response_code, value):
-    #     mock_response = MagicMock(spec_set=http_client.HTTPResponse)
-    #     mock_response.read.return_value = value
-    #     mock_response.getcode.return_value = response_code
-    #     mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
-
     def test_valid_token_retrieval(self, mocker):
         mock_response = MagicMock(spec_set=http_client.HTTPResponse)
+        try:
+            mock_response.getcode.return_value = 200
+        except:
+            # HTTPResponse is a Python 3 only feature. This uses a generic mock for python 2.6
+            mock_response = MagicMock()
+            mock_response.getcode.return_value = 200
+
         mock_response.read.return_value = 'foo-bar-token'
-        mock_response.getcode.return_value = 200
         mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
 
         response = conjur_variable._fetch_conjur_token('http://conjur', 'account', 'username', 'api_key')
@@ -81,8 +81,14 @@ class TestLookupModule:
 
     def test_valid_fetch_conjur_variable(self, mocker):
         mock_response = MagicMock(spec_set=http_client.HTTPResponse)
+        try:
+            mock_response.getcode.return_value = 200
+        except:
+            # HTTPResponse is a Python 3 only feature. This uses a generic mock for python 2.6
+            mock_response = MagicMock()
+            mock_response.getcode.return_value = 200
+
         mock_response.read.return_value = 'foo-bar'
-        mock_response.getcode.return_value = 200
         mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
 
         response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')
@@ -91,7 +97,13 @@ class TestLookupModule:
     def test_invalid_fetch_conjur_variable(self, mocker):
         for code in [401, 403, 404]:
             mock_response = MagicMock(spec_set=http_client.HTTPResponse)
-            mock_response.getcode.return_value = code
+            try:
+                mock_response.getcode.return_value = code
+            except:
+                # HTTPResponse is a Python 3 only feature. This uses a generic mock for python 2.6
+                mock_response = MagicMock()
+                mock_response.getcode.return_value = code
+
             mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
 
             with pytest.raises(AnsibleError):

--- a/test/units/plugins/lookup/test_conjur_variable.py
+++ b/test/units/plugins/lookup/test_conjur_variable.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# (c) 2015, Toshio Kuratomi <tkuratomi@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.compat.tests import unittest
+# from ansible.module_utils.urls import open_url
+# from ansible.compat.tests.mock import mock_open, patch
+from ansible.errors import AnsibleError
+from ansible.plugins.loader import PluginLoader
+from ansible.plugins.lookup import conjur_variable
+import tempfile
+
+
+
+class TestLookupModule(unittest.TestCase):
+    def test_valid_netrc_file(self):
+        temp_netrc = tempfile.NamedTemporaryFile()
+        temp_netrc.writelines([
+            "machine http://localhost/authn",
+            "  login admin",
+            "  password my-pass",
+        ])
+        temp_netrc.seek(0)
+
+        results = conjur_variable._load_identity_from_file(temp_netrc.name, 'http://localhost')
+
+        self.assertEquals(results['id'], 'admin')
+        self.assertEquals(results['api_key'], 'my-pass')
+        temp_netrc.close
+
+    def test_netrc_without_host_file(self):
+        temp_netrc = tempfile.NamedTemporaryFile()
+        temp_netrc.writelines([
+            "machine http://localhost/authn\n",
+            "  login admin\n",
+            "  password my-pass\n",
+        ])
+        temp_netrc.seek(0)
+
+        with self.assertRaises(AnsibleError):
+            conjur_variable._load_identity_from_file(temp_netrc.name, 'http://foo')
+
+        temp_netrc.close
+
+    def test_valid_configuration(self):
+        configuration_file = tempfile.NamedTemporaryFile()
+        configuration_file.writelines([
+            "---\n",
+            "account: demo-policy\n",
+            "plugins: []\n",
+            "appliance_url: http://localhost:8080\n"
+        ])
+        configuration_file.seek(0)
+        print(configuration_file.read())
+
+        results = conjur_variable._load_conf_from_file(configuration_file.name)
+
+        self.assertEquals(results['account'], 'demo-policy')
+        self.assertEquals(results['appliance_url'], 'http://localhost:8080')
+        configuration_file.close
+
+    # This test fails do to missing patch :(
+    # @patch('ansible.plugins.lookup.conjur_variable.open_url')
+    # def test_token_retrieval():
+    #     stream = open_url.return_value
+    #     stream.read.return_value = "foo-bar-token"
+    #     stream.getcode.return_value = 200
+    #     open_url.return_value = stream
+    #
+    #     response = conjur_variable._fetch_conjur_token('http://conjur', 'account', 'username', 'api_key')
+    #
+    #     self.assertEqual(stream.read.return_value, response)

--- a/test/units/plugins/lookup/test_conjur_variable.py
+++ b/test/units/plugins/lookup/test_conjur_variable.py
@@ -64,25 +64,35 @@ class TestLookupModule:
             assert results['account'] == 'demo-policy'
             assert results['appliance_url'] == 'http://localhost:8080'
 
-    def mock_open_url_response(self, mocker, response_code, value):
-        mock_response = MagicMock(spec_set=http_client.HTTPResponse)
-        mock_response.read.return_value = value
-        mock_response.getcode.return_value = response_code
-        mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
+    # def mock_open_url_response(self, mocker, response_code, value):
+    #     mock_response = MagicMock(spec_set=http_client.HTTPResponse)
+    #     mock_response.read.return_value = value
+    #     mock_response.getcode.return_value = response_code
+    #     mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
 
     def test_valid_token_retrieval(self, mocker):
-        self.mock_open_url_response(mocker, 200, 'foo-bar-token')
+        mock_response = MagicMock(spec_set=http_client.HTTPResponse)
+        mock_response.read.return_value = 'foo-bar-token'
+        mock_response.getcode.return_value = 200
+        mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
 
         response = conjur_variable._fetch_conjur_token('http://conjur', 'account', 'username', 'api_key')
         assert response == 'foo-bar-token'
 
     def test_valid_fetch_conjur_variable(self, mocker):
-        self.mock_open_url_response(mocker, 200, 'foo-bar')
+        mock_response = MagicMock(spec_set=http_client.HTTPResponse)
+        mock_response.read.return_value = 'foo-bar'
+        mock_response.getcode.return_value = 200
+        mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
+
         response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')
         assert response == 'foo-bar'
 
     def test_invalid_fetch_conjur_variable(self, mocker):
         for code in [401, 403, 404]:
-            self.mock_open_url_response(mocker, code, '')
+            mock_response = MagicMock(spec_set=http_client.HTTPResponse)
+            mock_response.getcode.return_value = code
+            mocker.patch.object(conjur_variable, 'open_url', return_value=mock_response)
+
             with pytest.raises(AnsibleError):
                 response = conjur_variable._fetch_conjur_token('super-secret', 'token', 'http://conjur', 'account')


### PR DESCRIPTION
##### SUMMARY
This PR adds an Ansible Lookup Plugin which allows Ansible to retrieve secrets from Conjur using the Ansible controller's Conjur identity.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Conjur Variable (ex. `lookup('conjur_variable', 'db/password')`

##### ANSIBLE VERSION
```
ansible 2.3.2.0
  config file =
  configured module search path = Default w/o overrides
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
This lookup plugin requires Conjur (https://www.conjur.org/) to be running and accessible from the machine executing the playbook using the Conjur lookup plugin.

I wrote a small project to simplify building and validating this plugin: https://github.com/jvanderhoof/ansible-testing. It uses Docker Compose provide all the parts necessary.
