### PR TITLE
Fixes for bigip monitors and profiles

### DIFF
--- a/lib/ansible/modules/network/f5/bigip_monitor_http.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_http.py
@@ -232,6 +232,11 @@ class Parameters(AnsibleF5Parameters):
                     # If the mapped value is not a @property
                     self._values[map_key] = v
 
+    def _fqdn_name(self, value):
+        if value is not None and not value.startswith('/'):
+            return '/{0}/{1}'.format(self.partition, value)
+        return value
+
     def to_return(self):
         result = {}
         try:
@@ -316,11 +321,7 @@ class Parameters(AnsibleF5Parameters):
     def parent(self):
         if self._values['parent'] is None:
             return None
-        if self._values['parent'].startswith('/'):
-            parent = os.path.basename(self._values['parent'])
-            result = '/{0}/{1}'.format(self.partition, parent)
-        else:
-            result = '/{0}/{1}'.format(self.partition, self._values['parent'])
+        result = self._fqdn_name(self._values['parent'])
         return result
 
     @property
@@ -355,7 +356,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent monitor cannot be changed"
             )
@@ -569,7 +570,7 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         self.argument_spec = dict(
             name=dict(required=True),
-            parent=dict(default='http'),
+            parent=dict(default='/Common/http'),
             send=dict(),
             receive=dict(),
             receive_disable=dict(required=False),

--- a/lib/ansible/modules/network/f5/bigip_monitor_https.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_https.py
@@ -221,6 +221,11 @@ class Parameters(AnsibleF5Parameters):
                     # If the mapped value is not a @property
                     self._values[map_key] = v
 
+    def _fqdn_name(self, value):
+        if value is not None and not value.startswith('/'):
+            return '/{0}/{1}'.format(self.partition, value)
+        return value
+
     def to_return(self):
         result = {}
         try:
@@ -313,11 +318,7 @@ class Parameters(AnsibleF5Parameters):
     def parent(self):
         if self._values['parent'] is None:
             return None
-        if self._values['parent'].startswith('/'):
-            parent = os.path.basename(self._values['parent'])
-            result = '/{0}/{1}'.format(self.partition, parent)
-        else:
-            result = '/{0}/{1}'.format(self.partition, self._values['parent'])
+        result = self._fqdn_name(self._values['parent'])
         return result
 
     @property
@@ -340,7 +341,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent monitor cannot be changed"
             )
@@ -551,7 +552,7 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         self.argument_spec = dict(
             name=dict(required=True),
-            parent=dict(default='https'),
+            parent=dict(default='/Common/https'),
             send=dict(),
             receive=dict(),
             receive_disable=dict(required=False),

--- a/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_snmp_dca.py
@@ -292,6 +292,11 @@ class Parameters(AnsibleF5Parameters):
                     # If the mapped value is not a @property
                     self._values[map_key] = v
 
+    def _fqdn_name(self, value):
+        if value is not None and not value.startswith('/'):
+            return '/{0}/{1}'.format(self.partition, value)
+        return value
+
     def to_return(self):
         result = {}
         try:
@@ -338,11 +343,7 @@ class Parameters(AnsibleF5Parameters):
     def parent(self):
         if self._values['parent'] is None:
             return None
-        if self._values['parent'].startswith('/'):
-            parent = os.path.basename(self._values['parent'])
-            result = '/{0}/{1}'.format(self.partition, parent)
-        else:
-            result = '/{0}/{1}'.format(self.partition, self._values['parent'])
+        result = self._fqdn_name(self._values['parent'])
         return result
 
     @property
@@ -406,7 +407,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent monitor cannot be changed"
             )
@@ -622,7 +623,7 @@ class ArgumentSpec(object):
         self.argument_spec = dict(
             name=dict(required=True),
             description=dict(),
-            parent=dict(),
+            parent=dict(default='/Common/snmp_dca'),
             ip=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_echo.py
@@ -194,6 +194,11 @@ class Parameters(AnsibleF5Parameters):
                     # If the mapped value is not a @property
                     self._values[map_key] = v
 
+    def _fqdn_name(self, value):
+        if value is not None and not value.startswith('/'):
+            return '/{0}/{1}'.format(self.partition, value)
+        return value
+
     def to_return(self):
         result = {}
         try:
@@ -289,7 +294,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent monitor cannot be changed"
             )
@@ -486,7 +491,7 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         self.argument_spec = dict(
             name=dict(required=True),
-            parent=dict(default='tcp_echo'),
+            parent=dict(default='/Common/tcp_echo'),
             ip=dict(),
             interval=dict(type='int'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_tcp_half_open.py
@@ -213,6 +213,11 @@ class Parameters(AnsibleF5Parameters):
                     # If the mapped value is not a @property
                     self._values[map_key] = v
 
+    def _fqdn_name(self, value):
+        if value is not None and not value.startswith('/'):
+            return '/{0}/{1}'.format(self.partition, value)
+        return value
+
     def to_return(self):
         result = {}
         try:
@@ -324,7 +329,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent monitor cannot be changed"
             )
@@ -533,7 +538,7 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         self.argument_spec = dict(
             name=dict(required=True),
-            parent=dict(default='tcp_half_open'),
+            parent=dict(default='/Common/tcp_half_open'),
             ip=dict(),
             port=dict(type='int'),
             interval=dict(type='int'),

--- a/lib/ansible/modules/network/f5/bigip_monitor_udp.py
+++ b/lib/ansible/modules/network/f5/bigip_monitor_udp.py
@@ -214,6 +214,11 @@ class Parameters(AnsibleF5Parameters):
                     # If the mapped value is not a @property
                     self._values[map_key] = v
 
+    def _fqdn_name(self, value):
+        if value is not None and not value.startswith('/'):
+            return '/{0}/{1}'.format(self.partition, value)
+        return value
+
     def to_return(self):
         result = {}
         try:
@@ -329,7 +334,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent monitor cannot be changed"
             )
@@ -539,7 +544,7 @@ class ArgumentSpec(object):
         self.supports_check_mode = True
         self.argument_spec = dict(
             name=dict(required=True),
-            parent=dict(default='udp'),
+            parent=dict(default='/Common/udp'),
             send=dict(),
             receive=dict(),
             receive_disable=dict(required=False),

--- a/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
+++ b/lib/ansible/modules/network/f5/bigip_profile_client_ssl.py
@@ -340,7 +340,7 @@ class Difference(object):
 
     @property
     def parent(self):
-        if self.want.parent != self.want.parent:
+        if self.want.parent != self.have.parent:
             raise F5ModuleError(
                 "The parent profile cannot be changed"
             )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
Fixed incorrect parent comparison. Fixed old fqdn_name usage.
Fixed incorrect default parents

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
bigip_monitor_* modules
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
ansible 2.5.0
  config file = None
  configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.14 (default, Dec 12 2017, 16:55:09) [GCC 4.9.2]
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
