### PR TITLE
removed panos_nat_policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) f
 * ec2_ami_search, use ec2_ami_facts instead.
 * nxos_mtu, use nxos_system's `system_mtu` option. To specify an interfaces MTU use nxos_interface.
   https://github.com/ansible/ansible/issues/29387
+* panos_nat_policy: Use panos_nat_rule the old module uses deprecated API calls
 
 ### New Plugins
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,6 @@ See [Porting Guide](http://docs.ansible.com/ansible/devel/porting_guides.html) f
 * ec2_vpc.
 * ec2_ami_search, use ec2_ami_facts instead.
 * nxos_mtu, use nxos_system's `system_mtu` option. To specify an interfaces MTU use nxos_interface.
-  https://github.com/ansible/ansible/issues/29387
 * panos_nat_policy: Use panos_nat_rule the old module uses deprecated API calls
 
 ### New Plugins

--- a/docs/docsite/rst/porting_guide_2.5.rst
+++ b/docs/docsite/rst/porting_guide_2.5.rst
@@ -141,6 +141,7 @@ The following modules will be removed in Ansible 2.9. Please update update your 
 * :ref:`nxos_portchannel <nxos_portchannel>` use :ref:`nxos_linkagg <nxos_linkagg>` instead.
 * :ref:`nxos_switchport <nxos_switchport>` use :ref:`nxos_l2_interface <nxos_l2_interface>` instead.
 * :ref:`panos_security_policy <panos_security_policy>` use :ref:`panos_security_rule <panos_security_rule>` instead.
+* :ref:`panos_nat_policy <panos_nat_policy>` use :ref:`panos_nat_rule <panos_nat_rule>` instead.
 * :ref:`vsphere_guest <vsphere_guest>` use :ref:`vmware_guest <vmware_guest>` instead.
 
 Noteworthy module changes

--- a/lib/ansible/modules/network/panos/_panos_nat_policy.py
+++ b/lib/ansible/modules/network/panos/_panos_nat_policy.py
@@ -19,6 +19,10 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['deprecated'],
+                    'supported_by': 'community'}
+
 DOCUMENTATION = '''
 ---
 module: panos_nat_policy
@@ -31,9 +35,9 @@ version_added: "2.3"
 requirements:
     - pan-python
 deprecated:
-  removed_in: "2.8"
-  why: M(panos_nat_rule) uses next generation SDK (PanDevice).
-  alternative: Use M(panos_nat_rule) instead.
+    alternative: Use M(panos_nat_rule) instead.
+    removed_in: '2.9'
+    why: This module depended on outdated and old SDK, use M(panos_nat_rule) instead.
 options:
     ip_address:
         description:
@@ -144,11 +148,6 @@ EXAMPLES = '''
 RETURN = '''
 # Default return values
 '''
-
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['deprecated'],
-                    'supported_by': 'community'}
-
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import get_exception


### PR DESCRIPTION
##### SUMMARY
removed panos_nat_policy deprecated module in lieu of new panos_nat_rule module. The old module uses deprecated API's that do not exist anymore.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
panos_nat_policy

##### ANSIBLE VERSION
```
ansible 2.4.2.0
  config file = None
  configured module search path = [u'/Users/ibojer/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/ibojer/.virtualenvs/ansible/lib/python2.7/site-packages/ansible
  executable location = /Users/ibojer/.virtualenvs/ansible/bin/ansible
  python version = 2.7.13 (default, Feb  6 2017, 11:22:10) [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)]
```

##### ADDITIONAL INFORMATION
