### PR TITLE
fix windows tests after recent patch

### DIFF
--- a/test/integration/targets/win_eventlog/tasks/main.yml
+++ b/test/integration/targets/win_eventlog/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Run tests for win_eventlog in normal mode
-  include_tasks: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: no
 
 - name: Run tests for win_eventlog in check-mode
-  include_tasks: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: yes
   check_mode: yes

--- a/test/integration/targets/win_eventlog_entry/tasks/main.yml
+++ b/test/integration/targets/win_eventlog_entry/tasks/main.yml
@@ -16,12 +16,12 @@
   block:
 
   - name: Test in normal mode
-    include_tasks: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: no
 
   - name: Test in check-mode
-    include_tasks: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: yes
     check_mode: yes

--- a/test/integration/targets/win_firewall/tasks/main.yml
+++ b/test/integration/targets/win_firewall/tasks/main.yml
@@ -25,13 +25,13 @@
 
 
   - name: Test in normal mode
-    include: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: no
 
 
   - name: Test in check-mode
-    include: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: yes
     check_mode: yes

--- a/test/integration/targets/win_group_membership/tasks/main.yml
+++ b/test/integration/targets/win_group_membership/tasks/main.yml
@@ -15,13 +15,13 @@
   block:
 
   - name: Test in normal mode
-    include_tasks: tests.yml
+    import_tasks: tests.yml
     vars:
       win_local_group: WinGroupMembershipTest
       in_check_mode: no
 
   - name: Test in check-mode
-    include_tasks: tests.yml
+    import_tasks: tests.yml
     vars:
       win_local_group: WinGroupMembershipTest
       in_check_mode: yes

--- a/test/integration/targets/win_scheduled_task/tasks/main.yml
+++ b/test/integration/targets/win_scheduled_task/tasks/main.yml
@@ -5,12 +5,12 @@
 - block:
   # old tests, remove once new code is considered stable
   - name: Test in normal mode
-    include_tasks: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: no
 
   - name: Test in check-mode
-    include_tasks: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: yes
     check_mode: yes
@@ -18,7 +18,7 @@
   - include_tasks: clean.yml
 
   - name: Test failure scenarios
-    include: failures.yml
+    include_tasks: failures.yml
 
   - name: Test normal scenarios
     include_tasks: new_tests.yml

--- a/test/integration/targets/win_shortcut/tasks/main.yml
+++ b/test/integration/targets/win_shortcut/tasks/main.yml
@@ -17,18 +17,18 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: Clean slate
-  include: clean.yml
+  import_tasks: clean.yml
 
 - name: Test in normal mode
-  include: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: no
 
 - name: Clean slate
-  include: clean.yml
+  import_tasks: clean.yml
 
 - name: Test in check-mode
-  include: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: yes
   check_mode: yes

--- a/test/integration/targets/win_timezone/tasks/main.yml
+++ b/test/integration/targets/win_timezone/tasks/main.yml
@@ -8,12 +8,12 @@
   block:
 
   - name: Test in normal mode
-    include: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: no
 
   - name: Test in check-mode
-    include: tests.yml
+    import_tasks: tests.yml
     vars:
       in_check_mode: yes
     check_mode: yes

--- a/test/integration/targets/win_toast/tasks/main.yml
+++ b/test/integration/targets/win_toast/tasks/main.yml
@@ -1,13 +1,13 @@
 - name: Set up tests
-  include_tasks: setup.yml
+  import_tasks: setup.yml
 
 - name: Test in normal mode
-  include_tasks: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: no
 
 - name: Test in check mode
-  include_tasks: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: yes
   check_mode: yes

--- a/test/integration/targets/win_unzip/tasks/main.yml
+++ b/test/integration/targets/win_unzip/tasks/main.yml
@@ -1,16 +1,16 @@
 - name: Clean slate
-  include: clean.yml
+  import_tasks: clean.yml
 
 - name: Test in normal mode
-  include: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: no
 
 - name: Clean slate
-  include: clean.yml
+  import_tasks: clean.yml
 
 - name: Test in check-mode
-  include: tests.yml
+  import_tasks: tests.yml
   vars:
     in_check_mode: yes
   check_mode: yes


### PR DESCRIPTION
##### SUMMARY
Fix various tests where `include_tasks` had a bug fixed where the `check_mode: yes` set on` include_tasks` would not be copied to the included tasks. These references where changed to `import_tasks` where it now works.

##### ISSUE TYPE
 - Tests Pull Request

##### COMPONENT NAME
windows

##### ANSIBLE VERSION
```
2.5
```