### PR TITLE
really disable inventory cache

### DIFF
--- a/lib/ansible/inventory/data.py
+++ b/lib/ansible/inventory/data.py
@@ -26,7 +26,6 @@ from ansible.errors import AnsibleError
 from ansible.inventory.group import Group
 from ansible.inventory.host import Host
 from ansible.module_utils.six import iteritems
-from ansible.plugins.cache import FactCache
 from ansible.utils.vars import combine_vars
 from ansible.utils.path import basedir
 
@@ -61,9 +60,6 @@ class InventoryData(object):
         for group in ('all', 'ungrouped'):
             self.add_group(group)
         self.add_child('all', 'ungrouped')
-
-        # prime cache
-        self.cache = FactCache()
 
     def serialize(self):
         data = dict()

--- a/lib/ansible/plugins/inventory/__init__.py
+++ b/lib/ansible/plugins/inventory/__init__.py
@@ -49,7 +49,7 @@ class BaseInventoryPlugin(object):
 
         self.inventory = None
         self.display = display
-        self.cache = cache
+        self.cache = cache or {}
 
     def parse(self, inventory, loader, path, cache=True):
         ''' Populates self.groups from the given data. Raises an error on any parse failure.  '''

--- a/lib/ansible/plugins/inventory/constructed.py
+++ b/lib/ansible/plugins/inventory/constructed.py
@@ -102,8 +102,8 @@ class InventoryModule(BaseInventoryPlugin):
 
                 # get available variables to templar
                 hostvars = inventory.hosts[host].get_vars()
-                if host in inventory.cache:  # adds facts if cache is active
-                    hostvars = combine_vars(hostvars, inventory.cache[host])
+                if host in self.cache:  # adds facts if cache is active
+                    hostvars = combine_vars(hostvars, self.cache[host])
 
                 # create composite vars
                 self._set_composite_vars(data.get('compose'), hostvars, host, strict=strict)

--- a/lib/ansible/plugins/inventory/openstack.py
+++ b/lib/ansible/plugins/inventory/openstack.py
@@ -148,9 +148,9 @@ class InventoryModule(BaseInventoryPlugin):
             self._config_data = {}
 
         source_data = None
-        if cache and cache_key in inventory.cache:
+        if cache and cache_key in self.cache:
             try:
-                source_data = inventory.cache[cache_key]
+                source_data = self.cache[cache_key]
             except KeyError:
                 pass
 
@@ -186,7 +186,7 @@ class InventoryModule(BaseInventoryPlugin):
             source_data = cloud_inventory.list_hosts(
                 expand=expand_hostvars, fail_on_cloud_config=fail_on_errors)
 
-            inventory.cache[cache_key] = source_data
+            self.cache[cache_key] = source_data
 
         self._populate_from_source(source_data)
 

--- a/lib/ansible/plugins/inventory/script.py
+++ b/lib/ansible/plugins/inventory/script.py
@@ -72,7 +72,7 @@ class InventoryModule(BaseInventoryPlugin):
 
         try:
             cache_key = self.get_cache_prefix(path)
-            if not cache or cache_key not in inventory.cache:
+            if not cache or cache_key not in self.cache:
                 try:
                     sp = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                 except OSError as e:
@@ -93,11 +93,11 @@ class InventoryModule(BaseInventoryPlugin):
                     raise AnsibleError("Inventory {0} contained characters that cannot be interpreted as UTF-8: {1}".format(path, to_native(e)))
 
                 try:
-                    inventory.cache[cache_key] = self.loader.load(data, file_name=path)
+                    self.cache[cache_key] = self.loader.load(data, file_name=path)
                 except Exception as e:
                     raise AnsibleError("failed to parse executable inventory script results from {0}: {1}\n{2}".format(path, to_native(e), err))
 
-            processed = inventory.cache[cache_key]
+            processed = self.cache[cache_key]
             if not isinstance(processed, Mapping):
                 raise AnsibleError("failed to parse executable inventory script results from {0}: needs to be a json dict\n{1}".format(path, err))
 

--- a/lib/ansible/plugins/inventory/virtualbox.py
+++ b/lib/ansible/plugins/inventory/virtualbox.py
@@ -176,9 +176,9 @@ class InventoryModule(BaseInventoryPlugin):
             raise AnsibleParserError("Incorrect plugin name in file: %s" % config_data.get('plugin', 'none found'))
 
         source_data = None
-        if cache and cache_key in inventory.cache:
+        if cache and cache_key in self.cache:
             try:
-                source_data = inventory.cache[cache_key]
+                source_data = self.cache[cache_key]
             except KeyError:
                 pass
 
@@ -203,6 +203,6 @@ class InventoryModule(BaseInventoryPlugin):
                 AnsibleParserError(to_native(e))
 
             source_data = p.stdout.read()
-            inventory.cache[cache_key] = to_text(source_data, errors='surrogate_or_strict')
+            self.cache[cache_key] = to_text(source_data, errors='surrogate_or_strict')
 
         self._populate_from_source(source_data.splitlines(), config_data)


### PR DESCRIPTION
##### SUMMARY
cache was not correctly added in 2.4 and was enabled by default w/o a toggle, previous attempt removed some of it, but this completes the removal. It will be added as a feature in the future.

Relates to https://github.com/ansible/ansible/pull/31262

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request


##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
inventory
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


  
  