### PR TITLE
Add new module mlnxos_magp for managing MAGP protocol on Mellanox MLMX-OS network devices

### DIFF
--- a/lib/ansible/modules/network/mlnxos/mlnxos_magp.py
+++ b/lib/ansible/modules/network/mlnxos/mlnxos_magp.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = """
+---
+module: mlnxos_magp
+version_added: "2.5"
+author: "Samer Deeb (@samerd)"
+short_description: Manage MAGP protocol on MLNX-OS network devices
+description:
+  - This module provides declarative management of MAGP protocol on vlan
+     interface of MLNX-OS network devices.
+notes:
+  - tested on Mellanox OS 3.6.4000
+options:
+  magp_id:
+    description:
+      - "MAGP instance number 1-255"
+    required: true
+  interface:
+    description:
+      - VLAN Interface name.
+    required: true
+  state:
+    description:
+      - vlan interface state
+    default: present
+    choices: ['present', 'absent', 'enabled', 'disabled']
+  router_ip:
+    description:
+      - MAGP router ip address
+  router_mac:
+    description:
+      - MAGP router MAC address
+"""
+
+EXAMPLES = """
+- name: run add vlan interface with magp
+  mlnxos_magp:
+    magp_id: 103
+    router_ip: 192.168.8.2
+    router_mac: AA:1B:2C:3D:4E:5F
+    interface: Vlan 1002
+"""
+
+RETURN = """
+commands:
+  description: The list of configuration mode commands to send to the device.
+  returned: always
+  type: list
+  sample:
+    - interface vlan 234 magp 103
+    - exit
+    - interface vlan 234 magp 103 ip virtual-router address 1.2.3.4
+"""
+import re
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible.module_utils.network.mlnxos.mlnxos import BaseMlnxosModule
+from ansible.module_utils.network.mlnxos.mlnxos import show_cmd
+
+
+class MlnxosMagpModule(BaseMlnxosModule):
+    IF_VLAN_REGEX = re.compile(r"^Vlan (\d+)$")
+
+    @classmethod
+    def _get_element_spec(cls):
+        return dict(
+            magp_id=dict(type='int', required=True),
+            state=dict(default='present',
+                       choices=['present', 'absent', 'enabled', 'disabled']),
+            interface=dict(required=True),
+            router_ip=dict(),
+            router_mac=dict(),
+        )
+
+    def init_module(self):
+        """ Ansible module initialization
+        """
+        element_spec = self._get_element_spec()
+        argument_spec = dict()
+        argument_spec.update(element_spec)
+        self._module = AnsibleModule(
+            argument_spec=argument_spec,
+            supports_check_mode=True)
+
+    def validate_magp_id(self, value):
+        if value and not 1 <= int(value) <= 255:
+            self._module.fail_json(msg='magp id must be between 1 and 255')
+
+    def get_required_config(self):
+        module_params = self._module.params
+        interface = module_params['interface']
+        match = self.IF_VLAN_REGEX.match(interface)
+        vlan_id = 0
+        if match:
+            vlan_id = int(match.group(1))
+        else:
+            self._module.fail_json(
+                msg='Invalid interface name: should be "Vlan <vlan_id>"')
+
+        self._required_config = dict(
+            magp_id=module_params['magp_id'],
+            state=module_params['state'],
+            vlan_id=vlan_id,
+            router_ip=module_params['router_ip'],
+            router_mac=module_params['router_mac'])
+        self.validate_param_values(self._required_config)
+
+    @classmethod
+    def get_magp_id(cls, item):
+        header = cls.get_config_attr(item, "header")
+        return int(header.split()[1])
+
+    def _create_magp_instance_data(self, magp_id, item):
+        vlan_id = int(self.get_config_attr(item, "Interface vlan"))
+        state = self.get_config_attr(item, "Admin state").lower()
+        return dict(
+            magp_id=magp_id,
+            state=state,
+            vlan_id=vlan_id,
+            router_ip=self.get_config_attr(item, "Virtual IP"),
+            router_mac=self.get_config_attr(item, "Virtual MAC"))
+
+    def _update_magp_data(self, magp_data):
+        for magp_item in magp_data:
+            magp_id = self.get_magp_id(magp_item)
+            inst_data = self._create_magp_instance_data(magp_id, magp_item)
+            self._current_config[magp_id] = inst_data
+
+    def _get_magp_config(self):
+        cmd = "show magp"
+        return show_cmd(self._module, cmd, json_fmt=True, fail_on_error=False)
+
+    def load_current_config(self):
+        # called in base class in run function
+        self._current_config = dict()
+        magp_data = self._get_magp_config()
+        if magp_data:
+            self._update_magp_data(magp_data)
+
+    def _generate_no_magp_commands(self):
+        req_vlan_id = self._required_config['vlan_id']
+        req_magp_id = self._required_config['magp_id']
+        curr_magp_data = self._current_config.get(req_magp_id)
+        if not curr_magp_data:
+            return
+        curr_vlan_id = curr_magp_data.get(req_vlan_id)
+        if curr_vlan_id == req_vlan_id:
+            cmd = 'interface vlan %s no magp %s' % (req_vlan_id, req_magp_id)
+            self._commands.append(cmd)
+
+    def _generate_magp_commands(self, req_state):
+        req_vlan_id = self._required_config['vlan_id']
+        req_magp_id = self._required_config['magp_id']
+        curr_magp_data = self._current_config.get(req_magp_id, dict())
+        curr_vlan_id = curr_magp_data.get('vlan_id')
+        magp_prefix = 'interface vlan %s magp %s' % (req_vlan_id, req_magp_id)
+        create_new_magp = False
+        if curr_vlan_id != req_vlan_id:
+            if curr_vlan_id:
+                cmd = 'interface vlan %s no magp %s' % (
+                    curr_vlan_id, req_magp_id)
+                self._commands.append(cmd)
+                create_new_magp = True
+            self._commands.append(magp_prefix)
+            self._commands.append('exit')
+        req_router_ip = self._required_config['router_ip']
+        curr_router_ip = curr_magp_data.get('router_ip')
+        if req_router_ip:
+            if curr_router_ip != req_router_ip or create_new_magp:
+                cmd = '%s ip virtual-router address %s' % (
+                    magp_prefix, req_router_ip)
+                self._commands.append(cmd)
+        else:
+            if curr_router_ip and curr_router_ip != '0.0.0.0':
+                cmd = '%s no ip virtual-router address' % magp_prefix
+                self._commands.append(cmd)
+        req_router_mac = self._required_config['router_mac']
+        curr_router_mac = curr_magp_data.get('router_mac')
+        if req_router_mac:
+            if curr_router_mac != req_router_mac or create_new_magp:
+                cmd = '%s ip virtual-router mac-address %s' % (
+                    magp_prefix, req_router_mac)
+                self._commands.append(cmd)
+        else:
+            if curr_router_mac and curr_router_mac != '00:00:00:00:00:00':
+                cmd = '%s no ip virtual-router mac-address' % magp_prefix
+                self._commands.append(cmd)
+        if req_state in ('enabled', 'disabled'):
+            curr_state = curr_magp_data.get('state', 'enabled')
+            if curr_state != req_state:
+                if req_state == 'enabled':
+                    suffix = 'no shutdown'
+                else:
+                    suffix = 'shutdown'
+                cmd = '%s %s' % (magp_prefix, suffix)
+                self._commands.append(cmd)
+
+    def generate_commands(self):
+        req_state = self._required_config['state']
+        if req_state == 'absent':
+            return self._generate_no_magp_commands()
+        return self._generate_magp_commands(req_state)
+
+
+def main():
+    """ main entry point for module execution
+    """
+    MlnxosMagpModule.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/test/units/modules/network/mlnxos/fixtures/mlnxos_magp_show.cfg
+++ b/test/units/modules/network/mlnxos/fixtures/mlnxos_magp_show.cfg
@@ -1,0 +1,18 @@
+[
+    {
+        "Interface vlan": "1243",
+        "Admin state": "Enabled",
+        "Virtual IP": "10.0.0.43",
+        "header": "MAGP 102",
+        "State": "Init",
+        "Virtual MAC": "01:02:03:04:05:06"
+    },
+    {
+        "Interface vlan": "1200",
+        "Admin state": "Disabled",
+        "Virtual IP": "0.0.0.0",
+        "header": "MAGP 103",
+        "State": "Init",
+        "Virtual MAC": "00:00:00:00:00:00"
+    }
+]

