### PR TITLE
Fix connection type in junos integration tests

### DIFF
--- a/test/integration/targets/junos_banner/tasks/netconf.yaml
+++ b/test/integration/targets/junos_banner/tasks/netconf.yaml
@@ -2,6 +2,8 @@
   find:
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
+  connection: local
+  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_banner/tasks/netconf.yaml
+++ b/test/integration/targets/junos_banner/tasks/netconf.yaml
@@ -3,7 +3,6 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_command/tasks/netconf_json.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_json.yaml
@@ -3,6 +3,8 @@
   find:
     paths: "{{ role_path }}/tests/netconf_json"
     patterns: "{{ testcase }}.yaml"
+  connection: local
+  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_command/tasks/netconf_json.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_json.yaml
@@ -4,7 +4,6 @@
     paths: "{{ role_path }}/tests/netconf_json"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_command/tasks/netconf_text.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_text.yaml
@@ -4,7 +4,6 @@
     paths: "{{ role_path }}/tests/netconf_text"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_command/tasks/netconf_text.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_text.yaml
@@ -3,6 +3,8 @@
   find:
     paths: "{{ role_path }}/tests/netconf_text"
     patterns: "{{ testcase }}.yaml"
+  connection: local
+  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_command/tasks/netconf_xml.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_xml.yaml
@@ -4,7 +4,6 @@
     paths: "{{ role_path }}/tests/netconf_xml"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_command/tasks/netconf_xml.yaml
+++ b/test/integration/targets/junos_command/tasks/netconf_xml.yaml
@@ -3,6 +3,8 @@
   find:
     paths: "{{ role_path }}/tests/netconf_xml"
     patterns: "{{ testcase }}.yaml"
+  connection: local
+  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_config/tasks/netconf.yaml
+++ b/test/integration/targets/junos_config/tasks/netconf.yaml
@@ -4,7 +4,6 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_config/tasks/netconf.yaml
+++ b/test/integration/targets/junos_config/tasks/netconf.yaml
@@ -3,6 +3,8 @@
   find:
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
+  connection: local
+  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_config/tests/netconf/backup.yaml
+++ b/test/integration/targets/junos_config/tests/netconf/backup.yaml
@@ -13,12 +13,13 @@
     paths: "{{ role_path }}/backup"
     pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
-  delegate_to: localhost
+  connection: local
 
 - name: delete backup files
   file:
     path: "{{ item.path }}"
     state: absent
+  connection: local
   with_items: "{{backup_files.files|default([])}}"
 
 - name: configure device with config
@@ -38,7 +39,7 @@
     paths: "{{ role_path }}/backup"
     pattern: "{{ inventory_hostname_short }}_config*"
   register: backup_files
-  delegate_to: localhost
+  connection: local
 
 - assert:
     that:

--- a/test/integration/targets/junos_facts/tasks/netconf.yaml
+++ b/test/integration/targets/junos_facts/tasks/netconf.yaml
@@ -2,6 +2,8 @@
   find:
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
+  connection: local
+  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_facts/tasks/netconf.yaml
+++ b/test/integration/targets/junos_facts/tasks/netconf.yaml
@@ -3,7 +3,6 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_interface/tasks/netconf.yaml
@@ -4,7 +4,6 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_interface/tasks/netconf.yaml
@@ -3,8 +3,9 @@
   find:
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
-  register: test_cases
+  connection: local
   delegate_to: localhost
+  register: test_cases
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_l3_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_l3_interface/tasks/netconf.yaml
@@ -4,7 +4,6 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   connection: local
-  delegate_to: localhost
   register: test_cases
 
 - name: set test_items

--- a/test/integration/targets/junos_l3_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_l3_interface/tasks/netconf.yaml
@@ -3,8 +3,9 @@
   find:
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
-  register: test_cases
+  connection: local
   delegate_to: localhost
