### PR TITLE
Fix junos integration failures

### DIFF
--- a/test/integration/targets/junos_banner/tasks/netconf.yaml
+++ b/test/integration/targets/junos_banner/tasks/netconf.yaml
@@ -7,8 +7,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_banner/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_banner/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_banner netconf/basic.yaml"
+- debug: msg="START junos_banner netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove login banner
   junos_banner:
@@ -190,3 +190,5 @@
     that:
       - "result.changed == true"
       - "'<announcement>this is my motd banner</announcement>' not in config.xml"
+
+- debug: msg="END junos_banner netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tasks/netconf_json.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_json.yaml
@@ -8,8 +8,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_command/tasks/netconf_text.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_text.yaml
@@ -8,8 +8,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_command/tasks/netconf_xml.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_xml.yaml
@@ -8,8 +8,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_command/tests/netconf_json/bad_operator.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/bad_operator.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/bad_operator.yaml"
+- debug: msg="START netconf_json/bad_operator.yaml on connection={{ ansible_connection }}"
 
 - name: test bad operator with json encoding
   junos_command:
@@ -18,4 +18,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_json/bad_operator.yaml"
+- debug: msg="END netconf_json/bad_operator.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/contains.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/contains.yaml"
+- debug: msg="START netconf_json/contains.yaml on connection={{ ansible_connection }}"
 
 - name: test contains operator with json encoding
   junos_command:
@@ -18,4 +18,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/contains.yaml"
+- debug: msg="END netconf_json/contains.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/equal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/equal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/equal.yaml"
+- debug: msg="START netconf_json/equal.yaml on connection={{ ansible_connection }}"
 
 - name: test == operator with xml encoding
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/equal.yaml"
+- debug: msg="END netconf_json/equal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/greaterthan.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/greaterthan.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/greaterthan.yaml"
+- debug: msg="START netconf_json/greaterthan.yaml on connection={{ ansible_connection }}"
 
 - name: test gt operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/greaterthan.yaml"
+- debug: msg="END netconf_json/greaterthan.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/greaterthanorequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/greaterthanorequal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/greaterthanorequal.yaml"
+- debug: msg="START netconf_json/greaterthanorequal.yaml on connection={{ ansible_connection }}"
 
 - name: test ge operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/greaterthanorequal.yaml"
+- debug: msg="END netconf_json/greaterthanorequal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/lessthan.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/lessthan.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/lessthan.yaml"
+- debug: msg="START netconf_json/lessthan.yaml on connection={{ ansible_connection }}"
 
 - name: test lt operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/lessthan.yaml"
+- debug: msg="END netconf_json/lessthan.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/lessthanorequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/lessthanorequal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/lessthanorequal.yaml"
+- debug: msg="START netconf_json/lessthanorequal.yaml on connection={{ ansible_connection }}"
 
 - name: test le operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/lessthanorequal.yaml"
+- debug: msg="END netconf_json/lessthanorequal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/notequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/notequal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/notequal.yaml"
+- debug: msg="START netconf_json/notequal.yaml on connection={{ ansible_connection }}"
 
 - name: test neq operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/notequal.yaml"
+- debug: msg="END netconf_json/notequal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_json/output.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_json/output.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_json/output.yaml"
+- debug: msg="START netconf_json/output.yaml on connection={{ ansible_connection }}"
 
 - name: get output for single command
   junos_command:
@@ -35,6 +35,7 @@
     provider:
       transport: cli
   register: result
+  connection: network_cli
 
 - assert:
     that:
@@ -51,6 +52,7 @@
     provider:
       transport: cli
   register: result
+  connection: network_cli
 
 - assert:
     that:
@@ -58,4 +60,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_json/output.yaml"
+- debug: msg="END netconf_json/output.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_text/bad_operator.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/bad_operator.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_text/bad_operator.yaml"
+- debug: msg="START netconf_text/bad_operator.yaml on connection={{ ansible_connection }}"
 
 - name: test bad operator with text encoding
   junos_command:
@@ -18,4 +18,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_text/bad_operator.yaml"
+- debug: msg="END netconf_text/bad_operator.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_text/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/contains.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_text/contains.yaml"
+- debug: msg="START netconf_text/contains.yaml on connection={{ ansible_connection }}"
 
 - name: test contains operator with text encoding
   junos_command:
