### PR TITLE
windows: added Ansible.IO c# code to work on paths greater than 260

### DIFF
--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -1,6 +1,1292 @@
 # Copyright (c) 2017 Ansible Project
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
+# Replacement for the below classes that support paths that are greater than 260 chars
+# See each URL for a list of method/properties that are supported
+#     System.IO.File - https://msdn.microsoft.com/en-us/library/system.io.file(v=vs.110).aspx
+#     System.IO.FileInfo - https://msdn.microsoft.com/en-us/library/system.io.fileinfo(v=vs.110).aspx
+#     System.IO.Directory - https://msdn.microsoft.com/en-us/library/system.io.directory(v=vs.110).aspx
+#     System.IO.DirectoryInfo - https://msdn.microsoft.com/en-us/library/system.io.directoryinfo(v=vs.110).aspx
+#
+# To use, make sure this function is called and then it can be used like
+#     $dir = New-Object -TypeName Ansible.IO.DirectoryInfo -ArgumentList "\\?\C:\temp"
+#     [Ansible.IO.Directory]::CreateDirectory("\\?\C:\temp")
+# You can also use a normal path like "C:\temp" as you would normally with the System.IO.*
+# classes but they are still subjectr to the restriction of 260 characters in the path
+Function Load-FileUtilFunctions {
+    $file_util = @"
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Text;
+
+namespace Ansible.IO
+{
+    internal static class Win32Errors
+    {
+
+        public const UInt32 ERROR_SUCCESS = 0;
+        public const UInt32 ERROR_FILE_NOT_FOUND = 2;
+        public const UInt32 ERROR_PATH_NOT_FOUND = 3;
+        public const UInt32 ERROR_NO_MORE_FILES = 18;
+        public const UInt32 ERROR_FILE_EXISTS = 80;
+        public const UInt32 ERROR_DIR_NOT_EMPTY = 145;
+        public const UInt32 ERROR_ALREADY_EXISTS = 183;
+    }
+
+    internal class Win32Exception : System.ComponentModel.Win32Exception
+    {
+        private string _msg;
+        public Win32Exception(string message) : this(Marshal.GetLastWin32Error(), message) { }
+        public Win32Exception(int errorCode, string message) : base(errorCode)
+        {
+            _msg = String.Format("{0} ({1}, Win32ErrorCode {2})", message, base.Message, errorCode);
+        }
+        public override string Message { get { return _msg; } }
+        public static explicit operator Win32Exception(string message) { return new Win32Exception(message); }
+    }
+
+    public class NativeHelpers
+    {
+        public enum GET_FILEEX_INFO_LEVELS
+        {
+            GetFileExInfoStandard,
+            GetFileExMaxInfoLevel
+        }
+
+        public enum SE_OBJECT_TYPE
+        {
+            SE_UNKNOWN_OBJECT_TYPE = 0,
+            SE_FILE_OBJECT,
+            SE_SERVICE,
+            SE_PRINTER,
+            SE_REGISTRY_KEY,
+            SE_LMSHARE,
+            SE_KERNEL_OBJECT,
+            SE_WINDOW_OBJECT,
+            SE_DS_OBJECT,
+            SE_DS_OBJECT_ALL,
+            SE_PROVIDER_DEFINED_OBJECT,
+            SE_WMIGUID_OBJECT,
+            SE_REGISTRY_WOW64_32KEY
+        }
+
+        [Flags]
+        public enum SECURITY_INFORMATION : uint
+        {
+            NONE = 0x00000000,
+            OWNER_SECURITY_INFORMATION = 0x00000001,
+            GROUP_SECURITY_INFORMATION = 0x00000002,
+            DACL_SECURITY_INFORMATION = 0x00000004,
+            SACL_SECURITY_INFORMATION = 0x00000008,
+            UNPROTECTED_SACL_SECURITY_INFORMATION = 0x10000000,
+            UNPROTECTED_DACL_SECURITY_INFORMATION = 0x20000000,
+            PROTECTED_SACL_SECURITY_INFORMATION = 0x40000000,
+            PROTECTED_DACL_SECURITY_INFORMATION = 0x80000000
+        }
+
+        [Flags]
+        public enum FlagsAndAttributes : uint
+        {
+            NONE = 0x00000000,
+            FILE_ATTRIBUTE_READONLY = 0x00000001,
+            FILE_ATTRIBUTE_HIDDEN = 0x00000002,
+            FILE_ATTRIBUTE_SYSTEM = 0x00000004,
+            FILE_ATTRIBUTE_ARCHIVE = 0x00000020,
+            FILE_ATTRIBUTE_NORMAL = 0x00000080,
+            FILE_ATTRIBUTE_TEMPORARY = 0x00000100,
+            FILE_ATTRIBUTE_OFFLINE = 0x00001000,
+            FILE_ATTRIBUTE_ENCRYPTED = 0x00004000,
+            FILE_FLAG_OPEN_NO_RECALL = 0x00100000,
+            FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000,
+            FILE_FLAG_SESSION_AWARE = 0x00800000,
+            FILE_FLAG_BACKUP_SEMANTICS = 0x02000000,
+            FILE_FLAG_DELETE_ON_CLOSE = 0x04000000,
+            FILE_FLAG_SEQUENTIAL_SCAN = 0x08000000,
+            FILE_FLAG_RANDOM_ACCESS = 0x10000000,
+            FILE_FLAG_NO_BUFFERING = 0x20000000,
+            FILE_FLAG_OVERLAPPED = 0x40000000,
+            FILE_FLAG_WRITE_THROUGH = 0x80000000,
+        }
+
+        [Flags]
+        public enum SECURITY_DESCRIPTOR_CONTROL : uint
+        {
+            SE_NONE = 0x0000,
+            SE_OWNER_DEFAULTED = 0x0001,
+            SE_GROUP_DEFAULTED = 0x0002,
+            SE_DACL_PRESENT = 0x0004,
+            SE_DACL_DEFAULTED = 0x0008,
+            SE_SACL_DEFAULTED = 0x0008,
+            SE_SACL_PRESENT = 0x0010,
+            SE_DACL_AUTO_INHERIT_REQ = 0x0100,
+            SE_SACL_AUTO_INHERIT_REQ = 0x0200,
+            SE_DACL_AUTO_INHERITED = 0x0400,
+            SE_SACL_AUTO_INHERITED = 0x0800,
+            SE_DACL_PROTECTED = 0x1000,
+            SE_SACL_PROTECTED = 0x2000,
+            SE_RM_CONTROL_VALID = 0x4000,
+            SE_SELF_RELATIVE = 0x8000,
+        }
+
+        [Flags]
+        public enum MoveFlags : uint
+        {
+            MOVEFILE_NONE = 0x00,
+            MOVEFILE_REPLACE_EXISTING = 0x01,
+            MOVEFILE_COPY_ALLOWED = 0x02,
+            MOVEFILE_DELAY_UNTIL_REBOOT = 0x04,
+            MOVEFILE_WRITE_THROUGH = 0x08,
+            MOVEFILE_CREATE_HARDLINK = 0x10,
+            MOVEFILE_FAIL_IF_NOT_TRACKABLE = 0x20,
+        }
+
+        [Flags]
+        public enum ReplaceFlags : uint
+        {
+            REPLACEFILE_WRITE_THROUGH = 0x00000001,
+            REPLACEFILE_IGNORE_MERGE_ERRORS = 0x00000002,
+            REAPLCEFILE_IGNORE_ACL_ERRORS = 0x00000004,
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct FILETIME
+        {
+            private UInt32 dwLowDateTime;
+            private UInt32 dwHighDateTime;
+
+            public static implicit operator long(FILETIME v) { return v.ToLong(); }
+            public long ToLong() { return (long)this.dwHighDateTime << 32 | (long)this.dwLowDateTime; }
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WIN32_FILE_ATTRIBUTE_DATA
+        {
+            public FileAttributes dwFileAttributes;
+            public FILETIME ftCreationTime;
+            public FILETIME ftLastAccessTime;
+            public FILETIME ftLastWriteTime;
+            public UInt32 nFileSizeHigh;
+            public UInt32 nFileSizeLow;
+        }
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct WIN32_FIND_DATA
+        {
+            public FileAttributes dwFileAttributes;
+            public FILETIME ftCreationTime;
+            public FILETIME ftLastAccessTime;
+            public FILETIME ftLastWriteTime;
+            public UInt32 nFileSizeHigh;
+            public UInt32 nFileSizeLow;
+            public UInt32 dwReserved0;
+            public UInt32 dwReserved1;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 260)] public string cFileName;
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 14)] public string cAlternateFileName;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct LUID
+        {
+            public UInt32 LowPart;
+            public UInt32 HighPart;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct TOKEN_PRIVILEGES
+        {
+            public UInt32 PrivilegeCount;
+            public LUID Luid;
+            public UInt32 Attributes;
+        }
+
+        [StructLayout(LayoutKind.Sequential)]
+        public class SecurityAttributes : IDisposable
+        {
+            public UInt32 nLength = 0;
+            public IntPtr lpSecurityDescriptor = IntPtr.Zero;
+            public bool bInheritHandle = false;
+
+            public SecurityAttributes(ObjectSecurity securityDescriptor)
+            {
+                if (securityDescriptor != null)
+                {
+                    byte[] secDesc = securityDescriptor.GetSecurityDescriptorBinaryForm();
+                    nLength = (UInt32)secDesc.Length;
+                    lpSecurityDescriptor = Marshal.AllocHGlobal(secDesc.Length);
+                    Marshal.Copy(secDesc, 0, lpSecurityDescriptor, secDesc.Length);
+                }
+            }
+
+            public void Dispose()
+            {
+                if (lpSecurityDescriptor != IntPtr.Zero)
+                    Marshal.FreeHGlobal(lpSecurityDescriptor);
+                GC.SuppressFinalize(this);
+            }
+            ~SecurityAttributes() { Dispose(); }
+        }
+    }
+
+    internal class NativeMethods
+    {
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool AdjustTokenPrivileges(
+            IntPtr TokenHandle,
+            [MarshalAs(UnmanagedType.Bool)] bool DisableAllPrivileges,
+            ref NativeHelpers.TOKEN_PRIVILEGES NewState,
+            UInt32 BufferLength,
+            IntPtr PreviousState,
+            IntPtr ReturnLength);
+
+        [DllImport("kernel32.dll")]
+        internal static extern bool CloseHandle(
+            IntPtr hObject);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CopyFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName,
+            [MarshalAs(UnmanagedType.Bool)] bool bFailIfExists);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool CreateDirectoryW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPathName,
+            NativeHelpers.SecurityAttributes lpSecurityAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern SafeFileHandle CreateFileW(
+             [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+             [MarshalAs(UnmanagedType.U4)] FileSystemRights dwDesiredAccess,
+             [MarshalAs(UnmanagedType.U4)] FileShare dwShareMode,
+             NativeHelpers.SecurityAttributes lpSecurityAttributes,
+             [MarshalAs(UnmanagedType.U4)] FileMode dwCreationDisposition,
+             NativeHelpers.FlagsAndAttributes dwFlagsAndAttributes,
+             IntPtr hTemplateFile);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool DecryptFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            UInt32 dwReserved);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool DeleteFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool EncryptFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool FindClose(
+            IntPtr hFindFile);
+
+        [DllImport("kernel32", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern IntPtr FindFirstFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            out NativeHelpers.WIN32_FIND_DATA lpFindFileData);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool FindNextFileW(
+            IntPtr hFindFile,
+            out NativeHelpers.WIN32_FIND_DATA lpFindFIleData);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr GetCurrentProcess();
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool GetFileAttributesExW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            NativeHelpers.GET_FILEEX_INFO_LEVELS fInfoLevelId,
+            out NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA lpFileInformation);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern UInt32 GetFullPathNameW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            UInt32 nBufferLength,
+            StringBuilder lpBuffer,
+            out IntPtr lpFilePart);
+
+        [DllImport("advapi32.dll", CharSet = CharSet.Unicode)]
+        internal static extern UInt32 GetNamedSecurityInfoW(
+            [MarshalAs(UnmanagedType.LPWStr)] string pObjectName,
+            NativeHelpers.SE_OBJECT_TYPE ObjectType,
+            NativeHelpers.SECURITY_INFORMATION SecurityInfo,
+            out IntPtr ppsidOwner,
+            out IntPtr ppsidGroup,
+            out IntPtr ppDacl,
+            out IntPtr ppSacl,
+            out IntPtr ppSecurityDescriptor);
+
+        [DllImport("advapi32.dll")]
+        internal static extern UInt32 GetSecurityDescriptorLength(
+            IntPtr pSecurityDescriptor);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorControl(
+            IntPtr pSecurityDescriptor,
+            out NativeHelpers.SECURITY_DESCRIPTOR_CONTROL pControl,
+            out UInt32 lpdwRevision);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorDacl(
+            IntPtr pSecurityDescriptor,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbDaclPresent,
+            out IntPtr pDacl,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbDaclDefaulted);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorGroup(
+            IntPtr pSecurityDescriptor,
+            out IntPtr pGroup,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbGroupDefaulted);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorOwner(
+            IntPtr pSecurityDescriptor,
+            out IntPtr pOwner,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbOwnerDefaulted);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool GetSecurityDescriptorSacl(
+            IntPtr pSecurityDescriptor,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbSaclPresent,
+            out IntPtr pSacl,
+            [MarshalAs(UnmanagedType.Bool)] out bool lpbSaclDefaulted);
+
+        [DllImport("kernel32.dll")]
+        internal static extern IntPtr LocalFree(
+            IntPtr hMem);
+
+        [DllImport("advapi32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool LookupPrivilegeValueW(
+            string lpSystemName,
+            string lpName,
+            [MarshalAs(UnmanagedType.Struct)] out NativeHelpers.LUID lpLuid);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool MoveFileExW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpExistingFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpNewFileName,
+            NativeHelpers.MoveFlags dwFlags);
+
+        [DllImport("advapi32.dll", SetLastError = true)]
+        internal static extern bool OpenProcessToken(
+            IntPtr ProcessHandle,
+            UInt32 DesiredAccess,
+            out IntPtr TokenHandle);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool ReplaceFileW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpReplacedFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpReplacementFileName,
+            [MarshalAs(UnmanagedType.LPWStr)] string lpBackupFileName,
+            NativeHelpers.ReplaceFlags dwReplaceFlags,
+            IntPtr lpExclude,
+            IntPtr lpReserved);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool SetFileAttributesW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpFileName,
+            FileAttributes dwFileAttributes);
+
+        [DllImport("kernel32.dll", SetLastError = true)]
+        internal static extern bool SetFileTime(
+            SafeFileHandle hFile,
+            ref long lpCreationTime,
+            ref long lpLastAccessTime,
+            ref long lpLastWriteTime);
+
+        [DllImport("advapi32.dll")]
+        internal static extern UInt32 SetNamedSecurityInfoW(
+            [MarshalAs(UnmanagedType.LPWStr)] string pObjectName,
+            NativeHelpers.SE_OBJECT_TYPE objectType,
+            NativeHelpers.SECURITY_INFORMATION securityInfo,
+            IntPtr pSidOwner,
+            IntPtr pSidGroup,
+            IntPtr pDacl,
+            IntPtr pSacl);
+
+        [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        internal static extern bool RemoveDirectoryW(
+            [MarshalAs(UnmanagedType.LPWStr)] string lpPathName);
+    }
+
+    public static class Privileges
+    {
+        public static void EnablePrivilege(string privilege)
+        {
+            NativeHelpers.TOKEN_PRIVILEGES tkpPrivileges;
+            IntPtr hToken;
+            // Open Process Token with TOKEN_ADJUST_PRIVILEGES 0x20 and TOKEN_QUERY 0x8
+            if (!NativeMethods.OpenProcessToken(NativeMethods.GetCurrentProcess(), 0x20 | 0x8, out hToken))
+                throw new Win32Exception("OpenProcessToken() failed");
+
+            try
+            {
+                NativeHelpers.LUID luid;
+                if (!NativeMethods.LookupPrivilegeValueW(null, privilege, out luid))
+                    throw new Win32Exception(String.Format("LookupPrivilegeValueW({0}) failed", privilege));
+
+                tkpPrivileges.PrivilegeCount = 1;
+                tkpPrivileges.Luid = luid;
+                tkpPrivileges.Attributes = 0x00000002; // SE_PRIVILEGE_ENABLED
+
+                if (!NativeMethods.AdjustTokenPrivileges(hToken, false, ref tkpPrivileges, 0, IntPtr.Zero, IntPtr.Zero))
+                    throw new Win32Exception("AdjustTokenPrivileges() failed");
+            }
+            finally
+            {
+                NativeMethods.CloseHandle(hToken);
+            }
+        }
+    }
+
+    public abstract class FileSystemInfo : MarshalByRefObject
+    {
+        #region Fields
+        internal bool IsInitialized = false;
+        internal NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA Win32AttributeData;
+        internal string OriginalPath;
+        internal string FullPath;
+        #endregion // Fields
+
+        #region Properties
+        public FileAttributes Attributes
+        {
+            get {
+                RefreshIfNotInitialized();
+                return Win32AttributeData.dwFileAttributes;
+            }
+            set
+            {
+                if (!NativeMethods.SetFileAttributesW(FullPath, value))
+                    throw new Win32Exception(String.Format("SetFileAttributesW({0}) failed", FullPath));
+            }
+        }
+
+        public DateTime CreationTime
+        {
+            get { return CreationTimeUtc.ToLocalTime(); }
+            set { CreationTimeUtc = value.ToUniversalTime(); }
+        }
+
+        public DateTime CreationTimeUtc
+        {
+            get
+            {
+                RefreshIfNotInitialized();
+                return DateTime.FromFileTimeUtc(Win32AttributeData.ftCreationTime);
+            }
+            set { SetFileTime(FullPath, value, null, null); }
+        }
+
+        public abstract bool Exists { get; }
+
+        public string Extension
+        {
+            get { return System.IO.Path.GetExtension(FullPath); }
+        }
+
+        public string FullName
+        {
+            get { return FullPath; }
+        }
+
+        public DateTime LastAccessTime
+        {
+            get { return LastAccessTimeUtc.ToLocalTime(); }
+            set { LastAccessTimeUtc = value.ToUniversalTime(); }
+        }
+
+        public DateTime LastAccessTimeUtc
+        {
+            get
+            {
+                RefreshIfNotInitialized();
+                return DateTime.FromFileTimeUtc(Win32AttributeData.ftLastAccessTime);
+            }
+            set { SetFileTime(FullPath, null, value, null); }
+        }
+
+        public DateTime LastWriteTime
+        {
+            get { return LastWriteTimeUtc.ToLocalTime(); }
+            set { LastWriteTimeUtc = value.ToUniversalTime(); }
+        }
+
+        public DateTime LastWriteTimeUtc
+        {
+            get
+            {
+                RefreshIfNotInitialized();
+                return DateTime.FromFileTimeUtc(Win32AttributeData.ftLastWriteTime);
+            }
+            set { SetFileTime(FullPath, null, null, value); }
+        }
+
+        public abstract string Name { get; }
+        #endregion // Properties
+
+        #region Methods
+        public abstract void Delete();
+
+        protected void RefreshIfNotInitialized()
+        {
+            if (!IsInitialized)
+                Refresh();
+        }
+
+        public void Refresh()
+        {
+            Win32AttributeData = GetFileAttributes(FullPath);
+            IsInitialized = true;
+        }
+
+        internal void Initialize(string path, bool isDirectory)
+        {
+            OriginalPath = path;
+
+            UInt32 bufferLength = 0;
+            StringBuilder lpBuffer = new StringBuilder(0);
+            IntPtr lpFilePart = IntPtr.Zero;
+            UInt32 returnLength = NativeMethods.GetFullPathNameW(path, bufferLength, lpBuffer, out lpFilePart);
+            if (returnLength == 0)
+                throw new Win32Exception(String.Format("GetFullPathName({0}) failed when getting buffer size", path));
+
+            lpBuffer.EnsureCapacity((int)returnLength);
+            returnLength = NativeMethods.GetFullPathNameW(path, returnLength, lpBuffer, out lpFilePart);
+            if (returnLength == 0)
+                throw new Win32Exception(String.Format("GetFullPathName({0}, {1}) failed when getting full path", path, returnLength));
+            FullPath = lpBuffer.ToString();
+        }
+
+        // Custom Methods
+        public static void Copy(string source, string target, bool failIfExists)
+        {
+            if (!NativeMethods.CopyFileW(source, target, failIfExists))
+                throw new Win32Exception(String.Format("CopyFileW failed to copy {0} to {1}", source, target));
+        }
+
+        public static T GetAcl<T>(string path, AccessControlSections includeSections) where T : ObjectSecurity, new()
+        {
+            NativeHelpers.SECURITY_INFORMATION secInfo = NativeHelpers.SECURITY_INFORMATION.NONE;
+            if ((includeSections & AccessControlSections.Access) != 0)
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.DACL_SECURITY_INFORMATION;
+            if ((includeSections & AccessControlSections.Audit) != 0)
+            {
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.SACL_SECURITY_INFORMATION;
+                Ansible.IO.Privileges.EnablePrivilege("SeSecurityPrivilege");
+            }
+            if ((includeSections & AccessControlSections.Group) != 0)
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.GROUP_SECURITY_INFORMATION;
+            if ((includeSections & AccessControlSections.Owner) != 0)
+                secInfo |= NativeHelpers.SECURITY_INFORMATION.OWNER_SECURITY_INFORMATION;
+
+            IntPtr pSidOwner, pSidGroup, pDacl, pSacl, pSecurityDescriptor = IntPtr.Zero;
+            UInt32 res = NativeMethods.GetNamedSecurityInfoW(path, NativeHelpers.SE_OBJECT_TYPE.SE_FILE_OBJECT, secInfo,
+                out pSidOwner, out pSidGroup, out pDacl, out pSacl, out pSecurityDescriptor);
+            if (res != Win32Errors.ERROR_SUCCESS)
+                throw new Win32Exception((int)res, String.Format("GetNamedSecurityInfoW({0}) failed", path));
+
+            var acl = new T();
+            try
+            {
+                UInt32 length = NativeMethods.GetSecurityDescriptorLength(pSecurityDescriptor);
+                byte[] securityDescriptor = new byte[length];
+                Marshal.Copy(pSecurityDescriptor, securityDescriptor, 0, (int)length);
+                acl.SetSecurityDescriptorBinaryForm(securityDescriptor);
+            }
+            finally
+            {
+                NativeMethods.LocalFree(pSecurityDescriptor);
+            }
+
+            return acl;
+        }
+
+        public static string GetDirectoryName(string path)
+        {
+            // return null if path is null or if the path denotes a root directory
+            if (path == null)
+                return null;
+
+            int rootLength = GetPathRoot(path).Length;
+            if (path.Length <= rootLength)
+                return null;
+
+            // Get the length up to the last \ or /
+            char dirSeparator = System.IO.Path.DirectorySeparatorChar;
+            char altDirSeparator = System.IO.Path.AltDirectorySeparatorChar;
+            int length = path.Length;
+            while (length > rootLength && path[--length] != dirSeparator && path[length] != altDirSeparator) { }
+
+            return path.Substring(0, length);
+        }
+
+        public static string GetPathRoot(string path)
+        {
+            // Strip the extended length path prefix if present
+            string pathPrefix = "";
+            if (path.StartsWith(@"\\?\"))
+            {
+                path = path.Substring(4);
+                pathPrefix = @"\\?\";
+            }
+            else if (path.ToUpper().StartsWith(@"\\UNC\"))
+            {
+                path = @"\\" + path.Substring(6);
+                pathPrefix = @"\\UNC\";
+            }
+
+            // Make sure we don't exceed 256 chars and get the root from there
+            // the extra path info isn't needed 
+            if (path.Length > 256)
+                path = path.Substring(0, 256);
+            string pathRoot = System.IO.Path.GetPathRoot(path);
+
+            // Make sure the \\server is changed back to \\UNC\server
+            if (pathPrefix == @"\\UNC\")
+                return pathPrefix + pathRoot.Substring(2);
+            else
+                return pathPrefix + pathRoot;
+        }
+
+        public static NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA GetFileAttributes(string path)
+        {
+            NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA attrData = new NativeHelpers.WIN32_FILE_ATTRIBUTE_DATA();
+            if (!NativeMethods.GetFileAttributesExW(path, NativeHelpers.GET_FILEEX_INFO_LEVELS.GetFileExInfoStandard, out attrData))
+            {
+                int lastErr = Marshal.GetLastWin32Error();
+                if ((uint)lastErr == Win32Errors.ERROR_FILE_NOT_FOUND || (uint)lastErr == Win32Errors.ERROR_PATH_NOT_FOUND)
+                    attrData.dwFileAttributes = (FileAttributes)(-1);
+                else
+                    throw new Win32Exception(String.Format("GetFileAttributesExW({0}) failed", path));
+            }
+            return attrData;
+        }
+
+        public static void Move(string sourcePath, string targetPath)
+        {
+            NativeHelpers.MoveFlags moveFlags = NativeHelpers.MoveFlags.MOVEFILE_WRITE_THROUGH;
+            if (!NativeMethods.MoveFileExW(sourcePath, targetPath, moveFlags))
+                throw new Win32Exception(String.Format("MoveFileExW() failed to copy {0} to {1}", sourcePath, targetPath));
+        }
+
+        public static void SetAcl(string path, ObjectSecurity objectSecurity)
+        {
+            byte[] securityInfoBytes = objectSecurity.GetSecurityDescriptorBinaryForm();
+            IntPtr securityInfo = Marshal.AllocHGlobal(securityInfoBytes.Length);
+            Marshal.Copy(securityInfoBytes, 0, securityInfo, securityInfoBytes.Length);
+            try
+            {
+                NativeHelpers.SECURITY_INFORMATION securityInformation = NativeHelpers.SECURITY_INFORMATION.NONE;
+
+                NativeHelpers.SECURITY_DESCRIPTOR_CONTROL control;
+                UInt32 lpdwRevision;
+                if (!NativeMethods.GetSecurityDescriptorControl(securityInfo, out control, out lpdwRevision))
+                    throw new Win32Exception("GetSecurityDescriptorControl() failed");
+
+                IntPtr pDacl = IntPtr.Zero;
+                bool daclPresent, daclDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorDacl(securityInfo, out daclPresent, out pDacl, out daclDefaulted))
+                    throw new Win32Exception("GetSecurityDescriptorDacl() failed");
+                if (daclPresent)
+                {
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.DACL_SECURITY_INFORMATION;
+                    securityInformation |= (control & NativeHelpers.SECURITY_DESCRIPTOR_CONTROL.SE_DACL_PROTECTED) != 0
+                        ? NativeHelpers.SECURITY_INFORMATION.PROTECTED_DACL_SECURITY_INFORMATION
+                        : NativeHelpers.SECURITY_INFORMATION.UNPROTECTED_DACL_SECURITY_INFORMATION;
+                }
+
+                IntPtr pGroup = IntPtr.Zero;
+                bool groupDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorGroup(securityInfo, out pGroup, out groupDefaulted))
+                    throw new Win32Exception("GetSecurityDescriptorGroup() failed");
+                if (pGroup != IntPtr.Zero)
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.GROUP_SECURITY_INFORMATION;
+
+                IntPtr pOwner = IntPtr.Zero;
+                bool ownerDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorOwner(securityInfo, out pOwner, out ownerDefaulted))
+                    throw new Win32Exception("GetSecurityDescriptorOwner() failed");
+                if (pOwner != IntPtr.Zero)
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.OWNER_SECURITY_INFORMATION;
+
+                IntPtr pSacl = IntPtr.Zero;
+                bool saclPresent, saclDefaulted;
+                if (!NativeMethods.GetSecurityDescriptorSacl(securityInfo, out saclPresent, out pSacl, out saclDefaulted))
+                    throw new Win32Exception("GetSecurityDescriptorSacl() failed");
+                if (saclPresent)
+                {
+                    securityInformation |= NativeHelpers.SECURITY_INFORMATION.SACL_SECURITY_INFORMATION;
+                    securityInformation |= (control & NativeHelpers.SECURITY_DESCRIPTOR_CONTROL.SE_SACL_PROTECTED) != 0
+                        ? NativeHelpers.SECURITY_INFORMATION.PROTECTED_SACL_SECURITY_INFORMATION
+                        : NativeHelpers.SECURITY_INFORMATION.UNPROTECTED_SACL_SECURITY_INFORMATION;
+                    Ansible.IO.Privileges.EnablePrivilege("SeSecurityPrivilege");
+                }
+
+                UInt32 res = NativeMethods.SetNamedSecurityInfoW(path, NativeHelpers.SE_OBJECT_TYPE.SE_FILE_OBJECT, securityInformation, pOwner, pGroup, pDacl, pSacl);
+                if (res != Win32Errors.ERROR_SUCCESS)
+                    throw new Win32Exception((int)res, String.Format("SetNamedSecurityInfoW({0}) failed", path));
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(securityInfo);
+            }
+        }
+
+        public static void SetFileTime(string path, DateTime? creationTime, DateTime? lastAccessTime, DateTime? lastWriteTime)
+        {
+            SafeFileHandle fileHandle = NativeMethods.CreateFileW(path, FileSystemRights.WriteAttributes, FileShare.Delete | FileShare.Write,
+                null, FileMode.Open, NativeHelpers.FlagsAndAttributes.FILE_FLAG_BACKUP_SEMANTICS, IntPtr.Zero);
+            if (fileHandle.IsInvalid)
+                throw new Win32Exception(String.Format("CreateFileW({0}) failed", path));
+
+            try
+            {
+                long creation = creationTime.HasValue ? creationTime.Value.ToFileTimeUtc() : (long)0;
+                long access = lastAccessTime.HasValue ? lastAccessTime.Value.ToFileTimeUtc() : (long)0;
+                long write = lastWriteTime.HasValue ? lastWriteTime.Value.ToFileTimeUtc() : (long)0;
+
+                if (!NativeMethods.SetFileTime(fileHandle, ref creation, ref access, ref write))
+                    throw new Win32Exception(String.Format("SetFileTime() for file {0} failed", path));
+            }
+            finally
+            {
+                fileHandle.Close();
+            }
+        }
+
+        public override string ToString() { return OriginalPath; }
+        #endregion // Methods
+    }
+
+    public static class File
+    {
+        private static Encoding DefaultEncoding = Encoding.UTF8;
+        private static int DefaultBuffer = 4096;
+
+        public static void AppendAllLines(string path, IEnumerable<string> contents) { AppendAllLines(path, contents, DefaultEncoding); }
+        public static void AppendAllLines(string path, IEnumerable<string> contents, Encoding encoding)
+        {
+            using (StreamWriter writer = AppendText(path))
+            {
+                foreach (string content in contents)
+                    writer.Write(content);
+            }
+        }
+        public static void AppendAllText(string path, string contents) { AppendAllText(path, contents, DefaultEncoding); }
+        public static void AppendAllText(string path, string contents, Encoding encoding)
+        {
+            using (StreamWriter writer = AppendText(path))
+            {
+                writer.Write(contents);
+            }
+        }
+        public static StreamWriter AppendText(string path) { return AppendText(path, DefaultEncoding); }
+        public static StreamWriter AppendText(string path, Encoding encoding)
+        {
+            FileStream fs = File.Open(path, FileMode.OpenOrCreate, FileAccess.Write);
+            try
+            {
+                fs.Seek(0, SeekOrigin.End);
+                return new StreamWriter(fs, encoding);
+            }
+            catch
+            {
+                fs.Close();
+                throw;
+            }
+        }
+        public static void Copy(string sourceFileName, string destFileName) { Copy(sourceFileName, destFileName, false); }
+        public static void Copy(string sourceFileName, string destFileName, bool overwrite) { FileSystemInfo.Copy(sourceFileName, destFileName, !overwrite); }
+        public static FileStream Create(string path) { return Open(path, FileMode.Create, FileAccess.ReadWrite); }
+        public static FileStream Create(string path, int bufferSize) { return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, FileOptions.None); }
+        public static FileStream Create(string path, int bufferSize, FileOptions options) { return Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, bufferSize, options); }
+        public static FileStream Create(string path, int bufferSize, FileOptions options, FileSecurity fileSecurity)
+        {
+            SafeFileHandle fileHandle = CreateFileHandle(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None, options, fileSecurity);
+            try
+            {
+                return new FileStream(fileHandle, FileAccess.ReadWrite, DefaultBuffer, options.HasFlag(FileOptions.Asynchronous));
+            }
+            catch
+            {
+                fileHandle.Dispose();
+                throw;
+            }
+        }
+        public static StreamWriter CreateText(string path) { return new StreamWriter(Open(path, FileMode.Create, FileAccess.ReadWrite)); }
+        public static void Decrypt(string path)
+        {
+            if (!NativeMethods.DecryptFileW(path, 0))
+                throw new Win32Exception(String.Format("DecryptFileW({0}) failed", path));
+        }
+        public static void Delete(string path)
+        {
+            if (!NativeMethods.DeleteFileW(path))
+                throw new Win32Exception(String.Format("DeleteFileW({0}) failed", path));
+        }
+        public static void Encrypt(string path)
+        {
+            if (!NativeMethods.EncryptFileW(path))
+                throw new Win32Exception(String.Format("EncryptFIleW({0}) failed", path));
+        }
+        public static bool Exists(string path) { return new FileInfo(path).Exists; }
+        public static FileSecurity GetAccessControl(string path) { return GetAccessControl(path, AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public static FileSecurity GetAccessControl(string path, AccessControlSections includeSections) { return FileSystemInfo.GetAcl<FileSecurity>(path, includeSections); }
+        public static FileAttributes GetAttributes(string path) { return FileSystemInfo.GetFileAttributes(path).dwFileAttributes; }
+        public static DateTime GetCreationTime(string path) { return new FileInfo(path).CreationTime; }
+        public static DateTime GetCreationTimeUtc(string path) { return new FileInfo(path).CreationTimeUtc; }
+        public static DateTime GetLastAccessTime(string path) { return new FileInfo(path).LastAccessTime; }
+        public static DateTime GetLastAccessTimeUtc(string path) { return new FileInfo(path).LastAccessTimeUtc; }
+        public static DateTime GetLastWriteTime(string path) { return new FileInfo(path).LastWriteTime; }
+        public static DateTime GetLastWriteTimeUtc(string path) { return new FileInfo(path).LastWriteTimeUtc; }
+        public static void Move(string sourceFileName, string destFileName) { FileSystemInfo.Move(sourceFileName, destFileName); }
+        public static FileStream Open(string path, FileMode mode) { return Open(path, mode, mode == FileMode.Append ? FileAccess.Write : FileAccess.ReadWrite, FileShare.None); }
+        public static FileStream Open(string path, FileMode mode, FileAccess access) { return Open(path, mode, access, FileShare.None); }
+        public static FileStream Open(string path, FileMode mode, FileAccess access, FileShare share) { return Open(path, mode, access, share, DefaultBuffer, FileOptions.None); }
+        public static FileStream Open(string path, FileMode mode, FileAccess access, FileShare share, int bufferSize, FileOptions options)
+        {
+            SafeFileHandle fileHandle = CreateFileHandle(path, mode, access, share, options, null);
+            try
+            {
+                return new FileStream(fileHandle, access, bufferSize, options.HasFlag(FileOptions.Asynchronous));
+            }
+            catch
+            {
+                fileHandle.Dispose();
+                throw;
+            }
+        }
+        public static FileStream OpenRead(string path) { return Open(path, FileMode.Open, FileAccess.Read); }
+        public static StreamReader OpenText(string path) { return OpenText(path, DefaultEncoding); }
+        public static StreamReader OpenText(string path, Encoding encoding) { return new StreamReader(OpenRead(path), encoding); }
+        public static FileStream OpenWrite(string path) { return Open(path, FileMode.OpenOrCreate, FileAccess.Write); }
+        public static byte[] ReadAllBytes(string path)
+        {
+            byte[] buffer = null;
+            using (FileStream fs = OpenRead(path))
+            {
+                buffer = new byte[fs.Length];
+                fs.Read(buffer, 0, (int)fs.Length);
+            }
+            return buffer;
+        }
+        public static string[] ReadAllLines(string path) { return ReadLines(path, DefaultEncoding).ToArray(); }
+        public static string[] ReadAllLines(string path, Encoding encoding) { return ReadLines(path, encoding).ToArray(); }
+        public static string ReadAllText(string path) { return ReadAllText(path, DefaultEncoding); }
+        public static string ReadAllText(string path, Encoding encoding)
+        {
+            using (StreamReader reader = OpenText(path, encoding)) {
+                return reader.ReadToEnd();
+            }
+        }
+        public static IEnumerable<string> ReadLines(string path) { return ReadLines(path, DefaultEncoding); }
+        public static IEnumerable<string> ReadLines(string path, Encoding encoding)
+        {
+            using (StreamReader reader = OpenText(path, encoding))
+            {
+                string line = null;
+                while ((line = reader.ReadLine()) != null)
+                    yield return line;
+            }
+        }
+        public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName) { Replace(sourceFileName, destinationFileName, destinationBackupFileName, false); }
+        public static void Replace(string sourceFileName, string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            NativeHelpers.ReplaceFlags replaceFlags = ignoreMetadataErrors ? NativeHelpers.ReplaceFlags.REPLACEFILE_IGNORE_MERGE_ERRORS | NativeHelpers.ReplaceFlags.REAPLCEFILE_IGNORE_ACL_ERRORS : 0;
+            if (!NativeMethods.ReplaceFileW(destinationFileName, sourceFileName, destinationBackupFileName, replaceFlags, IntPtr.Zero, IntPtr.Zero))
+                throw new Win32Exception(String.Format("ReplaceFileW() failed to replace file {0} with {1} with the backup path {2}", destinationFileName, sourceFileName, destinationBackupFileName));
+        }
+        public static void SetAccessControl(string path, FileSecurity fileSecurity) { FileSystemInfo.SetAcl(path, fileSecurity); }
+        public static void SetAttributes(string path, FileAttributes fileAttributes) { new FileInfo(path).Attributes = fileAttributes; }
+        public static void SetCreationTime(string path, DateTime creationTime) { SetCreationTimeUtc(path, creationTime.ToUniversalTime()); }
+        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystemInfo.SetFileTime(path, creationTimeUtc, null, null); }
+        public static void SetLastAccessTime(string path, DateTime lastAccessTime) { SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime()); }
+        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystemInfo.SetFileTime(path, null, lastAccessTimeUtc, null); }
+        public static void SetLastWriteTime(string path, DateTime lastWriteTime) { SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime()); }
+        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystemInfo.SetFileTime(path, null, null, lastWriteTimeUtc); }
+        public static void WriteAllBytes(string path, byte[] bytes)
+        {
+            using (FileStream fs = Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None))
+            {
+                fs.Write(bytes, 0, bytes.Length);
+            }
+        }
+        public static void WriteAllLines(string path, IEnumerable<string> contents) { WriteAllLines(path, contents, DefaultEncoding); }
+        public static void WriteAllLines(string path, IEnumerable<string> contents, Encoding encoding)
+        {
+            using (StreamWriter writer = WriteText(path, encoding))
+            {
+                foreach (string line in contents)
+                {
+                    writer.WriteLine(line);
+                }
+            }
+        }
+        public static void WriteAllLines(string path, string[] contents) { WriteAllLines(path, contents, DefaultEncoding); }
+        public static void WriteAllLines(string path, string[] contents, Encoding encoding)
+        {
+            using (StreamWriter writer = WriteText(path, encoding))
+            {
+                foreach (string line in contents)
+                {
+                    writer.WriteLine(line);
+                }
+            }
+        }
+        public static void WriteAllText(string path, string contents) { WriteAllText(path, contents, DefaultEncoding); }
+        public static void WriteAllText(string path, string contents, Encoding encoding)
+        {
+            using (StreamWriter writer = WriteText(path, encoding))
+            {
+                writer.Write(contents);
+            }
+        }
+        public static StreamWriter WriteText(string path) { return WriteText(path, DefaultEncoding); }
+        public static StreamWriter WriteText(string path, Encoding encoding) { return new StreamWriter(Open(path, FileMode.Create, FileAccess.ReadWrite, FileShare.None), encoding); }
+
+        private static SafeFileHandle CreateFileHandle(string path, FileMode mode, FileAccess access, FileShare share, FileOptions options, FileSecurity fileSecurity)
+        {
+            FileSystemRights accessRights;
+            if (access == FileAccess.Read)
+                accessRights = FileSystemRights.Read;
+            else if (access == FileAccess.Write)
+                accessRights = FileSystemRights.WriteData;
+            else
+                accessRights = FileSystemRights.ReadData | FileSystemRights.WriteData;
+            NativeHelpers.FlagsAndAttributes attr = (NativeHelpers.FlagsAndAttributes)options;
+            NativeHelpers.SecurityAttributes secAttr = new NativeHelpers.SecurityAttributes(fileSecurity);
+            if (fileSecurity != null)
+                accessRights |= (FileSystemRights)0x01000000;  // ACCESS_SYSTEM_SECURITY - Bit 24
+
+            SafeFileHandle fileHandle = NativeMethods.CreateFileW(path, accessRights, share, secAttr, mode, attr, IntPtr.Zero);
+            secAttr.Dispose();
+            if (fileHandle.IsInvalid)
+                throw new Win32Exception(String.Format("CreateFileW({0}) failed", path));
+            return fileHandle;
+        }
+    }
+
+    public sealed class FileInfo : FileSystemInfo
+    {
+        #region Constructor
+        public FileInfo(string path)
+        {
+            Initialize(path, false);
+        }
+        #endregion // Constructor
+
+        #region Properties
+        public DirectoryInfo Directory { get { return new Ansible.IO.DirectoryInfo(GetDirectoryName(FullPath)); } }
+        public string DirectoryName { get { return GetDirectoryName(FullPath); } }
+        public override bool Exists
+        {
+            get
+            {
+                try
+                {
+                    RefreshIfNotInitialized();
+                    FileAttributes attr = Win32AttributeData.dwFileAttributes;
+                    return (!attr.Equals((FileAttributes)(-1)) && !attr.HasFlag(FileAttributes.Directory));
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+
+        }
+        public bool IsReadOnly
+        {
+            get
+            {
+                RefreshIfNotInitialized();
+                return (Attributes & FileAttributes.ReadOnly) != 0;
+            }
+            set
+            {
+                if (value)
+                    Attributes |= FileAttributes.ReadOnly;
+                else
+                    Attributes &= ~FileAttributes.ReadOnly;
+            }
+        }
+        public long Length
+        {
+            get
+            {
+                RefreshIfNotInitialized();
+                FileAttributes attr = Win32AttributeData.dwFileAttributes;
+                if (attr.Equals((FileAttributes)(-1)))
+                    throw new IOException("Failed to initialize file data");
+                if (attr.HasFlag(FileAttributes.Directory))
+                    throw new FileNotFoundException("Cannot get Length for a directory");
+                return (long)Win32AttributeData.nFileSizeHigh << 32 | (long)Win32AttributeData.nFileSizeLow;
+            }
+        }
+        public override string Name { get { return System.IO.Path.GetFileName(FullPath); } }
+        #endregion // Properties
+
+        #region Methods
+        public StreamWriter AppendText() { return File.AppendText(FullPath); }
+        public FileInfo CopyTo(string destFileName) { return CopyTo(destFileName, false); }
+        public FileInfo CopyTo(string destFileName, bool overwrite) {
+            File.Copy(FullPath, destFileName, overwrite);
+            return new FileInfo(destFileName);
+        }
+        public FileStream Create() { return File.Create(FullPath); }
+        public StreamWriter CreateText() { return File.CreateText(FullPath); }
+        public void Decrypt() { File.Decrypt(FullPath); }
+        public override void Delete() { File.Delete(FullPath); }
+        public void Encrypt() { File.Encrypt(FullPath); }
+        public FileSecurity GetAccessControl() { return GetAccessControl(AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public FileSecurity GetAccessControl(AccessControlSections includeSelections) { return GetAcl<FileSecurity>(FullPath, includeSelections); }
+        public void MoveTo(string destFileName) { File.Move(FullPath, destFileName); }
+        public FileStream Open(FileMode mode) { return Open(mode, FileAccess.Read, FileShare.None); }
+        public FileStream Open(FileMode mode, FileAccess access) { return Open(mode, access, FileShare.None); }
+        public FileStream Open(FileMode mode, FileAccess access, FileShare share) { return File.Open(FullPath, mode, access, share); }
+        public FileStream OpenRead() { return File.OpenRead(FullPath); }
+        public StreamReader OpenText() { return File.OpenText(FullPath); }
+        public FileStream OpenWrite() { return File.OpenWrite(FullPath); }
+        public FileInfo Replace(string destinationFileName, string destinationBackupFileName) { return Replace(destinationFileName, destinationBackupFileName, false); }
+        public FileInfo Replace(string destinationFileName, string destinationBackupFileName, bool ignoreMetadataErrors)
+        {
+            File.Replace(FullPath, destinationFileName, destinationBackupFileName, ignoreMetadataErrors);
+            return new FileInfo(destinationFileName);
+        }
+        public void SetAccessControl(FileSecurity fileSecurity) { SetAcl(FullPath, fileSecurity); }
+        #endregion // Methods
+    }
+
+    public static class Directory
+    {
+        public static void Copy(string sourceDirPath, string destDirPath) { FileSystemInfo.Copy(sourceDirPath, destDirPath, true); }
+        public static void Copy(string sourceDirPath, string destDirPath, bool overwrite) { FileSystemInfo.Copy(sourceDirPath, destDirPath, !overwrite); }
+        public static DirectoryInfo CreateDirectory(string path) { return CreateDirectory(path, null); }
+        public static DirectoryInfo CreateDirectory(string path, DirectorySecurity directorySecurity)
+        {
+            Stack<string> dirsToCreate = new Stack<string>();
+            string directoryRoot = FileSystemInfo.GetPathRoot(path);
+            string dir = path;
+            while (directoryRoot != dir)
+            {
+                if (Exists(dir))
+                    break;
+                dirsToCreate.Push(dir);
+                dir = FileSystemInfo.GetDirectoryName(dir);
+            }
+
+            NativeHelpers.SecurityAttributes secAttr = new NativeHelpers.SecurityAttributes(directorySecurity);
+            while (dirsToCreate.Count > 0)
+            {
+                dir = dirsToCreate.Pop();
+                if (!NativeMethods.CreateDirectoryW(dir, secAttr))
+                {
+                    int lastErr = Marshal.GetLastWin32Error();
+                    if (lastErr != Win32Errors.ERROR_ALREADY_EXISTS)
+                    {
+                        secAttr.Dispose();
+                        throw new Win32Exception(lastErr, String.Format("CreateDirectoryW({0}) failed", dir));
+                    }
+                }
+            }
+            secAttr.Dispose();
+
+            return new DirectoryInfo(path);
+        }
+        public static void Delete(string path) { Delete(path, false); }
+        public static void Delete(string path, bool recursive)
+        {
+            if (recursive)
+            {
+                foreach (string filePath in EnumerateFileSystemEntries(path))
+                {
+                    FileAttributes fileAttributes = File.GetAttributes(filePath);
+                    if (fileAttributes.HasFlag(FileAttributes.Directory))
+                        Delete(filePath, true);
+                    else
+                        File.Delete(filePath);
+                }
+            }
+
+            if (!NativeMethods.RemoveDirectoryW(path))
+            {
+                int lastErr = Marshal.GetLastWin32Error();
+                if (lastErr != Win32Errors.ERROR_PATH_NOT_FOUND && lastErr != Win32Errors.ERROR_FILE_NOT_FOUND)
+                    throw new Win32Exception(lastErr, String.Format("RemoveDirectoryW({0}) failed", path));
+            }
+        }
+        public static IEnumerable<string> EnumerateDirectories(string path) { return EnumerateDirectories(path, "*", SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern) { return EnumerateDirectories(path, searchPattern, SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption) { return EnumerateFolder<string>(path, searchPattern, searchOption, true, false); }
+        public static IEnumerable<string> EnumerateFiles(string path) { return EnumerateFiles(path, "*", SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFiles(string path, string searchPattern) { return EnumerateFiles(path, searchPattern, SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption) { return EnumerateFolder<string>(path, searchPattern, searchOption, false, true); }
+        public static IEnumerable<string> EnumerateFileSystemEntries(string path) { return EnumerateFileSystemEntries(path, "*", SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern) { return EnumerateFileSystemEntries(path, searchPattern, SearchOption.TopDirectoryOnly); }
+        public static IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern, SearchOption searchOption) { return EnumerateFolder<string>(path, searchPattern, searchOption, true, true); }
+        public static bool Exists(string path) { return new DirectoryInfo(path).Exists; }
+        public static DirectorySecurity GetAccessControl(string path) { return GetAccessControl(path, AccessControlSections.Access | AccessControlSections.Group | AccessControlSections.Owner); }
+        public static DirectorySecurity GetAccessControl(string path, AccessControlSections includeSelections) { return FileSystemInfo.GetAcl<DirectorySecurity>(path, includeSelections); }
+        public static DateTime GetCreationTime(string path) { return new DirectoryInfo(path).CreationTime; }
+        public static DateTime GetCreationTimeUtc(string path) { return new DirectoryInfo(path).CreationTimeUtc; }
+        public static string[] GetDirectories(string path) { return EnumerateDirectories(path).ToArray(); }
+        public static string[] GetDirectories(string path, string searchPattern) { return EnumerateDirectories(path, searchPattern).ToArray(); }
+        public static string[] GetDirectories(string path, string searchPattern, SearchOption searchOption) { return EnumerateDirectories(path, searchPattern, searchOption).ToArray(); }
+        public static string[] GetFiles(string path) { return EnumerateFiles(path).ToArray(); }
+        public static string[] GetFiles(string path, string searchPattern) { return EnumerateFiles(path, searchPattern).ToArray(); }
+        public static string[] GetFiles(string path, string searchPattern, SearchOption searchOption) { return EnumerateFiles(path, searchPattern, searchOption).ToArray(); }
+        public static string[] GetFileSystemInfos(string path) { return EnumerateFileSystemEntries(path).ToArray(); }
+        public static string[] GetFileSystemInfos(string path, string searchPattern) { return EnumerateFileSystemEntries(path, searchPattern).ToArray(); }
+        public static string[] GetFileSystemInfos(string path, string searchPattern, SearchOption searchOption) { return EnumerateFileSystemEntries(path, searchPattern, searchOption).ToArray(); }
+        public static DateTime GetLastAccessTime(string path) { return new DirectoryInfo(path).LastAccessTime; }
+        public static DateTime GetLastAccessTimeUtc(string path) { return new DirectoryInfo(path).LastAccessTimeUtc; }
+        public static DateTime GetLastWriteTime(string path) { return new DirectoryInfo(path).LastWriteTime; }
+        public static DateTime GetLastWriteTimeUtc(string path) { return new DirectoryInfo(path).LastWriteTimeUtc; }
+        public static DirectoryInfo GetParent(string path) { return new DirectoryInfo(path).Parent; }
+        public static void Move(string sourceDirName, string destDirName) { FileSystemInfo.Move(sourceDirName, destDirName); }
+        public static void SetAccessControl(string path, DirectorySecurity directorySecurity) { FileSystemInfo.SetAcl(path, directorySecurity); }
+        public static void SetCreationTime(string path, DateTime creationTime) { SetCreationTimeUtc(path, creationTime.ToUniversalTime()); }
+        public static void SetCreationTimeUtc(string path, DateTime creationTimeUtc) { FileSystemInfo.SetFileTime(path, creationTimeUtc, null, null); }
+        public static void SetLastAccessTime(string path, DateTime lastAccessTime) { SetLastAccessTimeUtc(path, lastAccessTime.ToUniversalTime()); }
+        public static void SetLastAccessTimeUtc(string path, DateTime lastAccessTimeUtc) { FileSystemInfo.SetFileTime(path, null, lastAccessTimeUtc, null); }
+        public static void SetLastWriteTime(string path, DateTime lastWriteTime) { SetLastWriteTimeUtc(path, lastWriteTime.ToUniversalTime()); }
+        public static void SetLastWriteTimeUtc(string path, DateTime lastWriteTimeUtc) { FileSystemInfo.SetFileTime(path, null, null, lastWriteTimeUtc); }
+
+        internal static IEnumerable<T> EnumerateFolder<T>(string path, string searchPattern, SearchOption searchOption, bool returnFolders, bool returnFiles)
+        {
+            Queue<string> dirs = new Queue<string>();
+            dirs.Enqueue(path);
+
+            while (dirs.Count > 0)
+            {
+                string currentPath = dirs.Dequeue();
+                string searchPath;
+                if (currentPath.EndsWith("\\"))
+                    searchPath = currentPath + searchPattern;
+                else
+                    searchPath = currentPath + "\\" + searchPattern;
+
+                NativeHelpers.WIN32_FIND_DATA findData = new NativeHelpers.WIN32_FIND_DATA();
+                IntPtr findHandle = NativeMethods.FindFirstFileW(searchPath, out findData);
+                if (findHandle.ToInt64() == -1)
+                    throw new Win32Exception(String.Format("FindFirstFileW({0}) failed", searchPath));
+
+                do
+                {
+                    string fileName = findData.cFileName;
+                    string filePath = System.IO.Path.Combine(currentPath, fileName);
+                    FileAttributes attr = findData.dwFileAttributes;
+
+                    if (attr.HasFlag(FileAttributes.Directory))
+                    {
+                        // Skip current directory and parent directory names
+                        if (fileName == "." || fileName == "..")
+                            continue;
+                        else if (searchOption.HasFlag(SearchOption.AllDirectories))
+                            dirs.Enqueue(filePath);
+
+                        if (returnFolders)
+                            if (typeof(T) == typeof(string))
+                                yield return (T)(object)filePath;
+                            else
+                                yield return (T)(object)new DirectoryInfo(filePath);
+                    }
+                    else if (returnFiles)
+                        if (typeof(T) == typeof(string))
+                            yield return (T)(object)filePath;
+                        else
+                            yield return (T)(object)new FileInfo(filePath);
+                } while (NativeMethods.FindNextFileW(findHandle, out findData));
+
+                int lastErr = Marshal.GetLastWin32Error();
+                NativeMethods.FindClose(findHandle);
+                if (lastErr != Win32Errors.ERROR_NO_MORE_FILES)
+                    throw new Win32Exception(lastErr, "FindNextFileW() failed");
+            }
+        }
+    }
+
+    public sealed class DirectoryInfo : FileSystemInfo
+    {
+        #region Constructor
+        public DirectoryInfo(string path)
+        {
+            Initialize(path, true);
+        }
+        #endregion // Constructor
+
+        #region Properties
+        public override bool Exists
+        {
+            get
+            {
+                try
+                {
+                    RefreshIfNotInitialized();
+                    FileAttributes attr = Win32AttributeData.dwFileAttributes;
+                    return (!attr.Equals((FileAttributes)(-1)) && attr.HasFlag(FileAttributes.Directory));
+                }
+                catch
+                {
+                    return false;
+                }
+            }
+        }
+        public override string Name { get { return System.IO.Path.GetFileName(FullPath); } }
+        public DirectoryInfo Parent { get { return new DirectoryInfo(GetDirectoryName(FullPath)); } }
+        public DirectoryInfo Root { get { return new DirectoryInfo(GetPathRoot(FullPath)); } }
+        #endregion // Properties
+
+        #region Method
+        public DirectoryInfo CopyTo(string destDirPath) { return CopyTo(destDirPath, false); }
+        public DirectoryInfo CopyTo(string destDirPath, bool overwrite)
+        {
+            Directory.Copy(FullPath, destDirPath, overwrite);
+            return new DirectoryInfo(destDirPath);
+        }
+        public void Create() { Directory.CreateDirectory(FullPath); }
+        public void Create(DirectorySecurity directorySecurity) { Directory.CreateDirectory(FullPath, directorySecurity); }
+        public DirectoryInfo CreateSubDirectory(string path) { return Directory.CreateDirectory(Path.Combine(FullName, path)); }
+        public DirectoryInfo CreateSubDirectory(string path, DirectorySecurity directorySecurity) { return Directory.CreateDirectory(Path.Combine(FullName, path), directorySecurity); }
+        public override void Delete() { Directory.Delete(FullPath); }
+        public void Delete(bool recursive) { Directory.Delete(FullPath, recursive); }
+        public IEnumerable<DirectoryInfo> EnumerateDirectories() { return EnumerateDirectories("*", SearchOption.TopDirectoryOnly); }
+        public IEnumerable<DirectoryInfo> EnumerateDirectories(string searchPattern) { return EnumerateDirectories(searchPattern, SearchOption.TopDirectoryOnly); }
+        public IEnumerable<DirectoryInfo> EnumerateDirectories(string searchPattern, SearchOption searchOption) { return Directory.EnumerateFolder<DirectoryInfo>(FullPath, searchPattern, searchOption, true, false); }
+        public IEnumerable<FileInfo> EnumerateFiles() { return EnumerateFiles("*", SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileInfo> EnumerateFiles(string searchPattern) { return EnumerateFiles(searchPattern, SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileInfo> EnumerateFiles(string searchPattern, SearchOption searchOption) { return Directory.EnumerateFolder<FileInfo>(FullPath, searchPattern, searchOption, false, true); }
+        public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos() { return EnumerateFileSystemInfos("*", SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos(string searchPattern) { return EnumerateFileSystemInfos(searchPattern, SearchOption.TopDirectoryOnly); }
+        public IEnumerable<FileSystemInfo> EnumerateFileSystemInfos(string searchPattern, SearchOption searchOption) { return Directory.EnumerateFolder<FileSystemInfo>(FullPath, searchPattern, searchOption, true, true); }
+        public DirectorySecurity GetAccessControl() { return Directory.GetAccessControl(FullPath); }
+        public DirectorySecurity GetAccessControl(AccessControlSections includeSections) { return Directory.GetAccessControl(FullName, includeSections); }
+        public DirectoryInfo[] GetDirectories() { return EnumerateDirectories().ToArray(); }
+        public DirectoryInfo[] GetDirectories(string searchPattern) { return EnumerateDirectories(searchPattern).ToArray(); }
+        public DirectoryInfo[] GetDirectories(string searchPattern, SearchOption searchOption) { return EnumerateDirectories(searchPattern, searchOption).ToArray(); }
+        public FileInfo[] GetFiles() { return EnumerateFiles().ToArray(); }
+        public FileInfo[] GetFiles(string searchPattern) { return EnumerateFiles(searchPattern).ToArray(); }
+        public FileInfo[] GetFiles(string searchPattern, SearchOption searchOption) { return EnumerateFiles(searchPattern, searchOption).ToArray(); }
+        public FileSystemInfo[] GetFileSystemInfos() { return EnumerateFileSystemInfos().ToArray(); }
+        public FileSystemInfo[] GetFileSystemInfos(string searchPattern) { return EnumerateFileSystemInfos(searchPattern).ToArray(); }
+        public FileSystemInfo[] GetFileSystemInfos(string searchPattern, SearchOption searchOption) { return EnumerateFileSystemInfos(searchPattern, searchOption).ToArray(); }
+        public void MoveTo(string destDirName) { Directory.Move(FullPath, destDirName); }
+        public void SetAccessControl(DirectorySecurity directorySecurity) { SetAcl(FullPath, directorySecurity); }
+        #endregion // Methods
+    }
+}
+"@
+    Add-Type -TypeDefinition $file_util
+}
+
 <#
 Test-Path/Get-Item cannot find/return info on files that are locked like
 C:\pagefile.sys. These 2 functions are designed to work with these files and
@@ -44,4 +1330,4 @@ Function Get-AnsibleItem {
     }
 }
 
-Export-ModuleMember -Function Test-AnsiblePath, Get-AnsibleItem
+Export-ModuleMember -Function Test-FilePath, Get-FileItem, Load-FileUtilFunctions

--- a/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
+++ b/lib/ansible/module_utils/powershell/Ansible.ModuleUtils.FileUtil.psm1
@@ -1160,8 +1160,11 @@ namespace Ansible.IO
                 foreach (string filePath in EnumerateFileSystemEntries(path))
                 {
                     FileAttributes fileAttributes = File.GetAttributes(filePath);
-                    if (fileAttributes.HasFlag(FileAttributes.Directory))
+                    // only do a recursive delete if file entry is a dir and not a link
+                    if (fileAttributes.HasFlag(FileAttributes.Directory) && !fileAttributes.HasFlag(FileAttributes.ReparsePoint))
                         Delete(filePath, true);
+                    else if (fileAttributes.HasFlag(FileAttributes.Directory) && fileAttributes.HasFlag(FileAttributes.ReparsePoint))
+                        Delete(filePath, false);
                     else
                         File.Delete(filePath);
                 }

--- a/lib/ansible/modules/windows/win_command.ps1
+++ b/lib/ansible/modules/windows/win_command.ps1
@@ -28,6 +28,8 @@ $result = @{
     cmd = $raw_command_line
 }
 
+Load-FileUtilFunctions
+
 if ($creates -and $(Test-AnsiblePath -Path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }

--- a/lib/ansible/modules/windows/win_shell.ps1
+++ b/lib/ansible/modules/windows/win_shell.ps1
@@ -56,6 +56,8 @@ $result = @{
     cmd = $raw_command_line
 }
 
+Load-FileUtilFunctions
+
 if ($creates -and $(Test-AnsiblePath -Path $creates)) {
     Exit-Json @{msg="skipped, since $creates exists";cmd=$raw_command_line;changed=$false;skipped=$true;rc=0}
 }

--- a/lib/ansible/modules/windows/win_stat.ps1
+++ b/lib/ansible/modules/windows/win_stat.ps1
@@ -28,6 +28,8 @@ $result = @{
     }
 }
 
+Load-FileUtilFunctions
+
 # get_md5 will be an undocumented option in 2.9 to be removed at a later
 # date if possible (3.0+)
 if (Get-Member -inputobject $params -name "get_md5") {
@@ -98,14 +100,14 @@ If ($info -ne $null) {
 
         if ($get_md5) {
             try {
-                $stat.md5 = Get-FileChecksum -path $path -algorithm "md5"
+                $stat.md5 = Get-AnsibleFileHash -Path $path -Algorithm "md5"
             } catch {
                 Fail-Json -obj $result -message "failed to get MD5 hash of file, remove get_md5 to ignore this error: $($_.Exception.Message)"
             }
         }
         if ($get_checksum) {
             try {
-                $stat.checksum = Get-FileChecksum -path $path -algorithm $checksum_algorithm
+                $stat.checksum = Get-AnsibleFileHash -Path $path -Algorithm $checksum_algorithm
             } catch {
                 Fail-Json -obj $result -message "failed to get hash of file, set get_checksum to False to ignore this error: $($_.Exception.Message)"
             }

--- a/lib/ansible/modules/windows/win_wait_for.ps1
+++ b/lib/ansible/modules/windows/win_wait_for.ps1
@@ -26,6 +26,8 @@ $result = @{
     changed = $false
 }
 
+Load-FileUtilFunctions
+
 # validate the input with the various options
 if ($port -ne $null -and $path -ne $null) {
     Fail-Json $result "port and path parameter can not both be passed to win_wait_for"

--- a/test/integration/targets/win_module_utils/library/file_util_test.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test.ps1
@@ -43,7 +43,7 @@ try {
     Test-AnsiblePath -Path C:\Windows\*.exe
 } catch {
     $failed = $true
-    Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"GetAttributes`" with `"1`" argument(s): `"Illegal characters in path.`""
+    Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"GetAttributes`" with `"1`" argument(s): `"GetFileAttributesExW(C:\Windows\*.exe) failed (The filename, directory name, or volume label syntax is incorrect, Win32ErrorCode 123)`""
 }
 Assert-Equals -actual $failed -expected $true
 

--- a/test/integration/targets/win_module_utils/library/file_util_test_max_path.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test_max_path.ps1
@@ -1,0 +1,423 @@
+#!powershell
+
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+#Requires -Module Ansible.ModuleUtils.Legacy
+#Requires -Module Ansible.ModuleUtils.FileUtil
+
+$ErrorActionPreference = "Stop"
+
+$params = Parse-Args $args
+$path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
+
+$result = @{
+    changed = $false
+}
+Load-FileUtilFunctions
+
+Function Assert-Equals($actual, $expected, $msg) {
+    if ($actual -ne $expected) {
+        $call_stack = (Get-PSCallStack)[1]
+        $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
+        if ($msg) {
+            $error_msg += "`r`n$msg"
+        }
+        Fail-Json -obj $result -message $error_msg
+    }
+}
+
+Function Clear-TestDirectory($path) {
+    $path = "\\?\$path"
+    if ([Ansible.IO.Directory]::Exists($path)) {
+        [Ansible.IO.Directory]::Delete($path, $true) > $null
+    }
+    [Ansible.IO.Directory]::CreateDirectory($path) > $null
+}
+
+Function Test-FileClass($root_path) {
+    ### FileInfo Tests ### https://msdn.microsoft.com/en-us/library/system.io.fileinfo(v=vs.110).aspx
+    # Test Class Attributes when file does not exist
+
+    # Test Class Attributes when file does exist
+
+    # Test properties
+
+    # Test Functions
+
+    ### File Tests ### https://msdn.microsoft.com/en-us/library/system.io.file(v=vs.110).aspx
+    # AppendAllLines(String, IEnumerable<String>)
+    # AppendAllLines(String, IEnumerable<String>, Encoding)
+    # AppendAllText(String, String)
+    # AppendAllText(String, Encoding)
+    # AppendText(String)
+    # Copy(String, String)
+    # Copy(String, String, Boolean)
+    # Create(String)
+    # Create(String, Int32)
+    # Create(string, Int32, FileOptions)
+    # Create(String, Int32, FileOptions, FileSecurity)
+    # CreateText(String)
+    # Decrypt(String)
+    # Delete(string)
+    # Encrypt(String)
+    # Exists(String)
+    # GetAccessControl(String)
+    # GetAccessControl(String, AccessControlSelections)
+    # GetAttributes(String)
+    # GetCreationTime(String)
+    # GetCreationTimeUtc(String)
+    # GetLastAccessTime(String)
+    # GetLastAccessTimeUtc(String)
+    # GetLastWriteTime(String)
+    # GetLastWriteTimeUtc(String)
+    # Move(String, String)
+    # Open(String, FileMode)
+    # Open(String, FileMode, FileAccess)
+    # Open(String, FileMode, FileAccess, FileShare)
+    # OpenRead(String)
+    # OpenText(String)
+    # OpenWrite(String)
+    # ReadAllBytes(String)
+    # ReadAllLines(String)
+    # ReadAllLines(String, Encoding)
+    # ReadAllText(String)
+    # ReadAllText(String, Encoding)
+    # ReadLines(String)
+    # ReadLines(String, Encoding)
+    # Replace(String, String, String)
+    # Replace(String, String, String, Boolean)
+    # SetAccessControl(String, FileSecurity)
+    # SetAttributes(String, FileAttributes)
+    # SetCreationTime(String, DateTime)
+    # SetCreationTimeUtc(String, DateTime)
+    # SetLastAccessTime(String, DateTime)
+    # SetLastAccessTimeUtc(String, DateTime)
+    # SetLastWriteTime(String, DateTime)
+    # SetLastWriteTimeUtc(String, DateTime)
+    # WriteAllBytes(String, Byte[])
+    # WriteAllLines(String, IEnumerable<String>)
+    # WriteAllLines(String, IEnumerable<String>, Encoding)
+    # WriteAllLines(String, String[])
+    # WriteAllLines(String, String[], Encoding)
+    # WriteAllText(String, String)
+    # WriteAllText(String, String, Encoding)
+}
+Function Test-DirectoryClass($root_path) {
+    $directory_path = "$root_path\dir"
+
+    ### DirectoryInfo Tests ###
+    $dir = New-Object -TypeName Ansible.IO.DirectoryInfo -ArgumentList $directory_path
+
+    # Test class attributes when it doesn't exist
+    Assert-Equals -actual $dir.Exists -expected $false
+    Assert-Equals -actual $dir.Name -expected "dir"
+    Assert-Equals -actual $dir.Parent.ToString() -expected $root_path
+    if ($root_path.StartsWith("\\?\")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\?\C:\"
+    } else {
+        Assert-Equals -actual $dir.Root.ToString() -expected "C:\"
+    }
+    Assert-Equals -actual ([Int32]$dir.Attributes) -expected -1
+    Assert-Equals -actual $dir.CreationTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $dir.Extension -expected ""
+    Assert-Equals -actual $dir.FullName -expected $directory_path
+    Assert-Equals -actual $dir.LastAccessTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $dir.LastWriteTimeUtc.ToFileTimeUtc() -expected 0
+
+    # create directory
+    $current_time = (Get-Date).ToFileTimeUtc()
+    $dir.Create()
+    $dir.Refresh() # resets the properties of the class
+
+    # Test class attributes when it does exist
+    Assert-Equals -actual $dir.Exists -expected $true
+    Assert-Equals -actual $dir.Name -expected "dir"
+    Assert-Equals -actual $dir.Parent.ToString() -expected $root_path 
+    if ($root_path.StartsWith("\\?\")) {
+        Assert-Equals -actual $dir.Root.ToString() -expected "\\?\C:\"
+    } else {
+        Assert-Equals -actual $dir.Root.ToString() -expected "C:\"
+    }
+    Assert-Equals -actual $dir.Attributes -expected ([System.IO.FileAttributes]::Directory)
+    Assert-Equals -actual ($dir.CreationTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual $dir.Extension -expected ""
+    Assert-Equals -actual $dir.FullName -expected $directory_path
+    Assert-Equals -actual ($dir.LastAccessTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual ($dir.LastWriteTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    # set properties
+    $dir.Attributes = $dir.Attributes -bor [System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden
+    $dir.Refresh()
+    Assert-Equals -actual $dir.Attributes -expected ([System.IO.FileAttributes]::Directory -bor [System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden)
+
+    $new_date = (Get-Date -Date "1993-06-11 06:51:32Z")
+    $dir.CreationTimeUtc = $new_date
+    $dir.Refresh()
+    Assert-Equals -actual $dir.CreationTimeUtc.ToFileTimeUtc() -expected $new_date.ToFileTimeUtc()
+    $dir.LastAccessTimeUtc = $new_date
+    $dir.Refresh()
+    Assert-Equals -actual $dir.LastAccessTimeUtc.ToFileTimeUtc() -expected $new_date.ToFileTimeUtc()
+    $dir.LastWriteTimeUtc = $new_date
+    $dir.Refresh()
+    Assert-Equals -actual $dir.LastWriteTimeUtc.ToFileTimeUtc() -expected $new_date.ToFileTimeUtc()
+
+    # test DirectoryInfo methods
+    # create tests
+    $subdir = $dir.CreateSubDirectory("subdir")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir")) -expected $true
+
+    # enumerate tests
+    $subdir1 = $dir.CreateSubDirectory("subdir-1")
+    $subdir2 = $dir.CreateSubDirectory("subdir-2")
+    $subdir3 = $subdir1.CreateSubDirectory("subdir3")
+    $file = [Ansible.IO.File]::CreateText("$directory_path\file.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\anotherfile.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\file-1.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-2\file-2.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\subdir3\file-3.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+
+    $dir_dirs = $dir.EnumerateDirectories()
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.EnumerateDirectories("subdir-?")
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in ("subdir-1", "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.EnumerateDirectories("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+    }
+
+    $dir_dirs = $dir.GetDirectories()
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.GetDirectories("subdir-?")
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in ("subdir-1", "subdir-2")) -expected $true
+    }
+    $dir_dirs = $dir.GetDirectories("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+    }
+
+    $dir_files = $dir.EnumerateFiles()
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.EnumerateFiles("anotherfile*")
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.EnumerateFiles("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt")) -expected $true
+    }
+
+    $dir_files = $dir.GetFiles()
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.GetFiles("anotherfile*")
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_files = $dir.GetFiles("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
+        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt")) -expected $true
+    }
+
+    $dir_entries = $dir.EnumerateFileSystemInfos()
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "subdir", "subdir-1", "subdir-2")) -expected $true
+    }
+    $dir_entries = $dir.EnumerateFileSystemInfos("anotherfile*")
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_entries = $dir.EnumerateFileSystemInfos("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt", "subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+    }
+
+    $dir_entries = $dir.GetFileSystemInfos()
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "subdir", "subdir-1", "subdir-2")) -expected $true
+    }
+    $dir_entries = $dir.GetFileSystemInfos("anotherfile*")
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("anotherfile.txt")) -expected $true
+    }
+    $dir_entries = $dir.GetFileSystemInfos("*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt", "subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+    }
+    
+    # move tests
+    $subdir2.MoveTo("$directory_path\subdir-move")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-move")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\subdir-move\file-2.txt")) -expected $true
+
+    # delete tests
+    try {
+        # fail to delete a directory that has contents
+        $subdir1.Delete()
+    } catch {
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Delete`" with `"0`" argument(s): `"RemoveDirectoryW($($subdir1.FullName)) failed (The directory is not empty, Win32ErrorCode 145)`""
+    }
+    $subdir1.Delete($true)
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-1")) -expected $false
+    $subdir = $dir.CreateSubDirectory("subdir")
+    $subdir.Delete()
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir")) -expected $false
+
+    # ACL tests
+    $current_sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User
+    $everyone_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-1-0"
+
+    $dir_sec = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+    $read_rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $everyone_sid, "FullControl", "Allow"
+    $dir_sec.SetAccessRule($read_rule)
+    $dir_sec.SetOwner($current_sid)
+    $dir_sec.SetGroup($everyone_sid)
+    $acl_dir = $dir.CreateSubDirectory("acl-dir", $dir_sec)
+
+    $actual_acl = $acl_dir.GetAccessControl()
+    $access_rules = $actual_acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+
+    $acl_owner = $actual_acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $acl_group = $actual_acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $acl_owner -expected $current_sid
+    Assert-Equals -actual $acl_group -expected $everyone_sid
+
+    # only admins can set audit rules, we test for failure if not running as admin
+    $audit_rule = New-Object -TypeName System.Security.AccessControl.FileSystemAuditRule -ArgumentList $everyone_sid, "Read", "Success"
+    $dir_sec = $acl_dir.GetAccessControl()
+    $dir_sec.SetAuditRule($audit_rule)
+    if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $acl_dir.SetAccessControl($dir_sec)
+        $actual_acl = $acl_dir.GetAccessControl([System.Security.AccessControl.AccessControlSections]::All)
+        $audit_rules = $actual_acl.GetAuditRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+        Assert-Equals -actual $audit_rules.Count -expected 1
+        Assert-Equals -actual $audit_rules[0].FileSystemRights.ToString() -expected "Read"
+        Assert-Equals -actual $audit_rules[0].AuditFlags.ToString() -expected "Success"
+        Assert-Equals -actual $audit_rules[0].IsInherited -expected $false
+        Assert-Equals -actual $audit_rules[0].IdentityReference -expected $everyone_sid
+    } else {
+        try {
+            $acl_dir.SetAccessControl($dir_sec)
+        } catch {
+            Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"SetAccessControl`" with `"1`" argument(s): `"SetNamedSecurityInfoW($($acl_dir.FullName)) failed (A required privilege is not held by the client, Win32ErrorCode 1314)`""
+        }
+    }
+
+    ### Directory Tests ###
+    # CreateDirectory(String)
+    # CreateDirectory(String, DirectorySecurity)
+    # Delete(String)
+    # Delete(String, Boolean)
+    # EnumerateDirectories(String)
+    # EnumerateDirectories(String, String)
+    # EnumerateDirectories(String, String, SearchOption)
+    # EnumerateFiles(String)
+    # EnumerateFiles(String, String)
+    # EnumerateFiles(String, String, SearchOption)
+    # EnumerateFileSystemEntries(String)
+    # EnumerateFileSystemEntries(String, String)
+    # EnumerateFileSystemEntries(String, String, SearchOption)
+    # Exists(String)
+    # GetAccessControl(String)
+    # GetAccessControl(String, AccessControlSelections)
+    # GetCreationTime(String)
+    # GetCreationTimeUtc(String)
+    # GetDirectories(String)
+    # GetDirectories(String, String)
+    # GetDirectories(String, String, SearchOption)
+    # GetFiles(String)
+    # GetFiles(String, String)
+    # GetFiles(String, String, SearchOption)
+    # GetFileSystemEntries(String)
+    # GetFileSystemEntries(String, String)
+    # GetFileSystemEntries(String, String, SearchOption)
+    # GetLastAccessTime(String)
+    # GetLastAccessTimeUtc(String)
+    # GetLastWriteTime(String)
+    # GetLastWriteTimeUtc(String)
+    # GetParent(String)
+    # Move(String, String)
+    # SetAccessControl(String, DirectorySecurity)
+    # SetCreationTime(String, DateTime)
+    # SetCreationTimeUtc(String, DateTime)
+    # SetLastAccessTime(String, DateTime)
+    # SetLastAccessTimeUtc(String, DateTime)
+    # SetLastWriteTime(String, DateTime)
+    # SetLastWriteTimeUtc(String, DateTime)
+}
+
+# call each test three times
+# 1 - Normal Path
+# 2 - Normal Path with the \\?\ prefix
+# 3 - Path exceeding 260 chars with the \\?\ prefix
+Clear-TestDirectory -path $path
+Test-FileClass -root_path $path
+Test-DirectoryClass -root_path $path
+
+Clear-TestDirectory -path $path
+Test-FileClass -root_path "\\?\$path"
+Test-DirectoryClass -root_path "\\?\$path"
+
+Clear-TestDirectory -path $path
+$long_path = "\\?\$path\long-path-test\$("a" * 240)"
+[Ansible.IO.Directory]::CreateDirectory($long_path) > $null
+Test-FileClass -root_path $long_path
+Test-DirectoryClass -root_path $long_path
+
+[Ansible.IO.Directory]::Delete("\\?\" + $path, $true) > $null
+$result.data = "success"
+Exit-Json -obj $result
+

--- a/test/integration/targets/win_module_utils/library/file_util_test_max_path.ps1
+++ b/test/integration/targets/win_module_utils/library/file_util_test_max_path.ps1
@@ -1,8 +1,5 @@
 #!powershell
 
-# Copyright: (c) 2018, Ansible Project
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.FileUtil
 
@@ -10,19 +7,37 @@ $ErrorActionPreference = "Stop"
 
 $params = Parse-Args $args
 $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
+$encrypt_tests = Get-AnsibleParam -obj $params -name "encrypt_tests" -type "bool" -default $false
 
 $result = @{
     changed = $false
 }
 Load-FileUtilFunctions
 
-Function Assert-Equals($actual, $expected, $msg) {
+Function Assert-Equals($actual, $expected) {
     if ($actual -ne $expected) {
         $call_stack = (Get-PSCallStack)[1]
         $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
-        if ($msg) {
-            $error_msg += "`r`n$msg"
+        Fail-Json -obj $result -message $error_msg
+    }
+}
+
+Function Assert-ArrayEquals($actual, $expected) {
+    $equals = $true
+    if ($actual.Count -ne $expected.Count) {
+        $equals = $false
+    } else {
+        for ($i = 0; $i -lt $actual.Count; $i++) {
+            if ($actual[$i] -ne $expected[$i]) {
+                $equals = $false
+                break
+            }
         }
+    }
+    
+    if (-not $equals) {
+        $call_stack = (Get-PSCallStack)[1]
+        $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
         Fail-Json -obj $result -message $error_msg
     }
 }
@@ -36,72 +51,563 @@ Function Clear-TestDirectory($path) {
 }
 
 Function Test-FileClass($root_path) {
-    ### FileInfo Tests ### https://msdn.microsoft.com/en-us/library/system.io.fileinfo(v=vs.110).aspx
+    $file_path = "$root_path\file.txt"
+
+    ### FileInfo Tests ###
     # Test Class Attributes when file does not exist
+    $file = New-Object -TypeName Ansible.IO.FileInfo -ArgumentList $file_path
+    Assert-Equals -actual ([Int32]$file.Attributes) -expected -1
+    Assert-Equals -actual $file.CreationTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $file.Directory.FullName -expected $root_path
+    Assert-Equals -actual $file.DirectoryName -expected $root_path
+    Assert-Equals -actual $file.Exists -expected $false
+    Assert-Equals -actual $file.Extension -expected ".txt"
+    Assert-Equals -actual $file.FullName -expected $file_path
+    Assert-Equals -actual $file.IsReadOnly -expected $true
+    Assert-Equals -actual $file.LastAccessTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $file.LastWriteTimeUtc.ToFileTimeUtc() -expected 0
+    Assert-Equals -actual $file.Length -expected $null
+    Assert-Equals -actual $file.Name -expected "file.txt"
+    
+    # Test Class Attributes when file exists
+    $current_time = (Get-Date).ToFileTImeUtc()
+    $fs = $file.Create()
+    $fs.Close()
+    $file.Refresh()
+    Assert-Equals -actual $file.Attributes -expected ([System.IO.FileAttributes]::Archive)
+    Assert-Equals -actual ($file.CreationTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual $file.Directory.FullName -expected $root_path
+    Assert-Equals -actual $file.DirectoryName -expected $root_path
+    Assert-Equals -actual $file.Exists -expected $true
+    Assert-Equals -actual $file.Extension -expected ".txt"
+    Assert-Equals -actual $file.FullName -expected $file_path
+    Assert-Equals -actual $file.IsReadOnly -expected $false
+    Assert-Equals -actual ($file.LastAccessTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual ($file.LastWriteTimeUtc.ToFileTimeUtc() -ge $current_time) -expected $true
+    Assert-Equals -actual $file.Length -expected 0
+    Assert-Equals -actual $file.Name -expected "file.txt"
 
-    # Test Class Attributes when file does exist
+    # Set Properties
+    $file.Attributes = $file.Attributes -bor [System.IO.FileAttributes]::Hidden
+    $file.Refresh()
+    Assert-Equals -actual $file.Attributes -expected ([System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden)
 
-    # Test properties
+    $file.IsReadOnly = $true
+    $file.Refresh()
+    Assert-Equals -actual $file.Attributes.HasFlag([System.IO.FileAttributes]::ReadOnly) -expected $true
+
+    $file.IsReadOnly = $false
+    $file.Refresh()
+    Assert-Equals -actual $file.Attributes.HasFlag([System.IO.FileAttributes]::ReadOnly) -expected $false
+    
+    $new_date = (Get-Date -Date "1993-06-11 06:51:32Z")
+    $file.CreationTimeUtc = $new_date
+    $file.Refresh()
+    Assert-Equals -actual $file.CreationTimeUtc -expected $new_date
+
+    $file.LastAccessTimeUtc = $new_date
+    $file.Refresh()
+    Assert-Equals -actual $file.LastAccessTimeUtc -expected $new_date
+
+    $file.LastWriteTimeUtc = $new_date
+    $file.Refresh()
+    Assert-Equals -actual $file.LastWriteTimeUtc -expected $new_date
 
     # Test Functions
+    # CreateText() fails if the file is already open
+    $failed = $false
+    try {
+        $sw = $file.CreateText()
+        $sw.Close()
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"CreateText`" with `"0`" argument(s): `"CreateFileW($root_path\file.txt) failed (Access is denied, Win32ErrorCode 5)`""
+    }
+    Assert-Equals -actual $failed -expected $true
 
-    ### File Tests ### https://msdn.microsoft.com/en-us/library/system.io.file(v=vs.110).aspx
-    # AppendAllLines(String, IEnumerable<String>)
-    # AppendAllLines(String, IEnumerable<String>, Encoding)
-    # AppendAllText(String, String)
-    # AppendAllText(String, Encoding)
-    # AppendText(String)
-    # Copy(String, String)
-    # Copy(String, String, Boolean)
-    # Create(String)
-    # Create(String, Int32)
-    # Create(string, Int32, FileOptions)
-    # Create(String, Int32, FileOptions, FileSecurity)
-    # CreateText(String)
-    # Decrypt(String)
-    # Delete(string)
-    # Encrypt(String)
-    # Exists(String)
-    # GetAccessControl(String)
-    # GetAccessControl(String, AccessControlSelections)
-    # GetAttributes(String)
-    # GetCreationTime(String)
-    # GetCreationTimeUtc(String)
-    # GetLastAccessTime(String)
-    # GetLastAccessTimeUtc(String)
-    # GetLastWriteTime(String)
-    # GetLastWriteTimeUtc(String)
-    # Move(String, String)
-    # Open(String, FileMode)
-    # Open(String, FileMode, FileAccess)
-    # Open(String, FileMode, FileAccess, FileShare)
-    # OpenRead(String)
-    # OpenText(String)
-    # OpenWrite(String)
-    # ReadAllBytes(String)
-    # ReadAllLines(String)
-    # ReadAllLines(String, Encoding)
-    # ReadAllText(String)
-    # ReadAllText(String, Encoding)
-    # ReadLines(String)
-    # ReadLines(String, Encoding)
-    # Replace(String, String, String)
-    # Replace(String, String, String, Boolean)
-    # SetAccessControl(String, FileSecurity)
-    # SetAttributes(String, FileAttributes)
-    # SetCreationTime(String, DateTime)
-    # SetCreationTimeUtc(String, DateTime)
-    # SetLastAccessTime(String, DateTime)
-    # SetLastAccessTimeUtc(String, DateTime)
-    # SetLastWriteTime(String, DateTime)
-    # SetLastWriteTimeUtc(String, DateTime)
-    # WriteAllBytes(String, Byte[])
-    # WriteAllLines(String, IEnumerable<String>)
-    # WriteAllLines(String, IEnumerable<String>, Encoding)
-    # WriteAllLines(String, String[])
-    # WriteAllLines(String, String[], Encoding)
-    # WriteAllText(String, String)
-    # WriteAllText(String, String, Encoding)
+    $file.Delete()
+    $file.Refresh()
+    Assert-Equals -actual $file.Exists -expected $false
+    
+    $sw = $file.CreateText()
+    try {
+        $sw.WriteLine("line1")
+        $sw.WriteLine("line2")
+    } finally {
+        $sw.Close()
+    }
+    $file.Refresh()
+
+    $sr = $file.OpenText()
+    try {
+        $file_contents = $sr.ReadToEnd()
+    } finally {
+        $sr.Close()
+    }
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`n"
+
+    $copied_file = $file.CopyTo("$root_path\copy.txt")
+    Assert-Equals -actual $file.Exists -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy.txt")) -expected $true
+    $file_hash = Get-AnsibleFileHash -Path $file.FullName
+    $copied_file_hash = Get-AnsibleFileHash -Path $copied_file.FullName
+    Assert-Equals -actual $file_hash -expected $copied_file_hash
+
+    $failed = $false
+    try {
+        $file.CopyTo("$root_path\copy.txt")
+    } catch {
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"CopyTo`" with `"1`" argument(s): `"CopyFileW failed to copy $root_path\file.txt to $root_path\copy.txt (The file exists, Win32ErrorCode 80)`""
+        $failed = $true
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $sw = $file.AppendText()
+    try {
+        $sw.WriteLine("line3")
+    } finally {
+        $sw.Close()
+    }
+    $copied_file = $file.CopyTo("$root_path\copy.txt", $true)
+    Assert-Equals -actual $file.Exists -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy.txt")) -expected $true
+    $file_hash = Get-AnsibleFileHash -Path $file.FullName
+    $copied_file_hash = Get-AnsibleFileHash -Path $copied_file.FullName
+    Assert-Equals -actual $file_hash -expected $copied_file_hash
+
+    # also test out the line3 was appended correctly
+    $sr = $file.OpenText()
+    try {
+        $file_contents = $sr.ReadToEnd()
+    } finally {
+        $sr.Close()
+    }
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`nline3`r`n"
+
+    # these tests will only work over WinRM when become or CredSSP is used
+    if ($encrypt_tests) {
+        $file.Encrypt()
+        $file.Refresh()
+        Assert-Equals $file.Attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $true
+
+        $file.Decrypt()
+        $file.Refresh()
+        Assert-Equals $file.Attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $false
+    }
+
+    $original_hash = Get-AnsibleFileHash -Path $copied_file.FullName
+    $copied_file.MoveTo("$root_path\moved.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy.txt")) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\moved.txt")) -expected $true
+    $moved_hash = Get-AnsibleFileHash -path "$root_path\moved.txt"
+    Assert-Equals -actual $moved_hash -expected $original_hash
+
+    $target_file = New-Object -TypeName Ansible.IO.FileInfo -ArgumentList "$root_path\target.txt"
+    $backup_file = New-Object -TypeName Ansible.IO.FileInfo -ArgumentList "$root_path\backup.txt"
+    $sw = $target_file.CreateText()
+    try {
+        $sw.WriteLine("original target")
+    } finally {
+        $sw.Close()
+    }
+    $original_target_hash = Get-AnsibleFileHash -Path $target_file.FullName
+    $original_source_hash = Get-AnsibleFileHash -Path $file.FullName
+    $replaced_file = $file.Replace($target_file.FullName, $backup_file.FullName)
+    $file.Refresh()
+    $target_file.Refresh()
+    $backup_file.Refresh()
+    $new_target_hash = Get-AnsibleFileHash -Path $replaced_file.FullName
+    $backup_hash = Get-AnsibleFileHash -Path $backup_file.FullName
+    Assert-Equals -actual $file.Exists -expected $false
+    Assert-Equals -actual $replaced_file.FullName -expected $target_file.FullName
+    Assert-Equals -actual $replaced_file.Exists -expected $true
+    Assert-Equals -actual $backup_file.Exists -expected $true
+    Assert-Equals -actual $new_target_hash -expected $original_source_hash
+    Assert-Equals -actual $backup_hash -expected $original_target_hash
+    $file = $replaced_file
+
+    $fs = $file.OpenRead()
+    $failed = $false
+    try {
+        $fs.WriteByte([byte]0x21)
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"WriteByte`" with `"1`" argument(s): `"Stream does not support writing.`""
+    } finally {
+        $fs.Close()
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $fs = $file.OpenRead()
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`nline3`r`n"
+
+    $fs = $file.OpenWrite()
+    try {
+        $fs.WriteByte([byte]0x21)
+    } finally {
+        $fs.Close()
+    }
+    $fs = $file.OpenRead()
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "!ine1`r`nline2`r`nline3`r`n"
+
+    $fs = $file.Open([System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+    try {
+        $fs.WriteByte([byte]0x21)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $fs = $file.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "!"
+
+    # open a file with append (CreateFileW doesn't work with append so make sure the stuff around it is fine)
+    $fs = $file.Open([System.IO.FileMode]::Append, [System.IO.FileAccess]::Write)
+    try {
+        $fs.WriteByte([byte]0x21)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $fs = $file.Open([System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+    try {
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    Assert-Equals -actual $file_contents -expected "!!"
+
+    $current_sid = ([System.Security.Principal.WindowsIdentity]::GetCurrent()).User
+    $everyone_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-1-0"
+    
+    $acl = New-Object -TypeName System.Security.AccessControl.FileSecurity
+    $acl.SetGroup($everyone_sid)
+    $acl.SetOwner($current_sid)
+    $acl.SetAccessRule((New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $everyone_sid, "FullControl", "Allow"))
+    $file.SetAccessControl($acl)
+
+    $file.Refresh()
+    $acl = $file.GetAccessControl()
+    $access_rules = $acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $explicit_access_rules = $access_rules | Where-Object { $_.IsInherited -eq $false }
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $everyone_sid
+    Assert-Equals -actual $explicit_access_rules.Count -expected 1
+    Assert-Equals -actual $explicit_access_rules[0].IdentityReference -expected $everyone_sid
+    
+    $limited_acl = $file.GetAccessControl([System.Security.AccessControl.AccessControlSections]::Owner)
+    $owner = $limited_acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $limited_acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $null
+
+    ### File Tests ###
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($root_path)) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+
+    $fs = [Ansible.IO.File]::Create($file_path)
+    $fs.Close()
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $true
+
+    [Ansible.IO.File]::Delete($file_path)
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+
+    $fs = [Ansible.IO.File]::Create($file_path, 4096, [System.IO.FileOptions]::None, $acl)
+    $fs.Close()
+    $acl = [Ansible.IO.File]::GetAccessControl($file_path)
+    $access_rules = $acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $explicit_access_rules = $access_rules | Where-Object { $_.IsInherited -eq $false }
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $everyone_sid
+    Assert-Equals -actual $explicit_access_rules.Count -expected 1
+    Assert-Equals -actual $explicit_access_rules[0].IdentityReference -expected $everyone_sid
+
+    # need to be an admin to set this
+    if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $admin_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
+        $acl.SetOwner($admin_sid)
+        [Ansible.IO.File]::SetAccessControl($file_path, $acl)
+
+        $limited_acl = [Ansible.IO.File]::GetAccessControl($file_path, [System.Security.AccessControl.AccessControlSections]::Owner)
+        $owner = $limited_acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+        $group = $limited_acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+        Assert-Equals -actual $owner -expected $admin_sid
+        Assert-Equals -actual $group -expected $null
+    }
+
+    [Ansible.IO.File]::SetCreationTimeUtc($file_path, $new_date)
+    $creation_time = [Ansible.IO.File]::GetCreationTimeUtc($file_path)
+    Assert-Equals -actual $creation_time -expected $new_date
+
+    [Ansible.IO.File]::SetLastAccessTimeUtc($file_path, $new_date)
+    $lastaccess_time = [Ansible.IO.File]::GetLastAccessTimeUtc($file_path)
+    Assert-Equals -actual $lastaccess_time -expected $new_date
+
+    [Ansible.IO.File]::SetLastWriteTimeUtc($file_path, $new_date)
+    $lastwrite_time = [Ansible.IO.File]::GetLastWriteTimeUtc($file_path)
+    Assert-Equals -actual $lastwrite_time -expected $new_date
+
+    $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+    Assert-Equals -actual $attributes -expected ([System.IO.FileAttributes]::Archive)
+
+    [Ansible.IO.File]::SetAttributes($file_path, ($attributes -bor [System.IO.FileAttributes]::Hidden))
+    $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+    Assert-Equals -actual $attributes -expected ([System.IO.FileAttributes]::Archive -bor [System.IO.FileAttributes]::Hidden)
+
+    if ($encrypt_tests) {
+        [Ansible.IO.File]::Encrypt($file_path)
+        $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+        Assert-Equals -actual $attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $true
+
+        [Ansible.IO.File]::Decrypt($file_path)
+        $attributes = [Ansible.IO.File]::GetAttributes($file_path)
+        Assert-Equals -actual $attributes.HasFlag([System.IO.FileAttributes]::Encrypted) -expected $false
+    }
+
+    [Ansible.IO.File]::AppendAllText($file_path, "line1`r`nline2`r`n")
+    $file_contents = [Ansible.IO.File]::ReadAllText($file_path)
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`n"
+
+    [Ansible.IO.File]::AppendAllText($file_path, "line3`r`nline4`r`n")
+    $file_contents = [Ansible.IO.File]::ReadAllText($file_path)
+    Assert-Equals -actual $file_contents -expected "line1`r`nline2`r`nline3`r`nline4`r`n"
+
+    [Ansible.IO.File]::Copy($file_path, "$root_path\copy-file.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\copy-file.txt")) -expected $true
+    $source_hash = Get-AnsibleFileHash -Path $file_path
+    $target_hash = Get-AnsibleFileHash -Path "$root_path\copy-file.txt"
+    Assert-Equals -actual $target_hash -expected $source_hash
+
+    [Ansible.IO.File]::Move($file_path, "$root_path\move-file.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\move-file.txt")) -expected $true
+    $target_hash = Get-AnsibleFileHash -Path "$root_path\move-file.txt"
+    Assert-Equals -actual $target_hash -expected $source_hash
+
+    $failed = $false
+    try {
+        [Ansible.IO.File]::Move("$root_path\copy-file.txt", "$root_path\move-file.txt")
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Move`" with `"2`" argument(s): `"MoveFileExW() failed to copy $root_path\copy-file.txt to $root_path\move-file.txt (Cannot create a file when that file already exists, Win32ErrorCode 183)`""
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    $fs = [Ansible.IO.File]::Create($file_path)
+    $fs.Close()
+    [Ansible.IO.File]::AppendAllText($file_path, "source text")
+    [Ansible.IO.File]::Delete("$root_path\target.txt")
+    $fs = [Ansible.IO.File]::Create("$root_path\target.txt")
+    $fs.Close()
+    [Ansible.IO.File]::AppendAllText("$root_path\target.txt", "target text")
+
+    $source_hash = Get-AnsibleFileHash -Path $file_path
+    $target_hash = Get-AnsibleFileHash -Path "$root_path\target.txt"
+    [Ansible.IO.File]::Replace($file_path, "$root_path\target.txt", "$root_path\backup.txt")
+    Assert-Equals -actual ([Ansible.IO.File]::Exists($file_path)) -expected $false
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\target.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$root_path\backup.txt")) -expected $true
+    $new_target_hash = Get-AnsibleFileHash -Path "$root_path\target.txt"
+    $backup_hash = Get-AnsibleFileHash -Path "$root_path\backup.txt"
+    Assert-Equals -actual $new_target_hash -expected $source_hash
+    Assert-Equals -actual $backup_hash -expected $target_hash
+
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\target.txt")
+    $file_contents = ([System.Text.Encoding]::UTF8).GetString($file_bytes)
+    $a = ([System.Text.Encoding]::UTF8).GetBytes("source text")
+    Assert-Equals -actual $file_contents.Remove(0, 1) -expected "source text"
+
+    $utf8_bytes = ([System.Text.Encoding]::UTF8).GetBytes("Hello World!")
+    $utf16_bytes = ([System.Text.Encoding]::Unicode).GetBytes("Hello World!")
+    $fs = [Ansible.IO.File]::OpenWrite("$root_path\utf8.txt")
+    try {
+        $fs.Write($utf8_bytes, 0, $utf8_bytes.Length)
+    } finally {
+        $fs.Close()
+    }
+    $fs = [Ansible.IO.File]::OpenWrite("$root_path\utf16.txt")
+    try {
+        $fs.Write($utf16_bytes, 0, $utf16_bytes.Length)
+    } finally {
+        $fs.Close()
+    }
+
+    [Ansible.IO.File]::AppendAllText("$root_path\utf8.txt", "`r`nanother line")
+    $expected_text = "Hello World!`r`nanother line"
+    $expected_bytes = ([System.Text.Encoding]::UTF8).GetBytes($expected_text)
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    $file_text = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    $file_lines = [Ansible.IO.File]::ReadAllLines("$root_path\utf8.txt")
+    $file_lines_enumerable = [Ansible.IO.File]::ReadLines("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+    Assert-Equals -actual $file_text -expected $expected_text
+    Assert-Equals -actual $file_lines.Count -expected 2
+    Assert-Equals -actual $file_lines[0] -expected "Hello World!"
+    Assert-Equals -actual $file_lines[1] -expected "another line"
+    $is_first = $true
+    foreach ($line in $file_lines_enumerable) {
+        if ($is_first) {
+            Assert-Equals -actual $line -expected "Hello World!"
+        } else {
+            Assert-Equals -actual $line -expected "another line"
+        }
+        $is_first = $false
+    }
+
+
+    [Ansible.IO.File]::AppendAllText("$root_path\utf16.txt", "`r`nanother line", [System.Text.Encoding]::Unicode)
+    $expected_text = "Hello World!`r`nanother line"
+    $expected_bytes = ([System.Text.Encoding]::Unicode).GetBytes($expected_text)
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf16.txt")
+    $file_text = [Ansible.IO.File]::ReadAllText("$root_path\utf16.txt", [System.Text.Encoding]::Unicode)
+    $file_lines = [Ansible.IO.File]::ReadAllLines("$root_path\utf16.txt", [System.Text.Encoding]::Unicode)
+    $file_lines_enumerable = [Ansible.IO.File]::ReadLines("$root_path\utf16.txt", [System.Text.Encoding]::Unicode)
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+    Assert-Equals -actual $file_text -expected $expected_text
+    Assert-Equals -actual $file_lines.Count -expected 2
+    Assert-Equals -actual $file_lines[0] -expected "Hello World!"
+    Assert-Equals -actual $file_lines[1] -expected "another line"
+    $is_first = $true
+    foreach ($line in $file_lines_enumerable) {
+        if ($is_first) {
+            Assert-Equals -actual $line -expected "Hello World!"
+        } else {
+            Assert-Equals -actual $line -expected "another line"
+        }
+        $is_first = $false
+    }
+
+    [Ansible.IO.File]::WriteAllLines("$root_path\utf8.txt", [string[]]@("line 1", "line 2"))
+    $expected_bytes = [byte[]](([System.Text.Encoding]::UTF8).GetPreamble() + ([System.Text.Encoding]::UTF8).GetBytes("line 1`r`nline 2`r`n"))
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllLines("$root_path\utf16.txt", [string[]]@("line 1", "line 2"), [System.Text.Encoding]::Unicode)
+    $expected_bytes = [byte[]](([System.Text.Encoding]::Unicode).GetPreamble() + ([System.Text.Encoding]::Unicode).GetBytes("line 1`r`nline 2`r`n"))
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf16.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllText("$root_path\utf8.txt", "another line 1`r`nanother line 2`r`n")
+    $expected_bytes = [byte[]](([System.Text.Encoding]::UTF8).GetPreamble() + ([System.Text.Encoding]::UTF8).GetBytes("another line 1`r`nanother line 2`r`n"))
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllText("$root_path\utf16.txt", "another line 1`r`nanother line 2`r`n", [System.Text.Encoding]::Unicode)
+    $expected_bytes = [byte[]](([System.Text.Encoding]::Unicode).GetPreamble() + ([System.Text.Encoding]::Unicode).GetBytes("another line 1`r`nanother line 2`r`n"))
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf16.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected $expected_bytes
+
+    [Ansible.IO.File]::WriteAllBytes("$root_path\utf8.txt", [byte[]]@(0x21, 0x21))
+    $file_contents = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    Assert-Equals -actual $file_contents -expected "!!"
+
+    $sw = [Ansible.IO.File]::AppendText("$root_path\utf8.txt")
+    try {
+        $sw.WriteLine("!!")
+    } finally {
+        $sw.Close()
+    }
+    $file_contents = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    Assert-Equals -actual $file_contents -expected "!!!!`r`n"
+
+    $sw = [Ansible.IO.File]::CreateText("$root_path\utf8.txt")
+    try {
+        $sw.WriteLine("!!")
+    } finally {
+        $sw.Close()
+    }
+    $file_contents = [Ansible.IO.File]::ReadAllText("$root_path\utf8.txt")
+    Assert-Equals -actual $file_contents -expected "!!`r`n"
+
+    $sr = [Ansible.IO.File]::OpenText("$root_path\utf8.txt")
+    try {
+        $file_contents = $sr.ReadToEnd()
+    } finally {
+        $sr.Close()
+    }
+    Assert-Equals -actual $file_contents -expected "!!`r`n"
+
+    $fs = [Ansible.IO.File]::OpenRead("$root_path\utf8.txt")
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $true
+        Assert-Equals -actual $fs.CanWrite -expected $false
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(33, 33, 13, 10))
+
+    $fs = [Ansible.IO.File]::OpenWrite("$root_path\utf8.txt")
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $false
+        Assert-Equals -actual $fs.CanWrite -expected $true
+        $fs.WriteByte([byte]32)
+    } finally {
+        $fs.Close()
+    }
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(32, 33, 13, 10))
+
+    $fs = [Ansible.IO.File]::Open("$root_path\utf8.txt", [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::ReadWrite)
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $false
+        Assert-Equals -actual $fs.CanWrite -expected $true
+        $fs.WriteByte([byte]33)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $fs = [Ansible.IO.File]::Open("$root_path\utf8.txt", [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $true
+        Assert-Equals -actual $fs.CanWrite -expected $false
+        $file_bytes = New-Object -TypeName Byte[] -ArgumentList $fs.Length
+        $bytes_read = $fs.Read($file_bytes, 0, $fs.Length)
+    } finally {
+        $fs.Close()
+    }
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(33))
+
+    # open a file with append (CreateFileW doesn't work with append so make sure the stuff around it is fine)
+    $fs = [Ansible.IO.File]::Open("$root_path\utf8.txt", [System.IO.FileMode]::Append, [System.IO.FileAccess]::ReadWrite)
+    try {
+        Assert-Equals -actual $fs.CanRead -expected $true
+        Assert-Equals -actual $fs.CanWrite -expected $true
+        $fs.WriteByte([byte]32)
+        $fs.Flush()
+    } finally {
+        $fs.Close()
+    }
+    $file_bytes = [Ansible.IO.File]::ReadAllBytes("$root_path\utf8.txt")
+    Assert-ArrayEquals -actual $file_bytes -expected ([byte[]]@(33, 32))
 }
 Function Test-DirectoryClass($root_path) {
     $directory_path = "$root_path\dir"
@@ -205,39 +711,59 @@ Function Test-DirectoryClass($root_path) {
     $dir_dirs = $dir.EnumerateDirectories()
     foreach ($dir_name in $dir_dirs) {
         Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
-        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2")) -expected $true
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
     }
     $dir_dirs = $dir.EnumerateDirectories("subdir-?")
     foreach ($dir_name in $dir_dirs) {
         Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
-        Assert-Equals -actual ($dir_name.Name -in ("subdir-1", "subdir-2")) -expected $true
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir-1",
+            "subdir-2")) -expected $true
     }
     $dir_dirs = $dir.EnumerateDirectories("*", [System.IO.SearchOption]::AllDirectories)
     foreach ($dir_name in $dir_dirs) {
         Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
-        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
     }
 
     $dir_dirs = $dir.GetDirectories()
     foreach ($dir_name in $dir_dirs) {
         Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
-        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2")) -expected $true
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
     }
     $dir_dirs = $dir.GetDirectories("subdir-?")
     foreach ($dir_name in $dir_dirs) {
         Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
-        Assert-Equals -actual ($dir_name.Name -in ("subdir-1", "subdir-2")) -expected $true
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir-1",
+            "subdir-2")) -expected $true
     }
     $dir_dirs = $dir.GetDirectories("*", [System.IO.SearchOption]::AllDirectories)
     foreach ($dir_name in $dir_dirs) {
         Assert-Equals -actual $dir_name.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
-        Assert-Equals -actual ($dir_name.Name -in ("subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+        Assert-Equals -actual ($dir_name.Name -in (
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
     }
 
     $dir_files = $dir.EnumerateFiles()
     foreach ($dir_file in $dir_files) {
         Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
-        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt")) -expected $true
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt")) -expected $true
     }
     $dir_files = $dir.EnumerateFiles("anotherfile*")
     foreach ($dir_file in $dir_files) {
@@ -247,13 +773,20 @@ Function Test-DirectoryClass($root_path) {
     $dir_files = $dir.EnumerateFiles("*", [System.IO.SearchOption]::AllDirectories)
     foreach ($dir_file in $dir_files) {
         Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
-        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt")) -expected $true
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt")) -expected $true
     }
 
     $dir_files = $dir.GetFiles()
     foreach ($dir_file in $dir_files) {
         Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
-        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt")) -expected $true
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt")) -expected $true
     }
     $dir_files = $dir.GetFiles("anotherfile*")
     foreach ($dir_file in $dir_files) {
@@ -263,13 +796,23 @@ Function Test-DirectoryClass($root_path) {
     $dir_files = $dir.GetFiles("*", [System.IO.SearchOption]::AllDirectories)
     foreach ($dir_file in $dir_files) {
         Assert-Equals -actual $dir_file.GetType().FullName -expected "Ansible.IO.FileInfo"
-        Assert-Equals -actual ($dir_file.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt")) -expected $true
+        Assert-Equals -actual ($dir_file.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt")) -expected $true
     }
 
     $dir_entries = $dir.EnumerateFileSystemInfos()
     foreach ($dir_entry in $dir_entries) {
         Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
-        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "subdir", "subdir-1", "subdir-2")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
     }
     $dir_entries = $dir.EnumerateFileSystemInfos("anotherfile*")
     foreach ($dir_entry in $dir_entries) {
@@ -279,13 +822,27 @@ Function Test-DirectoryClass($root_path) {
     $dir_entries = $dir.EnumerateFileSystemInfos("*", [System.IO.SearchOption]::AllDirectories)
     foreach ($dir_entry in $dir_entries) {
         Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
-        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt", "subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
     }
 
     $dir_entries = $dir.GetFileSystemInfos()
     foreach ($dir_entry in $dir_entries) {
         Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
-        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "subdir", "subdir-1", "subdir-2")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2")) -expected $true
     }
     $dir_entries = $dir.GetFileSystemInfos("anotherfile*")
     foreach ($dir_entry in $dir_entries) {
@@ -295,7 +852,16 @@ Function Test-DirectoryClass($root_path) {
     $dir_entries = $dir.GetFileSystemInfos("*", [System.IO.SearchOption]::AllDirectories)
     foreach ($dir_entry in $dir_entries) {
         Assert-Equals -actual ($dir_entry.GetType().FullName -in @("Ansible.IO.FileInfo", "Ansible.IO.DirectoryInfo")) -expected $true
-        Assert-Equals -actual ($dir_entry.Name -in ("file.txt", "anotherfile.txt", "file-1.txt", "file-2.txt", "file-3.txt", "subdir", "subdir-1", "subdir-2", "subdir3")) -expected $true
+        Assert-Equals -actual ($dir_entry.Name -in (
+            "file.txt",
+            "anotherfile.txt",
+            "file-1.txt",
+            "file-2.txt",
+            "file-3.txt",
+            "subdir",
+            "subdir-1",
+            "subdir-2",
+            "subdir3")) -expected $true
     }
     
     # move tests
@@ -304,12 +870,15 @@ Function Test-DirectoryClass($root_path) {
     Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\subdir-move\file-2.txt")) -expected $true
 
     # delete tests
+    $failed = $false
     try {
         # fail to delete a directory that has contents
         $subdir1.Delete()
     } catch {
+        $failed = $true
         Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Delete`" with `"0`" argument(s): `"RemoveDirectoryW($($subdir1.FullName)) failed (The directory is not empty, Win32ErrorCode 145)`""
     }
+    Assert-Equals -actual $failed -expected $true
     $subdir1.Delete($true)
     Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-1")) -expected $false
     $subdir = $dir.CreateSubDirectory("subdir")
@@ -349,54 +918,304 @@ Function Test-DirectoryClass($root_path) {
         Assert-Equals -actual $audit_rules[0].IsInherited -expected $false
         Assert-Equals -actual $audit_rules[0].IdentityReference -expected $everyone_sid
     } else {
+        $failed = $false
         try {
             $acl_dir.SetAccessControl($dir_sec)
         } catch {
+            $failed = $true
             Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"SetAccessControl`" with `"1`" argument(s): `"SetNamedSecurityInfoW($($acl_dir.FullName)) failed (A required privilege is not held by the client, Win32ErrorCode 1314)`""
         }
+        Assert-Equals -actual $failed -expected $true
     }
 
+    # clear for the Ansible.IO.Directory tests
+    [Ansible.IO.Directory]::Delete($directory_path, $true)
+
     ### Directory Tests ###
-    # CreateDirectory(String)
-    # CreateDirectory(String, DirectorySecurity)
-    # Delete(String)
-    # Delete(String, Boolean)
-    # EnumerateDirectories(String)
-    # EnumerateDirectories(String, String)
-    # EnumerateDirectories(String, String, SearchOption)
-    # EnumerateFiles(String)
-    # EnumerateFiles(String, String)
-    # EnumerateFiles(String, String, SearchOption)
-    # EnumerateFileSystemEntries(String)
-    # EnumerateFileSystemEntries(String, String)
-    # EnumerateFileSystemEntries(String, String, SearchOption)
-    # Exists(String)
-    # GetAccessControl(String)
-    # GetAccessControl(String, AccessControlSelections)
-    # GetCreationTime(String)
-    # GetCreationTimeUtc(String)
-    # GetDirectories(String)
-    # GetDirectories(String, String)
-    # GetDirectories(String, String, SearchOption)
-    # GetFiles(String)
-    # GetFiles(String, String)
-    # GetFiles(String, String, SearchOption)
-    # GetFileSystemEntries(String)
-    # GetFileSystemEntries(String, String)
-    # GetFileSystemEntries(String, String, SearchOption)
-    # GetLastAccessTime(String)
-    # GetLastAccessTimeUtc(String)
-    # GetLastWriteTime(String)
-    # GetLastWriteTimeUtc(String)
-    # GetParent(String)
-    # Move(String, String)
-    # SetAccessControl(String, DirectorySecurity)
-    # SetCreationTime(String, DateTime)
-    # SetCreationTimeUtc(String, DateTime)
-    # SetLastAccessTime(String, DateTime)
-    # SetLastAccessTimeUtc(String, DateTime)
-    # SetLastWriteTime(String, DateTime)
-    # SetLastWriteTimeUtc(String, DateTime)
+    $dir = [Ansible.IO.Directory]::CreateDirectory($directory_path)
+    Assert-Equals -actual ($dir -is [Ansible.IO.DirectoryInfo]) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists($directory_path)) -expected $true
+
+    # ACL Tests
+    $acl = New-Object -TypeName System.Security.AccessControl.DirectorySecurity
+    $read_rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule -ArgumentList $everyone_sid, "FullControl", "Allow"
+    $acl.SetAccessRule($read_rule)
+    $acl.SetOwner($current_sid)
+    $acl.SetGroup($everyone_sid)
+    $acl_dir = [Ansible.IO.Directory]::CreateDirectory("$directory_path\acl-dir", $acl)
+    Assert-Equals -actual ($acl_dir -is [Ansible.IO.DirectoryInfo]) -expected $true
+
+    $acl = [Ansible.IO.Directory]::GetAccessControl("$directory_path\acl-dir")
+    $access_rules = $acl.GetAccessRules($true, $true, [System.Security.Principal.SecurityIdentifier])
+    $owner = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+    $group = $acl.GetGroup([System.Security.Principal.SecurityIdentifier])
+    Assert-Equals -actual $access_rules.Count -expected 1
+    Assert-Equals -actual $access_rules[0].IdentityReference -expected $everyone_sid
+    Assert-Equals -actual $access_rules[0].IsInherited -expected $false
+    Assert-Equals -actual $owner -expected $current_sid
+    Assert-Equals -actual $group -expected $everyone_sid
+
+    # only admins can set this
+    if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+        $acl = [Ansible.IO.Directory]::GetAccessControl("$directory_path\acl-dir")
+        $admin_sid = New-Object -TypeName System.Security.Principal.SecurityIdentifier -ArgumentList "S-1-5-32-544"
+        $acl.SetOwner($admin_sid)
+        [Ansible.IO.Directory]::SetAccessControl("$directory_path\acl-dir", $acl)
+
+        $acl_owner = [Ansible.IO.Directory]::GetAccessControl("$directory_path\acl-dir", [System.Security.AccessControl.AccessControlSections]::Owner)
+        $owner = $acl_owner.GetOwner([System.Security.Principal.SecurityIdentifier])
+        $group = $acl_owner.GetGroup([System.Security.Principal.SecurityIdentifier])
+        Assert-Equals -actual $owner -expected $admin_sid
+        Assert-Equals -actual $group -expected $null
+    }
+
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\subdir-1") > $null
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\subdir-1\subdir-3") > $null
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\subdir-2") > $null
+    $file = [Ansible.IO.File]::CreateText("$directory_path\file.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\anotherfile.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\file-1.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-1\subdir-3\file-3.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+    $file = [Ansible.IO.File]::CreateText("$directory_path\subdir-2\file-2.txt")
+    try {
+        $file.WriteLine("abc")
+    } finally {
+        $file.Dispose()
+    }
+
+    $dir_dirs = [Ansible.IO.Directory]::EnumerateDirectories($directory_path)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::EnumerateDirectories($directory_path, "acl-*")
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in ("$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::EnumerateDirectories($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+
+    $dir_dirs = [Ansible.IO.Directory]::GetDirectories($directory_path)
+    Assert-Equals -actual ($dir_dirs.Count) -expected 3
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::GetDirectories($directory_path, "acl-*")
+    Assert-Equals -actual ($dir_dirs.Count) -expected 1
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in ("$directory_path\acl-dir")) -expected $true
+    }
+    $dir_dirs = [Ansible.IO.Directory]::GetDirectories($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    Assert-Equals -actual ($dir_dirs.Count) -expected 4
+    foreach ($dir_name in $dir_dirs) {
+        Assert-Equals -actual $dir_name.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_name -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir")) -expected $true
+    }
+
+    $dir_files = [Ansible.IO.Directory]::EnumerateFiles($directory_path)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::EnumerateFiles($directory_path, "another*")
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::EnumerateFiles($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+
+    $dir_files = [Ansible.IO.Directory]::GetFiles($directory_path)
+    Assert-Equals -actual ($dir_files.Count) -expected 2
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::GetFiles($directory_path, "another*")
+    Assert-Equals -actual ($dir_files.Count) -expected 1
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_files = [Ansible.IO.Directory]::GetFiles($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    Assert-Equals -actual ($dir_files.Count) -expected 5
+    foreach ($dir_file in $dir_files) {
+        Assert-Equals -actual $dir_file.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_file -in (
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+
+    $dir_entries = [Ansible.IO.Directory]::EnumerateFileSystemEntries($directory_path)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::EnumerateFileSystemEntries($directory_path, "another*")
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::EnumerateFileSystemEntries($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+    
+    $dir_entries = [Ansible.IO.Directory]::GetFileSystemInfos($directory_path)
+    Assert-Equals -actual ($dir_entries.Count) -expected 5
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::GetFileSystemInfos($directory_path, "another*")
+    Assert-Equals -actual ($dir_entries.Count) -expected 1
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in ("$directory_path\anotherfile.txt")) -expected $true
+    }
+    $dir_entries = [Ansible.IO.Directory]::GetFileSystemInfos($directory_path, "*", [System.IO.SearchOption]::AllDirectories)
+    Assert-Equals -actual ($dir_entries.Count) -expected 9
+    foreach ($dir_entry in $dir_entries) {
+        Assert-Equals -actual $dir_entry.GetType().FullName -expected "System.String"
+        Assert-Equals -actual ($dir_entry -in (
+            "$directory_path\subdir-1",
+            "$directory_path\subdir-1\subdir-3",
+            "$directory_path\subdir-2",
+            "$directory_path\acl-dir",
+            "$directory_path\file.txt",
+            "$directory_path\anotherfile.txt",
+            "$directory_path\subdir-1\file-1.txt",
+            "$directory_path\subdir-1\subdir-3\file-3.txt",
+            "$directory_path\subdir-2\file-2.txt")) -expected $true
+    }
+
+    [Ansible.IO.Directory]::Move("$directory_path\subdir-1", "$directory_path\moved-dir")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\subdir-1")) -expected $false
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir")) -expected $true
+    
+    $parent_dir = [Ansible.IO.Directory]::GetParent("$directory_path\moved-dir")
+    Assert-Equals -actual $parent_dir.GetType().FullName -expected "Ansible.IO.DirectoryInfo"
+    Assert-Equals -actual $parent_dir.Fullname -expected $directory_path
+
+    [Ansible.IO.Directory]::Delete("$directory_path\acl-dir")
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\acl-dir")) -expected $false
+    $failed = $false
+    try {
+        [Ansible.IO.Directory]::Delete("$directory_path\moved-dir")
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "Exception calling `"Delete`" with `"1`" argument(s): `"RemoveDirectoryW($directory_path\moved-dir) failed (The directory is not empty, Win32ErrorCode 145)`""
+    }
+    Assert-Equals -actual $failed -expected $true
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir\subdir-3")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\moved-dir\file-1.txt")) -expected $true
+    Assert-Equals -actual ([Ansible.IO.File]::Exists("$directory_path\moved-dir\subdir-3\file-3.txt")) -expected $true
+
+    [Ansible.IO.Directory]::Delete("$directory_path\moved-dir", $true)
+    Assert-Equals -actual ([Ansible.IO.Directory]::Exists("$directory_path\moved-dir")) -expected $false
+
+    $current_time = (Get-Date).ToFileTimeUtc()
+    [Ansible.IO.Directory]::CreateDirectory("$directory_path\date") > $null
+
+    $creation_time = [Ansible.IO.Directory]::GetCreationTimeUtc("$directory_path\date")
+    Assert-Equals -actual $creation_time.GetType().FullName -expected "System.DateTime"
+    Assert-Equals -actual ($creation_time.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    $lastaccess_time = [Ansible.IO.Directory]::GetLastAccessTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastaccess_time.GetType().FullName -expected "System.DateTime"
+    Assert-Equals -actual ($lastaccess_time.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    $lastwrite_time = [Ansible.IO.Directory]::GetLastWriteTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastwrite_time.GetType().FullName -expected "System.DateTime"
+    Assert-Equals -actual ($lastwrite_time.ToFileTimeUtc() -ge $current_time) -expected $true
+
+    [Ansible.IO.Directory]::SetCreationTimeUtc("$directory_path\date", $new_date)
+    $creation_time = [Ansible.IO.Directory]::GetCreationTimeUtc("$directory_path\date")
+    Assert-Equals -actual $creation_time -expected $new_date
+
+    [Ansible.IO.Directory]::SetLastAccessTimeUtc("$directory_path\date", $new_date)
+    $lastaccess_time = [Ansible.IO.Directory]::GetLastAccessTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastaccess_time -expected $new_date
+
+    [Ansible.IO.Directory]::SetLastWriteTimeUtc("$directory_path\date", $new_date)
+    $lastwrite_time = [Ansible.IO.Directory]::GetLastWriteTimeUtc("$directory_path\date")
+    Assert-Equals -actual $lastwrite_time -expected $new_date
 }
 
 # call each test three times

--- a/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
+++ b/test/integration/targets/win_module_utils/library/symbolic_link_test.ps1
@@ -3,165 +3,212 @@
 #Requires -Module Ansible.ModuleUtils.Legacy
 #Requires -Module Ansible.ModuleUtils.LinkUtil
 #Requires -Module Ansible.ModuleUtils.CommandUtil
+#Requires -Module Ansible.ModuleUtils.FileUtil
 
 $ErrorActionPreference = 'Stop'
 
 $params = Parse-Args $args;
 $path = Get-AnsibleParam -obj $params -name "path" -type "path" -failifempty $true
 
-$folder_target = "$path\folder"
-$file_target = "$path\file"
-$symlink_file_path = "$path\file-symlink"
-$symlink_folder_path = "$path\folder-symlink"
-$hardlink_path = "$path\hardlink"
-$hardlink_path_2 = "$path\hardlink2"
-$junction_point_path = "$path\junction"
-
-if (Test-Path -Path $path) {
-    Remove-Item -Path $path -Force -Recurse | Out-Null
-}
-New-Item -Path $path -ItemType Directory | Out-Null
-New-Item -Path $folder_target -ItemType Directory | Out-Null
-New-Item -Path $file_target -ItemType File | Out-Null
-Set-Content -Path $file_target -Value "a"
-
-Function Assert-Equals($actual, $expected) {
-    if ($actual -ne $expected) {
-        Fail-Json @{} "actual != expected`nActual: $actual`nExpected: $expected"
-    }
-}
-
-Function Assert-True($expression, $message) {
-    if ($expression -ne $true) {
-        Fail-Json @{} $message
-    }
+$result = @{
+    changed = $false
 }
 
 # need to manually set this
 Load-LinkUtils
+Load-FileUtilFunctions
 
-# path is not a link
-$no_link_result = Get-Link -link_path $path
-Assert-True -expression ($no_link_result -eq $null) -message "did not return null result for a non link"
-
-# fail to create hard link pointed to a directory
-try {
-    New-Link -link_path "$path\folder-hard" -link_target $folder_target -link_type "hard"
-    Assert-True -expression $false -message "creation of hard link should have failed if target was a directory"
-} catch {
-    Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a hard link to a directory"
+Function Assert-Equals($actual, $expected) {
+    if ($actual -ne $expected) {
+        $call_stack = (Get-PSCallStack)[1]
+        $error_msg = "AssertionError:`r`nActual: `"$actual`" != Expected: `"$expected`"`r`nLine: $($call_stack.ScriptLineNumber), Method: $($call_stack.Position.Text)"
+        Fail-Json -obj $result -message $error_msg
+    }
 }
 
-# fail to create a junction point pointed to a file
-try {
-    New-Link -link_path "$path\junction-fail" -link_target $file_target -link_type "junction"
-    Assert-True -expression $false -message "creation of junction point should have failed if target was a file"
-} catch {
-    Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a junction point to a file"
+Function Run-LinkTests($path) {
+    $folder_target = "$path\folder"
+    $file_target = "$path\file"
+    $symlink_file_path = "$path\file-symlink"
+    $symlink_folder_path = "$path\folder-symlink"
+    $hardlink_path = "$path\hardlink"
+    $hardlink_path_2 = "$path\hardlink2"
+    $junction_point_path = "$path\junction"
+
+    if (Test-AnsiblePath -Path $path) {
+        [Ansible.IO.Directory]::Delete($path, $true)
+    }
+    [Ansible.IO.Directory]::CreateDirectory($path) > $null
+    [Ansible.IO.Directory]::CreateDirectory($folder_target) > $null
+    $sw = [Ansible.IO.File]::CreateText($file_target)
+    try {
+        $sw.Write("a")
+    } finally {
+        $sw.Close()
+    }
+
+    # path is not a link
+    $no_link_result = Get-Link -link_path $path
+    Assert-Equals -actual ($no_link_result -eq $null) -expected $true
+
+    # fail to create hard link pointed to a directory
+    $failed = $false
+    try {
+        New-Link -link_path "$path\folder-hard" -link_target $folder_target -link_type "hard"
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a hard link to a directory"
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    # fail to create a junction point pointed to a file
+    $failed = $false
+    try {
+        New-Link -link_path "$path\junction-fail" -link_target $file_target -link_type "junction"
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "cannot set the target for a junction point to a file"
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    # fail to create a symbolic link with non-existent target
+    try {
+        New-Link -link_path "$path\symlink-fail" -link_target "$path\fake-folder" -link_type "link"
+    } catch {
+        $failed = $true
+        Assert-Equals -actual $_.Exception.Message -expected "link_target '$path\fake-folder' does not exist, cannot create link"
+    }
+    Assert-Equals -actual $failed -expected $true
+
+    # create relative symlink
+    if ($path.StartsWith("\\?\")) {
+        $chdir = $path.Substring(4)
+    } else {
+        $chdir = $path
+    }
+    Run-Command -command "cmd.exe /c mklink /D symlink-rel folder" -working_directory $chdir | Out-Null
+    $rel_link_result = Get-Link -link_path "$path\symlink-rel"
+    Assert-Equals -actual $rel_link_result.Type -expected "SymbolicLink"
+    Assert-Equals -actual $rel_link_result.SubstituteName -expected "folder"
+    Assert-Equals -actual $rel_link_result.PrintName -expected "folder"
+    Assert-Equals -actual $rel_link_result.TargetPath -expected "folder"
+    Assert-Equals -actual $rel_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $rel_link_result.HardTargets -expected $null
+
+    # create a symbolic file test
+    New-Link -link_path $symlink_file_path -link_target $file_target -link_type "link"
+    $file_link_result = Get-Link -link_path $symlink_file_path
+    Assert-Equals -actual $file_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $file_link_result.SubstituteName -expected "\??\$($file_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $file_link_result.SubstituteName -expected "\??\$($file_target)"
+    }
+    Assert-Equals -actual $file_link_result.PrintName -expected $file_target
+    Assert-Equals -actual $file_link_result.TargetPath -expected $file_target
+    Assert-Equals -actual $file_link_result.AbsolutePath -expected $file_target
+    Assert-Equals -actual $file_link_result.HardTargets -expected $null
+
+    # create a symbolic link folder test
+    New-Link -link_path $symlink_folder_path -link_target $folder_target -link_type "link"
+    $folder_link_result = Get-Link -link_path $symlink_folder_path
+    Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $folder_link_result.PrintName -expected $folder_target
+    Assert-Equals -actual $folder_link_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $folder_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $folder_link_result.HardTargets -expected $null
+
+    # create a junction point test
+    New-Link -link_path $junction_point_path -link_target $folder_target -link_type "junction"
+    $junction_point_result = Get-Link -link_path $junction_point_path
+    Assert-Equals -actual $junction_point_result.Type -expected "JunctionPoint"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $junction_point_result.PrintName -expected $folder_target
+    Assert-Equals -actual $junction_point_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $junction_point_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $junction_point_result.HardTargets -expected $null
+
+    # create a hard link test
+    New-Link -link_path $hardlink_path -link_target $file_target -link_type "hard"
+    $hardlink_result = Get-Link -link_path $hardlink_path
+    Assert-Equals -actual $hardlink_result.Type -expected "HardLink"
+    Assert-Equals -actual $hardlink_result.SubstituteName -expected $null
+    Assert-Equals -actual $hardlink_result.PrintName -expected $null
+    Assert-Equals -actual $hardlink_result.TargetPath -expected $null
+    Assert-Equals -actual $hardlink_result.AbsolutePath -expected $null
+    if ($hardlink_result.HardTargets[0] -ne $hardlink_path -and $hardlink_result.HardTargets[1] -ne $hardlink_path) {
+        # file $hardlink_path is not a target of the hard link
+        Assert-Equals -actual $true -expected $false
+    }
+    if ($hardlink_result.HardTargets[0] -ne $file_target -and $hardlink_result.HardTargets[1] -ne $file_target) {
+        # file $file_target is not a target of the hard link
+        Assert-Equals -actual $true -expected $false
+    }
+    $hardlink_contents = [Ansible.IO.File]::ReadAllText($hardlink_path)
+    $file_contents = [Ansible.IO.File]::ReadAllText($file_target)
+    Assert-Equals -actual $hardlink_contents -expected $file_contents
+
+    # create a new hard link and verify targets go to 3
+    New-Link -link_path $hardlink_path_2 -link_target $file_target -link_type "hard"
+    $hardlink_result_2 = Get-Link -link_path $hardlink_path
+    Assert-Equals -actual ($hardlink_result_2.HardTargets.Count -eq 3) -expected $true
+
+    # check if broken symbolic link still works
+    Remove-Item -Path $folder_target -Force | Out-Null
+    $broken_link_result = Get-Link -link_path $symlink_folder_path
+    Assert-Equals -actual $broken_link_result.Type -expected "SymbolicLink"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $broken_link_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $broken_link_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $broken_link_result.PrintName -expected $folder_target
+    Assert-Equals -actual $broken_link_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $broken_link_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $broken_link_result.HardTargets -expected $null
+
+    # check if broken junction point still works
+    $broken_junction_result = Get-Link -link_path $junction_point_path
+    Assert-Equals -actual $broken_junction_result.Type -expected "JunctionPoint"
+    if ($path.StartsWith("\\?\")) {
+        Assert-Equals -actual $broken_junction_result.SubstituteName -expected "\??\$($folder_target.Substring(4))"
+    } else {
+        Assert-Equals -actual $broken_junction_result.SubstituteName -expected "\??\$($folder_target)"
+    }
+    Assert-Equals -actual $broken_junction_result.PrintName -expected $folder_target
+    Assert-Equals -actual $broken_junction_result.TargetPath -expected $folder_target
+    Assert-Equals -actual $broken_junction_result.AbsolutePath -expected $folder_target
+    Assert-Equals -actual $broken_junction_result.HardTargets -expected $null
+
+    # delete file symbolic link
+    Remove-Link -link_path $symlink_file_path
+    Assert-Equals -actual (-not (Test-Path -Path $symlink_file_path)) -expected $true
+
+    # delete folder symbolic link
+    Remove-Link -link_path $symlink_folder_path
+    Assert-Equals -actual (-not (Test-Path -Path $symlink_folder_path)) -expected $true
+
+    # delete junction point
+    Remove-Link -link_path $junction_point_path
+    Assert-Equals -actual (-not (Test-Path -Path $junction_point_path)) -expected $true
+
+    # delete hard link
+    Remove-Link -link_path $hardlink_path
+    Assert-Equals -actual (-not (Test-Path -Path $hardlink_path)) -expected $true
 }
 
-# fail to create a symbolic link with non-existent target
-try {
-    New-Link -link_path "$path\symlink-fail" -link_target "$path\fake-folder" -link_type "link"
-    Assert-True -expression $false -message "creation of symbolic link should have failed if target did not exist"
-} catch {
-    Assert-Equals -actual $_.Exception.Message -expected "link_target '$path\fake-folder' does not exist, cannot create link"
-}
+Run-LinkTests -path $path
+Run-LinkTests -path "\\?\$path"
 
-# create recursive symlink
-Run-Command -command "cmd.exe /c mklink /D symlink-rel folder" -working_directory $path | Out-Null
-$rel_link_result = Get-Link -link_path "$path\symlink-rel"
-Assert-Equals -actual $rel_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $rel_link_result.SubstituteName -expected "folder"
-Assert-Equals -actual $rel_link_result.PrintName -expected "folder"
-Assert-Equals -actual $rel_link_result.TargetPath -expected "folder"
-Assert-Equals -actual $rel_link_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $rel_link_result.HardTargets -expected $null
+$result.data = "success"
+Exit-Json -obj $result
 
-# create a symbolic file test
-New-Link -link_path $symlink_file_path -link_target $file_target -link_type "link"
-$file_link_result = Get-Link -link_path $symlink_file_path
-Assert-Equals -actual $file_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $file_link_result.SubstituteName -expected "\??\$file_target"
-Assert-Equals -actual $file_link_result.PrintName -expected $file_target
-Assert-Equals -actual $file_link_result.TargetPath -expected $file_target
-Assert-Equals -actual $file_link_result.AbsolutePath -expected $file_target
-Assert-Equals -actual $file_link_result.HardTargets -expected $null
-
-# create a symbolic link folder test
-New-Link -link_path $symlink_folder_path -link_target $folder_target -link_type "link"
-$folder_link_result = Get-Link -link_path $symlink_folder_path
-Assert-Equals -actual $folder_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $folder_link_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $folder_link_result.PrintName -expected $folder_target
-Assert-Equals -actual $folder_link_result.TargetPath -expected $folder_target
-Assert-Equals -actual $folder_link_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $folder_link_result.HardTargets -expected $null
-
-# create a junction point test
-New-Link -link_path $junction_point_path -link_target $folder_target -link_type "junction"
-$junction_point_result = Get-Link -link_path $junction_point_path
-Assert-Equals -actual $junction_point_result.Type -expected "JunctionPoint"
-Assert-Equals -actual $junction_point_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $junction_point_result.PrintName -expected $folder_target
-Assert-Equals -actual $junction_point_result.TargetPath -expected $folder_target
-Assert-Equals -actual $junction_point_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $junction_point_result.HardTargets -expected $null
-
-# create a hard link test
-New-Link -link_path $hardlink_path -link_target $file_target -link_type "hard"
-$hardlink_result = Get-Link -link_path $hardlink_path
-Assert-Equals -actual $hardlink_result.Type -expected "HardLink"
-Assert-Equals -actual $hardlink_result.SubstituteName -expected $null
-Assert-Equals -actual $hardlink_result.PrintName -expected $null
-Assert-Equals -actual $hardlink_result.TargetPath -expected $null
-Assert-Equals -actual $hardlink_result.AbsolutePath -expected $null
-if ($hardlink_result.HardTargets[0] -ne $hardlink_path -and $hardlink_result.HardTargets[1] -ne $hardlink_path) {
-    Assert-True -expression $false -message "file $hardlink_path is not a target of the hard link"
-}
-if ($hardlink_result.HardTargets[0] -ne $file_target -and $hardlink_result.HardTargets[1] -ne $file_target) {
-    Assert-True -expression $false -message "file $file_target is not a target of the hard link"
-}
-Assert-equals -actual (Get-Content -Path $hardlink_path -Raw) -expected (Get-Content -Path $file_target -Raw)
-
-# create a new hard link and verify targets go to 3
-New-Link -link_path $hardlink_path_2 -link_target $file_target -link_type "hard"
-$hardlink_result_2 = Get-Link -link_path $hardlink_path
-Assert-True -expression ($hardlink_result_2.HardTargets.Count -eq 3) -message "did not return 3 targets for the hard link, actual $($hardlink_result_2.Targets.Count)"
-
-# check if broken symbolic link still works
-Remove-Item -Path $folder_target -Force | Out-Null
-$broken_link_result = Get-Link -link_path $symlink_folder_path
-Assert-Equals -actual $broken_link_result.Type -expected "SymbolicLink"
-Assert-Equals -actual $broken_link_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $broken_link_result.PrintName -expected $folder_target
-Assert-Equals -actual $broken_link_result.TargetPath -expected $folder_target
-Assert-Equals -actual $broken_link_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $broken_link_result.HardTargets -expected $null
-
-# check if broken junction point still works
-$broken_junction_result = Get-Link -link_path $junction_point_path
-Assert-Equals -actual $broken_junction_result.Type -expected "JunctionPoint"
-Assert-Equals -actual $broken_junction_result.SubstituteName -expected "\??\$folder_target"
-Assert-Equals -actual $broken_junction_result.PrintName -expected $folder_target
-Assert-Equals -actual $broken_junction_result.TargetPath -expected $folder_target
-Assert-Equals -actual $broken_junction_result.AbsolutePath -expected $folder_target
-Assert-Equals -actual $broken_junction_result.HardTargets -expected $null
-
-# delete file symbolic link
-Remove-Link -link_path $symlink_file_path
-Assert-True -expression (-not (Test-Path -Path $symlink_file_path)) -message "failed to delete file symbolic link"
-
-# delete folder symbolic link
-Remove-Link -link_path $symlink_folder_path
-Assert-True -expression (-not (Test-Path -Path $symlink_folder_path)) -message "failed to delete folder symbolic link"
-
-# delete junction point
-Remove-Link -link_path $junction_point_path
-Assert-True -expression (-not (Test-Path -Path $junction_point_path)) -message "failed to delete junction point"
-
-# delete hard link
-Remove-Link -link_path $hardlink_path
-Assert-True -expression (-not (Test-Path -Path $hardlink_path)) -message "failed to delete hard link"
-
-Exit-Json @{ data = "success" }

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -101,7 +101,111 @@
 - name: call module with FileUtil tests for Ansible.IO c# code
   file_util_test_max_path:
     path: C:\ansible testing
+    encrypt_tests: no
   register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'
+
+- set_fact:
+    become_test_username: ansible_become_test
+    become_test_admin_username: ansible_become_admin
+    gen_pw: password123! + {{ lookup('password', '/dev/null chars=ascii_letters,digits length=8') }}
+
+- name: create normal user
+  win_user:
+    name: '{{ become_test_username }}'
+    password: '{{ gen_pw }}'
+    update_password: always
+    groups: Users
+
+- name: create admin user
+  win_user:
+    name: '{{ become_test_admin_username }}'
+    password: '{{ gen_pw }}'
+    update_password: always
+    groups: Administrators
+
+- name: execute become tests to ensure test user is deleted at the end
+  block:
+  - name: ensure current user is not the become user
+    win_shell: whoami
+    register: whoami_out
+    failed_when: whoami_out.stdout_lines[0].endswith(become_test_username) or whoami_out.stdout_lines[0].endswith(become_test_admin_username)
+
+  - name: get become user profile dir so we can clean it up later
+    vars: &become_vars
+      ansible_become_user: '{{ become_test_username }}'
+      ansible_become_password: '{{ gen_pw }}'
+      ansible_become_method: runas
+      ansible_become: yes
+    win_shell: $env:USERPROFILE
+    register: profile_dir_out
+
+  - name: ensure profile dir contains test username
+    assert:
+      that:
+      - become_test_username in profile_dir_out.stdout_lines[0]
+
+  - name: get become admin user profile dir so we can clean it up later
+    vars: &become_admin_vars
+      ansible_become_user: '{{ become_test_admin_username }}'
+      ansible_become_password: '{{ gen_pw }}'
+      ansible_become_method: runas
+      ansible_become: yes
+    win_shell: $env:USERPROFILE
+    register: admin_profile_dir_out
+
+  - name: ensure profile dir contains test username
+    assert:
+      that:
+      - become_test_admin_username in admin_profile_dir_out.stdout_lines[0]
+
+  - name: call module with FileUtil tests for Ansible.IO c# code as admin become user
+    file_util_test_max_path:
+      path: C:\ansible testing
+      encrypt_tests: yes
+    vars: *become_admin_vars
+    register: file_util_test
+
+  - assert:
+      that:
+      - file_util_test.data == 'success'
+
+  - name: call module with FileUtil tests for Ansible.IO c# code as normal become user
+    file_util_test_max_path:
+      path: C:\ansible testing
+      encrypt_tests: yes
+    vars: *become_vars
+    register: file_util_test
+
+  - assert:
+      that:
+      - file_util_test.data == 'success'
+
+  always:
+  - name: ensure become user is deleted
+    win_user:
+      name: '{{ become_test_username }}'
+      state: absent
+
+  - name: ensure become admin user is deleted
+    win_user:
+      name: '{{ become_test_admin_username }}'
+      state: absent
+
+  - name: ensure become user profile is deleted
+    win_shell: rmdir /S /Q {{ profile_dir_out.stdout_lines[0] }}
+    args:
+      executable: cmd.exe
+    when: become_test_username in profile_dir_out.stdout_lines[0]
+
+  - name: ensure become admin user profile is deleted
+    win_shell: rmdir /S /Q {{ admin_profile_dir_out.stdout_lines[0] }}
+    args:
+      executable: cmd.exe
+    when: become_test_admin_username in admin_profile_dir_out.stdout_lines[0]
 
 - assert:
     that:

--- a/test/integration/targets/win_module_utils/tasks/main.yml
+++ b/test/integration/targets/win_module_utils/tasks/main.yml
@@ -97,3 +97,12 @@
 - assert:
     that:
     - file_util_test.data == 'success'
+
+- name: call module with FileUtil tests for Ansible.IO c# code
+  file_util_test_max_path:
+    path: C:\ansible testing
+  register: file_util_test
+
+- assert:
+    that:
+    - file_util_test.data == 'success'

--- a/test/integration/targets/win_module_utils_legacy/tasks/main.yml
+++ b/test/integration/targets/win_module_utils_legacy/tasks/main.yml
@@ -19,7 +19,10 @@
   - path: C:\Windows
   - path: HKLM:\Software
   - path: '{{ bogus_driveletter.stdout_lines[0] }}:\goodpath'
+  - path: \\?\C:\long_path
   - path: '{{ bogus_driveletter.stdout_lines[0] }}:\badpath*%@:\blar'
+    should_fail: true
+  - path: \\?\{{ bogus_driveletter.stdout_lines[0] }}:\badpath*%@:\blar
     should_fail: true
 
 - name: test list parameters

--- a/test/integration/targets/win_stat/defaults/main.yml
+++ b/test/integration/targets/win_stat/defaults/main.yml
@@ -1,2 +1,5 @@
 win_stat_dir: '{{win_output_dir}}\win_stat'
+win_stat_dir_forward: "{{win_stat_dir|regex_replace('\\\\', '/')}}"
+win_stat_dir_double: "{{win_stat_dir|regex_replace('\\\\', '\\\\\\\\')}}"
+win_stat_dir_long: \\?\{{win_stat_dir}}
 win_stat_user: test-stat

--- a/test/integration/targets/win_stat/filter_plugins/update_path.py
+++ b/test/integration/targets/win_stat/filter_plugins/update_path.py
@@ -9,4 +9,3 @@ class FilterModule(object):
         for key, value in repl_dict.items():
             new_dict['stat'][key] = value
         return new_dict
-

--- a/test/integration/targets/win_stat/filter_plugins/update_path.py
+++ b/test/integration/targets/win_stat/filter_plugins/update_path.py
@@ -1,0 +1,12 @@
+class FilterModule(object):
+    def filters(self):
+        return {
+            'update_stat': self.update_stat
+        }
+
+    def update_stat(self, dict_value, repl_dict):
+        new_dict = dict_value.copy()
+        for key, value in repl_dict.items():
+            new_dict['stat'][key] = value
+        return new_dict
+

--- a/test/integration/targets/win_stat/tasks/tests.yml
+++ b/test/integration/targets/win_stat/tasks/tests.yml
@@ -4,6 +4,26 @@
     path: '{{win_stat_dir}}\nested\file.ps1'
   register: stat_file
 
+- name: test win_stat module on file with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested/file.ps1'
+  register: stat_file_forward
+
+- name: test win_stat module on file with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested\\file.ps1'
+  register: stat_file_double
+
+- name: test win_stat module on file with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested\file.ps1'
+  register: stat_file_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_file.stat.path}}'
+
 - name: check actual for file
   assert:
     that:
@@ -29,6 +49,10 @@
     - stat_file.stat.owner == 'BUILTIN\Administrators'
     - stat_file.stat.path == win_stat_dir + '\\nested\\file.ps1'
     - stat_file.stat.size == 3
+    - stat_file == stat_file_forward
+    - stat_file == stat_file_double
+    - stat_file_long.stat.path == '\\\\?\\' + stat_file.stat.path
+    - stat_file == stat_file_long|update_stat(long_override)
 
 # get_md5 will be undocumented in 2.9, remove this test then
 - name: test win_stat module on file with md5
@@ -142,6 +166,27 @@
     path: '{{win_stat_dir}}\nested\hard-link.ps1'
   register: stat_hard_link
 
+- name: test win_stat on hard link file with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested/hard-link.ps1'
+  register: stat_hard_link_forward
+
+- name: test win_stat on hard link file with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested\\hard-link.ps1'
+  register: stat_hard_link_double
+
+- name: test win_stat on hard link file with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested\hard-link.ps1'
+  register: stat_hard_link_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_hard_link.stat.path}}'
+      hlnk_targets: '{{stat_hard_link.stat.hlnk_targets}}'
+
 - name: check actual for hard link file
   assert:
     that:
@@ -166,11 +211,36 @@
     - stat_hard_link.stat.owner == 'BUILTIN\Administrators'
     - stat_hard_link.stat.path == win_stat_dir + '\\nested\\hard-link.ps1'
     - stat_hard_link.stat.size == 3
+    - stat_hard_link == stat_hard_link_forward
+    - stat_hard_link == stat_hard_link_double
+    - stat_hard_link_long.stat.path == '\\\\?\\' + stat_hard_link.stat.path
+    - stat_hard_link_long.stat.hlnk_targets == [ '\\\\?\\' + stat_hard_link.stat.hlnk_targets[0] ]
+    - stat_hard_link == stat_hard_link_long|update_stat(long_override)
 
 - name: test win_stat on directory
   win_stat:
     path: '{{win_stat_dir}}\nested'
   register: stat_directory
+
+- name: test win_stat module on directory with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested'
+  register: stat_directory_forward
+
+- name: test win_stat module on directory with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested'
+  register: stat_directory_double
+
+- name: test win_stat module on directory with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested'
+  register: stat_directory_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_directory.stat.path}}'
 
 - name: check actual for directory
   assert:
@@ -197,6 +267,10 @@
     - stat_directory.stat.owner == 'BUILTIN\Administrators'
     - stat_directory.stat.path == win_stat_dir + '\\nested'
     - stat_directory.stat.size == 24
+    - stat_directory == stat_directory_forward
+    - stat_directory == stat_directory_double
+    - stat_directory_long.stat.path == '\\\\?\\' + stat_directory.stat.path
+    - stat_directory == stat_directory_long|update_stat(long_override)
 
 - name: test win_stat on empty directory
   win_stat:
@@ -328,6 +402,28 @@
     path: '{{win_stat_dir}}\link'
   register: stat_symlink
 
+- name: test win_stat module on directory symlink with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/link'
+  register: stat_symlink_forward
+
+- name: test win_stat module on directory symlink with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\link'
+  register: stat_symlink_double
+
+- name: test win_stat module on directory symlink with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\link'
+  register: stat_symlink_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_symlink.stat.path}}'
+      lnk_source: '{{stat_symlink.stat.lnk_source}}'
+      lnk_target: '{{stat_symlink.stat.lnk_target}}'
+
 - name: assert directory symlink actual
   assert:
     that:
@@ -353,11 +449,39 @@
     - stat_symlink.stat.path == win_stat_dir + '\\link'
     - stat_symlink.stat.checksum is not defined
     - stat_symlink.stat.md5 is not defined
+    - stat_symlink == stat_symlink_forward
+    - stat_symlink == stat_symlink_double
+    - stat_symlink_long.stat.path == '\\\\?\\' + stat_symlink.stat.path
+    - stat_symlink_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\link-dest'
+    - stat_symlink_long.stat.lnk_target == '\\\\?\\' + win_stat_dir + '\\link-dest'
+    - stat_symlink == stat_symlink_long|update_stat(long_override)
 
 - name: test win_stat on file symlink
   win_stat:
     path: '{{win_stat_dir}}\file-link.txt'
   register: stat_file_symlink
+
+- name: test win_stat module on file symlink with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/file-link.txt'
+  register: stat_file_symlink_forward
+
+- name: test win_stat module ony file symlink with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\file-link.txt'
+  register: stat_file_symlink_double
+
+- name: test win_stat module on file symlink with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\file-link.txt'
+  register: stat_file_symlink_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_file_symlink.stat.path}}'
+      lnk_source: '{{stat_file_symlink.stat.lnk_source}}'
+      lnk_target: '{{stat_file_symlink.stat.lnk_target}}'
 
 - name: assert file symlink actual
   assert:
@@ -385,11 +509,38 @@
     - stat_file_symlink.stat.nlink == 1
     - stat_file_symlink.stat.owner == 'BUILTIN\\Administrators'
     - stat_file_symlink.stat.path == win_stat_dir + '\\file-link.txt'
+    - stat_file_symlink == stat_file_symlink_forward
+    - stat_file_symlink == stat_file_symlink_double
+    - stat_file_symlink_long.stat.path == '\\\\?\\' + stat_file_symlink.stat.path
+    - stat_file_symlink_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_symlink_long.stat.lnk_target == '\\\\?\\' + win_stat_dir + '\\nested\\file.ps1'
+    - stat_file_symlink == stat_file_symlink_long|update_stat(long_override)
 
 - name: test win_stat on relative symlink
   win_stat:
     path: '{{win_stat_dir}}\nested\nested\link-rel'
   register: stat_rel_symlink
+
+- name: test win_stat on relative symlink with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/nested/nested/link-rel'
+  register: stat_rel_symlink_forward
+
+- name: test win_stat on relative symlink with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\nested\\nested\\link-rel'
+  register: stat_rel_symlink_double
+
+- name: test win_stat on relative symlink with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\nested\nested\link-rel'
+  register: stat_rel_symlink_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_rel_symlink.stat.path}}'
+      lnk_source: '{{stat_rel_symlink.stat.lnk_source}}'
 
 - name: assert directory relative symlink actual
   assert:
@@ -416,11 +567,38 @@
     - stat_rel_symlink.stat.path == win_stat_dir + '\\nested\\nested\\link-rel'
     - stat_rel_symlink.stat.checksum is not defined
     - stat_rel_symlink.stat.md5 is not defined
+    - stat_rel_symlink == stat_rel_symlink_forward
+    - stat_rel_symlink == stat_rel_symlink_double
+    - stat_rel_symlink_long.stat.path == '\\\\?\\' + stat_rel_symlink.stat.path
+    - stat_rel_symlink_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\link-dest'
+    - stat_rel_symlink == stat_rel_symlink_long|update_stat(long_override)
 
 - name: test win_stat on junction
   win_stat:
     path: '{{win_stat_dir}}\junction-link'
   register: stat_junction_point
+
+- name: test win_stat on junction with forward slashes in path
+  win_stat:
+    path: '{{win_stat_dir_forward}}/junction-link'
+  register: stat_junction_point_forward
+
+- name: test win_stat on junction with double back slashes in path
+  win_stat:
+    path: '{{win_stat_dir_double}}\\junction-link'
+  register: stat_junction_point_double
+
+- name: test win_stat on junction with long path prefix in path
+  win_stat:
+    path: '{{win_stat_dir_long}}\junction-link'
+  register: stat_junction_point_long
+
+- name: set override assertion keys for long path
+  set_fact:
+    long_override:
+      path: '{{stat_junction_point.stat.path}}'
+      lnk_source: '{{stat_junction_point.stat.lnk_source}}'
+      lnk_target: '{{stat_junction_point.stat.lnk_target}}'
 
 - name: assert junction actual
   assert:
@@ -446,6 +624,12 @@
     - stat_junction_point.stat.owner == 'BUILTIN\\Administrators'
     - stat_junction_point.stat.path == win_stat_dir + '\\junction-link'
     - stat_junction_point.stat.size == 0
+    - stat_junction_point == stat_junction_point_forward
+    - stat_junction_point == stat_junction_point_double
+    - stat_junction_point_long.stat.path == '\\\\?\\' + stat_junction_point.stat.path
+    - stat_junction_point_long.stat.lnk_source == '\\\\?\\' + win_stat_dir + '\\junction-dest'
+    - stat_junction_point_long.stat.lnk_target == '\\\\?\\' + win_stat_dir + '\\junction-dest'
+    - stat_junction_point == stat_junction_point_long|update_stat(long_override)
 
 - name: test win_stat module non-existent path
   win_stat:


### PR DESCRIPTION
##### SUMMARY
This PR adds the following c# classes

* Ansible.IO.File
* Ansible.IO.FileInfo
* Ansible.IO.Directory
* Ansible.IO.DirectoryInfo

These classes are designed to be a like for like replacement of the `System.IO.*` class of the same name but also includes the ability to interact with files/directories that exceed the max path limit of 260 characters. Unfortunately we have no choice but to use the Win32 APIs to make these calls as .NET does not support the `\\?\` prefix which allows the paths to exceed the 260 limit.

Once this is in I will be looking at changing win_file, win_find, win_owner, win_acl, and win_acl_inheritance to use the new c# code in separate PRs.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Ansible.ModuleUtils.FileUtil.psm1
Ansible.ModuleUtils.LinkUtil.psm1
win_command
win_shell
win_stat
win_wait_for

##### ANSIBLE VERSION
```
2.5
```

  
  