### PR TITLE
win_package: remove case sensitive check for msi extension

### DIFF
--- a/lib/ansible/modules/windows/win_package.ps1
+++ b/lib/ansible/modules/windows/win_package.ps1
@@ -173,7 +173,7 @@ Function Get-ProgramMetadata($state, $path, $product_id, $credential, $creates_p
 
     # set the location type and validate the path
     if ($path -ne $null) {
-        if ($path.EndsWith(".msi")) {
+        if ($path.EndsWith(".msi", [System.StringComparison]::CurrentCultureIgnoreCase)) {
             $metadata.msi = $true
         } else {
             $metadata.msi = $false

--- a/test/integration/targets/win_package/tasks/msi_tests.yml
+++ b/test/integration/targets/win_package/tasks/msi_tests.yml
@@ -267,7 +267,7 @@
 
 - name: install local msi with arguments (check mode)
   win_package:
-    path: '{{test_win_package_path}}\good.msi'
+    path: '{{test_win_package_path}}\good.MSI'
     state: present
     arguments: ADDLOCAL=Cow
   register: install_msi_argument_check
@@ -293,7 +293,7 @@
 
 - name: install local msi with arguments
   win_package:
-    path: '{{test_win_package_path}}\good.msi'
+    path: '{{test_win_package_path}}\good.MSI'
     state: present
     arguments: ADDLOCAL=Cow
   register: install_msi_argument
@@ -319,7 +319,7 @@
 
 - name: install local msi with arguments (idempotent)
   win_package:
-    path: '{{test_win_package_path}}\good.msi'
+    path: '{{test_win_package_path}}\good.MSI'
     state: present
     arguments: ADDLOCAL=Cow
   register: install_msi_argument_again


### PR DESCRIPTION
##### SUMMARY
Makes sure the check for an MSI works on a case insensitive basis, so installers like `file.MSI` works.

Fixes https://github.com/ansible/ansible/issues/34465

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
win_package

##### ANSIBLE VERSION
```
2.5
```