### PR TITLE
include interface info in ansible_interfaces

### DIFF
--- a/lib/ansible/module_utils/facts/network/generic_bsd.py
+++ b/lib/ansible/module_utils/facts/network/generic_bsd.py
@@ -51,10 +51,12 @@ class GenericBsdIfconfigNetwork(Network):
 
         self.merge_default_interface(default_ipv4, interfaces, 'ipv4')
         self.merge_default_interface(default_ipv6, interfaces, 'ipv6')
-        network_facts['interfaces'] = sorted(list(interfaces.keys()))
+
+        network_facts['interfaces'] = {}
 
         for iface in interfaces:
             network_facts[iface] = interfaces[iface]
+            network_facts['interfaces'][iface] = interfaces[iface]
 
         network_facts['default_ipv4'] = default_ipv4
         network_facts['default_ipv6'] = default_ipv6

--- a/lib/ansible/module_utils/facts/network/hpux.py
+++ b/lib/ansible/module_utils/facts/network/hpux.py
@@ -42,7 +42,7 @@ class HPUXNetwork(Network):
         network_facts['interfaces'] = {}
         for iface in interfaces:
             network_facts[iface] = interfaces[iface]
-            network_fact['interfaces'][iface] = interfaces[iface]
+            network_facts['interfaces'][iface] = interfaces[iface]
 
         return network_facts
 

--- a/lib/ansible/module_utils/facts/network/hpux.py
+++ b/lib/ansible/module_utils/facts/network/hpux.py
@@ -39,9 +39,10 @@ class HPUXNetwork(Network):
         network_facts.update(default_interfaces_facts)
 
         interfaces = self.get_interfaces_info()
-        network_facts['interfaces'] = interfaces.keys()
+        network_facts['interfaces'] = {}
         for iface in interfaces:
             network_facts[iface] = interfaces[iface]
+            network_fact['interfaces'][iface] = interfaces[iface]
 
         return network_facts
 

--- a/lib/ansible/module_utils/facts/network/linux.py
+++ b/lib/ansible/module_utils/facts/network/linux.py
@@ -52,9 +52,10 @@ class LinuxNetwork(Network):
         default_ipv4, default_ipv6 = self.get_default_interfaces(ip_path,
                                                                  collected_facts=collected_facts)
         interfaces, ips = self.get_interfaces_info(ip_path, default_ipv4, default_ipv6)
-        network_facts['interfaces'] = interfaces.keys()
+        network_facts['interfaces'] = {}
         for iface in interfaces:
             network_facts[iface] = interfaces[iface]
+            network_facts['interfaces'][iface] = interfaces[iface]
         network_facts['default_ipv4'] = default_ipv4
         network_facts['default_ipv6'] = default_ipv6
         network_facts['all_ipv4_addresses'] = ips['all_ipv4_addresses']


### PR DESCRIPTION
##### SUMMARY
Fixes #30246 by implementing the changes @n-st suggested there

gather_facts currently creates a list `ansible_interfaces` of all interfaces on a host, and for each interface creates a dict `ansible_<interface_name>` containing the details of that interface. This PR changes `ansible_interfaces` to a dict, with interface names for keys, and the corresponding interface details for the value.

The rationale for this change is copied verbatim from #30246:

*I propose making the network interface facts available as a dictionary* (similar to what's done for disk devices) in the existing ansible_interfaces (which is currently only a list of names).
The dictionary approach is preferable, as it:
- reduces clutter in the hierarchy root,
- avoids name collisions (imagine someone named their network interface "dns", for example), and
- makes it much easier and "cleaner" to access those facts dynamically (see example playbook).

This change can be implemented in a backwards-compatible way due to the sematics of Python iterators:
for x in ["lo", "eth0"] iterates over list items, i.e. lo and eth0
for x in {"lo": {…}, "eth0": {…}} iterates over dictionary keys, i.e. lo and eth0


NOTE: of course the `ansible_<interface_name>` facts are left untouched for backward compatibility.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`setup` module

##### ANSIBLE VERSION
```
ansible 2.5.0 (ansible_interfaces 27e058953c) last updated 2018/01/03 13:26:48 (GMT +100)
  config file = None
  configured module search path = [u'/Users/buckleyd/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/buckleyd/projects/github/ansible/lib/ansible
  executable location = /Users/buckleyd/projects/github/ansible/bin/ansible
  python version = 2.7.10 (default, Oct 23 2015, 19:19:21) [GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.59.5)]
```

##### ADDITIONAL INFORMATION
Current implementation makes it non-trivial to iterate through the network interfaces and grab e.g. IP information. We can get around this by building an object in-play such as:
```
- name: Create interfaces dictionary
  set_fact:
    interfaces: "{{ interfaces | default({}) | combine( {item: hostvars[inventory_hostname]['ansible_' + item ]} ) }}"
  with_items: "{{ ansible_interfaces | replace('-', '_') }}"
```
but this is ugly, and can cost significant time/memory if there are many interfaces.

Before change:
```
"ansible_interfaces": [
            "awdl0",
            "bridge0",
            ...
        ]
```

After change:
```
"ansible_interfaces": {
        "awdl0": {
            "device": "awdl0",
            "flags": [
                "BROADCAST",
                "PROMISC",
                "SIMPLEX",
                "MULTICAST"
            ],
            "ipv4": [],
            "ipv6": [],
            ...
        },
        "bridge0": {
            "device": "bridge0",
            "flags": [
                "UP",
                "BROADCAST",
                "SMART",
                "RUNNING",
                "SIMPLEX",
                "MULTICAST"
            ],
            "ipv4": [],
            "ipv6": [],
            ...
        },
        ...
    }
```

  