@@ -18,4 +18,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_text/contains.yaml"
+- debug: msg="END netconf_text/contains.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_text/invalid.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/invalid.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_text/invalid.yaml"
+- debug: msg="START netconf_text/invalid.yaml on connection={{ ansible_connection }}"
 
 - name: run invalid command
   junos_command:
@@ -31,4 +31,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_text/invalid.yaml"
+- debug: msg="END netconf_text/invalid.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_text/output.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/output.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_text/output.yaml"
+- debug: msg="START netconf_text/output.yaml on connection={{ ansible_connection }}"
 
 - name: get output for single command
   junos_command:
@@ -59,4 +59,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_text/output.yaml"
+- debug: msg="END netconf_text/output.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_text/timeout.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_text/timeout.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_text/timeout.yaml"
+- debug: msg="START netconf_text/timeout.yaml on connection={{ ansible_connection }}"
 
 - name: test bad condition
   junos_command:
@@ -17,4 +17,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_text/timeout.yaml"
+- debug: msg="END netconf_text/timeout.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/bad_operator.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/bad_operator.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/bad_operator.yaml"
+- debug: msg="START netconf_xml/bad_operator.yaml on connection={{ ansible_connection }}"
 
 - name: test bad operator with xml encoding
   junos_command:
@@ -18,4 +18,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_xml/bad_operator.yaml"
+- debug: msg="END netconf_xml/bad_operator.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/contains.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/contains.yaml"
+- debug: msg="START netconf_xml/contains.yaml on connection={{ ansible_connection }}"
 
 - name: test contains operator with xml encoding
   junos_command:
@@ -18,4 +18,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/contains.yaml"
+- debug: msg="END netconf_xml/contains.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/equal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/equal.yaml"
+- debug: msg="START netconf_xml/equal.yaml on connection={{ ansible_connection }}"
 
 - name: test == operator with xml encoding
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/equal.yaml"
+- debug: msg="END netconf_xml/equal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/greaterthan.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/greaterthan.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/greaterthan.yaml"
+- debug: msg="START netconf_xml/greaterthan.yaml on connection={{ ansible_connection }}"
 
 - name: test gt operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/greaterthan.yaml"
+- debug: msg="END netconf_xml/greaterthan.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/greaterthanorequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/greaterthanorequal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/greaterthanorequal.yaml"
+- debug: msg="START netconf_xml/greaterthanorequal.yaml on connection={{ ansible_connection }}"
 
 - name: test ge operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/greaterthanorequal.yaml"
+- debug: msg="END netconf_xml/greaterthanorequal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/invalid.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/invalid.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/invalid.yaml"
+- debug: msg="START netconf_xml/invalid.yaml on connection={{ ansible_connection }}"
 
 - name: run invalid command
   junos_command:
@@ -28,4 +28,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_xml/invalid.yaml"
+- debug: msg="END netconf_xml/invalid.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/lessthan.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/lessthan.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/lessthan.yaml"
+- debug: msg="START netconf_xml/lessthan.yaml on connection={{ ansible_connection }}"
 
 - name: test lt operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/lessthan.yaml"
+- debug: msg="END netconf_xml/lessthan.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/lessthanorequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/lessthanorequal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/lessthanorequal.yaml"
+- debug: msg="START netconf_xml/lessthanorequal.yaml on connection={{ ansible_connection }}"
 
 - name: test le operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/lessthanorequal.yaml"
+- debug: msg="END netconf_xml/lessthanorequal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/notequal.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/notequal.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/notequal.yaml"
+- debug: msg="START netconf_xml/notequal.yaml on connection={{ ansible_connection }}"
 
 - name: test neq operator
   junos_command:
@@ -35,4 +35,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/notequal.yaml"
+- debug: msg="END netconf_xml/notequal.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/output.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/output.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/output.yaml"
+- debug: msg="START netconf_xml/output.yaml on connection={{ ansible_connection }}"
 
 - name: get output for single command
   junos_command:
@@ -35,6 +35,7 @@
     provider:
       transport: cli
   register: result
+  connection: network_cli
 
 - assert:
     that:
@@ -51,6 +52,7 @@
     provider:
       transport: cli
   register: result
+  connection: network_cli
 
 - assert:
     that:
@@ -58,4 +60,4 @@
       - "result.stdout is defined"
       - "result.stdout_lines is defined"
 
