### PR TITLE
Fix detection of import failure in firewalld module when the module is not installed

### DIFF
--- a/lib/ansible/modules/system/firewalld.py
+++ b/lib/ansible/modules/system/firewalld.py
@@ -808,6 +808,11 @@ def main():
         supports_check_mode=True
     )
 
+    if import_failure:
+        module.fail_json(
+            msg='firewalld and its python module are required for this module, version 0.2.11 or newer required (0.3.9 or newer for offline operations)'
+        )
+
     if fw_offline:
         # Pre-run version checking
         if FW_VERSION < "0.3.9":
@@ -824,11 +829,6 @@ def main():
         except AttributeError:
             module.fail_json(msg="firewalld connection can't be established,\
                     installed version (%s) likely too old. Requires firewalld >= 0.2.11" % FW_VERSION)
-
-    if import_failure:
-        module.fail_json(
-            msg='firewalld and its python module are required for this module, version 0.2.11 or newer required (0.3.9 or newer for offline operations)'
-        )
 
     permanent = module.params['permanent']
     desired_state = module.params['state']


### PR DESCRIPTION
##### SUMMARY

On a Debian system without the modules installed, it fail
with the following traceback:

    Traceback (most recent call last):
      File "/tmp/ansible_KNCWAU/ansible_module_firewalld.py", line 1017, in <module>
        main()
      File "/tmp/ansible_KNCWAU/ansible_module_firewalld.py", line 811, in main
        if fw_offline:
    NameError: global name 'fw_offline' is not defined


##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
firewalld
