### PR TITLE
Add VNC port range check

### DIFF
--- a/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
+++ b/lib/ansible/modules/remote_management/manageiq/manageiq_provider.py
@@ -672,6 +672,9 @@ def main():
         argument_spec=argument_spec,
         required_if=[
             ('state', 'present', ['provider'])],
+        required_together=[
+            ['host_default_vnc_port_start', 'host_default_vnc_port_end']
+        ],
     )
 
     name = module.params['name']


### PR DESCRIPTION
##### SUMMARY
This adds a check to ensure that both start and end of vnc range
is specified.

As discussed with @cben in #34112 

##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
remote_management/manageiq

##### ANSIBLE VERSION
```
ansible 2.5.0 (add-vnc-port-range-check 7bd66dd857) last updated 2018/01/04 17:15:02 (GMT +100)
```