### PR TITLE
Adds the non-deprecated ansible_host var

### DIFF
--- a/contrib/inventory/openstack.py
+++ b/contrib/inventory/openstack.py
@@ -121,6 +121,7 @@ def get_host_groups(inventory, refresh=False):
 def append_hostvars(hostvars, groups, key, server, namegroup=False):
     hostvars[key] = dict(
         ansible_ssh_host=server['interface_ip'],
+        ansible_host=server['interface_ip'],
         openstack=server)
     for group in get_groups_from_server(server, namegroup=namegroup):
         groups[group].append(key)


### PR DESCRIPTION
#### SUMMARY

OpenStack dynamic inventory is still using the deprecated
ansible_ssh_host. This patch adds ansible_host until such
time as ansible_ssh_host is removed

#### ISSUE TYPE

- Bugfix Pull Request

#### COMPONENT NAME
```
contrib/inventory/openstack.py
```
#### ANSIBLE VERSION
```
ansible 2.3.2.0
```

##### ADDITIONAL INFORMATION