### PR TITLE
Add CS module cs_network_offering

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -1,0 +1,364 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: cs_network_offering
+
+short_description: Manages network offerings on Apache CloudStack based clouds.
+
+description:
+    - Create, update, enable, disable and remove network offerings.
+
+version_added: '2.5'
+
+author: "David Passante (@dpassante)"
+
+options:
+  state:
+    description:
+      - State of the network offering.
+    required: false
+    default: 'present'
+    choices: [ 'enabled, 'present', 'disabled', 'absent']
+  display_text:
+    description:
+      - Display text of the network offerings
+    required: true
+    default: null
+  guest_ip_type:
+    description:
+      - Guest type of the network offering: Shared or Isolated
+    choices: ['Shared', 'Isolated']
+    required: true
+    default: null
+  name:
+    description:
+      - The name of the network offering
+    required: true
+    default: null
+  supported_services:
+    description:
+      - Services supported by the network offering
+    required: true
+    default: null
+  traffic_type:
+    description:
+      - The traffic type for the network offering. Supported type in current release is GUEST only
+    required: false
+    default: GUEST
+  availability:
+    description:
+      - The availability of network offering. Default value is Optional
+    required: false
+    default: null
+  conserve_mode:
+    description:
+      - true if the network offering is IP conserve mode enabled
+    choices: ['true', 'false']
+    required: false
+    default: true
+  details:
+    description:
+      - Network offering details in key/value pairs.
+      - Supported keys are internallbprovider/publiclbprovider with service provider as a value
+    choices: ['internallbprovider', 'publiclbprovider']
+    required: false
+    default: null
+  egress_default_policy:
+    description:
+      - True if guest network default egress policy is allow; false if default egress policy is deny
+    choices: ['true', 'false']
+    required: false
+    default: null
+  persistent:
+    description:
+      - True if network offering supports persistent networks; defaulted to false if not specified
+    required: false
+    default: false
+  keepalive_enabled:
+    description:
+      - If true keepalive will be turned on in the loadbalancer. 
+      - At the time of writing this has only an effect on haproxy; 
+      - the mode http and httpclose options are unset in the haproxy conf file.
+    choices: ['true', 'false']
+    required: false
+    default: null
+  max_connections:
+    description:
+      - Maximum number of concurrent connections supported by the network offering
+    required: false
+    default: true
+  network_rate:
+    description:
+      - Data transfer rate in megabits per second allowed
+    required: false
+    default: true
+  service_capability_list:
+    description:
+      - Desired service capabilities as part of network offering
+    required: false
+    default: true
+  service_offering_id:
+    description:
+      - The service offering ID used by virtual router provider
+    required: false
+    default: null
+  service_provider_list:
+    description:
+      - provider to service mapping. If not specified, the provider for the service will be mapped to the default provider on the physical network
+    required: false
+    default: null
+  specify_ip_ranges:
+    description:
+      - true if network offering supports specifying ip ranges; defaulted to false if not specified
+    choices: ['true', 'false']
+    required: false
+    default: null
+  specify_vlan:
+    description:
+      - true if network offering supports vlans
+    choices: ['true', 'false']
+    required: false
+    default: false
+extends_documentation_fragment: cloudstack
+'''
+
+EXAMPLES = '''
+# Create a network offering and enable it
+- local_action:
+    module: cs_network_offering
+    name: "my_network_offering"
+    display_text: "network offering description"
+    state: enabled
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+
+
+# Remove a network offering
+- local_action:
+    module: cs_network_offering
+    name: "my_network_offering"
+    display_text: "network offering description"
+    state: absent
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+'''
+
+RETURN = '''
+---
+id:
+  description: UUID of the network offering.
+  returned: success
+  type: string
+  sample: a6f7a5fc-43f8-11e5-a151-feff819cdc9f
+name:
+  description: The name of the network offering
+  returned: success
+  type: string
+  sample: MyCustomNetworkOffering
+display_text:
+  description: The display text of the network offering
+  returned: success
+  type: string
+  sample: My network offering
+state:
+  description: The state of the network offering
+  returned: success
+  type: string
+  sample: Enabled
+guestiptype:
+  returned: success
+  type: string
+  sample: Isolated
+availability:
+  returned: success
+  type: string
+  sample: Optional
+serviceofferingid:
+  returned: success
+  type: string
+  sample: c5f7a5fc-43f8-11e5-a151-feff819cdc9f
+'''
+
+# import cloudstack common
+from ansible.module_utils.cloudstack import *
+
+
+class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
+
+    def __init__(self, module):
+        super(AnsibleCloudStackNetworkOffering, self).__init__(module)
+        self.returns = {
+            'guestiptype': 'guest_ip_type',
+            'availability': 'availability',
+            'serviceofferingid': 'service_offering_id',
+        }
+        self.network_offering = None
+
+    def get_network_offering(self):
+        if self.network_offering:
+            return self.network_offering
+
+
+        args = {
+            'name': self.module.params.get('name'),
+            'guestiptype': self.module.params.get('guest_type'),
+        }
+        no = self.cs.listNetworkOfferings(**args)
+        if no:
+            self.network_offering = no['networkoffering'][0]
+
+        return self.network_offering
+
+    def create_or_update(self):
+        network_offering = self.get_network_offering()
+        if not network_offering:
+          network_offering = self.create_network_offering()
+
+        return self.update_network_offering(network_offering=network_offering)
+
+    def create_network_offering(self): 
+        self.result['changed'] = True
+        args = {
+            'state': self.module.params.get('state'),
+            'displaytext': self.module.params.get('display_text'),
+            'guestiptype': self.module.params.get('guest_ip_type'),
+            'name': self.module.params.get('name'),
+            'supportedservices': self.module.params.get('supported_services'),
+            'traffictype': self.module.params.get('traffic_type'),
+            'availability': self.module.params.get('availability'),
+            'conservemode': self.module.params.get('conserve_mode'),
+            'details': self.module.params.get('details'),
+            'egressdefaultpolicy': self.module.params.get('egress_default_policy'),
+            'ispersistent': self.module.params.get('persistent'),
+            'keepaliveenabled': self.module.params.get('keepalive_enabled'),
+            'maxconnections': self.module.params.get('max_connections'),
+            'networkrate': self.module.params.get('network_rate'),
+            'servicecapabilitylist': self.module.params.get('service_capability_list'),
+            'serviceofferingid': self.module.params.get('service_offering_id'),
+            'serviceproviderlist': self.module.params.get('service_provider_list'),
+            'specifyipranges': self.module.params.get('specify_ip_ranges'),
+            'specifyvlan': self.module.params.get('specify_vlan'),
+        }
+        if not self.module.check_mode:
+            res = self.cs.createNetworkOffering(**args)
+            if 'errortext' in res:
+                self.module.fail_json(msg="Failed: '%s'" % res['errortext'])
+            if res:
+                network_offering = res['networkoffering']
+
+        return network_offering
+
+    def delete_network_offering(self):
+        network_offering = self.get_network_offering()
+
+        if not network_offering:
+            return network_offering
+        
+        self.result['changed'] = True
+
+        if not self.module.check_mode:
+            res = self.cs.deleteNetworkOffering(id=network_offering['id'])
+
+        return network_offering
+
+    def update_network_offering(self, network_offering):
+        args = {
+            'id': network_offering['id'],
+            'state': self.module.params.get('state'),
+            'displaytext': self.module.params.get('display_text'),
+            'name': self.module.params.get('name'),
+            'availability': self.module.params.get('availability'),
+        }
+
+        if args['state'] == 'enabled' or args['state'] == 'disabled':
+            args['state'] = args['state'].title()
+        else:
+            del args['state']
+
+        for k,v in args.items():
+            if network_offering[k] != args[k]:
+                self.result['changed'] = True
+
+        if not self.module.check_mode:
+            network_offering = self.cs.updateNetworkOffering(**args)
+
+        return network_offering['networkoffering']
+
+def main():
+    argument_spec = cs_argument_spec()
+    argument_spec.update(dict(
+        state=dict(choices=['enabled', 'present', 'disabled', 'absent'], default='present'),
+        display_text=dict(required=True),
+        guest_ip_type=dict(required=True, choices=['Shared', 'Isolated']),
+        name=dict(required=True),
+        supported_services=dict(required=True),
+        traffic_type=dict(default='GUEST'),
+        availability=dict(default='Optional'),
+        conserve_mode=dict(type='bool', default=True),
+        details=dict(type='list'),
+        egress_default_policy=dict(type='bool'),
+        persistent=dict(type='bool', default=False),
+        keepalive_enabled=dict(type='bool', default=False),
+        max_connections=dict(),
+        network_rate=dict(),
+        service_capability_list=dict(type='list'),
+        service_offering_id=dict(),
+        service_provider_list=dict(type='list', required=True),
+        specify_ip_ranges=dict(type='bool', default=False),
+        specify_vlan=dict(type='bool', default=False),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    try:
+        acs_network_offering = AnsibleCloudStackNetworkOffering(module)
+
+        state = module.params.get('state')
+        if state in ['absent']:
+            network_offering = acs_network_offering.delete_network_offering()
+        else:
+            network_offering = acs_network_offering.create_or_update()
+
+        result = acs_network_offering.get_result(network_offering)
+
+    except CloudStackException as e:
+        module.fail_json(msg='CloudStackException: %s' % str(e))
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -79,7 +79,7 @@ options:
       - true if the network offering is IP conserve mode enabled
     choices: ['true', 'false']
     required: false
-    default: true
+    default: null
   details:
     description:
       - Network offering details in key/value pairs.
@@ -94,13 +94,13 @@ options:
       - false if default egress policy is deny
     choices: ['true', 'false']
     required: false
-    default: false
+    default: null
   persistent:
     description:
       - True if network offering supports persistent networks
       - defaulted to false if not specified
     required: false
-    default: false
+    default: null
   keepalive_enabled:
     description:
       - If true keepalive will be turned on in the loadbalancer.
@@ -108,7 +108,7 @@ options:
       - the mode http and httpclose options are unset in the haproxy conf file.
     choices: ['true', 'false']
     required: false
-    default: false
+    default: null
   max_connections:
     description:
       - Maximum number of concurrent connections supported by the network offering
@@ -119,9 +119,10 @@ options:
       - Data transfer rate in megabits per second allowed
     required: false
     default: null
-  service_capability_list:
+  service_capabilities:
     description:
       - Desired service capabilities as part of network offering
+    aliases: [ service_capability ]
     required: false
     default: null
   service_offering:
@@ -142,13 +143,13 @@ options:
       - defaulted to false if not specified
     choices: ['true', 'false']
     required: false
-    default: false
+    default: null
   specify_vlan:
     description:
       - true if network offering supports vlans
     choices: ['true', 'false']
     required: false
-    default: false
+    default: null
 extends_documentation_fragment: cloudstack
 '''
 
@@ -294,7 +295,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'keepaliveenabled': self.module.params.get('keepalive_enabled'),
             'maxconnections': self.module.params.get('max_connections'),
             'networkrate': self.module.params.get('network_rate'),
-            'servicecapabilitylist': self.module.params.get('service_capability_list'),
+            'servicecapabilitylist': self.module.params.get('service_capabilities'),
             'serviceofferingid': self.get_service_offering_id(),
             'serviceproviderlist': self.module.params.get('service_provider_list'),
             'specifyipranges': self.module.params.get('specify_ip_ranges'),
@@ -365,19 +366,19 @@ def main():
         name=dict(required=True),
         supported_services=dict(),
         traffic_type=dict(default='GUEST'),
-        availability=dict(default='Optional'),
-        conserve_mode=dict(type='bool', default=True),
+        availability=dict(),
+        conserve_mode=dict(type='bool'),
         details=dict(type='list'),
         egress_default_policy=dict(type='bool'),
-        persistent=dict(type='bool', default=False),
-        keepalive_enabled=dict(type='bool', default=False),
+        persistent=dict(type='bool'),
+        keepalive_enabled=dict(type='bool'),
         max_connections=dict(type='int'),
         network_rate=dict(type='int'),
-        service_capability_list=dict(type='list'),
+        service_capabilities=dict(type='list', aliases=['service_capability']),
         service_offering=dict(),
         service_provider_list=dict(type='list'),
-        specify_ip_ranges=dict(type='bool', default=False),
-        specify_vlan=dict(type='bool', default=False),
+        specify_ip_ranges=dict(type='bool'),
+        specify_vlan=dict(type='bool'),
     ))
 
     module = AnsibleModule(

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -45,13 +45,13 @@ options:
   display_text:
     description:
       - Display text of the network offerings
-    required: true
+    required: false
     default: null
   guest_ip_type:
     description:
       - Guest type of the network offering. Shared or Isolated
     choices: ['Shared', 'Isolated']
-    required: true
+    required: false
     default: null
   name:
     description:
@@ -61,13 +61,13 @@ options:
   supported_services:
     description:
       - Services supported by the network offering
-    required: true
+    required: false
     default: null
   traffic_type:
     description:
       - The traffic type for the network offering.
       - Supported type in current release is GUEST only
-    required: true
+    required: false
     default: GUEST
   availability:
     description:
@@ -300,6 +300,16 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'specifyipranges': self.module.params.get('specify_ip_ranges'),
             'specifyvlan': self.module.params.get('specify_vlan'),
         }
