### PR TITLE
Provide AnsibleAWSModule with _name attribute

### DIFF
--- a/lib/ansible/module_utils/aws/core.py
+++ b/lib/ansible/module_utils/aws/core.py
@@ -100,6 +100,7 @@ class AnsibleAWSModule(object):
                 msg='Python modules "botocore" or "boto3" are missing, please install both')
 
         self.check_mode = self._module.check_mode
+        self._name = self._module._name
 
     @property
     def params(self):


### PR DESCRIPTION
##### SUMMARY
_name attribute is used when providing generic error messages
(such as connection problems). As AnsibleAWSModule does not inherit
things from AnsibleModule by default, need to provide it.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
module_utils/aws/core.py

##### ANSIBLE VERSION
```
ansible 2.5.0 (devel 49739dda47) last updated 2018/01/08 10:18:30 (GMT +1000)
  config file = /etc/ansible/ansible.cfg
  configured module search path = [u'/home/will/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /home/will/src/ansible/lib/ansible
  executable location = /home/will/src/ansible/bin/ansible
  python version = 2.7.14 (default, Dec 11 2017, 16:08:01) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```


##### ADDITIONAL INFORMATION

Before:
```
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_RAL04G/ansible_module_ec2_vpc_net.py\", line 381, in <module>\n    main()\n  File \"/tmp/ansible_RAL04G/ansible_module_ec2_vpc_net.py\", line 292, in main\n    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)\n  File \"/tmp/ansible_RAL04G/ansible_modlib.zip/ansible/module_utils/ec2.py\", line 113, in boto3_conn\nAttributeError: 'AnsibleAWSModule' object has no attribute '_name'\n", 
```

After: 
```
    "msg": "The ec2_vpc_net module requires a region and none was found in configuration, environment variables or module parameters"
```