### PR TITLE
Update lxd_container example to use simplestreams

### DIFF
--- a/lib/ansible/modules/cloud/lxd/lxd_container.py
+++ b/lib/ansible/modules/cloud/lxd/lxd_container.py
@@ -61,7 +61,7 @@ options:
             (e.g. { "type": "image",
                     "mode": "pull",
                     "server": "https://images.linuxcontainers.org",
-                    "protocol": "lxd",
+                    "protocol": "simplestreams",
                     "alias": "ubuntu/xenial/amd64" }).
             See U(https://github.com/lxc/lxd/blob/master/doc/rest-api.md#post-1)'
         required: false
@@ -151,7 +151,7 @@ EXAMPLES = '''
           type: image
           mode: pull
           server: https://images.linuxcontainers.org
-          protocol: lxd
+          protocol: simplestreams
           alias: ubuntu/xenial/amd64
         profiles: ["default"]
         wait_for_ipv4_addresses: true


### PR DESCRIPTION
##### SUMMARY
There's a 404 error with the lxd protocol in the docs
http://docs.ansible.com/ansible/latest/lxd_container_module.html

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
lxd_container

##### ANSIBLE VERSION
ansible 2.4.2.0

##### ADDITIONAL INFORMATION
When running the example in the docs, the following error is returned:
```
fatal: [localhost]: FAILED! => {"actions": [], "changed": false, "msg": "Failed to fetch https://images.linuxcontainers.org/1.0/images/ubuntu%2Fxenial%2Famd64: 404 Not Found"}
```