### PR TITLE
get_url tests: controller and managed node can be distinct

### DIFF
--- a/test/integration/targets/get_url/tasks/main.yml
+++ b/test/integration/targets/get_url/tasks/main.yml
@@ -33,17 +33,18 @@
 
 - name: Define test files for file schema
   set_fact:
-    geturl_srcfile: "{{ output_dir | expanduser }}/aurlfile.txt"
-    geturl_dstfile: "{{ output_dir | expanduser }}/aurlfile_copy.txt"
+    geturl_srcfile: "{{ output_dir }}/aurlfile.txt"
+    geturl_dstfile: "{{ output_dir }}/aurlfile_copy.txt"
 
 - name: Create source file
   copy:
     dest: "{{ geturl_srcfile }}"
     content: "foobar"
+  register: source_file_copied
 
 - name: test file fetch
   get_url:
-    url: "{{ 'file://' + geturl_srcfile }}"
+    url: "file://{{ source_file_copied.dest }}"
     dest: "{{ geturl_dstfile }}"
   register: result
 
@@ -55,8 +56,8 @@
 
 - name: test nonexisting file fetch
   get_url:
-    url: "{{ 'file://' + geturl_srcfile + 'NOFILE' }}"
-    dest: "{{ geturl_dstfile + 'NOFILE' }}"
+    url: "file://{{ source_file_copied.dest }}NOFILE"
+    dest: "{{ geturl_dstfile }}NOFILE"
   register: result
   ignore_errors: True
 


### PR DESCRIPTION
##### SUMMARY
When control machine and managed host are distinct, `get_url` integration tests fail:

```
TASK [get_url : Create source file] **************************************************************************************************************************
fatal: [testhost]: FAILED! => {"attempts": 1, "changed": false, "checksum": "8843d7f92416211de9ebb963ff4ce28125932878", "msg": "Destination directory /home/pilou/ansible_testing does not exist"}
```

Templating happens on the Ansible controller, not on the task’s target host.
This pull request allows control machine to be distinct from managed host.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
get_url

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel da69f5aeae) last updated 2018/01/04 22:43:58 (GMT +200)
```

##### ADDITIONAL INFORMATION
Same as #33968.

~~Note that CI will fail until #33580 is fixed.~~
  