### PR TITLE
ec2_win_password: fix broken import and minor updates

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -118,7 +118,7 @@ def main():
         key_file=dict(required=True, type='path'),
         key_passphrase=dict(no_log=True, default=None, required=False),
         wait=dict(type='bool', default=False, required=False),
-        wait_timeout=dict(default=120, required=False),
+        wait_timeout=dict(default=120, required=False, type='int'),
     )
     )
     module = AnsibleModule(argument_spec=argument_spec)
@@ -136,7 +136,7 @@ def main():
     else:
         b_key_passphrase = to_bytes(module.params.get('key_passphrase'), errors='surrogate_or_strict')
     wait = module.params.get('wait')
-    wait_timeout = int(module.params.get('wait_timeout'))
+    wait_timeout = module.params.get('wait_timeout')
 
     ec2 = ec2_connect(module)
 

--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -16,7 +16,7 @@ DOCUMENTATION = '''
 module: ec2_win_password
 short_description: gets the default administrator password for ec2 windows instances
 description:
-    - Gets the default administrator password from any EC2 Windows instance.  The instance is referenced by its id (e.g. i-XXXXXXX). This module
+    - Gets the default administrator password from any EC2 Windows instance. The instance is referenced by its id (e.g. C(i-XXXXXXX)). This module
       has a dependency on python-boto.
 version_added: "2.0"
 author: "Rick Mendes (@rickmendes)"
@@ -33,7 +33,7 @@ options:
     version_added: "2.0"
     description:
       - The passphrase for the instance key pair. The key must use DES or 3DES encryption for this module to decrypt it. You can use openssl to
-        convert your password protected keys if they do not use DES or 3DES. ex) openssl rsa -in current_key -out new_key -des3.
+        convert your password protected keys if they do not use DES or 3DES. ex) C(openssl rsa -in current_key -out new_key -des3).
     required: false
     default: null
   wait:

--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -106,12 +106,6 @@ try:
 except ImportError:
     HAS_CRYPTOGRAPHY = False
 
-try:
-    import boto.ec2
-    HAS_BOTO = True
-except ImportError:
-    HAS_BOTO = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
 from ansible.module_utils._text import to_bytes

--- a/lib/ansible/modules/cloud/amazon/ec2_win_password.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_win_password.py
@@ -147,7 +147,7 @@ def main():
         while datetime.datetime.now() < end:
             data = ec2.get_password_data(instance_id)
             decoded = b64decode(data)
-            if wait and not decoded:
+            if not decoded:
                 time.sleep(5)
             else:
                 break

--- a/test/sanity/import/skip.txt
+++ b/test/sanity/import/skip.txt
@@ -1,4 +1,3 @@
-lib/ansible/modules/cloud/amazon/ec2_win_password.py
 lib/ansible/modules/cloud/azure/azure_rm_dnsrecordset.py
 lib/ansible/modules/cloud/dimensiondata/dimensiondata_network.py
 lib/ansible/modules/cloud/webfaction/webfaction_app.py


### PR DESCRIPTION
##### SUMMARY
`ec2_win_password`:
- fix [broken import](https://github.com/ansible/community/wiki/Testing%3A-progress-tracker#list-of-things-that-need-unit-tests-eg-libraries-under-module_utils)
- remove unused `HAS_BOTO`
- doc: use formatting function
- remove condition always `True`
- `wait_timeout` parameter: use `int` type

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ec2_win_password

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel da69f5aeae) last updated 2018/01/04 22:43:58 (GMT +200)
```