--- a/test/units/modules/network/mlnxos/test_mlnxos_magp.py
+++ b/test/units/modules/network/mlnxos/test_mlnxos_magp.py
@@ -1,0 +1,104 @@
+#
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# Make coding more python3-ish
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.compat.tests.mock import patch
+from ansible.modules.network.mlnxos import mlnxos_magp
+from units.modules.utils import set_module_args
+from .mlnxos_module import TestMlnxosModule, load_fixture
+
+
+class TestMlnxosMagpModule(TestMlnxosModule):
+
+    module = mlnxos_magp
+
+    def setUp(self):
+        super(TestMlnxosMagpModule, self).setUp()
+        self.mock_get_config = patch.object(
+            mlnxos_magp.MlnxosMagpModule,
+            "_get_magp_config")
+        self.get_config = self.mock_get_config.start()
+
+        self.mock_load_config = patch(
+            'ansible.module_utils.network.mlnxos.mlnxos.load_config')
+        self.load_config = self.mock_load_config.start()
+
+    def tearDown(self):
+        super(TestMlnxosMagpModule, self).tearDown()
+        self.mock_get_config.stop()
+        self.mock_load_config.stop()
+
+    def load_fixtures(self, commands=None, transport='cli'):
+        config_file = 'mlnxos_magp_show.cfg'
+        self.get_config.return_value = load_fixture(config_file)
+        self.load_config.return_value = None
+
+    def test_magp_absent_no_change(self):
+        set_module_args(dict(interface='Vlan 1002', magp_id=110,
+                             state='absent'))
+        self.execute_module(changed=False)
+
+    def test_magp_no_change(self):
+        set_module_args(dict(interface='Vlan 1200', magp_id=103,
+                             state='disabled'))
+        self.execute_module(changed=False)
+
+    def test_magp_present_no_change(self):
+        set_module_args(dict(interface='Vlan 1200', magp_id=103))
+        self.execute_module(changed=False)
+
+    def test_magp_enable(self):
+        set_module_args(dict(interface='Vlan 1200', magp_id=103,
+                             state='enabled'))
+        commands = ['interface vlan 1200 magp 103 no shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_magp_disable(self):
+        set_module_args(dict(interface='Vlan 1243', magp_id=102,
+                             state='disabled', router_ip='10.0.0.43',
+                             router_mac='01:02:03:04:05:06'))
+        commands = ['interface vlan 1243 magp 102 shutdown']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_magp_change_address(self):
+        set_module_args(dict(interface='Vlan 1243', magp_id=102,
+                             router_ip='10.0.0.44',
+                             router_mac='01:02:03:04:05:07'))
+        commands = [
+            'interface vlan 1243 magp 102 ip virtual-router address 10.0.0.44',
+            'interface vlan 1243 magp 102 ip virtual-router mac-address 01:02:03:04:05:07']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_magp_remove_address(self):
+        set_module_args(dict(interface='Vlan 1243', magp_id=102))
+        commands = [
+            'interface vlan 1243 magp 102 no ip virtual-router address',
+            'interface vlan 1243 magp 102 no ip virtual-router mac-address']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_magp_add(self):
+        set_module_args(dict(interface='Vlan 1244', magp_id=104,
+                             router_ip='10.0.0.44',
+                             router_mac='01:02:03:04:05:07'))
+        commands = [
+            'interface vlan 1244 magp 104',
+            'exit',
+            'interface vlan 1244 magp 104 ip virtual-router address 10.0.0.44',
+            'interface vlan 1244 magp 104 ip virtual-router mac-address 01:02:03:04:05:07']
+        self.execute_module(changed=True, commands=commands, sort=False)
+
+    def test_magp_change_vlan(self):
+        set_module_args(dict(interface='Vlan 1244', magp_id=102,
+                             router_ip='10.0.0.43',
+                             router_mac='01:02:03:04:05:06'))
+        commands = [
+            'interface vlan 1243 no magp 102',
+            'interface vlan 1244 magp 102',
+            'exit',
+            'interface vlan 1244 magp 102 ip virtual-router address 10.0.0.43',
+            'interface vlan 1244 magp 102 ip virtual-router mac-address 01:02:03:04:05:06']
+        self.execute_module(changed=True, commands=commands)


### PR DESCRIPTION
Signed-off-by: Samer Deeb <samerd@mellanox.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add new module mlnxos_magp for managing MAGP protocol on Mellanox MLMX-OS network devices
including MAGP instance, virtual router IP and MAC
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/mlnxos/mlnxos_magp

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (feature/net-magp c29bdad4ec) last updated 2017/12/30 05:37:00 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
