### PR TITLE
Use `dnf upgrade` in Fedora Dockerfiles.

### DIFF
--- a/test/utils/docker/fedora26py3/Dockerfile
+++ b/test/utils/docker/fedora26py3/Dockerfile
@@ -10,7 +10,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN dnf clean all && \
-    dnf -y update && \
+    dnf -y upgrade && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     bzip2 \

--- a/test/utils/docker/fedora27py3/Dockerfile
+++ b/test/utils/docker/fedora27py3/Dockerfile
@@ -10,7 +10,7 @@ rm -f /lib/systemd/system/basic.target.wants/*; \
 rm -f /lib/systemd/system/anaconda.target.wants/*;
 
 RUN dnf clean all && \
-    dnf -y update && \
+    dnf -y upgrade && \
     dnf -y --setopt=install_weak_deps=false install \
     acl \
     bzip2 \


### PR DESCRIPTION
##### SUMMARY

Use `dnf upgrade` in Fedora Dockerfiles.

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

test/utils/docker/fedora26py3/Dockerfile
test/utils/docker/fedora27py3/Dockerfile

##### ANSIBLE VERSION

```
ansible 2.5.0 (fedora-docker ebceebaaf9) last updated 2018/01/08 12:56:19 (GMT -700)
  config file = None
  configured module search path = [u'/Users/mclay/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
  ansible python module location = /Users/mclay/code/mattclay/ansible/lib/ansible
  executable location = /Users/mclay/code/mattclay/ansible/bin/ansible
  python version = 2.7.13 (default, Jul 18 2017, 09:17:00) [GCC 4.2.1 Compatible Apple LLVM 8.1.0 (clang-802.0.42)]
```
