### PR TITLE
Add examples and language to better showcase the 'parents' parameter in multiple network modules

### DIFF
--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -36,7 +36,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy 
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/aruba/aruba_config.py
+++ b/lib/ansible/modules/network/aruba/aruba_config.py
@@ -36,7 +36,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section or hierarchy 
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/asa/asa_config.py
+++ b/lib/ansible/modules/network/asa/asa_config.py
@@ -37,7 +37,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/cloudengine/ce_config.py
+++ b/lib/ansible/modules/network/cloudengine/ce_config.py
@@ -43,7 +43,7 @@ options:
     default: null
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/dellos10/dellos10_config.py
+++ b/lib/ansible/modules/network/dellos10/dellos10_config.py
@@ -39,7 +39,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/dellos6/dellos6_config.py
+++ b/lib/ansible/modules/network/dellos6/dellos6_config.py
@@ -37,7 +37,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/dellos9/dellos9_config.py
+++ b/lib/ansible/modules/network/dellos9/dellos9_config.py
@@ -38,7 +38,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/eos/eos_config.py
+++ b/lib/ansible/modules/network/eos/eos_config.py
@@ -49,7 +49,7 @@ options:
     default: null
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -242,7 +242,7 @@ EXAMPLES = """
     lines:
       - ip helper-address 172.26.1.10
       - ip helper-address 172.26.3.8
-    parents: {{ item }}
+    parents: "{{ item }}"
   with_items:
     - interface Ethernet1
     - interface Ethernet2

--- a/lib/ansible/modules/network/ios/ios_config.py
+++ b/lib/ansible/modules/network/ios/ios_config.py
@@ -48,7 +48,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.
@@ -236,6 +236,27 @@ EXAMPLES = """
       - description test interface
       - ip address 172.31.1.1 255.255.255.0
     parents: interface Ethernet1
+
+- name: configure ip helpers on multiple interfaces
+  ios_config:
+    lines:
+      - ip helper-address 172.26.1.10
+      - ip helper-address 172.26.3.8
+    parents: {{ item }}
+  with_items:
+    - interface Ethernet1
+    - interface Ethernet2
+    - interface GigabitEthernet1
+
+- name: configure policer in Scavenger class
+  ios_config:
+    lines:
+      - conform-action transmit
+      - exceed-action drop
+    parents:
+      - policy-map Foo
+      - class Scavenger
+      - police cir 64000
 
 - name: load new acl into device
   ios_config:

--- a/lib/ansible/modules/network/iosxr/iosxr_config.py
+++ b/lib/ansible/modules/network/iosxr/iosxr_config.py
@@ -41,7 +41,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/nxos/nxos_config.py
+++ b/lib/ansible/modules/network/nxos/nxos_config.py
@@ -47,7 +47,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/ordnance/ordnance_config.py
+++ b/lib/ansible/modules/network/ordnance/ordnance_config.py
@@ -36,7 +36,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.

--- a/lib/ansible/modules/network/sros/sros_config.py
+++ b/lib/ansible/modules/network/sros/sros_config.py
@@ -38,7 +38,7 @@ options:
     aliases: ['commands']
   parents:
     description:
-      - The ordered set of parents that uniquely identify the section
+      - The ordered set of parents that uniquely identify the section or hierarchy
         the commands should be checked against.  If the parents argument
         is omitted, the commands are checked against the set of top
         level or global commands.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
The parents parameter isn't well showcased in the examples or documentation. I added two more examples that show slightly more complex ways to use it.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
ios_config
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
>>> ansible.__version__
'2.5.0'
```