### PR TITLE
jenkins_script - Do not prevent username logging

### DIFF
--- a/lib/ansible/modules/web_infrastructure/jenkins_script.py
+++ b/lib/ansible/modules/web_infrastructure/jenkins_script.py
@@ -148,7 +148,7 @@ def main():
             script=dict(required=True, type="str"),
             url=dict(required=False, type="str", default="http://localhost:8080"),
             validate_certs=dict(required=False, type="bool", default=True),
-            user=dict(required=False, no_log=True, type="str", default=None),
+            user=dict(required=False, type="str", default=None),
             password=dict(required=False, no_log=True, type="str", default=None),
             timeout=dict(required=False, type="int", default=10),
             args=dict(required=False, type="dict", default=None)


### PR DESCRIPTION
##### SUMMARY
Jenkins username used for HTTP request is obscured by `********` in `jenkins_script` output. This is problematic as valid username has a nonzero chance in appearing in script output that is therefore mangled.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`jenkins_script`

##### ANSIBLE VERSION

```
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/ogondza/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Sep 20 2017, 01:25:59) [GCC 7.2.0]
```


##### ADDITIONAL INFORMATION
Username is not a secret as such so there is no need to obscure it. Sibling modules, `jenkins_job` and `jenkins_plugin`, do not use it.