### PR TITLE
Add support for vlan and loopback interfaces in mlnxos_interface

### DIFF
--- a/test/units/modules/network/mlnxos/fixtures/mlnxos_interfaces_show.cfg
+++ b/test/units/modules/network/mlnxos/fixtures/mlnxos_interfaces_show.cfg
@@ -40,5 +40,35 @@
             "discard packets": "0",
             "broadcast packets": "0"
         }
+    },
+    {
+        "Icmp redirect": "Enabled",
+        "Description": "N/A",
+        "Mac Address": "7C:FE:90:F0:54:C1",
+        "Autostate": "Enabled",
+        "Admin state": "Enabled",
+        "header": "Vlan 10",
+        "MTU": "1500 bytes",
+        "DHCP client": "Disabled",
+        "Operational state": "Up",
+        "VRF": "default",
+        "Arp timeout": "1500 seconds",
+        "Counters": "Disabled"
+    },
+    {
+        "Autostate": "Enabled",
+        "Icmp redirect": "Enabled",
+        "Broadcast address": "10.2.2.255",
+        "Description": "N/A",
+        "Mac Address": "7C:FE:90:F0:54:C1",
+        "Internet Address": "10.2.2.3/24",
+        "Admin state": "Enabled",
+        "header": "Vlan 1002",
+        "MTU": "1500 bytes",
+        "DHCP client": "Disabled",
+        "Operational state": "Down",
+        "VRF": "default",
+        "Arp timeout": "1500 seconds",
+        "Counters": "Disabled"
     }
 ]

--- a/test/units/modules/network/mlnxos/fixtures/mlnxos_interfaces_status.cfg
+++ b/test/units/modules/network/mlnxos/fixtures/mlnxos_interfaces_status.cfg
@@ -5,5 +5,11 @@
             "Operational state": "Down",
             "Speed": "100 Gbps"
         }
+    ],
+    "Vlan 1002": [
+        {
+            "State": "Down",
+            "Description": "N/A"
+        }
     ]
 }

--- a/test/units/modules/network/mlnxos/test_mlnxos_interface.py
+++ b/test/units/modules/network/mlnxos/test_mlnxos_interface.py
@@ -1,30 +1,13 @@
 #
-# (c) 2016 Red Hat Inc.
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import json
-
 from ansible.compat.tests.mock import patch
 from ansible.modules.network.mlnxos import mlnxos_interface
-from ansible.module_utils.network.mlnxos import mlnxos as mlnxos_utils
 from units.modules.utils import set_module_args
 from .mlnxos_module import TestMlnxosModule, load_fixture
 
@@ -94,11 +77,34 @@ class TestMlnxosInterfaceModule(TestMlnxosModule):
         commands = ['interface ethernet 1/1', 'shutdown', 'exit']
         self.execute_module(changed=True, commands=commands)
 
+    def test_add_loopback_if(self):
+        set_module_args(dict(name='Loopback 1', description='Loopback test'))
+        commands = ['interface loopback 1', 'description Loopback test',
+                    'exit']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_add_vlan_if(self):
+        set_module_args(dict(name='Vlan 101', description='Vlan test',
+                             enabled=True))
+        commands = ['interface vlan 101', 'description Vlan test',
+                    'no shutdown', 'exit']
+        self.execute_module(changed=True, commands=commands)
+
+    def test_remove_vlan_if(self):
+        set_module_args(dict(name='Vlan 1002', state='absent'))
+        commands = ['no interface vlan 1002']
+        self.execute_module(changed=True, commands=commands)
+
     def test_oper_state_check(self):
         set_module_args(dict(name='Eth1/1', enabled=True, state='down'))
         config_file = 'mlnxos_interfaces_status.cfg'
         self.get_interfaces_status.return_value = load_fixture(config_file)
-        commands = ['interface ethernet 1/1', 'shutdown', 'exit']
+        self.execute_module(changed=False)
+
+    def test_vlan_oper_state_check(self):
+        set_module_args(dict(name='Vlan 1002', state='down'))
+        config_file = 'mlnxos_interfaces_status.cfg'
+        self.get_interfaces_status.return_value = load_fixture(config_file)
         self.execute_module(changed=False)
 
     def test_rx_rate_check(self):


### PR DESCRIPTION
Signed-off-by: Samer Deeb <samerd@mellanox.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding support for vlan interfaces and loopback interfaces in mlnxos_interface module
(for now only ethenet physical interfaces were supported)
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/mlnxos/mlnxos_interface
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (feature/net-interface fccd7c709e) last updated 2018/01/01 04:00:43 (GMT +000)
  config file = /etc/ansible/ansible.cfg
  python version = 2.7.5 (default, Nov  6 2016, 00:28:07) [GCC 4.8.5 20150623 (Red Hat 4.8.5-11)]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
