### PR TITLE
docfix in cloud/amazon/rds module

### DIFF
--- a/lib/ansible/modules/cloud/amazon/rds.py
+++ b/lib/ansible/modules/cloud/amazon/rds.py
@@ -123,7 +123,7 @@ options:
     default: 3306 for mysql, 1521 for Oracle, 1433 for SQL Server, 5432 for PostgreSQL.
   upgrade:
     description:
-      - Indicates that minor version upgrades should be applied automatically. Used only when command=create or command=replicate.
+      - Indicates that minor version upgrades should be applied automatically. Used only when command=create, command=modify, or command=replicate.
     required: false
     default: no
     choices: [ "yes", "no" ]


### PR DESCRIPTION
Update description to reflect that the "upgrade" option can also be used with
the modify command.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes a minor omission in the documentation of the rds module.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
rds_module

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/ktstevenson/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.11 (default, Jun 17 2016, 20:01:51) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->
The documentation currently says that the "upgrade" option can only be used with the create and replicate commands. It also appears to work with the modify command, at least for postgres databases.

This code works:
```
- name: Set database database parameters
      rds:
        command: modify
        instance_name: "{{ dbInstanceName }}"
        region: us-east-1
        upgrade: yes
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
N/A
```
