### PR TITLE
win_mapped_drive: add extra note around win_mapped_drive

### DIFF
--- a/lib/ansible/modules/windows/win_mapped_drive.py
+++ b/lib/ansible/modules/windows/win_mapped_drive.py
@@ -23,6 +23,9 @@ notes:
 - This can only map a network drive for the current executing user and does not
   allow you to set a default drive for all users of a system. Use other
   Microsoft tools like GPOs to achieve this goal.
+- You cannot use this module to access a mapped drive in another Ansible task,
+  drives mapped with this module are only accessible when logging in
+  interactively with the user through the console or RDP.
 options:
   letter:
     description:


### PR DESCRIPTION
##### SUMMARY
Added extra note to the win_mapped_drive docs to say that a drive mapped by this module
won't be accessible in another Ansible task. It is only for creating a mapped drive for interactive
sessions like a console or RDP logon.

Fixes https://github.com/ansible/ansible/issues/33929

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
win_mapped_drive

##### ANSIBLE VERSION
```
2.5
```
  