### PR TITLE
Support project parameter for os_security_group module

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
+++ b/lib/ansible/modules/cloud/openstack/os_security_group_rule.py
@@ -61,6 +61,11 @@ options:
        - Should the resource be present or absent.
      choices: [present, absent]
      default: present
+   project:
+     description:
+        - Unique name or ID of the project.
+     required: false
+     version_added: "2.7"
    availability_zone:
      description:
        - Ignored. Present for backwards compatibility
@@ -114,6 +119,14 @@ EXAMPLES = '''
     security_group: loadbalancer_sg
     protocol: 112
     remote_group: loadbalancer-node_sg
+
+# Create a security group rule for a given project
+- os_security_group_rule:
+    cloud: mordred
+    security_group: foo
+    protocol: icmp
+    remote_ip_prefix: 0.0.0.0/0
+    project: myproj
 '''
 
 RETURN = '''
@@ -271,6 +284,7 @@ def main():
                        choices=['egress', 'ingress']),
         state=dict(default='present',
                    choices=['absent', 'present']),
+        project=dict(default=None),
     )
 
     module_kwargs = openstack_module_kwargs(
@@ -286,14 +300,29 @@ def main():
     state = module.params['state']
     security_group = module.params['security_group']
     remote_group = module.params['remote_group']
+    project = module.params['project']
     changed = False
 
     sdk, cloud = openstack_cloud_from_module(module)
     try:
-        secgroup = cloud.get_security_group(security_group)
+        if project is not None:
+            proj = cloud.get_project(project)
+            if proj is None:
+                module.fail_json(msg='Project %s could not be found' % project)
+            project_id = proj['id']
+        else:
+            project_id = cloud.current_project_id
+
+        if project_id:
+            filters = {'tenant_id': project_id}
+        else:
+            filters = None
+
+        secgroup = cloud.get_security_group(security_group, filters=filters)
 
         if remote_group:
-            remotegroup = cloud.get_security_group(remote_group)
+            remotegroup = cloud.get_security_group(remote_group,
+                                                   filters=filters)
         else:
             remotegroup = {'id': None}
 
@@ -307,6 +336,9 @@ def main():
 
             rule = _find_matching_rule(module, secgroup, remotegroup)
             if not rule:
+                kwargs = {}
+                if project_id:
+                    kwargs['project_id'] = project_id
                 rule = cloud.create_security_group_rule(
                     secgroup['id'],
                     port_range_min=module.params['port_range_min'],
@@ -315,7 +347,8 @@ def main():
                     remote_ip_prefix=module.params['remote_ip_prefix'],
                     remote_group_id=remotegroup['id'],
                     direction=module.params['direction'],
-                    ethertype=module.params['ethertype']
+                    ethertype=module.params['ethertype'],
+                    **kwargs
                 )
                 changed = True
             module.exit_json(changed=changed, rule=rule, id=rule['id'])


### PR DESCRIPTION
##### SUMMARY

Many OpenStack modules provide the ability to register a resource in a
project other than the one being used to authenticate with, by adding a
project parameter to the module. Examples include os_network, os_subnet,
and os_router. This change adds a project parameter to the
os_security_group module.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
os_security_group
os_security_group_rule