### PR TITLE
yum: handle exception in local_envra

### DIFF
--- a/lib/ansible/modules/packaging/os/yum.py
+++ b/lib/ansible/modules/packaging/os/yum.py
@@ -614,6 +614,8 @@ def local_envra(path):
     fd = os.open(path, os.O_RDONLY)
     try:
         header = ts.hdrFromFdno(fd)
+    except rpm.error as e:
+        return None
     finally:
         os.close(fd)
 
@@ -752,6 +754,8 @@ def install(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, i
 
             # most common case is the pkg is already installed
             envra = local_envra(package)
+            if envra is None:
+                module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
             installed_pkgs = is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot)
             if installed_pkgs:
                 res['results'].append('%s providing %s is already installed' % (installed_pkgs[0], package))
@@ -1046,6 +1050,9 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, up
                 # get the pkg e:name-v-r.arch
                 envra = local_envra(spec)
 
+                if envra is None:
+                    module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
+
                 # local rpm files can't be updated
                 if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):
                     pkgs['install'].append(spec)
@@ -1056,6 +1063,9 @@ def latest(module, items, repoq, yum_basecmd, conf_file, en_repos, dis_repos, up
                 # download package so that we can check if it's already installed
                 package = fetch_rpm_from_url(spec, module=module)
                 envra = local_envra(package)
+
+                if envra is None:
+                    module.fail_json(msg="Failed to get nevra information from RPM package: %s" % spec)
 
                 # local rpm files can't be updated
                 if not is_installed(module, repoq, envra, conf_file, en_repos=en_repos, dis_repos=dis_repos, installroot=installroot):

--- a/test/integration/targets/yum/tasks/yum.yml
+++ b/test/integration/targets/yum/tasks/yum.yml
@@ -557,3 +557,27 @@
         - "'msg' in yum_result"
         - "'rc' in yum_result"
         - "'results' in yum_result"
+
+- name: Create a temp RPM file which does not contain nevra information
+  file:
+    name: "/tmp/non_existent_pkg.rpm"
+    state: touch
+
+- name: Try installing RPM file which does not contain nevra information
+  yum:
+    name: "/tmp/non_existent_pkg.rpm"
+    state: present
+  register: no_nevra_info_result
+  ignore_errors: yes
+
+- name: Verify RPM failed to install
+  assert:
+    that:
+      - "'changed' in no_nevra_info_result"
+      - "'msg' in no_nevra_info_result"
+      - "'Failed to get nevra information from RPM package' in no_nevra_info_result.msg"
+
+- name: Delete a temp RPM file
+  file:
+    name: "/tmp/non_existent_pkg.rpm"
+    state: absent


### PR DESCRIPTION
##### SUMMARY
This fix adds rpm.error exception which is raised when
API unable to get envra information from RPM package.
Also, adds integration test for local_envra method.

Fixes: #30074

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
test/units/modules/packaging/os/test_yum.py
lib/ansible/modules/packaging/os/yum.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5devel
```