+  register: test_cases
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_linkagg/tasks/netconf.yaml
+++ b/test/integration/targets/junos_linkagg/tasks/netconf.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
   delegate_to: localhost
 
 - name: set test_items

--- a/test/integration/targets/junos_linkagg/tasks/netconf.yaml
+++ b/test/integration/targets/junos_linkagg/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_lldp/tasks/netconf.yaml
+++ b/test/integration/targets/junos_lldp/tasks/netconf.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
   delegate_to: localhost
 
 - name: set test_items

--- a/test/integration/targets/junos_lldp/tasks/netconf.yaml
+++ b/test/integration/targets/junos_lldp/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_lldp_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_lldp_interface/tasks/netconf.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
   delegate_to: localhost
 
 - name: set test_items

--- a/test/integration/targets/junos_lldp_interface/tasks/netconf.yaml
+++ b/test/integration/targets/junos_lldp_interface/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_logging/tasks/netconf.yaml
+++ b/test/integration/targets/junos_logging/tasks/netconf.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
   delegate_to: localhost
 
 - name: set test_items

--- a/test/integration/targets/junos_logging/tasks/netconf.yaml
+++ b/test/integration/targets/junos_logging/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_netconf/tasks/cli.yaml
+++ b/test/integration/targets/junos_netconf/tasks/cli.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_netconf/tasks/cli.yaml
+++ b/test/integration/targets/junos_netconf/tasks/cli.yaml
@@ -4,6 +4,8 @@
     paths: "{{ role_path }}/tests/cli"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_rpc/tasks/netconf.yaml
+++ b/test/integration/targets/junos_rpc/tasks/netconf.yaml
@@ -3,6 +3,8 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_rpc/tasks/netconf.yaml
+++ b/test/integration/targets/junos_rpc/tasks/netconf.yaml
@@ -4,7 +4,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_static_route/tasks/netconf.yaml
+++ b/test/integration/targets/junos_static_route/tasks/netconf.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
   delegate_to: localhost
 
 - name: set test_items

--- a/test/integration/targets/junos_static_route/tasks/netconf.yaml
+++ b/test/integration/targets/junos_static_route/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_system/tasks/netconf.yaml
+++ b/test/integration/targets/junos_system/tasks/netconf.yaml
@@ -4,6 +4,7 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
   delegate_to: localhost
 
 - name: set test_items

--- a/test/integration/targets/junos_system/tasks/netconf.yaml
+++ b/test/integration/targets/junos_system/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_user/tasks/netconf.yaml
+++ b/test/integration/targets/junos_user/tasks/netconf.yaml
@@ -5,7 +5,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_user/tasks/netconf.yaml
+++ b/test/integration/targets/junos_user/tasks/netconf.yaml
@@ -4,6 +4,8 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_vlan/tasks/netconf.yaml
+++ b/test/integration/targets/junos_vlan/tasks/netconf.yaml
@@ -3,6 +3,8 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_vlan/tasks/netconf.yaml
+++ b/test/integration/targets/junos_vlan/tasks/netconf.yaml
@@ -4,7 +4,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_vrf/tasks/netconf.yaml
+++ b/test/integration/targets/junos_vrf/tasks/netconf.yaml
@@ -3,6 +3,8 @@
     paths: "{{ role_path }}/tests/netconf"
     patterns: "{{ testcase }}.yaml"
   register: test_cases
+  connection: local
+  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"

--- a/test/integration/targets/junos_vrf/tasks/netconf.yaml
+++ b/test/integration/targets/junos_vrf/tasks/netconf.yaml
@@ -4,7 +4,6 @@
     patterns: "{{ testcase }}.yaml"
   register: test_cases
   connection: local
-  delegate_to: localhost
 
 - name: set test_items
   set_fact: test_items="{{ test_cases.files | map(attribute='path') | list }}"


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
*  For find module in junos integration test
   add connection type local and delegate task to localhost
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Test Pull Request

##### COMPONENT NAME
<!--- Name of the module, plugin, module or task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
