### PR TITLE
basic: make is_executable function directory aware

### DIFF
--- a/lib/ansible/module_utils/basic.py
+++ b/lib/ansible/module_utils/basic.py
@@ -644,7 +644,8 @@ def is_executable(path):
     # These are all bitfields so first bitwise-or all the permissions we're
     # looking for, then bitwise-and with the file's mode to determine if any
     # execute bits are set.
-    return ((stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH) & os.stat(path)[stat.ST_MODE])
+    st = os.stat(path)[stat.ST_MODE]
+    return stat.S_ISREG(st) and ((stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH) & st)
 
 
 def _load_params():


### PR DESCRIPTION
##### SUMMARY
This fix adds additional condition where only files are returned
as executables.

Fixes: #18688

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/basic.py
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```