### PR TITLE
ovirt_cluster: Fix cluster cpu arch comparision

### DIFF
--- a/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
+++ b/lib/ansible/modules/cloud/ovirt/ovirt_cluster.py
@@ -529,12 +529,13 @@ class ClustersModule(BaseModule):
     def update_check(self, entity):
         sched_policy = self._get_sched_policy()
         migration_policy = getattr(entity.migration, 'policy', None)
+        cluster_cpu = getattr(entity, 'cpu', dict())
         return (
             equal(self.param('comment'), entity.comment) and
             equal(self.param('description'), entity.description) and
             equal(self.param('switch_type'), str(entity.switch_type)) and
-            equal(self.param('cpu_arch'), str(entity.cpu.architecture)) and
-            equal(self.param('cpu_type'), entity.cpu.type) and
+            equal(self.param('cpu_arch'), str(getattr(cluster_cpu, 'architecture', None))) and
+            equal(self.param('cpu_type'), getattr(cluster_cpu, 'type', None)) and
             equal(self.param('ballooning'), entity.ballooning_enabled) and
             equal(self.param('gluster'), entity.gluster_service) and
             equal(self.param('virt'), entity.virt_service) and


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
oVirt REST API don't return cpu/arch elelemnt in case it's not set, so we fail the update check. We can just ignore that comparsion in case it's not set, so it's resolve the issue.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ovirt_cluster

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.4
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
