### PR TITLE
cloudstack: streamline cs_network_offering

### DIFF
--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -1,22 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright: (c) 2017, David Passante (@dpassante)
-#
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible. If not, see <http://www.gnu.org/licenses/>.
+# Copyright (c) 2017, David Passante (@dpassante)
+# Copyright (c) 2017, René Moser <mail@renemoser.net>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 ANSIBLE_METADATA = {'metadata_version': '1.1',
                     'status': ['preview'],
@@ -25,140 +12,96 @@ ANSIBLE_METADATA = {'metadata_version': '1.1',
 DOCUMENTATION = '''
 ---
 module: cs_network_offering
-
 short_description: Manages network offerings on Apache CloudStack based clouds.
-
 description:
     - Create, update, enable, disable and remove network offerings.
-
 version_added: '2.5'
-
 author: "David Passante (@dpassante)"
-
 options:
   state:
     description:
       - State of the network offering.
-    choices: ['enabled', 'present', 'disabled', 'absent']
-    required: false
+    choices: [ enabled, present, disabled, absent]
     default: present
   display_text:
     description:
-      - Display text of the network offerings
-    required: false
-    default: null
+      - Display text of the network offerings.
   guest_ip_type:
     description:
-      - Guest type of the network offering. Shared or Isolated
-    choices: ['Shared', 'Isolated']
-    required: false
-    default: null
+      - Guest type of the network offering.
+    choices: [ Shared, Isolated ]
   name:
     description:
-      - The name of the network offering
+      - The name of the network offering.
     required: true
-    default: null
   supported_services:
     description:
-      - Services supported by the network offering
-    required: false
-    default: null
+      - Services supported by the network offering.
   traffic_type:
     description:
       - The traffic type for the network offering.
-      - Supported type in current release is GUEST only
-    required: false
     default: GUEST
   availability:
     description:
       - The availability of network offering. Default value is Optional
-    required: false
-    default: null
   conserve_mode:
     description:
-      - true if the network offering is IP conserve mode enabled
-    choices: ['true', 'false']
-    required: false
-    default: null
+      - Whether the network offering has IP conserve mode enabled.
+    choices: [ yes, no ]
   details:
     description:
       - Network offering details in key/value pairs.
-      - Supported keys are internallbprovider/publiclbprovider
       - with service provider as a value
-    choices: ['internallbprovider', 'publiclbprovider']
-    required: false
-    default: null
+    choices: [ internallbprovider, publiclbprovider ]
   egress_default_policy:
     description:
-      - True if guest network default egress policy is allow.
-      - false if default egress policy is deny
-    choices: ['true', 'false']
-    required: false
-    default: null
+      - Whether the default egress policy is allow (yes) or to deny (no).
+    choices: [ yes no ]
   persistent:
     description:
       - True if network offering supports persistent networks
       - defaulted to false if not specified
-    required: false
-    default: null
   keepalive_enabled:
     description:
       - If true keepalive will be turned on in the loadbalancer.
-      - At the time of writing this has only an effect on haproxy;
+      - At the time of writing this has only an effect on haproxy.
       - the mode http and httpclose options are unset in the haproxy conf file.
-    choices: ['true', 'false']
-    required: false
-    default: null
+    choices: [ yes, no ]
   max_connections:
     description:
-      - Maximum number of concurrent connections supported by the network offering
-    required: false
-    default: null
+      - Maximum number of concurrent connections supported by the network offering.
   network_rate:
     description:
-      - Data transfer rate in megabits per second allowed
-    required: false
-    default: null
+      - Data transfer rate in megabits per second allowed.
   service_capabilities:
     description:
-      - Desired service capabilities as part of network offering
+      - Desired service capabilities as part of network offering.
     aliases: [ service_capability ]
-    required: false
-    default: null
   service_offering:
     description:
-      - The service offering name or ID used by virtual router provider
-    required: false
-    default: null
+      - The service offering name or ID used by virtual router provider.
   service_provider_list:
     description:
-      - provider to service mapping
-      - If not specified, the provider for the service
-      - will be mapped to the default provider on the physical network
-    required: false
-    default: null
+      - Provider to service mapping.
+      - If not specified, the provider for the service will be mapped to the default provider on the physical network.
   specify_ip_ranges:
     description:
-      - true if network offering supports specifying ip ranges
-      - defaulted to false if not specified
-    choices: ['true', 'false']
-    required: false
-    default: null
+      - Wheter the network offering supports specifying IP ranges.
+      - Defaulted to C(no) by the API if not specified.
+    choices: [ yes, no ]
   specify_vlan:
     description:
-      - true if network offering supports vlans
-    choices: ['true', 'false']
-    required: false
-    default: null
+      - Whether the network offering supports vlans or not.
+    choices: [ yes, no ]
 extends_documentation_fragment: cloudstack
 '''
 
 EXAMPLES = '''
-# Create a network offering and enable it
-- local_action:
+- name: Create a network offering and enable it
+  local_action:
     module: cs_network_offering
-    name: "my_network_offering"
-    display_text: "network offering description"
+    name: my_network_offering
+    display_text: network offering description
     state: enabled
     guest_ip_type: Isolated
     supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
@@ -167,17 +110,11 @@ EXAMPLES = '''
       - {service: 'dhcp', provider: 'virtualrouter'}
 
 
-# Remove a network offering
-- local_action:
+- name: Remove a network offering
+  local_action:
     module: cs_network_offering
-    name: "my_network_offering"
-    display_text: "network offering description"
+    name: my_network_offering
     state: absent
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
 '''
 
 RETURN = '''
@@ -188,27 +125,27 @@ id:
   type: string
   sample: a6f7a5fc-43f8-11e5-a151-feff819cdc9f
 name:
-  description: The name of the network offering
+  description: The name of the network offering.
   returned: success
   type: string
   sample: MyCustomNetworkOffering
 display_text:
-  description: The display text of the network offering
+  description: The display text of the network offering.
   returned: success
   type: string
   sample: My network offering
 state:
-  description: The state of the network offering
+  description: The state of the network offering.
   returned: success
   type: string
   sample: Enabled
 guest_ip_type:
-  description: Guest type of the network offering
+  description: Guest type of the network offering.
   returned: success
   type: string
   sample: Isolated
 availability:
-  description: The availability of network offering
+  description: The availability of network offering.
   returned: success
   type: string
   sample: Optional
@@ -320,13 +257,10 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
     def delete_network_offering(self):
         network_offering = self.get_network_offering()
 
-        if not network_offering:
-            return network_offering
-
-        self.result['changed'] = True
-
-        if not self.module.check_mode:
-            res = self.query_api('deleteNetworkOffering', id=network_offering['id'])
+        if network_offering:
+            self.result['changed'] = True
+            if not self.module.check_mode:
+                self.query_api('deleteNetworkOffering', id=network_offering['id'])
 
         return network_offering
 
@@ -342,7 +276,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'availability': self.module.params.get('availability'),
         }
 
