### PR TITLE
win_domain: added option to set database and sysvol path

### DIFF
--- a/lib/ansible/modules/windows/win_domain.ps1
+++ b/lib/ansible/modules/windows/win_domain.ps1
@@ -39,6 +39,8 @@ $parsed_args = Parse-Args $args -supports_check_mode $true
 $check_mode = Get-AnsibleParam $parsed_args "_ansible_check_mode" -default $false
 $dns_domain_name = Get-AnsibleParam $parsed_args "dns_domain_name" -failifempty $true
 $safe_mode_admin_password = Get-AnsibleParam $parsed_args "safe_mode_password" -failifempty $true
+$database_path = Get-AnsibleParam $parsed_args "database_path" -type "path"
+$sysvol_path = Get-AnsibleParam $parsed_args "sysvol_path" -type "path"
 
 $forest = $null
 
@@ -71,6 +73,12 @@ If(-not $forest) {
             SkipPreChecks=$true;
             InstallDNS=$true;
             NoRebootOnCompletion=$true;
+        }
+        if ($database_path) {
+            $install_forest_args.DatabasePath = $database_path
+        }
+        if ($sysvol_path) {
+            $install_forest_args.SysvolPath = $sysvol_path
         }
 
         $iaf = Install-ADDSForest @install_forest_args

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -39,6 +39,18 @@ options:
     description:
       - safe mode password for the domain controller
     required: true
+  database_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the
+      domain database will be created.
+    - If not set then the default path is C(%SYSTEMROOT%\NTDS).
+    version_added: '2.5'
+  sysvol_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the
+      Sysvol file will be created.
+    - If not set then the default path is C(%SYSTEMROOT%\SYSVOL).
+    version_added: '2.5'
 author:
     - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_domain.py
+++ b/lib/ansible/modules/windows/win_domain.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'core'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: win_domain
 short_description: Ensures the existence of a Windows domain.
 version_added: 2.3

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -54,6 +54,18 @@ options:
     choices:
       - domain_controller
       - member_server
+  database_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the
+      domain database will be created..
+    - If not set then the default path is C(%SYSTEMROOT%\NTDS).
+    version_added: '2.5'
+  sysvol_path:
+    description:
+    - The path to a directory on a fixed disk of the Windows host where the
+      Sysvol folder will be created.
+    - If not set then the default path is C(%SYSTEMROOT%\SYSVOL).
+    version_added: '2.5'
 author:
     - Matt Davis (@nitzmahone)
 '''

--- a/lib/ansible/modules/windows/win_domain_controller.py
+++ b/lib/ansible/modules/windows/win_domain_controller.py
@@ -23,7 +23,7 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'supported_by': 'core'}
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: win_domain_controller
 short_description: Manage domain controller/member server state for a Windows host
 version_added: 2.3


### PR DESCRIPTION
##### SUMMARY
Added the options `database_path` and `sysvol_path` to `win_domain` and `win_domain_controller` that can be used to set the AD database and sysvol path when promoting a server to a domain controller.

Fixes https://github.com/ansible/ansible/issues/34170

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_domain
win_domain_controller

##### ANSIBLE VERSION
```
2.5
```