### PR TITLE
Allow ec2_vpc_net to work in non classiclink regions

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_net.py
@@ -196,9 +196,17 @@ def vpc_exists(module, vpc, name, cidr_block, multi):
 def get_vpc(module, connection, vpc_id):
     try:
         vpc_obj = connection.describe_vpcs(VpcIds=[vpc_id])['Vpcs'][0]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to describe VPCs")
+    try:
         classic_link = connection.describe_vpc_classic_link(VpcIds=[vpc_id])['Vpcs'][0].get('ClassicLinkEnabled')
         vpc_obj['ClassicLinkEnabled'] = classic_link
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Message"] == "The functionality you requested is not available in this region.":
+            vpc_obj['ClassicLinkEnabled'] = False
+        else:
+            module.fail_json_aws(e, msg="Failed to describe VPCs")
+    except botocore.exceptions.BotoCoreError as e:
         module.fail_json_aws(e, msg="Failed to describe VPCs")
 
     return vpc_obj


### PR DESCRIPTION
##### SUMMARY
describe_vpc_classic_link only works in regions that support
EC2-Classic.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_net

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (devel 0a3da471f5) last updated 2018/01/02 10:31:55 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION
Could have been caught by running existing integration tests with region=us-east-2