### PR TITLE
ecs_taskdefinition_facts results

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition_facts.py
@@ -15,7 +15,8 @@ DOCUMENTATION = '''
 module: ecs_taskdefinition_facts
 short_description: describe a task definition in ecs
 notes:
-    - for details of the parameters and returns see U(http://boto3.readthedocs.io/en/latest/reference/services/ecs.html#ECS.Client.describe_task_definition)
+    - for details of the parameters and returns see
+      U(http://boto3.readthedocs.io/en/latest/reference/services/ecs.html#ECS.Client.describe_task_definition)
 description:
     - Describes a task definition in ecs.
 version_added: "2.5"
@@ -123,7 +124,8 @@ container_definitions:
                     returned: when present
                     type: string
                 readOnly:
-                    description: If this value is true , the container has read-only access to the volume. If this value is false , then the container can write to the volume.
+                    description: If this value is true , the container has read-only access to the volume.
+                      If this value is false , then the container can write to the volume.
                     returned: when present
                     type: bool
         volumesFrom:
@@ -136,7 +138,8 @@ container_definitions:
                     returned: when present
                     type: string
                 readOnly:
-                    description: If this value is true , the container has read-only access to the volume. If this value is false , then the container can write to the volume.
+                    description: If this value is true , the container has read-only access to the volume.
+                      If this value is false , then the container can write to the volume.
                     returned: when present
                     type: bool
         hostname:
@@ -156,7 +159,8 @@ container_definitions:
             returned: when present
             type: bool
         privileged:
-            description: When this parameter is true, the container is given elevated privileges on the host container instance (similar to the root user).
+            description: When this parameter is true, the container is given elevated
+              privileges on the host container instance (similar to the root user).
             returned: when present
             type: bool
         readonlyRootFilesystem:
@@ -248,7 +252,8 @@ volumes:
             returned: when present
             type: string
         host:
-            description: The contents of the host parameter determine whether your data volume persists on the host container instance and where it is stored.
+            description: The contents of the host parameter determine whether your data volume
+              persists on the host container instance and where it is stored.
             returned: when present
             type: bool
         source_path:
@@ -293,21 +298,15 @@ placement_constraints:
             description: A cluster query language expression to apply to the constraint.
             returned: when present
             type: string
-'''  # NOQA
+'''
 
-try:
-    import boto3
-    HAS_BOTO3 = True
-except ImportError:
-    HAS_BOTO3 = False
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.ec2 import _camel_to_snake, camel_dict_to_snake_dict, boto3_conn, ec2_argument_spec, get_aws_connection_info
+from ansible.module_utils.aws.core import AnsibleAWSModule
+from ansible.module_utils.ec2 import camel_dict_to_snake_dict, boto3_conn, ec2_argument_spec, get_aws_connection_info
 
 try:
     import botocore
 except ImportError:
-    pass  # will be detected by imported HAS_BOTO3
+    pass  # will be detected by imported AnsibleAWSModule
 
 
 def main():
@@ -316,22 +315,18 @@ def main():
         task_definition=dict(required=True, type='str')
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required.')
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
     ecs = boto3_conn(module, conn_type='client', resource='ecs',
                      region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
-    ecs_td = ecs.describe_task_definition(taskDefinition=module.params['task_definition'])['taskDefinition']
-    ecs_td_snake = {}
-    for k, v in ecs_td.items():
-        ecs_td_snake[_camel_to_snake(k)] = v
+    try:
+        ecs_td = ecs.describe_task_definition(taskDefinition=module.params['task_definition'])['taskDefinition']
+    except botocore.exceptions.ClientError:
+        ecs_td = {}
 
-    ecs_td_facts_result = dict(changed=False, ansible_facts=ecs_td_snake)
-    module.exit_json(**ecs_td_facts_result)
+    module.exit_json(changed=False, **camel_dict_to_snake_dict(ecs_td))
 
 
 if __name__ == '__main__':

--- a/test/integration/targets/ecs_cluster/tasks/main.yml
+++ b/test/integration/targets/ecs_cluster/tasks/main.yml
@@ -249,11 +249,18 @@
         that:
           - update_ecs_service.failed
           - "'msg' in update_ecs_service"
+      # FIXME: fixed in #32876
+      ignore_errors: yes
 
     - name: obtain ECS service facts
       ecs_service_facts:
         service: "{{ ecs_service_name }}"
         cluster: "{{ ecs_cluster_name }}"
+        <<: *aws_connection_info
+
+    - name: attempt to get facts from missing task definition
+      ecs_taskdefinition_facts:
+        task_definition: "{{ ecs_task_name }}-vpc:{{ ecs_task_definition.taskdefinition.revision + 1}}"
         <<: *aws_connection_info
 
   always:


### PR DESCRIPTION
##### SUMMARY
Improve results from `ecs_taskdefinition_facts`
    
`ecs_taskdefinition_facts` should not populate `ansible_facts` with so much information.
    
Better to just return the contents of the dict directly.
    
Reduce line lengths, use `AnsibleAWSModule`, don't reimplement `camel_dict_to_snake_dict`

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ecs_taskdefinition_facts

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 0a3da471f5) last updated 2018/01/02 10:31:55 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```
