### PR TITLE
fix ansible-galaxy requirements.yml import_tasks->include in docs

### DIFF
--- a/docs/docsite/rst/galaxy.rst
+++ b/docs/docsite/rst/galaxy.rst
@@ -152,7 +152,7 @@ Content of the *requirements.yml* file:
     # from galaxy
     - src: yatesr.timezone
 
-    - import_tasks: <path_to_requirements>/webserver.yml
+    - include: <path_to_requirements>/webserver.yml
 
 
 Content of the *webserver.yml* file:


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Docs change to fix the reference of using `import_tasks` inside a `requirements.yml` file to include another requirements file, should be `include`.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ansible-galaxy

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
$ ansible --version                                        
ansible 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/admiller/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python2.7/site-packages/ansible
  executable location = /usr/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 14:52:53) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]

```