-        if args['state'] == 'enabled' or args['state'] == 'disabled':
+        if args['state'] in ['enabled', 'disabled']:
             args['state'] = args['state'].title()
         else:
             del args['state']
@@ -398,6 +332,7 @@ def main():
     result = acs_network_offering.get_result(network_offering)
 
     module.exit_json(**result)
+
 
 if __name__ == '__main__':
     main()

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -177,6 +177,16 @@ egress_default_policy:
   returned: success
   type: string
   sample: allow
+is_persistent:
+  description: Whether persistent networks are supported or not.
+  returned: success
+  type: bool
+  sample: false
+is_default:
+  description: Whether network offering is the default offering or not.
+  returned: success
+  type: bool
+  sample: false
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -198,6 +208,8 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'networkrate': 'network_rate',
             'maxconnections': 'max_connections',
             'traffictype': 'traffic_type',
+            'isdefault': 'is_default',
+            'ispersistent': 'is_persistent',
         }
         self.network_offering = None
 

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -37,6 +37,9 @@ options:
   supported_services:
     description:
       - Services supported by the network offering.
+      - One or more of the choices.
+    choices: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    aliases: [ supported_service ]
   traffic_type:
     description:
       - The traffic type for the network offering.
@@ -104,8 +107,8 @@ EXAMPLES = '''
     display_text: network offering description
     state: enabled
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
 
@@ -327,7 +330,7 @@ def main():
         display_text=dict(),
         guest_ip_type=dict(choices=['Shared', 'Isolated']),
         name=dict(required=True),
-        supported_services=dict(),
+        supported_services=dict(type='list', aliases=['supported_service']),
         traffic_type=dict(default='Guest'),
         availability=dict(),
         conserve_mode=dict(type='bool'),

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -107,10 +107,10 @@ EXAMPLES = '''
     display_text: network offering description
     state: enabled
     guest_ip_type: Isolated
