### PR TITLE
Fix Linux blockdevice size computation

### DIFF
--- a/lib/ansible/module_utils/facts/hardware/linux.py
+++ b/lib/ansible/module_utils/facts/hardware/linux.py
@@ -601,7 +601,7 @@ class LinuxHardware(Hardware):
                     part['sectorsize'] = get_file_content(part_sysdir + "/queue/logical_block_size")
                     if not part['sectorsize']:
                         part['sectorsize'] = get_file_content(part_sysdir + "/queue/hw_sector_size", 512)
-                    part['size'] = bytes_to_human((float(part['sectors']) * float(part['sectorsize'])))
+                    part['size'] = bytes_to_human((float(part['sectors']) * 512.0))
                     part['uuid'] = get_partition_uuid(partname)
                     self.get_holders(part, part_sysdir)
 
@@ -621,7 +621,7 @@ class LinuxHardware(Hardware):
             d['sectorsize'] = get_file_content(sysdir + "/queue/logical_block_size")
             if not d['sectorsize']:
                 d['sectorsize'] = get_file_content(sysdir + "/queue/hw_sector_size", 512)
-            d['size'] = bytes_to_human(float(d['sectors']) * float(d['sectorsize']))
+            d['size'] = bytes_to_human(float(d['sectors']) * 512.0)
 
             d['host'] = ""
 


### PR DESCRIPTION
Linux' sysfs _always_ reports device size in 512b sector units,
regardless of the device's actual, physical blocksize.

##### SUMMARY
When establishing facts on a host, ansible queries sysfs for all block device's *sector size*, and then multiplies that information with the number of *sectors* sysfs reports. This yields incorrect results for block devices with physical sector sizes != 512b, since sysfs actually always reports sector count in units of (in case of a different block size, virtual) 512b sectors.

This change simply forces the factor in the computing multiplication to always be 512, which makes drives with e. g. 4K sectors stop from appearing 8x larger than they really are.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
*setup* module, *lib/ansible/module_utils/facts/hardware/linux.py*

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Incorrectly computed total size of NVME device with 4K sector size (before patch; output shortened and partially redacted):
```
$ ansible -i etc/hosts_PRODUCTION -m setup data-postgres-kali.ix -a filter=ansible_devices
data-postgres-kali.ix | SUCCESS => {
    "ansible_facts": {
        "ansible_devices": {
            "nvme0n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                "sectors": "3320974784", 
                "sectorsize": "4096", 
                "size": "12.37 TB", 
                "support_discard": "4096", 
                "vendor": null, 
                "virtual": 1
            }, 
            "sda": {
                "holders": [], 
                "host": "SATA controller: Intel Corporation C610/X99 series chipset sSATA Controller [AHCI mode] (rev 05)", 
                "model": "HGST HDN726050AL", 
                "partitions": {}, 
                "removable": "0", 
                "rotational": "1", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "deadline", 
                "sectors": "9767541168", 
                "sectorsize": "512", 
                "size": "4.55 TB", 
                "support_discard": "0", 
                "vendor": "ATA", 
                "virtual": 1, 
            }, 
[...]
```
Fixed version:
```
$ ansible -i etc/hosts_PRODUCTION -m setup data-postgres-kali.ix -a filter=ansible_devices
data-postgres-kali.ix | SUCCESS => {
    "ansible_facts": {
        "ansible_devices": {
            "nvme0n1": {
                "holders": [], 
                "host": "Non-Volatile memory controller: Intel Corporation PCIe Data Center SSD (rev 01)", 
                "sectors": "3320974784", 
                "sectorsize": "4096", 
                "size": "1.55 TB", 
                "support_discard": "4096", 
                "vendor": null, 
                "virtual": 1
            }, 
            "sda": {
                "holders": [], 
                "host": "SATA controller: Intel Corporation C610/X99 series chipset sSATA Controller [AHCI mode] (rev 05)", 
                "model": "HGST HDN726050AL", 
                "partitions": {}, 
                "removable": "0", 
                "rotational": "1", 
                "sas_address": null, 
                "sas_device_handle": null, 
                "scheduler_mode": "deadline", 
                "sectors": "9767541168", 
                "sectorsize": "512", 
                "size": "4.55 TB", 
                "support_discard": "0", 
                "vendor": "ATA", 
                "virtual": 1, 
            }, 
[...]
```