### PR TITLE
Add support for awsvpc on ecs_taskdefinition module and ecs_service

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ecs_service.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_service.py
@@ -322,7 +322,7 @@ class EcsServiceManager:
 
     def create_service(self, service_name, cluster_name, task_definition, load_balancers,
                        desired_count, client_token, role, deployment_configuration,
-                       placement_constraints, placement_strategy):
+                       placement_constraints, placement_strategy, network_configuration):
         response = self.ecs.create_service(
             cluster=cluster_name,
             serviceName=service_name,
@@ -333,7 +333,8 @@ class EcsServiceManager:
             role=role,
             deploymentConfiguration=deployment_configuration,
             placementConstraints=placement_constraints,
-            placementStrategy=placement_strategy)
+            placementStrategy=placement_strategy,
+            networkConfiguration=network_configuration)
         return self.jsonize(response['service'])
 
     def update_service(self, service_name, cluster_name, task_definition,
@@ -380,7 +381,8 @@ def main():
         repeat=dict(required=False, type='int', default=10),
         deployment_configuration=dict(required=False, default={}, type='dict'),
         placement_constraints=dict(required=False, default=[], type='list'),
-        placement_strategy=dict(required=False, default=[], type='list')
+        placement_strategy=dict(required=False, default=[], type='list'),
+        network_configuration=dict(required=False, default=[], type='dict')
     ))
 
     module = AnsibleModule(argument_spec=argument_spec,
@@ -449,7 +451,8 @@ def main():
                                                           role,
                                                           deploymentConfiguration,
                                                           module.params['placement_constraints'],
-                                                          module.params['placement_strategy'])
+                                                          module.params['placement_strategy'],
+                                                          module.params['network_configuration'])
 
                 results['service'] = response
 

--- a/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
+++ b/lib/ansible/modules/cloud/amazon/ecs_taskdefinition.py
@@ -216,7 +216,7 @@ def main():
         family=dict(required=False, type='str'),
         revision=dict(required=False, type='int'),
         containers=dict(required=False, type='list'),
-        network_mode=dict(required=False, default='bridge', choices=['bridge', 'host', 'none'], type='str'),
+        network_mode=dict(required=False, default='bridge', choices=['bridge', 'host', 'awsvpc', 'none'], type='str'),
         task_role_arn=dict(required=False, default='', type='str'),
         volumes=dict(required=False, type='list')))
 


### PR DESCRIPTION
##### SUMMARY
Add support for awsvpc on ecs_taskdefinition module and network_configuration parameter to ecs_service (required for awsvpc).

Add option 'awsvpc' for network_configuration parameter in ecs_taskdefinition module
Add parameter network_configuration in ecs_service (required to create a service using awsvpn network mode)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
ecs_taskdefinition
ecs_service

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/Users/jviana/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.12 (default, Jun 29 2016, 14:05:02) [GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)]
```


##### ADDITIONAL INFORMATION
