### PR TITLE
Don't use the Task object in the dictionary of results for include_role

### DIFF
--- a/lib/ansible/executor/task_executor.py
+++ b/lib/ansible/executor/task_executor.py
@@ -463,7 +463,7 @@ class TaskExecutor:
         # if this task is a IncludeRole, we just return now with a success code so the main thread can expand the task list for the given host
         elif self._task.action == 'include_role':
             include_variables = self._task.args.copy()
-            return dict(include_role=self._task, include_variables=include_variables)
+            return dict(include_variables=include_variables)
 
         # Now we do final validation on the task, which sets all fields to their final values.
         self._task.post_validate(templar=templar)


### PR DESCRIPTION
The short-circuiting of include_role in TaskExecutor was using the _task object
in the result dictionary. This causes the playbook class to be serialized, which
is something we no longer do due to speed/size problems with nested objects.

Simply removing this should fix a lot of memory and speed problems with include_role.
