### PR TITLE
Upgrade the azure storage version

### DIFF
--- a/lib/ansible/module_utils/azure_rm_common.py
+++ b/lib/ansible/module_utils/azure_rm_common.py
@@ -750,7 +750,7 @@ class AzureRMModuleBase(object):
         if not self._storage_client:
             self._storage_client = self.get_mgmt_svc_client(StorageManagementClient,
                                                             base_url=self._cloud_environment.endpoints.resource_manager,
-                                                            api_version='2017-06-01')
+                                                            api_version='2017-10-01')
         return self._storage_client
 
     @property

--- a/packaging/requirements/requirements-azure.txt
+++ b/packaging/requirements/requirements-azure.txt
@@ -2,7 +2,7 @@ packaging
 requests[security]
 azure-mgmt-compute>=2.0.0,<3
 azure-mgmt-network>=1.3.0,<2
-azure-mgmt-storage>=1.2.0,<2
+azure-mgmt-storage>=1.5.0,<2
 azure-mgmt-resource>=1.1.0,<2
 azure-storage>=0.35.1,<0.36
 azure-cli-core>=2.0.12,<3

--- a/test/runner/requirements/integration.cloud.azure.txt
+++ b/test/runner/requirements/integration.cloud.azure.txt
@@ -2,7 +2,7 @@ packaging
 requests[security]
 azure-mgmt-compute>=2.0.0,<3
 azure-mgmt-network>=1.3.0,<2
-azure-mgmt-storage>=1.2.0,<2
+azure-mgmt-storage>=1.5.0,<2
 azure-mgmt-resource>=1.1.0,<2
 azure-storage>=0.35.1,<0.36
 azure-cli-core>=2.0.12,<3


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

The azure-mgmt-storage version is upgrade, but the azure module uses the latest model version to call the old API version, results in the DeserializationError:

```
/tmp/ansible_frHOyW/ansible_module_azure_rm_storageaccount.py", line 416, in create_account
    poller = self.storage_client.storage_accounts.create(self.resource_group, self.name, parameters)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/azure/mgmt/storage/v2017_06_01/operations/storage_accounts_operations.py", line 159, in create
    body_content = self._serialize.body(parameters, 'StorageAccountCreateParameters')
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/msrest/serialization.py", line 460, in body
    SerializationError, "Unable to build a model: "+str(err), err)
  File "/home/travis/virtualenv/python2.7.14/lib/python2.7/site-packages/msrest/exceptions.py", line 48, in raise_with_traceback
    raise error
msrest.exceptions.SerializationError: Unable to build a model: <SkuName.standard_lrs: 'Standard_LRS'> is not valid value for enum <enum 'SkuName'>, DeserializationError: <SkuName.standard_lrs: 'Standard_LRS'> is not valid value for enum <enum 'SkuName'>
```

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
azure_rm

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```

azure_mgmt_storage-1.5.0


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
