### PR TITLE
timezone module: Enhanced update command for Debian/Ubuntu

### DIFF
--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -336,9 +336,8 @@ class NosystemdTimezone(Timezone):
         # Distribution-specific configurations
         if self.module.get_bin_path('dpkg-reconfigure') is not None:
             # Debian/Ubuntu
-            # With additional hack for https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806
-            self.update_timezone = ['rm -f /etc/localtime', '%s --frontend noninteractive tzdata' %
-                                    self.module.get_bin_path('dpkg-reconfigure', required=True)]
+            self.update_timezone = ['%s -f %s /etc/localtime' % (self.module.get_bin_path('ln', required=True), tzfile),
+                                    '%s --frontend noninteractive tzdata' % self.module.get_bin_path('dpkg-reconfigure', required=True)]
             self.conf_files['name'] = '/etc/timezone'
             self.allow_no_file['name'] = True
             self.conf_files['hwclock'] = '/etc/default/rcS'

--- a/lib/ansible/modules/system/timezone.py
+++ b/lib/ansible/modules/system/timezone.py
@@ -336,7 +336,7 @@ class NosystemdTimezone(Timezone):
         # Distribution-specific configurations
         if self.module.get_bin_path('dpkg-reconfigure') is not None:
             # Debian/Ubuntu
-            self.update_timezone = ['%s -f %s /etc/localtime' % (self.module.get_bin_path('ln', required=True), tzfile),
+            self.update_timezone = ['%s -sf %s /etc/localtime' % (self.module.get_bin_path('ln', required=True), tzfile),
                                     '%s --frontend noninteractive tzdata' % self.module.get_bin_path('dpkg-reconfigure', required=True)]
             self.conf_files['name'] = '/etc/timezone'
             self.allow_no_file['name'] = True


### PR DESCRIPTION
##### BACKGROUND

In debian/ubuntu, there are 2 way to update timezone setting:

1. Edit /etc/timezone then `dpkg-reconfigure tzdata`
1. Symlink tz file to /etc/localtime then `dpkg-reconfigure tzdata`

The first one can be found in [ubuntu's doc](https://help.ubuntu.com/community/UbuntuTime#Using_the_Command_Line_.28terminal.29), and I'd been believing it's better way.

However actually, as commented by @sumpfralle in https://github.com/ansible/ansible/pull/27546#issuecomment-347062382, the second one takes precedence over the first one and is better way to modify timezone.

See also:
- Comment No. 9 in https://bugs.launchpad.net/ubuntu/+source/tzdata/+bug/1554806
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=848143#10
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=813226#10

##### SUMMARY

Starting from https://github.com/ansible/ansible/pull/27546, the module deletes /etc/localtime to avoid conflicts between /etc/localtime and /etc/timezone.

This pull request modifies this behavior: instead of deleting /etc/localtime, update it to the desired state in addition to modify /etc/timezone.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

timezone module

##### ANSIBLE VERSION

```
ansible 2.5.0 (timezone-debian a0d2e34f9a) last updated 2018/01/03 18:19:41 (GMT +900)
  config file = None
  configured module search path = [u'/Users/01014505/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/01014505/Documents/dev/oss/ansible/lib/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.13 (default, Dec 17 2016, 23:03:43) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

