### PR TITLE
Add GALAXY_TOKEN config option

### DIFF
--- a/lib/ansible/cli/galaxy.py
+++ b/lib/ansible/cli/galaxy.py
@@ -545,14 +545,17 @@ class GalaxyCLI(CLI):
         """
         # Authenticate with github and retrieve a token
         if self.options.token is None:
-            login = GalaxyLogin(self.galaxy)
-            github_token = login.create_github_token()
+            if C.GALAXY_TOKEN:
+                github_token = C.GALAXY_TOKEN
+            else:
+                login = GalaxyLogin(self.galaxy)
+                github_token = login.create_github_token()
         else:
             github_token = self.options.token
 
         galaxy_response = self.api.authenticate(github_token)
 
-        if self.options.token is None:
+        if self.options.token is None and C.GALAXY_TOKEN is None:
             # Remove the token we created
             login.remove_github_token()
 

--- a/lib/ansible/config/base.yml
+++ b/lib/ansible/config/base.yml
@@ -1249,6 +1249,13 @@ GALAXY_SERVER:
   ini:
   - {key: server, section: galaxy}
   yaml: {key: galaxy.server}
+GALAXY_TOKEN:
+  default: null
+  description: "GitHub personnal access token"
+  env: [{name: ANSIBLE_GALAXY_TOKEN}]
+  ini:
+  - {key: token, section: galaxy}
+  yaml: {key: galaxy.token}
 HOST_KEY_CHECKING:
   name: Check host keys
   default: True


### PR DESCRIPTION
##### SUMMARY
This change lets user store token in configuration file or environment to
prevent exposing the secret on the command line.

##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
Galaxy, config

##### ANSIBLE VERSION
```
ansible-3 2.4.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/fedora/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3.6/site-packages/ansible
  executable location = /usr/bin/ansible-3
  python version = 3.6.3 (default, Oct  9 2017, 12:07:10) [GCC 7.2.1 20170915 (Red Hat 7.2.1-2)]
```
