### PR TITLE
add bug_internal_api.md to ticket_stubs

### DIFF
--- a/ticket_stubs/bug_internal_api.md
+++ b/ticket_stubs/bug_internal_api.md
@@ -1,5 +1,5 @@
-Interal Ansible API
-===================
+Internal Ansible API
+====================
 
 Hi!
 

--- a/ticket_stubs/bug_internal_api.md
+++ b/ticket_stubs/bug_internal_api.md
@@ -1,0 +1,16 @@
+Interal Ansible API
+===================
+
+Hi!
+
+Thanks very much for your submission to Ansible.  It sincerely means a lot to us
+to have an active community that is willing to submit feedback so that we may
+continue to make Ansible better.
+
+The internal Python API is considered an unsupported aspect of Ansible and this
+is not considered a bug unless there is an issue with an Ansible binary
+(`ansible`, `ansible-playbook`, `ansible-doc`, etc) or an issue with an external
+API such as are provided for the development of plugins (modules, dynamic
+inventories, callbacks, strategies, etc).
+
+Thank you once again for this and your interest in Ansible!


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Adding a ticket_stub message for bugs filed against the internal Ansible API.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
ticket_stubs

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0 (ticket_stubs 6e9052a2af) last updated 2018/01/02 13:31:27 (GMT -500)                                    
  config file = /etc/ansible/ansible.cfg                   
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']  
  ansible python module location = /home/admiller/src/dev/ansible/lib/ansible                                          
  executable location = /home/admiller/src/dev/ansible/bin/ansible                                                     
  python version = 2.7.14 (default, Nov  3 2017, 10:55:25) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]   
```

