### PR TITLE
Fix changing of nic parameters in vmware_guest

### DIFF
--- a/test/integration/targets/vmware_guest/tasks/main.yml
+++ b/test/integration/targets/vmware_guest/tasks/main.yml
@@ -30,4 +30,5 @@
 - include: network_negative_test.yml
 # Currently, VCSIM doesn't support DVPG (as portkeys are not available) so commenting this test
 #- include: network_with_dvpg.yml
+- include: modify_d1_c1_f0.yml
 #- include: template_d1_c1_f0.yml

--- a/test/integration/targets/vmware_guest/tasks/modify_d1_c1_f0.yml
+++ b/test/integration/targets/vmware_guest/tasks/modify_d1_c1_f0.yml
@@ -1,0 +1,88 @@
+# Test code for the vmware_guest module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 5000
+    state: started
+
+- name: kill vcsim
+  uri:
+    url: http://{{ vcsim }}:5000/killall
+- name: start vcsim with no folders
+  uri:
+    url: http://{{ vcsim }}:5000/spawn?datacenter=1&cluster=1&folder=0
+  register: vcsim_instance
+
+- name: Wait for Flask controller to come up online
+  wait_for:
+    host: "{{ vcsim }}"
+    port: 443
+    state: started
+
+- debug: var=vcsim_instance
+
+- name: create new VMs with automatic MAC address
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ item | basename }}"
+    guest_id: centos64Guest
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    hardware:
+        num_cpus: 1
+        memory_mb: 512
+    disk:
+        - size: 0gb
+          type: thin
+          autoselect_datastore: True
+    networks:
+        - name: VM Network
+          ip: 192.168.10.12
+          netmask: 255.255.255.0
+          gateway: 192.168.10.254
+    state: poweredoff
+    folder: "{{ item | dirname }}"
+  with_items:
+    - "/DC0/vm/DC0_H0_VM12"
+  register: clone_d1_c1_f0
+
+- debug: var=clone_d1_c1_f0
+
+- name: assert that initial settings were made
+  assert:
+    that:
+        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['addresstype'] == 'generated'"
+        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['macaddress'] != 'aa:bb:cc:dd:aa:42'"
+
+- name: modify VM with manual MAC address
+  vmware_guest:
+    validate_certs: False
+    hostname: "{{ vcsim }}"
+    username: "{{ vcsim_instance['json']['username'] }}"
+    password: "{{ vcsim_instance['json']['password'] }}"
+    name: "{{ item | basename }}"
+    datacenter: "{{ (item|basename).split('_')[0] }}"
+    networks:
+        - name: VM Network
+          ip: 192.168.10.12
+          netmask: 255.255.255.0
+          gateway: 192.168.10.254
+          mac: aa:bb:cc:dd:aa:42
+    state: present
+    folder: "{{ item | dirname }}"
+  with_items:
+    - "/DC0/vm/DC0_H0_VM12"
+  register: clone_d1_c1_f0
+
+- debug: var=clone_d1_c1_f0
+
+- name: assert that changes were made
+  assert:
+    that:
+        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['addresstype'] == 'manual'"
+        - "clone_d1_c1_f0.results[0]['instance']['hw_eth0']['macaddress'] == 'aa:bb:cc:dd:aa:42'"


### PR DESCRIPTION
##### SUMMARY
Currently, changing the parameters of a nic via vmware_guest does not correctly us pyvmomi api. This pull request fixes that and thus makes it possible for example to change a nic's mac address.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.4.2.0
  config file = /root/ansible/ansible.cfg
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Nov 24 2017, 17:33:09) [GCC 6.3.0 20170516]

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
