### PR TITLE
fix passing of package paths+URLs to package module when using apt

### DIFF
--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -28,7 +28,7 @@ options:
   name:
     description:
       - "Package name, or package specifier with version, like C(name-1.0)."
-      - This can be a package name, or with most package managers, a file path to a package or a URL.
+      - This can be a package name or list of package names, or with most package managers, a file path to a package or a URL.
       - "Be aware that packages are not always named the same and this module will not 'translate' them per distro."
     required: true
   state:
@@ -51,6 +51,13 @@ EXAMPLES = '''
 - name: install ntpdate
   package:
     name: ntpdate
+    state: present
+
+- name: install packages
+  package:
+    name:
+      - ntpdate
+      - ruby
     state: present
 
 # This uses a variable as this changes per distribution.

--- a/lib/ansible/modules/packaging/os/package.py
+++ b/lib/ansible/modules/packaging/os/package.py
@@ -28,6 +28,7 @@ options:
   name:
     description:
       - "Package name, or package specifier with version, like C(name-1.0)."
+      - This can be a package name, or with most package managers, a file path to a package or a URL.
       - "Be aware that packages are not always named the same and this module will not 'translate' them per distro."
     required: true
   state:

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -31,6 +31,12 @@ class ActionModule(ActionBase):
 
     TRANSFERS_FILES = False
 
+    def new_module_args(self):
+        new_args = self._task.args.copy()
+        if 'use' in new_args:
+            del new_args['use']
+        return new_args
+
     def run(self, tmp=None, task_vars=None):
         ''' handler for package operations '''
 
@@ -64,10 +70,7 @@ class ActionModule(ActionBase):
                     raise AnsibleActionFail('Could not find a module for %s.' % module)
                 else:
                     # run the 'package' module
-                    new_module_args = self._task.args.copy()
-                    if 'use' in new_module_args:
-                        del new_module_args['use']
-
+                    new_module_args = self.new_module_args()
                     display.vvvv("Running %s" % module)
                     result.update(self._execute_module(module_name=module, module_args=new_module_args, task_vars=task_vars, wrap_async=self._task.async_val))
             else:

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -35,6 +35,17 @@ class ActionModule(ActionBase):
         new_args = self._task.args.copy()
         if 'use' in new_args:
             del new_args['use']
+
+        # apt module requires a different option for files/URLs
+        names = new_args['name']
+        if not isinstance(names, list):
+            names = [names]
+        if len(names) > 1 and any(name.endswith('.deb') for name in names):
+            raise AnsibleActionFail("Only one .deb package path/URL can be passed at a time.")
+        if names[0].endswith('.deb'):
+            new_args['deb'] = names[0]
+            del new_args['name']
+
         return new_args
 
     def run(self, tmp=None, task_vars=None):

--- a/lib/ansible/plugins/action/package.py
+++ b/lib/ansible/plugins/action/package.py
@@ -36,13 +36,14 @@ class ActionModule(ActionBase):
         if 'use' in new_args:
             del new_args['use']
 
-        # apt module requires a different option for files/URLs
+        # normalize the names to be a list
         names = new_args['name']
         if not isinstance(names, list):
             names = [names]
         if len(names) > 1 and any(name.endswith('.deb') for name in names):
             raise AnsibleActionFail("Only one .deb package path/URL can be passed at a time.")
-        if names[0].endswith('.deb'):
+        # apt module requires a different option for files/URLs
+        if names and names[0].endswith('.deb'):
             new_args['deb'] = names[0]
             del new_args['name']
 

--- a/test/units/plugins/action/test_package.py
+++ b/test/units/plugins/action/test_package.py
@@ -1,0 +1,61 @@
+# (c) 2017, Aidan Feldman <aidan.feldman@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests import unittest
+from ansible.compat.tests.mock import MagicMock, Mock
+from ansible.plugins.action.package import ActionModule
+from ansible.playbook.task import Task
+
+
+class TestPackageAction(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_args_name_only(self):
+
+        play_context = Mock()
+        task = MagicMock(Task)
+        task.async_val = False
+        connection = Mock()
+
+        task.args = {'name': 'at'}
+        play_context.check_mode = False
+
+        self.mock_am = ActionModule(task, connection, play_context, loader=None, templar=None, shared_loader_obj=None)
+
+        self.assertDictEqual(self.mock_am.new_module_args(), {'name': 'at'})
+
+    def test_args_use_removed(self):
+
+        play_context = Mock()
+        task = MagicMock(Task)
+        task.async_val = False
+        connection = Mock()
+
+        task.args = {'name': 'at', 'use': 'yum'}
+        play_context.check_mode = False
+
+        self.mock_am = ActionModule(task, connection, play_context, loader=None, templar=None, shared_loader_obj=None)
+
+        self.assertDictEqual(self.mock_am.new_module_args(), {'name': 'at'})

--- a/test/units/plugins/action/test_package.py
+++ b/test/units/plugins/action/test_package.py
@@ -20,6 +20,7 @@ __metaclass__ = type
 
 from ansible.compat.tests import unittest
 from ansible.compat.tests.mock import MagicMock, Mock
+from ansible.errors import AnsibleActionFail
 from ansible.plugins.action.package import ActionModule
 from ansible.playbook.task import Task
 
@@ -59,3 +60,32 @@ class TestPackageAction(unittest.TestCase):
         self.mock_am = ActionModule(task, connection, play_context, loader=None, templar=None, shared_loader_obj=None)
 
         self.assertDictEqual(self.mock_am.new_module_args(), {'name': 'at'})
+
+    def test_args_deb(self):
+
+        play_context = Mock()
+        task = MagicMock(Task)
+        task.async_val = False
+        connection = Mock()
+
+        task.args = {'name': 'at.deb'}
+        play_context.check_mode = False
+
+        self.mock_am = ActionModule(task, connection, play_context, loader=None, templar=None, shared_loader_obj=None)
+
+        self.assertDictEqual(self.mock_am.new_module_args(), {'deb': 'at.deb'})
+
+    def test_args_deb_list(self):
+
+        play_context = Mock()
+        task = MagicMock(Task)
+        task.async_val = False
+        connection = Mock()
+
+        task.args = {'name': ['at.deb', 'foo']}
+        play_context.check_mode = False
+
+        self.mock_am = ActionModule(task, connection, play_context, loader=None, templar=None, shared_loader_obj=None)
+
+        with self.assertRaises(AnsibleActionFail):
+            self.mock_am.new_module_args()


### PR DESCRIPTION
##### SUMMARY
While most of the packaging modules support a package file path or URL being passed to their `name`, [the `apt` module requires a different one (`deb`)](https://docs.ansible.com/ansible/latest/apt_module.html#options). This change looks for a suffix of `.deb` and adjusts the arguments accordingly. Also added some tests around argument handling in the package module.

This change was inspired by seeing [a role that was installing packages cross-platform](https://github.com/singleplatform-eng/ansible-role-nessus-agent/blob/cb21622189efabef4c17245a9addac01654c8ae8/tasks/main.yml#L3-L9). The simplified version of their code:

```yaml
- name: Install from repo
  package: name={{pkg}}
  when: "'.deb' not in pkg"

- name: Install from .deb package
  apt: deb={{pkg}}
  when: "'.deb' in pkg"
```

Following this change, it could simply be

```yaml
- name: Install from repo
  package: name={{pkg}}
```

This will make cross-platform support in Ansible code just that little bit easier.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
package

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ubuntu/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/ubuntu/.local/lib/python2.7/site-packages/ansible
  executable location = /home/ubuntu/.local/bin/ansible
  python version = 2.7.12 (default, Nov 20 2017, 18:23:56) [GCC 5.4.0 20160609]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

With the following command, run on Ubuntu 16.04:

```sh
ansible all -b -i "localhost," -c local -m package -a "name=http://mirrors.kernel.org/ubuntu/pool/universe/c/cloc/cloc_1.60-1.1_all.deb"
```

Before:

```
localhost | FAILED! => {
    "changed": false,
    "msg": "No package matching 'http://mirrors.kernel.org/ubuntu/pool/universe/c/cloc/cloc_1.60-1.1_all.deb' is available"
}
```

After:

```
localhost | SUCCESS => {
    "changed": true,
    ...
}
```