### PR TITLE
Making letsencrypt module work with Python 3

### DIFF
--- a/lib/ansible/modules/web_infrastructure/letsencrypt.py
+++ b/lib/ansible/modules/web_infrastructure/letsencrypt.py
@@ -245,7 +245,7 @@ def get_cert_days(module, cert_file):
 
     openssl_bin = module.get_bin_path('openssl', True)
     openssl_cert_cmd = [openssl_bin, "x509", "-in", cert_file, "-noout", "-text"]
-    _, out, _ = module.run_command(openssl_cert_cmd, check_rc=True)
+    _, out, _ = module.run_command(openssl_cert_cmd, check_rc=True, encoding=None)
     try:
         not_after_str = re.search(r"\s+Not After\s*:\s+(.*)", out.decode('utf8')).group(1)
         not_after = datetime.fromtimestamp(time.mktime(time.strptime(not_after_str, '%b %d %H:%M:%S %Y %Z')))
@@ -367,7 +367,7 @@ class ACMEAccount(object):
             _, tmpsrc = tempfile.mkstemp()
             f = open(tmpsrc, 'wb')
             try:
-                f.write(self.key_content)
+                f.write(self.key_content.encode('utf-8'))
                 self.key = tmpsrc
             except Exception as err:
                 os.remove(tmpsrc)
@@ -759,7 +759,7 @@ class ACMEClient(object):
 
         new_cert = {
             "resource": "new-cert",
-            "csr": nopad_b64(out),
+            "csr": nopad_b64(to_bytes(out)),
         }
         result, info = self.account.send_signed_request(self.directory['new-cert'], new_cert)
 
@@ -833,7 +833,7 @@ class ACMEClient(object):
             if chain and self.module.params['fullchain']:
                 pem_cert += "\n".join(chain)
 
-            if write_file(self.module, self.dest, pem_cert):
+            if write_file(self.module, self.dest, pem_cert.encode('utf8')):
                 self.cert_days = get_cert_days(self.module, self.dest)
                 self.changed = True
 


### PR DESCRIPTION
##### SUMMARY
Makes the `letsencrypt` module (more) compatible with Python 3.
Fixes #28148.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
letsencrypt

##### ANSIBLE VERSION
```
2.4.2.0
```
(also applies to `devel` branch version)
