### PR TITLE
docfixes: spelling, width

### DIFF
--- a/lib/ansible/modules/cloud/amazon/cloudtrail.py
+++ b/lib/ansible/modules/cloud/amazon/cloudtrail.py
@@ -36,7 +36,7 @@ options:
   name:
     description:
       - Name for the CloudTrail.
-      - Names are unique per-region unless the CloudTrail is a mulit-region trail, in which case it is unique per-account.
+      - Names are unique per-region unless the CloudTrail is a multi-region trail, in which case it is unique per-account.
     required: true
   enable_logging:
     description:
@@ -76,27 +76,20 @@ options:
     version_added: "2.4"
   cloudwatch_logs_role_arn:
     description:
-      - Specifies a full ARN for an IAM role that assigns the proper permissions for CloudTrail to create and write to the log group listed below.
+      - Specifies a full ARN for an IAM role that assigns the proper permissions for CloudTrail to create and write to the log group.
       - See U(https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html)
-      - "Example arn:aws:iam::123456789012:role/CloudTrail_CloudWatchLogs_Role"
       - Required when C(cloudwatch_logs_log_group_arn)
     version_added: "2.4"
   cloudwatch_logs_log_group_arn:
     description:
       - A full ARN specifying a valid CloudWatch log group to which CloudTrail logs will be delivered. The log group should already exist.
       - See U(https://docs.aws.amazon.com/awscloudtrail/latest/userguide/send-cloudtrail-events-to-cloudwatch-logs.html)
-      - "Example arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup:*"
       - Required when C(cloudwatch_logs_role_arn)
     version_added: "2.4"
   kms_key_id:
     description:
       - Specifies the KMS key ID to use to encrypt the logs delivered by CloudTrail. This also has the effect of enabling log file encryption.
       - The value can be an alias name prefixed by "alias/", a fully specified ARN to an alias, a fully specified ARN to a key, or a globally unique identifier.
-      - Examples
-      - alias/MyAliasName
-      - "arn:aws:kms:us-east-1:123456789012:alias/MyAliasName"
-      - "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
-      - 12345678-1234-1234-1234-123456789012
       - See U(https://docs.aws.amazon.com/awscloudtrail/latest/userguide/encrypting-cloudtrail-log-files-with-aws-kms.html)
     version_added: "2.4"
   tags:
@@ -128,9 +121,20 @@ EXAMPLES = '''
     region: us-east-1
     is_multi_region_trail: true
     enable_log_file_validation: true
+    cloudwatch_logs_role_arn: "arn:aws:iam::123456789012:role/CloudTrail_CloudWatchLogs_Role"
+    cloudwatch_logs_log_group_arn: "arn:aws:logs:us-east-1:123456789012:log-group:CloudTrail/DefaultLogGroup:*"
+    kms_key_id: "alias/MyAliasName"
     tags:
       environment: dev
       Name: default
+
+- name: show another valid kms_key_id
+  cloudtrail:
+    state: present
+    name: default
+    s3_bucket_name: mylogbucket
+    kms_key_id: "arn:aws:kms:us-east-1:123456789012:key/12345678-1234-1234-1234-123456789012"
+    # simply "12345678-1234-1234-1234-123456789012" would be valid too.
 
 - name: pause logging the trail we just created
   cloudtrail:


### PR DESCRIPTION


##### SUMMARY
Remove examples from main section and make sure it is all in the examples. Should helpw ith the HTML breakage (it is too wide for most monitors).

tyop fixes too.

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
`cloudtrail`

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
.