### PR TITLE
Support datetime serialization in json encoder

### DIFF
--- a/lib/ansible/plugins/filter/core.py
+++ b/lib/ansible/plugins/filter/core.py
@@ -35,7 +35,7 @@ import uuid
 import yaml
 
 from collections import MutableMapping, MutableSequence
-from datetime import datetime
+import datetime
 from functools import partial
 from random import Random, SystemRandom, shuffle
 
@@ -69,6 +69,8 @@ class AnsibleJSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, HostVars):
             return dict(o)
+        elif isinstance(o, (datetime.date, datetime.datetime)):
+            return o.isoformat()
         else:
             return super(AnsibleJSONEncoder, self).default(o)
 
@@ -126,7 +128,7 @@ def to_bool(a):
 
 
 def to_datetime(string, format="%Y-%m-%d %H:%M:%S"):
-    return datetime.strptime(string, format)
+    return datetime.datetime.strptime(string, format)
 
 
 def strftime(string_format, second=None):


### PR DESCRIPTION
##### SUMMARY

This PR supports datetime serialization in the json encoder for filters. It does this serializing as iso8601 format which is widely supported.  We don't need anything for the YAML filters, as pyyaml handles this natively.

Fixes #34312

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
lib/ansible/plugins/filter/core.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```