-- debug: msg="END netconf_xml/output.yaml"
+- debug: msg="END netconf_xml/output.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_command/tests/netconf_xml/timeout.yaml
+++ b/test/integration/targets/junos_command/tests/netconf_xml/timeout.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf_xml/timeout.yaml"
+- debug: msg="START netconf_xml/timeout.yaml on connection={{ ansible_connection }}"
 
 - name: test bad condition
   junos_command:
@@ -16,4 +16,4 @@
       - "result.failed == true"
       - "result.msg is defined"
 
-- debug: msg="END netconf_xml/timeout.yaml"
+- debug: msg="END netconf_xml/timeout.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tasks/netconf.yaml
+++ b/test/integration/targets/junos_config/tasks/netconf.yaml
@@ -8,8 +8,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_config/tests/netconf/backup.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/backup.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/backup.yaml"
+- debug: msg="START netconf/backup.yaml on connection={{ ansible_connection }}"
 
 - name: setup
   junos_config:
@@ -44,4 +44,4 @@
     that:
       - "backup_files.files is defined"
 
-- debug: msg="END netconf/backup.yaml"
+- debug: msg="END netconf/backup.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/bad_action.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/bad_action.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/bad_action.yaml"
+- debug: msg="START netconf/bad_action.yaml on connection={{ ansible_connection }}"
 
 - name: configure single bad_action command
   junos_config:
@@ -13,4 +13,4 @@
     that:
       - "result.failed == true"
 
-- debug: msg="END netconf/bad_action.yaml"
+- debug: msg="END netconf/bad_action.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/invalid.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/invalid.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/invalid.yaml"
+- debug: msg="START netconf/invalid.yaml on connection={{ ansible_connection }}"
 
 - name: configure single invalid command
   junos_config:
@@ -26,4 +26,4 @@
     that:
       - "result.failed == true"
 
-- debug: msg="END netconf/invalid.yaml"
+- debug: msg="END netconf/invalid.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/multiple.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/multiple.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/multiple.yaml"
+- debug: msg="START netconf/multiple.yaml on connection={{ ansible_connection }}"
 
 - name: setup
   junos_config:
@@ -46,4 +46,4 @@
     provider: "{{ netconf }}"
   register: test
 
-- debug: msg="END netconf/multiple.yaml"
+- debug: msg="END netconf/multiple.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/single.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/single.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/single.yaml"
+- debug: msg="START netconf/single.yaml on connection={{ ansible_connection }}"
 
 # Ensure that when we change the hostname to `localhost` we cause a change
 - name: setup
@@ -79,4 +79,4 @@
     provider: "{{ netconf }}"
 
 
-- debug: msg="END netconf/single.yaml"
+- debug: msg="END netconf/single.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/src_basic.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/src_basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/src_basic.yaml"
+- debug: msg="START netconf/src_basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup
   junos_config:
@@ -101,4 +101,4 @@
     that:
       - "result.changed == true"
 
-- debug: msg="END netconf/src_basic.yaml"
+- debug: msg="END netconf/src_basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_config/tests/netconf/src_invalid.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/src_invalid.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/src_invalid.yaml"
+- debug: msg="START netconf/src_invalid.yaml on connection={{ ansible_connection }}"
 
 
 # Defend https://github.com/ansible/ansible-modules-core/issues/4797
@@ -16,4 +16,4 @@
       - "result.failed == true"
       - "result.msg == 'path specified in src not found'"
 
-- debug: msg="END netconf/src_invalid.yaml"
+- debug: msg="END netconf/src_invalid.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_facts/tasks/netconf.yaml
+++ b/test/integration/targets/junos_facts/tasks/netconf.yaml
@@ -7,8 +7,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_facts/tests/netconf/facts.yaml
+++ b/test/integration/targets/junos_facts/tests/netconf/facts.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/facts.yaml"
+- debug: msg="START netconf/facts.yaml on connection={{ ansible_connection }}"
 
 
 - name: Collect default facts from device
@@ -107,4 +107,4 @@
       - "result.changed == false"
       - "'system {\n    host-name {{ inventory_hostname_short }};' in result['ansible_facts']['ansible_net_config']"
 
-- debug: msg="END netconf/facts.yaml"
+- debug: msg="END netconf/facts.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_interface/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_interface/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_interface netconf/basic.yaml"
+- debug: msg="START junos_interface netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup remove interface
   junos_interface:
