### PR TITLE
win_domain_user allow to update generic attributes

### DIFF
--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -169,8 +169,8 @@ If ($state -eq 'present') {
 
         # Set additional attributes
         $set_args = @{}
+        $run_change = $false
         if ($attributes -ne $null) {
-            $run_change = $false
             $add_attributes = @{}
             $replace_attributes = @{}
             foreach ($attribute in $attributes.GetEnumerator()) {

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -64,6 +64,9 @@ $user_info = @{
     Country = Get-AnsibleParam -obj $params -name "country" -type "str"
 }
 
+# Additional attributes
+$attributes = Get-AnsibleParam -obj $params -name "attributes"
+
 # Parameter validation
 If ($account_locked -ne $null -and $account_locked) {
     Fail-Json $result "account_locked must be set to 'no' if provided"
@@ -163,6 +166,45 @@ If ($state -eq 'present') {
                 $user_obj = Get-ADUser -Identity $username -Properties *
             }
         }
+
+        # Set additional attributes
+        $set_args = @{}
+        if ($attributes -ne $null) {
+            $add_attributes = @{}
+            $replace_attributes = @{}
+            foreach ($attribute in $attributes.GetEnumerator()) {
+                $attribute_name = $attribute.Name
+                $attribute_value = $attribute.Value
+
+                $valid_property = [bool]($user_obj.PSobject.Properties.name -eq $attribute_name)
+                if ($valid_property) {
+                    $existing_value = $user_obj.$attribute_name
+                    if ($existing_value -cne $attribute_value) {
+                        $replace_attributes.$attribute_name = $attribute_value
+                    }                
+                } else {
+                    $add_attributes.$attribute_name = $attribute_value
+                }
+            }
+            if ($add_attributes.Count -gt 0) {
+                $set_args.Add = $add_attributes
+                $run_change = $true
+            }
+            if ($replace_attributes.Count -gt 0) {
+                $set_args.Replace = $replace_attributes
+                $run_change = $true
+            }
+        }
+
+        if ($run_change) {
+            try {
+                $user_obj = $user_obj | Set-ADUser -WhatIf:$check_mode -PassThru @set_args
+            } catch {
+                Fail-Json $result "failed to change user $($username): $($_.Exception.Message)"
+            }
+            $result.changed = $true
+        }
+
 
         # Configure group assignment
         If ($groups -ne $null) {
@@ -264,6 +306,11 @@ try {
             $user_groups += $group.name
         }
         $result.groups = $user_groups
+        Foreach ($attribute in $attributes.GetEnumerator()){
+            $attribute_name = $attribute.Name
+            $attribute_value = $attribute.Value
+            $result.$attribute_name = $attribute_value
+        }
         $result.msg = "User '$username' is present"
         $result.state = "present"
     }

--- a/lib/ansible/modules/windows/win_domain_user.ps1
+++ b/lib/ansible/modules/windows/win_domain_user.ps1
@@ -170,6 +170,7 @@ If ($state -eq 'present') {
         # Set additional attributes
         $set_args = @{}
         if ($attributes -ne $null) {
+            $run_change = $false
             $add_attributes = @{}
             $replace_attributes = @{}
             foreach ($attribute in $attributes.GetEnumerator()) {
@@ -306,11 +307,6 @@ try {
             $user_groups += $group.name
         }
         $result.groups = $user_groups
-        Foreach ($attribute in $attributes.GetEnumerator()){
-            $attribute_name = $attribute.Name
-            $attribute_value = $attribute.Value
-            $result.$attribute_name = $attribute_value
-        }
         $result.msg = "User '$username' is present"
         $result.state = "present"
     }

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -148,7 +148,7 @@ options:
         if you specify a path on an existing user, the user's path will not
         be updated - you must delete (e.g., state=absent) the user and
         then re-add the user with the appropriate path.
-    attributes:
+  attributes:
     description:
       - A dict of custom LDAP attributes to set on the user.
       - This can be used to set custom attributes that are not exposed as module

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -148,6 +148,12 @@ options:
         if you specify a path on an existing user, the user's path will not
         be updated - you must delete (e.g., state=absent) the user and
         then re-add the user with the appropriate path.
+    attributes:
+    description:
+      - A dict of custom LDAP attributes to set on the user.
+      - This can be used to set custom attributes that are not exposed as module
+        parameters, e.g. C(telephoneNumber).
+      - See the examples on how to format this parameter.
 notes:
   - Works with Windows 2012R2 and newer.
   - If running on a server that is not a Domain Controller, credential
@@ -175,6 +181,8 @@ EXAMPLES = r'''
     state_province: IN
     postal_code: 12345
     country: US
+    attributes:
+      telephoneNumber: 555-123456
 
 - name: Ensure user bob is present in OU ou=test,dc=domain,dc=local
   win_domain_user:

--- a/lib/ansible/modules/windows/win_domain_user.py
+++ b/lib/ansible/modules/windows/win_domain_user.py
@@ -154,6 +154,7 @@ options:
       - This can be used to set custom attributes that are not exposed as module
         parameters, e.g. C(telephoneNumber).
       - See the examples on how to format this parameter.
+    version_added: "2.5"
 notes:
   - Works with Windows 2012R2 and newer.
   - If running on a server that is not a Domain Controller, credential


### PR DESCRIPTION
Signed-off-by: Marko Koehne <marko@mkoehne.de>

##### SUMMARY
Extend the win_domain_user module to allow the update of generic attributes.
(same functionality as win_domain_group)

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
win_domain_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5.0
```


##### ADDITIONAL INFORMATION
