### PR TITLE
windows become - info about blank passwords

### DIFF
--- a/docs/docsite/rst/become.rst
+++ b/docs/docsite/rst/become.rst
@@ -423,17 +423,14 @@ specified.
 Accounts without a Password
 ---------------------------
 
-.. Warning:: Not setting a password for a Windows account is not recommended
-    and should be avoided in most scenarios. There are some security
-    restrictions that are set by default which would need to be bypassed to get
-    this working.
+.. Warning:: As a general security best practice, you should avoid allowing accounts without passwords.
 
-Ansible can be used to become an account that does not have a password like the
-``Guest`` account. To become an account without a password, set up the
+Ansible can be used to become an account that does not have a password (like the
+``Guest`` account). To become an account without a password, set up the
 variables like normal but either do not define ``ansible_become_pass`` or set
 ``ansible_become_pass: ''``.
 
-Before become would work on an account like this, the local policy
+Before become can work on an account like this, the local policy
 `Accounts: Limit local account use of blank passwords to console logon only <https://technet.microsoft.com/en-us/library/jj852174.aspx>`_
 must be disabled. This can either be done through a Group Policy Object (GPO)
 or with this Ansible task:

--- a/docs/docsite/rst/become.rst
+++ b/docs/docsite/rst/become.rst
@@ -420,6 +420,38 @@ Because local service accounts do not have passwords, the
 ``ansible_become_password`` parameter is not required and is ignored if
 specified.
 
+Accounts without a Password
+---------------------------
+
+.. Warning:: Not setting a password for a Windows account is not recommended
+    and should be avoided in most scenarios. There are some security
+    restrictions that are set by default which would need to be bypassed to get
+    this working.
+
+Ansible can be used to become an account that does not have a password like the
+``Guest`` account. To become an account without a password, set up the
+variables like normal but either do not define ``ansible_become_pass`` or set
+``ansible_become_pass: ''``.
+
+Before become would work on an account like this, the local policy
+`Accounts: Limit local account use of blank passwords to console logon only <https://technet.microsoft.com/en-us/library/jj852174.aspx>`_
+must be disabled. This can either be done through a Group Policy Object (GPO)
+or with this Ansible task:
+
+.. code-block:: yaml
+
+   - name: allow blank password on become
+     win_regedit:
+       path: HKLM:\SYSTEM\CurrentControlSet\Control\Lsa
+       name: LimitBlankPasswordUse
+       data: 0
+       type: dword
+       state: present
+
+.. Note:: This is only for accounts that do not have a password. You still need
+    to set the account's password under ``ansible_become_pass`` if the
+    become_user has a password.
+
 Limitations
 -----------
 


### PR DESCRIPTION
##### SUMMARY
Add info to the become docs for how to become a Windows account that does not have a password.

Fixes https://github.com/ansible/ansible/issues/34214

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
windows become

##### ANSIBLE VERSION
```
2.5
```