@@ -295,3 +295,5 @@
 - assert:
     that:
       - 'result.changed == false'
+
+- debug: msg="END junos_interface netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_interface/tests/netconf/intent.yaml
+++ b/test/integration/targets/junos_interface/tests/netconf/intent.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_interface netconf/intent.yaml"
+- debug: msg="START junos_interface netconf/intent.yaml on connection={{ ansible_connection }}"
 
 - name: get facts
   junos_facts:
@@ -92,3 +92,5 @@
 - assert:
     that:
       - "result.failed == false"
+
+- debug: msg="END junos_interface netconf/intent.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_l3_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_l3_interface/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_l3_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_l3_interface/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_l3_interface netconf/basic.yaml"
+- debug: msg="START junos_l3_interface netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove interface address
   junos_l3_interface:
@@ -253,3 +253,5 @@
 - assert:
     that:
       - 'result.changed == false'
+
+- debug: msg="END junos_l3_interface netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_linkagg/tasks/netconf.yaml
+++ b/test/integration/targets/junos_linkagg/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_linkagg/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_linkagg/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_linkagg netconf/basic.yaml"
+- debug: msg="START junos_linkagg netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove linkagg
   junos_linkagg:
@@ -236,3 +236,5 @@
 - assert:
     that:
       - "result.changed == false"
+
+- debug: msg="END junos_linkagg netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp/tasks/netconf.yaml
+++ b/test/integration/targets/junos_lldp/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_lldp netconf/basic.yaml"
+- debug: msg="START junos_lldp netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - Disable lldp and remove it's configuration
   junos_lldp:
@@ -115,3 +115,5 @@
 - assert:
     that:
       - "result.changed == false"
+
+- debug: msg="END junos_lldp netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_lldp_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_lldp_interface/tasks/netconf.yaml
@@ -9,8 +9,17 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: set test_items
+  set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
+
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_lldp_interface/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_lldp_interface netconf/basic.yaml"
+- debug: msg="START junos_lldp_interface netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - Remove lldp interface configuration
   junos_lldp_interface:
@@ -102,3 +102,5 @@
 - assert:
     that:
       - "result.changed == false"
+
+- debug: msg="END junos_lldp_interface netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_logging/tasks/netconf.yaml
+++ b/test/integration/targets/junos_logging/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_logging/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_logging/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_logging netconf/basic.yaml"
+- debug: msg="START junos_logging netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove file logging
   junos_logging:
@@ -390,3 +390,5 @@
 - assert:
     that:
       - "result.changed == false"
+
+- debug: msg="END junos_logging netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_netconf/tasks/cli.yaml
+++ b/test/integration/targets/junos_netconf/tasks/cli.yaml
@@ -8,8 +8,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=network_cli)
+  include: "{{ test_case_to_run }} ansible_connection=network_cli"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/changeport.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/changeport.yaml"
+- debug: msg="START netconf/changeport.yaml on connection={{ ansible_connection }}"
 
 
 - name: Setup
@@ -38,6 +38,7 @@
     - get-software-information
     provider: "{{ netconf }}"
     port: 8022
+  connection: netconf
 
 - name: wait for persistent socket to timeout
   pause:
@@ -49,6 +50,7 @@
     rpcs: get-software-information
     provider: "{{ netconf }}"
   register: result
+  connection: netconf
   ignore_errors: true
 
 - assert:
@@ -69,5 +71,6 @@
     rpcs:
     - get-software-information
     provider: "{{ netconf }}"
+  connection: netconf
 
-- debug: msg="END netconf/changeport.yaml"
+- debug: msg="END netconf/changeport.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
+++ b/test/integration/targets/junos_netconf/tests/cli/netconf.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/netconf.yaml"
+- debug: msg="START netconf/netconf.yaml on connection={{ ansible_connection }}"
 
 
 - name: Ensure netconf is enabled
@@ -26,6 +26,7 @@
   junos_command:
     rpcs: get-software-information
     provider: "{{ netconf }}"
+  connection: netconf
 
 # Disable netconf
 
@@ -56,6 +57,7 @@
     rpcs: get-software-information
     provider: "{{ netconf }}"
   register: result
+  connection: netconf
   ignore_errors: true
 
 - assert:
@@ -68,4 +70,4 @@
   register: result
 
 