+
+        required_params = [
+            'display_text',
+            'guest_ip_type',
+            'supported_services',
+            'service_provider_list',
+        ]
+
+        self.module.fail_on_missing_params(required_params=required_params)
+
         if not self.module.check_mode:
             res = self.query_api('createNetworkOffering', **args)
             network_offering = res['networkoffering']
@@ -350,10 +360,10 @@ def main():
     argument_spec = cs_argument_spec()
     argument_spec.update(dict(
         state=dict(choices=['enabled', 'present', 'disabled', 'absent'], default='present'),
-        display_text=dict(required=True),
-        guest_ip_type=dict(required=True, choices=['Shared', 'Isolated']),
+        display_text=dict(),
+        guest_ip_type=dict(choices=['Shared', 'Isolated']),
         name=dict(required=True),
-        supported_services=dict(required=True),
+        supported_services=dict(),
         traffic_type=dict(default='GUEST'),
         availability=dict(default='Optional'),
         conserve_mode=dict(type='bool', default=True),
@@ -365,7 +375,7 @@ def main():
         network_rate=dict(type='int'),
         service_capability_list=dict(type='list'),
         service_offering=dict(),
-        service_provider_list=dict(type='list', required=True),
+        service_provider_list=dict(type='list'),
         specify_ip_ranges=dict(type='bool', default=False),
         specify_vlan=dict(type='bool', default=False),
     ))

