### PR TITLE
Handle role version conflicts in comparisons for py3

### DIFF
--- a/lib/ansible/galaxy/role.py
+++ b/lib/ansible/galaxy/role.py
@@ -234,7 +234,14 @@ class GalaxyRole(object):
                     # of the master branch
                     if len(role_versions) > 0:
                         loose_versions = [LooseVersion(a.get('name', None)) for a in role_versions]
-                        loose_versions.sort()
+                        try:
+                            loose_versions.sort()
+                        except TypeError:
+                            raise AnsibleError(
+                                'Unable to compare role versions (%s) to determine the most recent version due to incompatible version formats. '
+                                'Please contact the role author to resolve versioning conflicts, or specify an explicit role version to '
+                                'install.' % ', '.join([v.vstring for v in loose_versions])
+                            )
                         self.version = str(loose_versions[-1])
                     elif role_data.get('github_branch', None):
                         self.version = role_data['github_branch']


### PR DESCRIPTION
##### SUMMARY
Catch exception comparing role versions, and provide a user friendly error message. Fixes #32301. Fixes #32301

In python3 `LooseVersion` will perform the following parsing:

* `v1.1.0` -> `['v', 1, 1, 0]`
* `1.0.0` -> `[1, 0, 0]`

When it tries to compare those lists, it fails to compare a string with an integer.  There aren't any good ways around this in `LooseVersion`.  Simply stripping leading non-integer chars helps, but can cause issues with trailing non-integers.

Instead of going down the path of finding a way to do something useful with these versions, we will simple catch the exception and provide a more user friendly error to the user.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/galaxy/role.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION

This could be a candidate for use cases elsewhere in the code, but for now I think it's ok to live here.