-- debug: msg="END netconf/netconfg.yaml"
+- debug: msg="END netconf/netconfg.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_rpc/tasks/netconf.yaml
+++ b/test/integration/targets/junos_rpc/tasks/netconf.yaml
@@ -7,8 +7,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_rpc/tests/netconf/rpc.yaml
+++ b/test/integration/targets/junos_rpc/tests/netconf/rpc.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START netconf/rpc.yaml"
+- debug: msg="START netconf/rpc.yaml on connection={{ ansible_connection }}"
 
 - name: Execute RPC on device
   junos_rpc:
@@ -69,4 +69,4 @@
     that:
       - "result.failed == true"
 
-- debug: msg="END netconf/rpc.yaml"
+- debug: msg="END netconf/rpc.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_static_route/tasks/netconf.yaml
+++ b/test/integration/targets/junos_static_route/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_static_route/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_static_route/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_static_route netconf/basic.yaml"
+- debug: msg="START junos_static_route netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove static route
   junos_static_route:
@@ -247,3 +247,5 @@
 - assert:
     that:
       - "result.changed == false"
+
+- debug: msg="END junos_static_route netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_system/tasks/netconf.yaml
+++ b/test/integration/targets/junos_system/tasks/netconf.yaml
@@ -9,8 +9,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_system/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_system/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_system netconf/basic.yaml"
+- debug: msg="START junos_system netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove hostname
   junos_system:
@@ -403,3 +403,5 @@
       - "result.changed == true"
       - "'<name>8.8.8.8</name>' not in config.xml"
       - "'<name>8.8.4.4</name>' not in config.xml"
+
+- debug: msg="END junos_system netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_user/tasks/netconf.yaml
+++ b/test/integration/targets/junos_user/tasks/netconf.yaml
@@ -8,8 +8,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_user/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_user/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_user netconf/basic.yaml"
+- debug: msg="START junos_user netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove user
   junos_user:
@@ -191,3 +191,5 @@
       - "result.changed == true"
       - result.diff.prepared is search("\- *user test_user1")
       - result.diff.prepared is search("\- *user test_user2")
+
+- debug: msg="END junos_user netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_vlan/tasks/netconf.yaml
+++ b/test/integration/targets/junos_vlan/tasks/netconf.yaml
@@ -7,8 +7,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_vlan/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_vlan/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_vlan netconf/basic.yaml"
+- debug: msg="START junos_vlan netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove vlan
   junos_vlan:
@@ -188,3 +188,5 @@
 - assert:
     that:
       - 'result.changed == false'
+
+- debug: msg="END junos_vlan netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/junos_vrf/tasks/netconf.yaml
+++ b/test/integration/targets/junos_vrf/tasks/netconf.yaml
@@ -7,8 +7,14 @@
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"
 
-- name: run test case
-  include: "{{ test_case_to_run }}"
+- name: run test case (connection=netconf)
+  include: "{{ test_case_to_run }} ansible_connection=netconf"
+  with_items: "{{ test_items }}"
+  loop_control:
+    loop_var: test_case_to_run
+
+- name: run test case (connection=local)
+  include: "{{ test_case_to_run }} ansible_connection=local"
   with_items: "{{ test_items }}"
   loop_control:
     loop_var: test_case_to_run

--- a/test/integration/targets/junos_vrf/tests/netconf/basic.yaml
+++ b/test/integration/targets/junos_vrf/tests/netconf/basic.yaml
@@ -1,5 +1,5 @@
 ---
-- debug: msg="START junos_vrf netconf/basic.yaml"
+- debug: msg="START junos_vrf netconf/basic.yaml on connection={{ ansible_connection }}"
 
 - name: setup - remove vrf
   junos_vrf:
@@ -320,3 +320,5 @@
 - assert:
     that:
       - "result.changed == false"
+
+- debug: msg="END junos_vrf netconf/basic.yaml on connection={{ ansible_connection }}"

--- a/test/integration/targets/prepare_junos_tests/tasks/main.yml
+++ b/test/integration/targets/prepare_junos_tests/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: Ensure netconf is enabled
   junos_netconf:
     state: present
+  connection: network_cli
 
 - name: wait for netconf server to come up
   pause:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  Add connection=netconf in individual roles for modules that run using netconf connection
plugin.
*  Add connection=network_cli for junos_netconf and junos_command
as applicable.
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```

  