--- a/test/integration/targets/cs_network_offering/aliases
+++ b/test/integration/targets/cs_network_offering/aliases
@@ -1,0 +1,2 @@
+cloud/cs
+posix/ci/cloud/group1/cs

--- a/test/integration/targets/cs_network_offering/meta/main.yml
+++ b/test/integration/targets/cs_network_offering/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - cs_common

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -398,4 +398,3 @@
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Enabled"
     - netoffer.display_text == "network offering description"
-

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -1,13 +1,32 @@
 ---
-- name: test fail if missing params
+- name: setup
+  cs_network_offering: name={{ cs_resource_prefix }}_name state=absent
+  register: netoffer
+- name: verify setup
+  assert:
+    that:
+    - netoffer is successful
+
+- name: test fail if missing name
   action: cs_network_offering
+  register: netoffer
+  ignore_errors: true
+- name: verify results of fail if missing name
+  assert:
+    that:
+    - netoffer is failed
+    - 'netoffer.msg == "missing required arguments: name"'
+
+- name: test fail if missing params
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
   register: netoffer
   ignore_errors: true
 - name: verify results of fail if missing params
   assert:
     that:
     - netoffer is failed
-    - 'netoffer.msg == "missing required arguments: service_provider_list, supported_services, guest_ip_type, name, display_text"'
+    - 'netoffer.msg == "missing required arguments: display_text, guest_ip_type, supported_services, service_provider_list"'
 
 - name: test create network offer in check mode
   cs_network_offering:
@@ -258,6 +277,52 @@
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description renamed"
 
+- name: test update offer with minimal params in check_mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description update"
+  register: netoffer
+  check_mode: yes
+- name: verify results of update offer with minimal params in check_mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description renamed"
+
+- name: test update offer with minimal params
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description update"
+  register: netoffer
+- name: verify results of update offer with minimal params
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description update"
+
+- name: test update offer with minimal params idempotency
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description update"
+  register: netoffer
+- name: verify results of update offer with minimal params idempotency
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description update"
+
 - name: test remove network offer in check_mode
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
@@ -278,7 +343,7 @@
     - netoffer.name == "{{ cs_resource_prefix }}_name"
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
-    - netoffer.display_text == "network offering description renamed"
+    - netoffer.display_text == "network offering description update"
 
 - name: test remove network offer
   cs_network_offering:
@@ -299,7 +364,7 @@
     - netoffer.name == "{{ cs_resource_prefix }}_name"
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
-    - netoffer.display_text == "network offering description renamed"
+    - netoffer.display_text == "network offering description update"
 
 - name: test remove network offer idempotence
   cs_network_offering:

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -1,0 +1,401 @@
+---
+- name: test fail if missing params
+  action: cs_network_offering
+  register: netoffer
+  ignore_errors: true
+- name: verify results of fail if missing params
+  assert:
+    that:
+    - netoffer is failed
+    - 'netoffer.msg == "missing required arguments: service_provider_list, supported_services, guest_ip_type, name, display_text"'
+
+- name: test create network offer in check mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+  register: netoffer
+  check_mode: yes
+- name: verify results of network offer in check mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+
+- name: test create network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+  register: netoffer
+- name: verify results of network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test create network offer idempotence
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+  register: netoffer
+- name: verify results of create network offer idempotence
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test enabling network offer in check_mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: enabled
+  register: netoffer
+  check_mode: yes
+- name: verify results of enabling network offer in check_mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test enabling network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: enabled
+  register: netoffer
+- name: verify results of enabling network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Enabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test enabling network offer idempotence
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: enabled
+  register: netoffer
+- name: verify results of enabling network idempotence
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Enabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test disabling network offer in check_mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: disabled
+  register: netoffer
+  check_mode: yes
+- name: verify results of disabling network offer in check_mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Enabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test disabling network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: disabled
+  register: netoffer
+- name: verify results of disabling network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test disabling network offer idempotence
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: disabled
+  register: netoffer
+- name: verify results of disabling network idempotence
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test rename network offer in check_mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: disabled
+  register: netoffer
+  check_mode: yes
+- name: verify results of rename network offer in check_mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test rename network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: disabled
+  register: netoffer
+- name: verify results of rename network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description renamed"
+
+- name: test rename network offer idempotence
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: disabled
+  register: netoffer
+- name: verify results of rename network offer idempotence
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description renamed"
+
+- name: test remove network offer in check_mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: absent
+  register: netoffer
+  check_mode: yes
+- name: verify results of rename network offer in check_mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description renamed"
+
+- name: test remove network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: absent
+  register: netoffer
+- name: verify results of rename network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Disabled"
+    - netoffer.display_text == "network offering description renamed"
+
+- name: test remove network offer idempotence
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: absent
+  register: netoffer
+- name: verify results of rename network offer idempotence
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+
+- name: test create enabled network offer in check mode
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: enabled
+  register: netoffer
+  check_mode: yes
+- name: verify results of create enabled network offer in check mode
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+
+- name: test create enabled network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: enabled
+  register: netoffer
+- name: verify results of create enabled network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Enabled"
+    - netoffer.display_text == "network offering description"
+
+- name: test create enabled network offer idempotence
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: enabled
+  register: netoffer
+- name: verify results of create enabled network offer idempotence
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is not changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Enabled"
+    - netoffer.display_text == "network offering description"
+
+- name: remove network offer
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    display_text: "network offering description renamed"
+    guest_ip_type: Isolated
+    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
+    service_provider_list:
+      - {service: 'dns', provider: 'virtualrouter'}
+      - {service: 'dhcp', provider: 'virtualrouter'}
+    state: absent
+  register: netoffer
+- name: verify results of remove network offer
+  assert:
+    that:
+    - netoffer is successful
+    - netoffer is changed
+    - netoffer.name == "{{ cs_resource_prefix }}_name"
+    - netoffer.guest_ip_type == "Isolated"
+    - netoffer.state == "Enabled"
+    - netoffer.display_text == "network offering description"
+


