### PR TITLE
remove erroneous '.' in docsite footer

### DIFF
--- a/docs/docsite/_themes/srtd/footer.html
+++ b/docs/docsite/_themes/srtd/footer.html
@@ -30,6 +30,6 @@
   {%- endif %}
   </p>
 <p>
-Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}. Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <a href="https://github.com/ansible/ansible/tree/devel/lib/ansible/modules">modules directory</a> of the <a href="https://github.com/ansible/ansible/">core source code repository</a>. {% endif %}
+Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</a> using <a href="http://sphinx-doc.org/">Sphinx</a> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <a href="https://github.com/ansible/ansible/tree/devel/lib/ansible/modules">modules directory</a> of the <a href="https://github.com/ansible/ansible/">core source code repository</a>. {% endif %}
 </p>
 </footer>

--- a/docs/docsite/rst/dev_guide/style_guide/_themes/srtd/footer.html
+++ b/docs/docsite/rst/dev_guide/style_guide/_themes/srtd/footer.html
@@ -20,6 +20,6 @@
   {%- endif %}
   </p>
 
-Ansible docs are generated from <a href="http://github.com/ansible/ansible">GitHub sources</A> using <A HREF="http://sphinx-doc.org/">Sphinx</A> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}. Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <A HREF="https://github.com/ansible/ansible-modules-core">core</A> and <A HREF="https://github.com/ansible/ansible-modules-extras">extras</A> modules source repositories. {% endif %}
+Ansible docs are generated from <a href="http://github.com/ansible/ansible">GitHub sources</A> using <A HREF="http://sphinx-doc.org/">Sphinx</A> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. {% if pagename.endswith("_module") %}Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <A HREF="https://github.com/ansible/ansible-modules-core">core</A> and <A HREF="https://github.com/ansible/ansible-modules-extras">extras</A> modules source repositories. {% endif %}
 
 </footer>


### PR DESCRIPTION
This removes an erroneous '.' in the docsite that someone pointed out
on irc.