### PR TITLE
make eos_vlan idempotent

### DIFF
--- a/lib/ansible/modules/network/eos/eos_vlan.py
+++ b/lib/ansible/modules/network/eos/eos_vlan.py
@@ -140,7 +140,8 @@ def map_obj_to_commands(updates, module):
         elif state == 'present':
             if not obj_in_have:
                 commands.append('vlan %s' % w['vlan_id'])
-                commands.append('name %s' % w['name'])
+                if w['name']:
+                    commands.append('name %s' % w['name'])
 
                 if w['interfaces']:
                     for i in w['interfaces']:
@@ -172,13 +173,15 @@ def map_obj_to_commands(updates, module):
         else:
             if not obj_in_have:
                 commands.append('vlan %s' % w['vlan_id'])
-                commands.append('name %s' % w['name'])
+                if w['name']:
+                    commands.append('name %s' % w['name'])
                 commands.append('state %s' % w['state'])
-            elif obj_in_have['name'] != w['name'] or obj_in_have['state'] != w['state']:
+            elif (w['name'] and obj_in_have['name'] != w['name']) or obj_in_have['state'] != w['state']:
                 commands.append('vlan %s' % w['vlan_id'])
 
-                if obj_in_have['name'] != w['name']:
-                    commands.append('name %s' % w['name'])
+                if w['name']:
+                    if obj_in_have['name'] != w['name']:
+                        commands.append('name %s' % w['name'])
 
                 if obj_in_have['state'] != w['state']:
                     commands.append('state %s' % w['state'])


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/33711
The module misses the condition if `name` is None, hence converts it into string `'None'` which makes vlan name `'None'` and causes idempotence failure.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/eos/eos_vlan
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```
  
  