### PR TITLE
Add 'init' option to docker_container module to support docker's `--init` option

### DIFF
--- a/lib/ansible/module_utils/docker_common.py
+++ b/lib/ansible/module_utils/docker_common.py
@@ -162,6 +162,10 @@ class AnsibleDockerClient(Client):
         except Exception as exc:
             self.fail("Error connecting: %s" % exc)
 
+        docker_api_version = self.version()["ApiVersion"]
+        if self.module.params.get("init") and LooseVersion(docker_api_version) < LooseVersion("1.25"):
+            self.fail("docker API version is %s. Minimum version required is 1.25 to set init option." % (docker_api_version,))
+
     def log(self, msg, pretty_print=False):
         pass
         # if self.debug:

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -131,6 +131,12 @@ options:
     description:
       - Repository path and tag used to create the container. If an image is not found or pull is true, the image
         will be pulled from the registry. If no tag is included, 'latest' will be used.
+  init:
+    description:
+      - Run an init inside the container that forwards signals and reaps processes.
+        This option requires Docker API 1.25+.
+    default: 'no'
+    version_added: "2.6"
   interactive:
     description:
       - Keep stdin open after a container is launched, even if not attached.
@@ -650,6 +656,7 @@ class TaskParameters(DockerBaseClass):
         self.hostname = None
         self.ignore_image = None
         self.image = None
+        self.init = None
         self.interactive = None
         self.ipc_mode = None
         self.keep_volumes = None
@@ -891,7 +898,8 @@ class TaskParameters(DockerBaseClass):
             group_add='groups',
             devices='devices',
             pid_mode='pid_mode',
-            tmpfs='tmpfs'
+            tmpfs='tmpfs',
+            init='init'
         )
 
         if HAS_DOCKER_PY_2 or HAS_DOCKER_PY_3:
@@ -1992,6 +2000,7 @@ def main():
         hostname=dict(type='str'),
         ignore_image=dict(type='bool', default=False),
         image=dict(type='str'),
+        init=dict(type='bool', default=False),
         interactive=dict(type='bool', default=False),
         ipc_mode=dict(type='str'),
         keep_volumes=dict(type='bool', default=True),

--- a/lib/ansible/modules/cloud/docker/docker_container.py
+++ b/lib/ansible/modules/cloud/docker/docker_container.py
@@ -135,6 +135,7 @@ options:
     description:
       - Run an init inside the container that forwards signals and reaps processes.
         This option requires Docker API 1.25+.
+    type: bool
     default: 'no'
     version_added: "2.6"
   interactive:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add 'init' option to [docker_container module](http://docs.ansible.com/ansible/latest/docker_container_module.html) to support docker's `--init` option.
[This option requires Docker API 1.25+](https://docs.docker.com/engine/reference/commandline/run/#options).

Fixes #30761

##### ISSUE TYPE

 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->
[docker_container module's](http://docs.ansible.com/ansible/latest/docker_container_module.html) `init` option

##### ANSIBLE VERSION

```
v2.4
```