### PR TITLE
Update httptester.yml to match Dockerfile

### DIFF
--- a/test/utils/docker/httptester/httptester.yml
+++ b/test/utils/docker/httptester/httptester.yml
@@ -72,7 +72,7 @@
 
     - name: Generate ca key
       command: >
-        openssl req -new -x509 -days 3650 -nodes -extensions v3_ca -keyout /root/ca/private/cakey.pem -out /root/ca/cacert.pem
+        openssl req -new -x509 -nodes -extensions v3_ca -keyout /root/ca/private/cakey.pem -out /root/ca/cacert.pem
           -subj "/C=US/ST=North Carolina/L=Durham/O=Ansible/CN=ansible.http.tests"
 
     - name: Generate ansible.http.tests key
@@ -82,7 +82,7 @@
 
     - name: Generate ansible.http.tests cert
       shell: >
-        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/ansible.http.tests-cert.pem -infiles /root/ca/ansible.http.tests-req.pem
+        yes | openssl ca -config /etc/ssl/openssl.cnf -days 3650 -out /root/ca/ansible.http.tests-cert.pem -infiles /root/ca/ansible.http.tests-req.pem
 
     - name: Generate sni1.ansible.http.tests key
       command: >
@@ -91,7 +91,7 @@
 
     - name: Generate sni1.ansible.http.tests cert
       shell: >
-        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni1.ansible.http.tests-cert.pem -infiles /root/ca/sni1.ansible.http.tests-req.pem
+        yes | openssl ca -config /etc/ssl/openssl.cnf -days 3650 -out /root/ca/sni1.ansible.http.tests-cert.pem -infiles /root/ca/sni1.ansible.http.tests-req.pem
 
     - name: Generate sni2.ansible.http.tests key
       command: >
@@ -100,7 +100,7 @@
 
     - name: Generate sni2.ansible.http.tests cert
       shell: >
-        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem
+        yes | openssl ca -config /etc/ssl/openssl.cnf -days 3650 -out /root/ca/sni2.ansible.http.tests-cert.pem -infiles /root/ca/sni2.ansible.http.tests-req.pem
 
     - name: Generate client key
       command: >
@@ -109,7 +109,7 @@
 
     - name: Generate client.ansible.http.tests cert
       shell: >
-        yes | openssl ca -config /etc/ssl/openssl.cnf -out /root/ca/client.ansible.http.tests-cert.pem -infiles /root/ca/client.ansible.http.tests-req.pem
+        yes | openssl ca -config /etc/ssl/openssl.cnf -days 3650 -out /root/ca/client.ansible.http.tests-cert.pem -infiles /root/ca/client.ansible.http.tests-req.pem
 
     - name: Copy cacert.pem into nginx doc root for easy retrieval
       copy:
@@ -129,14 +129,16 @@
 
     - name: Install gunicorn and httpbin
       pip:
-        name: "{{ item }}"
+        name: "{{ item.name }}"
+        version: "{{ item.version|default(omit) }}"
       with_items:
-        - gunicorn
-        - httpbin
+        - name: gunicorn
+        - name: httpbin
+          version: '0.5.0'
 
     - name: Copy services.sh script
       copy:
-        src: services.sh
+        src: "{{ playbook_dir }}/services.sh"
         dest: /services.sh
         mode: 0755
 


### PR DESCRIPTION
##### SUMMARY

Following on https://github.com/ansible/ansible/commit/fba178d8521757168d80904cbec9bf1a4b386d84 update the httptester.yml playbook to match the Dockerfile

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
test/utils/docker/httptester/httptester.yml

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```