### PR DESCRIPTION
##### SUMMARY
Add a new CloudStack module to manage network offerings.

##### ISSUE TYPE
New Module Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/cloudstack/cs_network_offering.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/dpassante/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Sample playbook :

```
---
- name: Configure network offerings
  hosts: localhost
  tasks:
    - name: "Cloudstack Network offering module test"
      local_action:
        module: cs_network_offering
        state: enabled
        display_text: "test"
        guest_ip_type: Isolated
        name: "test"
        supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
        traffic_type: "GUEST"
        availability: "Optional"
        conserve_mode: True
        details:
          - {publiclbprovider: 'virtualrouter'}
        egress_default_policy: True
        persistent: False
        keepalive_enabled: False
        max_connections: 100
        network_rate: 800
        service_capability_list:
          - {capabilitytype: 'RedundantRouter', service: 'SourceNat', capabilityvalue: 'true'}
        service_offering_id: "a6b1e886-0d61-4415-a8e3-4235a235088e"
        service_provider_list:
          - {service: 'dns', provider: 'virtualrouter'}
          - {service: 'dhcp', provider: 'virtualrouter'}
          - {service: 'UserData', provider: 'virtualrouter'}
          - {service: 'SourceNat', provider: 'virtualrouter'}
          - {service: 'StaticNat', provider: 'virtualrouter'}
          - {service: 'Firewall', provider: 'virtualrouter'}
          - {service: 'Lb', provider: 'virtualrouter'}
          - {service: 'Vpn', provider: 'virtualrouter'}
        specify_ip_ranges: False
        specify_vlan: False
```
