### PR TITLE
Bug Fix at cnos.py

### DIFF
--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -71,7 +71,7 @@ def interfaceConfig(
                     deviceType, "portchannel_interface_string", interfaceArg2)
                 if(value == "ok"):
                     newPrompt = "(config-if-range)#"
-                    if '/' in  interfaceArg2:
+                    if '/' in interfaceArg2:
                         newPrompt = "(config-if)#"
                     retVal = retVal + \
                         waitForDeviceResponse(command, newPrompt, timeout, obj)
@@ -108,7 +108,7 @@ def interfaceConfig(
                     command = command + \
                         interfaceArg1 + " " + interfaceArg2 + "\n"
                     newPrompt = "(config-if-range)#"
-                    if '/' in  interfaceArg2:
+                    if '/' in interfaceArg2:
                         newPrompt = "(config-if)#"
                     retVal = retVal + \
                         waitForDeviceResponse(command, newPrompt, timeout, obj)

--- a/lib/ansible/module_utils/network/cnos/cnos.py
+++ b/lib/ansible/module_utils/network/cnos/cnos.py
@@ -71,6 +71,8 @@ def interfaceConfig(
                     deviceType, "portchannel_interface_string", interfaceArg2)
                 if(value == "ok"):
                     newPrompt = "(config-if-range)#"
+                    if '/' in  interfaceArg2:
+                        newPrompt = "(config-if)#"
                     retVal = retVal + \
                         waitForDeviceResponse(command, newPrompt, timeout, obj)
                 else:
@@ -106,6 +108,8 @@ def interfaceConfig(
                     command = command + \
                         interfaceArg1 + " " + interfaceArg2 + "\n"
                     newPrompt = "(config-if-range)#"
+                    if '/' in  interfaceArg2:
+                        newPrompt = "(config-if)#"
                     retVal = retVal + \
                         waitForDeviceResponse(command, newPrompt, timeout, obj)
                 else:


### PR DESCRIPTION
##### SUMMARY
Some of Switch ports support break-out, such as there maybe "interface eth 1/87/1" for G8296.
interfaceConfig() will expect "(config-if-range)#" as the prompt, actually it is just one port, so the prompt should be "(config-if)#"
This bug has to be fixed for both ethernet as well as portchannel methods

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
lib/ansible/module_utils/network/cnos/cnos.py

##### ANSIBLE VERSION
ansible 2.5.0
config file = /etc/ansible/ansible.cfg
configured module search path = [u'/root/.ansible/plugins/modules', u'/usr/share/ansible/plugins/modules']
ansible python module location = /usr/local/lib/python2.7/dist-packages/ansible-2.5.0-py2.7.egg/ansible
executable location = /usr/local/bin/ansible
python version = 2.7.6 (default, Oct 26 2016, 20:30:19) [GCC 4.8.4]

##### ADDITIONAL INFORMATION
This is fix for a bug which came to limelight when used in field.
