### PR TITLE
influxdb: add login aliases

### DIFF
--- a/lib/ansible/module_utils/influxdb.py
+++ b/lib/ansible/module_utils/influxdb.py
@@ -42,8 +42,8 @@ class InfluxDb():
         return dict(
             hostname=dict(default='localhost', type='str'),
             port=dict(default=8086, type='int'),
-            username=dict(default='root', type='str'),
-            password=dict(default='root', type='str', no_log=True),
+            username=dict(default='root', type='str', aliases=['login_username']),
+            password=dict(default='root', type='str', no_log=True, aliases=['login_password']),
             ssl=dict(default=False, type='bool'),
             validate_certs=dict(default=True, type='bool'),
             timeout=dict(type='int'),

--- a/lib/ansible/modules/database/influxdb/influxdb_user.py
+++ b/lib/ansible/modules/database/influxdb/influxdb_user.py
@@ -17,81 +17,62 @@ DOCUMENTATION = '''
 module: influxdb_user
 short_description: Manage InfluxDB users
 description:
-    - Manage InfluxDB users
+  - Manage InfluxDB users
 version_added: 2.5
 author: "Vitaliy Zhhuta (@zhhuta)"
 requirements:
-    - "python >= 2.6"
-    - "influxdb >= 0.9"
+  - "python >= 2.6"
+  - "influxdb >= 0.9"
 options:
-    hostname:
-        description:
-            - The hostname or IP address on which InfluxDB server is listening
-        default: localhost
-        required: false
-    user_name:
-        description:
-            - User that we want to create
-        default: None
-        required: True
-    user_password:
-        description:
-            - Password that we want to set for user
-        default: None
-        required: false
-    admin:
-        description:
-            - specify if user should be admin
-        default: False
-        required: false
-
-    port:
-        description:
-            - The port on which InfluxDB server is listening
-        default: 8086
-        required: false
-    state:
-        description:
-            - Determines if the database should be created or destroyed
-        choices: ['present', 'absent']
-        default: present
-        required: false
-    username:
-        description:
-            - user to auth with influxdb
-        default: root
-        required: false
-    password:
-        description:
-            - password to auth username with influxdb
-        default: root
-        required: false
+  user_name:
+    description:
+      - Name of the user.
+    required: True
+  user_password:
+    description:
+      - Password to be set for the user.
+    required: false
+  admin:
+    description:
+      - Whether the user should be in the admin role or not.
+    default: no
+    choices: [ yes, no]
+  state:
+    description:
+      - State of the user.
+    choices: [ present, absent ]
+    default: present
+extends_documentation_fragment: influxdb
 '''
 
 EXAMPLES = '''
-# Example influxdb_user command from Ansible Playbooks
-- name: Create User
+- name: Create a user on localhost using default login credentials
   influxdb_user:
-      user_name: "{{influxdb_user_name}}"
-      user_password: "{{influxdb_user_password}}"
-      state: present
+    user_name: john
+    user_password: s3cr3t
 
-- name: Destroy User
+- name: Create a user on localhost using custom login credentials
   influxdb_user:
-      user_name: "{{influxdb_user_name}}"
-      username: "{{influxdb_password}}"
-      password: "{{influxdb_user_password}}"
-      state: absent
+    user_name: john
+    user_password: s3cr3t
+    login_username: "{{ influxdb_username }}"
+    login_password: "{{ influxdb_password }}"
 
-- name: Create user on dest host
+- name: Create an admin user on a remote host using custom login credentials
   influxdb_user:
-      hostname: "{{influxdb_ip_address}}"
-      username: "{{influxdb_username}}"
-      password: "{{influxdb_password}}"
-      user_name: "{{influxdb_user_name}}"
-      user_password: "{{influxdb_user_password}}"
-      admin: true
-      state: present
+    user_name: john
+    user_password: s3cr3t
+    admin: yes
+    hostname: "{{ influxdb_hostname }}"
+    login_username: "{{ influxdb_username }}"
+    login_password: "{{ influxdb_password }}"
+
+- name: Destroy a user using custom login credentials
+  influxdb_user:
+    user_name: john
+    login_username: "{{ influxdb_username }}"
+    login_password: "{{ influxdb_password }}"
+    state: absent
 '''
 
 RETURN = '''

--- a/lib/ansible/utils/module_docs_fragments/influxdb.py
+++ b/lib/ansible/utils/module_docs_fragments/influxdb.py
@@ -9,17 +9,21 @@ class ModuleDocFragment(object):
 options:
   hostname:
     description:
-    - The hostname or IP address on which InfluxDB server is listening
+    - The hostname or IP address on which InfluxDB server is listening.
     - Since version 2.5, defaulted to localhost.
     default: localhost
   username:
     description:
-    - Username that will be used to authenticate against InfluxDB server
+    - Username that will be used to authenticate against InfluxDB server.
+    - Alias C(login_username) added in version 2.5.
     default: root
+    aliases: [ login_username ]
   password:
     description:
-    - Password that will be used to authenticate against InfluxDB server
+    - Password that will be used to authenticate against InfluxDB server.
+    - Alias C(login_password) added in version 2.5.
     default: root
+    aliases: [ login_password ]
   port:
     description:
     - The port on which InfluxDB server is listening


### PR DESCRIPTION
##### SUMMARY
influxdb_user module has user_name, user_password which may confuse with existing
login arg username and password. Added aliases prefixed ith login_ to
help distinguish.

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Docs Pull Request

##### COMPONENT NAME
influxdb_user

##### ANSIBLE VERSION
<!--- Paste verbatim output from "ansible --version" between quotes below -->
```
2.5
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
