### PR TITLE
[WIP] Treat meta tasks as regular

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -507,6 +507,8 @@ class TaskExecutor:
         elif self._task.action == 'include_role':
             include_variables = self._task.args.copy()
             return dict(include_variables=include_variables)
+        elif self._task.action == 'meta':
+            return dict(meta=True, play_context_attrs=self._play_context.dump_attrs())
 
         # Now we do final validation on the task, which sets all fields to their final values.
         self._task.post_validate(templar=templar)

--- a/lib/ansible/plugins/strategy/free.py
+++ b/lib/ansible/plugins/strategy/free.py
@@ -147,18 +147,14 @@ class StrategyModule(StrategyBase):
                                 del self._blocked_hosts[host_name]
                                 continue
 
-                        if task.action == 'meta':
-                            self._execute_meta(task, play_context, iterator, target_host=host)
-                            self._blocked_hosts[host_name] = False
-                        else:
-                            # handle step if needed, skip meta actions as they are used internally
-                            if not self._step or self._take_step(task, host_name):
-                                if task.any_errors_fatal:
-                                    display.warning("Using any_errors_fatal with the free strategy is not supported, "
-                                                    "as tasks are executed independently on each host")
+                        if not self._step or self._take_step(task, host_name):
+                            if task.any_errors_fatal:
+                                display.warning("Using any_errors_fatal with the free strategy is not supported, "
+                                                "as tasks are executed independently on each host")
+                            if not task.action == 'meta':
                                 self._tqm.send_callback('v2_playbook_on_task_start', task, is_conditional=False)
-                                self._queue_task(host, task, task_vars, play_context)
-                                del task_vars
+                            self._queue_task(host, task, task_vars, play_context)
+                            del task_vars
                     else:
                         display.debug("%s is blocked, skipping for now" % host_name)
 


### PR DESCRIPTION
##### SUMMARY
First hacky iteration of moving executing meta tasks through workers, the same way as regular tasks.

Fixes https://github.com/ansible/ansible/issues/27520 https://github.com/ansible/ansible/issues/33505

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
meta tasks

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
This fixes the following scenarios:
```
- hosts: el7host
  gather_facts: no
  tasks:
    - ping:
    - meta: reset_connection
    - ping:

- hosts: el7host
  gather_facts: no
  remote_user: "{{ test_user }}"
  tasks:
    - ping:
    - meta: reset_connection
    - ping:

- hosts: el7host
  gather_facts: no
  strategy: free
  tasks:
    - ping:
    - meta: reset_connection
    - ping:

- hosts: el7host
  gather_facts: no
  remote_user: "{{ test_user }}"
  strategy: free
  tasks:
    - ping:
    - meta: reset_connection
    - ping:
```