-    service_provider_list:
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
 
 
 - name: Remove a network offering
@@ -260,7 +260,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'networkrate': self.module.params.get('network_rate'),
             'servicecapabilitylist': self.module.params.get('service_capabilities'),
             'serviceofferingid': self.get_service_offering_id(),
-            'serviceproviderlist': self.module.params.get('service_provider_list'),
+            'serviceproviderlist': self.module.params.get('service_providers'),
             'specifyipranges': self.module.params.get('specify_ip_ranges'),
             'specifyvlan': self.module.params.get('specify_vlan'),
         }
@@ -269,7 +269,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'display_text',
             'guest_ip_type',
             'supported_services',
-            'service_provider_list',
+            'service_providers',
         ]
 
         self.module.fail_on_missing_params(required_params=required_params)
@@ -342,7 +342,7 @@ def main():
         network_rate=dict(type='int'),
         service_capabilities=dict(type='list', aliases=['service_capability']),
         service_offering=dict(),
-        service_provider_list=dict(type='list'),
+        service_providers=dict(type='list', aliases=['service_provider']),
         specify_ip_ranges=dict(type='bool'),
         specify_vlan=dict(type='bool'),
     ))

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -300,6 +300,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'displaytext': self.module.params.get('display_text'),
             'name': self.module.params.get('name'),
             'availability': self.module.params.get('availability'),
+            'maxconnections': self.module.params.get('max_connections'),
         }
 
         if args['state'] in ['enabled', 'disabled']:

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -40,7 +40,7 @@ options:
   traffic_type:
     description:
       - The traffic type for the network offering.
-    default: GUEST
+    default: Guest
   availability:
     description:
       - The availability of network offering. Default value is Optional
@@ -154,6 +154,11 @@ service_offering:
   returned: success
   type: string
   sample: c5f7a5fc-43f8-11e5-a151-feff819cdc9f
