### PR TITLE
Update ec2_asg_lifecycle_hook to recent AWS coding standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Ansible Changes By Release
   * aws_kms_facts
   * aws_s3_cors
   * aws_ssm_parameter_store
+  * ec2_asg_lifecycle_hook
   * ec2_ami_facts
   * ec2_placement_group
   * ec2_placement_group_facts


### PR DESCRIPTION
##### SUMMARY

* Use `AnsibleAWSModule`
* Update exception handling to use `fail_json_aws` and check
  for `BotoCoreError` exceptions associated with bad connection
  parameters.
* Remove connection creation exception handling as it does nothing.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_asg_lifecycle_hook

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 0a3da471f5) last updated 2018/01/02 10:31:55 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Nov  2 2017, 18:42:05) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```

##### ADDITIONAL INFORMATION

~This could be split into two PRs, one that just did `version_added` which is the most significant problem - most of the others are stylistic~ (this was done as #34380)
  