### PR TITLE
bug into snmp_facts on some cisco

### DIFF
--- a/lib/ansible/modules/net_tools/snmp_facts.py
+++ b/lib/ansible/modules/net_tools/snmp_facts.py
@@ -118,7 +118,7 @@ class DefineOid(object):
 
         # From IF-MIB
         self.ifIndex = dp + "1.3.6.1.2.1.2.2.1.1"
-        self.ifDescr = dp + "1.3.6.1.2.1.2.2.1.2"
+        self.ifDescr = dp + "1.3.6.1.2.1.2.2.1.2."
         self.ifMtu = dp + "1.3.6.1.2.1.2.2.1.4"
         self.ifSpeed = dp + "1.3.6.1.2.1.2.2.1.5"
         self.ifPhysAddress = dp + "1.3.6.1.2.1.2.2.1.6"


### PR DESCRIPTION
Hi,

snmp_facts module gets informations from network equipement using snmp. On some Cisco, name field is wrong.

```
        "2": {
            "adminstatus": "up", 
            "description": "plop", 
            "ifindex": "1106333", 
            "ipv4": [
                {
                    "address": "10.10.2.1", 
                    "netmask": "255.255.255.0"
                }
            ], 
            "mac": "aca015ba46b7", 
            "mtu": "1500", 
            "name": "0",
            "operstatus": "up", 
            "speed": "1500"
        }, 
```

Using snmpget, value is correct.

`iso.3.6.1.2.1.2.2.1.2.2 = STRING: "FastEthernet0/1"`

Best regards