+traffic_type:
+  description: The traffic type.
+  returned: success
+  type: string
+  sample: Guest
 '''
 
 from ansible.module_utils.basic import AnsibleModule
@@ -172,6 +177,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'guestiptype': 'guest_ip_type',
             'availability': 'availability',
             'serviceofferingid': 'service_offering',
+            'traffictype': 'traffic_type',
         }
         self.network_offering = None
 
@@ -299,7 +305,7 @@ def main():
         guest_ip_type=dict(choices=['Shared', 'Isolated']),
         name=dict(required=True),
         supported_services=dict(),
-        traffic_type=dict(default='GUEST'),
+        traffic_type=dict(default='Guest'),
         availability=dict(),
         conserve_mode=dict(type='bool'),
         details=dict(type='list'),

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -154,6 +154,16 @@ service_offering_id:
   returned: success
   type: string
   sample: c5f7a5fc-43f8-11e5-a151-feff819cdc9f
+max_connections:
+  description: The maximum number of concurrents connections to be handled by LB.
+  returned: success
+  type: int
+  sample: 300
+network_rate:
+  description: The network traffic transfer ate in Mbit/s.
+  returned: success
+  type: int
+  sample: 200
 traffic_type:
   description: The traffic type.
   returned: success
@@ -177,6 +187,8 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
             'guestiptype': 'guest_ip_type',
             'availability': 'availability',
             'serviceofferingid': 'service_offering_id',
+            'networkrate': 'network_rate',
+            'maxconnections': 'max_connections',
             'traffictype': 'traffic_type',
         }
         self.network_offering = None

--- a/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
+++ b/lib/ansible/modules/cloud/cloudstack/cs_network_offering.py
@@ -149,8 +149,8 @@ availability:
   returned: success
   type: string
   sample: Optional
-service_offering:
-  description: The service offering name or ID
+service_offering_id:
+  description: The service offering ID.
   returned: success
   type: string
   sample: c5f7a5fc-43f8-11e5-a151-feff819cdc9f
@@ -176,7 +176,7 @@ class AnsibleCloudStackNetworkOffering(AnsibleCloudStack):
         self.returns = {
             'guestiptype': 'guest_ip_type',
             'availability': 'availability',
-            'serviceofferingid': 'service_offering',
+            'serviceofferingid': 'service_offering_id',
             'traffictype': 'traffic_type',
         }
         self.network_offering = None

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -35,10 +35,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
   register: netoffer
   check_mode: yes
 - name: verify results of network offer in check mode
@@ -52,10 +52,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
   register: netoffer
 - name: verify results of network offer
   assert:
@@ -72,10 +72,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
   register: netoffer
 - name: verify results of create network offer idempotence
   assert:
@@ -87,19 +87,13 @@
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description"
 
-- name: test enabling network offer in check_mode
+- name: test enabling existing network offer in check_mode
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: enabled
   register: netoffer
   check_mode: yes
-- name: verify results of enabling network offer in check_mode
+- name: verify results of enabling existing network offer in check_mode
   assert:
     that:
     - netoffer is successful
@@ -109,18 +103,12 @@
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description"
 
-- name: test enabling network offer
+- name: test enabling existing network offer
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: enabled
   register: netoffer
-- name: verify results of enabling network offer
+- name: verify results of enabling existing network offer
   assert:
     that:
     - netoffer is successful
@@ -130,18 +118,12 @@
     - netoffer.state == "Enabled"
     - netoffer.display_text == "network offering description"
 
-- name: test enabling network offer idempotence
+- name: test enabling existing network offer idempotence
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: enabled
   register: netoffer
-- name: verify results of enabling network idempotence
+- name: verify results of enabling existing network idempotence
   assert:
     that:
     - netoffer is successful
@@ -156,10 +138,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: disabled
   register: netoffer
   check_mode: yes
@@ -178,10 +160,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: disabled
   register: netoffer
 - name: verify results of disabling network offer
@@ -199,10 +181,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: disabled
   register: netoffer
 - name: verify results of disabling network idempotence
@@ -220,10 +202,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description renamed"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: disabled
   register: netoffer
   check_mode: yes
@@ -242,10 +224,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description renamed"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: disabled
   register: netoffer
 - name: verify results of rename network offer
@@ -263,10 +245,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description renamed"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: disabled
   register: netoffer
 - name: verify results of rename network offer idempotence
@@ -372,10 +354,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: enabled
   register: netoffer
   check_mode: yes
@@ -390,10 +372,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: enabled
   register: netoffer
 - name: verify results of create enabled network offer
@@ -411,10 +393,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
     service_provider_list:
       - {service: 'dns', provider: 'virtualrouter'}
       - {service: 'dhcp', provider: 'virtualrouter'}
+    supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     state: enabled
   register: netoffer
 - name: verify results of create enabled network offer idempotence

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -28,17 +28,17 @@
   assert:
     that:
     - netoffer is failed
-    - 'netoffer.msg == "missing required arguments: display_text, guest_ip_type, supported_services, service_provider_list"'
+    - 'netoffer.msg == "missing required arguments: display_text, guest_ip_type, supported_services, service_providers"'
 
 - name: test create network offer in check mode
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
   register: netoffer
   check_mode: yes
 - name: verify results of network offer in check mode
@@ -52,10 +52,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
   register: netoffer
 - name: verify results of network offer
   assert:
@@ -72,10 +72,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
   register: netoffer
 - name: verify results of create network offer idempotence
   assert:
@@ -138,10 +138,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: disabled
   register: netoffer
   check_mode: yes
@@ -160,10 +160,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: disabled
   register: netoffer
 - name: verify results of disabling network offer
@@ -181,10 +181,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: disabled
   register: netoffer
 - name: verify results of disabling network idempotence
@@ -202,10 +202,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description renamed"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: disabled
   register: netoffer
   check_mode: yes
@@ -224,10 +224,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description renamed"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: disabled
   register: netoffer
 - name: verify results of rename network offer
@@ -245,10 +245,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description renamed"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: disabled
   register: netoffer
 - name: verify results of rename network offer idempotence
@@ -354,10 +354,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: enabled
   register: netoffer
   check_mode: yes
@@ -372,10 +372,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: enabled
   register: netoffer
 - name: verify results of create enabled network offer
@@ -393,10 +393,10 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
+    service_providers:
+      - { service: 'dns', provider: 'virtualrouter' }
+      - { service: 'dhcp', provider: 'virtualrouter' }
     state: enabled
   register: netoffer
 - name: verify results of create enabled network offer idempotence

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -265,6 +265,7 @@
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description update"
+    max_connections: 300
   register: netoffer
   check_mode: yes
 - name: verify results of update offer with minimal params in check_mode
@@ -276,11 +277,13 @@
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description renamed"
+    - netoffer.max_connections == 300
 
 - name: test update offer with minimal params
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description update"
+    max_connections: 300
   register: netoffer
 - name: verify results of update offer with minimal params
   assert:
@@ -291,11 +294,13 @@
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description update"
+    - netoffer.max_connections == 300
 
 - name: test update offer with minimal params idempotency
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description update"
+    max_connections: 300
   register: netoffer
 - name: verify results of update offer with minimal params idempotency
   assert:
@@ -306,6 +311,7 @@
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description update"
+    - netoffer.max_connections == 300
 
 - name: test remove network offer in check_mode
   cs_network_offering:

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -1,6 +1,8 @@
 ---
 - name: setup
-  cs_network_offering: name={{ cs_resource_prefix }}_name state=absent
+  cs_network_offering:
+    name: "{{ cs_resource_prefix }}_name"
+    state: absent
   register: netoffer
 - name: verify setup
   assert:
@@ -326,12 +328,6 @@
 - name: test remove network offer in check_mode
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description renamed"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: absent
   register: netoffer
   check_mode: yes
@@ -348,12 +344,6 @@
 - name: test remove network offer
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description renamed"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: absent
   register: netoffer
 - name: verify results of rename network offer
@@ -369,12 +359,6 @@
 - name: test remove network offer idempotence
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description renamed"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: absent
   register: netoffer
 - name: verify results of rename network offer idempotence
@@ -446,12 +430,6 @@
 - name: remove network offer
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
-    display_text: "network offering description renamed"
-    guest_ip_type: Isolated
-    supported_services: Dns,PortForwarding,Dhcp,SourceNat,UserData,Firewall,StaticNat,Vpn,Lb
-    service_provider_list:
-      - {service: 'dns', provider: 'virtualrouter'}
-      - {service: 'dhcp', provider: 'virtualrouter'}
     state: absent
   register: netoffer
 - name: verify results of remove network offer

--- a/test/integration/targets/cs_network_offering/tasks/main.yml
+++ b/test/integration/targets/cs_network_offering/tasks/main.yml
@@ -35,6 +35,7 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
+    max_connections: 300
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     service_providers:
       - { service: 'dns', provider: 'virtualrouter' }
@@ -52,6 +53,7 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
+    max_connections: 300
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     service_providers:
       - { service: 'dns', provider: 'virtualrouter' }
@@ -72,6 +74,7 @@
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description"
     guest_ip_type: Isolated
+    max_connections: 300
     supported_services: [ Dns, PortForwarding, Dhcp, SourceNat, UserData, Firewall, StaticNat, Vpn, Lb ]
     service_providers:
       - { service: 'dns', provider: 'virtualrouter' }
@@ -265,7 +268,7 @@
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description update"
-    max_connections: 300
+    max_connections: 400
   register: netoffer
   check_mode: yes
 - name: verify results of update offer with minimal params in check_mode
@@ -283,7 +286,7 @@
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description update"
-    max_connections: 300
+    max_connections: 400
   register: netoffer
 - name: verify results of update offer with minimal params
   assert:
@@ -294,13 +297,13 @@
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description update"
-    - netoffer.max_connections == 300
+    - netoffer.max_connections == 400
 
 - name: test update offer with minimal params idempotency
   cs_network_offering:
     name: "{{ cs_resource_prefix }}_name"
     display_text: "network offering description update"
-    max_connections: 300
+    max_connections: 400
   register: netoffer
 - name: verify results of update offer with minimal params idempotency
   assert:
@@ -311,7 +314,7 @@
     - netoffer.guest_ip_type == "Isolated"
     - netoffer.state == "Disabled"
     - netoffer.display_text == "network offering description update"
-    - netoffer.max_connections == 300
+    - netoffer.max_connections == 400
 
 - name: test remove network offer in check_mode
   cs_network_offering:


### PR DESCRIPTION
##### SUMMARY
This is a folow up of the new module in 2.5, this patch looks bigger than it acually is because I steamlined some docs.

* extended returns
* changed default_egress_policy choices
* renamed params server_provider_list to server_providers
* extended tests

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request


##### COMPONENT NAME
cs_network_offering
##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
/cc @dpassante