### PR TITLE
Add modules for Geo-Replication

### DIFF
--- a/lib/ansible/modules/storage/gluster/georep.py
+++ b/lib/ansible/modules/storage/gluster/georep.py
@@ -1,0 +1,153 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: geo_rep (actions module for geo-replication)
+
+short_description: module to start and stop of geo-replication session in gluster enabled hosts
+
+version_added: "2.4"
+
+description:
+    - "module helps to start and stop a geo-rep session in gluster enabled hosts"
+
+options:
+    start:
+        description: starts a geo-rep session with the credentials gained from the status action in the georep_facts module in the gluster enabled hosts.
+    stop:
+        description: stops a geo-rep session with the credentials gained from the status action in the georep_facts module in the gluster enabled hosts.
+author:
+    - Ashmitha Ambastha (@ashmitha7)
+'''
+EXAMPLES = '''
+#the module will get information such as volume names, nodes and slave user name from georep_facts module and then run the tasks to
+#start and stop geo-rep sessions.
+
+# If the module is used to ONLY start a geo-rep session
+# then the playbook will have a task like below,
+ - name: starting geo-rep status
+    geo_rep: action=start
+             mastervol=master_volume
+             slavevol=10.11.77.12:slave_volume
+             georepuser=root
+             force=yes
+
+# If the module is used to ONLY stop a geo-rep session
+# then the playbook will have a task like below,
+- name: stopping geo-rep session
+    geo_rep: action=stop
+             mastervol=master_volume
+             slavevol=10.11.77.12:slave_volume
+             georepuser=root
+             force=yes
+'''
+RETURN = '''
+MASTER NODE- <master volume IP>
+MASTER VOL- <master_volume name>
+MASTER BRICK- <for example, /gluster-bricks/b1/b1>
+SLAVE USER- <for example,root>
+SLAVE-<for example, ssh://10.11.77.12::volume1>
+'''
+
+import sys
+import re
+import shlex
+from subprocess import Popen
+import subprocess
+import os
+
+
+from collections import OrderedDict
+from ansible.module_utils.basic import *
+from ast import literal_eval
+
+class GeoRep(object):
+    def __init__(self, module):
+        self.module = module
+        self.action = self._validated_params('action')
+        self.gluster_georep_ops()
+
+    def get_playbook_params(self, opt):
+        return self.module.params[opt]
+
+    def _validated_params(self, opt):
+        value = self.get_playbook_params(opt)
+        if value is None:
+            msg = "Please provide %s option in the playbook!" % opt
+            self.module.fail_json(msg=msg)
+        return value
+
+    def gluster_georep_ops(self):
+
+        mastervol = self._validated_params('mastervol')
+        slavevol = self._validated_params('slavevol')
+        slavevol = self.check_pool_exclusiveness(mastervol, slavevol)
+
+        if self.action in ['start','stop']:
+            force = self._validated_params('force')
+            force = 'force' if force == 'yes' else ' '
+
+        if self.action == 'start':
+            rc, output, err = self.call_gluster_cmd(' volume', ' geo-replication ',
+                    mastervol, slavevol,self.action,force)
+            self._get_output(rc, output, err)
+
+        if self.action == 'stop' and self.user == 'root':
+            rc,output,err = self.call_gluster_cmd(' volume',' geo-replication ',
+                mastervol,slavevol,
+                self.action,force)
+            self._get_output(rc,output,err)
+
+    def call_gluster_cmd(self, *args, **kwargs):
+        params = ' '.join(opt for opt in args)
+        key_value_pair = ' '.join(' %s %s ' % (key, value)
+                for key, value in kwargs)
+        return self._run_command('gluster', ' ' + params + ' ' + key_value_pair )
+
+    def _get_output(self, rc, output, err):
+        carryon = True if self.action in  ['stop'] else False
+        changed = 0 if (carryon and rc) else 1
+        if self.action in ['stop'] and (
+                self.user == 'root' and changed == 0):
+            return
+        if not rc or carryon:
+            self.module.exit_json(stdout=output, changed=changed)
+        else:
+            self.module.fail_json(msg=err)
+
+    def _run_command(self, op, opts):
+        cmd = self.module.get_bin_path(op, True) + opts
+        return self.module.run_command(cmd)
+
+def run_module():
+    module = AnsibleModule(
+        argument_spec=dict(
+        action=dict(required=True, choices=['start',
+            'stop']),
+        mastervol=dict(),
+        slavevol=dict(),
+        georepuser=dict(),
+        force=dict(),
+        ),
+    )
+    GeoRep(module)
+
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()
+

--- a/lib/ansible/modules/storage/gluster/georep_facts.py
+++ b/lib/ansible/modules/storage/gluster/georep_facts.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: georep_facts
+
+short_description: module to get status of a geo-replication session.
+
+version_added: "2.4"
+
+description:
+    - "module helps to get status and volume name of geo-replication session in gluster enabled hosts"
+
+options:
+    status:
+        description:to get the status of geo replication sessions in the hosts. With the status options we get information such as the
+                    master node, slave user name and the names of the master and slave volumes etc.
+        required: true
+author:
+    - Ashmitha Ambastha (@ashmitha7)
+'''
+EXAMPLES = '''
+# To get status
+ - name: get status of a geo-rep session
+   geo_rep: action=status
+
+#the module will get information such as volume names, nodes and slave user name from action=status task and then run the tasks to
+#start and stop geo-rep sessions.
+
+
+'''
+RETURN = '''
+MASTER VOL- <master_volume name>
+SLAVE-<for example, ssh://10.11.77.12::volume1>
+STATUS- <for example, active/passive,stopped>
+'''
+
+import sys
+import re
+import shlex
+from subprocess import Popen
+import subprocess
+import os
+
+
+from collections import OrderedDict
+from ansible.module_utils.basic import *
+from ast import literal_eval
+
+class GeoRep(object):
+    def __init__(self, module):
+        self.module = module
+        self.action = self._validated_params('action')
+        self.gluster_georep_ops()
+
+    def get_playbook_params(self, opt):
+        return self.module.params[opt]
+
+    def _validated_params(self, opt):
+        value = self.get_playbook_params(opt)
+        if value is None:
+            msg = "Please provide %s option in the playbook!" % opt
+            self.module.fail_json(msg=msg)
+        return value
+
+    def gluster_georep_ops(self):
+        if self.action == 'status':
+            rc, output, err = self.call_gluster_cmd('volume ','geo-replication ', self.action)
+            self._get_output(rc, output, err)
+        if self.action == 'get_vol_data':
+            return self.gluster_status_vol()
+
+    def gluster_status_vol(self):
+        cmd_str="gluster volume geo-replication status --xml"
+        try:
+            cmd = Popen(
+                shlex.split(cmd_str),
+                stdin=open(os.devnull, "r"),
+                stderr=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                close_fds=True
+            )
+            op, err = cmd.communicate()
+            info = ElementTree.fromstring(op)
+            it = info.iter("volume")
+            georep_dict = {}
+            try:
+                while True:
+                    volume = it.next()
+                    # georep_dict[volume.find("name").text] = []
+                    vol_sessions = volume.iter("sessions")
+                    try:
+                        while True:
+                            vol_session = vol_sessions.next()
+                            session_it = vol_session.iter("session")
+                            try:
+                                while True:
+                                    session = session_it.next()
+                                    session_slave_val = session.find("session_slave").text
+                                    georep_dict[volume.find("name").text] = session_slave_val
+                            except StopIteration:
+                                pass
+                    except StopIteration:
+                        pass
+            except StopIteration:
+                pass
+            # print georep_dict
+            for k,v in georep_dict.iteritems():
+                s_value = v.split("//")[1].split(":")
+                slave_vol = '::'.join([s_value[0],s_value[2]])
+                # print slave_vol
+                dict_georep={}
+                dict_georep[k]=slave_vol
+                self.module.exit_json(rc=0,msg=dict_georep)
+        except (subprocess.CalledProcessError, ValueError):
+            print "Error....."
+
+    def call_gluster_cmd(self, *args):
+        params = ' '.join(opt for opt in args)
+        return self._run_command('gluster', ' ' + params )
+
+    def _get_output(self, rc, output, err):
+        carryon = False
+        changed = 0 if (carryon and rc) else 1
+        if not rc or carryon:
+            self.module.exit_json(stdout=output, changed=changed)
+        else:
+            self.module.fail_json(msg=err)
+
+    def _run_command(self, op, opts):
+        cmd = self.module.get_bin_path(op, True) + opts
+        return self.module.run_command(cmd)
+
+def run_module():
+    module = AnsibleModule(
+        argument_spec=dict(
+        action=dict(required=True, choices=['status','get_vol_data']),
+        ),
+    )
+    GeoRep(module)
+
+try:
+    import xml.etree.cElementTree as ElementTree
+except ImportError:
+    import xml.etree.ElementTree as ElementTree
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
##### SUMMARY
Modules to start and stop the geo-replication process in gluster enabled hosts.
georep_facts.py - This module gets the status and volume details of the geo-replication session. 
georep.py - This module is the actions module, starts and stops the geo-replication session.


