### PR TITLE
Fix Windows integration tests.

### DIFF
--- a/test/integration/targets/win_find/tasks/tests.yml
+++ b/test/integration/targets/win_find/tasks/tests.yml
@@ -25,6 +25,7 @@
 - name: set expected value for files in a single directory
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 5
       failed: False
@@ -108,6 +109,7 @@
 - name: set fact for hidden files
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 11
       failed: False
@@ -150,6 +152,7 @@
 - name: set fact for pattern files
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 5
       failed: False
@@ -188,6 +191,7 @@
 - name: set expected value for files in a nested directory
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 8
       failed: False
@@ -257,6 +261,7 @@
 - name: set expected value for files in a nested directory while following links
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 10
       failed: False
@@ -340,6 +345,7 @@
 - name: set expected fact for directories with recurse and follow
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 2
       failed: False
@@ -405,6 +411,7 @@
 - name: set expected fact for files by size
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 5
       failed: False
@@ -448,6 +455,7 @@
 - name: set expected fact for files by size (less than)
   set_fact:
     expected:
+      attempts: 1
       changed: False
       examined: 5
       failed: False

--- a/test/integration/targets/win_reg_stat/tasks/main.yml
+++ b/test/integration/targets/win_reg_stat/tasks/main.yml
@@ -50,6 +50,7 @@
 - name: set expected value for reg structure
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -78,6 +79,7 @@
 - name: set expected value for reg key with no sub keys but some properties
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -101,6 +103,7 @@
 - name: set expected value for reg key without sub keys or properties
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -121,6 +124,7 @@
 - name: set expected value for non-existent reg key
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: false
       failed: false
@@ -139,6 +143,7 @@
 - name: set expected string property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -160,6 +165,7 @@
 - name: set expected expand string property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -181,6 +187,7 @@
 - name: set expected multi string property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -202,6 +209,7 @@
 - name: set expected binary property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -223,6 +231,7 @@
 - name: set expected dword property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -244,6 +253,7 @@
 - name: set expected qword property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -265,6 +275,7 @@
 - name: set expected none property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -286,6 +297,7 @@
 - name: set expected none with value property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: true
       failed: false
@@ -307,6 +319,7 @@
 - name: set expected non-existence property
   set_fact:
     expected:
+      attempts: 1
       changed: false
       exists: false
       failed: false


### PR DESCRIPTION
##### SUMMARY

Fix Windows integration tests.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

Windows integration tests

##### ANSIBLE VERSION

```
ansible 2.5.0 (test-fix 1b83e5a1d6) last updated 2018/01/05 16:52:21 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
