### PR TITLE
Improve editor selection while executing vault commnad

### DIFF
--- a/lib/ansible/parsing/vault/__init__.py
+++ b/lib/ansible/parsing/vault/__init__.py
@@ -853,6 +853,7 @@ class VaultEditor:
         except:
             # whatever happens, destroy the decrypted file
             self._shred_file(tmp_path)
+            raise
 
         b_tmpdata = self.read_data(tmp_path)
 

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -442,7 +442,12 @@ class TestVaultEditor(unittest.TestCase):
                                 ve.decrypt_file,
                                 src_file_path)
 
-    def test_create_file(self):
+    @patch.object(vault.VaultEditor, '_editor_shell_command')
+    def test_create_file(self, mock_editor_shell_command):
+
+        def sc_side_effect():
+            return 'touch'
+        mock_editor_shell_command.side_effect = sc_side_effect
 
         tmp_file = tempfile.NamedTemporaryFile()
         os.unlink(tmp_file.name)

--- a/test/units/parsing/vault/test_vault_editor.py
+++ b/test/units/parsing/vault/test_vault_editor.py
@@ -442,12 +442,7 @@ class TestVaultEditor(unittest.TestCase):
                                 ve.decrypt_file,
                                 src_file_path)
 
-    @patch.object(vault.VaultEditor, '_editor_shell_command')
-    def test_create_file(self, mock_editor_shell_command):
-
-        def sc_side_effect(filename):
-            return ['touch', filename]
-        mock_editor_shell_command.side_effect = sc_side_effect
+    def test_create_file(self):
 
         tmp_file = tempfile.NamedTemporaryFile()
         os.unlink(tmp_file.name)


### PR DESCRIPTION
Imrove editor selection by first looking command pointed by VISUAL, then EDITOR
and falling back on using 'vi' if commands pointed b yVISUAL and EDITOR are not
found.
Also give better error message when no executable editor is not found in path.

##### SUMMARY
Current code doesn't look editor set by VISUAL env variable. VISUAL should take precedence over EDITOR. Also the code doesn't check if the actual command exists and is executable resulting in vague "File not found" error if no editor is found.
This fixes both issues and Fixes #34295

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /home/tmy/.ansible.cfg
  configured module search path = [u'/home/tmy/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib64/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 22 2017, 11:31:09) [GCC 7.2.0]

```

##### ADDITIONAL INFORMATION
