### PR TITLE
New module to setup error page profile

### DIFF
--- a/lib/ansible/modules/network/avi/avi_errorpageprofile.py
+++ b/lib/ansible/modules/network/avi/avi_errorpageprofile.py
@@ -1,25 +1,11 @@
 #!/usr/bin/python
 #
-# Created on Aug 25, 2016
 # @author: Gaurav Rastogi (grastogi@avinetworks.com)
 #          Eric Anderson (eanderson@avinetworks.com)
 # module_check: supported
 #
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# Copyright: (c) 2017 Gaurav Rastogi, <grastogi@avinetworks.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 #
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',

--- a/lib/ansible/modules/network/avi/avi_errorpageprofile.py
+++ b/lib/ansible/modules/network/avi/avi_errorpageprofile.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+#
+# Created on Aug 25, 2016
+# @author: Gaurav Rastogi (grastogi@avinetworks.com)
+#          Eric Anderson (eanderson@avinetworks.com)
+# module_check: supported
+#
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = '''
+---
+module: avi_errorpageprofile
+author: Gaurav Rastogi (grastogi@avinetworks.com)
+
+short_description: Module for setup of ErrorPageProfile Avi RESTful Object
+description:
+    - This module is used to configure ErrorPageProfile object
+    - more examples at U(https://github.com/avinetworks/devops)
+requirements: [ avisdk ]
+version_added: "2.5"
+options:
+    state:
+        description:
+            - The state that should be applied on the entity.
+        default: present
+        choices: ["absent", "present"]
+    avi_api_update_method:
+        description:
+            - Default method for object update is HTTP PUT.
+            - Setting to patch will override that behavior to use HTTP PATCH.
+        version_added: "2.5"
+        default: put
+        choices: ["put", "patch"]
+    avi_api_patch_op:
+        description:
+            - Patch operation to use when using avi_api_update_method as patch.
+        version_added: "2.5"
+        choices: ["add", "replace", "delete"]
+    app_name:
+        description:
+            - Name of the virtual service which generated the error page.
+            - Field introduced in 17.2.4.
+            - Default value when not specified in API or module is interpreted by Avi Controller as VS Name.
+    company_name:
+        description:
+            - Name of the company to show in error page.
+            - Field introduced in 17.2.4.
+            - Default value when not specified in API or module is interpreted by Avi Controller as Avi Networks.
+    error_pages:
+        description:
+            - Defined error pages for http status codes.
+            - Field introduced in 17.2.4.
+    host_name:
+        description:
+            - Fully qualified domain name for which the error page is generated.
+            - Field introduced in 17.2.4.
+            - Default value when not specified in API or module is interpreted by Avi Controller as Host Header.
+    name:
+        description:
+            - Field introduced in 17.2.4.
+    tenant_ref:
+        description:
+            - It is a reference to an object of type tenant.
+            - Field introduced in 17.2.4.
+    url:
+        description:
+            - Avi controller URL of the object.
+    uuid:
+        description:
+            - Field introduced in 17.2.4.
+extends_documentation_fragment:
+    - avi
+'''
+
+EXAMPLES = """
+- name: Example to create ErrorPageProfile object
+  avi_errorpageprofile:
+    controller: 10.10.25.42
+    username: admin
+    password: something
+    state: present
+    name: sample_errorpageprofile
+"""
+
+RETURN = '''
+obj:
+    description: ErrorPageProfile (api/errorpageprofile) object
+    returned: success, changed
+    type: dict
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+try:
+    from ansible.module_utils.network.avi.avi import (
+        avi_common_argument_spec, HAS_AVI, avi_ansible_api)
+except ImportError:
+    HAS_AVI = False
+
+
+def main():
+    argument_specs = dict(
+        state=dict(default='present',
+                   choices=['absent', 'present']),
+        avi_api_update_method=dict(default='put',
+                                   choices=['put', 'patch']),
+        avi_api_patch_op=dict(choices=['add', 'replace', 'delete']),
+        app_name=dict(type='str',),
+        company_name=dict(type='str',),
+        error_pages=dict(type='list',),
+        host_name=dict(type='str',),
+        name=dict(type='str',),
+        tenant_ref=dict(type='str',),
+        url=dict(type='str',),
+        uuid=dict(type='str',),
+    )
+    argument_specs.update(avi_common_argument_spec())
+    module = AnsibleModule(
+        argument_spec=argument_specs, supports_check_mode=True)
+    if not HAS_AVI:
+        return module.fail_json(msg=(
+            'Avi python API SDK (avisdk>=17.1) is not installed. '
+            'For more details visit https://github.com/avinetworks/sdk.'))
+    return avi_ansible_api(module, 'errorpageprofile',
+                           set([]))
+
+if __name__ == '__main__':
+    main()

--- a/lib/ansible/modules/network/avi/avi_errorpageprofile.py
+++ b/lib/ansible/modules/network/avi/avi_errorpageprofile.py
@@ -63,6 +63,7 @@ options:
     name:
         description:
             - Field introduced in 17.2.4.
+        required: true
     tenant_ref:
         description:
             - It is a reference to an object of type tenant.
@@ -113,7 +114,7 @@ def main():
         company_name=dict(type='str',),
         error_pages=dict(type='list',),
         host_name=dict(type='str',),
-        name=dict(type='str',),
+        name=dict(type='str', required=True),
         tenant_ref=dict(type='str',),
         url=dict(type='str',),
         uuid=dict(type='str',),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
New module to setup error page profile

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
avi_errorpageprofile

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = /home/grastogi/.ansible.cfg
  configured module search path = [u'/home/grastogi/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/grastogi/trace/ansible2.5/local/lib/python2.7/site-packages/ansible
  executable location = /home/grastogi/trace/ansible2.5/bin/ansible
  python version = 2.7.6 (default, Jun 22 2015, 17:58:13) [GCC 4.8.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
