### PR TITLE
ec2_vpc_vgw_facts: fix facts for gateways without tags - fixes #34458

### DIFF
--- a/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_facts.py
+++ b/lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_facts.py
@@ -110,7 +110,7 @@ def get_virtual_gateway_info(virtual_gateway):
                             'State': virtual_gateway['State'],
                             'Type': virtual_gateway['Type'],
                             'VpcAttachments': virtual_gateway['VpcAttachments'],
-                            'Tags': virtual_gateway['Tags']}
+                            'Tags': virtual_gateway.get('Tags', [])}
     return virtual_gateway_info
 
 


### PR DESCRIPTION
##### SUMMARY
Fix KeyError if a virtual gateway has no tags. Fixes #34458.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/modules/cloud/amazon/ec2_vpc_vgw_facts.py

##### ANSIBLE VERSION
```
2.5.0
```

