### PR TITLE
Handle platform os version for sandbox nxos_nxapi

### DIFF
--- a/lib/ansible/modules/network/nxos/nxos_nxapi.py
+++ b/lib/ansible/modules/network/nxos/nxos_nxapi.py
@@ -79,7 +79,7 @@ options:
         the NXAPI feature is configured for the first time.  When the
         C(sandbox) argument is set to True, the developer sandbox URL
         will accept requests and when the value is set to False, the
-        sandbox URL is unavailable.
+        sandbox URL is unavailable. This is supported on NX-OS 7K series.
     required: false
     default: no
     choices: ['yes', 'no']
@@ -133,9 +133,14 @@ from ansible.module_utils.six import iteritems
 
 def check_args(module, warnings):
     device_info = get_capabilities(module)
+
     network_api = device_info.get('network_api', 'nxapi')
     if network_api == 'nxapi':
         module.fail_json(msg='module not supported over nxapi transport')
+
+    os_platform = device_info['device_info']['network_os_platform']
+    if '7K' not in os_platform and module.params['sandbox']:
+        module.fail_json(msg='sandbox or enable_sandbox is supported on NX-OS 7K series of switches')
 
     state = module.params['state']
 

--- a/test/units/modules/network/nxos/test_nxos_nxapi.py
+++ b/test/units/modules/network/nxos/test_nxos_nxapi.py
@@ -39,7 +39,7 @@ class TestNxosNxapiModule(TestNxosModule):
 
         self.mock_get_capabilities = patch('ansible.modules.network.nxos.nxos_nxapi.get_capabilities')
         self.get_capabilities = self.mock_get_capabilities.start()
-        self.get_capabilities.return_value = {'network_api': 'cliconf'}
+        self.get_capabilities.return_value = {'device_info': {'network_os_platform': 'N7K-C7018'}, 'network_api': 'cliconf'}
 
     def tearDown(self):
         super(TestNxosNxapiModule, self).tearDown()


### PR DESCRIPTION
Signed-off-by: Trishna Guha <trishnaguha17@gmail.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fixes https://github.com/ansible/ansible/issues/32635
fixes https://github.com/ansible/ansible/issues/26371
sandbox option is only supported on 7K.
https://github.com/ansible/ansible/blob/devel/test/integration/targets/nxos_nxapi/tests/cli/configure.yaml#L4
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
modules/network/nxos/nxos_nxapi
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```
  