### PR TITLE
Fix for with_ini when used with YAML parameters.

### DIFF
--- a/lib/ansible/plugins/lookup/ini.py
+++ b/lib/ansible/plugins/lookup/ini.py
@@ -68,13 +68,23 @@ from io import StringIO
 from ansible.errors import AnsibleError, AnsibleAssertionError
 from ansible.module_utils.six.moves import configparser
 from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils.six import iteritems
 from ansible.plugins.lookup import LookupBase
+
+paramvals = {
+    'file': 'ansible.ini',
+    'type': "ini",
+    'section': "global",
+    're': False,
+    'default': None,
+    'encoding': 'utf-8',
+}
 
 
 def _parse_params(term):
     '''Safely split parameter term to preserve spaces'''
 
-    keys = ['key', 'type', 'section', 'file', 're', 'default', 'encoding']
+    keys = ['key'] + list(paramvals.keys())
     params = {}
     for k in keys:
         params[k] = ''
@@ -97,7 +107,7 @@ class LookupModule(LookupBase):
 
     def get_value(self, key, section, dflt, is_regexp):
         # Retrieve all values from a section using a regexp
-        if is_regexp:
+        if bool(is_regexp):
             return [v for k, v in self.cp.items(section) if re.match(key, k)]
         value = None
         # Retrieve a single value
@@ -111,52 +121,53 @@ class LookupModule(LookupBase):
 
         self.cp = configparser.ConfigParser()
 
+        key = terms.pop(0)
+        # terms may contain only one element
+        # ex: [ "value[1-2] section=section1 file=lookup.ini re=true" ]
+        # in this case, we build an array with the following content (from line above):
+        # [ 'value[1-2]', { 'section': 'section1'}, { 'file': 'lookup.ini'}, { 're': true} ]
+        if len(terms) == 0:
+            terms = _parse_params(key)
+            key = terms.pop(0)
+            _terms = []
+            for term in terms:
+                # Split at first equal and strip space around elements
+                _term = term.split('=', 1)
+                _terms.append({_term[0].strip(): _term[1].strip()})
+            terms = _terms
         ret = []
         for term in terms:
-            params = _parse_params(term)
-            key = params[0]
-
-            paramvals = {
-                'file': 'ansible.ini',
-                're': False,
-                'default': None,
-                'section': "global",
-                'type': "ini",
-                'encoding': 'utf-8',
-            }
-
             # parameters specified?
             try:
-                for param in params[1:]:
-                    name, value = param.split('=')
+                for name, value in iteritems(term):
                     if name not in paramvals:
                         raise AnsibleAssertionError('%s not in paramvals' % name)
                     paramvals[name] = value
             except (ValueError, AssertionError) as e:
                 raise AnsibleError(e)
 
-            # Retrieve file path
-            path = self.find_file_in_search_path(variables, 'files', paramvals['file'])
+        # Retrieve file path
+        path = self.find_file_in_search_path(variables, 'files', paramvals['file'])
 
-            # Create StringIO later used to parse ini
-            config = StringIO()
-            # Special case for java properties
-            if paramvals['type'] == "properties":
-                config.write(u'[java_properties]\n')
-                paramvals['section'] = 'java_properties'
+        # Create StringIO later used to parse ini
+        config = StringIO()
+        # Special case for java properties
+        if paramvals['type'] == "properties":
+            config.write(u'[java_properties]\n')
+            paramvals['section'] = 'java_properties'
 
-            # Open file using encoding
-            contents, show_data = self._loader._get_file_contents(path)
-            contents = to_text(contents, errors='surrogate_or_strict', encoding=paramvals['encoding'])
-            config.write(contents)
-            config.seek(0, os.SEEK_SET)
+        # Open file using encoding
+        contents, show_data = self._loader._get_file_contents(path)
+        contents = to_text(contents, errors='surrogate_or_strict', encoding=paramvals['encoding'])
+        config.write(contents)
+        config.seek(0, os.SEEK_SET)
 
-            self.cp.readfp(config)
-            var = self.get_value(key, paramvals['section'], paramvals['default'], paramvals['re'])
-            if var is not None:
-                if isinstance(var, MutableSequence):
-                    for v in var:
-                        ret.append(v)
-                else:
-                    ret.append(var)
+        self.cp.readfp(config)
+        var = self.get_value(key, paramvals['section'], paramvals['default'], paramvals['re'])
+        if var is not None:
+            if isinstance(var, MutableSequence):
+                for v in var:
+                    ret.append(v)
+            else:
+                ret.append(var)
         return ret

--- a/test/integration/targets/lookup_properties/test_lookup_properties.yml
+++ b/test/integration/targets/lookup_properties/test_lookup_properties.yml
@@ -69,3 +69,14 @@
         that:
           - '_.results.0.item == "section1/value1"'
           - '_.results.1.item == "section1/value2"'
+    - debug: msg="{{item}}"
+      with_ini:
+        - value[1-2]
+        - section: section1
+        - file: lookup.ini
+        - re: true
+      register: _
+    - assert:
+        that:
+          - '_.results.0.item == "section1/value1"'
+          - '_.results.1.item == "section1/value2"'


### PR DESCRIPTION
##### SUMMARY

Lookup ini is not working with current example in Ansible documentation.
Fix the bug in the lookup plugin and add a new test in integration test.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME

lookup ini

##### ANSIBLE VERSION

```
ansible 2.5.0 (fix-with-ini 95b77fdb9d) last updated 2017/12/31 08:09:24 (GMT +200)
  config file = /home/yannig/.ansible.cfg
  configured module search path = [u'/home/yannig/dev/common/playbooks/library']
  ansible python module location = /home/yannig/dev/ansible/lib/ansible
  executable location = /home/yannig/dev/ansible/bin/ansible
  python version = 2.7.13 (default, Nov 23 2017, 15:37:09) [GCC 6.3.0 20170406]
```

##### ADDITIONAL INFORMATION

Create a playbook **test.yml** with the following content:

```yaml
- name: "test"
  hosts: localhost
  gather_facts: no
  tasks:
    - name: "Test ini lookup"
      debug: var=item
      with_ini:
        - .*
        - section: section1
        - file: test.ini
        - re: true
```

You will need a file **test.ini** with the following content:

```ini
[section1]
a=1
b=2
[section2]
a=1
b=2
c=3
```

Launch this playbook (**ansible-playbook test.yml**).

What you get:

```
[WARNING]: Unable to find 'ansible.ini' in expected paths.

fatal: [localhost]: FAILED! => {"msg": "Invalid filename: 'None'"}
msg:
Invalid filename: 'None'
        to retry, use: --limit @/home/yannig/tmp/test.retry
```

Expected result:

```
ok: [localhost] => (item=1) => {
    "changed": false, 
    "item": "1"
}
ok: [localhost] => (item=2) => {
    "changed": false, 
    "item": "2"
}
```
